### PR TITLE
Stride to be the number of aligned bytes in each row

### DIFF
--- a/src/servo-gfx/render_layers.rs
+++ b/src/servo-gfx/render_layers.rs
@@ -50,17 +50,18 @@ pub fn render_layers(layer_ref: *RenderLayer,
                 let width = right - x;
                 let height = bottom - y;
 
-                // Round the width up the nearest 32 pixels for DMA on the Mac.
-                let mut stride = width;
-                if stride % 32 != 0 {
-                    stride = (stride & !(32 - 1)) + 32;
-                }
-                assert!(stride % 32 == 0);
-                assert!(stride >= width);
-
-                debug!("tile stride %u", stride);
-
                 let tile_rect = Rect(Point2D(x, y), Size2D(width, height));
+                
+                // Round the width up the nearest 32 pixels for DMA on the Mac.
+                let aligned_width = if width % 32 == 0 {
+                    width
+                } else {
+                    (width & !(32 - 1)) + 32
+                };
+                assert!(aligned_width % 32 == 0);
+                assert!(aligned_width >= width);
+
+                debug!("tile aligned_width %u", aligned_width);
 
                 let buffer;
                 // FIXME: Try harder to search for a matching tile.
@@ -72,7 +73,9 @@ pub fn render_layers(layer_ref: *RenderLayer,
                     // Create a new buffer.
                     debug!("creating tile, (%u, %u)", x, y);
 
-                    let size = Size2D(stride as i32, height as i32);
+                    let size = Size2D(aligned_width as i32, height as i32);
+                    // FIXME: This may not be always true.
+                    let stride = size.width * 4;
 
                     let mut data: ~[u8] = ~[0];
                     let offset;
@@ -82,7 +85,7 @@ pub fn render_layers(layer_ref: *RenderLayer,
 
                         let align = 256;
 
-                        let len = ((size.width * size.height * 4) as uint) + align;
+                        let len = ((stride * size.height) as uint) + align;
                         vec::reserve(&mut data, len);
                         vec::raw::set_len(&mut data, len);
 
@@ -102,10 +105,10 @@ pub fn render_layers(layer_ref: *RenderLayer,
                                                                data,
                                                                offset,
                                                                size,
-                                                               size.width * 4,
+                                                               stride,
                                                                B8G8R8A8),
                         rect: tile_rect,
-                        stride: stride
+                        stride: stride as uint
                     };
                 //}
 

--- a/src/servo/platform/osmain.rs
+++ b/src/servo/platform/osmain.rs
@@ -83,7 +83,7 @@ struct AzureDrawTargetImageData {
 
 impl layers::layers::ImageData for AzureDrawTargetImageData {
     fn size(&self) -> Size2D<uint> { self.size }
-    fn stride(&self) -> uint { self.data_source_surface.get_size().width as uint }
+    fn stride(&self) -> uint { self.data_source_surface.stride() as uint }
     fn format(&self) -> layers::layers::Format {
         // FIXME: This is not always correct. We should query the Azure draw target for the format.
         layers::layers::ARGB32Format
@@ -341,7 +341,7 @@ fn Surface(backend: BackendType) -> Surface {
     let layer_buffer = LayerBuffer {
         draw_target: DrawTarget::new(backend, Size2D(800i32, 600i32), B8G8R8A8),
         rect: Rect(Point2D(0u, 0u), Size2D(800u, 600u)),
-        stride: 800
+        stride: 800 * 4 
     };
     let layer_buffer_set = LayerBufferSet { buffers: ~[ layer_buffer ] };
     Surface { layer_buffer_set: layer_buffer_set, have: true }


### PR DESCRIPTION
I think stride means the number of aligned bytes in each row.
Many of servo source code use stride as the same meaning but there are some codes that do not meet this definition(width of each row).

This patch fixes such code so that 'stride's have the same idea.
