### PR TITLE
Generate bindings for HTMLBodyElement

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -546,6 +546,7 @@ def addHTMLElement(element):
   }
 
 addHTMLElement('HTMLAnchorElement')
+addHTMLElement('HTMLBodyElement')
 addHTMLElement('HTMLDivElement')
 addHTMLElement('HTMLElement')
 addHTMLElement('HTMLHeadElement')

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4618,6 +4618,7 @@ class CGBindingRoot(CGThing):
                           'dom::element::{Element, HTMLHeadElement, HTMLHtmlElement}', #XXXjdm
                           'dom::element::{HTMLDivElement, HTMLSpanElement, HTMLParagraphElement}', #XXXjdm
                           'dom::htmlanchorelement::HTMLAnchorElement', #XXXjdm
+                          'dom::htmlbodyelement::HTMLBodyElement', 
                           'dom::htmlelement::HTMLElement', #XXXjdm
                           'dom::htmldocument::HTMLDocument', #XXXjdm
                           'dom::htmlhrelement::HTMLHRElement',

--- a/src/components/script/dom/bindings/codegen/HTMLBodyElement.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLBodyElement.webidl
@@ -1,0 +1,26 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * http://www.whatwg.org/specs/web-apps/current-work/
+ *
+ * © Copyright 2004-2011 Apple Computer, Inc., Mozilla Foundation, and
+ * Opera Software ASA. You are granted a license to use, reproduce
+ * and create derivative works of this document.
+ */
+
+interface HTMLBodyElement : HTMLElement {
+};
+
+partial interface HTMLBodyElement {
+    [TreatNullAs=EmptyString, SetterThrows] attribute DOMString text;
+    [TreatNullAs=EmptyString, SetterThrows] attribute DOMString link;
+    [TreatNullAs=EmptyString, SetterThrows] attribute DOMString vLink;
+    [TreatNullAs=EmptyString, SetterThrows] attribute DOMString aLink;
+    [TreatNullAs=EmptyString, SetterThrows] attribute DOMString bgColor;
+    [SetterThrows]                          attribute DOMString background;
+};
+
+//HTMLBodyElement implements WindowEventHandlers;

--- a/src/components/script/dom/bindings/node.rs
+++ b/src/components/script/dom/bindings/node.rs
@@ -8,11 +8,12 @@ use dom::bindings::utils;
 use dom::bindings::utils::{CacheableWrapper, WrapperCache, DerivedWrapper};
 use dom::element::{HTMLHeadElementTypeId, HTMLHtmlElementTypeId, HTMLAnchorElementTypeId};
 use dom::element::{HTMLDivElementTypeId, HTMLImageElementTypeId, HTMLSpanElementTypeId};
-use dom::element::{HTMLHRElementTypeId};
+use dom::element::{HTMLBodyElementTypeId, HTMLHRElementTypeId};
 use dom::element::{HTMLParagraphElementTypeId, HTMLScriptElementTypeId};
 use dom::element::{HTMLHeadElement, HTMLHtmlElement, HTMLDivElement, HTMLSpanElement};
 use dom::element::{HTMLParagraphElement};
 use dom::htmlanchorelement::HTMLAnchorElement;
