### PR TITLE
Various fixes for crashes and frequent task failure at shutdown

### DIFF
--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -801,7 +801,7 @@ impl Constellation {
     fn set_ids(&self, frame_tree: @mut FrameTree) {
         let (port, chan) = comm::stream();
         self.compositor_chan.send(SetIds(frame_tree.to_sendable(), chan, self.chan.clone()));
-        port.recv();
+        port.try_recv();
         for frame in frame_tree.iter() {
             frame.pipeline.grant_paint_permission();
         }

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -200,7 +200,7 @@ impl Pipeline {
     }
 
     pub fn grant_paint_permission(&self) {
-        self.render_chan.send(PaintPermissionGranted);
+        self.render_chan.try_send(PaintPermissionGranted);
     }
 
     pub fn revoke_paint_permission(&self) {

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4027,7 +4027,7 @@ def finalizeHook(descriptor, hookName, context):
         pass
     else:
         assert descriptor.nativeIsISupports
-        release = """let val = JS_GetReservedSlot(obj, 0);
+        release = """let val = JS_GetReservedSlot(obj, dom_object_slot(obj));
 let _: @mut %s = cast::transmute(RUST_JSVAL_TO_PRIVATE(val));
 debug!("%s finalize: %%p", this);
 """ % (descriptor.concreteType, descriptor.concreteType)

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -121,14 +121,19 @@ pub fn is_dom_proxy(obj: *JSObject) -> bool {
 }
 
 #[fixed_stack_segment]
-pub unsafe fn unwrap<T>(obj: *JSObject) -> T {
+pub unsafe fn dom_object_slot(obj: *JSObject) -> u32 {
     let clasp = JS_GetClass(obj);
-    let slot = if is_dom_class(clasp) {
-        DOM_OBJECT_SLOT
+    if is_dom_class(clasp) {
+        DOM_OBJECT_SLOT as u32
     } else {
         assert!(is_dom_proxy(obj));
-        DOM_PROXY_OBJECT_SLOT
-    } as u32;
+        DOM_PROXY_OBJECT_SLOT as u32
+    }
+}
+
+#[fixed_stack_segment]
+pub unsafe fn unwrap<T>(obj: *JSObject) -> T {
+    let slot = dom_object_slot(obj);
     let val = JS_GetReservedSlot(obj, slot);
     cast::transmute(RUST_JSVAL_TO_PRIVATE(val))
 }

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -629,7 +629,9 @@ impl ScriptTask {
         }
     }
 
-    fn handle_exit_window_msg(&mut self, _id: PipelineId) -> bool {
+    fn handle_exit_window_msg(&mut self, id: PipelineId) -> bool {
+        self.handle_exit_pipeline_msg(id);
+
         // TODO(tkuehn): currently there is only one window,
         // so this can afford to be naive and just shut down the
         // compositor. In the future it'll need to be smarter.


### PR DESCRIPTION
Fixes #1004. I haven't seen the other ones be reported, but I saw often saw `task <unnamed> failed at 'RenderChan.send: render port closed', /home/jdm/sdb/servo/src/components/gfx/render_task.rs:76`, `task <unnamed> failed at 'receiving on closed channel', /home/jdm/sdb/servo/src/compiler/rust/src/libstd/rt/comm.rs:487`, and failed assertions due to layout running after we had begun tearing down the window.
