### PR TITLE
Dynamic Resolution

### DIFF
--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -10,6 +10,7 @@ use windowing::{ApplicationMethods, WindowMethods, WindowMouseEvent, WindowClick
 use windowing::{WindowMouseDownEvent, WindowMouseUpEvent};
 use servo_msg::compositor::{RenderListener, LayerBufferSet, RenderState};
 use servo_msg::compositor::{ReadyState, ScriptListener};
+use gfx::render_task::{RenderChan, ReRenderMsg};
 
 use azure::azure_hl::{DataSourceSurface, DrawTarget, SourceSurfaceMethods, current_gl_context};
 use azure::azure::AzGLContext;
@@ -28,6 +29,7 @@ use layers::scene::Scene;
 use servo_util::{time, url};
 use servo_util::time::profile;
 use servo_util::time::ProfilerChan;
+
 
 /// The implementation of the layers-based compositor.
 #[deriving(Clone)]
@@ -84,6 +86,8 @@ pub enum Msg {
     ChangeRenderState(RenderState),
     /// Sets the channel to the current layout task
     SetLayoutChan(LayoutChan),
+    /// Sets the channel to the current renderer
+    SetRenderChan(RenderChan<CompositorChan>),
 }
 
 /// Azure surface wrapping to work with the layers infrastructure.
@@ -166,6 +170,11 @@ impl CompositorTask {
 
         // Keeps track of the current zoom factor
         let world_zoom = @mut 1f32;
+        // Keeps track of local zoom factor. Reset to 1 after a rerender event.
+        let local_zoom = @mut 1f32;
+        // Channel to the current renderer.
+        // FIXME: This probably shouldn't be stored like this.
+        let render_chan: @mut Option<RenderChan<CompositorChan>> = @mut None;
 
         let update_layout_callbacks: @fn(LayoutChan) = |layout_chan: LayoutChan| {
             let layout_chan_clone = layout_chan.clone();
@@ -200,6 +209,16 @@ impl CompositorTask {
                         event = MouseDownEvent(button, world_mouse_point(layer_mouse_point));
                     }
                     WindowMouseUpEvent(button, layer_mouse_point) => {
+                        
+                        // rerender layer at new zoom level
+                        // FIXME: this should happen when the user stops zooming, definitely not here
+                        match *render_chan {
+                            Some(ref r_chan) => {
+                                r_chan.send(ReRenderMsg(*world_zoom));
+                            }
+                            None => {} // Nothing to do
+                        }
+                        
                         event = MouseUpEvent(button, world_mouse_point(layer_mouse_point));
                     }
                 }
@@ -218,6 +237,10 @@ impl CompositorTask {
 
                     SetLayoutChan(layout_chan) => {
                         update_layout_callbacks(layout_chan);
+                    }
+
+                    SetRenderChan(new_render_chan) => {
+                        *render_chan = Some(new_render_chan);
                     }
 
                     GetGLContext(chan) => chan.send(current_gl_context()),
@@ -248,7 +271,7 @@ impl CompositorTask {
                                 None => {
                                     debug!("osmain: adding new texture layer");
                                     texture_layer = @mut TextureLayer::new(@buffer.draw_target.clone() as @TextureManager,
-                                                                           buffer.rect.size);
+                                                                           buffer.screen_pos.size);
                                     root_layer.add_child(TextureLayerKind(texture_layer));
                                     None
                                 }
@@ -272,6 +295,21 @@ impl CompositorTask {
                             let transform = transform.scale(width as f32, height as f32, 1.0);
                             texture_layer.common.set_transform(transform);
                         }
+
+                        // Delete leftover layers
+                        while current_layer_child.is_some() {
+                            let trash = current_layer_child.get();
+                            do current_layer_child.get().with_common |common| {
+                                current_layer_child = common.next_sibling;
+                            }
+                            root_layer.remove_child(trash);
+                        }
+
+                        // Reset zoom
+                        *local_zoom = 1f32;
+                        root_layer.common.set_transform(identity().translate(-world_offset.x,
+                                                                             -world_offset.y,
+                                                                             0.0));
 
                         // TODO: Recycle the old buffers; send them back to the renderer to reuse if
                         // it wishes.
@@ -304,24 +342,25 @@ impl CompositorTask {
 
             // Clamp the world offset to the screen size.
             let max_x = (page_size.width * *world_zoom - window_size.width as f32).max(&0.0);
-            world_offset.x = world_offset.x.clamp(&0.0, &max_x);
+            world_offset.x = world_offset.x.clamp(&0.0, &max_x).round();
             let max_y = (page_size.height * *world_zoom - window_size.height as f32).max(&0.0);
-            world_offset.y = world_offset.y.clamp(&0.0, &max_y);
-
+            world_offset.y = world_offset.y.clamp(&0.0, &max_y).round();
+            
             debug!("compositor: scrolled to %?", *world_offset);
-
+            
+            
             let mut scroll_transform = identity();
-
-            scroll_transform = scroll_transform.translate(window_size.width as f32 / 2f32 * *world_zoom - world_offset.x,
-                                                      window_size.height as f32 / 2f32 * *world_zoom - world_offset.y,
-                                                      0.0);
-            scroll_transform = scroll_transform.scale(*world_zoom, *world_zoom, 1f32);
+            
+            scroll_transform = scroll_transform.translate(window_size.width as f32 / 2f32 * *local_zoom - world_offset.x,
+                                                          window_size.height as f32 / 2f32 * *local_zoom - world_offset.y,
+                                                          0.0);
+            scroll_transform = scroll_transform.scale(*local_zoom, *local_zoom, 1f32);
             scroll_transform = scroll_transform.translate(window_size.width as f32 / -2f32,
-                                                      window_size.height as f32 / -2f32,
-                                                      0.0);
-
+                                                          window_size.height as f32 / -2f32,
+                                                          0.0);
+            
             root_layer.common.set_transform(scroll_transform);
-
+            
             window.set_needs_display()
         }
 
@@ -333,6 +372,7 @@ impl CompositorTask {
 
             // Determine zoom amount
             *world_zoom = (*world_zoom * magnification).max(&1.0);            
+            *local_zoom = *local_zoom * *world_zoom/old_world_zoom;
 
             // Update world offset
             let corner_to_center_x = world_offset.x + window_size.width as f32 / 2f32;
@@ -345,23 +385,22 @@ impl CompositorTask {
 
             // Clamp to page bounds when zooming out
             let max_x = (page_size.width * *world_zoom - window_size.width as f32).max(&0.0);
-            world_offset.x = world_offset.x.clamp(&0.0, &max_x);
+            world_offset.x = world_offset.x.clamp(&0.0, &max_x).round();
             let max_y = (page_size.height * *world_zoom - window_size.height as f32).max(&0.0);
-            world_offset.y = world_offset.y.clamp(&0.0, &max_y);
-
-
+            world_offset.y = world_offset.y.clamp(&0.0, &max_y).round();
+            
             // Apply transformations
             let mut zoom_transform = identity();
-            zoom_transform = zoom_transform.translate(window_size.width as f32 / 2f32 * *world_zoom - world_offset.x,
-                                                      window_size.height as f32 / 2f32 * *world_zoom - world_offset.y,
+            zoom_transform = zoom_transform.translate(window_size.width as f32 / 2f32 * *local_zoom - world_offset.x,
+                                                      window_size.height as f32 / 2f32 * *local_zoom - world_offset.y,
                                                       0.0);
-            zoom_transform = zoom_transform.scale(*world_zoom, *world_zoom, 1f32);
+            zoom_transform = zoom_transform.scale(*local_zoom, *local_zoom, 1f32);
             zoom_transform = zoom_transform.translate(window_size.width as f32 / -2f32,
                                                       window_size.height as f32 / -2f32,
                                                       0.0);
             root_layer.common.set_transform(zoom_transform);
-
-
+            
+            
             window.set_needs_display()
         }
         // Enter the main event loop.

--- a/src/components/main/engine.rs
+++ b/src/components/main/engine.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use compositing::{CompositorChan, SetLayoutChan};
+use compositing::{CompositorChan, SetLayoutChan, SetRenderChan};
 use layout::layout_task;
 
 use core::cell::Cell;
@@ -62,6 +62,8 @@ impl Engine {
 
 
         compositor_chan.send(SetLayoutChan(layout_chan.clone()));
+        compositor_chan.send(SetRenderChan(render_chan.clone()));
+
         let compositor_chan = Cell(compositor_chan);
 
         let opts = Cell(copy *opts);

--- a/src/components/msg/compositor.rs
+++ b/src/components/msg/compositor.rs
@@ -11,8 +11,9 @@ pub struct LayerBuffer {
     draw_target: DrawTarget,
 
     // The rect in the containing RenderLayer that this represents.
-    rect: Rect<uint>,
+    rect: Rect<f32>,
 
+    // The rect in pixels that will be drawn to the screen.
     screen_pos: Rect<uint>,
 
     // NB: stride is in pixels, like OpenGL GL_UNPACK_ROW_LENGTH.


### PR DESCRIPTION
There is now a SharedChan from the compositor to the renderer. Using this, tiles are re-rendered the tiles at a higher resolution after zooming (this is currently bound to a MouseClickUp event). Also, extra texture layers are deleted, which fixes a bug where old content was being displayed when a new paint message was sent.

Depends on rust-layers: 1e1e359da32c9d0ddb4f93b505a658d669008426
