### PR TITLE
Fix UA stylesheet: remove Rust string escaping

### DIFF
--- a/src/components/main/css/user-agent.css
+++ b/src/components/main/css/user-agent.css
@@ -58,17 +58,17 @@ ol, ul, dir,
 ol ul, ul ol,
     ul ul, ol ol    { margin-top: 0; margin-bottom: 0 }
     u, ins          { text-decoration: underline }
-    br:before       { content: \"\\A\"; white-space: pre-line }
+    br:before       { content: "\A"; white-space: pre-line }
 center          { text-align: center }
 :link, :visited { text-decoration: underline }
 :focus          { outline: thin dotted invert }
 
 /* Begin bidirectionality settings (do not change) */
-BDO[DIR=\"ltr\"]  { direction: ltr; unicode-bidi: bidi-override }
-BDO[DIR=\"rtl\"]  { direction: rtl; unicode-bidi: bidi-override }
+BDO[DIR="ltr"]  { direction: ltr; unicode-bidi: bidi-override }
+BDO[DIR="rtl"]  { direction: rtl; unicode-bidi: bidi-override }
 
-*[DIR=\"ltr\"]    { direction: ltr; unicode-bidi: embed }
-*[DIR=\"rtl\"]    { direction: rtl; unicode-bidi: embed }
+*[DIR="ltr"]    { direction: ltr; unicode-bidi: embed }
+*[DIR="rtl"]    { direction: rtl; unicode-bidi: embed }
 
 @media print {
 h1            { page-break-before: always }


### PR DESCRIPTION
Oops, I broke the UA stylesheet in #1017. The fact that our tests still passed is not a good sign :/
