### PR TITLE
Use str.char_offset_iter instead of manually calling str.char_range_at.

### DIFF
--- a/src/components/gfx/text/shaping/harfbuzz.rs
+++ b/src/components/gfx/text/shaping/harfbuzz.rs
@@ -266,12 +266,8 @@ impl Shaper {
             byteToGlyph = vec::from_elem(byte_max, NO_GLYPH);
         } else {
             byteToGlyph = vec::from_elem(byte_max, CONTINUATION_BYTE);
-            let mut i = 0;
-            while i < byte_max {
+            for (i, _) in text.char_offset_iter() {
                 byteToGlyph[i] = NO_GLYPH;
-                let range = text.char_range_at(i);
-                ignore(range.ch);
-                i = range.next;
             }
         }
 
@@ -292,11 +288,8 @@ impl Shaper {
 
         debug!("text: %s", text);
         debug!("(char idx): char->(glyph index):");
-        let mut i = 0u;
-        while i < byte_max {
-            let range = text.char_range_at(i);
-            debug!("%u: %? --> %d", i, range.ch, byteToGlyph[i] as int);
-            i = range.next;
+        for (i, ch) in text.char_offset_iter() {
+            debug!("%u: %? --> %d", i, ch, byteToGlyph[i] as int);
         }
 
         // some helpers
@@ -367,11 +360,6 @@ impl Shaper {
                     let loc = glyph_data.byte_offset_of_glyph(j);
                     if !char_byte_span.contains(loc) {
                         all_glyphs_are_within_cluster = false;
-                        break
-                    }
-
-                    // If true, keep checking. Else, stop.
-                    if !all_glyphs_are_within_cluster {
                         break
                     }
                 }
@@ -554,4 +542,3 @@ extern fn get_font_table_func(_: *hb_face_t, tag: hb_tag_t, user_data: *c_void) 
 extern fn destroy_blob_func(_: *c_void) {
     // TODO: Previous code here was broken. Rewrite.
 }
-

--- a/src/components/gfx/text/text_run.rs
+++ b/src/components/gfx/text/text_run.rs
@@ -179,7 +179,7 @@ impl<'self> TextRun {
 
         // Create a glyph store for the final slice if it's nonempty.
         if byte_i > byte_last_boundary {
-            let slice = text.slice(byte_last_boundary, text.len()).to_owned();
+            let slice = text.slice_from(byte_last_boundary).to_owned();
             debug!("creating glyph store for final slice %? (ws? %?), %? - %? in run %?",
                 slice, cur_slice_is_whitespace, byte_last_boundary, text.len(), text);
             glyphs.push(font.shape_text(slice, cur_slice_is_whitespace));

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -776,7 +776,7 @@ pub fn FindEnumStringIndex(cx: *JSContext,
             return Err(());
         }
         let length = 0;
-        let chars = JS_GetStringCharsAndLength(cx, jsstr, ptr::to_unsafe_ptr(&length));
+        let chars = JS_GetStringCharsAndLength(cx, jsstr, &length);
         if chars.is_null() {
             return Err(());
         }


### PR DESCRIPTION
And 3 other minor clean-ups: removing a redundant `if`, a redundant function call, and using `slice_from` where it is possible.
