### PR TITLE
Sync submodule recursively

### DIFF
--- a/configure
+++ b/configure
@@ -368,6 +368,14 @@ then
     "${CFG_GIT}" submodule status --recursive
 
     msg "git: submodule update"
+    "${CFG_GIT}" submodule --quiet update --init
+    need_ok "git failed"
+
+    msg "git: submodule foreach sync"
+    "${CFG_GIT}" submodule --quiet foreach --recursive 'if test -e .gitmodules; then git submodule sync; fi'
+    need_ok "git failed"
+
+    msg "git: submodule foreach update"
     "${CFG_GIT}" submodule --quiet update --init --recursive
     need_ok "git failed"
 


### PR DESCRIPTION
Submodule may have its own submodules, and the sub-sub-module url may be
changed.
Thus, if `submodule update --recursive` is done without url sync,
sub-sub-module may fail to find appropriate commit.
This patch fixes the problem by `git submodule update` locally
before recursive sync.
## 

I failed to run `./configure` when `src/rust` submodule has updated and therefore `src/rust/src/libuv` remote has changed (https://github.com/mozilla/rust/commit/c707a2d73cfbb630ff7f38790732586d026a5e8a), but not synced by `configure`.
