### PR TITLE
Turn on parallel builds.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -187,7 +187,6 @@ $$(DONE_$(1)) : $$(DONE_DEPS_$(1)) $$(ROUGH_DEPS_$(1)) $$(RUSTC_DEP_$(1))
 # main submodule target
 $(1) : $$(DONE_$(1))
 .PHONY : $(1)
-.NOTPARALLEL : $(1)
 endef
 
 $(foreach submodule,$(SUBMODULES),\


### PR DESCRIPTION
The bugs are believed to be worked out. From a `make clean`, `make` took 8:41
and `make -j6` took 4:43.
