### PR TITLE
Close the correct pipelines when evicted from navigation context.

### DIFF
--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -770,12 +770,13 @@ impl Constellation {
         match navigation_type {
             constellation_msg::Load => {
                 let evicted = self.navigation_context.load(frame_tree);
+                let mut exited = HashSet::new();
+                // exit any pipelines that don't exist outside the evicted frame trees
                 for frame_tree in evicted.iter() {
-                    // exit any pipelines that don't exist outside the evicted frame trees
-                    for frame in frame_tree.iter() {
-                        if !self.navigation_context.contains(frame.pipeline.id) {
-                            frame_tree.pipeline.exit();
-                            self.pipelines.remove(&frame_tree.pipeline.id);
+                    for @FrameTree { pipeline, _ } in frame_tree.iter() {
+                        if !self.navigation_context.contains(pipeline.id) {
+                            pipeline.exit();
+                            self.pipelines.remove(&pipeline.id);
                         }
                     }
                 }

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -26,6 +26,7 @@ use gfx::font_context::FontContext;
 use gfx::geometry::Au;
 use gfx::opts::Opts;
 use gfx::render_task::{RenderMsg, RenderChan, RenderLayer};
+use gfx::render_task;
 use newcss::select::SelectCtx;
 use newcss::stylesheet::Stylesheet;
 use newcss::types::OriginAuthor;
@@ -162,6 +163,9 @@ impl LayoutTask {
             }
             ExitMsg => {
                 debug!("layout: ExitMsg received");
+                let (response_port, response_chan) = stream();
+                self.render_chan.send(render_task::ExitMsg(response_chan));
+                response_port.recv();
                 return false
             }
         }

--- a/src/components/main/macros.rs
+++ b/src/components/main/macros.rs
@@ -5,7 +5,7 @@
 macro_rules! special_stream(
     ($Chan:ident) => (
         {
-            let (port, chan) = comm::stream::();
+            let (port, chan) = stream::();
             (port, $Chan::new(chan))
         }
     );

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -217,7 +217,7 @@ impl Pipeline {
 
     pub fn exit(&self) {
         // Script task handles shutting down layout, as well
-        self.script_chan.send(script_task::ExitMsg);
+        self.script_chan.send(script_task::ExitMsg(self.id));
 
         let (response_port, response_chan) = comm::stream();
         self.render_chan.send(render_task::ExitMsg(response_chan));

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -6,7 +6,6 @@ use extra::url::Url;
 use compositing::CompositorChan;
 use gfx::render_task::{RenderChan, RenderTask};
 use gfx::render_task::{PaintPermissionGranted, PaintPermissionRevoked};
-use gfx::render_task;
 use gfx::opts::Opts;
 use layout::layout_task::LayoutTask;
 use script::layout_interface::LayoutChan;
@@ -21,7 +20,6 @@ use servo_util::time::ProfilerChan;
 use geom::size::Size2D;
 use extra::future::Future;
 use std::cell::Cell;
-use std::comm;
 use std::task;
 
 /// A uniquely-identifiable pipeline of script task, layout task, and render task. 
@@ -216,12 +214,9 @@ impl Pipeline {
     }
 
     pub fn exit(&self) {
-        // Script task handles shutting down layout, as well
-        self.script_chan.send(script_task::ExitMsg(self.id));
-
-        let (response_port, response_chan) = comm::stream();
-        self.render_chan.send(render_task::ExitMsg(response_chan));
-        response_port.recv();
+        // Script task handles shutting down layout, 
+        // and layout handles shutting down the renderer.
+        self.script_chan.try_send(script_task::ExitPipelineMsg(self.id));
     }
 }
 

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -212,7 +212,7 @@ impl Window {
                         match timer_port.recv() {
                             TimerMessage_Close => break,
                             TimerMessage_Fire(td) => script_chan.send(FireTimerMsg(id, td)),
-                            TimerMessage_TriggerExit => script_chan.send(ExitMsg),
+                            TimerMessage_TriggerExit => script_chan.send(ExitMsg(id)),
                         }
                     }
                 }
@@ -225,7 +225,6 @@ impl Window {
         };
 
         unsafe {
-            // TODO(tkuehn): This just grabs the top-level page. Need to handle subframes.
             let cache = ptr::to_unsafe_ptr(win.get_wrappercache());
             win.wrap_object_shared(cx, ptr::null()); //XXXjdm proper scope
             let global = (*cache).wrapper;

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -10,7 +10,7 @@ use dom::node::{AbstractNode, ScriptView};
 use dom::navigator::Navigator;
 
 use layout_interface::ReflowForDisplay;
-use script_task::{ExitMsg, FireTimerMsg, Page, ScriptChan};
+use script_task::{ExitWindowMsg, FireTimerMsg, Page, ScriptChan};
 use servo_msg::compositor_msg::ScriptListener;
 use servo_net::image_cache_task::ImageCacheTask;
 
@@ -212,7 +212,7 @@ impl Window {
                         match timer_port.recv() {
                             TimerMessage_Close => break,
                             TimerMessage_Fire(td) => script_chan.send(FireTimerMsg(id, td)),
-                            TimerMessage_TriggerExit => script_chan.send(ExitMsg(id)),
+                            TimerMessage_TriggerExit => script_chan.send(ExitWindowMsg(id)),
                         }
                     }
                 }

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -71,7 +71,7 @@ pub enum ScriptMsg {
     /// Notifies script that window has been resized but to not take immediate action.
     ResizeInactiveMsg(PipelineId, Size2D<uint>),
     /// Exits the constellation.
-    ExitMsg,
+    ExitMsg(PipelineId),
 }
 
 pub struct NewLayoutInfo {
@@ -170,6 +170,28 @@ impl PageTree {
         PageTreeIterator {
             stack: ~[self],
         }
+    }
+
+    // must handle root case separately
+    pub fn remove(&mut self, id: PipelineId) -> Option<PageTree> {
+        let remove_idx = {
+            self.inner.mut_iter()
+                .enumerate()
+                .find(|&(_idx, ref page_tree)| page_tree.page.id == id)
+                .map(|&(idx, _)| idx)
+        };
+        match remove_idx {
+            Some(idx) => return Some(self.inner.remove(idx)),
+            None => {
+                for page_tree in self.inner.mut_iter() {
+                    match page_tree.remove(id) {
+                        found @ Some(_) => return found,
+                        None => (), // keep going...
+                    }
+                }
+            }
+        }
+        None
     }
 }
 
@@ -494,9 +516,8 @@ impl ScriptTask {
                 NavigateMsg(direction) => self.handle_navigate_msg(direction),
                 ReflowCompleteMsg(id, reflow_id) => self.handle_reflow_complete_msg(id, reflow_id),
                 ResizeInactiveMsg(id, new_size) => self.handle_resize_inactive_msg(id, new_size),
-                ExitMsg => {
-                    self.handle_exit_msg();
-                    return false
+                ExitMsg(id) => {
+                    if self.handle_exit_msg(id) { return false }
                 },
                 ResizeMsg(*) => fail!("should have handled ResizeMsg already"),
             }
@@ -603,12 +624,29 @@ impl ScriptTask {
     }
 
     /// Handles a request to exit the script task and shut down layout.
-    fn handle_exit_msg(&mut self) {
-        for page in self.page_tree.iter() {
-            page.join_layout();
-            page.layout_chan.send(layout_interface::ExitMsg);
+    /// Returns true if the script task should shut down and false otherwise.
+    fn handle_exit_msg(&mut self, id: PipelineId) -> bool {
+        // If root is being exited, shut down all pages
+        if self.page_tree.page.id == id {
+            for page in self.page_tree.iter() {
+                page.join_layout();
+                page.layout_chan.send(layout_interface::ExitMsg);
+            }
+            return true
         }
-        self.compositor.close();
+        // otherwise find just the matching page and exit all sub-pages
+        match self.page_tree.remove(id) {
+            Some(ref mut page_tree) => {
+                for page in page_tree.iter() {
+                    page.join_layout();
+                    page.layout_chan.send(layout_interface::ExitMsg);
+                }
+                return false
+            }
+            None => fail!("ScriptTask: Received exit message from
+                           pipeline whose id is not in page tree"),
+        }
+        
     }
 
     /// The entry point to document loading. Defines bindings, sets up the window and document


### PR DESCRIPTION
Fixes #967 and #965 

This has been wrong for a long time. Previously, only the pipeline associated with the root frame evicted would be shut down. 1) It shouldn't necessarily be closed, because there could be references to it still in the navigation context, and 2) Presumably none of the children pipelines of the root frame were ever exiting.

It's hard to test this right now because #965 covers up other pipeline exiting issues, but when that's fixed, a pathological case in which things would have broken down would be:

1) Load a page with an iframe that contains a link
2) Click the link
3) Press backspace to navigate back
4) Navigate to any new page, at which point the forward page would be evicted from the navigation context, and the outer frame's pipeline would be shut down improperly.
5) Press backspace, at which point there is no longer a pipeline for the old page, because it was shut down prematurely. Presumably this would cause a crash.

I also changed the FrameTree function `find_mut` to `find` because find_mut implies it's doing something to cause mutability, but the mutability is caused by the type of object being iterated over, nothing else.

Additionally, script was exiting completely when receiving an exit message. Instead, it needs to handle exit messages according to who sent it. It should only close the subframes of the frame whose pipeline sent the exit message. This is now fixed.

Inexplicably, script was also closing the compositor upon receiving an exit message. This doesn't seem like it'd ever be the right thing to do. _Edit: this is _only_ the right thing to do when received from the window._ I've fixed that. I don't think anyone shuts down the compositor now. _Edit: the script shuts down the compositor only when receiving an exit from the window._
