### PR TITLE
Ignore objdir directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ servo-test
 Makefile
 Servo.app
 build
+objdir
 config.mk
 config.stamp
 config.tmp


### PR DESCRIPTION
This is the directory that moz buildbots use to build Servo.
