### PR TITLE
Fix the case of the invisible iframes

### DIFF
--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -244,10 +244,15 @@ impl CompositorLayer {
         let transform = |x: &mut CompositorLayerChild| -> bool {
             match x.container.scissor {
                 Some(scissor) => {
-                    let new_rect = window_rect.intersection(&scissor);
+                    let new_rect = rect.intersection(&scissor);
                     match new_rect {
                         Some(new_rect) => {
-                            x.child.get_buffer_request(new_rect, scale)
+                            // Child layers act as if they are rendered at (0,0), so we
+                            // subtract the layer's (x,y) coords in its containing page
+                            // to make the child_rect appear in coordinates local to it.
+                            let child_rect = Rect(new_rect.origin.sub(&scissor.origin),
+                                                  new_rect.size);
+                            x.child.get_buffer_request(child_rect, scale)
                         }
                         None => {
                             false //Layer is offscreen


### PR DESCRIPTION
The quadtree was checking to see if a window's position was within the clip region before drawing it. However, the window's position is in page-relative coordinates whereas the clip region is in window-relative coordinates. So, unless the iframe happened to fall in the clip range, it would never have tiles returned.

If an iframe had enough content that it spilled outside of its clip range, different logic was triggered that would cause it to receive a ReRenderMsg anyway, which circumvented all of this.

@eschweic, can you please review this if you have a minute? I believe that I've correctly captured the four checks we want to make (two each for `x` and `y` directions to determine if the window is in or out, but I'd appreciate another set of eyes on it.

For some example data, in a call to `get_tile_rects` for an iframe that is sized to 400x400 and is 428-ish pixels down the page, with a browser frame that is 600 total pixels tall, that function is called with:
window origin geom::point::Point2D<f32>{x: 9f32, y: 428.6000061f32}
window size geom::size::Size2D<f32>{width: 400f32, height: 171.3999939f32}
self origin geom::point::Point2D<f32>{x: 0f32, y: 0f32}
self size 512f32" 
clip: size::Size2D<f32>{width: 400f32, height: 400f32}
