### PR TITLE
Fix profiler usage when not flagged

### DIFF
--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -9,7 +9,7 @@ use azure::azure_hl::{B8G8R8A8, DrawTarget};
 use display_list::DisplayList;
 use servo_msg::compositor_msg::{RenderListener, IdleRenderState, RenderingRenderState, LayerBuffer};
 use servo_msg::compositor_msg::{LayerBufferSet, Epoch};
-use servo_msg::constellation_msg::PipelineId;
+use servo_msg::constellation_msg::{ConstellationChan, PipelineId, RendererReadyMsg};
 use font_context::FontContext;
 use geom::matrix2d::Matrix2D;
 use geom::size::Size2D;
@@ -17,8 +17,8 @@ use geom::rect::Rect;
 use opts::Opts;
 use render_context::RenderContext;
 
-use std::cell::Cell;
 use std::comm::{Chan, Port, SharedChan};
+use std::task::spawn_with;
 use extra::arc::Arc;
 
 use servo_util::time::{ProfilerChan, profile};
@@ -86,6 +86,7 @@ struct RenderTask<C,T> {
     id: PipelineId,
     port: Port<Msg<T>>,
     compositor: C,
+    constellation_chan: ConstellationChan,
     font_ctx: @mut FontContext,
     opts: Opts,
 
@@ -110,24 +111,21 @@ impl<C: RenderListener + Send,T:Send+Freeze> RenderTask<C,T> {
     pub fn create(id: PipelineId,
                   port: Port<Msg<T>>,
                   compositor: C,
+                  constellation_chan: ConstellationChan,
                   opts: Opts,
                   profiler_chan: ProfilerChan) {
-        let compositor = Cell::new(compositor);
-        let opts = Cell::new(opts);
-        let port = Cell::new(port);
-        let profiler_chan = Cell::new(profiler_chan);
 
-        do spawn {
-            let compositor = compositor.take();
+        do spawn_with((port, compositor, constellation_chan, opts, profiler_chan))
+            |(port, compositor, constellation_chan, opts, profiler_chan)| {
+
             let share_gl_context = compositor.get_gl_context();
-            let opts = opts.take();
-            let profiler_chan = profiler_chan.take();
 
             // FIXME: rust/#5967
             let mut render_task = RenderTask {
                 id: id,
-                port: port.take(),
+                port: port,
                 compositor: compositor,
+                constellation_chan: constellation_chan,
                 font_ctx: @mut FontContext::new(opts.render_backend.clone(),
                                                 false,
                                                 profiler_chan.clone()),
@@ -155,6 +153,8 @@ impl<C: RenderListener + Send,T:Send+Freeze> RenderTask<C,T> {
                     if self.paint_permission {
                         self.epoch.next();
                         self.compositor.set_layer_page_size(self.id, render_layer.size, self.epoch);
+                    } else {
+                        self.constellation_chan.send(RendererReadyMsg(self.id));
                     }
                     self.render_layer = Some(render_layer);
                     self.last_paint_msg = None;
@@ -284,6 +284,8 @@ impl<C: RenderListener + Send,T:Send+Freeze> RenderTask<C,T> {
             debug!("render_task: returning surface");
             if self.paint_permission {
                 self.compositor.paint(self.id, layer_buffer_set.clone(), self.epoch);
+            } else {
+                self.constellation_chan.send(RendererReadyMsg(self.id));
             }
             debug!("caching paint msg");
             self.last_paint_msg = Some(layer_buffer_set);

--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -59,19 +59,12 @@ pub fn BufferRequest(screen_rect: Rect<uint>, page_rect: Rect<f32>) -> BufferReq
 }
 
 #[deriving(Clone)]
-pub struct RenderChan<T> {
-    chan: SharedChan<Msg<T>>,
-}
-
+pub struct RenderChan<T>{chan:SharedChan<Msg<T>>}
 impl<T> RenderChan<T> {
     pub fn new(chan: Chan<Msg<T>>) -> RenderChan<T> {
-        RenderChan {
-            chan: SharedChan::new(chan),
-        }
+        RenderChan{chan:SharedChan::new(chan)}
     }
-    pub fn send(&self, msg: Msg<T>) {
-        self.chan.send(msg);
-    }
+    pub fn send(&self, msg: Msg<T>) { self.chan.send(msg) }
 }
 
 struct RenderTask<C,T> {

--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -438,7 +438,7 @@ impl Constellation {
                     if pipeline.subpage_id.expect("Constellation: child frame does not have a
                         subpage id. This should not be possible.") == subpage_id {
                         child_frame_tree.rect = Some(rect.clone());
-                        let Rect { size: Size2D { width, height }, _ } = rect;
+                        let Size2D { width, height } = rect.size;
                         pipeline.script_chan.send(ResizeMsg(pipeline.id.clone(), Size2D {
                             width:  width  as uint,
                             height: height as uint

--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -428,45 +428,52 @@ impl Constellation {
         debug!("Received frame rect %? from %?, %?", rect, pipeline_id, subpage_id);
         let mut already_sent = HashSet::new();
 
+        // Returns true if a child frame tree's subpage id matches the given subpage id
+        let subpage_eq = |child_frame_tree: & &mut ChildFrameTree| {
+            child_frame_tree.frame_tree.pipeline.subpage_id.expect("Constellation:
+                child frame does not have a subpage id. This should not be possible.")
+                == subpage_id
+        };
+
+        // Update a child's frame rect and inform its script task of the change,
+        // if it hasn't been already. Optionally inform the compositor if 
+        // resize happens immediately.
+        let update_child_rect = |child_frame_tree: &mut ChildFrameTree, is_active: bool| {
+            child_frame_tree.rect = Some(rect.clone());
+            let pipeline = &child_frame_tree.frame_tree.pipeline;
+            if !already_sent.contains(&pipeline.id) {
+                let Size2D { width, height } = rect.size;
+                if is_active {
+                    pipeline.script_chan.send(ResizeMsg(pipeline.id, Size2D {
+                        width:  width  as uint,
+                        height: height as uint
+                    }));
+                    self.compositor_chan.send(SetLayerClipRect(pipeline.id, rect));
+                } else {
+                    pipeline.script_chan.send(ResizeInactiveMsg(pipeline.id,
+                                                                Size2D(width as uint, height as uint)));
+                }
+                already_sent.insert(pipeline.id);
+            }
+        };
+
         // If the subframe is in the current frame tree, the compositor needs the new size
         for current_frame in self.current_frame().iter() {
             debug!("Constellation: Sending size for frame in current frame tree.");
             let source_frame = current_frame.find_mut(pipeline_id);
             for source_frame in source_frame.iter() {
-                for child_frame_tree in source_frame.children.mut_iter() {
-                    let pipeline = &child_frame_tree.frame_tree.pipeline;
-                    if pipeline.subpage_id.expect("Constellation: child frame does not have a
-                        subpage id. This should not be possible.") == subpage_id {
-                        child_frame_tree.rect = Some(rect.clone());
-                        let Size2D { width, height } = rect.size;
-                        pipeline.script_chan.send(ResizeMsg(pipeline.id.clone(), Size2D {
-                            width:  width  as uint,
-                            height: height as uint
-                        }));
-                        self.compositor_chan.send(SetLayerClipRect(pipeline.id, rect));
-                        already_sent.insert(pipeline.id.clone());
-                        break;
-                    }
-                } 
+                let found_child = source_frame.children.mut_iter()
+                    .find(|child| subpage_eq(child));
+                found_child.map_move(|child| update_child_rect(child, true));
             }
         }
-        // Traverse the navigation context and pending frames and tell each associated pipeline to resize.
+
+        // Update all frames with matching pipeline- and subpage-ids
         let frames = self.find_all(pipeline_id);
         for frame_tree in frames.iter() {
-            for child_frame_tree in frame_tree.children.mut_iter() {
-                let pipeline = &child_frame_tree.frame_tree.pipeline;
-                if pipeline.subpage_id.expect("Constellation: child frame does not have a
-                    subpage id. This should not be possible.") == subpage_id {
-                    child_frame_tree.rect = Some(rect.clone());
-                    if !already_sent.contains(&pipeline.id) {
-                        let Size2D { width, height } = rect.size;
-                        pipeline.script_chan.send(ResizeInactiveMsg(pipeline.id.clone(),
-                                                                    Size2D(width as uint, height as uint)));
-                        already_sent.insert(pipeline.id.clone());
-                    }
-                    break;
-                }
-            }
+            let found_child = frame_tree.children.mut_iter()
+                .find(|child| subpage_eq(child));
+            found_child.map_move(|child| update_child_rect(child, false));
         }
 
         // At this point, if no pipelines were sent a resize msg, then this subpage id
@@ -588,7 +595,7 @@ impl Constellation {
         // changes would be overriden by changing the subframe associated with source_id.
 
         let parent = source_frame.parent.clone();
-        let subpage_id = source_frame.pipeline.subpage_id.clone();
+        let subpage_id = source_frame.pipeline.subpage_id;
         let next_pipeline_id = self.get_next_pipeline_id();
 
         let pipeline = @mut Pipeline::create(next_pipeline_id,
@@ -743,15 +750,15 @@ impl Constellation {
     fn handle_resized_window_msg(&mut self, new_size: Size2D<uint>) {
         let mut already_seen = HashSet::new();
         for &@FrameTree { pipeline: pipeline, _ } in self.current_frame().iter() {
-            pipeline.script_chan.send(ResizeMsg(pipeline.id.clone(), new_size));
-            already_seen.insert(pipeline.id.clone());
+            pipeline.script_chan.send(ResizeMsg(pipeline.id, new_size));
+            already_seen.insert(pipeline.id);
         }
         for frame_tree in self.navigation_context.previous.iter()
             .chain(self.navigation_context.next.iter()) {
             let pipeline = &frame_tree.pipeline;
             if !already_seen.contains(&pipeline.id) {
-                pipeline.script_chan.send(ResizeInactiveMsg(pipeline.id.clone(), new_size));
-                already_seen.insert(pipeline.id.clone());
+                pipeline.script_chan.send(ResizeInactiveMsg(pipeline.id, new_size));
+                already_seen.insert(pipeline.id);
             }
         }
     }

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -54,6 +54,7 @@ impl Pipeline {
         RenderTask::create(id,
                            render_port,
                            compositor_chan.clone(),
+                           constellation_chan.clone(),
                            opts.clone(),
                            profiler_chan.clone());
 
@@ -136,6 +137,7 @@ impl Pipeline {
             RenderTask::create(id,
                                render_port,
                                compositor_chan.clone(),
+                               constellation_chan.clone(),
                                opts.clone(),
                                profiler_chan.clone());
 

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -47,7 +47,7 @@ use gfx::opts;
 
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
-use servo_util::time::{Profiler, ProfilerChan, PrintMsg};
+use servo_util::time::{Profiler, ProfilerChan};
 
 pub use gfx::opts::Opts;
 pub use gfx::text;
@@ -56,7 +56,7 @@ use std::comm;
 #[cfg(not(test))]
 use std::os;
 use std::rt::rtio::RtioTimer;
-use std::rt::io::timer::Timer;
+use std::task::spawn_with;
 
 #[path="compositing/mod.rs"]
 pub mod compositing;
@@ -127,38 +127,19 @@ fn start(argc: int, argv: **u8, crate_map: *u8) -> int {
 
 fn run(opts: Opts) {
     let (shutdown_port, shutdown_chan) = comm::stream();
-    let (profiler_port, profiler_chan) = comm::stream();
-    let (compositor_port, compositor_chan) = comm::stream();
+    let (profiler_port, profiler_chan) = special_stream!(ProfilerChan);
+    let (compositor_port, compositor_chan) = special_stream!(CompositorChan);
 
-    let profiler_chan = ProfilerChan::new(profiler_chan);
-    Profiler::create(profiler_port);
-    do opts.profiler_period.map |&period| {
-        let profiler_chan = profiler_chan.clone();
-        let period = (period * 1000f) as u64;
-        do spawn {
-            let mut tm = Timer::new().unwrap();
-            loop {
-                tm.sleep(period);
-                profiler_chan.send(PrintMsg);
-            }
-        }
-    };
-    let compositor_chan = CompositorChan::new(compositor_chan);
-    let profiler_chan_clone = profiler_chan.clone();
+    Profiler::create(profiler_port, profiler_chan.clone(), opts.profiler_period);
 
-    let opts_clone = opts.clone();
+    do spawn_with((profiler_chan.clone(), compositor_chan, opts.clone()))
+        |(profiler_chan, compositor_chan, opts)| {
 
-    do spawn {
-        let profiler_chan = profiler_chan_clone.clone();
-        let compositor_chan = compositor_chan.clone();
-
-        let opts = &opts_clone.clone();
-
+        let opts = &opts;
         // Create a Servo instance.
-
         let resource_task = ResourceTask();
         let image_cache_task = ImageCacheTask(resource_task.clone());
-        let constellation_chan = Constellation::start(compositor_chan.clone(),
+        let constellation_chan = Constellation::start(compositor_chan,
                                                       opts,
                                                       resource_task,
                                                       image_cache_task,

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -12,18 +12,10 @@ use geom::size::Size2D;
 use geom::rect::Rect;
 
 #[deriving(Clone)]
-pub struct ConstellationChan {
-    chan: SharedChan<Msg>,
-}
-
+pub struct ConstellationChan(SharedChan<Msg>);
 impl ConstellationChan {
     pub fn new(chan: Chan<Msg>) -> ConstellationChan {
-        ConstellationChan {
-            chan: SharedChan::new(chan),
-        }
-    }
-    pub fn send(&self, msg: Msg) {
-        self.chan.send(msg);
+        ConstellationChan(SharedChan::new(chan))
     }
 }
 

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -111,17 +111,9 @@ pub struct Reflow {
 
 /// Encapsulates a channel to the layout task.
 #[deriving(Clone)]
-pub struct LayoutChan {
-    chan: SharedChan<Msg>,
-}
-
+pub struct LayoutChan(SharedChan<Msg>);
 impl LayoutChan {
     pub fn new(chan: Chan<Msg>) -> LayoutChan {
-        LayoutChan {
-            chan: SharedChan::new(chan),
-        }
-    }
-    pub fn send(&self, msg: Msg) {
-        self.chan.send(msg);
+        LayoutChan(SharedChan::new(chan))
     }
 }

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -83,20 +83,11 @@ pub struct NewLayoutInfo {
 
 /// Encapsulates external communication with the script task.
 #[deriving(Clone)]
-pub struct ScriptChan {
-    /// The channel used to send messages to the script task.
-    chan: SharedChan<ScriptMsg>,
-}
-
+pub struct ScriptChan(SharedChan<ScriptMsg>);
 impl ScriptChan {
     /// Creates a new script chan.
     pub fn new(chan: Chan<ScriptMsg>) -> ScriptChan {
-        ScriptChan {
-            chan: SharedChan::new(chan)
-        }
-    }
-    pub fn send(&self, msg: ScriptMsg) {
-        self.chan.send(msg);
+        ScriptChan(SharedChan::new(chan))
     }
 }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -21,7 +21,7 @@ use layout_interface::{ReflowDocumentDamage, ReflowForDisplay, ReflowGoal};
 use layout_interface::ReflowMsg;
 use layout_interface;
 use servo_msg::constellation_msg::{ConstellationChan, LoadUrlMsg, NavigationDirection};
-use servo_msg::constellation_msg::{PipelineId, SubpageId, RendererReadyMsg};
+use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_msg::constellation_msg::{LoadIframeUrlMsg, IFrameSandboxed, IFrameUnsandboxed};
 use servo_msg::constellation_msg;
 
@@ -582,7 +582,6 @@ impl ScriptTask {
         if page_tree.page.last_reflow_id == reflow_id {
             page_tree.page.layout_join_port = None;
         }
-        self.constellation_chan.send(RendererReadyMsg(pipeline_id));
         self.compositor.set_ready_state(FinishedLoading);
     }
 


### PR DESCRIPTION
- Profiler is now close to a no-op when `-p` is not passed in
- The profiler's printing `Timer` now stops looping when the profiler is closed
- Most task `Chans` are now newtype `structs`
- Some more `Cell` removals in places where `spawn_with` is appropriate
