### PR TITLE
Fix handling of float children of floats

### DIFF
--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -401,7 +401,8 @@ impl LayoutTreeBuilder {
 
         let new_generator = match (display, parent_generator.flow, sibling_flow) { 
             // Floats
-            (CSSDisplayBlock, BlockFlow(_), _) if !is_float.is_none() => {
+            (CSSDisplayBlock, BlockFlow(_), _) |
+            (CSSDisplayBlock, FloatFlow(_), _) if !is_float.is_none() => {
                 self.create_child_generator(node, parent_generator, Flow_Float(is_float.get()))
             }
             // If we're placing a float after an inline, append the float to the inline flow,


### PR DESCRIPTION
This makes acid1 have all 6 boxes show up, and almost correctly positioned.

r? @eric93
