### PR TITLE
Add document.createElement and document.createTextNode.

### DIFF
--- a/src/components/script/dom/bindings/codegen/Document.webidl
+++ b/src/components/script/dom/bindings/codegen/Document.webidl
@@ -45,10 +45,10 @@ interface Document /*: Node*/ { //XXXjdm Requires servo/#623
   [Creator, Throws]
   Element createElementNS(DOMString? namespace, DOMString qualifiedName);
   /*[Creator]
-    DocumentFragment createDocumentFragment();
+  DocumentFragment createDocumentFragment();*/
   [Creator]
   Text createTextNode(DOMString data);
-  [Creator]
+  /*[Creator]
   Comment createComment(DOMString data);
   [Creator, Throws]
   ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);*/

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -209,7 +209,7 @@ fn js_script_listener(to_parent: SharedChan<HtmlDiscoveryMessage>,
 // Silly macros to handle constructing      DOM nodes. This produces bad code and should be optimized
 // via atomization (issue #85).
 
-fn build_element_from_tag(cx: *JSContext, tag: &str) -> AbstractNode<ScriptView> {
+pub fn build_element_from_tag(cx: *JSContext, tag: &str) -> AbstractNode<ScriptView> {
     // TODO (Issue #85): use atoms
     handle_element!(cx, tag, "a",       HTMLAnchorElementTypeId, HTMLAnchorElement, []);
     handle_element!(cx, tag, "applet",  HTMLAppletElementTypeId, HTMLAppletElement, []);

--- a/src/test/html/content/test_create_element.html
+++ b/src/test/html/content/test_create_element.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <title></title>
+  <script src="harness.js"></script>
+</head>
+<body>
+  <script>
+    var elem = document.createElement("foo");
+    is(elem.tagName, "FOO");
+    var elem = document.createElement("p");
+    is(elem instanceof HTMLParagraphElement, true);
+    var text = document.createTextNode("hello");
+    is(text instanceof Text, true);
+    finish();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This re-uses the parser's node creation code. That could probably be put
somewhere nicer. Suggestions welcome!
