### PR TITLE
updated paint message policy and removed unnecessary render layer buffer set cloning

### DIFF
--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -23,7 +23,6 @@ use std::comm;
 use std::comm::{Chan, SharedChan, Port};
 use std::num::Orderable;
 use std::task;
-use std::util;
 use geom::matrix::identity;
 use geom::point::Point2D;
 use geom::size::Size2D;
@@ -289,7 +288,7 @@ impl CompositorTask {
                         // Iterate over the children of the container layer.
                         let mut current_layer_child = root_layer.first_child;
 
-                        for new_layer_buffer_set.buffers.each |buffer| {
+                        for new_layer_buffer_set.buffers.iter().advance |buffer| {
                             let width = buffer.rect.size.width as uint;
                             let height = buffer.rect.size.height as uint;
 

--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -36,6 +36,7 @@ use servo_util::{time, url};
 use servo_util::time::profile;
 use servo_util::time::ProfilerChan;
 
+use extra::arc;
 pub use windowing;
 
 /// The implementation of the layers-based compositor.
@@ -47,28 +48,34 @@ pub struct CompositorChan {
 
 /// Implementation of the abstract `ScriptListener` interface.
 impl ScriptListener for CompositorChan {
+
     fn set_ready_state(&self, ready_state: ReadyState) {
         let msg = ChangeReadyState(ready_state);
         self.chan.send(msg);
     }
+
 }
 
 /// Implementation of the abstract `RenderListener` interface.
 impl RenderListener for CompositorChan {
+
     fn get_gl_context(&self) -> AzGLContext {
         let (port, chan) = comm::stream();
         self.chan.send(GetGLContext(chan));
         port.recv()
     }
-    fn paint(&self, id: uint, layer_buffer_set: LayerBufferSet, new_size: Size2D<uint>) {
+
+    fn paint(&self, id: uint, layer_buffer_set: arc::ARC<LayerBufferSet>, new_size: Size2D<uint>) {
         self.chan.send(Paint(id, layer_buffer_set, new_size))
     }
+
     fn set_render_state(&self, render_state: RenderState) {
         self.chan.send(ChangeRenderState(render_state))
     }
 }
 
 impl CompositorChan {
+
     pub fn new(chan: Chan<Msg>) -> CompositorChan {
         CompositorChan {
             chan: SharedChan::new(chan),
@@ -86,7 +93,7 @@ pub enum Msg {
     /// Requests the compositors GL context.
     GetGLContext(Chan<AzGLContext>),
     /// Requests that the compositor paint the given layer buffer set for the given page size.
-    Paint(uint, LayerBufferSet, Size2D<uint>),
+    Paint(uint, arc::ARC<LayerBufferSet>, Size2D<uint>),
     /// Alerts the compositor to the current status of page loading.
     ChangeReadyState(ReadyState),
     /// Alerts the compositor to the current status of rendering.
@@ -277,16 +284,12 @@ impl CompositorTask {
 
                         *page_size = Size2D(new_size.width as f32, new_size.height as f32);
 
-                        let mut new_layer_buffer_set = new_layer_buffer_set;
+                        let new_layer_buffer_set = new_layer_buffer_set.get();
 
                         // Iterate over the children of the container layer.
                         let mut current_layer_child = root_layer.first_child;
 
-                        // Replace the image layer data with the buffer data. Also compute the page
-                        // size here.
-                        let buffers = util::replace(&mut new_layer_buffer_set.buffers, ~[]);
-
-                        for buffers.each |buffer| {
+                        for new_layer_buffer_set.buffers.each |buffer| {
                             let width = buffer.rect.size.width as uint;
                             let height = buffer.rect.size.height as uint;
 

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -47,7 +47,6 @@ impl Pipeline {
                            render_port,
                            compositor_chan.clone(),
                            copy opts,
-                           constellation_chan.clone(),
                            profiler_chan.clone());
 
         LayoutTask::create(layout_port,

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -6,7 +6,8 @@ use azure::azure_hl::DrawTarget;
 use azure::azure::AzGLContext;
 use geom::rect::Rect;
 use geom::size::Size2D;
-use std::util::NonCopyable;
+
+use extra::arc;
 
 #[deriving(Clone)]
 pub struct LayerBuffer {
@@ -24,7 +25,6 @@ pub struct LayerBuffer {
 
 /// A set of layer buffers. This is an atomic unit used to switch between the front and back
 /// buffers.
-#[deriving(Clone)]
 pub struct LayerBufferSet {
     buffers: ~[LayerBuffer]
 }
@@ -49,7 +49,7 @@ pub enum ReadyState {
 /// submit them to be drawn to the display.
 pub trait RenderListener {
     fn get_gl_context(&self) -> AzGLContext;
-    fn paint(&self, id: uint, layer_buffer_set: LayerBufferSet, new_size: Size2D<uint>);
+    fn paint(&self, id: uint, layer_buffer_set: arc::ARC<LayerBufferSet>, new_size: Size2D<uint>);
     fn set_render_state(&self, render_state: RenderState);
 }
 

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -58,20 +58,3 @@ pub trait RenderListener {
 pub trait ScriptListener : Clone {
     fn set_ready_state(&self, ReadyState);
 }
-
-/// Signifies to the renderer likely control of the compositor. Controlling the compositor token
-/// is necessary but not sufficient for the renderer to successfully send paint messages to the
-/// compositor. Only the render tasks controlling compositor tokens may send messages, and the
-/// compositor is guaranteed to only accept messages from one of those tasks at a time.
-pub struct CompositorToken {
-    construction_restrictor: NonCopyable,
-}
-
-impl CompositorToken {
-    pub fn new() -> CompositorToken {
-        CompositorToken {
-            // Of course, this doesn't guarantee that renderers will invalidate their tokens
-            construction_restrictor: NonCopyable::new(),
-        }
-    }
-}


### PR DESCRIPTION
- constellation grants permission to renderers instead of passing tokens
- render tasks wrap layer buffer sets in ARCs
- removed no-longer-used field (constellation chan) from render task struct
