### PR TITLE
Replace with_imm_node by with_base and with_mut_node by with_mut_base

### DIFF
--- a/src/servo-util/tree.rs
+++ b/src/servo-util/tree.rs
@@ -7,10 +7,10 @@
 /// The basic trait. This function is meant to encapsulate a clonable reference to a tree node.
 pub trait TreeNodeRef<N> : Clone {
     /// Borrows this node as immutable.
-    fn with_imm_node<R>(&self, callback: &fn(&N) -> R) -> R;
+    fn with_base<R>(&self, callback: &fn(&N) -> R) -> R;
 
     /// Borrows this node as mutable.
-    fn with_mut_node<R>(&self, callback: &fn(&mut N) -> R) -> R;
+    fn with_mut_base<R>(&self, callback: &fn(&mut N) -> R) -> R;
 }
 
 /// The contents of a tree node.
@@ -73,14 +73,14 @@ pub trait TreeUtils {
 
 impl<NR:TreeNodeRef<N>,N:TreeNode<NR>> TreeUtils for NR {
     fn is_leaf(&self) -> bool {
-        do self.with_imm_node |this_node| {
+        do self.with_base |this_node| {
             this_node.first_child().is_none()
         }
     }
 
     fn add_child(&self, new_child: NR) {
-        do self.with_mut_node |this_node| {
-            do new_child.with_mut_node |new_child_node| {
+        do self.with_mut_base |this_node| {
+            do new_child.with_mut_base |new_child_node| {
                 assert!(new_child_node.parent_node().is_none());
                 assert!(new_child_node.prev_sibling().is_none());
                 assert!(new_child_node.next_sibling().is_none());
@@ -88,7 +88,7 @@ impl<NR:TreeNodeRef<N>,N:TreeNode<NR>> TreeUtils for NR {
                 match this_node.last_child() {
                     None => this_node.set_first_child(Some(new_child.clone())),
                     Some(last_child) => {
-                        do last_child.with_mut_node |last_child_node| {
+                        do last_child.with_mut_base |last_child_node| {
                             assert!(last_child_node.next_sibling().is_none());
                             last_child_node.set_next_sibling(Some(new_child.clone()));
                             new_child_node.set_prev_sibling(Some(last_child.clone()));
@@ -103,14 +103,14 @@ impl<NR:TreeNodeRef<N>,N:TreeNode<NR>> TreeUtils for NR {
     }
 
     fn remove_child(&self, child: NR) {
-        do self.with_mut_node |this_node| {
-            do child.with_mut_node |child_node| {
+        do self.with_mut_base |this_node| {
+            do child.with_mut_base |child_node| {
                 assert!(child_node.parent_node().is_some());
 
                 match child_node.prev_sibling() {
                     None => this_node.set_first_child(child_node.next_sibling()),
                     Some(prev_sibling) => {
-                        do prev_sibling.with_mut_node |prev_sibling_node| {
+                        do prev_sibling.with_mut_base |prev_sibling_node| {
                             prev_sibling_node.set_next_sibling(child_node.next_sibling());
                         }
                     }
@@ -119,7 +119,7 @@ impl<NR:TreeNodeRef<N>,N:TreeNode<NR>> TreeUtils for NR {
                 match child_node.next_sibling() {
                     None => this_node.set_last_child(child_node.prev_sibling()),
                     Some(next_sibling) => {
-                        do next_sibling.with_mut_node |next_sibling_node| {
+                        do next_sibling.with_mut_base |next_sibling_node| {
                             next_sibling_node.set_prev_sibling(child_node.prev_sibling());
                         }
                     }
@@ -133,14 +133,14 @@ impl<NR:TreeNodeRef<N>,N:TreeNode<NR>> TreeUtils for NR {
     }
 
     fn each_child(&self, callback: &fn(NR) -> bool) {
-        let mut maybe_current = self.with_imm_node(|n| n.first_child());
+        let mut maybe_current = self.with_base(|n| n.first_child());
         while !maybe_current.is_none() {
             let current = maybe_current.get_ref().clone();
             if !callback(current.clone()) {
                 break;
             }
 
-            maybe_current = current.with_imm_node(|n| n.next_sibling());
+            maybe_current = current.with_base(|n| n.next_sibling());
         }
     }
 

--- a/src/servo/content/content_task.rs
+++ b/src/servo/content/content_task.rs
@@ -234,8 +234,8 @@ pub impl Content {
                                   ptr::to_mut_unsafe_ptr(&mut *self)); //FIXME store this safely
             let document = Document(root, Some(window));
 
-            do root.with_mut_node |node| {
-                node.add_to_doc(document);
+            do root.with_mut_base |base| {
+                base.add_to_doc(document);
             }
 
             self.damage.add(MatchSelectorsDamage);

--- a/src/servo/dom/bindings/node.rs
+++ b/src/servo/dom/bindings/node.rs
@@ -81,8 +81,8 @@ extern fn getFirstChild(cx: *JSContext, _argc: c_uint, vp: *mut JSVal) -> JSBool
         }
 
         let node = unwrap(obj);
-        let rval = do node.with_mut_node |node| {
-            node.getFirstChild()
+        let rval = do node.with_mut_base |base| {
+            base.getFirstChild()
         };
         match rval {
             Some(n) => {
@@ -103,8 +103,8 @@ extern fn getNextSibling(cx: *JSContext, _argc: c_uint, vp: *mut JSVal) -> JSBoo
         }
 
         let node = unwrap(obj);
-        let rval = do node.with_mut_node |node| {
-            node.getNextSibling()
+        let rval = do node.with_mut_base |base| {
+            base.getNextSibling()
         };
         match rval {
             Some(n) => {
@@ -129,7 +129,7 @@ impl Node {
     fn getNextSibling(&mut self) -> Option<&mut AbstractNode> {
         match self.next_sibling {
             // transmute because the compiler can't deduce that the reference
-            // is safe outside of with_mut_node blocks.
+            // is safe outside of with_mut_base blocks.
             Some(ref mut n) => Some(unsafe { cast::transmute(n) }),
             None => None
         }
@@ -138,7 +138,7 @@ impl Node {
     fn getFirstChild(&mut self) -> Option<&mut AbstractNode> {
         match self.first_child {
             // transmute because the compiler can't deduce that the reference
-            // is safe outside of with_mut_node blocks.
+            // is safe outside of with_mut_base blocks.
             Some(ref mut n) => Some(unsafe { cast::transmute(n) }),
             None => None
         }
@@ -153,8 +153,8 @@ extern fn getNodeType(cx: *JSContext, _argc: c_uint, vp: *mut JSVal) -> JSBool {
         }
 
         let node = unwrap(obj);
-        let rval = do node.with_imm_node |node| {
-            node.getNodeType()
+        let rval = do node.with_base |base| {
+            base.getNodeType()
         };
         *vp = INT_TO_JSVAL(rval);
     }
@@ -163,9 +163,9 @@ extern fn getNodeType(cx: *JSContext, _argc: c_uint, vp: *mut JSVal) -> JSBool {
 
 impl CacheableWrapper for AbstractNode {
     fn get_wrappercache(&mut self) -> &mut WrapperCache {
-        do self.with_mut_node |node| {
+        do self.with_mut_base |base| {
             unsafe {
-                cast::transmute(&node.wrapper)
+                cast::transmute(&base.wrapper)
             }
         }
     }

--- a/src/servo/dom/document.rs
+++ b/src/servo/dom/document.rs
@@ -27,9 +27,9 @@ pub fn Document(root: AbstractNode,
         window: window
     };
     let compartment = global_content().compartment.get();
-    do root.with_imm_node |node| {
-        assert!(node.wrapper.get_wrapper().is_not_null());
-        let rootable = node.wrapper.get_rootable();
+    do root.with_base |base| {
+        assert!(base.wrapper.get_wrapper().is_not_null());
+        let rootable = base.wrapper.get_rootable();
         JS_AddObjectRoot(compartment.cx.ptr, rootable);
     }
     document::create(compartment, doc);
@@ -40,9 +40,9 @@ pub fn Document(root: AbstractNode,
 impl Drop for Document {
     fn finalize(&self) {
         let compartment = global_content().compartment.get();
-        do self.root.with_imm_node |node| {
-            assert!(node.wrapper.get_wrapper().is_not_null());
-            let rootable = node.wrapper.get_rootable();
+        do self.root.with_base |base| {
+            assert!(base.wrapper.get_wrapper().is_not_null());
+            let rootable = base.wrapper.get_rootable();
             JS_RemoveObjectRoot(compartment.cx.ptr, rootable);
         }
     }

--- a/src/servo/dom/node.rs
+++ b/src/servo/dom/node.rs
@@ -205,12 +205,12 @@ impl TreeNode<AbstractNode> for Node {
 }
 
 impl TreeNodeRef<Node> for AbstractNode {
-    // FIXME: The duplication between `with_imm_node` and `with_imm_node` is ugly.
-    fn with_imm_node<R>(&self, callback: &fn(&Node) -> R) -> R {
+    // FIXME: The duplication between `with_base` and `with_mut_base` is ugly.
+    fn with_base<R>(&self, callback: &fn(&Node) -> R) -> R {
         self.transmute(callback)
     }
 
-    fn with_mut_node<R>(&self, callback: &fn(&mut Node) -> R) -> R {
+    fn with_mut_base<R>(&self, callback: &fn(&mut Node) -> R) -> R {
         self.transmute_mut(callback)
     }
 }
@@ -220,44 +220,44 @@ impl AbstractNode {
 
     /// Returns the type ID of this node. Fails if this node is borrowed mutably.
     pub fn type_id(self) -> NodeTypeId {
-        self.with_imm_node(|n| n.type_id)
+        self.with_base(|b| b.type_id)
     }
 
     /// Returns the parent node of this node. Fails if this node is borrowed mutably.
     pub fn parent_node(self) -> Option<AbstractNode> {
-        self.with_imm_node(|n| n.parent_node)
+        self.with_base(|b| b.parent_node)
     }
 
     /// Returns the first child of this node. Fails if this node is borrowed mutably.
     pub fn first_child(self) -> Option<AbstractNode> {
-        self.with_imm_node(|n| n.first_child)
+        self.with_base(|b| b.first_child)
     }
 
     /// Returns the last child of this node. Fails if this node is borrowed mutably.
     pub fn last_child(self) -> Option<AbstractNode> {
-        self.with_imm_node(|n| n.last_child)
+        self.with_base(|b| b.last_child)
     }
 
     /// Returns the previous sibling of this node. Fails if this node is borrowed mutably.
     pub fn prev_sibling(self) -> Option<AbstractNode> {
-        self.with_imm_node(|n| n.prev_sibling)
+        self.with_base(|b| b.prev_sibling)
     }
 
     /// Returns the next sibling of this node. Fails if this node is borrowed mutably.
     pub fn next_sibling(self) -> Option<AbstractNode> {
-        self.with_imm_node(|n| n.next_sibling)
+        self.with_base(|b| b.next_sibling)
     }
 
     // NB: You must not call these if you are not layout. We should do something with scoping to
     // ensure this.
     pub fn layout_data(self) -> @mut LayoutData {
-        self.with_imm_node(|n| n.layout_data.get())
+        self.with_base(|b| b.layout_data.get())
     }
     pub fn has_layout_data(self) -> bool {
-        self.with_imm_node(|n| n.layout_data.is_some())
+        self.with_base(|b| b.layout_data.is_some())
     }
     pub fn set_layout_data(self, data: @mut LayoutData) {
-        self.with_mut_node(|n| n.layout_data = Some(data))
+        self.with_mut_base(|b| b.layout_data = Some(data))
     }
 
     //
@@ -401,8 +401,8 @@ impl Node {
         let mut node = self.first_child;
         while node.is_some() {
             for node.get().traverse_preorder |node| {
-                do node.with_mut_node |node_data| {
-                    node_data.owner_doc = Some(doc);
+                do node.with_mut_base |node_base| {
+                    node_base.owner_doc = Some(doc);
                 }
             };
             node = node.get().next_sibling();

--- a/src/servo/layout/block.rs
+++ b/src/servo/layout/block.rs
@@ -86,7 +86,7 @@ impl BlockFlowData {
         for BlockFlow(self).each_child |child_ctx| {
             assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow());
 
-            do child_ctx.with_imm_node |child_node| {
+            do child_ctx.with_base |child_node| {
                 min_width = au::max(min_width, child_node.min_width);
                 pref_width = au::max(pref_width, child_node.pref_width);
             }
@@ -130,7 +130,7 @@ impl BlockFlowData {
         for BlockFlow(self).each_child |kid| {
             assert!(kid.starts_block_flow() || kid.starts_inline_flow());
 
-            do kid.with_mut_node |child_node| {
+            do kid.with_mut_base |child_node| {
                 child_node.position.origin.x = left_used;
                 child_node.position.size.width = remaining_width;
             }
@@ -141,7 +141,7 @@ impl BlockFlowData {
         let mut cur_y = Au(0);
 
         for BlockFlow(self).each_child |kid| {
-            do kid.with_mut_node |child_node| {
+            do kid.with_mut_base |child_node| {
                 child_node.position.origin.y = cur_y;
                 cur_y += child_node.position.size.height;
             }

--- a/src/servo/layout/box_builder.rs
+++ b/src/servo/layout/box_builder.rs
@@ -323,7 +323,7 @@ pub impl LayoutTreeBuilder {
         let flow = &mut this_ctx.default_collector.flow;
         let flow: &FlowContext = flow;
         for flow.each_child |child_flow| {
-            do child_flow.with_imm_node |child_node| {
+            do child_flow.with_base |child_node| {
                 let dom_node = child_node.node;
                 assert!(dom_node.has_layout_data());
                 dom_node.layout_data().flow = Some(child_flow);
@@ -364,7 +364,7 @@ pub impl LayoutTreeBuilder {
                 // of its RenderBox or FlowContext children, and possibly keep alive other junk
                 let parent_flow = parent_ctx.default_collector.flow;
 
-                let (first_child, last_child) = do parent_flow.with_imm_node |parent_node| {
+                let (first_child, last_child) = do parent_flow.with_base |parent_node| {
                     (parent_node.first_child, parent_node.last_child)
                 };
 

--- a/src/servo/layout/display_list_builder.rs
+++ b/src/servo/layout/display_list_builder.rs
@@ -55,7 +55,7 @@ impl FlowDisplayListBuilderMethods for FlowContext {
                                     offset: &Point2D<Au>,
                                     list: &Cell<DisplayList>) {
         // Adjust the dirty rect to child flow context coordinates.
-        do child_flow.with_imm_node |child_node| {
+        do child_flow.with_base |child_node| {
             let abs_flow_bounds = child_node.position.translate(offset);
             let adj_offset = offset.add(&child_node.position.origin);
 

--- a/src/servo/layout/flow.rs
+++ b/src/servo/layout/flow.rs
@@ -68,7 +68,7 @@ impl Clone for FlowContext {
 }
 
 impl TreeNodeRef<FlowData> for FlowContext {
-    fn with_imm_node<R>(&self, callback: &fn(&FlowData) -> R) -> R {
+    fn with_base<R>(&self, callback: &fn(&FlowData) -> R) -> R {
         match *self {
             AbsoluteFlow(info) => callback(info),
             BlockFlow(info) => {
@@ -82,7 +82,7 @@ impl TreeNodeRef<FlowData> for FlowContext {
             TableFlow(info) => callback(info)
         }
     }
-    fn with_mut_node<R>(&self, callback: &fn(&mut FlowData) -> R) -> R {
+    fn with_mut_base<R>(&self, callback: &fn(&mut FlowData) -> R) -> R {
         match *self {
             AbsoluteFlow(info) => callback(info),
             BlockFlow(info) => {
@@ -189,7 +189,7 @@ impl<'self> FlowContext {
     /// being borrowed mutably.
     #[inline(always)]
     pub fn position(&self) -> Rect<Au> {
-        do self.with_imm_node |common_info| {
+        do self.with_base |common_info| {
             common_info.position
         }
     }
@@ -198,7 +198,7 @@ impl<'self> FlowContext {
     /// borrowed mutably.
     #[inline(always)]
     pub fn id(&self) -> int {
-        do self.with_imm_node |info| {
+        do self.with_base |info| {
             info.id
         }
     }
@@ -253,7 +253,7 @@ impl<'self> FlowContext {
                                       dirty: &Rect<Au>,
                                       offset: &Point2D<Au>,
                                       list: &Cell<DisplayList>) {
-        do self.with_imm_node |info| {
+        do self.with_base |info| {
             debug!("FlowContext::build_display_list at %?: %s", info.position, self.debug_str());
         }
 
@@ -369,8 +369,8 @@ impl DebugMethods for FlowContext {
             _ => ~"(Unknown flow)"
         };
 
-        do self.with_imm_node |this_node| {
-            fmt!("f%? %?", this_node.id, repr)
+        do self.with_base |base| {
+            fmt!("f%? %?", base.id, repr)
         }
     }
 }


### PR DESCRIPTION
This is a refactoring patch that replaces `with_imm_node` by `with_base` and `with_mut_node` by `with_mut_base`. The intention is that the new names better reflect how we actually use these methods. In the case of `with_base` the name is also shorter, which is nice.
