### PR TITLE
Add a submodule for rust-cssparser

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,3 +100,6 @@
 [submodule "src/support/glfw/glfw-rs"]
 	path = src/support/glfw/glfw-rs
 	url = https://github.com/mozilla-servo/glfw-rs.git
+[submodule "src/support/css/rust-cssparser"]
+	path = src/support/css/rust-cssparser
+	url = https://github.com/mozilla-servo/rust-cssparser.git

--- a/configure
+++ b/configure
@@ -401,6 +401,7 @@ CFG_SUBMODULES="\
     support/alert/rust-alert \
     support/azure/rust-azure \
     support/css/rust-css \
+    support/css/rust-cssparser \
     support/geom/rust-geom \
     support/glut/rust-glut \
     support/glfw/glfw \


### PR DESCRIPTION
[As discussed](https://github.com/mozilla/servo/wiki/Meeting-2013-07-01#css), even though this parser is not used yet, having it built and tested with the rest of Servo helps ensure it does not bitrot.
