### PR TITLE
Add initial support for the line-height property.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@ config.mk
 config.stamp
 config.tmp
 parser.out
-src/components/servo/dom/bindings/codegen/*.rs
-src/components/servo/dom/bindings/codegen/_cache/
-src/components/servo/dom/bindings/codegen/test/*.rs
-src/components/servo/dom/bindings/codegen/PrototypeList.h
-src/components/servo/dom/bindings/codegen/UnionTypes.h
-src/components/servo/dom/bindings/codegen/UnionConversions.h
+src/components/script/dom/bindings/codegen/*.rs
+src/components/script/dom/bindings/codegen/PrototypeList.h
+src/components/script/dom/bindings/codegen/UnionConversions.h
+src/components/script/dom/bindings/codegen/UnionTypes.h
+src/components/script/dom/bindings/codegen/_cache/
+src/components/script/dom/bindings/codegen/test/*.rs

--- a/src/components/gfx/platform/linux/font.rs
+++ b/src/components/gfx/platform/linux/font.rs
@@ -219,7 +219,7 @@ impl FontHandleMethods for FontHandle {
             x_height:         geometry::from_pt(0.0), //FIXME
             em_size:          em_size,
             ascent:           ascent,
-            descent:          descent,
+            descent:          -descent,
             max_advance:      max_advance
         }
     }

--- a/src/components/gfx/platform/macos/font.rs
+++ b/src/components/gfx/platform/macos/font.rs
@@ -150,13 +150,17 @@ impl FontHandleMethods for FontHandle {
                                                           &glyphs[0],
                                                           ptr::null(),
                                                           1);
-        Some(advance as FractionalPixel)
+        // TODO; On mac the font spacing looks a little small. Need to figure out why.
+        Some(advance * 1.08f as FractionalPixel)
     }
 
     fn get_metrics(&self) -> FontMetrics {
         let bounding_rect: CGRect = self.ctfont.bounding_box();
         let ascent = Au::from_pt(self.ctfont.ascent() as float);
         let descent = Au::from_pt(self.ctfont.descent() as float);
+        let em_size = Au::from_frac_px(self.ctfont.pt_size() as float);
+
+        let scale = (self.ctfont.pt_size() as float * 72f / 96f) / (self.ctfont.ascent() as float + self.ctfont.descent() as float);
 
         let metrics =  FontMetrics {
             underline_size:   Au::from_pt(self.ctfont.underline_thickness() as float),
@@ -168,9 +172,9 @@ impl FontHandleMethods for FontHandle {
             underline_offset: Au::from_pt(self.ctfont.underline_position() as float),
             leading:          Au::from_pt(self.ctfont.leading() as float),
             x_height:         Au::from_pt(self.ctfont.x_height() as float),
-            em_size:          ascent + descent,
-            ascent:           ascent,
-            descent:          descent,
+            em_size:          em_size,
+            ascent:           ascent.scale_by(scale),
+            descent:          descent.scale_by(scale),
             max_advance:      Au::from_pt(bounding_rect.size.width as float)
         };
 

--- a/src/components/gfx/text/util.rs
+++ b/src/components/gfx/text/util.rs
@@ -28,15 +28,15 @@ impl Eq for CompressionMode {
 // 
 // High level TODOs:
 //
-// * Issue #113: consider incoming text state (preceding spaces, arabic, etc)
+// * Issue #113: consider incoming text state (arabic, etc)
 //               and propogate outgoing text state (dual of above) 
 //
 // * Issue #114: record skipped and kept chars for mapping original to new text
 //
 // * Untracked: various edge cases for bidi, CJK, etc.
-pub fn transform_text(text: &str, mode: CompressionMode) -> ~str {
+pub fn transform_text(text: &str, mode: CompressionMode, incoming_whitespace: bool) -> (~str, bool) {
     let mut out_str: ~str = ~"";
-    match mode {
+    let out_whitespace = match mode {
         CompressNone | DiscardNewline => {
             for str::each_char(text) |ch: char| {
                 if is_discardable_char(ch, mode) {
@@ -49,18 +49,14 @@ pub fn transform_text(text: &str, mode: CompressionMode) -> ~str {
                     str::push_char(&mut out_str, ch);
                 }
             }
+            text.len() > 0 && is_in_whitespace(text.char_at_reverse(0), mode)
         },
 
         CompressWhitespace | CompressWhitespaceNewline => {
-            let mut in_whitespace: bool = false;
+            let mut in_whitespace: bool = incoming_whitespace;
             for str::each_char(text) |ch: char| {
                 // TODO: discard newlines between CJK chars
-                let mut next_in_whitespace: bool = match (ch, mode) {
-                    (' ', _)  => true,
-                    ('\t', _) => true,
-                    ('\n', CompressWhitespaceNewline) => true,
-                    (_, _)    => false
-                };
+                let mut next_in_whitespace: bool = is_in_whitespace(ch, mode);
                 
                 if !next_in_whitespace {
                     if is_always_discardable_char(ch) {
@@ -82,10 +78,20 @@ pub fn transform_text(text: &str, mode: CompressionMode) -> ~str {
                 // save whitespace context for next char
                 in_whitespace = next_in_whitespace;
             } /* /for str::each_char */
