### PR TITLE
Add a getter for document.head and document.title

### DIFF
--- a/src/components/script/dom/htmldocument.rs
+++ b/src/components/script/dom/htmldocument.rs
@@ -6,9 +6,9 @@ use dom::bindings::codegen::HTMLDocumentBinding;
 use dom::bindings::utils::{DOMString, ErrorResult, null_string};
 use dom::bindings::utils::{CacheableWrapper, BindingObject, WrapperCache};
 use dom::document::{AbstractDocument, Document, WrappableDocument, HTML};
-use dom::element::Element;
+use dom::element::{Element, HTMLHeadElementTypeId};
 use dom::htmlcollection::HTMLCollection;
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::{AbstractNode, ScriptView, ElementNodeTypeId};
 use dom::window::Window;
 
 use js::jsapi::{JSObject, JSContext};
@@ -68,7 +68,14 @@ impl HTMLDocument {
     }
 
     pub fn GetHead(&self) -> Option<AbstractNode<ScriptView>> {
-        None
+        let mut headNode: Option<AbstractNode<ScriptView>> = None;
+        let _ = for self.parent.root.traverse_preorder |child| {
+            if child.type_id() == ElementNodeTypeId(HTMLHeadElementTypeId) {
+                headNode = Some(child);
+                break;
+            }
+        };
+        headNode 
     }
 
     pub fn Images(&self) -> @mut HTMLCollection {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -349,6 +349,13 @@ impl<'self, View> AbstractNode<View> {
         self.transmute(f)
     }
 
+    pub fn with_mut_text<R>(self, f: &fn(&mut Text) -> R) -> R {
+        if !self.is_text() {
+            fail!(~"node is not text");
+        }
+        self.transmute_mut(f)
+    }
+
     pub fn is_element(self) -> bool {
         match self.type_id() {
             ElementNodeTypeId(*) => true,

--- a/src/test/html/test_bindings.html
+++ b/src/test/html/test_bindings.html
@@ -2,6 +2,8 @@
 <html>
   <!-- comment -->
   <head>
+      <title>test_binding 
+          page  </title>
     <script src="test_bindings.js"></script>
   </head>
   <body>

--- a/src/test/html/test_bindings.js
+++ b/src/test/html/test_bindings.js
@@ -96,6 +96,11 @@ window.alert(tags.length);
 window.alert(tags[0]);
 window.alert(tags[0].tagName);
 
+window.alert("Document:");
+let head = document.head;
+window.alert(head);
+window.alert(head.tagName);
+
 window.alert("DOMParser:");
 window.alert(DOMParser);
 let parser = new DOMParser();


### PR DESCRIPTION
Add a getter for document.head and document.title.

Like in the modified test (document.title="changed title"), setters for elements doesn't seem to be called.
