### PR TITLE
Handle style attributes in element setter instead of html parser

### DIFF
--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -105,6 +105,13 @@ impl DOMString {
           null_string => ~""
         }
     }
+
+    pub fn get_ref<'a>(&'a self) -> &'a str {
+        match *self {
+            str(ref s) => s.as_slice(),
+            null_string => &'a "",
+        }
+    }
 }
 
 pub struct rust_box<T> {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -47,6 +47,7 @@ use js::jsapi::{JSContext, JSObject};
 use std::cell::Cell;
 use std::comm;
 use std::str::eq_slice;
+use extra::net::url;
 
 pub struct Element {
     parent: Node<ScriptView>,
@@ -262,8 +263,7 @@ impl<'self> Element {
 
     pub fn set_attr(&mut self, name: &DOMString, value: &DOMString) {
         let name = name.to_str();
-        let value = value.to_str();
-        let value_cell = Cell::new(value);
+        let value_cell = Cell::new(value.to_str());
         let mut found = false;
         for self.attrs.mut_iter().advance |attr| {
             if eq_slice(attr.name, name) {
@@ -274,6 +274,13 @@ impl<'self> Element {
         }
         if !found {
             self.attrs.push(Attr::new(name.to_str(), value_cell.take().clone()));
+        }
+
+        if "style" == name {
+            self.style_attribute = Some(
+                Stylesheet::from_attribute(
+                    url::from_str("http://www.example.com/").unwrap(),
+                    value.get_ref()));
         }
 
         match self.parent.owner_doc {
@@ -312,7 +319,7 @@ impl Element {
         null_string
     }
 
-    pub fn SetAttribute(&self, _name: &DOMString, _value: &DOMString, _rv: &mut ErrorResult) {
+    pub fn SetAttribute(&mut self, _name: &DOMString, _value: &DOMString, _rv: &mut ErrorResult) {
     }
 
     pub fn SetAttributeNS(&self, _namespace: &DOMString, _localname: &DOMString, _value: &DOMString, _rv: &mut ErrorResult) {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -311,15 +311,19 @@ impl Element {
     pub fn SetId(&self, _id: &DOMString) {
     }
 
-    pub fn GetAttribute(&self, _name: &DOMString) -> DOMString {
-        null_string
+    pub fn GetAttribute(&self, name: &DOMString) -> DOMString {
+        match self.get_attr(name.get_ref()) {
+            Some(val) => str(val.to_owned()),
+            None => null_string
+        }
     }
 
     pub fn GetAttributeNS(&self, _namespace: &DOMString, _localname: &DOMString) -> DOMString {
         null_string
     }
 
-    pub fn SetAttribute(&mut self, _name: &DOMString, _value: &DOMString, _rv: &mut ErrorResult) {
+    pub fn SetAttribute(&mut self, name: &DOMString, value: &DOMString, _rv: &mut ErrorResult) {
+        self.set_attr(name, value);
     }
 
     pub fn SetAttributeNS(&self, _namespace: &DOMString, _localname: &DOMString, _value: &DOMString, _rv: &mut ErrorResult) {

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -42,10 +42,11 @@ use dom::htmltablesectionelement::HTMLTableSectionElement;
 use dom::htmltextareaelement::HTMLTextAreaElement;
 use dom::htmltitleelement::HTMLTitleElement;
 use dom::htmlulistelement::HTMLUListElement;
-use dom::element::{Element, Attr};
+use dom::element::Element;
 use dom::htmlelement::HTMLElement;
 use dom::node::{AbstractNode, Comment, Doctype, ElementNodeTypeId, Node, ScriptView};
 use dom::node::{Text};
+use dom::bindings::utils::str;
 use html::cssparse::{InlineProvenance, StylesheetProvenance, UrlProvenance, spawn_css_parser};
 use js::jsapi::JSContext;
 use newcss::stylesheet::Stylesheet;
@@ -343,14 +344,7 @@ pub fn parse_html(cx: *JSContext,
             debug!("-- attach attrs");
             do node.as_mut_element |element| {
                 for tag.attributes.iter().advance |attr| {
-                    element.attrs.push(Attr::new(attr.name.clone(), attr.value.clone()));
-
-                    if "style" == attr.name {
-                        element.style_attribute = Some(
-                            Stylesheet::from_attribute(
-                                url::from_str("http://www.example.com/").unwrap(),
-                                attr.value));
-                    }
+                    element.set_attr(&str(attr.name.clone()), &str(attr.value.clone()));
                 }
             }
 

--- a/src/test/html/color-change-text.html
+++ b/src/test/html/color-change-text.html
@@ -9,6 +9,7 @@
 <script src="color-change-text.js"></script>
 </head>
 <body>
-<div id="change" class="red">Hello, World!</div>
+    <div id="change" class="red">Hello, World!</div>
+    <div id="change" style="color:blue;">Hello, Servo!</div>
 </body>
 </html>

--- a/src/test/html/color-change-text.js
+++ b/src/test/html/color-change-text.js
@@ -1,3 +1,4 @@
 window.setTimeout(function () {
     window.document.getElementsByTagName('div')[0].setAttribute('class', 'blue');
+    window.document.getElementsByTagName('div')[1].setAttribute('style', 'color:red;');
 }, 1000);


### PR DESCRIPTION
This fixes issue #699. tweaks a test case.

The last commit implements new {Set,Get}Attribute() by calling old {get, set}_attr(). but I'm not sure if this is the right approach. Should I reimplement the body of the functions? 
@metajack I think you might have an opinions for this.
