### PR TITLE
Add extra aclocal config required for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ On OS X (homebrew):
     brew install automake libtool
     brew install pkg-config
 
+Note, there is an [issue][] on homebrew which requires the following manual
+configuration as well:
+
+    sudo sh -c 'echo /usr/local/share/aclocal >> /usr/share/aclocal/dirlist'
+
 On OS X (MacPorts):
 
     sudo port install autoconf213
@@ -30,3 +35,5 @@ compiler.
     ../configure
     make && make check
     ./servo ../src/test/about-mozilla.html
+
+[issue]: https://github.com/mxcl/homebrew/issues/5117


### PR DESCRIPTION
On at least some homebrew systems you will encounter the following
error after a new install when running servo's configure:

```
servo/src/pixman/configure: line 13682: PKG_PROG_PKG_CONFIG: command not found
servo/src/pixman/configure: line 13756: syntax error near unexpected token `GTK,'
servo/src/pixman/configure: line 13756: `   PKG_CHECK_MODULES(GTK, gtk+-2.0 pixman-1)'
```

This appears to be related to mxcl/homebrew#5117 and mxcl/homebrew#3209.

Add a note to the README.md about how to resolve this issue with some
manual configuration.
