### PR TITLE
Clean up

### DIFF
--- a/src/servo-gfx/compositor.rs
+++ b/src/servo-gfx/compositor.rs
@@ -22,7 +22,7 @@ The interface used to by the renderer to aquire draw targets for
 each rendered frame and submit them to be drawn to the display
 */
 pub trait Compositor {
-    fn begin_drawing(next_dt: pipes::Chan<LayerBufferSet>);
-    fn draw(next_dt: pipes::Chan<LayerBufferSet>, +draw_me: LayerBufferSet);
+    fn begin_drawing(&self, next_dt: pipes::Chan<LayerBufferSet>);
+    fn draw(&self, next_dt: pipes::Chan<LayerBufferSet>, +draw_me: LayerBufferSet);
 }
 

--- a/src/servo-gfx/display_list.rs
+++ b/src/servo-gfx/display_list.rs
@@ -101,7 +101,7 @@ pub impl DisplayList {
         self.list.push(move item);
     }
 
-    fn draw_into_context(ctx: &RenderContext) {
+    fn draw_into_context(&self, ctx: &RenderContext) {
         debug!("beginning display list");
         for self.list.each |item| {
             // FIXME(Issue #150): crashes

--- a/src/servo-gfx/font_list.rs
+++ b/src/servo-gfx/font_list.rs
@@ -53,7 +53,7 @@ pub impl FontList {
         return move list;
     }
 
-    priv fn refresh(_fctx: &native::FontContextHandle) {
+    priv fn refresh(&self, _fctx: &native::FontContextHandle) {
         // TODO(Issue #186): don't refresh unless something actually
         // changed.  Does OSX have a notification for this event?
         //
@@ -63,7 +63,7 @@ pub impl FontList {
         }
     }
 
-    fn find_font_in_family(family_name: &str, 
+    fn find_font_in_family(&self, family_name: &str, 
                            style: &SpecifiedFontStyle) -> Option<@FontEntry> {
         let family = self.find_family(family_name);
         let mut result : Option<@FontEntry> = None;
@@ -81,7 +81,7 @@ pub impl FontList {
         return result;
     }
 
-    priv fn find_family(family_name: &str) -> Option<@FontFamily> {
+    priv fn find_family(&self, family_name: &str) -> Option<@FontFamily> {
         // look up canonical name
         let family = self.family_map.find(&str::from_slice(family_name));
 
@@ -160,9 +160,9 @@ pub impl FontEntry {
         }
     }
 
-    pure fn is_bold() -> bool { 
+    pure fn is_bold(&self) -> bool { 
         self.weight.is_bold()
     }
 
-    pure fn is_italic() -> bool { self.italic }
+    pure fn is_italic(&self) -> bool { self.italic }
 }

--- a/src/servo-gfx/fontconfig/font_list.rs
+++ b/src/servo-gfx/fontconfig/font_list.rs
@@ -36,7 +36,7 @@ pub impl FontconfigFontListHandle {
         FontconfigFontListHandle { fctx: fctx.clone() }
     }
 
-    fn get_available_families() -> FontFamilyMap {
+    fn get_available_families(&self) -> FontFamilyMap {
         let mut family_map : FontFamilyMap = linear::LinearMap::new();
         unsafe {
             let config = FcConfigGetCurrent();
@@ -59,7 +59,7 @@ pub impl FontconfigFontListHandle {
         return family_map;
     }
 
-    fn load_variations_for_family(family: @FontFamily) {
+    fn load_variations_for_family(&self, family: @FontFamily) {
         debug!("getting variations for %?", family);
         let config = FcConfigGetCurrent();
         let font_set = FcConfigGetFonts(config, FcSetSystem);

--- a/src/servo-gfx/freetype_impl/font.rs
+++ b/src/servo-gfx/freetype_impl/font.rs
@@ -73,7 +73,7 @@ pub struct FreeTypeFontTable {
 }
 
 pub impl FreeTypeFontTable : FontTableMethods {
-    fn with_buffer(_blk: fn&(*u8, uint)) {
+    fn with_buffer(&self, _blk: fn&(*u8, uint)) {
         fail
     }
 }
@@ -187,21 +187,21 @@ pub impl FreeTypeFontHandle {
 
 pub impl FreeTypeFontHandle : FontHandleMethods {
     // an identifier usable by FontContextHandle to recreate this FontHandle.
-    pure fn face_identifier() -> ~str {
+    pure fn face_identifier(&self) -> ~str {
         /* FT_Get_Postscript_Name seems like a better choice here, but it
            doesn't give usable results for fontconfig when deserializing. */
         unsafe { str::raw::from_c_str((*self.face).family_name) }
     }
-    pure fn family_name() -> ~str {
+    pure fn family_name(&self) -> ~str {
         unsafe { str::raw::from_c_str((*self.face).family_name) }
     }
-    pure fn face_name() -> ~str {
+    pure fn face_name(&self) -> ~str {
         unsafe { str::raw::from_c_str(FT_Get_Postscript_Name(self.face)) }
     }
-    pure fn is_italic() -> bool {
+    pure fn is_italic(&self) -> bool {
         unsafe { (*self.face).style_flags & FT_STYLE_FLAG_ITALIC != 0 }
     }
-    pure fn boldness() -> CSSFontWeight {
+    pure fn boldness(&self) -> CSSFontWeight {
         let default_weight = FontWeight400;
         if unsafe { (*self.face).style_flags & FT_STYLE_FLAG_BOLD == 0 } {
             default_weight
@@ -228,7 +228,7 @@ pub impl FreeTypeFontHandle : FontHandleMethods {
         }
     }
 
-    fn clone_with_style(fctx: &native::FontContextHandle,
+    fn clone_with_style(&self, fctx: &native::FontContextHandle,
                         style: &UsedFontStyle) -> Result<FreeTypeFontHandle, ()> {
         match self.source {
             FontSourceMem(buf) => {
@@ -240,7 +240,7 @@ pub impl FreeTypeFontHandle : FontHandleMethods {
         }
     }
 
-    pub fn glyph_index(codepoint: char) -> Option<GlyphIndex> {
+    pub fn glyph_index(&self, codepoint: char) -> Option<GlyphIndex> {
         assert self.face.is_not_null();
         let idx = FT_Get_Char_Index(self.face, codepoint as FT_ULong);
         return if idx != 0 as FT_UInt {
@@ -251,7 +251,7 @@ pub impl FreeTypeFontHandle : FontHandleMethods {
         };
     }
 
-    pub fn glyph_h_advance(glyph: GlyphIndex) -> Option<FractionalPixel> {
+    pub fn glyph_h_advance(&self, glyph: GlyphIndex) -> Option<FractionalPixel> {
         assert self.face.is_not_null();
         let res =  FT_Load_Glyph(self.face, glyph as FT_UInt, 0);
         if res.succeeded() {
@@ -271,7 +271,7 @@ pub impl FreeTypeFontHandle : FontHandleMethods {
         }
     }
 
-    pub fn get_metrics() -> FontMetrics {
+    pub fn get_metrics(&self) -> FontMetrics {
         /* TODO(Issue #76): complete me */
         let face = self.get_face_rec();
 
@@ -294,19 +294,19 @@ pub impl FreeTypeFontHandle : FontHandleMethods {
         }
     }
 
-    fn get_table_for_tag(_tag: FontTableTag) -> Option<FontTable> {
+    fn get_table_for_tag(&self, _tag: FontTableTag) -> Option<FontTable> {
         None
     }
 }
 
 pub impl FreeTypeFontHandle {
-    priv fn get_face_rec() -> &self/FT_FaceRec {
+    priv fn get_face_rec(&self) -> &self/FT_FaceRec {
         unsafe {
             &(*self.face)
         }
     }
 
-    priv fn font_units_to_au(value: float) -> Au {
+    priv fn font_units_to_au(&self, value: float) -> Au {
 
         let face = self.get_face_rec();
 

--- a/src/servo-gfx/freetype_impl/font_context.rs
+++ b/src/servo-gfx/freetype_impl/font_context.rs
@@ -49,12 +49,12 @@ pub impl FreeTypeFontContextHandle : FontContextHandleMethods {
         FreeTypeFontContextHandle { ctx: self.ctx }
     }
 
-    fn create_font_from_identifier(name: ~str, style: UsedFontStyle)
+    fn create_font_from_identifier(&self, name: ~str, style: UsedFontStyle)
         -> Result<FontHandle, ()> {
         debug!("Creating font handle for %s", name);
         do path_from_identifier(name).chain |file_name| {
             debug!("Opening font face %s", file_name);
-            FreeTypeFontHandle::new_from_file(&self, file_name, &style)
+            FreeTypeFontHandle::new_from_file(self, file_name, &style)
         }
     }
 }

--- a/src/servo-gfx/geometry.rs
+++ b/src/servo-gfx/geometry.rs
@@ -70,8 +70,8 @@ pub fn box<T:Copy + Ord + Add<T,T> + Sub<T,T>>(x: T, y: T, w: T, h: T) -> Rect<T
 }
 
 pub impl Au {
-    pub pure fn scale_by(factor: float) -> Au {
-        Au(((*self as float) * factor) as i32)
+    pub pure fn scale_by(&const self, factor: float) -> Au {
+        Au(((**self as float) * factor) as i32)
     }
 
     static pub pure fn from_px(i: int) -> Au {

--- a/src/servo-gfx/image/holder.rs
+++ b/src/servo-gfx/image/holder.rs
@@ -23,25 +23,25 @@ pub struct ImageHolder {
 }
 
 impl ImageHolder {
-	static pub fn new(url: Url, local_image_cache: @LocalImageCache) -> ImageHolder {
-		debug!("ImageHolder::new() %?", url.to_str());
-		let holder = ImageHolder {
-			url: move url,
-			image: None,
-			cached_size: Size2D(0,0),
-			local_image_cache: local_image_cache,
-		};
+    static pub fn new(url: Url, local_image_cache: @LocalImageCache) -> ImageHolder {
+        debug!("ImageHolder::new() %?", url.to_str());
+        let holder = ImageHolder {
+            url: move url,
+            image: None,
+            cached_size: Size2D(0,0),
+            local_image_cache: local_image_cache,
+        };
 
-		// Tell the image cache we're going to be interested in this url
-		// FIXME: These two messages must be sent to prep an image for use
-		// but they are intended to be spread out in time. Ideally prefetch
-		// should be done as early as possible and decode only once we
-		// are sure that the image will be used.
-		local_image_cache.prefetch(&holder.url);
-		local_image_cache.decode(&holder.url);
+        // Tell the image cache we're going to be interested in this url
+        // FIXME: These two messages must be sent to prep an image for use
+        // but they are intended to be spread out in time. Ideally prefetch
+        // should be done as early as possible and decode only once we
+        // are sure that the image will be used.
+        local_image_cache.prefetch(&holder.url);
+        local_image_cache.decode(&holder.url);
 
-		move holder
-	}
+        move holder
+    }
 
     /**
     This version doesn't perform any computation, but may be stale w.r.t.
@@ -53,12 +53,12 @@ impl ImageHolder {
     pure fn size() -> Size2D<int> {
         self.cached_size
     }
-    
+
     /** Query and update current image size */
     fn get_size() -> Option<Size2D<int>> {
         debug!("get_size() %?", self.url);
         match self.get_image() {
-            Some(img) => { 
+            Some(img) => {
                 let img_ref = get(&img);
                 self.cached_size = Size2D(img_ref.width as int,
                                           img_ref.height as int);

--- a/src/servo-gfx/image/holder.rs
+++ b/src/servo-gfx/image/holder.rs
@@ -50,12 +50,12 @@ impl ImageHolder {
     The intent is that the impure version is used during layout when
     dimensions are used for computing layout.
     */
-    pure fn size() -> Size2D<int> {
+    pure fn size(&self) -> Size2D<int> {
         self.cached_size
     }
 
     /** Query and update current image size */
-    fn get_size() -> Option<Size2D<int>> {
+    fn get_size(&self) -> Option<Size2D<int>> {
         debug!("get_size() %?", self.url);
         match self.get_image() {
             Some(img) => {
@@ -68,7 +68,7 @@ impl ImageHolder {
         }
     }
 
-    fn get_image() -> Option<ARC<~Image>> {
+    fn get_image(&self) -> Option<ARC<~Image>> {
         debug!("get_image() %?", self.url);
 
         // If this is the first time we've called this function, load

--- a/src/servo-gfx/render_context.rs
+++ b/src/servo-gfx/render_context.rs
@@ -76,27 +76,27 @@ impl RenderContext  {
 }
 
 trait to_float {
-    fn to_float() -> float;
+    fn to_float(self) -> float;
 }
 
 impl u8 : to_float {
-    fn to_float() -> float {
+    fn to_float(self) -> float {
         (self as float) / 255f
     }
 }
 
 trait ToAzureRect {
-    fn to_azure_rect() -> Rect<AzFloat>;
-    fn to_azure_snapped_rect() -> Rect<AzFloat>;
+    fn to_azure_rect(&self) -> Rect<AzFloat>;
+    fn to_azure_snapped_rect(&self) -> Rect<AzFloat>;
 }
 
 impl Rect<Au> : ToAzureRect {
-    fn to_azure_rect() -> Rect<AzFloat> {
+    fn to_azure_rect(&self) -> Rect<AzFloat> {
         Rect(Point2D(self.origin.x.to_px() as AzFloat, self.origin.y.to_px() as AzFloat),
              Size2D(self.size.width.to_px() as AzFloat, self.size.height.to_px() as AzFloat))
     }
 
-    fn to_azure_snapped_rect() -> Rect<AzFloat> {
+    fn to_azure_snapped_rect(&self) -> Rect<AzFloat> {
         Rect(Point2D(self.origin.x.to_px() as AzFloat + 0.5f as AzFloat,
 					 self.origin.y.to_px() as AzFloat + 0.5f as AzFloat),
              Size2D(self.size.width.to_px() as AzFloat,

--- a/src/servo-gfx/render_task.rs
+++ b/src/servo-gfx/render_task.rs
@@ -80,7 +80,7 @@ priv struct Renderer<C> {
 }
 
 impl<C: Compositor Owned> Renderer<C> {
-    fn start() {
+    fn start(&self) {
         debug!("renderer: beginning rendering loop");
 
         loop {
@@ -94,7 +94,7 @@ impl<C: Compositor Owned> Renderer<C> {
         }
     }
 
-    fn render(render_layer: RenderLayer) {
+    fn render(&self, render_layer: RenderLayer) {
         debug!("renderer: got render request");
 
         let layer_buffer_set_port = self.layer_buffer_set_port.take();

--- a/src/servo-gfx/resource/image_cache_task.rs
+++ b/src/servo-gfx/resource/image_cache_task.rs
@@ -49,8 +49,8 @@ pub enum ImageResponseMsg {
 }
 
 impl ImageResponseMsg {
-    pure fn clone() -> ImageResponseMsg {
-        match &self {
+    pure fn clone(&self) -> ImageResponseMsg {
+        match self {
           &ImageReady(ref img) => ImageReady(unsafe { clone_arc(img) }),
           &ImageNotReady => ImageNotReady,
           &ImageFailed => ImageFailed
@@ -172,7 +172,7 @@ enum AfterPrefetch {
 #[allow(non_implicitly_copyable_typarams)]
 impl ImageCache {
 
-    pub fn run() {
+    pub fn run(&self) {
 
         let mut msg_handlers: ~[fn~(msg: &Msg)] = ~[];
 
@@ -231,18 +231,18 @@ impl ImageCache {
         }
     }
 
-    priv fn get_state(url: Url) -> ImageState {
+    priv fn get_state(&self, url: Url) -> ImageState {
         match move self.state_map.find(&url) {
             Some(move state) => move state,
             None => Init
         }
     }
 
-    priv fn set_state(url: Url, state: ImageState) {
+    priv fn set_state(&self, url: Url, state: ImageState) {
         self.state_map.insert(move url, move state);
     }
 
-    priv fn prefetch(url: Url) {
+    priv fn prefetch(&self, url: Url) {
         match self.get_state(copy url) {
             Init => {
                 let to_cache = self.chan.clone();
@@ -273,7 +273,7 @@ impl ImageCache {
         }
     }
 
-    priv fn store_prefetched_image_data(url: Url, data: Result<Cell<~[u8]>, ()>) {
+    priv fn store_prefetched_image_data(&self, url: Url, data: Result<Cell<~[u8]>, ()>) {
         match self.get_state(copy url) {
           Prefetching(next_step) => {
             match data {
@@ -302,7 +302,7 @@ impl ImageCache {
         }
     }
 
-    priv fn decode(url: Url) {
+    priv fn decode(&self, url: Url) {
         match self.get_state(copy url) {
             Init => fail!(~"decoding image before prefetch"),
 
@@ -345,7 +345,7 @@ impl ImageCache {
         }
     }
 
-    priv fn store_image(url: Url, image: Option<ARC<~Image>>) {
+    priv fn store_image(&self, url: Url, image: Option<ARC<~Image>>) {
 
         match self.get_state(copy url) {
           Decoding => {
@@ -372,7 +372,7 @@ impl ImageCache {
 
     }
 
-    priv fn purge_waiters(url: Url, f: fn() -> ImageResponseMsg) {
+    priv fn purge_waiters(&self, url: Url, f: fn() -> ImageResponseMsg) {
         match self.wait_map.find(&url) {
           Some(waiters) => {
             let waiters = &mut *waiters;
@@ -391,7 +391,7 @@ impl ImageCache {
     }
 
 
-    priv fn get_image(url: Url, response: Chan<ImageResponseMsg>) {
+    priv fn get_image(&self, url: Url, response: Chan<ImageResponseMsg>) {
         match self.get_state(copy url) {
           Init => fail!(~"request for image before prefetch"),
 
@@ -416,7 +416,7 @@ impl ImageCache {
         }
     }
 
-    priv fn wait_for_image(url: Url, response: Chan<ImageResponseMsg>) {
+    priv fn wait_for_image(&self, url: Url, response: Chan<ImageResponseMsg>) {
         match self.get_state(copy url) {
             Init => fail!(~"request for image before prefetch"),
 
@@ -448,12 +448,12 @@ impl ImageCache {
 
 
 trait ImageCacheTaskClient {
-    fn exit();
+    fn exit(&self);
 }
 
 impl ImageCacheTask: ImageCacheTaskClient {
 
-    fn exit() {
+    fn exit(&self) {
         let (response_port, response_chan) = stream();
         self.send(Exit(move response_chan));
         response_port.recv();

--- a/src/servo-gfx/resource/local_image_cache.rs
+++ b/src/servo-gfx/resource/local_image_cache.rs
@@ -39,12 +39,12 @@ pub impl LocalImageCache {
     /// The local cache will only do a single remote request for a given
     /// URL in each 'round'. Layout should call this each time it begins
     // FIXME: 'pub' is an unexpected token?
-    /* pub */ fn next_round(on_image_available: @fn() -> ~fn(ImageResponseMsg)) {
+    /* pub */ fn next_round(&self, on_image_available: @fn() -> ~fn(ImageResponseMsg)) {
         self.round_number += 1;
         self.on_image_available = Some(move on_image_available);
     }
 
-    pub fn prefetch(url: &Url) {
+    pub fn prefetch(&self, url: &Url) {
         let state = self.get_state(url);
         if !state.prefetched {
             self.image_cache_task.send(Prefetch(copy *url));
@@ -52,7 +52,7 @@ pub impl LocalImageCache {
         }
     }
 
-    pub fn decode(url: &Url) {
+    pub fn decode(&self, url: &Url) {
         let state = self.get_state(url);
         if !state.decoded {
             self.image_cache_task.send(Decode(copy *url));
@@ -61,7 +61,7 @@ pub impl LocalImageCache {
     }
 
     // FIXME: Should return a Future
-    pub fn get_image(url: &Url) -> Port<ImageResponseMsg> {
+    pub fn get_image(&self, url: &Url) -> Port<ImageResponseMsg> {
         let state = self.get_state(url);
 
         // Save the previous round number for comparison
@@ -132,7 +132,7 @@ pub impl LocalImageCache {
         return move port;
     }
 
-    priv fn get_state(url: &Url) -> @ImageState {
+    priv fn get_state(&self, url: &Url) -> @ImageState {
         match self.state_map.find(url) {
             Some(state) => state,
             None => {

--- a/src/servo-gfx/resource/resource_task.rs
+++ b/src/servo-gfx/resource/resource_task.rs
@@ -51,12 +51,12 @@ pub fn ResourceTask() -> ResourceTask {
 }
 
 fn create_resource_task_with_loaders(loaders: ~[(~str, LoaderTaskFactory)]) -> ResourceTask {
-	let loaders_cell = Cell(loaders);
+    let loaders_cell = Cell(loaders);
     let chan = do spawn_listener |from_client| {
         // TODO: change copy to move once we can move out of closures
         ResourceManager(from_client, loaders_cell.take()).start()
     };
-	SharedChan(chan)
+    SharedChan(chan)
 }
 
 pub struct ResourceManager {
@@ -66,7 +66,7 @@ pub struct ResourceManager {
 }
 
 
-pub fn ResourceManager(from_client: Port<ControlMsg>, 
+pub fn ResourceManager(from_client: Port<ControlMsg>,
                        loaders: ~[(~str, LoaderTaskFactory)]) -> ResourceManager {
     ResourceManager {
         from_client : move from_client,
@@ -105,13 +105,13 @@ impl ResourceManager {
 
     fn get_loader_factory(url: &Url) -> Option<LoaderTask> {
         for self.loaders.each |scheme_loader| {
-			match *scheme_loader {
-				(ref scheme, ref loader_factory) => {
-					if (*scheme) == url.scheme {
-						return Some((*loader_factory)());
-					}
-				}
-			}
+            match *scheme_loader {
+                (ref scheme, ref loader_factory) => {
+                    if (*scheme) == url.scheme {
+                        return Some((*loader_factory)());
+                    }
+                }
+            }
         }
         return None;
     }
@@ -130,8 +130,8 @@ fn test_bad_scheme() {
     let progress = Port();
     resource_task.send(Load(url::from_str(~"bogus://whatever").get(), progress.chan()));
     match progress.recv() {
-      Done(result) => { assert result.is_err() }
-      _ => fail
+        Done(result) => { assert result.is_err() }
+        _ => fail
     }
     resource_task.send(Exit);
 }

--- a/src/servo-gfx/resource/resource_task.rs
+++ b/src/servo-gfx/resource/resource_task.rs
@@ -76,7 +76,7 @@ pub fn ResourceManager(from_client: Port<ControlMsg>,
 
 
 impl ResourceManager {
-    fn start() {
+    fn start(&self) {
         loop {
             match self.from_client.recv() {
               Load(url, progress_chan) => {
@@ -89,7 +89,7 @@ impl ResourceManager {
         }
     }
 
-    fn load(url: Url, progress_chan: Chan<ProgressMsg>) {
+    fn load(&self, url: Url, progress_chan: Chan<ProgressMsg>) {
 
         match self.get_loader_factory(&url) {
             Some(loader_factory) => {
@@ -103,7 +103,7 @@ impl ResourceManager {
         }
     }
 
-    fn get_loader_factory(url: &Url) -> Option<LoaderTask> {
+    fn get_loader_factory(&self, url: &Url) -> Option<LoaderTask> {
         for self.loaders.each |scheme_loader| {
             match *scheme_loader {
                 (ref scheme, ref loader_factory) => {

--- a/src/servo-gfx/surface.rs
+++ b/src/servo-gfx/surface.rs
@@ -7,7 +7,7 @@ pub enum format {
 }
 
 impl format {
-    fn bpp() -> uint {
+    fn bpp(self) -> uint {
         match self {
             fo_rgba_8888 => 32u 
         }

--- a/src/servo-gfx/text/glyph.rs
+++ b/src/servo-gfx/text/glyph.rs
@@ -186,7 +186,7 @@ impl GlyphEntry {
         //assert self.is_simple();
         Point2D(Au(0), Au(0))
     }
-    
+
     pure fn is_ligature_start() -> bool {
         self.has_flag(!FLAG_NOT_LIGATURE_GROUP_START)
     }
@@ -194,7 +194,7 @@ impl GlyphEntry {
     pure fn is_cluster_start() -> bool {
         self.has_flag(!FLAG_NOT_CLUSTER_START)
     }
-    
+
     // True if original char was normal (U+0020) space. Other chars may
     // map to space glyph, but this does not account for them.
     pure fn char_is_space() -> bool {
@@ -290,26 +290,26 @@ struct DetailedGlyphRecord {
 
 impl DetailedGlyphRecord : Ord {
     pure fn lt(&self, other: &DetailedGlyphRecord) -> bool {
-		self.entry_offset <  other.entry_offset
-	}
+        self.entry_offset <  other.entry_offset
+    }
     pure fn le(&self, other: &DetailedGlyphRecord) -> bool {
-		self.entry_offset <= other.entry_offset
-	}
+        self.entry_offset <= other.entry_offset
+    }
     pure fn ge(&self, other: &DetailedGlyphRecord) -> bool {
-		self.entry_offset >= other.entry_offset
-	}
+        self.entry_offset >= other.entry_offset
+    }
     pure fn gt(&self, other: &DetailedGlyphRecord) -> bool {
-		self.entry_offset >  other.entry_offset
-	}
+        self.entry_offset >  other.entry_offset
+    }
 }
 
 impl DetailedGlyphRecord : Eq {
     pure fn eq(&self, other : &DetailedGlyphRecord) -> bool {
-		self.entry_offset == other.entry_offset
-	}
+        self.entry_offset == other.entry_offset
+    }
     pure fn ne(&self, other : &DetailedGlyphRecord) -> bool {
-		self.entry_offset != other.entry_offset
-	}
+        self.entry_offset != other.entry_offset
+    }
 }
 
 // Manages the lookup table for detailed glyphs. Sorting is deferred
@@ -439,13 +439,13 @@ pub struct GlyphData {
     ligature_start: bool,
 }
 
-pub pure fn GlyphData(index: GlyphIndex, 
-                   advance: Au,
-                   offset: Option<Point2D<Au>>,
-                   is_missing: bool,
-                   cluster_start: bool,
-                   ligature_start: bool) -> GlyphData {
-    
+pub pure fn GlyphData(index: GlyphIndex,
+                      advance: Au,
+                      offset: Option<Point2D<Au>>,
+                      is_missing: bool,
+                      cluster_start: bool,
+                      ligature_start: bool) -> GlyphData {
+
     let _offset = match offset {
         None => geometry::zero_point(),
         Some(o) => o
@@ -599,7 +599,7 @@ pub impl GlyphStore {
 
         let entry = &self.entry_buffer[i];
         match entry.is_simple() {
-            true => { 
+            true => {
                 let proxy = SimpleGlyphInfo(&self, i);
                 cb(i, move proxy);
             },
@@ -611,7 +611,7 @@ pub impl GlyphStore {
                 }
             }
         }
-	return true;
+        return true;
     }
 
     pure fn iter_glyphs_for_char_range(range: &const Range, cb: fn&(uint, GlyphInfo/&) -> bool) {
@@ -625,8 +625,8 @@ pub impl GlyphStore {
         }
 
         for range.eachi |i| {
-	    if !self.iter_glyphs_for_char_index(i, cb) { break; }
-	}
+            if !self.iter_glyphs_for_char_index(i, cb) { break; }
+        }
     }
 
     pure fn iter_all_glyphs(cb: fn&(uint, GlyphInfo/&) -> bool) {

--- a/src/servo-gfx/text/glyph.rs
+++ b/src/servo-gfx/text/glyph.rs
@@ -172,91 +172,92 @@ pure fn MissingGlyphsEntry(glyphCount: uint) -> GlyphEntry {
 impl GlyphEntry {
     // getter methods
     #[inline(always)]
-    pure fn advance() -> Au {
+    pure fn advance(self) -> Au {
         //assert self.is_simple();
         NumCast::from((self.value & GLYPH_ADVANCE_MASK) >> GLYPH_ADVANCE_SHIFT)
     }
 
-    pure fn index() -> GlyphIndex {
+    pure fn index(self) -> GlyphIndex {
         //assert self.is_simple();
         self.value & GLYPH_ID_MASK
     }
 
-    pure fn offset() -> Point2D<Au> {
+    pure fn offset(self) -> Point2D<Au> {
         //assert self.is_simple();
         Point2D(Au(0), Au(0))
     }
 
-    pure fn is_ligature_start() -> bool {
+    pure fn is_ligature_start(self) -> bool {
         self.has_flag(!FLAG_NOT_LIGATURE_GROUP_START)
     }
 
-    pure fn is_cluster_start() -> bool {
+    pure fn is_cluster_start(self) -> bool {
         self.has_flag(!FLAG_NOT_CLUSTER_START)
     }
 
     // True if original char was normal (U+0020) space. Other chars may
     // map to space glyph, but this does not account for them.
-    pure fn char_is_space() -> bool {
+    pure fn char_is_space(self) -> bool {
         self.has_flag(FLAG_CHAR_IS_SPACE)
     }
 
-    pure fn char_is_tab() -> bool {
+    pure fn char_is_tab(self) -> bool {
         !self.is_simple() && self.has_flag(FLAG_CHAR_IS_TAB)
     }
 
-    pure fn char_is_newline() -> bool {
+    pure fn char_is_newline(self) -> bool {
         !self.is_simple() && self.has_flag(FLAG_CHAR_IS_NEWLINE)
     }
 
-    pure fn can_break_before() -> BreakType {
+    pure fn can_break_before(self) -> BreakType {
         let flag = ((self.value & FLAG_CAN_BREAK_MASK) >> FLAG_CAN_BREAK_SHIFT) as u8;
         break_flag_to_enum(flag)
     }
 
     // setter methods
     #[inline(always)]
-    pure fn set_char_is_space() -> GlyphEntry {
+    pure fn set_char_is_space(self) -> GlyphEntry {
         GlyphEntry(self.value | FLAG_CHAR_IS_SPACE)
     }
 
     #[inline(always)]
-    pure fn set_char_is_tab() -> GlyphEntry {
+    pure fn set_char_is_tab(self) -> GlyphEntry {
         assert !self.is_simple();
         GlyphEntry(self.value | FLAG_CHAR_IS_TAB)
     }
 
     #[inline(always)]
-    pure fn set_char_is_newline() -> GlyphEntry {
+    pure fn set_char_is_newline(self) -> GlyphEntry {
         assert !self.is_simple();
         GlyphEntry(self.value | FLAG_CHAR_IS_NEWLINE)
     }
 
     #[inline(always)]
-    pure fn set_can_break_before(e: BreakType) -> GlyphEntry {
+    pure fn set_can_break_before(self, e: BreakType) -> GlyphEntry {
         let flag = (break_enum_to_flag(e) as u32) << FLAG_CAN_BREAK_SHIFT;
         GlyphEntry(self.value | flag)
     }
 
     // helper methods
 
-    /*priv*/ pure fn glyph_count() -> u16 {
+    /*priv*/ pure fn glyph_count(self) -> u16 {
         assert !self.is_simple();
         ((self.value & GLYPH_COUNT_MASK) >> GLYPH_COUNT_SHIFT) as u16
     }
 
     #[inline(always)]
-    pure fn is_simple() -> bool {
+    pure fn is_simple(self) -> bool {
         self.has_flag(FLAG_IS_SIMPLE_GLYPH)
     }
 
     #[inline(always)]
-    /*priv*/ pure fn has_flag(flag: u32) -> bool {
+    /*priv*/ pure fn has_flag(self, flag: u32) -> bool {
         (self.value & flag) != 0
     }
 
     #[inline(always)]
-    pure fn adapt_character_flags_of_entry(other: GlyphEntry) -> GlyphEntry {
+    pure fn adapt_character_flags_of_entry(self,
+                                           other: GlyphEntry) -> GlyphEntry {
         GlyphEntry { value: self.value | other.value }
     }
 }
@@ -471,37 +472,37 @@ enum GlyphInfo {
 }
 
 impl GlyphInfo {
-    fn index() -> GlyphIndex {
-        match self {
+    fn index(&self) -> GlyphIndex {
+        match *self {
             SimpleGlyphInfo(store, entry_i) => store.entry_buffer[entry_i].index(),
             DetailGlyphInfo(store, entry_i, detail_j) => store.detail_store.get_detailed_glyph_with_index(entry_i, detail_j).index
         }
     }
 
     #[inline(always)]
-    fn advance() -> Au {
-        match self {
+    fn advance(&self) -> Au {
+        match *self {
             SimpleGlyphInfo(store, entry_i) => store.entry_buffer[entry_i].advance(),
             DetailGlyphInfo(store, entry_i, detail_j) => store.detail_store.get_detailed_glyph_with_index(entry_i, detail_j).advance
         }
     }
 
-    fn offset() -> Option<Point2D<Au>> {
-        match self {
+    fn offset(&self) -> Option<Point2D<Au>> {
+        match *self {
             SimpleGlyphInfo(_, _) => None,
             DetailGlyphInfo(store, entry_i, detail_j) => Some(store.detail_store.get_detailed_glyph_with_index(entry_i, detail_j).offset)
         }
     }
 
-    fn is_ligature_start() -> bool {
-        match self {
+    fn is_ligature_start(&self) -> bool {
+        match *self {
             SimpleGlyphInfo(store, entry_i) => store.entry_buffer[entry_i].is_ligature_start(),
             DetailGlyphInfo(store, entry_i, _) => store.entry_buffer[entry_i].is_ligature_start()
         }
     }
 
-    fn is_cluster_start() -> bool {
-        match self {
+    fn is_cluster_start(&self) -> bool {
+        match *self {
             SimpleGlyphInfo(store, entry_i) => store.entry_buffer[entry_i].is_cluster_start(),
             DetailGlyphInfo(store, entry_i, _) => store.entry_buffer[entry_i].is_cluster_start()
         }
@@ -594,19 +595,19 @@ pub impl GlyphStore {
         self.entry_buffer[i] = entry;
     }
 
-    pure fn iter_glyphs_for_char_index(i: uint, cb: fn&(uint, GlyphInfo/&) -> bool) -> bool {
+    pure fn iter_glyphs_for_char_index(&self, i: uint, cb: fn&(uint, GlyphInfo/&) -> bool) -> bool {
         assert i < self.entry_buffer.len();
 
         let entry = &self.entry_buffer[i];
         match entry.is_simple() {
             true => {
-                let proxy = SimpleGlyphInfo(&self, i);
+                let proxy = SimpleGlyphInfo(self, i);
                 cb(i, move proxy);
             },
             false => {
                 let glyphs = self.detail_store.get_detailed_glyphs_for_entry(i, entry.glyph_count());
                 for uint::range(0, glyphs.len()) |j| {
-                    let proxy = DetailGlyphInfo(&self, i, j as u16);
+                    let proxy = DetailGlyphInfo(self, i, j as u16);
                     cb(i, move proxy);
                 }
             }
@@ -614,7 +615,7 @@ pub impl GlyphStore {
         return true;
     }
 
-    pure fn iter_glyphs_for_char_range(range: &const Range, cb: fn&(uint, GlyphInfo/&) -> bool) {
+    pure fn iter_glyphs_for_char_range(&self, range: &const Range, cb: fn&(uint, GlyphInfo/&) -> bool) {
         if range.begin() >= self.entry_buffer.len() {
             error!("iter_glyphs_for_range: range.begin beyond length!");
             return;
@@ -629,39 +630,39 @@ pub impl GlyphStore {
         }
     }
 
-    pure fn iter_all_glyphs(cb: fn&(uint, GlyphInfo/&) -> bool) {
+    pure fn iter_all_glyphs(&self, cb: fn&(uint, GlyphInfo/&) -> bool) {
         for uint::range(0, self.entry_buffer.len()) |i| {
             if !self.iter_glyphs_for_char_index(i, cb) { break; }
         }
     }
 
     // getter methods
-    pure fn char_is_space(i: uint) -> bool {
+    pure fn char_is_space(&self, i: uint) -> bool {
         assert i < self.entry_buffer.len();
         self.entry_buffer[i].char_is_space()
     }
 
-    pure fn char_is_tab(i: uint) -> bool {
+    pure fn char_is_tab(&self, i: uint) -> bool {
         assert i < self.entry_buffer.len();
         self.entry_buffer[i].char_is_tab()
     }
 
-    pure fn char_is_newline(i: uint) -> bool {
+    pure fn char_is_newline(&self, i: uint) -> bool {
         assert i < self.entry_buffer.len();
         self.entry_buffer[i].char_is_newline()
     }
 
-    pure fn is_ligature_start(i: uint) -> bool {
+    pure fn is_ligature_start(&self, i: uint) -> bool {
         assert i < self.entry_buffer.len();
         self.entry_buffer[i].is_ligature_start()
     }
 
-    pure fn is_cluster_start(i: uint) -> bool {
+    pure fn is_cluster_start(&self, i: uint) -> bool {
         assert i < self.entry_buffer.len();
         self.entry_buffer[i].is_cluster_start()
     }
 
-    pure fn can_break_before(i: uint) -> BreakType {
+    pure fn can_break_before(&self, i: uint) -> BreakType {
         assert i < self.entry_buffer.len();
         self.entry_buffer[i].can_break_before()
     }

--- a/src/servo-gfx/text/harfbuzz/shaper.rs
+++ b/src/servo-gfx/text/harfbuzz/shaper.rs
@@ -132,8 +132,8 @@ pub impl ShapedGlyphData {
 
         unsafe {
             ShapedGlyphEntry {
-                cluster: (*glyph_info_i).cluster as uint, 
-                codepoint: (*glyph_info_i).codepoint as GlyphIndex, 
+                cluster: (*glyph_info_i).cluster as uint,
+                codepoint: (*glyph_info_i).codepoint as GlyphIndex,
                 advance: x_advance,
                 offset: move offset,
             }
@@ -167,7 +167,7 @@ pub impl HarfbuzzShaper {
         let pt_size = font.style.pt_size;
         hb_font_set_ppem(hb_font, pt_size as c_uint, pt_size as c_uint);
         // Set scaling. Note that this takes 16.16 fixed point.
-        hb_font_set_scale(hb_font, 
+        hb_font_set_scale(hb_font,
                           HarfbuzzShaper::float_to_fixed(pt_size) as c_int,
                           HarfbuzzShaper::float_to_fixed(pt_size) as c_int);
 
@@ -181,7 +181,7 @@ pub impl HarfbuzzShaper {
             hb_font_set_funcs(hb_font, hb_funcs, font_data, ptr::null());
         };
 
-        HarfbuzzShaper { 
+        HarfbuzzShaper {
             font: font,
             hb_face: hb_face,
             hb_font: hb_font,
@@ -202,7 +202,7 @@ pub impl HarfbuzzShaper {
     }
 }
 
-impl ShaperMethods for HarfbuzzShaper {    
+impl ShaperMethods for HarfbuzzShaper {
     /**
     Calculate the layout metrics associated with a some given text
     when rendered in a specific font.
@@ -213,7 +213,7 @@ impl ShaperMethods for HarfbuzzShaper {
 
         // Using as_buf because it never does a copy - we don't need the trailing null
         str::as_buf(text, |ctext: *u8, _l: uint| {
-            hb_buffer_add_utf8(hb_buffer, 
+            hb_buffer_add_utf8(hb_buffer,
                                ctext as *c_char,
                                text.len() as c_int,
                                0 as c_uint,
@@ -262,7 +262,7 @@ pub impl HarfbuzzShaper {
                 i = range.next;
             }
         }
-        
+
         debug!("(glyph idx) -> (text byte offset)");
         for uint::range(0, glyph_data.len()) |i| {
             // loc refers to a *byte* offset within the utf8 string.
@@ -333,7 +333,7 @@ pub impl HarfbuzzShaper {
                            glyph_span.begin(), glyph_span.length());
                 }
 
-            
+
                 // if there's just one glyph, then we don't need further checks.
                 if glyph_span.length() == 1 { break; }
 
@@ -367,7 +367,7 @@ pub impl HarfbuzzShaper {
             //and set glyph info for those and empty infos for the chars that are continuations.
 
             // a simple example:
-            // chars:  'f'     't'   't'   
+            // chars:  'f'     't'   't'
             // glyphs: 'ftt'   ''    ''
             // cgmap:  t        f     f
             // gspan:  [-]
@@ -375,7 +375,7 @@ pub impl HarfbuzzShaper {
             // covsp:  [---------------]
             let mut covered_byte_span = copy char_byte_span;
             // extend, clipping at end of text range.
-            while covered_byte_span.end() < byte_max 
+            while covered_byte_span.end() < byte_max
                 && byteToGlyph[covered_byte_span.end()] == NO_GLYPH {
                 let range = str::char_range_at(text, covered_byte_span.end());
                 ignore(range.ch);
@@ -407,8 +407,8 @@ pub impl HarfbuzzShaper {
 
                 for glyph_span.eachi |glyph_i| {
                     let shape = glyph_data.get_entry_for_glyph(glyph_i, &mut y_pos);
-                    datas.push(GlyphData(shape.codepoint, 
-                                         shape.advance, 
+                    datas.push(GlyphData(shape.codepoint,
+                                         shape.advance,
                                          shape.offset,
                                          false, // not missing
                                          true,  // treat as cluster start
@@ -418,7 +418,7 @@ pub impl HarfbuzzShaper {
 
                 // now add the detailed glyph entry.
                 glyphs.add_glyphs_for_char_index(char_idx, dvec::unwrap(move datas));
-                
+
                 // set the other chars, who have no glyphs
                 let mut i = covered_byte_span.begin();
                 loop {
@@ -454,8 +454,8 @@ extern fn glyph_func(_font: *hb_font_t,
     assert font.is_not_null();
     unsafe {
         return match (*font).glyph_index(unicode as char) {
-          Some(g) => { *glyph = g as hb_codepoint_t; true },
-          None => false
+            Some(g) => { *glyph = g as hb_codepoint_t; true },
+            None => false
         } as hb_bool_t;
     }
 }

--- a/src/servo-gfx/text/harfbuzz/shaper.rs
+++ b/src/servo-gfx/text/harfbuzz/shaper.rs
@@ -106,10 +106,10 @@ pub impl ShapedGlyphData {
         }
     }
 
-    pure fn len() -> uint { self.count }
+    pure fn len(&self) -> uint { self.count }
 
     // Returns shaped glyph data for one glyph, and updates the y-position of the pen.
-    fn get_entry_for_glyph(i: uint, y_pos: &mut Au) -> ShapedGlyphEntry {
+    fn get_entry_for_glyph(&self, i: uint, y_pos: &mut Au) -> ShapedGlyphEntry {
         assert i < self.count;
 
         let glyph_info_i = ptr::offset(self.glyph_infos, i);
@@ -207,7 +207,7 @@ impl ShaperMethods for HarfbuzzShaper {
     Calculate the layout metrics associated with a some given text
     when rendered in a specific font.
     */
-    fn shape_text(text: &str, glyphs: &mut GlyphStore) {
+    fn shape_text(&self, text: &str, glyphs: &mut GlyphStore) {
         let hb_buffer: *hb_buffer_t = hb_buffer_create();
         hb_buffer_set_direction(hb_buffer, HB_DIRECTION_LTR);
 
@@ -228,7 +228,7 @@ impl ShaperMethods for HarfbuzzShaper {
 
 pub impl HarfbuzzShaper {
 
-    priv fn save_glyph_results(text: &str, glyphs: &mut GlyphStore, buffer: *hb_buffer_t) {
+    priv fn save_glyph_results(&self, text: &str, glyphs: &mut GlyphStore, buffer: *hb_buffer_t) {
         let glyph_data = ShapedGlyphData::new(buffer);
         let glyph_count = glyph_data.len();
         let byte_max = text.len();

--- a/src/servo-gfx/text/shaper.rs
+++ b/src/servo-gfx/text/shaper.rs
@@ -11,7 +11,7 @@ use harfbuzz;
 pub type Shaper/& = harfbuzz::shaper::HarfbuzzShaper;
 
 pub trait ShaperMethods {
-    fn shape_text(text: &str, glyphs: &mut GlyphStore);
+    fn shape_text(&self, text: &str, glyphs: &mut GlyphStore);
 }
 
 // TODO(Issue #163): this is a workaround for static methods and

--- a/src/servo-gfx/text/text_run.rs
+++ b/src/servo-gfx/text/text_run.rs
@@ -103,7 +103,7 @@ pub impl TextRun {
         }
     }
 
-    pure fn char_len() -> uint { self.glyphs.entry_buffer.len() }
+    pure fn char_len(&self) -> uint { self.glyphs.entry_buffer.len() }
     pure fn glyphs(&self) -> &self/GlyphStore { &self.glyphs }
 
     pure fn range_is_trimmable_whitespace(&self, range: &const Range) -> bool {

--- a/src/servo-gfx/text/text_run.rs
+++ b/src/servo-gfx/text/text_run.rs
@@ -147,7 +147,7 @@ pub impl TextRun {
                 }
             }
         }
-        
+
         // flush any remaining chars as a line
         if in_clump {
             clump.extend_to(range.end());
@@ -160,7 +160,7 @@ pub impl TextRun {
 
         loop {
             // extend clump to non-break-before characters.
-            while clump.end() < range.end() 
+            while clump.end() < range.end()
                 && self.glyphs.can_break_before(clump.end()) != BreakTypeNormal {
 
                 clump.extend_by(1);

--- a/src/servo-gfx/util/cache.rs
+++ b/src/servo-gfx/util/cache.rs
@@ -2,10 +2,10 @@ use core::cmp::*;
 
 pub trait Cache<K: Copy Eq, V: Copy> {
     static fn new(size: uint) -> Self;
-    fn insert(key: &K, value: V);
-    fn find(key: &K) -> Option<V>;
-    fn find_or_create(key: &K, blk: pure fn&(&K) -> V) -> V;
-    fn evict_all();
+    fn insert(&self, key: &K, value: V);
+    fn find(&self, key: &K) -> Option<V>;
+    fn find_or_create(&self, key: &K, blk: pure fn&(&K) -> V) -> V;
+    fn evict_all(&self);
 }
 
 pub struct MonoCache<K, V> {
@@ -17,18 +17,18 @@ pub impl<K: Copy Eq, V: Copy> MonoCache<K,V> : Cache<K,V> {
         MonoCache { entry: None }
     }
 
-    fn insert(key: &K, value: V) {
+    fn insert(&self, key: &K, value: V) {
         self.entry = Some((copy *key, value));
     }
 
-    fn find(key: &K) -> Option<V> {
+    fn find(&self, key: &K) -> Option<V> {
         match self.entry {
             None => None,
             Some((ref k,v)) => if *k == *key { Some(v) } else { None }
         }
     }
 
-    fn find_or_create(key: &K, blk: pure fn&(&K) -> V) -> V {
+    fn find_or_create(&self, key: &K, blk: pure fn&(&K) -> V) -> V {
         return match self.find(key) {
             None => { 
                 let value = blk(key);
@@ -38,7 +38,7 @@ pub impl<K: Copy Eq, V: Copy> MonoCache<K,V> : Cache<K,V> {
             Some(v) => v
         };
     }
-    fn evict_all() {
+    fn evict_all(&self) {
         self.entry = None;
     }
 }


### PR DESCRIPTION
Clean up whitespace and methods with missing "self" argument. Pages full of compiler warnings are gross. I'm not very well-versed in rust, but I did my best to choose between `self` and `&self`.
