### PR TITLE
Implement GetElementById

### DIFF
--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -92,7 +92,7 @@ extern fn InterfaceObjectToString(cx: *JSContext, _argc: uint, vp: *mut JSVal) -
   }
 }
 
-#[deriving(Clone)]
+#[deriving(Clone,Eq)]
 pub enum DOMString {
     str(~str),
     null_string

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -231,8 +231,22 @@ impl Document {
         HTMLCollection::new(~[], cx, scope)
     }
 
-    pub fn GetElementById(&self, _id: &DOMString) -> Option<AbstractNode<ScriptView>> {
-        None
+    pub fn GetElementById(&self, id: &DOMString) -> Option<AbstractNode<ScriptView>> {
+        let name = str(~"id");
+        let mut ret = None;
+        for self.root.traverse_preorder |child| {
+            if child.is_element() {
+                do child.with_imm_element |elem| {
+                    if *id == elem.GetAttribute(&name) {
+                        ret = Some(child);
+                    }
+                }
+                if ret.is_some() {
+                    break;
+                }
+            }
+        }
+        ret
     }
 
     pub fn CreateElement(&self, _local_name: &DOMString, _rv: &mut ErrorResult) -> AbstractNode<ScriptView> {


### PR DESCRIPTION
This implements document.getElementById().

`Element.GetAttribute()` function is called in the middle of this implementation and that function simply returns `null_string`. but once the function implemented properly, `GetElementById()` would work. 
PR #719 contains the implementation of `Element.GetAttribute()` (892e248).
