### PR TITLE
Build on linux

### DIFF
--- a/src/servo-gfx/fontconfig/font_list.rs
+++ b/src/servo-gfx/fontconfig/font_list.rs
@@ -4,6 +4,9 @@ extern mod fontconfig;
 use fc = fontconfig;
 use ft = freetype;
 
+use font_context::FontContextHandleMethods;
+use font::FontHandleMethods;
+
 use gfx_font::FontHandle;
 use gfx_font_list::{FontEntry, FontFamily, FontFamilyMap};
 use freetype_impl::font_context::FreeTypeFontContextHandle;


### PR DESCRIPTION
I tried to get servo to build on linux over the weekend.

The commit for the rust-freetype submodule is provided by the pull request at  mozilla-servo/rust-freetype#1.