+use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlhrelement::HTMLHRElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlscriptelement::HTMLScriptElement;
@@ -82,6 +83,7 @@ macro_rules! generate_element(
 pub fn create(cx: *JSContext, node: &mut AbstractNode<ScriptView>) -> *JSObject {
     match node.type_id() {
         ElementNodeTypeId(HTMLAnchorElementTypeId) => generate_element!(HTMLAnchorElement),
+        ElementNodeTypeId(HTMLBodyElementTypeId) => generate_element!(HTMLBodyElement),
         ElementNodeTypeId(HTMLDivElementTypeId) => generate_element!(HTMLDivElement),
         ElementNodeTypeId(HTMLHeadElementTypeId) => generate_element!(HTMLHeadElement),
         ElementNodeTypeId(HTMLHRElementTypeId) => generate_element!(HTMLHRElement),

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -617,7 +617,7 @@ pub extern fn ThrowingConstructor(_cx: *JSContext, _argc: uint, _vp: *JSVal) -> 
 }
 
 pub fn initialize_global(global: *JSObject) {
-    let protoArray = @mut ([0 as *JSObject, ..39]);
+    let protoArray = @mut ([0 as *JSObject, ..40]);
     assert!(protoArray.len() == PrototypeList::id::_ID_Count as uint);
     unsafe {
         //XXXjdm we should be storing the box pointer instead of the inner

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -5,7 +5,7 @@
 //! Element nodes.
 
 use dom::bindings::codegen::{HTMLHeadElementBinding, HTMLHtmlElementBinding};
-use dom::bindings::codegen::{HTMLAnchorElementBinding, HTMLDivElementBinding, HTMLSpanElementBinding};
+use dom::bindings::codegen::{HTMLAnchorElementBinding, HTMLBodyElementBinding, HTMLDivElementBinding, HTMLSpanElementBinding};
 use dom::bindings::codegen::{HTMLHRElementBinding};
 use dom::bindings::codegen::{HTMLParagraphElementBinding, HTMLScriptElementBinding};
 use dom::bindings::codegen::{HTMLImageElementBinding};
@@ -14,6 +14,7 @@ use dom::bindings::utils::{BindingObject, CacheableWrapper, DOMString, ErrorResu
 use dom::clientrect::ClientRect;
 use dom::clientrectlist::ClientRectList;
 use dom::htmlanchorelement::HTMLAnchorElement;
+use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElement;
 use dom::htmlhrelement::HTMLHRElement;
@@ -103,7 +104,6 @@ pub enum ElementTypeId {
 
 pub struct HTMLAsideElement     { parent: HTMLElement }
 pub struct HTMLBRElement        { parent: HTMLElement }
-pub struct HTMLBodyElement      { parent: HTMLElement }
 pub struct HTMLBoldElement      { parent: HTMLElement }
 pub struct HTMLDivElement       { parent: HTMLElement }
 pub struct HTMLFontElement      { parent: HTMLElement }
@@ -191,6 +191,8 @@ generate_cacheable_wrapper!(HTMLHtmlElement, HTMLHtmlElementBinding::Wrap)
 generate_binding_object!(HTMLHtmlElement)
 generate_cacheable_wrapper!(HTMLAnchorElement, HTMLAnchorElementBinding::Wrap)
 generate_binding_object!(HTMLAnchorElement)
+generate_cacheable_wrapper!(HTMLBodyElement, HTMLBodyElementBinding::Wrap)
+generate_binding_object!(HTMLBodyElement)
 generate_cacheable_wrapper!(HTMLDivElement, HTMLDivElementBinding::Wrap)
 generate_binding_object!(HTMLDivElement)
 generate_cacheable_wrapper!(HTMLImageElement, HTMLImageElementBinding::Wrap)

--- a/src/components/script/dom/htmlbodyelement.rs
+++ b/src/components/script/dom/htmlbodyelement.rs
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::utils::{DOMString, null_string, ErrorResult};
+use dom::htmlelement::HTMLElement;
+
+pub struct HTMLBodyElement {
+    parent: HTMLElement
+}
+
+impl HTMLBodyElement {
+    pub fn Text(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetText(&mut self, _text: &DOMString, _rv: &mut ErrorResult) {
+    }
+
+    pub fn Link(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetLink(&self, _link: &DOMString, _rv: &mut ErrorResult) {
+    }
+
+    pub fn VLink(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetVLink(&self, _v_link: &DOMString, _rv: &mut ErrorResult) {
+    }
+
+    pub fn ALink(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetALink(&self, _a_link: &DOMString, _rv: &mut ErrorResult) {
+    }
+
+    pub fn BgColor(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetBgColor(&self, _bg_color: &DOMString, _rv: &mut ErrorResult) {
+    }
+
+    pub fn Background(&self) -> DOMString {
+        null_string
+    }
+
+    pub fn SetBackground(&self, _background: &DOMString, _rv: &mut ErrorResult) {
+    }
+}

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -15,7 +15,7 @@ use dom::element::{HTMLAnchorElementTypeId, HTMLAsideElementTypeId, HTMLBRElemen
                    HTMLTableCellElementTypeId, HTMLTableElementTypeId,
                    HTMLTableRowElementTypeId, HTMLTitleElementTypeId, HTMLUListElementTypeId,
                    UnknownElementTypeId};
-use dom::element::{HTMLAsideElement, HTMLBRElement, HTMLBodyElement,
+use dom::element::{HTMLAsideElement, HTMLBRElement,
                    HTMLBoldElement, HTMLDivElement, HTMLFontElement, HTMLFormElement,
                    HTMLHeadElement, HTMLHeadingElement, HTMLHtmlElement,
                    HTMLInputElement, HTMLIframeElement,
@@ -28,6 +28,7 @@ use dom::element::{HTMLAsideElement, HTMLBRElement, HTMLBodyElement,
 use dom::element::{HTMLHeadingElementTypeId, Heading1, Heading2, Heading3, Heading4, Heading5,
                    Heading6};
 use dom::htmlanchorelement::HTMLAnchorElement;
+use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlhrelement::HTMLHRElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlscriptelement::HTMLScriptElement;

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -43,6 +43,7 @@ pub mod dom {
             pub mod EventTargetBinding;
             pub mod FormDataBinding;
             pub mod HTMLAnchorElementBinding;
+            pub mod HTMLBodyElementBinding;
             pub mod HTMLCollectionBinding;
             pub mod HTMLDivElementBinding;
             pub mod HTMLDocumentBinding;
@@ -75,6 +76,7 @@ pub mod dom {
     pub mod eventtarget;
     pub mod formdata;
     pub mod htmlanchorelement;
+    pub mod htmlbodyelement;
     pub mod htmlcollection;
     pub mod htmldocument;
     pub mod htmlelement;

--- a/src/test/html/test_bindings.js
+++ b/src/test/html/test_bindings.js
@@ -131,6 +131,7 @@ window.alert(document.title);
 
 window.alert(document.links[0]);
 
+window.alert(document.getElementsByTagName("body")[0]);
 //TODO: Doesn't work until we throw proper exceptions instead of returning 0 on
 //      unwrap failure.
 /*try {


### PR DESCRIPTION
I commented out the last line of HTMLBodyElement.webidl, 'HTMLBodyElement implements WindowEventHandlers;' in order to avoid compile error.
