### PR TITLE
Updating servo for new kind-checking rules

### DIFF
--- a/src/servo/engine.rs
+++ b/src/servo/engine.rs
@@ -5,7 +5,7 @@ enum msg {
     exit(comm::chan<()>)
 }
 
-fn engine<S: renderer::sink send>(sink: S) -> comm::chan<msg> {
+fn engine<S: renderer::sink send copy>(sink: S) -> comm::chan<msg> {
 
     task::spawn_listener::<msg> {|self_ch|
         // The renderer

--- a/src/servo/gfx/renderer.rs
+++ b/src/servo/gfx/renderer.rs
@@ -19,7 +19,7 @@ iface sink {
     fn draw(next_dt: chan<AzDrawTargetRef>, draw_me: AzDrawTargetRef);
 }
 
-fn renderer<S: sink send>(sink: S) -> chan<msg> {
+fn renderer<S: sink send copy>(sink: S) -> chan<msg> {
     task::spawn_listener::<msg> {|po|
         listen {|draw_target_ch|
             #debug("renderer: beginning rendering loop");


### PR DESCRIPTION
The incoming rules to prevent accidentally capturing non-copyable values breaks servo. Here's a fix.
