### PR TITLE
Precursor to Parallel Layout

### DIFF
--- a/src/components/main/layout/aux.rs
+++ b/src/components/main/layout/aux.rs
@@ -4,7 +4,7 @@
 
 //! Code for managing the layout data in the DOM.
 
-use layout::flow::FlowContext;
+use layout::flow::{FlowContext,SequentialView};
 use layout::incremental::RestyleDamage;
 
 use newcss::complete::CompleteSelectResults;
@@ -20,7 +20,7 @@ pub struct LayoutData {
     restyle_damage: Option<RestyleDamage>,
 
     /// The CSS flow that this node is associated with.
-    flow: Option<FlowContext>,
+    flow: Option<FlowContext<SequentialView,SequentialView>>,
 }
 
 impl LayoutData {

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -6,7 +6,7 @@
 
 use layout::box::{RenderBox};
 use layout::context::LayoutContext;
-use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::display_list_builder::ExtraDisplayListData;
 use layout::flow::{BlockFlow, FlowContext, FlowData, InlineBlockFlow, FloatFlow};
 use layout::flow::{VisitChildView, VisitOrChildView};
 use layout::inline::InlineLayout;

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -416,7 +416,6 @@ impl<V:VisitOrChildView> BlockFlowData<V,VisitChildView> {
     }
 
     pub fn build_display_list_block<E:ExtraDisplayListData>(@mut self,
-                                                            builder: &DisplayListBuilder,
                                                             dirty: &Rect<Au>, 
                                                             list: &Cell<DisplayList<E>>) 
                                                             -> bool {
@@ -428,7 +427,7 @@ impl<V:VisitOrChildView> BlockFlowData<V,VisitChildView> {
 
         // add box that starts block context
         self.box.map(|&box| {
-            box.build_display_list(builder, dirty, &self.common.abs_position, list)
+            box.build_display_list(dirty, &self.common.abs_position, list)
         });
 
 

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -389,8 +389,8 @@ impl<V:VisitOrChildView> BlockFlowData<V,VisitChildView> {
 
         for self.box.iter().advance |&box| {
             let style = box.style();
-            let maybe_height = MaybeAuto::from_height(style.height(), Au(0));
-            let maybe_height = maybe_height.spec_or_default(Au(0));
+            let maybe_height = MaybeAuto::from_height(style.height(), Au(0), style.font_size());
+            let maybe_height = maybe_height.specified_or_zero();
             height = geometry::max(height, maybe_height);
         }
 

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -7,7 +7,6 @@
 use css::node_style::StyledNode;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData, ToGfxColor};
-use layout::flow::FlowContext;
 use layout::model::{BoxModel, MaybeAuto};
 use layout::text;
 
@@ -149,10 +148,7 @@ pub enum SplitBoxResult {
 /// Data common to all render boxes.
 pub struct RenderBoxBase {
     /// The DOM node that this `RenderBox` originates from.
-    node: AbstractNode<LayoutView>,
-
-    /// The reference to the containing flow context which this box participates in.
-    ctx: FlowContext,
+    priv node: AbstractNode<LayoutView>,
 
     /// The position of this box relative to its owning flow.
     position: Rect<Au>,
@@ -168,15 +164,18 @@ pub struct RenderBoxBase {
 
 impl RenderBoxBase {
     /// Constructs a new `RenderBoxBase` instance.
-    pub fn new(node: AbstractNode<LayoutView>, flow_context: FlowContext, id: int)
+    pub fn new(node: AbstractNode<LayoutView>, id: int)
                -> RenderBoxBase {
         RenderBoxBase {
             node: node,
-            ctx: flow_context,
             position: Au::zero_rect(),
             model: Zero::zero(),
             id: id,
         }
+    }
+
+    pub fn different_node(&self, other: &RenderBoxBase) -> bool {
+        self.node != other.node
     }
 }
 
@@ -544,7 +543,7 @@ impl RenderBox {
     }
 
     /// A convenience function to access the DOM node that this render box represents.
-    pub fn node(&self) -> AbstractNode<LayoutView> {
+    priv fn node(&self) -> AbstractNode<LayoutView> {
         self.with_base(|base| base.node)
     }
 
@@ -552,7 +551,7 @@ impl RenderBox {
     /// represents.
     ///
     /// If there is no ancestor-or-self `Element` node, fails.
-    pub fn nearest_ancestor_element(&self) -> AbstractNode<LayoutView> {
+    priv fn nearest_ancestor_element(&self) -> AbstractNode<LayoutView> {
         do self.with_base |base| {
             let mut node = base.node;
             while !node.is_element() {

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -270,7 +270,7 @@ impl RenderBox {
 
     /// Attempts to split this box so that its width is no more than `max_width`. Fails if this box
     /// is an unscanned text box.
-    pub fn split_to_width(&self, _: &LayoutContext, max_width: Au, starts_line: bool)
+    pub fn split_to_width(&self, max_width: Au, starts_line: bool)
                       -> SplitBoxResult {
         match *self {
             GenericRenderBoxClass(*) | ImageRenderBoxClass(*) => CannotSplit(*self),

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -6,7 +6,7 @@
 
 use css::node_style::StyledNode;
 use layout::context::LayoutContext;
-use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData, ToGfxColor};
+use layout::display_list_builder::{ExtraDisplayListData, ToGfxColor};
 use layout::model::{BoxModel, MaybeAuto};
 use layout::text;
 
@@ -583,7 +583,6 @@ impl RenderBox {
     /// items, each box puts its display items into the correct stack layer according to CSS 2.1
     /// Appendix E. Finally, the builder flattens the list.
     pub fn build_display_list<E:ExtraDisplayListData>(&self,
-                                                  _: &DisplayListBuilder,
                                                   dirty: &Rect<Au>,
                                                   offset: &Point2D<Au>,
                                                   list: &Cell<DisplayList<E>>) {

--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -13,6 +13,7 @@ use layout::box::{RenderBox_Text, UnscannedTextRenderBox, UnscannedTextRenderBox
 use layout::context::LayoutContext;
 use layout::flow::{AbsoluteFlow, BlockFlow, FloatFlow, Flow_Absolute, Flow_Block, Flow_Float};
 use layout::flow::{Flow_Inline, Flow_InlineBlock, Flow_Root, Flow_Table, FlowContext};
+use layout::flow::SequentialView;
 use layout::flow::{FlowContextType, FlowData, InlineBlockFlow, InlineFlow, TableFlow};
 use layout::inline::{InlineFlowData, InlineLayout};
 use layout::text::TextRunScanner;
@@ -33,7 +34,7 @@ use servo_util::range::Range;
 use servo_util::tree::{TreeNodeRef, TreeNode, TreeUtils};
 
 pub struct LayoutTreeBuilder {
-    root_flow: Option<FlowContext>,
+    root_flow: Option<FlowContext<SequentialView,SequentialView>>,
     next_cid: int,
     next_bid: int,
 }
@@ -51,7 +52,7 @@ impl LayoutTreeBuilder {
 // helper object for building the initial box list and making the
 // mapping between DOM nodes and boxes.
 struct BoxGenerator {
-    flow: FlowContext,
+    flow: FlowContext<SequentialView,SequentialView>,
     range_stack: ~[uint],
 }
 
@@ -97,7 +98,7 @@ priv fn simulate_UA_display_rules(node: AbstractNode<LayoutView>) -> CSSDisplay 
 impl BoxGenerator {
     /* Debug ids only */
 
-    fn new(flow: FlowContext) -> BoxGenerator {
+    fn new(flow: FlowContext<SequentialView,SequentialView>) -> BoxGenerator {
         debug!("Creating box generator for flow: %s", flow.debug_str());
         BoxGenerator {
             flow: flow,
@@ -246,10 +247,10 @@ impl BoxGenerator {
                 layout_ctx: &LayoutContext,
                 ty: RenderBoxType,
                 node: AbstractNode<LayoutView>,
-                flow_context: FlowContext,
+                _: FlowContext<SequentialView,SequentialView>,
                 builder: &mut LayoutTreeBuilder)
                 -> RenderBox {
-        let base = RenderBoxBase::new(node, flow_context, builder.next_box_id());
+        let base = RenderBoxBase::new(node, builder.next_box_id());
         let result = match ty {
             RenderBox_Generic => GenericRenderBoxClass(@mut base),
             RenderBox_Text => UnscannedTextRenderBoxClass(@mut UnscannedTextRenderBox::new(base)),
@@ -339,10 +340,10 @@ impl LayoutTreeBuilder {
         // boxes that correspond to child_flow.node. These boxes may
         // eventually be elided or split, but the mapping between
         // nodes and FlowContexts should not change during layout.
-        let flow: &FlowContext = &this_generator.flow;
+        let flow = &this_generator.flow;
         for flow.each_child |child_flow| {
             do child_flow.with_base |child_node| {
-                let dom_node = child_node.node;
+                let dom_node = child_node.node();
                 assert!(dom_node.has_layout_data());
                 dom_node.layout_data().flow = Some(child_flow);
             }
@@ -384,7 +385,7 @@ impl LayoutTreeBuilder {
             }
         };
 
-        let sibling_flow: Option<FlowContext> = sibling_generator.map(|gen| gen.flow);
+        let sibling_flow: Option<FlowContext<SequentialView, SequentialView>> = sibling_generator.map(|gen| gen.flow);
 
         // TODO(eatkinson): use the value of the float property to
         // determine whether to float left or right.
@@ -508,14 +509,16 @@ impl LayoutTreeBuilder {
     ///
     /// The latter can only be done immediately adjacent to, or at the beginning or end of a block
     /// flow. Otherwise, the whitespace might affect whitespace collapsing with adjacent text.
-    pub fn simplify_children_of_flow(&self, ctx: &LayoutContext, parent_flow: &mut FlowContext) {
+    pub fn simplify_children_of_flow(&self, 
+                                     ctx: &LayoutContext, 
+                                     parent_flow: &mut FlowContext<SequentialView, SequentialView>) {
         match *parent_flow {
             InlineFlow(*) => {
                 let mut found_child_inline = false;
                 let mut found_child_block = false;
 
                 let flow = *parent_flow;
-                for flow.each_child |child_ctx: FlowContext| {
+                for flow.each_child |child_ctx: FlowContext<SequentialView, SequentialView>| {
                     match child_ctx {
                         InlineFlow(*) | InlineBlockFlow(*) => found_child_inline = true,
                         BlockFlow(*) => found_child_block = true,
@@ -533,7 +536,7 @@ impl LayoutTreeBuilder {
 
                 // check first/last child for whitespace-ness
                 let first_child = do parent_flow.with_base |parent_node| {
-                    parent_node.first_child
+                    parent_node.first_child()
                 };
                 for first_child.iter().advance |&first_flow| {
                     if first_flow.starts_inline_flow() {
@@ -556,7 +559,7 @@ impl LayoutTreeBuilder {
                 }
 
                 let last_child = do parent_flow.with_base |parent_node| {
-                    parent_node.last_child
+                    parent_node.last_child()
                 };
                 for last_child.iter().advance |&last_flow| {
                     if last_flow.starts_inline_flow() {
@@ -580,7 +583,7 @@ impl LayoutTreeBuilder {
 
                 // Issue 543: We only need to do this if there are inline child
                 // flows, but there's not a quick way to check at the moment.
-                for (*parent_flow).each_child |child_flow: FlowContext| {
+                for (*parent_flow).each_child |child_flow: FlowContext<SequentialView, SequentialView>| {
                     match child_flow {
                         InlineFlow(*) | InlineBlockFlow(*) => {
                             let mut scanner = TextRunScanner::new();
@@ -594,14 +597,14 @@ impl LayoutTreeBuilder {
         }
     }
 
-    pub fn fixup_split_inline(&self, _: FlowContext) {
+    pub fn fixup_split_inline(&self, _: FlowContext<SequentialView, SequentialView>) {
         // TODO: finish me. 
         fail!(~"TODO: handle case where an inline is split by a block")
     }
 
     /// Entry point for box creation. Should only be called on the root DOM element.
     pub fn construct_trees(&mut self, layout_ctx: &LayoutContext, root: AbstractNode<LayoutView>)
-                       -> Result<FlowContext, ()> {
+                       -> Result<FlowContext<SequentialView,SequentialView>, ()> {
         let new_flow = self.make_flow(Flow_Root, root);
         let new_generator = @mut BoxGenerator::new(new_flow);
 
@@ -611,7 +614,7 @@ impl LayoutTreeBuilder {
     }
 
     /// Creates a flow of the given type for the supplied node.
-    pub fn make_flow(&mut self, ty: FlowContextType, node: AbstractNode<LayoutView>) -> FlowContext {
+    pub fn make_flow(&mut self, ty: FlowContextType, node: AbstractNode<LayoutView>) -> FlowContext<SequentialView,SequentialView> {
         let info = FlowData::new(self.next_flow_id(), node);
         let result = match ty {
             Flow_Absolute       => AbsoluteFlow(@mut info),

--- a/src/components/main/layout/clq.rs
+++ b/src/components/main/layout/clq.rs
@@ -67,7 +67,7 @@ impl<T> WorkstealingDeque<T> {
             let a = self.array.load(SeqCst);
             self.bottom.store(b, SeqCst);
             let t = self.top.load(SeqCst);
-            fail!("in pop t = %u b = %u", t, b);
+            debug!("in pop t = %u b = %u", t, b);
             let mut x: Option<*T>;
             if t <= b {
                 let size = (*a).size.load(SeqCst); // XXX: Pick ordering.

--- a/src/components/main/layout/clq.rs
+++ b/src/components/main/layout/clq.rs
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::option::*;
 use std::unstable::intrinsics;
 use std::unstable::atomics::{AtomicPtr, SeqCst, AtomicUint};
-use std::cast::{transmute, forget};
+use std::cast::{transmute};
 use std::vec;
  
 pub struct WorkstealingDeque<T> {

--- a/src/components/main/layout/clq.rs
+++ b/src/components/main/layout/clq.rs
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::option::*;
+use std::unstable::intrinsics;
+use std::unstable::atomics::{AtomicPtr, SeqCst, AtomicUint};
+use std::cast::{transmute, forget};
+use std::vec;
+ 
+pub struct WorkstealingDeque<T> {
+    count: AtomicUint,
+    top: AtomicUint,
+    bottom: AtomicUint,
+    array: AtomicPtr<DequeArray<T>>
+}
+ 
+pub struct DequeArray<T> {
+    size: AtomicUint,
+    raw: ~[AtomicPtr<T>]
+}
+ 
+impl<T> DequeArray<T> {
+    pub fn new(init_size: uint) -> DequeArray<T> {
+        unsafe {
+            DequeArray {
+                size: AtomicUint::new(init_size),
+                raw: vec::from_elem(init_size, AtomicPtr::new(intrinsics::uninit()))
+            }
+        }
+    }
+}
+ 
+impl<T> WorkstealingDeque<T> {
+    pub fn new(init_size: uint) -> WorkstealingDeque<T> {
+        unsafe {
+            WorkstealingDeque {
+                count: AtomicUint::new(1),
+                top: AtomicUint::new(0),
+                bottom: AtomicUint::new(0),
+                array: AtomicPtr::new(transmute(~DequeArray::new::<T>(init_size)))
+            }
+        }
+    }
+ 
+    pub fn push(&mut self, value: *T) {
+        unsafe {
+            let b = self.bottom.load(SeqCst);
+            let t = self.top.load(SeqCst);
+            let a: *mut DequeArray<T> = self.array.load(SeqCst);
+            let size = (*a).size.load(SeqCst); // XXX: Pick ordering.
+            if b - t > size - 1 {
+                fail!("deque overfilled, no resize implemented");
+                //self.resize();
+            }
+            let size = (*a).size.load(SeqCst); // XXX: Pick ordering.
+            let value: *mut T = transmute(value);
+            debug!("about to push onto raw array: length is: %u", (*a).raw.len());
+            (*a).raw[b % size].store(value, SeqCst);
+            self.bottom.store(b+1, SeqCst);                       
+        }
+    }
+ 
+    pub fn pop(&mut self) -> Option<*T> {
+        unsafe {
+            let b = self.bottom.load(SeqCst) - 1;
+            let a = self.array.load(SeqCst);
+            self.bottom.store(b, SeqCst);
+            let t = self.top.load(SeqCst);
+            fail!("in pop t = %u b = %u", t, b);
+            let mut x: Option<*T>;
+            if t <= b {
+                let size = (*a).size.load(SeqCst); // XXX: Pick ordering.
+                x = Some(transmute((*a).raw[b % size].load(SeqCst)));
+                if t == b {
+                    // XXX: "compare_exchange_strong_explicit" is what in rust?
+                    if 0 != self.top.compare_and_swap(t, t+1, SeqCst) {
+                        x = None;
+                    }
+                    self.bottom.store(b+1, SeqCst);
+                }
+            } else {
+                x = None;
+                self.bottom.store(b+1, SeqCst);
+            }
+            return x;
+        }
+    }
+ 
+    pub fn steal(&mut self) -> Option<*T> {
+        unsafe {
+            let t = self.top.load(SeqCst);
+            let b = self.bottom.load(SeqCst);
+            let mut x: Option<*T> = None;
+            if (t < b) {
+                let a = self.array.load(SeqCst);
+                let size = (*a).size.load(SeqCst); // XXX: Pick ordering.
+                x = Some(transmute((*a).raw[t % size].load(SeqCst)));
+                // XXX: "compare_exchange_strong_explicit" is what in rust?
+                if 0 != self.top.compare_and_swap(t, t+1, SeqCst) {
+                    return None;
+                }
+            }
+            return x;
+        }
+    }
+ 
+    pub fn is_empty(&self) -> bool {
+        // XXX: This is almost certainly too restrictive an ordering.
+        let b = self.bottom.load(SeqCst);
+        let t = self.top.load(SeqCst);
+        return b == t;
+    }
+}

--- a/src/components/main/layout/float.rs
+++ b/src/components/main/layout/float.rs
@@ -35,6 +35,9 @@ pub struct FloatFlowData {
     /// Index into the box list for inline floats
     index: Option<uint>,
 
+    /// Number of floated children
+    floated_children: uint,
+
 }
 
 impl FloatFlowData {
@@ -63,7 +66,7 @@ impl FloatFlowData {
     pub fn bubble_widths_float(@mut self, ctx: &LayoutContext) {
         let mut min_width = Au(0);
         let mut pref_width = Au(0);
-        let mut num_floats = 1;
+        let mut num_floats = 0;
 
         for FloatFlow(self).each_child |child_ctx| {
             //assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow());
@@ -71,12 +74,12 @@ impl FloatFlowData {
             do child_ctx.with_mut_base |child_node| {
                 min_width = geometry::max(min_width, child_node.min_width);
                 pref_width = geometry::max(pref_width, child_node.pref_width);
-
                 num_floats = num_floats + child_node.num_floats;
             }
         }
 
-        self.common.num_floats = num_floats;
+        self.common.num_floats = 1;
+        self.floated_children = num_floats;
 
 
         self.box.map(|&box| {
@@ -100,6 +103,9 @@ impl FloatFlowData {
         let mut remaining_width = self.common.position.size.width;
         self.containing_width = remaining_width;
         let mut x_offset = Au(0);
+        
+        // Parent usually sets this, but floats are never inorder
+        self.common.is_inorder = false;
 
         for self.box.iter().advance |&box| {
             let style = box.style();
@@ -154,25 +160,61 @@ impl FloatFlowData {
 
         self.common.position.size.width = remaining_width;
 
+        let has_inorder_children = self.common.num_floats > 0;
         for FloatFlow(self).each_child |kid| {
             //assert!(kid.starts_block_flow() || kid.starts_inline_flow());
 
             do kid.with_mut_base |child_node| {
                 child_node.position.origin.x = x_offset;
                 child_node.position.size.width = remaining_width;
+                child_node.is_inorder = has_inorder_children;
+
+                if !child_node.is_inorder {
+                    child_node.floats_in = FloatContext::new(0);
+                }
             }
         }
     }
 
+    pub fn assign_height_inorder_float(@mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height_inorder_float: assigning height for float %?", self.common.id);
+        // assign_height_float was already called by the traversal function
+        // so this is well-defined
+
+        let mut height = Au(0);
+        self.box.map(|&box| {
+            height = do box.with_base |base| {
+                base.position.size.height
+            };
+        });
+
+        let info = PlacementInfo {
+            width: self.common.position.size.width,
+            height: height,
+            ceiling: Au(0),
+            max_width: self.containing_width,
+            f_type: self.float_type,
+        };
+
+        // Place the float and return the FloatContext back to the parent flow.
+        // After, grab the position and use that to set our position.
+        self.common.floats_out = self.common.floats_in.add_float(&info);
+        self.rel_pos = self.common.floats_out.last_float_pos();
+    }
+
     pub fn assign_height_float(@mut self, ctx: &mut LayoutContext) {
-        let mut float_ctx = FloatContext::new(self.common.num_floats);
-        for FloatFlow(self).each_child |kid| {
-            do kid.with_mut_base |child_node| {
-                child_node.floats_in = float_ctx.clone();
-            }
-            kid.assign_height(ctx);
-            do kid.with_mut_base |child_node| {
-                float_ctx = child_node.floats_out.clone();
+        debug!("assign_height_float: assigning height for float %?", self.common.id);
+        let has_inorder_children = self.common.num_floats > 0;
+        if has_inorder_children {
+            let mut float_ctx = FloatContext::new(self.floated_children);
+            for FloatFlow(self).each_child |kid| {
+                do kid.with_mut_base |child_node| {
+                    child_node.floats_in = float_ctx.clone();
+                }
+                kid.assign_height_inorder(ctx);
+                do kid.with_mut_base |child_node| {
+                    float_ctx = child_node.floats_out.clone();
+                }
             }
         }
 
@@ -229,19 +271,8 @@ impl FloatFlowData {
                 base.position.size.height = height;
             }
         }
-
-        let info = PlacementInfo {
             width: self.common.position.size.width + full_noncontent_width,
             height: height + full_noncontent_height,
-            ceiling: Au(0),
-            max_width: self.containing_width,
-            f_type: self.float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.common.floats_out = self.common.floats_in.add_float(&info);
-        self.rel_pos = self.common.floats_out.last_float_pos();
     }
 
     pub fn build_display_list_float<E:ExtraDisplayListData>(@mut self,

--- a/src/components/main/layout/float.rs
+++ b/src/components/main/layout/float.rs
@@ -277,7 +277,6 @@ impl<V:VisitOrChildView> FloatFlowData<V,VisitChildView> {
     }
 
     pub fn build_display_list_float<E:ExtraDisplayListData>(@mut self,
-                                                            builder: &DisplayListBuilder,
                                                             dirty: &Rect<Au>, 
                                                             list: &Cell<DisplayList<E>>) 
                                                             -> bool {
@@ -291,7 +290,7 @@ impl<V:VisitOrChildView> FloatFlowData<V,VisitChildView> {
         let offset = self.common.abs_position + self.rel_pos;
         // add box that starts block context
         self.box.map(|&box| {
-            box.build_display_list(builder, dirty, &offset, list)
+            box.build_display_list(dirty, &offset, list)
         });
 
 

--- a/src/components/main/layout/float.rs
+++ b/src/components/main/layout/float.rs
@@ -4,7 +4,7 @@
 
 use layout::box::{RenderBox};
 use layout::context::LayoutContext;
-use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::display_list_builder::ExtraDisplayListData;
 use layout::flow::FlowData;
 use layout::flow::{VisitOrChildView,VisitChildView};
 use layout::model::{MaybeAuto};
@@ -50,6 +50,7 @@ impl<V,CV> FloatFlowData<V,CV> {
             index: None,
             float_type: float_type,
             rel_pos: Point2D(Au(0), Au(0)),
+            floated_children: 0,
         }
     }
 

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -29,7 +29,7 @@ use layout::block::BlockFlowData;
 use layout::float::FloatFlowData;
 use layout::box::RenderBox;
 use layout::context::LayoutContext;
-use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::display_list_builder::ExtraDisplayListData;
 use layout::inline::{InlineFlowData};
 use layout::float_context::{FloatContext, Invalid, FloatType};
 use layout::incremental::RestyleDamage;

--- a/src/components/main/layout/flow_interface.rs
+++ b/src/components/main/layout/flow_interface.rs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use layout::flow::{FlowContext, VisitChildView, VisitOrChildView};
+use layout::flow::{BlockFlow,FloatFlow,InlineFlow};
+use layout::block::BlockFlowData;
+use layout::float::FloatFlowData;
+use layout::inline::InlineFlowData;
+
+// This file defines useful methods for use in layout visitors. Each type of FlowData
+// is given a method to access its parent flow, and each flow is given a method to
+// iterate over its children.
+
+pub trait Visitor<Child> {
+    pub fn each_child(&self, &fn(Child) -> bool) -> bool;
+}
+
+impl<V:VisitOrChildView> Visitor<FlowContext<VisitChildView,VisitChildView>>
+for FlowContext<V,VisitChildView> {
+    pub fn each_child(&self, 
+                      callback: &fn(FlowContext<VisitChildView,VisitChildView>) -> bool)
+                      -> bool {
+        let mut maybe_current = self.first_child();
+        while !maybe_current.is_none() {
+            let current = maybe_current.get_ref().clone();
+            if !callback(current.clone()) {
+                break;
+            }
+
+            maybe_current = current.next_sibling();
+        }
+
+        true
+    }
+}
+
+pub trait FlowDataMethods<R:Visitor<FlowContext<VisitChildView,VisitChildView>>> {
+    pub fn flow(@mut self) -> R;
+}
+
+impl<V:VisitOrChildView> FlowDataMethods<FlowContext<V,VisitChildView>> 
+for  BlockFlowData<V,VisitChildView> {
+    fn flow(@mut self) -> FlowContext<V,VisitChildView> {
+        BlockFlow(self)
+    }
+}
+
+impl<V:VisitOrChildView> FlowDataMethods<FlowContext<V,VisitChildView>> 
+for  FloatFlowData<V,VisitChildView> {
+    fn flow(@mut self) -> FlowContext<V,VisitChildView> {
+        FloatFlow(self)
+    }
+}
+
+impl<V:VisitOrChildView> FlowDataMethods<FlowContext<V,VisitChildView>> 
+for  InlineFlowData<V,VisitChildView> {
+    fn flow(@mut self) -> FlowContext<V,VisitChildView> {
+        InlineFlow(self)
+    }
+}
+

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -574,6 +574,7 @@ impl InlineFlowData {
         for InlineFlow(self).each_child |kid| {
             do kid.with_mut_base |base| {
                 base.position.size.width = self.common.position.size.width;
+                base.is_inorder = self.common.is_inorder;
             }
         }
         // There are no child contexts, so stop here.
@@ -585,11 +586,16 @@ impl InlineFlowData {
         // 'inline-block' box that created this flow before recursing.
     }
 
+    pub fn assign_height_inorder_inline(@mut self, ctx: &mut LayoutContext) {
+        for InlineFlow(self).each_child |kid| {
+            kid.assign_height_inorder(ctx);
+        }
+        self.assign_height_inline(ctx);
+    }
+
     pub fn assign_height_inline(@mut self, ctx: &mut LayoutContext) {
 
-        for InlineFlow(self).each_child |kid| {
-            kid.assign_height(ctx);
-        }
+        debug!("assign_height_inline: assigning height for flow %?", self.common.id);
 
         // Divide the boxes into lines
         // TODO(#226): Get the CSS `line-height` property from the containing block's style to
@@ -765,7 +771,9 @@ impl InlineFlowData {
 
         // TODO(#225): Should `inline-block` elements have flows as children of the inline flow or
         // should the flow be nested inside the box somehow?
-        true
+        
+        // For now, don't traverse the subtree rooted here
+        false
     }
 }
 

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -8,9 +8,11 @@ use layout::box::{SplitDidFit, SplitDidNotFit, TextRenderBoxClass};
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{FlowContext, FlowData, InlineFlow};
+use layout::flow::{VisitChildView, VisitOrChildView};
 use layout::float_context::FloatContext;
 use layout::util::{ElementMapping};
 use layout::float_context::{PlacementInfo, FloatLeft};
+use layout::flow_interface::{FlowDataMethods,Visitor};
 
 use std::u16;
 use std::util;
@@ -21,7 +23,6 @@ use newcss::values::{CSSTextAlignLeft, CSSTextAlignCenter, CSSTextAlignRight, CS
 use newcss::units::{Em, Px, Pt};
 use newcss::values::{CSSLineHeightNormal, CSSLineHeightNumber, CSSLineHeightLength, CSSLineHeightPercentage};
 use servo_util::range::Range;
-use servo_util::tree::{TreeNodeRef, TreeUtils};
 use extra::deque::Deque;
 
 /*
@@ -58,8 +59,8 @@ struct LineBox {
     green_zone: Size2D<Au>
 }
 
-struct LineboxScanner {
-    flow: FlowContext,
+struct LineboxScanner<V,CV> {
+    flow: FlowContext<V,CV>,
     floats: FloatContext,
     new_boxes: ~[RenderBox],
     work_list: @mut Deque<RenderBox>,
@@ -68,8 +69,8 @@ struct LineboxScanner {
     cur_y: Au,
 }
 
-impl LineboxScanner {
-    pub fn new(inline: FlowContext, float_ctx: FloatContext) -> LineboxScanner {
+impl<V,CV> LineboxScanner<V,CV> {
+    pub fn new(inline: FlowContext<V,CV>, float_ctx: FloatContext) -> LineboxScanner<V,CV> {
         assert!(inline.starts_inline_flow());
 
         LineboxScanner {
@@ -109,7 +110,7 @@ impl LineboxScanner {
         self.reset_scanner();
 
         { // FIXME: manually control borrow length
-            let inline: &InlineFlowData = self.flow.inline();
+            let inline: &InlineFlowData<V,CV> = self.flow.inline();
             let mut i = 0u;
 
             loop {
@@ -145,7 +146,7 @@ impl LineboxScanner {
         }
 
         { // FIXME: scope the borrow
-            let inline: &mut InlineFlowData = self.flow.inline();
+            let inline: &mut InlineFlowData<V,CV> = self.flow.inline();
             inline.elems.repair_for_box_changes(inline.boxes, self.new_boxes);
         }
         self.swap_out_results();
@@ -156,7 +157,7 @@ impl LineboxScanner {
                self.lines.len(),
                self.flow.id());
 
-        let inline: &mut InlineFlowData = self.flow.inline();
+        let inline: &mut InlineFlowData<V,CV> = self.flow.inline();
         util::swap(&mut inline.boxes, &mut self.new_boxes);
         util::swap(&mut inline.lines, &mut self.lines);
     }
@@ -462,9 +463,9 @@ impl LineboxScanner {
     }
 }
 
-pub struct InlineFlowData {
+pub struct InlineFlowData<View,ChildView> {
     /// Data common to all flows.
-    common: FlowData,
+    common: FlowData<View,ChildView>,
 
     // A vec of all inline render boxes. Several boxes may
     // correspond to one Node/Element.
@@ -479,8 +480,8 @@ pub struct InlineFlowData {
     elems: ElementMapping
 }
 
-impl InlineFlowData {
-    pub fn new(common: FlowData) -> InlineFlowData {
+impl<V,CV> InlineFlowData<V,CV> {
+    pub fn new(common: FlowData<V,CV>) -> InlineFlowData<V,CV> {
         InlineFlowData {
             common: common,
             boxes: ~[],
@@ -502,7 +503,7 @@ pub trait InlineLayout {
     fn starts_inline_flow(&self) -> bool;
 }
 
-impl InlineLayout for FlowContext {
+impl<V,CV> InlineLayout for FlowContext<V,CV> {
     fn starts_inline_flow(&self) -> bool {
         match *self {
             InlineFlow(*) => true,
@@ -511,11 +512,11 @@ impl InlineLayout for FlowContext {
     }
 }
 
-impl InlineFlowData {
+impl<V:VisitOrChildView> InlineFlowData<V,VisitChildView> {
     pub fn bubble_widths_inline(@mut self, ctx: &mut LayoutContext) {
         let mut num_floats = 0;
 
-        for InlineFlow(self).each_child |kid| {
+        for self.flow().each_child |kid| {
             do kid.with_mut_base |base| {
                 num_floats += base.num_floats;
                 base.floats_in = FloatContext::new(base.num_floats);
@@ -571,7 +572,7 @@ impl InlineFlowData {
             } // End of for loop.
         }
 
-        for InlineFlow(self).each_child |kid| {
+        for self.flow().each_child |kid| {
             do kid.with_mut_base |base| {
                 base.position.size.width = self.common.position.size.width;
                 base.is_inorder = self.common.is_inorder;
@@ -587,7 +588,7 @@ impl InlineFlowData {
     }
 
     pub fn assign_height_inorder_inline(@mut self, ctx: &mut LayoutContext) {
-        for InlineFlow(self).each_child |kid| {
+        for self.flow().each_child |kid| {
             kid.assign_height_inorder(ctx);
         }
         self.assign_height_inline(ctx);
@@ -748,7 +749,7 @@ impl InlineFlowData {
                                                                 -self.common.position.size.height));
     }
 
-    pub fn build_display_list_inline<E:ExtraDisplayListData>(&self,
+    pub fn build_display_list_inline<E:ExtraDisplayListData>(@mut self,
                                                              builder: &DisplayListBuilder,
                                                              dirty: &Rect<Au>,
                                                              list: &Cell<DisplayList<E>>)

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -750,7 +750,6 @@ impl<V:VisitOrChildView> InlineFlowData<V,VisitChildView> {
     }
 
     pub fn build_display_list_inline<E:ExtraDisplayListData>(@mut self,
-                                                             builder: &DisplayListBuilder,
                                                              dirty: &Rect<Au>,
                                                              list: &Cell<DisplayList<E>>)
                                                              -> bool {
@@ -767,7 +766,7 @@ impl<V:VisitOrChildView> InlineFlowData<V,VisitChildView> {
                self.boxes.len());
 
         for self.boxes.iter().advance |box| {
-            box.build_display_list(builder, dirty, &self.common.abs_position, list)
+            box.build_display_list(dirty, &self.common.abs_position, list)
         }
 
         // TODO(#225): Should `inline-block` elements have flows as children of the inline flow or

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use layout::box::{CannotSplit, GenericRenderBoxClass, ImageRenderBoxClass, RenderBox};
 use layout::box::{SplitDidFit, SplitDidNotFit, TextRenderBoxClass};
 use layout::context::LayoutContext;
-use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::display_list_builder::ExtraDisplayListData;
 use layout::flow::{FlowContext, FlowData, InlineFlow};
 use layout::flow::{VisitChildView, VisitOrChildView};
 use layout::float_context::FloatContext;

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -11,7 +11,6 @@ use layout::aux::{LayoutData, LayoutAuxMethods};
 use layout::box::RenderBox;
 use layout::box_builder::LayoutTreeBuilder;
 use layout::context::LayoutContext;
-use layout::display_list_builder::{DisplayListBuilder};
 use layout::flow::{FlowContext,SequentialView};
 use layout::parallel_traversal::SequentialTraverser;
 use layout::incremental::{RestyleDamage, BubbleWidths};
@@ -290,10 +289,6 @@ impl LayoutTask {
         // Build the display list if necessary, and send it to the renderer.
         if data.goal == ReflowForDisplay {
             do profile(time::LayoutDispListBuildCategory, self.profiler_chan.clone()) {
-                let builder = DisplayListBuilder {
-                    ctx: &layout_ctx,
-                };
-
                 let display_list = @Cell::new(DisplayList::new());
 
                 // TODO: Set options on the builder before building.
@@ -398,10 +393,6 @@ impl LayoutTask {
                         Err(())
                     }
                     Some(flow) => {
-                        let layout_ctx = self.build_layout_context();
-                        let builder = DisplayListBuilder {
-                            ctx: &layout_ctx,
-                        };
                         let display_list: @Cell<DisplayList<RenderBox>> =
                             @Cell::new(DisplayList::new());
                         let traverser = SequentialTraverser::new();

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -302,7 +302,7 @@ impl LayoutTask {
                 // TODO: Set options on the builder before building.
                 // TODO: Be smarter about what needs painting.
                 do traverser.partially_traverse_preorder(layout_root) |flow| {
-                    flow.build_display_list(&builder, &layout_root.position(), display_list)
+                    flow.build_display_list(&layout_root.position(), display_list)
                 }
 
                 let root_size = do layout_root.with_base |base| {
@@ -409,8 +409,7 @@ impl LayoutTask {
                             @Cell::new(DisplayList::new());
                         let traverser = SequentialTraverser::new();
                         do traverser.partially_traverse_preorder(flow) |this_flow| {
-                            this_flow.build_display_list(&builder,
-                                                         &flow.position(),
+                            this_flow.build_display_list(&flow.position(),
                                                          display_list)
                         }
                         let (x, y) = (Au::from_frac_px(point.x as float),

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -283,7 +283,9 @@ impl LayoutTask {
 
             // For now, this is an inorder traversal
             // FIXME: prune this traversal as well
-            layout_root.assign_height(&mut layout_ctx);
+            for layout_root.traverse_bu_sub_inorder |flow| {
+                flow.assign_height(&mut layout_ctx);
+            }
         }
 
         // Build the display list if necessary, and send it to the renderer.

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -283,7 +283,6 @@ impl LayoutTask {
                 flow.assign_widths(&mut layout_ctx);
             };
 
-            // For now, this is an inorder traversal
             // FIXME: prune this traversal as well
             for traverser.traverse_bu_sub_inorder(layout_root) |flow| {
                 flow.assign_height(&mut layout_ctx);

--- a/src/components/main/layout/parallel_traversal.rs
+++ b/src/components/main/layout/parallel_traversal.rs
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use servo_util::tree::TreeUtils;
+use layout::flow::{FlowContext,SequentialView,VisitView,VisitChildView};
+
+/// Stub sequential traverser to test out memory safety.
+pub struct SequentialTraverser;
+
+impl SequentialTraverser {
+    pub fn new() -> SequentialTraverser {
+        return SequentialTraverser;
+    }
+
+    pub fn traverse_preorder(&self, 
+                         tree: FlowContext<SequentialView,SequentialView>, 
+                         callback: &fn(FlowContext<VisitView,VisitChildView>) -> bool) 
+                         -> bool {
+    
+        unsafe {
+            if !callback(FlowContext::decode(tree.encode())) {
+                return false;
+            }
+        }
+
+        for tree.each_child |kid| {
+            // FIXME: Work around rust#2202. We should be able to pass the callback directly.
+            if !self.traverse_preorder(kid, |a| callback(a)) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    pub fn traverse_postorder(&self, 
+                         tree: FlowContext<SequentialView,SequentialView>, 
+                         callback: &fn(FlowContext<VisitView,VisitChildView>) -> bool) 
+                         -> bool {
+
+        for tree.each_child |kid| {
+            // FIXME: Work around rust#2202. We should be able to pass the callback directly.
+            if !self.traverse_postorder(kid, |a| callback(a)) {
+                return false;
+            }
+        }
+        unsafe {
+            callback(FlowContext::decode(tree.encode()))
+        }
+    }
+
+    /// Like traverse_preorder, but don't end the whole traversal if the callback
+    /// returns false.
+    pub fn partially_traverse_preorder(&self, 
+                         tree: FlowContext<SequentialView,SequentialView>, 
+                         callback: &fn(FlowContext<VisitView,VisitChildView>) -> bool) {
+
+        unsafe {
+            if !callback(FlowContext::decode(tree.encode())) {
+                return;
+            }
+        }
+
+        for tree.each_child |kid| {
+            // FIXME: Work around rust#2202. We should be able to pass the callback directly.
+            self.partially_traverse_preorder(kid, |a| callback(a));
+        }
+    }
+
+    // Like traverse_postorder, but only visits nodes not marked as inorder
+    pub fn traverse_bu_sub_inorder(&self, 
+                         tree: FlowContext<SequentialView,SequentialView>, 
+                         callback: &fn(FlowContext<VisitView,VisitChildView>) -> bool) 
+                         -> bool {
+
+        for tree.each_child |kid| {
+            // FIXME: Work around rust#2202. We should be able to pass the callback directly.
+            if !self.traverse_bu_sub_inorder(kid, |a| callback(a)) {
+                return false;
+            }
+        }
+
+        if !tree.is_inorder() {
+            unsafe {
+                callback(FlowContext::decode(tree.encode()))
+            }
+        } else {
+            true
+        }
+    }
+}
+

--- a/src/components/main/layout/parallel_traversal.rs
+++ b/src/components/main/layout/parallel_traversal.rs
@@ -2,8 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use servo_util::tree::TreeUtils;
+use servo_util::tree::{TreeUtils, TreeNodeRef, TreeNode};
 use layout::flow::{FlowContext,SequentialView,VisitView,VisitChildView};
+use layout::clq::WorkstealingDeque;
+
+use std::vec;
+use std::rand::random;
+use std::uint;
+use std::unstable::atomics::{AtomicUint,SeqCst};
+use std::unstable::sync::UnsafeAtomicRcBox;
+use extra::arc::ARC;
 
 /// Stub sequential traverser to test out memory safety.
 pub struct SequentialTraverser;
@@ -19,7 +27,7 @@ impl SequentialTraverser {
                          -> bool {
     
         unsafe {
-            if !callback(FlowContext::decode(tree.encode())) {
+            if !callback(tree.restrict_view()) {
                 return false;
             }
         }
@@ -46,7 +54,7 @@ impl SequentialTraverser {
             }
         }
         unsafe {
-            callback(FlowContext::decode(tree.encode()))
+            callback(tree.restrict_view())
         }
     }
 
@@ -57,7 +65,7 @@ impl SequentialTraverser {
                          callback: &fn(FlowContext<VisitView,VisitChildView>) -> bool) {
 
         unsafe {
-            if !callback(FlowContext::decode(tree.encode())) {
+            if !callback(tree.restrict_view()) {
                 return;
             }
         }
@@ -83,11 +91,93 @@ impl SequentialTraverser {
 
         if !tree.is_inorder() {
             unsafe {
-                callback(FlowContext::decode(tree.encode()))
+                callback(tree.restrict_view())
             }
         } else {
             true
         }
+    }
+}
+
+
+/// Similar to a task pool, this allows farming out work to a number of tasks to
+/// improve parallelism. However, tasks here are not actually swapped, so there
+/// is no context switching overhead.
+priv struct WorkPool<Work,Shared> {
+    queues: ~[WorkstealingDeque<Work>]
+}
+
+
+impl<W,S:Freeze+Send> WorkPool<W,S> {
+    fn new(num_tasks: uint, max_work: uint) -> WorkPool<W,S> {
+        unsafe {
+            WorkPool {
+                queues: (vec::from_fn(num_tasks, |_| { WorkstealingDeque::new(max_work) }))
+            }
+        }
+    }
+
+    /// Add an initial item of work to the queue
+    fn add_work(&mut self, work: *W) {
+        self.queues[0].push(work);
+    }
+
+    /// Run the tasks on work items in the queue.
+    /// The callee can obtain new work by calling the pop function,
+    /// And can add work to the queue by calling the push function.
+    /// Work stops when the callback returns false.
+    fn execute(&mut self, 
+               shared_data: ARC<S>,
+               cb_factory: &fn() -> ~fn(shared: &ARC<S>, 
+                                        push: &fn(work: *W), 
+                                        pop: &fn() -> Option<*W>) 
+                                        -> bool) {
+        unsafe {
+            let unsafe_queues: *mut ~[WorkstealingDeque<W>] = &mut self.queues;
+            for uint::range(0,self.queues.len()) |i| {
+                let data = shared_data.clone();
+                let callback = cb_factory();
+                do spawn {
+                    let mut this_q = (*unsafe_queues)[i];
+                    loop {
+                        // The push function simply adds work to this tasks queue.
+                        // The pop function tries to pull work from the current
+                        // queue, but steals from a random queue if this is not
+                        // possible.
+                        if !callback(&data, |w| { this_q.push(w) }, || {
+                            match this_q.pop() {
+                                None => {
+                                    (*unsafe_queues)[random::<uint>() % (*unsafe_queues).len()].steal()
+                                }
+                                Some(work) => Some(work)
+                            }}) {
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+priv trait TraversableTree {
+    fn each_leaf (&self, callback: &fn(leaf: Self) -> bool) -> bool;
+}
+
+impl TraversableTree for FlowContext<SequentialView,SequentialView> {
+    fn each_leaf (&self, 
+                  callback: &fn(leaf: FlowContext<SequentialView,SequentialView>) -> bool) 
+                  -> bool {
+        for self.traverse_postorder |node| {
+            if node.is_leaf(){
+                if !callback(node){
+                    break;
+                }
+            }
+        }
+
+        return true;
     }
 }
 
@@ -101,14 +191,20 @@ pub enum TraversalSubtype {
     Inorder
 }
 
+trait ParallelTraversalHelper{
+    fn get_or_none(&self, uint) -> Option<TraversalType>;
+}
 
-impl [Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)>] {
+impl ParallelTraversalHelper for 
+~[(TraversalType, ~fn:Send+Freeze(FlowContext<VisitView,VisitChildView>) -> bool)] {
     fn get_or_none(&self, index: uint) -> Option<TraversalType> {
         if index > self.len() {
             return None;
         }
 
-        self[index]
+        match self[index] {
+            (traversal,_) => Some(traversal)
+        }
     }
 }
 
@@ -117,169 +213,178 @@ impl [Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)
 /// td-bu-td-buSubInorder). This is enough for layout and makes the scheduler simple, but
 /// we may have to support other traversal sequences in the future.
 pub struct ParallelTraverser {
-    traversals: ~[Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)>]
-    traversals_added: uint,
-}
-
-struct SharedData {
-    traversals: ~[Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)>]
-    cur_traversal: uint,
+    traversals: ~[(TraversalType, ~fn:Send+Freeze(FlowContext<VisitView,VisitChildView>) -> bool)],
 }
 
 impl ParallelTraverser {
-    pub fn new(num_traversals: int) -> ParallelTraverser {
+    pub fn new(num_traversals: uint) -> ParallelTraverser {
         ParallelTraverser {
-            traversals: vec::from_elem(num_traversals, None),
-            traversals_added: 0
+            traversals: vec::with_capacity(num_traversals),
         }
     }
 
     pub fn add_traversal(&mut self,
-                         ty: TraversalType, 
-                         cb: ~fn(FlowContext<VisitView,VisitChildView>) -> bool) {
-        assert!(self.traversals_added < self.traversals.len(), "Tried to add too many traversals");
+            ty: TraversalType, 
+            cb: ~fn:Send+Freeze(FlowContext<VisitView,VisitChildView>) -> bool) {
 
-        self.traversals[traversals_added] = Some(ty,cb);
-        traversals_added += 1;
+        self.traversals.push((ty,cb));
     }
 
-    pub fn run(~self, tree: FlowContext<SequentialView,SequentialView>, num_tasks: uint) {
-        if self.traversals_added == 0 {
+    pub fn run(~self, 
+               tree: FlowContext<SequentialView,SequentialView>, 
+               num_tasks: uint, 
+               max_nodes: uint) {
+
+        if self.traversals.len() == 0 {
             return;
         }
 
-        let last_nodes = AtomicUint::new(match self.traversals[self.traversals_added - 1] {
-            Some((BottomUp(_), _)) => 1,
-            _ => fail!("Last traversal must be bottom-up")
+        let last_nodes = AtomicUint::new(match self.traversals[self.traversals.len() - 1] {
+                (BottomUp(_), _) => 1,
+                _ => fail!("Last traversal must be bottom-up")
         });
 
-        let q: [WorkstealingDequeue<uint>] = 
-            vec::fom_fn(num_tasks, |_| { WorkstealingDequeue::new() });
+        let last_nodes = UnsafeAtomicRcBox::new(last_nodes);
 
         // all threads need access to the traversals, so wrap them in an ARC
         let shared_traversals = ARC(self.traversals);
 
+        let mut work_pool = WorkPool::new(num_tasks, max_nodes);
+
+        // Initial conditions. Reset the traversal
+        // counters on each starting node before
+        // adding them to the work queue.
         unsafe {
             let data = shared_traversals.get();
-            // Initial conditions. Reset the traversal
-            // counters on each starting node before
-            // adding them to the work queue.
             match data[0] {
                 // TD starts at the root.
-                Some((TopDown, _)) => {
+                (TopDown, _) => {
                     tree.set_traversal(0);
-                    q[0].push(tree.encode()),
+                    work_pool.add_work(tree.encode());
                 }
 
                 // Both types of BU start at the leaves
-                Some((BottomUp(_), _)) => {
+                (BottomUp(_), _) => {
                     for tree.each_leaf |leaf| {
                         leaf.set_traversal(0);
-                        q[0].push(leaf.encode());
+                        work_pool.add_work(leaf.encode());
                     }
                 }
             }
+        }
 
-            // Each task should only push and pop from its own queue in
-            // this array. Pushing or popping from another queue will
-            // be racy and possibly memory-unsafe. Any task can steal
-            // from any queue safely.
-            let q_ptr : *[WorkstealingDequeue<uint>] = &q;
-            for uint::range(0, num_tasks) |i| {
-                let this_data = shared.clone();
-                do spawn {
 
-                    let this_q = *q_ptr[i];
-                    let traversals = this_data.get();
+        unsafe {
+            do work_pool.execute(shared_traversals) { 
+                let this_last_nodes = last_nodes.clone();
+                |traversals, push, pop| {
+                    let mut last_nodes = *this_last_nodes.get();
+                    let node = match pop() {
+                        None => {
+                            None
+                        }
+                        Some(work) => {
+                            Some(FlowContext::decode(work))
+                        }
+                    };
 
-                    match this_q.pop() {
-                        // If there's no more work to do, try to steal a random thread's
-                        // work.
-                        None => {    
-                            match *q_ptr[random::<uint>() % q_ptr.len()].steal() {
-                                None = { 
-                                    if last_nodes <= 0 {
-                                        break;
-                                    }
-                                }
-                                Some(val) => { this_q.push(val); }
+                    let traversals = traversals.get();
+
+                    match node {
+                        None => {
+                            if last_nodes.compare_and_swap(0, 0, SeqCst) == 0 {
+                                false
+                            } else {
+                                true
                             }
                         }
-
                         Some(node) => {
-
-                            let node = FlowContext::decode(node);
                             match traversals[node.get_traversal()] {
-                                Some(TopDown, callback) => {
+                                (TopDown, ref callback) => {
                                     // simple case: visit the node then add its children
                                     // to the work queue
-                                    callback(node.restrict_view());
+                                    unsafe {
+                                        (*callback)(node.restrict_view());
+                                    }
                                     node.set_traversal(node.get_traversal() + 1);
 
                                     let mut has_children = false;
                                     for node.each_child |child| {
                                         has_children = true;
                                         child.set_traversal(node.get_traversal() - 1);
-                                        this_q.push(child.encode());
+
+                                        unsafe {
+                                            push(child.encode());
+                                        }
                                     }
 
                                     // if the node is a leaf, try and start the next traversal
                                     // in the sequence
                                     if !has_children {
                                         match traversals.get_or_none(node.get_traversal()) {
-                                            None => { last_nodes.fetch_sub(1); }
-                                            Some(BottomUp)
-                                            | Some (BottomUpInorder) ==> {
-                                                this_q.push(node.encode());
+                                            None => { last_nodes.fetch_sub(1, SeqCst); }
+                                            Some(BottomUp(_)) => {
+                                                unsafe{
+                                                    push(node.encode());
+                                                }
                                             }
                                             _ => fail!("Unsupported traversal sequence")
                                         }
                                     }
                                 }
 
-                                Some(BottomUp(subtype), callback) => {
+                                (BottomUp(subtype), ref callback) => {
 
-                                    match subtype {
-                                        Normal => { callback(node.restrict_view()); }
-                                        Inorder => {
-                                            if !node.is_inorder {
-                                                callback(node.restrict_view());
+                                    unsafe {
+                                        match subtype {
+                                            Normal => { (*callback)(node.restrict_view()); }
+                                            Inorder => {
+                                                if !node.is_inorder() {
+                                                    (*callback)(node.restrict_view());
+                                                }
                                             }
                                         }
                                     }
 
                                     node.set_traversal(node.get_traversal() + 1);
 
-                                    match node.parent_node() {
-                                        // if the node is the root, try and start the next traversal
-                                        // in the sequence
-                                        None => {
-                                            match traversals.get_or_none(node.get_traversal()) {
-                                                None => { last_nodes.fetch_sub(1); }
-                                                Some(TopDown) => {
-                                                    this_q.push(node.encode());
+                                    do node.with_base |base| {
+                                        match base.parent_node() {
+                                            // if the node is the root, try and start the next traversal
+                                            // in the sequence
+                                            None => {
+                                                match traversals.get_or_none(node.get_traversal()) {
+                                                    None => { last_nodes.fetch_sub(1, SeqCst); }
+                                                    Some(TopDown) => {
+                                                        unsafe {
+                                                            push(node.encode());
+                                                        }
+                                                    }
+                                                    _ => fail!("Unsupported traversal sequence")
                                                 }
-                                                _ => fail!("Unsupported traversal sequence")
                                             }
-                                        }
-                                        Some(parent) => {
-                                            // update_child_counter synchronizes on the parent node,
-                                            // so only one thread will add the parent to the queue
-                                            if parent.update_child_counter() {
-                                                parent.set_traversal(node.get_traversal() - 1);
-                                                this_q.push(node.parent().encode());
+
+                                            Some(ref mut parent) => {
+                                                // update_child_counter synchronizes on the parent node,
+                                                // so only one thread will add the parent to the queue
+                                                if parent.update_child_counter() {
+                                                    parent.set_traversal(node.get_traversal() - 1);
+
+                                                    unsafe {
+                                                        push(base.parent_node().get().encode());
+                                                    }
+                                                }
                                             }
                                         }
                                     }
                                 }
-                            }
+                            };
+                            true
                         }
                     }
                 }
             }
-
-            // Block until the worker threads are done.
-            while last_nodes > 0 {}
-        }
+        };
     }
 }
+

--- a/src/components/main/layout/parallel_traversal.rs
+++ b/src/components/main/layout/parallel_traversal.rs
@@ -91,3 +91,195 @@ impl SequentialTraverser {
     }
 }
 
+pub enum TraversalType {
+    TopDown,
+    BottomUp(TraversalSubtype),
+}
+
+pub enum TraversalSubtype {
+    Normal,
+    Inorder
+}
+
+
+impl [Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)>] {
+    fn get_or_none(&self, index: uint) -> Option<TraversalType> {
+        if index > self.len() {
+            return None;
+        }
+
+        self[index]
+    }
+}
+
+/// Parallel traversal handler. Traversals are run lazily so transitions can be optimized.
+/// Currently, this only handles traversals that alternate in direction (e.g. 
+/// td-bu-td-buSubInorder). This is enough for layout and makes the scheduler simple, but
+/// we may have to support other traversal sequences in the future.
+pub struct ParallelTraverser {
+    traversals: ~[Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)>]
+    traversals_added: uint,
+}
+
+struct SharedData {
+    traversals: ~[Option<(TraversalType, ~fn(FlowContext<VisitView,VisitChildView>) -> bool)>]
+    cur_traversal: uint,
+}
+
+impl ParallelTraverser {
+    pub fn new(num_traversals: int) -> ParallelTraverser {
+        ParallelTraverser {
+            traversals: vec::from_elem(num_traversals, None),
+            traversals_added: 0
+        }
+    }
+
+    pub fn add_traversal(&mut self,
+                         ty: TraversalType, 
+                         cb: ~fn(FlowContext<VisitView,VisitChildView>) -> bool) {
+        assert!(self.traversals_added < self.traversals.len(), "Tried to add too many traversals");
+
+        self.traversals[traversals_added] = Some(ty,cb);
+        traversals_added += 1;
+    }
+
+    pub fn run(~self, tree: FlowContext<SequentialView,SequentialView>, num_tasks: uint) {
+        if self.traversals_added == 0 {
+            return;
+        }
+
+        let last_nodes = AtomicUint::new(match self.traversals[self.traversals_added - 1] {
+            Some((BottomUp(_), _)) => 1,
+            _ => fail!("Last traversal must be bottom-up")
+        });
+
+        let q: [WorkstealingDequeue<uint>] = 
+            vec::fom_fn(num_tasks, |_| { WorkstealingDequeue::new() });
+
+        // all threads need access to the traversals, so wrap them in an ARC
+        let shared_traversals = ARC(self.traversals);
+
+        unsafe {
+            let data = shared_traversals.get();
+            // Initial conditions. Reset the traversal
+            // counters on each starting node before
+            // adding them to the work queue.
+            match data[0] {
+                // TD starts at the root.
+                Some((TopDown, _)) => {
+                    tree.set_traversal(0);
+                    q[0].push(tree.encode()),
+                }
+
+                // Both types of BU start at the leaves
+                Some((BottomUp(_), _)) => {
+                    for tree.each_leaf |leaf| {
+                        leaf.set_traversal(0);
+                        q[0].push(leaf.encode());
+                    }
+                }
+            }
+
+            // Each task should only push and pop from its own queue in
+            // this array. Pushing or popping from another queue will
+            // be racy and possibly memory-unsafe. Any task can steal
+            // from any queue safely.
+            let q_ptr : *[WorkstealingDequeue<uint>] = &q;
+            for uint::range(0, num_tasks) |i| {
+                let this_data = shared.clone();
+                do spawn {
+
+                    let this_q = *q_ptr[i];
+                    let traversals = this_data.get();
+
+                    match this_q.pop() {
+                        // If there's no more work to do, try to steal a random thread's
+                        // work.
+                        None => {    
+                            match *q_ptr[random::<uint>() % q_ptr.len()].steal() {
+                                None = { 
+                                    if last_nodes <= 0 {
+                                        break;
+                                    }
+                                }
+                                Some(val) => { this_q.push(val); }
+                            }
+                        }
+
+                        Some(node) => {
+
+                            let node = FlowContext::decode(node);
+                            match traversals[node.get_traversal()] {
+                                Some(TopDown, callback) => {
+                                    // simple case: visit the node then add its children
+                                    // to the work queue
+                                    callback(node.restrict_view());
+                                    node.set_traversal(node.get_traversal() + 1);
+
+                                    let mut has_children = false;
+                                    for node.each_child |child| {
+                                        has_children = true;
+                                        child.set_traversal(node.get_traversal() - 1);
+                                        this_q.push(child.encode());
+                                    }
+
+                                    // if the node is a leaf, try and start the next traversal
+                                    // in the sequence
+                                    if !has_children {
+                                        match traversals.get_or_none(node.get_traversal()) {
+                                            None => { last_nodes.fetch_sub(1); }
+                                            Some(BottomUp)
+                                            | Some (BottomUpInorder) ==> {
+                                                this_q.push(node.encode());
+                                            }
+                                            _ => fail!("Unsupported traversal sequence")
+                                        }
+                                    }
+                                }
+
+                                Some(BottomUp(subtype), callback) => {
+
+                                    match subtype {
+                                        Normal => { callback(node.restrict_view()); }
+                                        Inorder => {
+                                            if !node.is_inorder {
+                                                callback(node.restrict_view());
+                                            }
+                                        }
+                                    }
+
+                                    node.set_traversal(node.get_traversal() + 1);
+
+                                    match node.parent_node() {
+                                        // if the node is the root, try and start the next traversal
+                                        // in the sequence
+                                        None => {
+                                            match traversals.get_or_none(node.get_traversal()) {
+                                                None => { last_nodes.fetch_sub(1); }
+                                                Some(TopDown) => {
+                                                    this_q.push(node.encode());
+                                                }
+                                                _ => fail!("Unsupported traversal sequence")
+                                            }
+                                        }
+                                        Some(parent) => {
+                                            // update_child_counter synchronizes on the parent node,
+                                            // so only one thread will add the parent to the queue
+                                            if parent.update_child_counter() {
+                                                parent.set_traversal(node.get_traversal() - 1);
+                                                this_q.push(node.parent().encode());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Block until the worker threads are done.
+            while last_nodes > 0 {}
+        }
+    }
+}

--- a/src/components/main/layout/text.rs
+++ b/src/components/main/layout/text.rs
@@ -12,7 +12,7 @@ use gfx::text::util::{CompressWhitespaceNewline, transform_text};
 use layout::box::{RenderBox, RenderBoxBase, TextRenderBox};
 use layout::box::{TextRenderBoxClass, UnscannedTextRenderBoxClass};
 use layout::context::LayoutContext;
-use layout::flow::FlowContext;
+use layout::flow::{FlowContext,SequentialView};
 use layout::util::{NodeRange};
 use newcss::values::{CSSTextDecoration, CSSTextDecorationUnderline};
 use servo_util::range::Range;
@@ -68,7 +68,9 @@ impl TextRunScanner {
         }
     }
 
-    pub fn scan_for_runs(&mut self, ctx: &LayoutContext, flow: FlowContext) {
+    pub fn scan_for_runs(&mut self, 
+                         ctx: &LayoutContext, 
+                         flow: FlowContext<SequentialView,SequentialView>) {
         let inline = flow.inline();
         assert!(inline.boxes.len() > 0);
         debug!("TextRunScanner: scanning %u boxes for text runs...", inline.boxes.len());
@@ -120,7 +122,7 @@ impl TextRunScanner {
     /// necessary.
     pub fn flush_clump_to_list(&mut self,
                                ctx: &LayoutContext,
-                               flow: FlowContext,
+                               flow: FlowContext<SequentialView,SequentialView>,
                                last_whitespace: bool,
                                out_boxes: &mut ~[RenderBox]) -> bool {
         let inline = &mut *flow.inline();

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -104,7 +104,7 @@ impl ElementMapping {
                 while new_j < new_boxes.len() {
                     let should_leave = do old_boxes[old_i].with_base |old_box_base| {
                         do new_boxes[new_j].with_base |new_box_base| {
-                            old_box_base.node != new_box_base.node
+                            old_box_base.different_node(new_box_base)
                         }
                     };
                     if should_leave {

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -72,6 +72,7 @@ pub mod layout {
     pub mod block;
     pub mod box;
     pub mod box_builder;
+    pub mod clq;
     pub mod context;
     pub mod display_list_builder;
     pub mod float_context;

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -77,9 +77,11 @@ pub mod layout {
     pub mod float_context;
     pub mod float;
     pub mod flow;
+    pub mod flow_interface;
     pub mod layout_task;
     pub mod inline;
     pub mod model;
+    pub mod parallel_traversal;
     pub mod text;
     pub mod util;
     pub mod incremental;

--- a/src/components/util/tree.rs
+++ b/src/components/util/tree.rs
@@ -51,6 +51,9 @@ pub trait TreeUtils {
     /// Returns true if this node is disconnected from the tree or has no children.
     fn is_leaf(&self) -> bool;
 
+    /// Returns the number of children the given node has.
+    fn num_children(&self) -> uint;
+
     /// Adds a new child to the end of this node's list of children.
     ///
     /// Fails unless `new_child` is disconnected from the tree.
@@ -90,6 +93,15 @@ impl<NR:TreeNodeRef<N>,N:TreeNode<NR>> TreeUtils for NR {
         do self.with_base |this_node| {
             this_node.first_child().is_none()
         }
+    }
+
+    //TODO: make this O(1)
+    fn num_children(&self) -> uint {
+        let mut result = 0;
+        for self.each_child |_| {
+            result += 1;
+        }
+        result
     }
 
     fn add_child(&self, new_child: NR) {


### PR DESCRIPTION
This is a rollup of some of the changes necessary for parallel layout:
- Make assign_height partially bottom-up when there are no floats
- Use phantom types to ensure safety when perfoming the traversals
- Add an outline of the code that will eventually run traversals in parallel (this is not currently enabled or working)

The code in parallel_traversal.rs is a basic outline, but won't actually work yet. Comments on the general structure would be appreciated, but there's no need to look at it in detail yet. I also have some doubts about bringing the Chase-Lev queue into the tree, as we're hopefully going to use one from the Rust runtime and I don't even know if this one works (also, not sure about the license).
