### PR TITLE
Remove '--quiet' option from git commands in /configure.

### DIFF
--- a/configure
+++ b/configure
@@ -370,21 +370,21 @@ then
     "${CFG_GIT}" submodule status --recursive
 
     msg "git: submodule update"
-    "${CFG_GIT}" submodule --quiet update --init
+    "${CFG_GIT}" submodule update --init
     need_ok "git failed"
 
     msg "git: submodule foreach sync"
-    "${CFG_GIT}" submodule --quiet foreach --recursive 'if test -e .gitmodules; then git submodule sync; fi'
+    "${CFG_GIT}" submodule foreach --recursive 'if test -e .gitmodules; then git submodule sync; fi'
     need_ok "git failed"
 
     msg "git: submodule foreach update"
-    "${CFG_GIT}" submodule --quiet update --init --recursive
+    "${CFG_GIT}" submodule update --init --recursive
     need_ok "git failed"
 
     msg "git: submodule clobber"
-    "${CFG_GIT}" submodule --quiet foreach --recursive git clean -dxf
+    "${CFG_GIT}" submodule foreach --recursive git clean -dxf
     need_ok "git failed"
-    "${CFG_GIT}" submodule --quiet foreach --recursive git checkout .
+    "${CFG_GIT}" submodule foreach --recursive git checkout .
     need_ok "git failed"
 
     cd ${CFG_BUILD_DIR}


### PR DESCRIPTION
Should we display information about `git submodule` when `configure` ?

When I called `configure` after cloning servo repository, it resolved and initialized git sub modules. However, the first `git submodule` after clone the repository needs long times for initializing sub repository (e.g. skia, rust) and it doesn't display any progress about submodules. At this time, we cannot know that `configure` works correctly, or has some error if we uses `--quiet` option.

I think we shouldn't use `--quiet` option.
