### PR TITLE
Remove HTML Element interface to fix LibGFX failing to build

### DIFF
--- a/src/components/script/dom/bindings/codegen/HTMLCollection.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLCollection.webidl
@@ -10,8 +10,6 @@
  * liability, trademark and document use rules apply.
  */
 
-interface Element;
-
 interface HTMLCollection {
   readonly attribute unsigned long length;
   getter Element? item(unsigned long index);


### PR DESCRIPTION
`interface Element;` in HTMLCollection.webidl makes the build to fail while compiling libgfx.dummy.
This patch fixes that; thanks to @jdm for directions.
