### PR TITLE
Don't send a resize event if the window size didn't change

### DIFF
--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -182,9 +182,14 @@ impl CompositorTask {
             let layout_chan_clone = layout_chan.clone();
             // Hook the windowing system's resize callback up to the resize rate limiter.
             do window.set_resize_callback |width, height| {
-                debug!("osmain: window resized to %ux%u", width, height);
-                *window_size = Size2D(width as int, height as int);
-                layout_chan_clone.chan.send(RouteScriptMsg(SendEventMsg(ResizeEvent(width, height))));
+                let new_size = Size2D(width as int, height as int);
+                if *window_size != new_size {
+                    debug!("osmain: window resized to %ux%u", width, height);
+                    *window_size = new_size;
+                    layout_chan_clone.chan.send(RouteScriptMsg(SendEventMsg(ResizeEvent(width, height))));
+                } else {
+                    debug!("osmain: dropping window resize since size is still %ux%u", width, height);
+                }
             }
 
             let layout_chan_clone = layout_chan.clone();

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -440,7 +440,7 @@ impl ScriptContext {
     ///
     /// This function fails if there is no root frame.
     fn reflow(&mut self, goal: ReflowGoal) {
-        debug!("script: performing reflow");
+        debug!("script: performing reflow for goal %?", goal);
 
         // Now, join the layout so that they will see the latest changes we have made.
         self.join_layout();


### PR DESCRIPTION
Performance will be better and benchmarking easier if we don't run layout an extra unnecessary time when loading a page from the commandline. This is happening because we always send a resize event to the script task from the compositor whenever the platform tells us one happened, even if the window size didn't change. This PR fixes this by checking that the window size is actually different before sending the event.
