### PR TITLE
Not handling "missing font-family" very gracefully

### DIFF
--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -112,13 +112,13 @@ pub impl<'self> FontContext {
 
         debug!("(create font group) --- starting ---");
 
+        let list = self.get_font_list();
+
         // TODO(Issue #193): make iteration over 'font-family' more robust.
         for str::each_split_char(style.families, ',') |family| {
             let family_name = str::trim(family);
             let transformed_family_name = self.transform_family(family_name);
             debug!("(create font group) transformed family is `%s`", transformed_family_name);
-
-            let list = self.get_font_list();
 
             let result = list.find_font_in_family(transformed_family_name, style);
             let mut found = false;
@@ -131,6 +131,16 @@ pub impl<'self> FontContext {
 
             if !found {
                 debug!("(create font group) didn't find `%s`", transformed_family_name);
+            }
+        }
+
+        let last_resort = FontList::get_last_resort_font_families();
+
+        for last_resort.each |family| {
+            let result = list.find_font_in_family(*family,style);
+            for result.each |font_entry| {
+                let instance = Font::new_from_existing_handle(self, &font_entry.handle, style, self.backend);
+                do result::iter(&instance) |font: &@mut Font| { fonts.push(*font); }
             }
         }
 

--- a/src/components/gfx/font_list.rs
+++ b/src/components/gfx/font_list.rs
@@ -19,6 +19,7 @@ pub type FontFamilyMap = HashMap<~str, @mut FontFamily>;
 trait FontListHandleMethods {
     fn get_available_families(&self, fctx: &FontContextHandle) -> FontFamilyMap;
     fn load_variations_for_family(&self, family: @mut FontFamily);
+    fn get_last_resort_font_families() -> ~[~str];
 }
 
 /// The platform-independent font list abstraction.
@@ -85,6 +86,11 @@ pub impl FontList {
 
         // TODO(Issue #188): look up localized font family names if canonical name not found
         family.map(|f| **f)
+    }
+
+    pub fn get_last_resort_font_families() -> ~[~str] {
+        let last_resort = FontListHandle::get_last_resort_font_families();
+        last_resort
     }
 }
 

--- a/src/components/gfx/platform/linux/font_list.rs
+++ b/src/components/gfx/platform/linux/font_list.rs
@@ -125,6 +125,10 @@ pub impl FontListHandle {
             FcObjectSetDestroy(object_set);
         }
     }
+
+    fn get_last_resort_font_families() -> ~[~str] {
+        ~[~"Arial"]
+    }
 }
 
 struct AutoPattern {

--- a/src/components/gfx/platform/macos/font_list.rs
+++ b/src/components/gfx/platform/macos/font_list.rs
@@ -55,4 +55,8 @@ pub impl FontListHandle {
             family.entries.push(entry)
         }
     }
+
+    fn get_last_resort_font_families() -> ~[~str] {
+        ~[~"Arial Unicode MS",~"Arial"]
+    }
 }


### PR DESCRIPTION
This seems to occur in places where "font-family" is specified.

On my mac, "about-mozilla.html" renders correctly (it uses `font-family: serif;` in several places)

However, "ligatures.html" fails to render when specifying `font-family: Calibri;`

I haven't dug in very deep yet, but it seems like maybe falling back on a default font would be a more correct or safe behaviour than just dying.

I'll be able to look at this a bit more next week if it's still open

---

I should add, this is not limited to the mac, dholbert had run into this on linux x64 as well (died testing about-mozilla.html)

```
rust: task failed at 'assertion failed: fonts.len() > 0', /Users/caitp/git/servo/src/components/servo-gfx/font_context.rs:130
rust: domain main @0x7fba3980c010 root task failed
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: task failed at 'killed', /Users/caitp/git/servo/src/compiler/rust/src/libcore/pipes.rs:281
rust: ~"tracing 4430275392:"
rust: ~"tracing first child"
rust: ~"tracing last child"
rust: ~"tracing 4430275440:"
rust: ~"tracing parent"
rust: ~"tracing first child"
rust: ~"tracing last child"
rust: ~"tracing 4430275728:"
rust: ~"tracing parent"
rust: ~"tracing first child"
rust: ~"tracing last child"
rust: ~"tracing prev sibling"
rust: ~"tracing 4430275920:"
rust: ~"tracing parent"
rust: ~"tracing prev sibling"
rust: ~"tracing 4430275824:"
rust: ~"tracing parent"
rust: ~"tracing first child"
rust: ~"tracing last child"
rust: ~"tracing next sibling"
rust: ~"tracing prev sibling"
rust: ~"tracing 4430275872:"
rust: ~"tracing parent"
rust: ~"tracing 4430275776:"
rust: ~"tracing parent"
rust: ~"tracing next sibling"
rust: ~"tracing 4430275488:"
rust: ~"tracing parent"
rust: ~"tracing first child"
rust: ~"tracing last child"
rust: ~"tracing next sibling"
rust: ~"tracing 4430275680:"
rust: ~"tracing parent"
rust: ~"tracing prev sibling"
rust: ~"tracing 4430275584:"
rust: ~"tracing parent"
rust: ~"tracing first child"
rust: ~"tracing last child"
rust: ~"tracing next sibling"
rust: ~"tracing prev sibling"
rust: ~"tracing 4430275632:"
rust: ~"tracing parent"
rust: ~"tracing 4430275536:"
rust: ~"tracing parent"
rust: ~"tracing next sibling"
Assertion failed: (!borrow_list), function delete_this, file /Users/caitp/git/servo/src/compiler/rust/src/rt/rust_task.cpp, line 80.
```
