### PR TITLE
https submodule already works because it's used everywhere.  but git submodule is often blocked behind firewalls.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -87,13 +87,13 @@
 	url = https://github.com/mozilla/rust.git
 [submodule "src/support/alert/rust-alert"]
 	path = src/support/alert/rust-alert
-	url = git://github.com/mozilla-servo/rust-alert.git
+	url = https://github.com/mozilla-servo/rust-alert.git
 [submodule "src/support/nss/nss"]
 	path = src/support/nss/nss
-	url = git://github.com/mozilla-servo/nss.git
+	url = https://github.com/mozilla-servo/nss.git
 [submodule "src/support/nss/nspr"]
 	path = src/support/nss/nspr
-	url = git://github.com/mozilla-servo/nspr.git
+	url = https://github.com/mozilla-servo/nspr.git
 [submodule "src/support/glfw/glfw"]
 	path = src/support/glfw/glfw
 	url = https://github.com/mozilla-servo/glfw.git

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Servo cannot be built in-tree; you must create a directory in which to run
 configure and make and place the build artifacts.
 
 ``` sh
-git clone git://github.com/mozilla/servo.git
+git clone https://github.com/mozilla/servo.git
 cd servo
 mkdir -p build && cd build
 ../configure


### PR DESCRIPTION
git port is blocked behind firewalls, use one clone protocol everywhere.
