### PR TITLE
Generate bindings for HTMLTitleElement

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -563,6 +563,7 @@ addHTMLElement('HTMLSpanElement')
 addHTMLElement('HTMLStyleElement')
 addHTMLElement('HTMLTableElement')
 addHTMLElement('HTMLTableSectionElement')
+addHTMLElement('HTMLTitleElement')
 
 # If you add one of these, you need to make sure nsDOMQS.h has the relevant
 # macros added for it

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4631,6 +4631,7 @@ class CGBindingRoot(CGThing):
                           'dom::htmlstyleelement::HTMLStyleElement',
                           'dom::htmltableelement::HTMLTableElement',
                           'dom::htmltablesectionelement::HTMLTableSectionElement',
+                          'dom::htmltitleelement::HTMLTitleElement', #XXXyusukesuzuki
                           'dom::bindings::utils::*',
                           'dom::bindings::conversions::*',
                           'dom::blob::*', #XXXjdm

--- a/src/components/script/dom/bindings/codegen/HTMLTitleElement.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLTitleElement.webidl
@@ -1,0 +1,13 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * http://www.whatwg.org/specs/web-apps/current-work/#the-title-element
+ */
+
+interface HTMLTitleElement : HTMLElement {
+           [SetterThrows]
+           attribute DOMString text;
+};

--- a/src/components/script/dom/bindings/node.rs
+++ b/src/components/script/dom/bindings/node.rs
@@ -17,6 +17,8 @@ use dom::element::{HTMLTableSectionElementTypeId};
 use dom::element::{HTMLHeadElement, HTMLHtmlElement, HTMLDivElement, HTMLSpanElement};
 use dom::element::{HTMLParagraphElement};
 use dom::htmlelement::HTMLElement;
+use dom::element::{HTMLDivElementTypeId, HTMLImageElementTypeId, HTMLTitleElementTypeId};
+use dom::element::{HTMLHeadElement, HTMLHtmlElement, HTMLDivElement};
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlhrelement::HTMLHRElement;
@@ -29,6 +31,7 @@ use dom::htmlscriptelement::HTMLScriptElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::htmltableelement::HTMLTableElement;
 use dom::htmltablesectionelement::HTMLTableSectionElement;
+use dom::htmltitleelement::HTMLTitleElement;
 use dom::node::{AbstractNode, Node, ElementNodeTypeId, TextNodeTypeId, CommentNodeTypeId};
 use dom::node::{DoctypeNodeTypeId, ScriptView, Text};
 
@@ -112,6 +115,7 @@ pub fn create(cx: *JSContext, node: &mut AbstractNode<ScriptView>) -> *JSObject 
         ElementNodeTypeId(HTMLStyleElementTypeId) => generate_element!(HTMLStyleElement),
         ElementNodeTypeId(HTMLTableElementTypeId) => generate_element!(HTMLTableElement),
         ElementNodeTypeId(HTMLTableSectionElementTypeId) => generate_element!(HTMLTableSectionElement),
