### PR TITLE
Add 'document.head' binding

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -39,6 +39,19 @@ pub fn Document(root: AbstractNode<ScriptView>, window: Option<@mut Window>) -> 
 }
 
 impl Document {
+    pub fn getHead(&self) -> Option<AbstractNode<ScriptView>> {
+        let mut headNode:Option<AbstractNode<ScriptView>> = None;
+        let _ = for self.root.traverse_preorder |child| {
+            if child.is_head_element() {
+                match headNode {
+                   Some(_val) => {},
+                   None() => headNode = Some(child)
+                }
+            }
+        };
+        headNode
+    }
+
     pub fn getElementsByTagName(&self, tag: DOMString) -> Option<@mut HTMLCollection> {
         let mut elements = ~[];
         let tag = tag.to_str();

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -9,7 +9,7 @@ use dom::bindings::utils::WrapperCache;
 use dom::bindings;
 use dom::characterdata::CharacterData;
 use dom::document::Document;
-use dom::element::{Element, ElementTypeId, HTMLImageElement, HTMLImageElementTypeId, HTMLIframeElementTypeId, HTMLIframeElement};
+use dom::element::{Element, ElementTypeId, HTMLHeadElementTypeId, HTMLImageElement, HTMLImageElementTypeId, HTMLIframeElementTypeId, HTMLIframeElement};
 use dom::element::{HTMLStyleElementTypeId};
 use script_task::global_script_context;
 
@@ -327,6 +327,10 @@ impl<'self, View> AbstractNode<View> {
             fail!(~"node is not an element");
         }
         self.transmute_mut(f)
+    }
+
+    pub fn is_head_element(self) -> bool {
+        self.type_id() == ElementNodeTypeId(HTMLHeadElementTypeId)
     }
 
     pub fn is_image_element(self) -> bool {

--- a/src/test/html/test_bindings.js
+++ b/src/test/html/test_bindings.js
@@ -52,6 +52,11 @@ window.alert(tags[1]);
 window.alert(tags[1].tagName);
 window.alert(tags[2]);
 
+window.alert("HTMLElement:");
+let head = document.head;
+window.alert(head);
+window.alert(head.tagName);
+
 window.alert("DOMParser:");
 window.alert(DOMParser);
 let parser = new DOMParser();


### PR DESCRIPTION
Add 'document.head' which returns the head element of the current document. Modify a test file 'test_bindings.js'.
