### PR TITLE
Automatic tile removal

### DIFF
--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -305,12 +305,9 @@ impl CompositorTask {
         let ask_for_tiles: @fn() = || {
             match *quadtree {
                 Some(ref mut quad) => {
-                    let valid = |tile: &~LayerBuffer| -> bool {
-                        tile.resolution == *world_zoom
-                    };
                     let (tile_request, redisplay) = quad.get_tile_rects(Rect(Point2D(world_offset.x as int,
                                                                                      world_offset.y as int),
-                                                                             *window_size), valid, *world_zoom);
+                                                                             *window_size), *world_zoom);
 
                     if !tile_request.is_empty() {
                         match *render_chan {
@@ -415,10 +412,9 @@ impl CompositorTask {
                     
                     NewLayer(new_size, tile_size) => {
                         *page_size = Size2D(new_size.width as f32, new_size.height as f32);
-                        *quadtree = Some(Quadtree::new(0, 0,
-                                                       new_size.width.max(&(window_size.width as uint)),
+                        *quadtree = Some(Quadtree::new(new_size.width.max(&(window_size.width as uint)),
                                                        new_size.height.max(&(window_size.height as uint)),
-                                                       tile_size));
+                                                       tile_size, Some(10000000u)));
                         ask_for_tiles();
                         
                     }
@@ -569,7 +565,7 @@ impl CompositorTask {
                 composite();
             }
 
-            timer::sleep(&uv_global_loop::get(), 100);
+            timer::sleep(&uv_global_loop::get(), 10);
 
             // If a pinch-zoom happened recently, ask for tiles at the new resolution
             if *zoom_action && precise_time_s() - *zoom_time > 0.3 {

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -9,6 +9,7 @@ use geom::size::Size2D;
 
 use extra::arc;
 
+
 #[deriving(Clone)]
 pub struct LayerBuffer {
     draw_target: DrawTarget,
@@ -67,4 +68,22 @@ pub trait RenderListener {
 /// which is used in displaying the appropriate message in the window's title.
 pub trait ScriptListener : Clone {
     fn set_ready_state(&self, ReadyState);
+}
+
+/// The interface used by the quadtree to get info about LayerBuffers
+pub trait Tile {
+    /// Returns the amount of memory used by the tile
+    fn get_mem(&self) -> uint;
+    /// Returns true if the tile is displayable at the given scale
+    fn is_valid(&self, f32) -> bool;
+}
+
+impl Tile for ~LayerBuffer {
+    fn get_mem(&self) -> uint {
+        // This works for now, but in the future we may want a better heuristic
+        self.screen_pos.size.width * self.screen_pos.size.height
+    }
+    fn is_valid(&self, scale: f32) -> bool {
+        self.resolution.approx_eq(&scale)
+    }    
 }


### PR DESCRIPTION
The quadtree is now initialized with a memory limit, and tiles are deleted automatically if that limit is exceeded. The memory limit can also be set to None to prevent this behavior.
