### PR TITLE
Add glyph advance cache to enhance speed of layout

### DIFF
--- a/src/components/gfx/font.rs
+++ b/src/components/gfx/font.rs
@@ -478,12 +478,12 @@ impl Font {
     }
 
     pub fn glyph_h_advance(&mut self, glyph: GlyphIndex) -> FractionalPixel {
-	do self.glyph_advance_cache.find_or_create(&glyph) |glyph| {
-	    match self.handle.glyph_h_advance(*glyph) {
-	        Some(adv) => adv,
-		None => /* FIXME: Need fallback strategy */ 10f as FractionalPixel
-	    }
-	}
+        do self.glyph_advance_cache.find_or_create(&glyph) |glyph| {
+            match self.handle.glyph_h_advance(*glyph) {
+                Some(adv) => adv,
+                None => /* FIXME: Need fallback strategy */ 10f as FractionalPixel
+            }
+        }
     }
 }
 

--- a/src/components/gfx/platform/android/font.rs
+++ b/src/components/gfx/platform/android/font.rs
@@ -198,7 +198,7 @@ impl FontHandleMethods for FontHandle {
     }
 
     #[fixed_stack_segment]
-    fn glyph_h_advance(&self,
+    fn glyph_h_advance(&mut self,
                            glyph: GlyphIndex) -> Option<FractionalPixel> {
         assert!(self.face.is_not_null());
         unsafe {

--- a/src/components/gfx/platform/linux/font.rs
+++ b/src/components/gfx/platform/linux/font.rs
@@ -198,7 +198,7 @@ impl FontHandleMethods for FontHandle {
     }
 
     #[fixed_stack_segment]
-    fn glyph_h_advance(&self,
+    fn glyph_h_advance(&mut self,
                            glyph: GlyphIndex) -> Option<FractionalPixel> {
         assert!(self.face.is_not_null());
         unsafe {

--- a/src/components/gfx/platform/macos/font.rs
+++ b/src/components/gfx/platform/macos/font.rs
@@ -147,7 +147,7 @@ impl FontHandleMethods for FontHandle {
         return Some(glyphs[0] as GlyphIndex);
     }
 
-    fn glyph_h_advance(&self, glyph: GlyphIndex) -> Option<FractionalPixel> {
+    fn glyph_h_advance(&mut self, glyph: GlyphIndex) -> Option<FractionalPixel> {
         let glyphs = [glyph as CGGlyph];
         let advance = self.ctfont.get_advances_for_glyphs(kCTFontDefaultOrientation,
                                                           &glyphs[0],

--- a/src/components/gfx/text/shaping/harfbuzz.rs
+++ b/src/components/gfx/text/shaping/harfbuzz.rs
@@ -13,7 +13,6 @@ use servo_util::range::Range;
 use text::util::{float_to_fixed, fixed_to_float, fixed_to_rounded_int};
 
 use std::cast::transmute;
-use std::cast;
 use std::char;
 use std::libc::{c_uint, c_int, c_void, c_char};
 use std::ptr;
@@ -510,7 +509,7 @@ extern fn glyph_h_advance_func(_: *hb_font_t,
                                glyph: hb_codepoint_t,
                                _: *c_void)
                             -> hb_position_t {
-    let font: *mut Font = unsafe { cast::transmute(font_data as *Font) };
+    let font: *mut Font = font_data as *mut Font;
     assert!(font.is_not_null());
 
     unsafe {

--- a/src/components/gfx/text/shaping/harfbuzz.rs
+++ b/src/components/gfx/text/shaping/harfbuzz.rs
@@ -13,6 +13,7 @@ use servo_util::range::Range;
 use text::util::{float_to_fixed, fixed_to_float, fixed_to_rounded_int};
 
 use std::cast::transmute;
+use std::cast;
 use std::char;
 use std::libc::{c_uint, c_int, c_void, c_char};
 use std::ptr;
@@ -509,7 +510,7 @@ extern fn glyph_h_advance_func(_: *hb_font_t,
                                glyph: hb_codepoint_t,
                                _: *c_void)
                             -> hb_position_t {
-    let font: *Font = font_data as *Font;
+    let font: *mut Font = unsafe { cast::transmute(font_data as *Font) };
     assert!(font.is_not_null());
 
     unsafe {


### PR DESCRIPTION
To reduce number of FT_Load_Glyph call, use glyph advance cache.
