### PR TITLE
#341: Add config.tmp to the git ingore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Servo.app
 build
 config.mk
 config.stamp
+config.tmp
 parser.out
 src/servo/dom/bindings/codegen/*.rs
 src/servo/dom/bindings/codegen/_cache/


### PR DESCRIPTION
In case the ../configure script fails or the user cancels it, the temporary file
generated is shown as "untracked file" when running "git status". 

Adding it to the ignore file.

Fixes #341