+            in_whitespace
         } 
-    }
+    };
 
-    return out_str;
+    return (out_str, out_whitespace);
+
+    fn is_in_whitespace(ch: char, mode: CompressionMode) -> bool {
+        match (ch, mode) {
+            (' ', _)  => true,
+            ('\t', _) => true,
+            ('\n', CompressWhitespaceNewline) => true,
+            (_, _)    => false
+        }
+    }
 
     fn is_discardable_char(ch: char, mode: CompressionMode) -> bool {
         if is_always_discardable_char(ch) {
@@ -143,7 +149,8 @@ fn test_transform_compress_none() {
     let mode = CompressNone;
 
     for uint::range(0, test_strs.len()) |i| {
-        assert!(transform_text(test_strs[i], mode) == test_strs[i]);
+        (trimmed_str, out) = transform_text(test_strs[i], mode, true);
+        assert!(trimmed_str == test_strs[i])
     }
 }
 
@@ -170,7 +177,8 @@ fn test_transform_discard_newline() {
     let mode = DiscardNewline;
 
     for uint::range(0, test_strs.len()) |i| {
-        assert!(transform_text(test_strs[i], mode) == oracle_strs[i]);
+        (trimmed_str, out) = transform_text(test_strs[i], mode, true);
+        assert!(trimmed_str == oracle_strs[i])
     }
 }
 
@@ -196,7 +204,8 @@ fn test_transform_compress_whitespace() {
     let mode = CompressWhitespace;
 
     for uint::range(0, test_strs.len()) |i| {
-        assert!(transform_text(test_strs[i], mode) == oracle_strs[i]);
+        (trimmed_str, out) = transform_text(test_strs[i], mode, true);
+        assert!(trimmed_str == oracle_strs[i])
     }
 }
 
@@ -210,7 +219,7 @@ fn test_transform_compress_whitespace_newline() {
                                  ~"foo bar baz",
                                  ~"foobarbaz\n\n"];
 
-    let oracle_strs : ~[~str] = ~[~" foo bar",
+    let oracle_strs : ~[~str] = ~[~"foo bar",
                                  ~"foo bar ",
                                  ~"foo bar",
                                  ~"foo bar",
@@ -222,6 +231,36 @@ fn test_transform_compress_whitespace_newline() {
     let mode = CompressWhitespaceNewline;
 
     for uint::range(0, test_strs.len()) |i| {
-        assert!(transform_text(test_strs[i], mode) == oracle_strs[i]);
+        (trimmed_str, out) = transform_text(test_strs[i], mode, true);
+        assert!(trimmed_str == oracle_strs[i])
+    }
+}
+
+#[test]
+fn test_transform_compress_whitespace_newline() {
+    let  test_strs : ~[~str] = ~[~"  foo bar",
+                                 ~"\nfoo bar",
+                                 ~"foo bar  ",
+                                 ~"foo\n bar",
+                                 ~"foo \nbar",
+                                 ~"  foo  bar  \nbaz",
+                                 ~"foo bar baz",
+                                 ~"foobarbaz\n\n"];
+
+    let oracle_strs : ~[~str] = ~[~" foo bar",
+                                 ~" foo bar",
+                                 ~"foo bar ",
+                                 ~"foo bar",
+                                 ~"foo bar",
+                                 ~" foo bar baz",
+                                 ~"foo bar baz",
+                                 ~"foobarbaz "];
+
+    assert!(test_strs.len() == oracle_strs.len());
+    let mode = CompressWhitespaceNewline;
+
+    for uint::range(0, test_strs.len()) |i| {
+        (trimmed_str, out) = transform_text(test_strs[i], mode, false);
+        assert!(trimmed_str == oracle_strs[i])
     }
 }

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -20,6 +20,12 @@ use gfx::text::util::*;
 use newcss::values::{CSSTextAlignCenter, CSSTextAlignJustify, CSSTextAlignLeft};
 use newcss::values::{CSSTextAlignRight, CSSTextDecoration, CSSTextDecorationUnderline};
 use script::dom::node::{AbstractNode, LayoutView};
+use newcss::values::{CSSTextAlignRight};
+use newcss::values::CSSTextDecorationUnderline;
+use newcss::values::CSSTextDecoration;
+use newcss::units::{Em, Px, Pt};
+use newcss::values::{CSSLineHeightNormal, CSSLineHeightNumber, CSSLineHeightLength, CSSLineHeightPercentage};
+
 use servo_util::range::Range;
 use std::deque::Deque;
 
@@ -191,17 +197,18 @@ impl TextRunScanner {
         assert!(inline.boxes.len() > 0);
         debug!("TextRunScanner: scanning %u boxes for text runs...", inline.boxes.len());
 
+        let mut last_whitespace = true;
         let mut out_boxes = ~[];
         for uint::range(0, flow.inline().boxes.len()) |box_i| {
             debug!("TextRunScanner: considering box: %?", flow.inline().boxes[box_i].debug_str());
             if box_i > 0 && !can_coalesce_text_nodes(flow.inline().boxes, box_i-1, box_i) {
-                self.flush_clump_to_list(ctx, flow, &mut out_boxes);
+                last_whitespace = self.flush_clump_to_list(ctx, flow, last_whitespace, &mut out_boxes);
             }
             self.clump.extend_by(1);
         }
         // handle remaining clumps
         if self.clump.length() > 0 {
-            self.flush_clump_to_list(ctx, flow, &mut out_boxes);
+            self.flush_clump_to_list(ctx, flow, last_whitespace, &mut out_boxes);
         }
 
         debug!("TextRunScanner: swapping out boxes.");
@@ -238,7 +245,8 @@ impl TextRunScanner {
     fn flush_clump_to_list(&mut self,
                            ctx: &mut LayoutContext,
                            flow: FlowContext,
-                           out_boxes: &mut ~[RenderBox]) {
+                           last_whitespace: bool,
+                           out_boxes: &mut ~[RenderBox]) -> bool {
         let inline = &mut *flow.inline();
         let in_boxes = &inline.boxes;
 
@@ -258,6 +266,8 @@ impl TextRunScanner {
             _ => false
         };
 
+        let mut new_whitespace = last_whitespace;
+
         match (is_singleton, is_text_clump) {
             (false, false) => {
                 fail!(~"WAT: can't coalesce non-text nodes in flush_clump_to_list()!")
@@ -275,35 +285,42 @@ impl TextRunScanner {
                 // TODO(#115): Use the actual CSS `white-space` property of the relevant style.
                 let compression = CompressWhitespaceNewline;
 
-                let transformed_text = transform_text(text, compression);
+                let (transformed_text, whitespace) = transform_text(text, compression, last_whitespace);
+                new_whitespace = whitespace;
 
-                // TODO(#177): Text run creation must account for the renderability of text by
-                // font group fonts. This is probably achieved by creating the font group above
-                // and then letting `FontGroup` decide which `Font` to stick into the text run.
-                let fontgroup = ctx.font_ctx.get_resolved_font_for_style(&font_style);
-                let run = @fontgroup.create_textrun(transformed_text, underline);
+                if transformed_text.len() > 0 {
+                    // TODO(#177): Text run creation must account for the renderability of text by
+                    // font group fonts. This is probably achieved by creating the font group above
+                    // and then letting `FontGroup` decide which `Font` to stick into the text run.
+                    let fontgroup = ctx.font_ctx.get_resolved_font_for_style(&font_style);
+                    let run = @fontgroup.create_textrun(transformed_text, underline);
 
-                debug!("TextRunScanner: pushing single text box in range: %?", self.clump);
-                let new_box = do old_box.with_imm_base |old_box_base| {
-                    let range = Range::new(0, run.char_len());
-                    @mut adapt_textbox_with_range(*old_box_base, run, range)
-                };
+                    debug!("TextRunScanner: pushing single text box in range: %?", self.clump);
+                    let new_box = do old_box.with_imm_base |old_box_base| {
+                        let range = Range::new(0, run.char_len());
+                        @mut adapt_textbox_with_range(*old_box_base, run, range)
+                    };
 
-                out_boxes.push(TextRenderBoxClass(new_box));
+                    out_boxes.push(TextRenderBoxClass(new_box));
+                }
             },
             (false, true) => {
                 // TODO(#115): Use the actual CSS `white-space` property of the relevant style.
                 let compression = CompressWhitespaceNewline;
 
                 // First, transform/compress text of all the nodes.
+                let mut last_whitespace = true;
                 let transformed_strs: ~[~str] = do vec::from_fn(self.clump.length()) |i| {
                     // TODO(#113): We should be passing the compression context between calls to
                     // `transform_text`, so that boxes starting and/or ending with whitespace can
                     // be compressed correctly with respect to the text run.
                     let idx = i + self.clump.begin();
-                    transform_text(in_boxes[idx].raw_text(), compression)
+                    let (new_str, new_whitespace) = transform_text(in_boxes[idx].raw_text(), compression, last_whitespace);
+                    last_whitespace = new_whitespace;
+                    new_str
                 };
-
+                new_whitespace = last_whitespace;
+                
                 // Next, concatenate all of the transformed strings together, saving the new
                 // character indices.
                 let mut run_str: ~str = ~"";
@@ -328,7 +345,7 @@ impl TextRunScanner {
                 // TextRuns contain a cycle which is usually resolved by the teardown
                 // sequence. If no clump takes ownership, however, it will leak.
                 let clump = self.clump;
-                let run = if clump.length() != 0 {
+                let run = if clump.length() != 0 && run_str.len() > 0 {
                     Some(@TextRun::new(fontgroup.fonts[0], run_str, underline))
                 } else {
                     None
@@ -373,6 +390,8 @@ impl TextRunScanner {
 
         let end = self.clump.end(); // FIXME: borrow checker workaround
         self.clump.reset(end, 0);
+
+        new_whitespace
     } // End of `flush_clump_to_list`.
 }
 
@@ -748,7 +767,6 @@ impl InlineFlowData {
         // TODO(#226): Get the CSS `line-height` property from each non-replaced inline element to
         // determine its height for computing linebox height.
 
-        let line_height = Au::from_px(20);
         let mut cur_y = Au(0);
 
         for self.lines.eachi |i, line_span| {
@@ -756,62 +774,62 @@ impl InlineFlowData {
 
             // These coordinates are relative to the left baseline.
             let mut linebox_bounding_box = Au::zero_rect();
+            let mut linebox_height = Au(0);
+            let mut baseline_offset = Au(0);
+
             let boxes = &mut self.boxes;
+
             for line_span.eachi |box_i| {
                 let cur_box = boxes[box_i]; // FIXME: borrow checker workaround
 
-                // Compute the height of each box.
-                match cur_box {
+                // Compute the height and bounding box of each box.
+                let bounding_box = match cur_box {
                     ImageRenderBoxClass(image_box) => {
                         let size = image_box.image.get_size();
                         let height = Au::from_px(size.get_or_default(Size2D(0, 0)).height);
                         image_box.base.position.size.height = height;
+
+                        image_box.base.position.translate(&Point2D(Au(0), -height))
                     }
-                    TextRenderBoxClass(*) => {
-                        // Text boxes are preinitialized.
+                    TextRenderBoxClass(text_box) => {
+
+                        let range = &text_box.range;
+                        let run = &text_box.run;
+                        
+                        // Compute the height based on the line-height and font size
+                        let text_bounds = run.metrics_for_range(range).bounding_box;
+                        let em_size = text_bounds.size.height;
+                        let line_height = match cur_box.line_height() {
+                            CSSLineHeightNormal => em_size.scale_by(1.14f),
+                            CSSLineHeightNumber(l) => em_size.scale_by(l),
+                            CSSLineHeightLength(Em(l)) => em_size.scale_by(l),
+                            CSSLineHeightLength(Px(l)) => Au::from_frac_px(l),
+                            CSSLineHeightLength(Pt(l)) => Au::from_pt(l),
+                            CSSLineHeightPercentage(p) => em_size.scale_by(p / 100.0f)
+                        };
+
+                        // If this is the current tallest box then use it for baseline
+                        // calculations.
+                        // TODO: this will need to take into account type of line-height
+                        // and the vertical-align value.
+                        if line_height > linebox_height {
+                            linebox_height = line_height;
+                            // Offset from the top of the linebox
+                            baseline_offset = text_box.run.font.metrics.ascent +
+                                    (linebox_height - em_size).scale_by(0.5f);
+                        }
+                        text_bounds.translate(&Point2D(text_box.base.position.origin.x, Au(0)))
                     }
                     GenericRenderBoxClass(generic_box) => {
                         // TODO(Issue #225): There will be different cases here for `inline-block`
                         // and other replaced content.
                         // FIXME(pcwalton): This seems clownshoes; can we remove?
                         generic_box.position.size.height = Au::from_px(30);
+                        generic_box.position
                     }
                     // FIXME(pcwalton): This isn't very type safe!
                     _ => {
                         fail!(fmt!("Tried to assign height to unknown Box variant: %s",
-                                   cur_box.debug_str()))
-                    }
-                }
-
-                // Compute the bounding rect with the left baseline as origin. Determining line box
-                // height is a matter of lining up ideal baselines and then taking the union of all
-                // these rects.
-                let bounding_box = match cur_box {
-                    // Adjust to baseline coordinates.
-                    //
-                    // TODO(#227): Use left/right margins, border, padding for nonreplaced content,
-                    // and also use top/bottom margins, border, padding for replaced or
-                    // inline-block content.
-                    //
-                    // TODO(#225): Use height, width for `inline-block` and other replaced content.
-                    ImageRenderBoxClass(*) | GenericRenderBoxClass(*) => {
-                        let height = cur_box.position().size.height;
-                        cur_box.position().translate(&Point2D(Au(0), -height))
-                    },
-
-                    // Adjust the bounding box metric to the box's horizontal offset.
-                    //
-                    // TODO: We can use font metrics directly instead of re-measuring for the
-                    // bounding box.
-                    TextRenderBoxClass(text_box) => {
-                        let range = &text_box.range;
-                        let run = &text_box.run;
-                        let text_bounds = run.metrics_for_range(range).bounding_box;
-                        text_bounds.translate(&Point2D(text_box.base.position.origin.x, Au(0)))
-                    },
-
-                    _ => {
-                        fail!(fmt!("Tried to compute bounding box of unknown Box variant: %s",
                                    cur_box.debug_str()))
                     }
                 };
@@ -825,9 +843,6 @@ impl InlineFlowData {
                 debug!("assign_height_inline: linebox bounding box = %?", linebox_bounding_box);
             }
 
-            let linebox_height = linebox_bounding_box.size.height;
-            let baseline_offset = -linebox_bounding_box.origin.y;
-
             // Now go back and adjust the Y coordinates to match the baseline we determined.
             for line_span.eachi |box_i| {
                 let cur_box = boxes[box_i];
@@ -835,30 +850,20 @@ impl InlineFlowData {
                 // TODO(#226): This is completely wrong. We need to use the element's `line-height`
                 // when calculating line box height. Then we should go back over and set Y offsets
                 // according to the `vertical-align` property of the containing block.
-                let halfleading = match cur_box {
+                let offset = match cur_box {
                     TextRenderBoxClass(text_box) => {
-                        //ad is the AD height as defined by CSS 2.1 § 10.8.1
-                        let ad = text_box.run.font.metrics.ascent + text_box.run.font.metrics.descent;
-                        (line_height - ad).scale_by(0.5)
+                        baseline_offset - text_box.run.font.metrics.ascent
                     },
                     _ => Au(0),
                 };
 
-                //FIXME: when line-height is set on an inline element, the half leading
-                //distance can be negative.
-                let halfleading = Au::max(halfleading, Au(0));
-                
-                let height = match cur_box {
-                    TextRenderBoxClass(text_box) => text_box.run.font.metrics.ascent,
-                    _ => cur_box.position().size.height
-                };
-
                 do cur_box.with_mut_base |base| {
-                    base.position.origin.y = cur_y + halfleading + baseline_offset - height;
+                    let height = base.position.size.height;
+                    base.position.origin.y = offset + cur_y;
                 }
             }
 
-            cur_y += Au::max(line_height, linebox_height);
+            cur_y += linebox_height;
         } // End of `lines.each` loop.
 
         self.common.position.size.height = cur_y;

--- a/src/test/html/lineheight-simple.css
+++ b/src/test/html/lineheight-simple.css
@@ -1,0 +1,10 @@
+#larger1 {
+	font-size: 20px;
+	line-height: 2;
+}
+
+#larger2 {
+	font-size: 30px;
+	line-height: 1;
+}
+

--- a/src/test/html/lineheight-simple.html
+++ b/src/test/html/lineheight-simple.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="lineheight-simple.css"/>
+</head>
+<body>
+<div>Regular font <span id="larger1">Even larger with line-height 2</span></div>
+<div id="larger2">Large line 2!</div>
+</body>
+</html>


### PR DESCRIPTION
Line height is only based on the tallest box in each line and does not factor in the vertical-alignment. Improves whitespace handling by passing the whitespace state between function invocations.

There were too many changes on master to easily rebase. It was easier to merge to a fresh branch.

Here is the original PR: https://github.com/mozilla/servo/pull/509
