### PR TITLE
Do not assume python is an interpreter for Python 2

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -190,7 +190,7 @@ bindinggen_dependencies := $(addprefix $(BINDINGS_SRC)/, BindingGen.py Bindings.
 
 $(AUTOGEN_SRC_servo): %Binding.rs: $(bindinggen_dependencies) \
                                    %.webidl
-	PYTHONDONTWRITEBYTECODE=1 python $(BINDINGS_SRC)/pythonpath.py \
+	PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(BINDINGS_SRC) \
 	  $(BINDINGS_SRC)/BindingGen.py rs \
@@ -204,7 +204,7 @@ $(CACHE_DIR)/.done:
 
 $(BINDINGS_SRC)/ParserResults.pkl: $(globalgen_dependencies) \
                                    $(WEBIDL_servo)
-	PYTHONDONTWRITEBYTECODE=1 python $(BINDINGS_SRC)/pythonpath.py \
+	PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(BINDINGS_SRC) \
 	  $(BINDINGS_SRC)/GlobalGen.py $(BINDINGS_SRC)/Bindings.conf . \

--- a/configure
+++ b/configure
@@ -296,6 +296,7 @@ fi
 step_msg "looking for build programs"
 
 probe_need CFG_GIT         git
+probe_need CFG_PYTHON2     python2 python2.7 python
 probe CFG_CLANG            clang++
 probe CFG_GCC              gcc
 probe CFG_LD               ld


### PR DESCRIPTION
On some distributions and configurations, the python command might refer to
python3 instead of python2, breaking the build. Fix this by using the first of
python2, python2.7, or python.
