### PR TITLE
Convert tagName to uppercase ASCII per spec (closes #834)

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -19,6 +19,7 @@ use js::jsapi::{JSContext, JSObject};
 use std::cell::Cell;
 use std::comm;
 use std::str::eq_slice;
+use std::ascii::StrAsciiExt;
 use std::FromStr;
 
 pub struct Element {
@@ -171,7 +172,7 @@ impl<'self> Element {
 
 impl Element {
     pub fn TagName(&self) -> DOMString {
-        str(self.tag_name.to_owned())
+        str(self.tag_name.to_owned().to_ascii_upper())
     }
 
     pub fn Id(&self) -> DOMString {

--- a/src/test/html/content/test_prototypes.html
+++ b/src/test/html/content/test_prototypes.html
@@ -3,6 +3,7 @@
   <script src="harness.js"></script>
 </head>
 <body>
+  <foo-á>foo</foo-á>
   <script src="test_prototypes.js"></script>
 </body>
 </html>

--- a/src/test/html/content/test_prototypes.js
+++ b/src/test/html/content/test_prototypes.js
@@ -4,4 +4,7 @@ is(window.document.documentElement instanceof HTMLElement, true);
 is(window.document.documentElement instanceof HTMLHtmlElement, true);
 is(window.document instanceof Document, true);
 is(window.document instanceof HTMLDocument, true);
+is(window.document.documentElement.tagName, "HTML");
+is(window.document.getElementsByTagName('foo-á')[0] instanceof HTMLUnknownElement, true);
+is(window.document.getElementsByTagName('foo-á')[0].tagName, "FOO-á");
 finish();


### PR DESCRIPTION
http://dom.spec.whatwg.org/#dom-element-tagname

I added `window.alert(elem.tagName);` to line 14 of `test_bindings.js` to test (segfault at line 17), and it indeed uppercased the tagName. I didn't add that to this commit, however, because `tagName` is already tested on line 50 of that file. I'm assuming the duplication isn't necessary. Am I correct in that assumption? Or should tests be added somewhere for this? Where?
