### PR TITLE
Refactor the compositing interface to use messages instead of callbacks.

### DIFF
--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -5,13 +5,10 @@
 use compositing::resize_rate_limiter::ResizeRateLimiter;
 use platform::{Application, Window};
 use script::script_task::{LoadMsg, ScriptMsg, SendEventMsg};
-use windowing::{ApplicationMethods, WindowMethods, WindowMouseEvent, WindowClickEvent};
-use windowing::{WindowMouseDownEvent, WindowMouseUpEvent};
-
-use gfx::compositor::RenderState;
-use script::dom::event::{Event, ClickEvent, MouseDownEvent, MouseUpEvent};
-use script::compositor_interface::{ReadyState, CompositorInterface};
-use script::compositor_interface;
+use windowing::{ApplicationMethods, CompositeWindowEvent, IdleWindowEvent, MouseWindowClickEvent};
+use windowing::{MouseWindowEvent, MouseWindowEventClass, MouseWindowMouseDownEvent};
+use windowing::{MouseWindowMouseUpEvent, NavigateWindowEvent, QuitWindowEvent, ResizeWindowEvent};
+use windowing::{ScrollWindowEvent, WindowMethods, ZoomWindowEvent};
 
 use azure::azure_hl::{DataSourceSurface, DrawTarget, SourceSurfaceMethods, current_gl_context};
 use azure::azure::AzGLContext;
@@ -28,6 +25,9 @@ use layers::layers::{ImageData, WithDataFn};
 use layers::layers::{TextureLayerKind, TextureLayer, TextureManager};
 use layers::rendergl;
 use layers::scene::Scene;
+use script::dom::event::{Event, ClickEvent, MouseDownEvent, MouseUpEvent};
+use script::compositor_interface::{ReadyState, CompositorInterface};
+use script::compositor_interface;
 use servo_util::{time, url};
 use servo_util::time::profile;
 use servo_util::time::ProfilerChan;
