### PR TITLE
Paint bgcolor of inline box

### DIFF
--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -599,6 +599,10 @@ impl RenderBox {
         match *self {
             UnscannedTextRenderBoxClass(*) => fail!(~"Shouldn't see unscanned boxes here."),
             TextRenderBoxClass(text_box) => {
+
+                // Add the background to the list, if applicable.
+                self.paint_background_if_applicable(list, &absolute_box_bounds);
+
                 let nearest_ancestor_element = self.nearest_ancestor_element();
                 let color = nearest_ancestor_element.style().color().to_gfx_color();
 

--- a/src/test/html/inline_bg_color_simple.html
+++ b/src/test/html/inline_bg_color_simple.html
@@ -1,0 +1,11 @@
+<html>
+    <head></head>
+    <body>
+        [block background color test]
+        <p style="background-color:yellow">paragraph yellow</p>
+
+        [inline background color test] 
+        <span style="background-color:blue;">span blue</span>texttexttext<span style="background-color:yellow;">span yellow<span style="background-color:red">nested-span red</span>test finishes</span>
+
+    </body>
+</html>


### PR DESCRIPTION
In case that inline element has `background-color`, bgcolor doesn't work.
Fix the error and add a test case.
