### PR TITLE
Fix infinite bindings generation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -254,11 +254,13 @@ bindinggen_dependencies := $(addprefix $(BINDINGS_SRC)/, BindingGen.py Bindings.
 
 $(AUTOGEN_SRC_script): %Binding.rs: $(bindinggen_dependencies) \
                                    %.webidl
-	PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
+	@echo "Maybe generating $(shell basename $@)..."
+	$(Q)PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(BINDINGS_SRC) \
 	  $(BINDINGS_SRC)/BindingGen.py rs \
 	  $(BINDINGS_SRC)/Bindings.conf $*Binding $*.webidl
+	$(Q)touch $@
 
 globalgen_dependencies := $(addprefix $(BINDINGS_SRC)/, GlobalGen.py Bindings.conf Configuration.py CodegenRust.py parser/WebIDL.py) $(CACHE_DIR)/.done
 
@@ -268,7 +270,7 @@ $(CACHE_DIR)/.done:
 
 $(BINDINGS_SRC)/ParserResults.pkl: $(globalgen_dependencies) \
                                    $(WEBIDL_script)
-	PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
+	$(Q)PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(BINDINGS_SRC) \
 	  $(BINDINGS_SRC)/GlobalGen.py $(BINDINGS_SRC)/Bindings.conf . \

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -39,6 +39,8 @@ def replaceFileIfChanged(filename, newContents):
     f.write(newContents)
     f.close()
 
+    return True
+
 def toStringBool(arg):
     return str(not not arg).lower()
 


### PR DESCRIPTION
This touches the `.rs` files even if they don't change. This will cause libscript to rebuild sometimes even when it doesn't have to. This seems better than having bindgen run every time as the case where CodegenRust.py changes but doesn't change the output `.rs` seems like it should be rare.

r? @jdm
