### PR TITLE
Fix dynamic borrow check errors.

### DIFF
--- a/src/components/servo-gfx/platform/linux/font_list.rs
+++ b/src/components/servo-gfx/platform/linux/font_list.rs
@@ -66,60 +66,64 @@ pub impl FontListHandle {
         let font_set = FcConfigGetFonts(config, FcSetSystem);
         let font_set_array_ptr = ptr::to_unsafe_ptr(&font_set);
         unsafe {
+            let pattern = FcPatternCreate();
+            let pattern = FcPatternCreate();
+            assert!(pattern.is_not_null());
             do str::as_c_str("family") |FC_FAMILY| {
                 do str::as_c_str(family.family_name) |family_name| {
-                    let pattern = FcPatternCreate();
-                    assert!(pattern.is_not_null());
-                    let family_name = family_name as *FcChar8;
-                    let ok = FcPatternAddString(pattern, FC_FAMILY, family_name);
+                    let ok = FcPatternAddString(pattern, FC_FAMILY, family_name as *FcChar8);
                     assert!(ok != 0);
-
-                    let object_set = FcObjectSetCreate();
-                    assert!(object_set.is_not_null());
-
-                    str::as_c_str("file", |FC_FILE| FcObjectSetAdd(object_set, FC_FILE) );
-                    str::as_c_str("index", |FC_INDEX| FcObjectSetAdd(object_set, FC_INDEX) );
-
-                    let matches = FcFontSetList(config, font_set_array_ptr, 1, pattern, object_set);
-
-                    debug!("found %? variations", (*matches).nfont);
-
-                    for uint::range(0, (*matches).nfont as uint) |i| {
-                        let font = (*matches).fonts.offset(i);
-                        let file = do str::as_c_str("file") |FC_FILE| {
-                            let file: *FcChar8 = ptr::null();
-                            if FcPatternGetString(*font, FC_FILE, 0, &file) == FcResultMatch {
-                                str::raw::from_c_str(file as *libc::c_char)
-                            } else {
-                                fail!();
-                            }
-                        };
-                        let index = do str::as_c_str("index") |FC_INDEX| {
-                            let index: libc::c_int = 0;
-                            if FcPatternGetInteger(*font, FC_INDEX, 0, &index) == FcResultMatch {
-                                index
-                            } else {
-                                fail!();
-                            }
-                        };
-
-                        debug!("variation file: %?", file);
-                        debug!("variation index: %?", index);
-
-                        let font_handle = FontHandle::new_from_file_unstyled(&self.fctx,
-                                                                             file);
-                        let font_handle = font_handle.unwrap();
-
-                        debug!("Creating new FontEntry for face: %s", font_handle.face_name());
-                        let entry = @FontEntry::new(family, font_handle);
-                        family.entries.push(entry);
-                    }
-
-                    FcFontSetDestroy(matches);
-                    FcPatternDestroy(pattern);
-                    FcObjectSetDestroy(object_set);
                 }
             }
+
+            let object_set = FcObjectSetCreate();
+            assert!(object_set.is_not_null());
+
+            do str::as_c_str("file") |FC_FILE| {
+                FcObjectSetAdd(object_set, FC_FILE);
+            }
+            do str::as_c_str("index") |FC_INDEX| {
+                FcObjectSetAdd(object_set, FC_INDEX);
+            }
+
+            let matches = FcFontSetList(config, font_set_array_ptr, 1, pattern, object_set);
+
+            debug!("found %? variations", (*matches).nfont);
+
+            for uint::range(0, (*matches).nfont as uint) |i| {
+                let font = (*matches).fonts.offset(i);
+                let file = do str::as_c_str("file") |FC_FILE| {
+                    let file: *FcChar8 = ptr::null();
+                    if FcPatternGetString(*font, FC_FILE, 0, &file) == FcResultMatch {
+                        str::raw::from_c_str(file as *libc::c_char)
+                    } else {
+                        fail!();
+                    }
+                };
+                let index = do str::as_c_str("index") |FC_INDEX| {
+                    let index: libc::c_int = 0;
+                    if FcPatternGetInteger(*font, FC_INDEX, 0, &index) == FcResultMatch {
+                        index
+                    } else {
+                        fail!();
+                    }
+                };
+
+                debug!("variation file: %?", file);
+                debug!("variation index: %?", index);
+
+                let font_handle = FontHandle::new_from_file_unstyled(&self.fctx,
+                                                                     file);
+                let font_handle = font_handle.unwrap();
+
+                debug!("Creating new FontEntry for face: %s", font_handle.face_name());
+                let entry = @FontEntry::new(family, font_handle);
+                family.entries.push(entry);
+            }
+
+            FcFontSetDestroy(matches);
+            FcPatternDestroy(pattern);
+            FcObjectSetDestroy(object_set);
         }
     }
 }

--- a/src/components/servo-gfx/platform/linux/font_list.rs
+++ b/src/components/servo-gfx/platform/linux/font_list.rs
@@ -67,7 +67,6 @@ pub impl FontListHandle {
         let font_set_array_ptr = ptr::to_unsafe_ptr(&font_set);
         unsafe {
             let pattern = FcPatternCreate();
-            let pattern = FcPatternCreate();
             assert!(pattern.is_not_null());
             do str::as_c_str("family") |FC_FAMILY| {
                 do str::as_c_str(family.family_name) |family_name| {


### PR DESCRIPTION
This reduces the scope of the borrow on `family` to the single FFI call that
needs it.
