### PR TITLE
Includes unused_variable in Codegen

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -93,7 +93,7 @@ rust: $(CFG_RUSTC)
 
 define DEF_SUBMODULE_VARS
 DEPS_$(1) =
-CFLAGS_$(1) = -O2
+CFLAGS_$(1) = $$(CFLAGS) 
 # any "done" dummy files must be named libSOMETHING.dummy. 
 #
 # We can't auto-compute this, because some modules have lib* prefix in

--- a/src/servo/dom/bindings/codegen/CodegenRust.py
+++ b/src/servo/dom/bindings/codegen/CodegenRust.py
@@ -2142,7 +2142,7 @@ class CGImports(CGWrapper):
         # TODO imports to cover descriptors, etc.
 
         def _useString(imports):
-            return '#[allow(unused_imports)];' + ''.join(['use %s;\n' % i for i in imports]) + '\n'
+            return '#[allow(unused_imports,unused_variable)];' + ''.join(['use %s;\n' % i for i in imports]) + '\n'
         CGWrapper.__init__(self, child,
                            declarePre=_useString(sorted(declareImports)))
 


### PR DESCRIPTION
Issue #386

Allow unused_variable in dom bindings codegen.

Note: this will increase the number of warnings until the the mentioned rustc commit is in.  The build will still be successful with these increased warnings.
