### PR TITLE
Implement FormData constuctor.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1312,14 +1312,17 @@ def instantiateJSToNativeConversionTemplate(templateTuple, replacements,
 
     originalDeclName = replacements["declName"]
     if declType is not None:
-        if dealWithOptional:
-            mutableDeclType = CGWrapper(declType, pre="Option< ", post=" >")
+        if dealWithOptional and not initialValue:
+            declType = CGWrapper(declType, pre="Option< ", post=" >")
         newDecl = [CGGeneric("let mut "),
                    CGGeneric(originalDeclName),
                    CGGeneric(": "),
                    declType]
         if initialValue:
             newDecl.append(CGGeneric(" = " + initialValue))
+        else:
+            if dealWithOptional:
+                newDecl.append(CGGeneric(" = None"))
         newDecl.append(CGGeneric(";"))
         result.append(CGList(newDecl))
 

--- a/src/components/script/dom/bindings/codegen/FormData.webidl
+++ b/src/components/script/dom/bindings/codegen/FormData.webidl
@@ -7,7 +7,7 @@
  * http://xhr.spec.whatwg.org
  */
 
-/*[Constructor(optional HTMLFormElement form)]*/
+[Constructor(optional HTMLFormElement form)]
 interface FormData {
   void append(DOMString name, Blob value, optional DOMString filename);
   void append(DOMString name, DOMString value);

--- a/src/components/script/dom/formdata.rs
+++ b/src/components/script/dom/formdata.rs
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::utils::{CacheableWrapper, BindingObject, DerivedWrapper};
-use dom::bindings::utils::{WrapperCache, DOMString, str};
+use dom::bindings::utils::{WrapperCache, ErrorResult, DOMString, str};
 use dom::bindings::codegen::FormDataBinding;
 use dom::blob::Blob;
+use dom::node::{AbstractNode, ScriptView};
+use dom::window::Window;
 use script_task::{page_from_context};
 
 use js::jsapi::{JSObject, JSContext, JSVal};
@@ -46,6 +48,13 @@ impl FormData {
 
     pub fn Append_(&mut self, name: &DOMString, value: &DOMString) {
         self.data.insert(name.to_str(), StringData((*value).clone()));
+    }
+
+    pub fn Constructor(_global: @mut Window,
+                       _form: Option<AbstractNode<ScriptView>>,
+                       _rv: &mut ErrorResult) -> @mut FormData {
+        FormData::new()
+        // Todo: Add elements from form.
     }
 }
 


### PR DESCRIPTION
I am not sure if this is a forward compatible change to the Codegen, but at least all existing bindings still compile.
