### PR TITLE
minor refactor of profiler

### DIFF
--- a/src/components/util/time.rs
+++ b/src/components/util/time.rs
@@ -52,14 +52,6 @@ pub enum ProfilerCategory {
     // FIXME(rust#8803): workaround for lack of CTFE function on enum types to return length
     NumBuckets,
 }
-type ProfilerBuckets = TreeMap<ProfilerCategory, ~[float]>;
-
-// back end of the profiler that handles data aggregation and performance metrics
-pub struct Profiler {
-    port: Port<ProfilerMsg>,
-    buckets: ProfilerBuckets,
-    last_msg: Option<ProfilerMsg>,
-}
 
 impl ProfilerCategory {
     // convenience function to not have to cast every time
@@ -97,6 +89,15 @@ impl ProfilerCategory {
         };
         fmt!("%s%?", padding, self)
     }
+}
+
+type ProfilerBuckets = TreeMap<ProfilerCategory, ~[float]>;
+
+// back end of the profiler that handles data aggregation and performance metrics
+pub struct Profiler {
+    port: Port<ProfilerMsg>,
+    buckets: ProfilerBuckets,
+    last_msg: Option<ProfilerMsg>,
 }
 
 impl Profiler {

--- a/src/components/util/time.rs
+++ b/src/components/util/time.rs
@@ -80,9 +80,8 @@ impl ProfilerCategory {
     }
 
     // enumeration of all ProfilerCategory types
-    // TODO(tkuehn): is there a better way to ensure proper order of categories?
     fn empty_buckets() -> ProfilerBuckets {
-        let buckets = [
+        [
             ProfilerBucket::new(CompositingCategory),
             ProfilerBucket::new(LayoutQueryCategory),
             ProfilerBucket::new(LayoutPerformCategory),
@@ -96,19 +95,7 @@ impl ProfilerCategory {
             ProfilerBucket::new(RenderingDrawingCategory),
             ProfilerBucket::new(RenderingPrepBuffCategory),
             ProfilerBucket::new(RenderingCategory),
-        ];
-
-        ProfilerCategory::check_order(&buckets);
-        buckets
-    }
-
-    // ensure that the order of the buckets matches the order of the enum categories
-    fn check_order(vec: &ProfilerBuckets) {
-        for (i, bucket) in vec.iter().enumerate() {
-            if bucket.category as uint != i {
-                fail!("Enum category does not match bucket index. This is a bug.");
-            }
-        }
+        ]
     }
 
     // some categories are subcategories of LayoutPerformCategory
@@ -207,4 +194,14 @@ pub fn time<T>(msg: &str, callback: &fn() -> T) -> T{
     return val;
 }
 
-
+#[cfg(test)]
+mod test {
+    // ensure that the order of the buckets matches the order of the enum categories
+    #[test]
+    fn check_order() {
+        let buckets = ProfilerCategory::empty_buckets();
+        for (i, bucket) in buckets.iter().enumerate() {
+            assert!(bucket.category as uint == i);
+        }
+    }
+}

--- a/src/components/util/time.rs
+++ b/src/components/util/time.rs
@@ -41,7 +41,7 @@ pub enum ProfilerCategory {
     RenderingDrawingCategory,
     RenderingPrepBuffCategory,
     RenderingCategory,
-    // hackish but helps prevent errors when adding new categories
+    // FIXME(rust#8803): workaround for lack of CTFE function on enum types to return length
     NumBuckets,
 }
 struct ProfilerBucket {
@@ -56,7 +56,7 @@ impl ProfilerBucket {
         }
     }
 }
-// FIXME(rust#5873) this should be initialized by a NumBuckets cast,
+// FIXME(rust#5873) this should be initialized by a NumBuckets cast
 type ProfilerBuckets = [ProfilerBucket, ..13];
 
 pub enum ProfilerMsg {


### PR DESCRIPTION
- Use ProfilerBucket structs instead of (ProfilerCategory, ~[Float]) tuples
- Simplify the order check of bucket categories
