### PR TITLE
Refactor flow tree construction and actually use display property

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -117,7 +117,9 @@ impl BlockFlowData {
     /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
     /// contexts.
     pub fn assign_widths_block(@mut self, ctx: &LayoutContext) { 
+        debug!("assign_widths_block: assigning width for flow %?",  self.common.id);
         if self.is_root {
+            debug!("Setting root position");
             self.common.position.origin = Au::zero_point();
             self.common.position.size.width = ctx.screen_size.size.width;
         }

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -624,7 +624,21 @@ pub impl RenderBox {
                 });
             },
 
-            GenericRenderBoxClass(_) => {}
+            GenericRenderBoxClass(_) => {
+                debug!("%?", { 
+                // Compute the text box bounds and draw a border surrounding them.
+                do list.with_mut_ref |list| {
+                    let border_display_item = ~BorderDisplayItem {
+                        base: BaseDisplayItem {
+                                bounds: absolute_box_bounds,
+                        },
+                        width: Au::from_px(1),
+                        color: rgb(0, 0, 0).to_gfx_color(),
+                    };
+                        list.append_item(BorderDisplayItemClass(border_display_item))
+                }
+                });
+            }
 
             ImageRenderBoxClass(image_box) => {
                 match image_box.image.get_image() {

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -412,7 +412,7 @@ impl<'self> FlowContext {
         };
 
         do self.with_base |base| {
-            fmt!("f%? %?", base.id, repr)
+            fmt!("f%? %? size %?", base.id, repr, base.position)
         }
     }
 }

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -230,6 +230,8 @@ impl Layout {
             self.render_task.channel.send(RenderMsg(render_layer));
         } // time(layout: display list building)
 
+        debug!("%?", layout_root.dump());
+
         // Tell script that we're done.
         data.script_join_chan.send(());
     }

--- a/src/test/test_underline_helloworld.html
+++ b/src/test/test_underline_helloworld.html
@@ -9,8 +9,7 @@
 <body>
 
     <div>
-        <div>Hello</div>
-
+        <div>Hello!</div>
         <div>World</div>
     </div>
 </body>


### PR DESCRIPTION
Eliminates a level of indirection in flow tree construction and uses 'display' to construct flows.
