### PR TITLE
Align text at baseline

### DIFF
--- a/src/components/servo/layout/inline.rs
+++ b/src/components/servo/layout/inline.rs
@@ -841,7 +841,7 @@ impl InlineFlowData {
                 let halfleading = match cur_box {
                     TextRenderBoxClass(text_box) => {
                         //ad is the AD height as defined by CSS 2.1 § 10.8.1
-                        let ad = text_box.text_data.run.font.metrics.ascent + text_box.text_data.run.font.metrics.descent;
+                        let ad = text_box.run.font.metrics.ascent + text_box.run.font.metrics.descent;
                         (line_height - ad).scale_by(0.5)
                     },
                     _ => Au(0),
@@ -852,7 +852,7 @@ impl InlineFlowData {
                 let halfleading = Au::max(halfleading, Au(0));
                 
                 let height = match cur_box {
-                    TextRenderBoxClass(text_box) => text_box.text_data.run.font.metrics.ascent,
+                    TextRenderBoxClass(text_box) => text_box.run.font.metrics.ascent,
                     _ => cur_box.position().size.height
                 };
 

--- a/src/components/servo/layout/inline.rs
+++ b/src/components/servo/layout/inline.rs
@@ -840,13 +840,23 @@ impl InlineFlowData {
                 // according to the `vertical-align` property of the containing block.
                 let halfleading = match cur_box {
                     TextRenderBoxClass(text_box) => {
-                        (text_box.run.font.metrics.em_size - line_height).scale_by(0.5)
+                        //ad is the AD height as defined by CSS 2.1 § 10.8.1
+                        let ad = text_box.text_data.run.font.metrics.ascent + text_box.text_data.run.font.metrics.descent;
+                        (line_height - ad).scale_by(0.5)
                     },
                     _ => Au(0),
                 };
 
+                //FIXME: when line-height is set on an inline element, the half leading
+                //distance can be negative.
+                let halfleading = Au::max(halfleading, Au(0));
+                
+                let height = match cur_box {
+                    TextRenderBoxClass(text_box) => text_box.text_data.run.font.metrics.ascent,
+                    _ => cur_box.position().size.height
+                };
+
                 do cur_box.with_mut_base |base| {
-                    let height = base.position.size.height;
                     base.position.origin.y = cur_y + halfleading + baseline_offset - height;
                 }
             }


### PR DESCRIPTION
Aligns text based on baseline, as opposed to some weird alignment happening now. Makes underline look better, but a full solution would implement line-height and text-align.
