### PR TITLE
Add MacPorts instructions/required ports/workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ given day. Good luck!
 
 ### Prerequisites
 
-On OS X:
+On OS X (homebrew):
 
     brew install https://raw.github.com/Homebrew/homebrew-versions/master/autoconf213.rb
     brew install sdl cairo
 
+On OS X (MacPorts):
+
+    sudo port install autoconf213 libsdl cairo +x11 +quartz
+    
 On Debian-based Linuxes:
 
     sudo apt-get install libsdl1.2-dev libcairo2-dev libpango1.0-dev autoconf2.13 freeglut3-dev
@@ -32,3 +36,18 @@ On Debian-based Linuxes:
     ../configure
     make check && make
     ./servo ../src/test/test.html
+
+
+### Build Workarounds
+
+#### MacPorts
+
+Currently, the Makefile for the rust-azure submodule has a hardcoded
+library path that assumes cairo has been installed with homebrew. If
+you have installed with MacPorts, you will need to change the library
+path to cairo. The following command should apply a patch with the fix:
+
+    cd src/rust-azure && git diff 1e811d44^1 1e811d44 | patch -p1
+
+This problem should go away once Issue #40 is fixed, and an
+externally-built cairo is no longer needed.


### PR DESCRIPTION
Eventually, the build workarounds section won't be needed. Until then, this will save people some time.
