### PR TITLE
Implement 'vertical-align' property.

### DIFF
--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -30,7 +30,7 @@ use newcss::units::{Cursive, Em, Fantasy, Monospace, Pt, Px, SansSerif, Serif};
 use newcss::values::{CSSClearNone, CSSClearLeft, CSSClearRight, CSSClearBoth};
 use newcss::values::{CSSFontFamilyFamilyName, CSSFontFamilyGenericFamily};
 use newcss::values::{CSSFontSizeLength, CSSFontStyleItalic, CSSFontStyleNormal};
-use newcss::values::{CSSFontStyleOblique, CSSTextAlign, CSSTextDecoration, CSSLineHeight};
+use newcss::values::{CSSFontStyleOblique, CSSTextAlign, CSSTextDecoration, CSSLineHeight, CSSVerticalAlign};
 use newcss::values::{CSSTextDecorationNone, CSSFloatNone, CSSPositionStatic};
 use newcss::values::{CSSDisplayInlineBlock, CSSDisplayInlineTable};
 use script::dom::node::{AbstractNode, LayoutView};
@@ -822,6 +822,10 @@ impl RenderBox {
 
     pub fn line_height(&self) -> CSSLineHeight {
         self.nearest_ancestor_element().style().line_height()
+    }
+
+    pub fn vertical_align(&self) -> CSSVerticalAlign {
+        self.nearest_ancestor_element().style().vertical_align()
     }
 
     /// Returns the text decoration of the computed style of the nearest `Element` node

--- a/src/test/html/vertical_align_simple.html
+++ b/src/test/html/vertical_align_simple.html
@@ -1,0 +1,24 @@
+<html>
+    <head>
+    </head>
+    <body>
+        <p>
+        [test1] <b style="font-size:20px">nested b</b><img src="test.jpeg"></img>
+        </p>
+        <p>
+        [test2] <b style="font-size:20px; vertical-align:top">vertical-align:top</b><img src="test.jpeg"></img>
+        </p>
+        <p>
+        [test3] <b style="font-size:20px; vertical-align:middle">vertical-align:middle</b><img src="test.jpeg"></img>
+        </p>
+        <p>
+        [test4] <b style="font-size:20px; vertical-align:bottom">vertical-align:bottom</b><img src="test.jpeg"></img>
+        </p>
+        <p>
+        [test5] <b style="font-size:20px;">img=>text-top</b><img src="test.jpeg" style="vertical-align: text-top;"></img>
+        </p>
+        <p>
+        [test6] <b style="font-size:20px;">img=>text-bottom</b><img src="test.jpeg" style="vertical-align: text-bottom;"></img>
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
It implements 'vertical-align' property and adds a simple test case.

However, there are several things to be fixed.
- We should calculate top and bottom value for margin, border, and padding in advance.
- For the 'middle' value of vertical-align, we should know 'x-height' of font.
- For the 'sub' and 'super' value of vertical-align, the proper position should be chosen.
