### PR TITLE
Only restore rust if the backup exists.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -285,5 +285,4 @@ backup-rust:
 	mv src/compiler/rust ..
 
 restore-rust:
-	rm -rf src/compiler/rust
-	mv ../rust src/
+	if [ -d ../rust ]; then rm -rf src/rust; mv ../rust src/; fi


### PR DESCRIPTION
For #402
