### PR TITLE
Cache shaped text at word granularity

### DIFF
--- a/src/components/gfx/font.rs
+++ b/src/components/gfx/font.rs
@@ -86,7 +86,7 @@ pub struct FontMetrics {
 }
 
 // TODO(Issue #200): use enum from CSS bindings for 'font-weight'
-#[deriving(Eq)]
+#[deriving(Clone, Eq)]
 pub enum CSSFontWeight {
     FontWeight100,
     FontWeight200,
@@ -114,7 +114,7 @@ impl CSSFontWeight {
 // the instance's properties.
 //
 // For now, the cases are differentiated with a typedef
-#[deriving(Eq)]
+#[deriving(Clone, Eq)]
 pub struct FontStyle {
     pt_size: float,
     weight: CSSFontWeight,
@@ -139,7 +139,7 @@ struct ResolvedFont {
 // It's used to swizzle/unswizzle gfx::Font instances when
 // communicating across tasks, such as the display list between layout
 // and render tasks.
-#[deriving(Eq)]
+#[deriving(Clone, Eq)]
 pub struct FontDescriptor {
     style: UsedFontStyle,
     selector: FontSelector,
@@ -155,7 +155,7 @@ impl FontDescriptor {
 }
 
 // A FontSelector is a platform-specific strategy for serializing face names.
-#[deriving(Eq)]
+#[deriving(Clone, Eq)]
 pub enum FontSelector {
     SelectorPlatformIdentifier(~str),
 }

--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -6,8 +6,7 @@ use font::{Font, FontDescriptor, FontGroup, FontHandleMethods, FontStyle,
            SelectorPlatformIdentifier};
 use font::{SpecifiedFontStyle, UsedFontStyle};
 use font_list::FontList;
-use servo_util::cache::Cache;
-use servo_util::cache::LRUCache;
+use servo_util::cache::{Cache, LRUCache};
 use servo_util::time::ProfilerChan;
 
 use platform::font::FontHandle;
@@ -90,7 +89,7 @@ impl<'self> FontContext {
             None => {
                 debug!("font group cache miss");
                 let fg = self.create_font_group(style);
-                self.group_cache.insert(style, fg);
+                self.group_cache.insert(style.clone(), fg);
                 fg
             }
         }
@@ -107,7 +106,7 @@ impl<'self> FontContext {
                 let result = self.create_font_instance(desc);
                 match result {
                     Ok(font) => {
-                        self.instance_cache.insert(desc, font);
+                        self.instance_cache.insert(desc.clone(), font);
                     }, _ => {}
                 };
                 result

--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -14,7 +14,6 @@ use platform::font_context::FontContextHandle;
 
 use azure::azure_hl::BackendType;
 use std::hashmap::HashMap;
-use std::str;
 use std::result;
 
 // TODO(Rust #3934): creating lots of new dummy styles is a workaround

--- a/src/components/gfx/text/glyph.rs
+++ b/src/components/gfx/text/glyph.rs
@@ -507,18 +507,28 @@ impl<'self> GlyphInfo<'self> {
 pub struct GlyphStore {
     entry_buffer: ~[GlyphEntry],
     detail_store: DetailedGlyphStore,
+    is_whitespace: bool,
 }
 
 impl<'self> GlyphStore {
     // Initializes the glyph store, but doesn't actually shape anything.
     // Use the set_glyph, set_glyphs() methods to store glyph data.
-    pub fn new(length: uint) -> GlyphStore {
+    pub fn new(length: uint, is_whitespace: bool) -> GlyphStore {
         assert!(length > 0);
 
         GlyphStore {
             entry_buffer: vec::from_elem(length, GlyphEntry::initial()),
             detail_store: DetailedGlyphStore::new(),
+            is_whitespace: is_whitespace,
         }
+    }
+
+    pub fn char_len(&self) -> uint {
+        self.entry_buffer.len()
+    }
+
+    pub fn is_whitespace(&self) -> bool {
+        self.is_whitespace
     }
 
     pub fn finalize_changes(&mut self) {

--- a/src/components/main/layout/text.rs
+++ b/src/components/main/layout/text.rs
@@ -21,15 +21,16 @@ use servo_util::range::Range;
 /// Creates a TextRenderBox from a range and a text run.
 pub fn adapt_textbox_with_range(mut base: RenderBoxBase, run: @TextRun, range: Range)
                                 -> TextRenderBox {
-    assert!(range.begin() < run.char_len());
-    assert!(range.end() <= run.char_len());
-    assert!(range.length() > 0);
-
-    debug!("Creating textbox with span: (strlen=%u, off=%u, len=%u) of textrun: %s",
+    debug!("Creating textbox with span: (strlen=%u, off=%u, len=%u) of textrun (%s) (len=%u)",
            run.char_len(),
            range.begin(),
            range.length(),
-           run.text);
+           run.text,
+           run.char_len());
+
+    assert!(range.begin() < run.char_len());
+    assert!(range.end() <= run.char_len());
+    assert!(range.length() > 0);
 
     let metrics = run.metrics_for_range(&range);
     base.position.size = metrics.bounding_box.size;
@@ -170,7 +171,7 @@ impl TextRunScanner {
                     let fontgroup = ctx.font_ctx.get_resolved_font_for_style(&font_style);
                     let run = @fontgroup.create_textrun(transformed_text, underline);
 
-                    debug!("TextRunScanner: pushing single text box in range: %?", self.clump);
+                    debug!("TextRunScanner: pushing single text box in range: %? (%?)", self.clump, text);
                     let new_box = do old_box.with_base |old_box_base| {
                         let range = Range::new(0, run.char_len());
                         @mut adapt_textbox_with_range(*old_box_base, run, range)

--- a/src/components/util/range.rs
+++ b/src/components/util/range.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::uint;
+use std::cmp::{max, min};
 
 enum RangeRelation {
     OverlapsBegin(/* overlap */ uint),
@@ -51,6 +52,10 @@ impl Range {
         self.begin() < s.len() && self.end() <= s.len() && self.length() <= s.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     pub fn shift_by(&mut self, i: int) { 
         self.off = ((self.off as int) + i) as uint;
     }
@@ -71,6 +76,17 @@ impl Range {
     pub fn reset(&mut self, off_i: uint, len_i: uint) {
         self.off = off_i;
         self.len = len_i;
+    }
+
+    pub fn intersect(&self, other: &Range) -> Range {
+        let begin = max(self.begin(), other.begin());
+        let end = min(self.end(), other.end());
+
+        if end < begin {
+            Range::empty()
+        } else {
+            Range::new(begin, end - begin)
+        }
     }
 
     /// Computes the relationship between two ranges (`self` and `other`),


### PR DESCRIPTION
This PR makes text runs store the results of shaping as a vector of ARC<GlyphStore>; each element of the vector holds the shaped glyphs for a nonbreakable unit of text (basically a word). This change allows us to cache the shaped glyphs for the words, an approach that Gecko (and probably WebKit) uses. We get pretty good cache hit ratios even on the first run of layout for a page (I saw 62% on Wikipedia's main page today), although a lot of that is due to whitespace. This really comes into its own on subsequent layout runs, though, which are completely cached in the typical case.
