### PR TITLE
Specify 64bit-only in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Servo Parallel Browser Project
 
 Servo is a prototype web browser engine written in the [Rust](https://github.com/mozilla/rust)
-language. It is currently developed on OS X and Linux.
+language. It is currently developed on OS X and 64bit Linux.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Servo Parallel Browser Project
 
 Servo is a prototype web browser engine written in the [Rust](https://github.com/mozilla/rust)
-language. It is currently developed on OS X and 64bit Linux.
+language. It is currently developed on 64bit OS X and 64bit Linux.
 
 ## Prerequisites
 


### PR DESCRIPTION
It would have saved me some time (see issue #307) if the README had at least mentioned that 64bit is currently the only target.
