### PR TITLE
Fix missing dependency in brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ language. It is currently developed on OS X and Linux.
 On OS X (homebrew):
 
     brew install https://raw.github.com/Homebrew/homebrew-versions/master/autoconf213.rb
+    brew install automake
 
 On OS X (MacPorts):
 


### PR DESCRIPTION
Needed automake to get beyond 
./configure: line 409: aclocal: command not found
XCode 4.6, pretty virgin setup