@@ -76,7 +76,7 @@ impl CompositorTask {
 pub enum Msg {
     /// Requests that the compositor shut down.
     Exit,
-    /// Requests the compositors GL context.
+    /// Requests the compositor's OpenGL context.
     GetGLContext(Chan<AzGLContext>),
     /// Requests that the compositor paint the given layer buffer set for the given page size.
     Paint(LayerBufferSet, Size2D<uint>),
@@ -211,124 +211,7 @@ fn run_main_loop(port: Port<Msg>,
         }
     };
 
-    do window.set_composite_callback {
-        do profile(time::CompositingCategory, profiler_chan.clone()) {
-            debug!("compositor: compositing");
-            // Adjust the layer dimensions as necessary to correspond to the size of the window.
-            scene.size = window.size();
-
-            // Render the scene.
-            rendergl::render_scene(context, scene);
-        }
-
-        window.present();
-    }
-
-    // Hook the windowing system's resize callback up to the resize rate limiter.
-    do window.set_resize_callback |width, height| {
-        debug!("osmain: window resized to %ux%u", width, height);
-        *window_size = Size2D(width, height);
-        resize_rate_limiter.window_resized(width, height)
-    }
-
     let script_chan_clone = script_chan.clone();
-
-    // When the user enters a new URL, load it.
-    do window.set_load_url_callback |url_string| {
-        debug!("osmain: loading URL `%s`", url_string);
-        script_chan_clone.send(LoadMsg(url::make_url(url_string.to_str(), None)))
-    }
-
-    let script_chan_clone = script_chan.clone();
-
-    // When the user triggers a mouse event, perform appropriate hit testing
-    do window.set_mouse_callback |window_mouse_event: WindowMouseEvent| {
-        let event: Event;
-        let world_mouse_point = |layer_mouse_point: Point2D<f32>| {
-            layer_mouse_point + *world_offset
-        };
-        match window_mouse_event {
-            WindowClickEvent(button, layer_mouse_point) => {
-                event = ClickEvent(button, world_mouse_point(layer_mouse_point));
-            }
-            WindowMouseDownEvent(button, layer_mouse_point) => {
-                event = MouseDownEvent(button, world_mouse_point(layer_mouse_point));
-            }
-            WindowMouseUpEvent(button, layer_mouse_point) => {
-                event = MouseUpEvent(button, world_mouse_point(layer_mouse_point));
-            }
-        }
-        script_chan_clone.send(SendEventMsg(event));
-    }
-
-    // When the user scrolls, move the layer around.
-    do window.set_scroll_callback |delta| {
-        // FIXME (Rust #2528): Can't use `-=`.
-        let world_offset_copy = *world_offset;
-        *world_offset = world_offset_copy - delta;
-
-        // Clamp the world offset to the screen size.
-        let max_x = (page_size.width * *world_zoom - window_size.width as f32).max(&0.0);
-        world_offset.x = world_offset.x.clamp(&0.0, &max_x);
-        let max_y = (page_size.height * *world_zoom - window_size.height as f32).max(&0.0);
-        world_offset.y = world_offset.y.clamp(&0.0, &max_y);
-
-        debug!("compositor: scrolled to %?", *world_offset);
-
-        let mut scroll_transform = identity();
-
-        scroll_transform = scroll_transform.translate(window_size.width as f32 / 2f32 * *world_zoom - world_offset.x,
-                                                  window_size.height as f32 / 2f32 * *world_zoom - world_offset.y,
-                                                  0.0);
-        scroll_transform = scroll_transform.scale(*world_zoom, *world_zoom, 1f32);
-        scroll_transform = scroll_transform.translate(window_size.width as f32 / -2f32,
-                                                  window_size.height as f32 / -2f32,
-                                                  0.0);
-
-        root_layer.common.set_transform(scroll_transform);
-
-        window.set_needs_display()
-    }
-
-
-
-    // When the user pinch-zooms, scale the layer
-    do window.set_zoom_callback |magnification| {
-        let old_world_zoom = *world_zoom;
-
-        // Determine zoom amount
-        *world_zoom = (*world_zoom * magnification).max(&1.0);            
-
-        // Update world offset
-        let corner_to_center_x = world_offset.x + window_size.width as f32 / 2f32;
-        let new_corner_to_center_x = corner_to_center_x * *world_zoom / old_world_zoom;
-        world_offset.x = world_offset.x + new_corner_to_center_x - corner_to_center_x;
-
-        let corner_to_center_y = world_offset.y + window_size.height as f32 / 2f32;
-        let new_corner_to_center_y = corner_to_center_y * *world_zoom / old_world_zoom;
-        world_offset.y = world_offset.y + new_corner_to_center_y - corner_to_center_y;        
-
-        // Clamp to page bounds when zooming out
-        let max_x = (page_size.width * *world_zoom - window_size.width as f32).max(&0.0);
-        world_offset.x = world_offset.x.clamp(&0.0, &max_x);
-        let max_y = (page_size.height * *world_zoom - window_size.height as f32).max(&0.0);
-        world_offset.y = world_offset.y.clamp(&0.0, &max_y);
-
-
-        // Apply transformations
-        let mut zoom_transform = identity();
-        zoom_transform = zoom_transform.translate(window_size.width as f32 / 2f32 * *world_zoom - world_offset.x,
-                                                  window_size.height as f32 / 2f32 * *world_zoom - world_offset.y,
-                                                  0.0);
-        zoom_transform = zoom_transform.scale(*world_zoom, *world_zoom, 1f32);
-        zoom_transform = zoom_transform.translate(window_size.width as f32 / -2f32,
-                                                  window_size.height as f32 / -2f32,
-                                                  0.0);
-        root_layer.common.set_transform(zoom_transform);
-
-
-        window.set_needs_display()
-    }
 
     // Enter the main event loop.
     while !*done {
@@ -336,7 +219,132 @@ fn run_main_loop(port: Port<Msg>,
         check_for_messages();
 
         // Check for messages coming from the windowing system.
-        window.check_loop();
+        match window.recv() {
+            CompositeWindowEvent => {
+                do profile(time::CompositingCategory, profiler_chan.clone()) {
+                    debug!("compositor: compositing");
+                    // Adjust the layer dimensions as necessary to correspond to the size of the
+                    // window.
+                    scene.size = window.size();
+
+                    // Render the scene.
+                    rendergl::render_scene(context, scene);
+                }
+
+                window.present();
+            }
+
+            ResizeWindowEvent(new_window_size) => {
+                // Hook the windowing system's resize callback up to the resize rate limiter.
+                *window_size = new_window_size;
+                resize_rate_limiter.window_resized(new_window_size.width, new_window_size.height)
+            }
+
+            NavigateWindowEvent(url_string) => {
+                // When the user enters a new URL, load it.
+                debug!("osmain: loading URL `%s`", url_string);
+                script_chan_clone.send(LoadMsg(url::make_url(url_string.to_str(), None)))
+            }
+
+            MouseWindowEventClass(window_mouse_event) => {
+                // When the user triggers a mouse event, perform appropriate hit testing
+                let event: Event;
+                let world_mouse_point = |layer_mouse_point: Point2D<f32>| {
+                    layer_mouse_point + *world_offset
+                };
+                match window_mouse_event {
+                    MouseWindowClickEvent(button, layer_mouse_point) => {
+                        event = ClickEvent(button, world_mouse_point(layer_mouse_point));
+                    }
+                    MouseWindowMouseDownEvent(button, layer_mouse_point) => {
+                        event = MouseDownEvent(button, world_mouse_point(layer_mouse_point));
+                    }
+                    MouseWindowMouseUpEvent(button, layer_mouse_point) => {
+                        event = MouseUpEvent(button, world_mouse_point(layer_mouse_point));
+                    }
+                }
+                script_chan_clone.send(SendEventMsg(event));
+            }
+
+            ScrollWindowEvent(delta) => {
+                // When the user scrolls, move the layer around.
+                //
+                // FIXME (Rust #2528): Can't use `-=`.
+                let world_offset_copy = *world_offset;
+                *world_offset = world_offset_copy - delta;
+
+                // Clamp the world offset to the screen size.
+                let max_x = (page_size.width * *world_zoom -
+                             window_size.width as f32).max(&0.0);
+                world_offset.x = world_offset.x.clamp(&0.0, &max_x);
+                let max_y = (page_size.height * *world_zoom -
+                             window_size.height as f32).max(&0.0);
+                world_offset.y = world_offset.y.clamp(&0.0, &max_y);
+
+                debug!("compositor: scrolled to %?", *world_offset);
+
+                let mut scroll_transform = identity();
+
+                scroll_transform = scroll_transform.translate(window_size.width as f32 / 2f32 *
+                                                              *world_zoom - world_offset.x,
+                                                              window_size.height as f32 / 2f32 *
+                                                              *world_zoom - world_offset.y,
+                                                              0.0);
+                scroll_transform = scroll_transform.scale(*world_zoom, *world_zoom, 1f32);
+                scroll_transform = scroll_transform.translate(window_size.width as f32 / -2.0,
+                                                              window_size.height as f32 / -2.0,
+                                                              0.0);
+
+                root_layer.common.set_transform(scroll_transform);
+
+                window.set_needs_display()
+            }
+
+            ZoomWindowEvent(magnification) => {
+                // When the user pinch-zooms, scale the layer.
+                let old_world_zoom = *world_zoom;
+
+                // Determine zoom amount
+                *world_zoom = (*world_zoom * magnification).max(&1.0);            
+
+                // Update world offset.
+                let corner_to_center_x = world_offset.x + window_size.width as f32 / 2f32;
+                let new_corner_to_center_x = corner_to_center_x * *world_zoom / old_world_zoom;
+                world_offset.x = world_offset.x + new_corner_to_center_x - corner_to_center_x;
+
+                let corner_to_center_y = world_offset.y + window_size.height as f32 / 2f32;
+                let new_corner_to_center_y = corner_to_center_y * *world_zoom / old_world_zoom;
+                world_offset.y = world_offset.y + new_corner_to_center_y - corner_to_center_y;        
+
+                // Clamp to page bounds when zooming out.
+                let max_x = (page_size.width * *world_zoom -
+                             window_size.width as f32).max(&0.0);
+                world_offset.x = world_offset.x.clamp(&0.0, &max_x);
+                let max_y = (page_size.height * *world_zoom -
+                             window_size.height as f32).max(&0.0);
+                world_offset.y = world_offset.y.clamp(&0.0, &max_y);
+
+
+                // Apply transformations.
+                let mut zoom_transform = identity();
+                zoom_transform = zoom_transform.translate(window_size.width as f32 / 2f32 *
+                                                          *world_zoom - world_offset.x,
+                                                          window_size.height as f32 / 2f32 *
+                                                          *world_zoom - world_offset.y,
+                                                          0.0);
+                zoom_transform = zoom_transform.scale(*world_zoom, *world_zoom, 1f32);
+                zoom_transform = zoom_transform.translate(window_size.width as f32 / -2f32,
+                                                          window_size.height as f32 / -2f32,
+                                                          0.0);
+                root_layer.common.set_transform(zoom_transform);
+
+                window.set_needs_display()
+            }
+
+            IdleWindowEvent => {}
+
+            QuitWindowEvent => break,
+        }
     }
 
     shutdown_chan.send(())

--- a/src/components/main/platform/common/glut_windowing.rs
+++ b/src/components/main/platform/common/glut_windowing.rs
@@ -7,13 +7,15 @@
 /// GLUT is a very old and bare-bones toolkit. However, it has good cross-platform support, at
 /// least on desktops. It is designed for testing Servo without the need of a UI.
 
-use windowing::{ApplicationMethods, CompositeCallback, LoadUrlCallback, MouseCallback};
-use windowing::{ResizeCallback, ScrollCallback, WindowMethods, WindowMouseEvent, WindowClickEvent};
-use windowing::{WindowMouseDownEvent, WindowMouseUpEvent, ZoomCallback};
+use windowing::{ApplicationMethods, CompositeWindowEvent, IdleWindowEvent, MouseWindowClickEvent};
+use windowing::{MouseWindowEventClass, MouseWindowMouseDownEvent, MouseWindowMouseUpEvent};
+use windowing::{NavigateWindowEvent, ResizeWindowEvent, ScrollWindowEvent, WindowEvent};
+use windowing::{WindowMethods, ZoomWindowEvent};
 
 use alert::{Alert, AlertMethods};
 use core::cell::Cell;
 use core::libc::c_int;
+use core::util;
 use geom::point::Point2D;
 use geom::size::Size2D;
 use gfx::compositor::{IdleRenderState, RenderState, RenderingRenderState};
@@ -39,12 +41,7 @@ impl ApplicationMethods for Application {
 pub struct Window {
     glut_window: glut::Window,
 
-    composite_callback: Option<CompositeCallback>,
-    resize_callback: Option<ResizeCallback>,
-    load_url_callback: Option<LoadUrlCallback>,
-    mouse_callback: Option<MouseCallback>,
-    scroll_callback: Option<ScrollCallback>,
-    zoom_callback: Option<ZoomCallback>,
+    event_queue: @mut ~[WindowEvent],
 
     drag_origin: Point2D<c_int>,
 
@@ -58,7 +55,7 @@ pub struct Window {
 
 impl WindowMethods<Application> for Window {
     /// Creates a new window.
-    pub fn new(_: &Application) -> @mut Window {
+    fn new(_: &Application) -> @mut Window {
         // Create the GLUT window.
         unsafe { glut::bindgen::glutInitWindowSize(800, 600); }
         let glut_window = glut::create_window(~"Servo");
@@ -67,12 +64,7 @@ impl WindowMethods<Application> for Window {
         let window = @mut Window {
             glut_window: glut_window,
 
-            composite_callback: None,
-            resize_callback: None,
-            load_url_callback: None,
-            mouse_callback: None,
-            scroll_callback: None,
-            zoom_callback: None,
+            event_queue: @mut ~[],
 
             drag_origin: Point2D(0, 0),
 
@@ -83,6 +75,8 @@ impl WindowMethods<Application> for Window {
             render_state: IdleRenderState,
             throbber_frame: 0,
         };
+
+        let event_queue = window.event_queue;
 
         // Spin the event loop every 50 ms to allow the Rust channels to be polled.
         //
@@ -98,17 +92,11 @@ impl WindowMethods<Application> for Window {
 
         // Register event handlers.
         do glut::reshape_func(window.glut_window) |width, height| {
-            match window.resize_callback {
-                None => {}
-                Some(callback) => callback(width as uint, height as uint),
-            }
+            event_queue.push(ResizeWindowEvent(Size2D(width as uint, height as uint)))
         }
         do glut::display_func {
             // FIXME(pcwalton): This will not work with multiple windows.
-            match window.composite_callback {
-                None => {}
-                Some(callback) => callback(),
-            }
+            event_queue.push(CompositeWindowEvent)
         }
         do glut::keyboard_func |key, _, _| {
             window.handle_key(key)
@@ -126,9 +114,9 @@ impl WindowMethods<Application> for Window {
             };
 
             match wheel {
-                1 => window.handle_scroll(Point2D(delta, 0.0)),
-                2 => window.handle_zoom(delta),
-                _ => window.handle_scroll(Point2D(0.0, delta)),
+                1 => event_queue.push(ScrollWindowEvent(Point2D(delta, 0.0))),
+                2 => event_queue.push(ZoomWindowEvent(delta)),
+                _ => event_queue.push(ScrollWindowEvent(Point2D(0.0, delta))),
             }
         }
         (*register_timer_callback)();
@@ -139,63 +127,43 @@ impl WindowMethods<Application> for Window {
     }
 
     /// Returns the size of the window.
-    pub fn size(&self) -> Size2D<f32> {
+    fn size(&self) -> Size2D<f32> {
         Size2D(glut::get(WindowWidth) as f32, glut::get(WindowHeight) as f32)
     }
 
     /// Presents the window to the screen (perhaps by page flipping).
-    pub fn present(&mut self) {
+    fn present(&mut self) {
         glut::swap_buffers();
     }
 
-    /// Registers a callback to run when a composite event occurs.
-    pub fn set_composite_callback(&mut self, new_composite_callback: CompositeCallback) {
-        self.composite_callback = Some(new_composite_callback)
-    }
+    /// Spins the event loop and returns the next event.
+    fn recv(@mut self) -> WindowEvent {
+        if self.event_queue.len() > 0 {
+            return self.event_queue.shift()
+        }
 
-    /// Registers a callback to run when a resize event occurs.
-    pub fn set_resize_callback(&mut self, new_resize_callback: ResizeCallback) {
-        self.resize_callback = Some(new_resize_callback)
-    }
+        glut::check_loop();
 
-    /// Registers a callback to be run when a new URL is to be loaded.
-    pub fn set_load_url_callback(&mut self, new_load_url_callback: LoadUrlCallback) {
-        self.load_url_callback = Some(new_load_url_callback)
-    }
-
-    /// Registers a callback to be run when a mouse event occurs.
-    pub fn set_mouse_callback(&mut self, new_mouse_callback: MouseCallback) {
-        self.mouse_callback = Some(new_mouse_callback)
-    }
-
-    /// Registers a callback to be run when the user scrolls.
-    pub fn set_scroll_callback(&mut self, new_scroll_callback: ScrollCallback) {
-        self.scroll_callback = Some(new_scroll_callback)
-    }
-
-    /// Registers a zoom to be run when the user zooms.
-    pub fn set_zoom_callback(&mut self, new_zoom_callback: ZoomCallback) {
-        self.zoom_callback = Some(new_zoom_callback)
-    }
-
-    /// Spins the event loop.
-    pub fn check_loop(@mut self) {
-        glut::check_loop()
+        if self.event_queue.len() > 0 {
+            self.event_queue.shift()
+        } else {
+            IdleWindowEvent
+        }
     }
 
     /// Schedules a redisplay.
-    pub fn set_needs_display(@mut self) {
+    fn set_needs_display(@mut self) {
         glut::post_redisplay()
     }
 
     /// Sets the ready state.
-    pub fn set_ready_state(@mut self, ready_state: ReadyState) {
+    fn set_ready_state(@mut self, ready_state: ReadyState) {
         self.ready_state = ready_state;
         self.update_window_title()
     }
 
     /// Sets the render state.
-    pub fn set_render_state(@mut self, render_state: RenderState) {
+    fn set_render_state(@mut self, render_state: RenderState) {
         self.render_state = render_state;
         self.update_window_title()
     }
@@ -231,14 +199,10 @@ impl Window {
         match key {
             12 => self.load_url(),                                                      // Ctrl+L
             k if k == ('=' as u8) && (glut::get_modifiers() & ACTIVE_CTRL) != 0 => {    // Ctrl++
-                for self.zoom_callback.each |&callback| {
-                    callback(0.1);
-                }
+                self.event_queue.push(ZoomWindowEvent(0.1))
             }
             k if k == 31 && (glut::get_modifiers() & ACTIVE_CTRL) != 0 => {             // Ctrl+-
-                for self.zoom_callback.each |&callback| {
-                    callback(-0.1);
-                }
+                self.event_queue.push(ZoomWindowEvent(-0.1))
             }
             _ => {}
         }
@@ -248,67 +212,47 @@ impl Window {
     fn handle_mouse(&self, button: c_int, state: c_int, x: c_int, y: c_int) {
         // FIXME(tkuehn): max pixel dist should be based on pixel density
         let max_pixel_dist = 10f;
-        match self.mouse_callback {
-            None => {}
-            Some(callback) => {
-                let event: WindowMouseEvent;
-                match state {
-                    glut::MOUSE_DOWN => {
-                        event = WindowMouseDownEvent(button as uint, Point2D(x as f32, y as f32));
-                        *self.mouse_down_point = Point2D(x, y);
-                        *self.mouse_down_button = button;
-                    }
-                    glut::MOUSE_UP => {
-                        event = WindowMouseUpEvent(button as uint, Point2D(x as f32, y as f32));
-                        if *self.mouse_down_button == button {
-                            let pixel_dist = *self.mouse_down_point - Point2D(x, y);
-                            let pixel_dist = ((pixel_dist.x * pixel_dist.x +
-                                              pixel_dist.y * pixel_dist.y) as float).sqrt();
-                            if pixel_dist < max_pixel_dist {
-                                let click_event = WindowClickEvent(button as uint,
-                                                                   Point2D(x as f32, y as f32));
-                                callback(click_event);
-                            }
-                        }
-                    }
-                    _ => fail!("I cannot recognize the type of mouse action that occured. :-(")
-                };
-                callback(event);
+        match state {
+            glut::MOUSE_DOWN => {
+                let mouse_event = MouseWindowMouseDownEvent(button as uint,
+                                                            Point2D(x as f32, y as f32));
+                self.event_queue.push(MouseWindowEventClass(mouse_event));
+
+                *self.mouse_down_point = Point2D(x, y);
+                *self.mouse_down_button = button;
             }
-        }
-    }
+            glut::MOUSE_UP => {
+                let mouse_event = MouseWindowMouseUpEvent(button as uint,
+                                                          Point2D(x as f32, y as f32));
+                self.event_queue.push(MouseWindowEventClass(mouse_event));
 
-    /// Helper function to handle a scroll.
-    fn handle_scroll(&mut self, delta: Point2D<f32>) {
-        match self.scroll_callback {
-            None => {}
-            Some(callback) => callback(delta),
-        }
-    }
-
-    /// Helper function to handle a zoom.
-    fn handle_zoom(&mut self, magnification: f32) {
-        match self.zoom_callback {
-            None => {}
-            Some(callback) => callback(magnification),
+                if *self.mouse_down_button == button {
+                    let pixel_dist = *self.mouse_down_point - Point2D(x, y);
+                    let pixel_dist = ((pixel_dist.x * pixel_dist.x +
+                                      pixel_dist.y * pixel_dist.y) as float).sqrt();
+                    if pixel_dist < max_pixel_dist {
+                        let mouse_event = MouseWindowClickEvent(button as uint,
+                                                                Point2D(x as f32, y as f32));
+                        self.event_queue.push(MouseWindowEventClass(mouse_event));
+                    }
+                }
+            }
+            _ => fail!("I cannot recognize the type of mouse action that occured. :-(")
         }
     }
 
     /// Helper function to pop up an alert box prompting the user to load a URL.
     fn load_url(&self) {
-        match self.load_url_callback {
-            None => error!("no URL callback registered, doing nothing"),
-            Some(callback) => {
-                let mut alert: Alert = AlertMethods::new("Navigate to:");
-                alert.add_prompt();
-                alert.run();
-                let value = alert.prompt_value();
-                if "" == value {    // To avoid crashing on Linux.
-                    callback("http://purple.com/")
-                } else {
-                    callback(value)
-                }
-            }
+        let mut alert: Alert = AlertMethods::new("Navigate to:");
+        alert.add_prompt();
+        alert.run();
+
+        let value = alert.prompt_value();
+        if "" == value {    // To avoid crashing on Linux.
+            self.event_queue.push(NavigateWindowEvent(~"http://purple.com/"))
+        } else {
+            // FIXME(pcwalton): Do we need this `.to_str()` copy?
+            self.event_queue.push(NavigateWindowEvent(value.to_str()))
         }
     }
 }

--- a/src/components/main/windowing.rs
+++ b/src/components/main/windowing.rs
@@ -9,29 +9,34 @@ use geom::size::Size2D;
 use gfx::compositor::RenderState;
 use script::compositor_interface::ReadyState;
 
-pub enum WindowMouseEvent {
-    WindowClickEvent(uint, Point2D<f32>),
-    WindowMouseDownEvent(uint, Point2D<f32>),
-    WindowMouseUpEvent(uint, Point2D<f32>),
+pub enum MouseWindowEvent {
+    MouseWindowClickEvent(uint, Point2D<f32>),
+    MouseWindowMouseDownEvent(uint, Point2D<f32>),
+    MouseWindowMouseUpEvent(uint, Point2D<f32>),
 }
 
-/// Type of the function that is called when the screen is to be redisplayed.
-pub type CompositeCallback = @fn();
-
-/// Type of the function that is called when the window is resized.
-pub type ResizeCallback = @fn(uint, uint);
-
-/// Type of the function that is called when a new URL is to be loaded.
-pub type LoadUrlCallback = @fn(&str);
-
-/// Type of the function that is called when a mouse hit test is to be performed.
-pub type MouseCallback = @fn(WindowMouseEvent);
-
-/// Type of the function that is called when the user scrolls.
-pub type ScrollCallback = @fn(Point2D<f32>);
-
-///Type of the function that is called when the user zooms.
-pub type ZoomCallback = @fn(f32);
+/// Events that the windowing system sends to Servo.
+pub enum WindowEvent {
+    /// Sent when no message has arrived.
+    ///
+    /// FIXME(pcwalton): This is a bogus event and is only used because we don't have the new
+    /// scheduler integrated with the platform event loop.
+    IdleWindowEvent,
+    /// Sent when the window is to be redisplayed.
+    CompositeWindowEvent,
+    /// Sent when the window is resized.
+    ResizeWindowEvent(Size2D<uint>),
+    /// Sent when a new URL is to be loaded.
+    NavigateWindowEvent(~str),
+    /// Sent when a mouse event occurs.
+    MouseWindowEventClass(MouseWindowEvent),
+    /// Sent when the user scrolls.
+    ScrollWindowEvent(Point2D<f32>),
+    /// Sent when the user zooms.
+    ZoomWindowEvent(f32),
+    /// Sent when the user quits the application.
+    QuitWindowEvent,
+}
 
 /// Methods for an abstract Application.
 pub trait ApplicationMethods {
@@ -46,21 +51,9 @@ pub trait WindowMethods<A> {
     /// Presents the window to the screen (perhaps by page flipping).
     pub fn present(&mut self);
 
-    /// Registers a callback to run when a composite event occurs.
-    pub fn set_composite_callback(&mut self, new_composite_callback: CompositeCallback);
-    /// Registers a callback to run when a resize event occurs.
-    pub fn set_resize_callback(&mut self, new_resize_callback: ResizeCallback);
-    /// Registers a callback to run when a new URL is to be loaded.
-    pub fn set_load_url_callback(&mut self, new_load_url_callback: LoadUrlCallback);
-    /// Registers a callback to run when the user clicks.
-    pub fn set_mouse_callback(&mut self, new_mouse_callback: MouseCallback);
-    /// Registers a callback to run when the user scrolls.
-    pub fn set_scroll_callback(&mut self, new_scroll_callback: ScrollCallback);
-    /// Registers a callback to run when the user zooms.
-    pub fn set_zoom_callback(&mut self, new_zoom_callback: ZoomCallback);
+    /// Spins the event loop and returns the next event.
+    pub fn recv(@mut self) -> WindowEvent;
 
-    /// Spins the event loop.
-    pub fn check_loop(@mut self);
     /// Schedules a redisplay at the next turn of the event loop.
     pub fn set_needs_display(@mut self);
     /// Sets the ready state of the current page.


### PR DESCRIPTION
This will enable compositing to be cleaned up drastically and is necessary
for proper integration with the new scheduler.

r? @metajack
