### PR TITLE
Add support for inline iframes.

### DIFF
--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -117,8 +117,12 @@ impl<'self> BoxGenerator<'self> {
                     for spacer in inline_spacer.iter() {
                         inline.boxes.push(*spacer);
                     }
+                } else {
+                    // TODO: cases for inline-block, etc.
+                    let new_box = BoxGenerator::make_box(ctx, box_type, node, builder);
+                    inline.boxes.push(new_box);
+                    debug!("BoxGenerator: creating box for node %s, now %? boxes", node.debug_str(), inline.boxes.len());
                 }
-                // TODO: cases for inline-block, etc.
             },
             BlockFlow(ref mut block) => {
                 debug!("BoxGenerator[f%d]: point b", block.common.id);


### PR DESCRIPTION
Do not merge; this is to start a conversation with @eric93.

This will also help to fix #905.

It currently has a problem that when you resize the window, even though the iframes are all children of the inline flow, an iframe cut off by the edge of the window does not wrap to the next line (though text and images clearly do).
