### PR TITLE
Preliminary HTTP support based on rust-http and rt::io

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -120,4 +120,4 @@
 	url = http://github.com/mozilla-servo/rust-glut.git
 [submodule "src/support/http/rust-http"]
 	path = src/support/http/rust-http
-	url = git://github.com/mozilla-servo/rust-http
+	url = https://github.com/mozilla-servo/rust-http

--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
 [submodule "src/support/glut/rust-glut"]
 	path = src/support/glut/rust-glut
 	url = http://github.com/mozilla-servo/rust-glut.git
+[submodule "src/support/http/rust-http"]
+	path = src/support/http/rust-http
+	url = git://github.com/mozilla-servo/rust-http

--- a/configure
+++ b/configure
@@ -480,6 +480,7 @@ CFG_SUBMODULES="\
     support/css/rust-cssparser \
     support/geom/rust-geom \
     support/harfbuzz/rust-harfbuzz \
+    support/http/rust-http \
     support/hubbub/libhubbub \
     support/hubbub/rust-hubbub \
     support/layers/rust-layers \

--- a/src/components/net/net.rc
+++ b/src/components/net/net.rc
@@ -9,7 +9,7 @@
 #[crate_type = "lib"];
 
 extern mod geom;
-//extern mod http_client;
+extern mod http;
 extern mod servo_util (name = "util");
 extern mod stb_image;
 extern mod extra;
@@ -25,7 +25,7 @@ pub mod image {
 }
 
 pub mod file_loader;
-//pub mod http_loader;
+pub mod http_loader;
 pub mod image_cache_task;
 pub mod local_image_cache;
 pub mod resource_task;

--- a/src/components/net/resource_task.rs
+++ b/src/components/net/resource_task.rs
@@ -5,7 +5,7 @@
 //! A task that takes a URL and streams back the binary data.
 
 use file_loader;
-//use http_loader;
+use http_loader;
 
 use std::cell::Cell;
 use std::comm::{Chan, Port, SharedChan};
@@ -43,10 +43,10 @@ pub type LoaderTask = ~fn(url: Url, Chan<ProgressMsg>);
 /// Create a ResourceTask with the default loaders
 pub fn ResourceTask() -> ResourceTask {
     let file_loader_factory: LoaderTaskFactory = file_loader::factory;
-    //let http_loader_factory: LoaderTaskFactory = http_loader::factory;
+    let http_loader_factory: LoaderTaskFactory = http_loader::factory;
     let loaders = ~[
         (~"file", file_loader_factory),
-        //(~"http", http_loader_factory)
+        (~"http", http_loader_factory)
     ];
     create_resource_task_with_loaders(loaders)
 }


### PR DESCRIPTION
This adds rust-http as a submodule and wires it into the resource loader for http urls. It _does not_ do DNS resolution yet, sadly, since Rust doesn't support it yet. That's what I'll be working on next.
