### PR TITLE
fix ABI incompatibility problem of some JS direct-connected API

### DIFF
--- a/src/servo/dom/bindings/codegen/CodegenRust.py
+++ b/src/servo/dom/bindings/codegen/CodegenRust.py
@@ -3568,7 +3568,7 @@ def finalizeHook(descriptor, hookName, context):
         pass
     else:
         assert descriptor.nativeIsISupports
-        release = """let val = JS_GetReservedSlot(obj, 0);
+        release = """let val = GetReservedSlot(obj, 0);
 let _: %s = cast::reinterpret_cast(&RUST_JSVAL_TO_PRIVATE(val));
 """ % (descriptor.pointerType + descriptor.nativeType)
     #return clearWrapper + release

--- a/src/servo/dom/bindings/document.rs
+++ b/src/servo/dom/bindings/document.rs
@@ -8,7 +8,7 @@ use js::{JS_ARGV, JSPROP_ENUMERATE, JSPROP_SHARED,
 use js::jsapi::{JSContext, JSVal, JSObject, JSBool, JSFreeOp,
                 JSPropertySpec, JSPropertyOpWrapper, JSStrictPropertyOpWrapper,
                 JSNativeWrapper, JSFunctionSpec};
-use js::jsapi::bindgen::{JS_GetReservedSlot, JS_SetReservedSlot,
+use js::jsapi::bindgen::{JS_SetReservedSlot,
                          JS_DefineFunctions, JS_DefineProperties};
 use js::glue::bindgen::*;
 use js::glue::{PROPERTY_STUB, STRICT_PROPERTY_STUB};
@@ -66,14 +66,14 @@ extern fn getElementsByTagName(cx: *JSContext, _argc: c_uint, vp: *JSVal) -> JSB
 
 unsafe fn unwrap(obj: *JSObject) -> *mut rust_box<Document> {
     //TODO: some kind of check if this is a Document object
-    let val = JS_GetReservedSlot(obj, 0);
+    let val = GetReservedSlot(obj, 0);
     RUST_JSVAL_TO_PRIVATE(val) as *mut rust_box<Document>
 }
 
 extern fn finalize(_fop: *JSFreeOp, obj: *JSObject) {
     debug!("document finalize!");
     unsafe {
-        let val = JS_GetReservedSlot(obj, 0);
+        let val = GetReservedSlot(obj, 0);
         let _doc: @Document = cast::reinterpret_cast(&RUST_JSVAL_TO_PRIVATE(val));
     }
 }

--- a/src/servo/dom/bindings/element.rs
+++ b/src/servo/dom/bindings/element.rs
@@ -24,7 +24,7 @@ use js::{JS_THIS_OBJECT, JS_SET_RVAL, JSPROP_NATIVE_ACCESSORS};
 extern fn finalize(_fop: *JSFreeOp, obj: *JSObject) {
     debug!("element finalize: %?!", obj as uint);
     unsafe {
-        let val = JS_GetReservedSlot(obj, DOM_OBJECT_SLOT as u32);
+        let val = GetReservedSlot(obj, DOM_OBJECT_SLOT as u32);
         let node: AbstractNode = cast::reinterpret_cast(&RUST_JSVAL_TO_PRIVATE(val));
         let _elem: ~Element = cast::transmute(node.raw_object());
     }

--- a/src/servo/dom/bindings/utils.rs
+++ b/src/servo/dom/bindings/utils.rs
@@ -10,7 +10,7 @@ use js::{JSCLASS_HAS_RESERVED_SLOTS, JSPROP_ENUMERATE, JSVAL_NULL,
 use js::jsapi::{JSContext, JSVal, JSObject, JSBool, jsid, JSClass, JSNative,
                 JSFunctionSpec, JSPropertySpec, JSVal, JSPropertyDescriptor};
 use js::jsapi::bindgen::{JS_ValueToString,
-                         JS_GetReservedSlot, JS_SetReservedSlot, JS_NewStringCopyN,
+                         JS_SetReservedSlot, JS_NewStringCopyN,
                          JS_DefineFunctions, JS_DefineProperty,
                          JS_GetClass, JS_GetPrototype, JS_LinkConstructorAndPrototype,
                          JS_AlreadyHasOwnProperty, JS_NewObject, JS_NewFunction,
@@ -20,7 +20,7 @@ use js::jsapi::bindgen::{JS_ValueToString,
                          JS_HasPropertyById, JS_GetPrototype, JS_GetGlobalForObject,
                          JS_EncodeString, JS_free};
 use js::jsfriendapi::bindgen::JS_NewObjectWithUniqueType;
-use js::glue::bindgen::{DefineFunctionWithReserved, GetObjectJSClass, RUST_OBJECT_TO_JSVAL};
+use js::glue::bindgen::{DefineFunctionWithReserved, GetObjectJSClass, RUST_OBJECT_TO_JSVAL, GetReservedSlot};
 use js::glue::{PROPERTY_STUB, STRICT_PROPERTY_STUB, ENUMERATE_STUB, CONVERT_STUB,
                   RESOLVE_STUB};
 use js::glue::bindgen::*;
@@ -111,7 +111,7 @@ pub unsafe fn unwrap<T>(obj: *JSObject) -> T {
     } else {
         DOM_PROXY_OBJECT_SLOT
     } as u32;
-    let val = JS_GetReservedSlot(obj, slot);
+    let val = GetReservedSlot(obj, slot);
     cast::transmute(RUST_JSVAL_TO_PRIVATE(val))
 }
 
@@ -347,7 +347,7 @@ pub struct DOMJSClass {
 pub fn GetProtoOrIfaceArray(global: *JSObject) -> **JSObject {
     unsafe {
         /*assert ((*JS_GetClass(global)).flags & JSCLASS_DOM_GLOBAL) != 0;*/
-        cast::transmute(RUST_JSVAL_TO_PRIVATE(JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT)))
+        cast::transmute(RUST_JSVAL_TO_PRIVATE(GetReservedSlot(global, DOM_PROTOTYPE_SLOT)))
     }
 }
 

--- a/src/servo/dom/bindings/window.rs
+++ b/src/servo/dom/bindings/window.rs
@@ -17,7 +17,7 @@ use js::global::jsval_to_rust_str;
 use js::glue::bindgen::*;
 use js::glue::bindgen::RUST_JSVAL_TO_INT;
 use js::jsapi::bindgen::{JS_DefineFunctions};
-use js::jsapi::bindgen::{JS_GetReservedSlot, JS_SetReservedSlot};
+use js::jsapi::bindgen::{JS_SetReservedSlot};
 use js::jsapi::bindgen::{JS_ValueToString};
 use js::jsapi::{JSContext, JSVal, JSObject, JSBool, JSFreeOp, JSFunctionSpec};
 use js::jsapi::{JSNativeWrapper};
@@ -64,14 +64,14 @@ extern fn close(cx: *JSContext, _argc: c_uint, vp: *JSVal) -> JSBool {
 }
 
 unsafe fn unwrap(obj: *JSObject) -> *rust_box<Window> {
-    let val = JS_GetReservedSlot(obj, 0);
+    let val = GetReservedSlot(obj, 0);
     cast::reinterpret_cast(&RUST_JSVAL_TO_PRIVATE(val))
 }
 
 extern fn finalize(_fop: *JSFreeOp, obj: *JSObject) {
     debug!("finalize!");
     unsafe {
-        let val = JS_GetReservedSlot(obj, 0);
+        let val = GetReservedSlot(obj, 0);
         let _: @Window = cast::reinterpret_cast(&RUST_JSVAL_TO_PRIVATE(val));
     }
 }


### PR DESCRIPTION
As you know, there is a issue when connect rust to c(++) between another ABIs.
So I added some glue code to use JS API normally regardless of ABI difference.

I had also modified the module : rust-mozjs
actual commit is on my local github.
https://github.com/aydinkim/rust-mozjs/commit/35c775238ef6c8e2297986b96cfaf269c9ab2782

and the source code diff is attached below.
https://gist.github.com/aydinkim/5450506