+        ElementNodeTypeId(HTMLTitleElementTypeId) => generate_element!(HTMLTitleElement),
         ElementNodeTypeId(_) => element::create(cx, node).ptr,
         CommentNodeTypeId |
         DoctypeNodeTypeId => text::create(cx, node).ptr,

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -617,7 +617,7 @@ pub extern fn ThrowingConstructor(_cx: *JSContext, _argc: uint, _vp: *JSVal) -> 
 }
 
 pub fn initialize_global(global: *JSObject) {
-    let protoArray = @mut ([0 as *JSObject, ..47]);
+    let protoArray = @mut ([0 as *JSObject, ..48]);
     assert!(protoArray.len() == PrototypeList::id::_ID_Count as uint);
     unsafe {
         //XXXjdm we should be storing the box pointer instead of the inner

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -5,7 +5,7 @@
 use dom::bindings::codegen::DocumentBinding;
 use dom::bindings::utils::{DOMString, WrapperCache, ErrorResult, null_string, str};
 use dom::bindings::utils::{BindingObject, CacheableWrapper, rust_box, DerivedWrapper};
-use dom::element::{Element, HTMLHtmlElement, HTMLTitleElement};
+use dom::element::{Element, HTMLHtmlElement};
 use dom::element::{HTMLHtmlElementTypeId, HTMLHeadElementTypeId, HTMLTitleElementTypeId};
 use dom::event::Event;
 use dom::htmlcollection::HTMLCollection;
@@ -14,6 +14,7 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{AbstractNode, ScriptView, Node, ElementNodeTypeId, Text};
 use dom::window::Window;
 use dom::windowproxy::WindowProxy;
+use dom::htmltitleelement::HTMLTitleElement;
 
 use js::jsapi::{JS_AddObjectRoot, JS_RemoveObjectRoot, JSObject, JSContext, JSVal};
 use js::glue::RUST_OBJECT_TO_JSVAL;

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -15,6 +15,10 @@ use dom::bindings::codegen::{HTMLTableElementBinding};
 use dom::bindings::codegen::{HTMLTableSectionElementBinding};
 use dom::bindings::utils::{null_string, str};
 use dom::bindings::utils::{BindingObject, CacheableWrapper, DOMString, ErrorResult, WrapperCache};
+use dom::bindings::codegen::{HTMLAnchorElementBinding, HTMLDivElementBinding};
+use dom::bindings::codegen::{HTMLImageElementBinding, HTMLTitleElementBinding};
+use dom::bindings::utils::{DOMString, null_string, ErrorResult};
+use dom::bindings::utils::{CacheableWrapper, BindingObject, WrapperCache};
 use dom::clientrect::ClientRect;
 use dom::clientrectlist::ClientRectList;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -31,6 +35,7 @@ use dom::htmlscriptelement::HTMLScriptElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::htmltableelement::HTMLTableElement;
 use dom::htmltablesectionelement::HTMLTableSectionElement;
+use dom::htmltitleelement::HTMLTitleElement;
 use dom::node::{ElementNodeTypeId, Node, ScriptView, AbstractNode};
 use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery};
 use layout_interface::{ContentBoxesResponse};
@@ -120,7 +125,6 @@ pub struct HTMLSmallElement     { parent: HTMLElement }
 pub struct HTMLSpanElement      { parent: HTMLElement }
 pub struct HTMLTableCellElement { parent: HTMLElement }
 pub struct HTMLTableRowElement  { parent: HTMLElement }
-pub struct HTMLTitleElement     { parent: HTMLElement }
 pub struct HTMLUListElement     { parent: HTMLElement }
 pub struct UnknownElement       { parent: HTMLElement }
 
@@ -210,6 +214,8 @@ generate_cacheable_wrapper!(HTMLTableElement, HTMLTableElementBinding::Wrap)
 generate_binding_object!(HTMLTableElement)
 generate_cacheable_wrapper!(HTMLTableSectionElement, HTMLTableSectionElementBinding::Wrap)
 generate_binding_object!(HTMLTableSectionElement)
+generate_cacheable_wrapper!(HTMLTitleElement, HTMLTitleElementBinding::Wrap)
+generate_binding_object!(HTMLTitleElement)
 
 //
 // Fancier elements

--- a/src/components/script/dom/htmltitleelement.rs
+++ b/src/components/script/dom/htmltitleelement.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::utils::{DOMString, null_string, ErrorResult};
+use dom::htmlelement::HTMLElement;
+
+pub struct HTMLTitleElement {
+    parent: HTMLElement,
+}
+
+impl HTMLTitleElement {
+    pub fn Text(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetText(&mut self, _text: &DOMString, _rv: &mut ErrorResult) {
+    }
+}

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -23,7 +23,7 @@ use dom::element::{HTMLDivElement, HTMLFontElement, HTMLFormElement,
                    HTMLSelectElement, HTMLSmallElement,
                    HTMLSpanElement,
                    HTMLTableCellElement, HTMLTableRowElement,
-                   HTMLTitleElement, HTMLUListElement};
+                   HTMLUListElement};
 use dom::element::{HTMLHeadingElementTypeId, Heading1, Heading2, Heading3, Heading4, Heading5,
                    Heading6};
 use dom::htmlbrelement::HTMLBRElement;
@@ -38,6 +38,7 @@ use dom::htmlscriptelement::HTMLScriptElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::htmltableelement::HTMLTableElement;
 use dom::htmltablesectionelement::HTMLTableSectionElement;
+use dom::htmltitleelement::HTMLTitleElement;
 use dom::element::{Element, Attr};
 use dom::htmlelement::HTMLElement;
 use dom::node::{AbstractNode, Comment, Doctype, ElementNodeTypeId, Node, ScriptView};

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -62,6 +62,7 @@ pub mod dom {
             pub mod HTMLStyleElementBinding;
             pub mod HTMLTableElementBinding;
             pub mod HTMLTableSectionElementBinding;
+            pub mod HTMLTitleElementBinding;
             pub mod MouseEventBinding;
             pub mod NodeBinding;
             pub mod PrototypeList;
@@ -97,6 +98,7 @@ pub mod dom {
     pub mod htmlstyleelement;
     pub mod htmltableelement;
     pub mod htmltablesectionelement;
+    pub mod htmltitleelement;
     pub mod mouseevent;
     pub mod node;
     pub mod uievent;


### PR DESCRIPTION
I've ported HTMLTitleElement webidl from mozilla-central.

https://groups.google.com/forum/#!topic/mozilla.dev.servo/2TzNkht_NMM/discussion
https://github.com/mozilla/servo/wiki/HTMLElement-binding-conversion
