### PR TITLE
msttcorefonts is a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install autoconf2.13 curl freeglut3-dev libtool \
     libfreetype6-dev libfontconfig1-dev libgl1-mesa-dri libglib2.0-dev \
-    xorg-dev libpng-dev
+    xorg-dev libpng-dev msttcorefonts
 ```
 
 Servo builds its own copy of Rust, so there is no need to provide a Rust


### PR DESCRIPTION
assertion will fail if msttcorefonts is not installed.  the page will come up successfuly now  when literally following the README.md (a segfault when the window is closed, but good progress now).
