### PR TITLE
Preliminary float functionality

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -267,7 +267,7 @@ impl BlockFlowData {
         // child[i-1].floats_out -> child[i].floats_in
         // visit child[i]
         // repeat until all children are visited.
-        // last_child.floats_out -> self.floats_out (done at the end of this function)
+        // last_child.floats_out -> self.floats_out (done at the end of this method)
         let mut float_ctx = self.common.floats_in.clone();
         for BlockFlow(self).each_child |kid| {
             do kid.with_mut_base |child_node| {

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -249,11 +249,13 @@ impl BlockFlowData {
     pub fn assign_height_block(@mut self, ctx: &mut LayoutContext) {
         let mut cur_y = Au(0);
         let mut top_offset = Au(0);
+        let mut left_offset = Au(0);
 
         for self.box.each |&box| {
             do box.with_model |model| {
                 top_offset = model.margin.top + model.border.top + model.padding.top;
                 cur_y += top_offset;
+                left_offset = model.offset();
             }
         }
 
@@ -268,7 +270,7 @@ impl BlockFlowData {
         // visit child[i]
         // repeat until all children are visited.
         // last_child.floats_out -> self.floats_out (done at the end of this method)
-        let mut float_ctx = self.common.floats_in.clone();
+        let mut float_ctx = self.common.floats_in.translate(Point2D(-left_offset, -top_offset));
         for BlockFlow(self).each_child |kid| {
             do kid.with_mut_base |child_node| {
                 child_node.floats_in = float_ctx.clone();
@@ -310,7 +312,7 @@ impl BlockFlowData {
         self.common.position.size.height = height + noncontent_height;
 
     
-        self.common.floats_out = float_ctx.translate(Point2D(Au(0), self.common.position.size.height));
+        self.common.floats_out = float_ctx.translate(Point2D(left_offset, self.common.position.size.height));
     }
 
     pub fn build_display_list_block<E:ExtraDisplayListData>(@mut self,

--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -161,6 +161,18 @@ impl BoxGenerator {
                 assert!(block.box.is_none());
                 block.box = Some(new_box);
             },
+            FloatFlow(float) => {
+                debug!("BoxGenerator[f%d]: point b", float.common.id);
+                let new_box = self.make_box(ctx, box_type, node, self.flow, builder);
+
+                debug!("BoxGenerator[f%d]: attaching box[b%d] to float flow (node: %s)",
+                       float.common.id,
+                       new_box.id(),
+                       node.debug_str());
+
+                assert!(float.box.is_none());
+                float.box = Some(new_box);
+            },
             _ => warn!("push_node() not implemented for flow f%d", self.flow.id()),
         }
     }
@@ -384,7 +396,9 @@ pub impl LayoutTreeBuilder {
             // Inlines that are children of blocks create new flows if their
             // previous sibling was a block.
             (CSSDisplayInline, BlockFlow(*), Some(BlockFlow(*))) |
-            (CSSDisplayInlineBlock, BlockFlow(*), Some(BlockFlow(*))) => {
+            (CSSDisplayInlineBlock, BlockFlow(*), Some(BlockFlow(*))) |
+            (CSSDisplayInline, BlockFlow(*), Some(FloatFlow(*))) |
+            (CSSDisplayInlineBlock, BlockFlow(*), Some(FloatFlow(*))) => {
                 self.create_child_generator(node, parent_generator, Flow_Inline)
             }
 

--- a/src/components/main/layout/float.rs
+++ b/src/components/main/layout/float.rs
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use layout::box::{RenderBox};
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::display_list_builder::{FlowDisplayListBuilderMethods};
+use layout::flow::{FloatFlow, FlowData};
+use layout::model::{MaybeAuto};
+use layout::float_context::{FloatContext, PlacementInfo, FloatLeft};
+
+use core::cell::Cell;
+use geom::point::Point2D;
+use geom::rect::Rect;
+use gfx::display_list::DisplayList;
+use gfx::geometry::Au;
+use gfx::geometry;
+use servo_util::tree::{TreeNodeRef, TreeUtils};
+
+pub struct FloatFlowData {
+    /// Data common to all flows.
+    common: FlowData,
+
+    /// The associated render box.
+    box: Option<RenderBox>,
+
+    containing_width: Au,
+
+
+    /// Index into the box list for inline floats
+    index: Option<uint>,
+
+}
+
+impl FloatFlowData {
+    pub fn new(common: FlowData) -> FloatFlowData {
+        FloatFlowData {
+            common: common,
+            containing_width: Au(0),
+            box: None,
+            index: None,
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        self.common.teardown();
+        for self.box.each |box| {
+            box.teardown();
+        }
+        self.box = None;
+        self.index = None;
+    }
+}
+
+impl FloatFlowData {
+    pub fn bubble_widths_float(@mut self, ctx: &LayoutContext) {
+        let mut min_width = Au(0);
+        let mut pref_width = Au(0);
+
+        self.common.num_floats = 1;
+
+        for FloatFlow(self).each_child |child_ctx| {
+            //assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow());
+
+            do child_ctx.with_mut_base |child_node| {
+                min_width = geometry::max(min_width, child_node.min_width);
+                pref_width = geometry::max(pref_width, child_node.pref_width);
+                child_node.floats_in = FloatContext::new(child_node.num_floats);
+            }
+        }
+
+        self.box.map(|&box| {
+            let style = box.style();
+            do box.with_model |model| {
+                model.compute_borders(style)
+            }
+
+            min_width = min_width.add(&box.get_min_width(ctx));
+            pref_width = pref_width.add(&box.get_pref_width(ctx));
+        });
+
+        self.common.min_width = min_width;
+        self.common.pref_width = pref_width;
+    }
+
+    pub fn assign_widths_float(@mut self, _: &LayoutContext) { 
+        debug!("assign_widths_block: assigning width for flow %?",  self.common.id);
+        // position.size.width is set by parent even though we don't know
+        // position.origin yet.
+        let mut remaining_width = self.common.position.size.width;
+        self.containing_width = remaining_width;
+        let mut x_offset = Au(0);
+
+        for self.box.each |&box| {
+            let style = box.style();
+            do box.with_model |model| {
+                // Can compute padding here since we know containing block width.
+                model.compute_padding(style, remaining_width);
+
+                // Margins for floats are 0 if auto.
+                let margin_top = MaybeAuto::from_margin(style.margin_top(),
+                                                        remaining_width).spec_or_default(Au(0));
+                let margin_bottom = MaybeAuto::from_margin(style.margin_bottom(),
+                                                           remaining_width).spec_or_default(Au(0));
+                let margin_left = MaybeAuto::from_margin(style.margin_left(),
+                                                        remaining_width).spec_or_default(Au(0));
+                let margin_right = MaybeAuto::from_margin(style.margin_right(),
+                                                           remaining_width).spec_or_default(Au(0));
+
+
+
+                let shrink_to_fit = geometry::min(self.common.pref_width, 
+                                                  geometry::max(self.common.min_width, 
+                                                                remaining_width));
+
+
+                let width = MaybeAuto::from_width(style.width(), 
+                                                  remaining_width).spec_or_default(shrink_to_fit);
+
+                model.margin.top = margin_top;
+                model.margin.right = margin_right;
+                model.margin.bottom = margin_bottom;
+                model.margin.left = margin_left;
+
+                self.common.position.size.width = width;
+                x_offset = model.offset();
+                remaining_width = width;
+            }
+
+            do box.with_mut_base |base| {
+                //The associated box is the border box of this flow
+                base.position.origin.x = base.model.margin.left;
+
+                let pb = base.model.padding.left + base.model.padding.right +
+                    base.model.border.left + base.model.border.right;
+                base.position.size.width = remaining_width + pb;
+            }
+        }
+
+        for FloatFlow(self).each_child |kid| {
+            //assert!(kid.starts_block_flow() || kid.starts_inline_flow());
+
+            do kid.with_mut_base |child_node| {
+                child_node.position.origin.x = x_offset;
+                child_node.position.size.width = remaining_width;
+            }
+        }
+    }
+
+    pub fn assign_height_float(@mut self, ctx: &mut LayoutContext) {
+        for FloatFlow(self).each_child |kid| {
+            kid.assign_height(ctx);
+        }
+
+        let mut cur_y = Au(0);
+        let mut top_offset = Au(0);
+
+        for self.box.each |&box| {
+            do box.with_model |model| {
+                top_offset = model.margin.top + model.border.top + model.padding.top;
+                cur_y += top_offset;
+            }
+        }
+
+        for FloatFlow(self).each_child |kid| {
+            do kid.with_mut_base |child_node| {
+                child_node.position.origin.y = cur_y;
+                cur_y += child_node.position.size.height;
+            }
+        }
+
+        let height = cur_y - top_offset;
+        
+        let mut noncontent_height = Au(0);
+        self.box.map(|&box| {
+            do box.with_mut_base |base| {
+                //The associated box is the border box of this flow
+                base.position.origin.y = base.model.margin.top;
+
+                noncontent_height = base.model.padding.top + base.model.padding.bottom +
+                    base.model.border.top + base.model.border.bottom;
+                base.position.size.height = height + noncontent_height;
+
+                noncontent_height += base.model.margin.top + base.model.margin.bottom;
+            }
+        });
+
+        //TODO(eatkinson): compute heights using the 'height' property.
+        self.common.position.size.height = height + noncontent_height;
+
+        let info = PlacementInfo {
+            width: self.common.position.size.width,
+            height: self.common.position.size.height,
+            ceiling: Au(0),
+            max_width: self.containing_width,
+            f_type: FloatLeft,
+        };
+
+        self.common.floats_out = self.common.floats_in.add_float(&info);
+
+
+
+    }
+
+    pub fn build_display_list_float<E:ExtraDisplayListData>(@mut self,
+                                                            builder: &DisplayListBuilder,
+                                                            dirty: &Rect<Au>, 
+                                                            offset: &Point2D<Au>,
+                                                            list: &Cell<DisplayList<E>>) {
+        self.box.map(|&box| {
+            box.build_display_list(builder, dirty, offset, list)
+        });
+
+
+        // go deeper into the flow tree
+        let flow = FloatFlow(self);
+        for flow.each_child |child| {
+            flow.build_display_list_for_child(builder, child, dirty, offset, list)
+        }
+    }
+}
+

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -420,11 +420,17 @@ impl<'self> FlowContext {
                     None => ~"BlockFlow",
                 }
             },
+            FloatFlow(float) => {
+                match float.box {
+                    Some(box) => fmt!("FloatFlow(box=b%d)", box.id()),
+                    None => ~"FloatFlow",
+                }
+            },
             _ => ~"(Unknown flow)"
         };
 
         do self.with_base |base| {
-            fmt!("f%? %? floats %?", base.id, repr, base.num_floats)
+            fmt!("f%? %? floats %? size %?", base.id, repr, base.num_floats, base.position)
         }
     }
 }

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -26,10 +26,12 @@
 ///   similar methods.
 
 use layout::block::BlockFlowData;
+use layout::float::FloatFlowData;
 use layout::box::RenderBox;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::inline::{InlineFlowData};
+use layout::float_context::{FloatContext, Invalid};
 
 use core::cell::Cell;
 use geom::point::Point2D;
@@ -44,7 +46,7 @@ use servo_util::tree::{TreeNode, TreeNodeRef, TreeUtils};
 pub enum FlowContext {
     AbsoluteFlow(@mut FlowData), 
     BlockFlow(@mut BlockFlowData),
-    FloatFlow(@mut FlowData),
+    FloatFlow(@mut FloatFlowData),
     InlineBlockFlow(@mut FlowData),
     InlineFlow(@mut InlineFlowData),
     TableFlow(@mut FlowData),
@@ -70,10 +72,10 @@ impl FlowContext {
     pub fn teardown(&self) {
         match *self {
           AbsoluteFlow(data) |
-          FloatFlow(data) |
           InlineBlockFlow(data) |
           TableFlow(data) => data.teardown(),
           BlockFlow(data) => data.teardown(),
+          FloatFlow(data) => data.teardown(),
           InlineFlow(data) => data.teardown()
         }
     }
@@ -110,7 +112,7 @@ impl TreeNodeRef<FlowData> for FlowContext {
             BlockFlow(info) => {
                 callback(&info.common)
             }
-            FloatFlow(info) => callback(info),
+            FloatFlow(info) => callback(&info.common),
             InlineBlockFlow(info) => callback(info),
             InlineFlow(info) => {
                 callback(&info.common)
@@ -124,7 +126,7 @@ impl TreeNodeRef<FlowData> for FlowContext {
             BlockFlow(info) => {
                 callback(&mut info.common)
             }
-            FloatFlow(info) => callback(info),
+            FloatFlow(info) => callback(&mut info.common),
             InlineBlockFlow(info) => callback(info),
             InlineFlow(info) => {
                 callback(&mut info.common)
@@ -156,6 +158,9 @@ pub struct FlowData {
     min_width: Au,
     pref_width: Au,
     position: Rect<Au>,
+    floats_in: FloatContext,
+    floats_out: FloatContext,
+    num_floats: uint,
 }
 
 impl TreeNode<FlowContext> for FlowData {
@@ -216,6 +221,9 @@ impl FlowData {
             min_width: Au(0),
             pref_width: Au(0),
             position: Au::zero_rect(),
+            floats_in: Invalid,
+            floats_out: Invalid,
+            num_floats: 0,
         }
     }
 }
@@ -264,6 +272,7 @@ impl<'self> FlowContext {
         match *self {
             BlockFlow(info)  => info.bubble_widths_block(ctx),
             InlineFlow(info) => info.bubble_widths_inline(ctx),
+            FloatFlow(info)  => info.bubble_widths_float(ctx),
             _ => fail!(fmt!("Tried to bubble_widths of flow: f%d", self.id()))
         }
     }
@@ -272,6 +281,7 @@ impl<'self> FlowContext {
         match *self {
             BlockFlow(info)  => info.assign_widths_block(ctx),
             InlineFlow(info) => info.assign_widths_inline(ctx),
+            FloatFlow(info)  => info.assign_widths_float(ctx),
             _ => fail!(fmt!("Tried to assign_widths of flow: f%d", self.id()))
         }
     }
@@ -280,6 +290,7 @@ impl<'self> FlowContext {
         match *self {
             BlockFlow(info)  => info.assign_height_block(ctx),
             InlineFlow(info) => info.assign_height_inline(ctx),
+            FloatFlow(info)  => info.assign_height_float(ctx),
             _ => fail!(fmt!("Tried to assign_height of flow: f%d", self.id()))
         }
     }
@@ -296,6 +307,7 @@ impl<'self> FlowContext {
         match *self {
             BlockFlow(info)  => info.build_display_list_block(builder, dirty, offset, list),
             InlineFlow(info) => info.build_display_list_inline(builder, dirty, offset, list),
+            FloatFlow(info)  => info.build_display_list_float(builder, dirty, offset, list),
             _ => fail!(fmt!("Tried to build_display_list_recurse of flow: %?", self))
         }
     }
@@ -412,7 +424,7 @@ impl<'self> FlowContext {
         };
 
         do self.with_base |base| {
-            fmt!("f%? %? size %?", base.id, repr, base.position)
+            fmt!("f%? %? floats %?", base.id, repr, base.num_floats)
         }
     }
 }

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -225,9 +225,9 @@ impl Layout {
             for layout_root.traverse_preorder |flow| {
                 flow.assign_widths(&mut layout_ctx);
             };
-            for layout_root.traverse_postorder |flow| {
-                flow.assign_height(&mut layout_ctx);
-            };
+
+            // For now, this is an inorder traversal
+            layout_root.assign_height(&mut layout_ctx);
         }
 
         // Build the display list if necessary, and send it to the renderer.

--- a/src/components/main/layout/model.rs
+++ b/src/components/main/layout/model.rs
@@ -20,6 +20,7 @@ use newcss::units::{Em, Pt, Px};
 use newcss::values::{CSSBorderWidth, CSSBorderWidthLength, CSSBorderWidthMedium};
 use newcss::values::{CSSBorderWidthThick, CSSBorderWidthThin};
 use newcss::values::{CSSWidth, CSSWidthLength, CSSWidthPercentage, CSSWidthAuto};
+use newcss::values::{CSSHeight, CSSHeightLength, CSSHeightPercentage, CSSHeightAuto};
 use newcss::values::{CSSMargin, CSSMarginLength, CSSMarginPercentage, CSSMarginAuto};
 use newcss::values::{CSSPadding, CSSPaddingLength, CSSPaddingPercentage};
 /// Encapsulates the borders, padding, and margins, which we collectively call the "box model".
@@ -58,6 +59,17 @@ impl MaybeAuto{
             CSSWidthLength(Px(v)) | 
             CSSWidthLength(Pt(v)) | 
             CSSWidthLength(Em(v)) => Specified(Au::from_frac_px(v)),
+        }
+    }
+
+    pub fn from_height(height: CSSHeight, cb_height: Au) -> MaybeAuto{
+        match height {
+            CSSHeightAuto => Auto,
+            CSSHeightPercentage(percent) => Specified(cb_height.scale_by(percent/100.0)),
+            //FIXME(eatkinson): Compute pt and em values properly
+            CSSHeightLength(Px(v)) | 
+            CSSHeightLength(Pt(v)) | 
+            CSSHeightLength(Em(v)) => Specified(Au::from_frac_px(v)),
         }
     }
 

--- a/src/components/main/layout/model.rs
+++ b/src/components/main/layout/model.rs
@@ -112,7 +112,7 @@ impl BoxModel {
     }
 
     /// Helper function to compute the border width in app units from the CSS border width.
-    priv fn compute_border_width(&self, width: CSSBorderWidth) -> Au {
+    pub fn compute_border_width(&self, width: CSSBorderWidth) -> Au {
         match width {
             CSSBorderWidthLength(Px(v)) |
             CSSBorderWidthLength(Em(v)) |
@@ -126,7 +126,7 @@ impl BoxModel {
         }
     }
 
-    fn compute_padding_length(&self, padding: CSSPadding, content_box_width: Au) -> Au {
+    pub fn compute_padding_length(&self, padding: CSSPadding, content_box_width: Au) -> Au {
         match padding {
             CSSPaddingLength(Px(v)) |
             CSSPaddingLength(Pt(v)) |

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -73,7 +73,8 @@ pub mod layout {
     pub mod inline;
     pub mod model;
     pub mod text;
-    pub mod floats;
+    pub mod float_context;
+    pub mod float;
     mod aux;
 }
 

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -73,6 +73,7 @@ pub mod layout {
     pub mod inline;
     pub mod model;
     pub mod text;
+    pub mod floats;
     mod aux;
 }
 


### PR DESCRIPTION
I added the minimal amount of code needed to place left-floats on the screen (right floats should also be possible soon). Text does not wrap around floats yet.

One thing I'm curious about is whether some existing abstractions (like Cell) can be used instead of this weird overwriting thing done in float_context.rs.
