### PR TITLE
Add libtool to brew install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ language. It is currently developed on OS X and Linux.
 On OS X (homebrew):
 
     brew install https://raw.github.com/Homebrew/homebrew-versions/master/autoconf213.rb
-    brew install automake
+    brew install automake libtool
 
 On OS X (MacPorts):
 


### PR DESCRIPTION
Configure failed to find `glibtoolize`, which gets installed with `libtool`
