### PR TITLE
Fix union ABI incompatibility of spidermonkey on ARM arch.

### DIFF
--- a/src/components/servo/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/servo/dom/bindings/codegen/CodegenRust.py
@@ -1454,7 +1454,7 @@ def getWrapTemplateForType(type, descriptorProvider, result, successCode,
         """
         if failureCode is None:
             if not haveSuccessCode:
-                return wrapCall + ";\n" + "return if *vp != 0 { 1 } else { 0 };"
+                return wrapCall + ";\n" + "return if (*vp).v != 0 { 1 } else { 0 };"
             failureCode = "return 0;"
         str = ("if !%s {\n" +
                CGIndenter(CGGeneric(failureCode)).define() + "\n" +


### PR DESCRIPTION
This is a fix for #309 and #308 along with https://github.com/mozilla-servo/rust-mozjs/pull/18. 
Change JSVal from u64 to {u64}
