### PR TITLE
Change the profiler loop to use try_recv to avoid recv on closed port

### DIFF
--- a/src/components/util/time.rs
+++ b/src/components/util/time.rs
@@ -131,8 +131,11 @@ impl Profiler {
 
     pub fn start(&mut self) {
         loop {
-            let msg = self.port.recv();
-            self.handle_msg(msg);
+            let msg = self.port.try_recv();
+            match msg {
+               Some (msg) => self.handle_msg(msg),
+               None => break
+            }
         }
     }
 


### PR DESCRIPTION
Will exit during shutdown instead of crashing trying to recv on a closed port.
