### PR TITLE
Fixes #479 - Implement basic last-resort font selection.

### DIFF
--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -112,13 +112,13 @@ pub impl<'self> FontContext {
 
         debug!("(create font group) --- starting ---");
 
+        let list = self.get_font_list();
+
         // TODO(Issue #193): make iteration over 'font-family' more robust.
         for str::each_split_char(style.families, ',') |family| {
             let family_name = str::trim(family);
             let transformed_family_name = self.transform_family(family_name);
             debug!("(create font group) transformed family is `%s`", transformed_family_name);
-
-            let list = self.get_font_list();
 
             let result = list.find_font_in_family(transformed_family_name, style);
             let mut found = false;
@@ -131,6 +131,16 @@ pub impl<'self> FontContext {
 
             if !found {
                 debug!("(create font group) didn't find `%s`", transformed_family_name);
+            }
+        }
+
+        let last_resort = FontList::get_last_resort_font_families();
+
+        for last_resort.each |family| {
+            let result = list.find_font_in_family(*family,style);
+            for result.each |font_entry| {
+                let instance = Font::new_from_existing_handle(self, &font_entry.handle, style, self.backend);
+                do result::iter(&instance) |font: &@mut Font| { fonts.push(*font); }
             }
         }
 

--- a/src/components/gfx/font_list.rs
+++ b/src/components/gfx/font_list.rs
@@ -19,6 +19,7 @@ pub type FontFamilyMap = HashMap<~str, @mut FontFamily>;
 trait FontListHandleMethods {
     fn get_available_families(&self, fctx: &FontContextHandle) -> FontFamilyMap;
     fn load_variations_for_family(&self, family: @mut FontFamily);
+    fn get_last_resort_font_families() -> ~[~str];
 }
 
 /// The platform-independent font list abstraction.
@@ -85,6 +86,11 @@ pub impl FontList {
 
         // TODO(Issue #188): look up localized font family names if canonical name not found
         family.map(|f| **f)
+    }
+
+    pub fn get_last_resort_font_families() -> ~[~str] {
+        let last_resort = FontListHandle::get_last_resort_font_families();
+        last_resort
     }
 }
 

--- a/src/components/gfx/platform/linux/font_list.rs
+++ b/src/components/gfx/platform/linux/font_list.rs
@@ -125,6 +125,10 @@ pub impl FontListHandle {
             FcObjectSetDestroy(object_set);
         }
     }
+
+    fn get_last_resort_font_families() -> ~[~str] {
+        ~[~"Arial"]
+    }
 }
 
 struct AutoPattern {

--- a/src/components/gfx/platform/macos/font_list.rs
+++ b/src/components/gfx/platform/macos/font_list.rs
@@ -55,4 +55,8 @@ pub impl FontListHandle {
             family.entries.push(entry)
         }
     }
+
+    fn get_last_resort_font_families() -> ~[~str] {
+        ~[~"Arial Unicode MS",~"Arial"]
+    }
 }


### PR DESCRIPTION
Return lists of last-resort font family names in platform-specific font_list code, so that they can be appended to the end of FontGroup and used if the requested font faces are not available.
