### PR TITLE
Add license headers

### DIFF
--- a/src/contenttest/contenttest.rs
+++ b/src/contenttest/contenttest.rs
@@ -1,3 +1,12 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 extern mod std;
 
 use std::test::{TestOpts, run_tests_console, TestDesc};

--- a/src/etc/licenseck.py
+++ b/src/etc/licenseck.py
@@ -50,9 +50,12 @@ license4 = """\
 licenses = [license0, license1, license2, license3, license4]
 
 exceptions = [
-    "rust-http-client/http_parser.c", # Joyent, BSD
-    "rust-http-client/http_parser.h", # Joyent, BSD
-    "rust-opengles/gl2.h", # Khronos, SGI Free Software B License Version 2.0
+    "rust-http-client/http_parser.c", # BSD, Joyent
+    "rust-http-client/http_parser.h", # BSD, Joyent
+    "rust-opengles/gl2.h", # SGI Free Software B License Version 2.0, Khronos Group
+    "servo/dom/bindings/codegen/ply/ply/yacc.py", # BSD
+    "servo/dom/bindings/codegen/ply/ply/__init__.py", # BSD
+    "servo/dom/bindings/codegen/ply/ply/lex.py", # BSD
 ]
 
 def check_license(name, contents):

--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -32,25 +32,21 @@ def do_license_check(name, contents):
         report_error_name_no(name, 1, "incorrect license")
 
 exceptions = [
-    "src/cairo",
-    "src/libcss",
-    "src/libhubbub",
-    "src/libparserutils",
-    "src/libwapcaplet",
-    "src/mozjs",
-    "src/pixman",
-    "src/rust/",
-    "src/rust-azure/src",
-    "src/rust-azure/include",
-    "src/rust-harfbuzz/harfbuzz",
-    "src/skia",
-    "src/servo/dom/bindings/codegen",
+    "src/cairo", # Upstream
+    "src/libcss", # Upstream
+    "src/libhubbub", # Upstream
+    "src/libparserutils", # Upstream
+    "src/libwapcaplet", # Upstream
+    "src/mozjs", # Upstream
+    "src/pixman", # Upstream
+    "src/rust/", # Upstream
+    "src/rust-azure/src", # Upstream
+    "src/rust-azure/include", # Upstream
+    "src/rust-harfbuzz/harfbuzz", # Upstream
+    "src/skia", # Upstream
+    "src/servo/dom/bindings/codegen", # Generated and upstream code combined with our own. Could use cleanup
     "src/rust-opengles", # Need to contact copyright holders
     "src/rust-stb-image", # "
-    "src/servo", # "
-    "src/servo-gfx", # "
-    "src/reftest", # "
-    "src/contenttest", # "
 ]
 
 def should_check(name):

--- a/src/reftest/rasterize.py
+++ b/src/reftest/rasterize.py
@@ -1,3 +1,12 @@
+# Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 import sys, os
 from selenium import webdriver
 

--- a/src/reftest/reftest.rs
+++ b/src/reftest/reftest.rs
@@ -1,3 +1,12 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 extern mod std;
 extern mod servo;
 

--- a/src/servo-gfx/color.rs
+++ b/src/servo-gfx/color.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use azure::AzFloat;
 use AzColor = azure::azure_hl::Color;
 

--- a/src/servo-gfx/compositor.rs
+++ b/src/servo-gfx/compositor.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use azure::azure_hl::{DrawTarget};
 use geom::rect::Rect;
 

--- a/src/servo-gfx/display_list.rs
+++ b/src/servo-gfx/display_list.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use color::{Color, rgb};
 use geometry::Au;
 use image::base::Image;

--- a/src/servo-gfx/font.rs
+++ b/src/servo-gfx/font.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use color::Color;
 use font_context::FontContext;
 use geometry::Au;

--- a/src/servo-gfx/font_context.rs
+++ b/src/servo-gfx/font_context.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use font::{Font, FontDescriptor, FontGroup, FontStyle, SelectorPlatformIdentifier};
 use font::{SelectorStubDummy, SpecifiedFontStyle, UsedFontStyle};
 use font_list::FontList;

--- a/src/servo-gfx/font_list.rs
+++ b/src/servo-gfx/font_list.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use font::{CSSFontWeight, SpecifiedFontStyle};
 use gfx_font::FontHandleMethods;
 use native::FontHandle;

--- a/src/servo-gfx/fontconfig/font_list.rs
+++ b/src/servo-gfx/fontconfig/font_list.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 extern mod freetype;
 extern mod fontconfig;
 

--- a/src/servo-gfx/freetype_impl/font.rs
+++ b/src/servo-gfx/freetype_impl/font.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 extern mod freetype;
 
 use native;

--- a/src/servo-gfx/freetype_impl/font_context.rs
+++ b/src/servo-gfx/freetype_impl/font_context.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 extern mod freetype;
 extern mod fontconfig;
 

--- a/src/servo-gfx/geometry.rs
+++ b/src/servo-gfx/geometry.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;

--- a/src/servo-gfx/image/base.rs
+++ b/src/servo-gfx/image/base.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use stb_image = stb_image::image;
 
 // FIXME: Images must not be copied every frame. Instead we should atomically

--- a/src/servo-gfx/image/encode/tga.rs
+++ b/src/servo-gfx/image/encode/tga.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::io::WriterUtil;
 use surface;
 

--- a/src/servo-gfx/image/holder.rs
+++ b/src/servo-gfx/image/holder.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use image::base::Image;
 use resource::image_cache_task::{ImageReady, ImageNotReady, ImageFailed};
 use resource::local_image_cache::LocalImageCache;

--- a/src/servo-gfx/native.rs
+++ b/src/servo-gfx/native.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file exists just to make it easier to import platform-specific
   implementations.
  

--- a/src/servo-gfx/opts.rs
+++ b/src/servo-gfx/opts.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 //! Configuration options for a single run of the servo application. Created
 //! from command line arguments.
 

--- a/src/servo-gfx/quartz/font.rs
+++ b/src/servo-gfx/quartz/font.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /// Implementation of Quartz (CoreGraphics) fonts.
 
 extern mod core_foundation;

--- a/src/servo-gfx/quartz/font_context.rs
+++ b/src/servo-gfx/quartz/font_context.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 extern mod core_foundation;
 extern mod core_graphics;
 extern mod core_text;

--- a/src/servo-gfx/quartz/font_list.rs
+++ b/src/servo-gfx/quartz/font_list.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 extern mod core_foundation;
 extern mod core_text;
 

--- a/src/servo-gfx/render_context.rs
+++ b/src/servo-gfx/render_context.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use compositor::LayerBuffer;
 use font_context::FontContext;
 use geometry::Au;

--- a/src/servo-gfx/render_layers.rs
+++ b/src/servo-gfx/render_layers.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use compositor::{LayerBuffer, LayerBufferSet};
 use display_list::DisplayList;
 use opts::Opts;

--- a/src/servo-gfx/render_task.rs
+++ b/src/servo-gfx/render_task.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // The task that handles all rendering/painting.
 
 use azure::AzFloat;

--- a/src/servo-gfx/resource/file_loader.rs
+++ b/src/servo-gfx/resource/file_loader.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::task::spawn;
 use resource::resource_task::{Payload, Done, LoaderTask};
 use core::io::{file_reader, ReaderUtil};

--- a/src/servo-gfx/resource/http_loader.rs
+++ b/src/servo-gfx/resource/http_loader.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::comm::SharedChan;
 use core::task::spawn;
 use resource::resource_task::{Payload, Done, LoaderTask};

--- a/src/servo-gfx/resource/image_cache_task.rs
+++ b/src/servo-gfx/resource/image_cache_task.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use image::base::{Image, load_from_memory};
 use resource::resource_task;
 use resource::resource_task::ResourceTask;

--- a/src/servo-gfx/resource/local_image_cache.rs
+++ b/src/servo-gfx/resource/local_image_cache.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*!
 An adapter for ImageCacheTask that does local caching to avoid
 extra message traffic, it also avoids waiting on the same image

--- a/src/servo-gfx/resource/resource_task.rs
+++ b/src/servo-gfx/resource/resource_task.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*!
 
 A task that takes a URL and streams back the binary data

--- a/src/servo-gfx/resource/util.rs
+++ b/src/servo-gfx/resource/util.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::comm::{Chan, Port};
 
 pub fn spawn_listener<A: Owned>(f: ~fn(Port<A>)) -> Chan<A> {

--- a/src/servo-gfx/servo_gfx.rc
+++ b/src/servo-gfx/servo_gfx.rc
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #[link(name = "servo_gfx",
        vers = "0.1",
        uuid = "0106bb54-6ea9-45bf-a39e-a738621f15e5",

--- a/src/servo-gfx/surface.rs
+++ b/src/servo-gfx/surface.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use geom::size::Size2D;
 
 #[deriving(Eq)]

--- a/src/servo-gfx/text/glyph.rs
+++ b/src/servo-gfx/text/glyph.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use geometry::Au;
 use servo_gfx_util::range::Range;
 use servo_gfx_util::vec::*;

--- a/src/servo-gfx/text/harfbuzz/shaper.rs
+++ b/src/servo-gfx/text/harfbuzz/shaper.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 extern mod harfbuzz;
 
 use geom::Point2D;

--- a/src/servo-gfx/text/mod.rs
+++ b/src/servo-gfx/text/mod.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file exists just to make it easier to import things inside of
  ./text/ without specifying the file they came out of imports.
  

--- a/src/servo-gfx/text/shaper.rs
+++ b/src/servo-gfx/text/shaper.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
 Shaper encapsulates a specific shaper, such as Harfbuzz, 
 Uniscribe, Pango, or Coretext.

--- a/src/servo-gfx/text/text_run.rs
+++ b/src/servo-gfx/text/text_run.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use font_context::FontContext;
 use geometry::Au;
 use text::glyph::{BreakTypeNormal, GlyphStore};

--- a/src/servo-gfx/text/util.rs
+++ b/src/servo-gfx/text/util.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 enum CompressionMode {
     CompressNone,
     CompressWhitespace,

--- a/src/servo-gfx/util/cache.rs
+++ b/src/servo-gfx/util/cache.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 pub trait Cache<K: Copy + Eq, V: Copy> {
     fn new(size: uint) -> Self;
     fn insert(&mut self, key: &K, value: V);

--- a/src/servo-gfx/util/range.rs
+++ b/src/servo-gfx/util/range.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 enum RangeRelation {
     OverlapsBegin(/* overlap */ uint),
     OverlapsEnd(/* overlap */ uint),

--- a/src/servo-gfx/util/time.rs
+++ b/src/servo-gfx/util/time.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Timing functions.
 use std::time::precise_time_ns;
 

--- a/src/servo-gfx/util/url.rs
+++ b/src/servo-gfx/util/url.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use std::net::url;
 use std::net::url::Url;
 use core::hashmap::HashMap;

--- a/src/servo-gfx/util/vec.rs
+++ b/src/servo-gfx/util/vec.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::cmp::{Ord, Eq};
 
 pub trait BinarySearchMethods<T: Ord + Eq> {

--- a/src/servo/content/content_task.rs
+++ b/src/servo/content/content_task.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*!
 The content task is the main task that runs JavaScript and spawns layout
 tasks.

--- a/src/servo/content/jsnames.rs
+++ b/src/servo/content/jsnames.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 type name_pool = {
     
 };

--- a/src/servo/css/matching.rs
+++ b/src/servo/css/matching.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // High-level interface to CSS selector matching.
 
 use css::node_util::NodeUtil;

--- a/src/servo/css/node_style.rs
+++ b/src/servo/css/node_style.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Style retrieval from DOM elements.
 
 use css::node_util::NodeUtil;

--- a/src/servo/css/node_util.rs
+++ b/src/servo/css/node_util.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use dom::node::AbstractNode;
 use newcss::complete::CompleteSelectResults;
 

--- a/src/servo/css/node_void_ptr.rs
+++ b/src/servo/css/node_void_ptr.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 //! CSS library requires that DOM nodes be convertable to *c_void through this trait
 extern mod netsurfcss;
 

--- a/src/servo/css/select.rs
+++ b/src/servo/css/select.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use std::net::url::Url;
 use url_from_str = std::net::url::from_str;
 use core::cell::Cell;

--- a/src/servo/css/select_handler.rs
+++ b/src/servo/css/select_handler.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 ///
 /// Implementation of the callbacks that the CSS selector engine uses to query the DOM.
 ///

--- a/src/servo/dom/bindings/clientrect.rs
+++ b/src/servo/dom/bindings/clientrect.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use content::content_task::task_from_context;
 use dom::bindings::utils::{CacheableWrapper, WrapperCache, BindingObject, OpaqueBindingReference};
 use dom::bindings::codegen::ClientRectBinding;

--- a/src/servo/dom/bindings/clientrectlist.rs
+++ b/src/servo/dom/bindings/clientrectlist.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use content::content_task::task_from_context;
 use dom::bindings::clientrect::{ClientRect, ClientRectImpl};
 use dom::bindings::codegen::ClientRectListBinding;

--- a/src/servo/dom/bindings/conversions.rs
+++ b/src/servo/dom/bindings/conversions.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use js::jsapi::JSVal;
 use js::glue::bindgen::{RUST_INT_TO_JSVAL, RUST_JSVAL_TO_INT};
 

--- a/src/servo/dom/bindings/document.rs
+++ b/src/servo/dom/bindings/document.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use js::rust::{Compartment, jsobj};
 use js::{JS_ARGV, JSPROP_ENUMERATE, JSPROP_SHARED,
             JSVAL_NULL, JS_THIS_OBJECT, JS_SET_RVAL, JSPROP_NATIVE_ACCESSORS};

--- a/src/servo/dom/bindings/element.rs
+++ b/src/servo/dom/bindings/element.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use content::content_task::task_from_context;
 use dom::bindings::utils::{domstring_to_jsval, WrapNewBindingObject};
 use dom::bindings::utils::{str, CacheableWrapper, DOM_OBJECT_SLOT};

--- a/src/servo/dom/bindings/htmlcollection.rs
+++ b/src/servo/dom/bindings/htmlcollection.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use content::content_task::task_from_context;
 use dom::node::AbstractNode;
 use dom::bindings::codegen::HTMLCollectionBinding;

--- a/src/servo/dom/bindings/node.rs
+++ b/src/servo/dom/bindings/node.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use dom::bindings::utils::{CacheableWrapper, WrapperCache};
 use dom::bindings::utils::{DOM_OBJECT_SLOT};
 use dom::node::{AbstractNode, Node, ElementNodeTypeId, TextNodeTypeId, CommentNodeTypeId};

--- a/src/servo/dom/bindings/proxyhandler.rs
+++ b/src/servo/dom/bindings/proxyhandler.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use js::jsapi::{JSContext, jsid, JSPropertyDescriptor, JSObject, JSString, jschar};
 use js::jsapi::bindgen::{JS_GetPropertyDescriptorById, JS_NewUCString, JS_malloc, JS_free};
 use js::glue::bindgen::{RUST_JSVAL_IS_VOID, RUST_JSVAL_TO_OBJECT, GetProxyExtra};

--- a/src/servo/dom/bindings/utils.rs
+++ b/src/servo/dom/bindings/utils.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use js;
 use js::rust::Compartment;
 use js::{JSCLASS_HAS_RESERVED_SLOTS, JSPROP_ENUMERATE, JSVAL_NULL,

--- a/src/servo/dom/bindings/window.rs
+++ b/src/servo/dom/bindings/window.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // DOM bindings for the Window object.
 
 use dom::bindings::utils::{rust_box, squirrel_away, CacheableWrapper};

--- a/src/servo/dom/document.rs
+++ b/src/servo/dom/document.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use dom::bindings::htmlcollection::HTMLCollection;
 use dom::bindings::utils::{DOMString, WrapperCache, str};
 use dom::node::AbstractNode;

--- a/src/servo/dom/element.rs
+++ b/src/servo/dom/element.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 //
 // Element nodes.
 //

--- a/src/servo/dom/event.rs
+++ b/src/servo/dom/event.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 pub enum Event {
     ResizeEvent(uint, uint, comm::Chan<()>),
     ReflowEvent        

--- a/src/servo/dom/node.rs
+++ b/src/servo/dom/node.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 //
 // The core DOM types. Defines the basic DOM hierarchy as well as all the HTML elements.
 //

--- a/src/servo/dom/window.rs
+++ b/src/servo/dom/window.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use content::content_task::{ControlMsg, Timer, ExitMsg};
 use dom::bindings::utils::WrapperCache;
 use js::jsapi::JSVal;

--- a/src/servo/engine.rs
+++ b/src/servo/engine.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use content::content_task::{ContentTask, ExecuteMsg, ParseMsg};
 use content::content_task;
 use dom::event::Event;

--- a/src/servo/html/cssparse.rs
+++ b/src/servo/html/cssparse.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*!
 Some little helpers for hooking up the HTML parser with the CSS parser
 */

--- a/src/servo/html/hubbub_html_parser.rs
+++ b/src/servo/html/hubbub_html_parser.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use dom::element::*;
 use dom::node::{AbstractNode, Comment, Doctype, Element, ElementNodeTypeId, Node, Text};
 use html::cssparse::{InlineProvenance, StylesheetProvenance, UrlProvenance, spawn_css_parser};

--- a/src/servo/image.rs
+++ b/src/servo/image.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* This file exists just to make it easier to import things inside of
  ./images/ without specifying the file they came out of imports.
  

--- a/src/servo/layout/aux.rs
+++ b/src/servo/layout/aux.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
 Code for managing the DOM aux pointer
 */

--- a/src/servo/layout/block.rs
+++ b/src/servo/layout/block.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Block layout.
 
 use core::cell::Cell;

--- a/src/servo/layout/box.rs
+++ b/src/servo/layout/box.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* Fundamental layout structures and algorithms. */
 
 use css::node_style::StyledNode;

--- a/src/servo/layout/box_builder.rs
+++ b/src/servo/layout/box_builder.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /** Creates CSS boxes from a DOM. */
 
 use dom::element::*;

--- a/src/servo/layout/context.rs
+++ b/src/servo/layout/context.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use geom::rect::Rect;
 use gfx::font_context::FontContext;
 use gfx::geometry::Au;

--- a/src/servo/layout/debug.rs
+++ b/src/servo/layout/debug.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 pub trait BoxedMutDebugMethods {
     fn dump(@mut self);
     fn dump_indent(@mut self, ident: uint);

--- a/src/servo/layout/display_list_builder.rs
+++ b/src/servo/layout/display_list_builder.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 ///
 /// Constructs display lists from render boxes.
 ///

--- a/src/servo/layout/flow.rs
+++ b/src/servo/layout/flow.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core;
 use core::cell::Cell;
 use dom::node::AbstractNode;

--- a/src/servo/layout/inline.rs
+++ b/src/servo/layout/inline.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core;
 use core::cell::Cell;
 use dom::node::AbstractNode;

--- a/src/servo/layout/layout_task.rs
+++ b/src/servo/layout/layout_task.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /// The layout task. Performs layout on the DOM, builds display lists and sends them to be
 /// rendered.
 

--- a/src/servo/layout/root.rs
+++ b/src/servo/layout/root.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::cell::Cell;
 use geom::point::Point2D;
 use geom::rect::Rect;

--- a/src/servo/layout/text.rs
+++ b/src/servo/layout/text.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /** Text layout. */
 
 use layout::box::{TextBox, RenderBox, RenderBoxData, UnscannedTextBox};

--- a/src/servo/layout/traverse.rs
+++ b/src/servo/layout/traverse.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use layout::flow::{FlowContext, FlowTree};
 
 /** Trait for running tree-based traversals over layout contexts */

--- a/src/servo/macros.rs
+++ b/src/servo/macros.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 {
     macro_rules! move_ref(
         { $x:expr } => { unsafe { let y <- *ptr::addr_of(*$x); y } }

--- a/src/servo/net.rs
+++ b/src/servo/net.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export uri, input_stream, channel, io_service, file_channel;
 
 import uri::uri;

--- a/src/servo/platform/base.rs
+++ b/src/servo/platform/base.rs
@@ -1,1 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 

--- a/src/servo/platform/osmain.rs
+++ b/src/servo/platform/osmain.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use ShareGlContext = sharegl::platform::Context;
 use dom::event::Event;
 use platform::resize_rate_limiter::ResizeRateLimiter;

--- a/src/servo/platform/resize_rate_limiter.rs
+++ b/src/servo/platform/resize_rate_limiter.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /*!
 A little class that rate limits the number of resize events sent to the content task
 based on how fast content dispatches those events. It waits until each event is handled

--- a/src/servo/servo.rc
+++ b/src/servo/servo.rc
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #[link(name = "servo",
        vers = "0.1",
        uuid = "637ffc98-9058-471d-9de7-abfc49ef0549",

--- a/src/servo/util/mod.rs
+++ b/src/servo/util/mod.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 pub use gfx::util::cache;
 pub use gfx::util::time;
 

--- a/src/servo/util/task.rs
+++ b/src/servo/util/task.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use core::cell::Cell;
 use core::comm::{Chan, Port};
 use core::task;

--- a/src/servo/util/tree.rs
+++ b/src/servo/util/tree.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // A generic tree datatype.
 //
 // TODO: Use traits.


### PR DESCRIPTION
r?

This adds MPL headers to all of servo's files.

Even though there are 9 non-moco contrtibutors to the main repo, `git blame` only indicates about a half-dozen lines of non-moco code here, none if it copyrightable in my non-expert opinion. So I've gone ahead and put the headers everywhere.

All that's left is rust-stb-image and rust-opengles, both of which have potentially non-trivial outside contributions.

I do have emails out to get permission from everybody. 6 have responded so far.  Once I've got all the responses I'll tar and sign them and throw them in the repo somewhere.
