### PR TITLE
Remove unused imports in htmlformelement

### DIFF
--- a/src/components/script/dom/htmlformelement.rs
+++ b/src/components/script/dom/htmlformelement.rs
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::utils::{Reflectable, DOMString, ErrorResult};
-use dom::element::HTMLFormElementTypeId;
 use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, ElementNodeTypeId, Node, ScriptView};
+use dom::node::{AbstractNode, ScriptView};
 
 use js::jsapi::{JSObject, JSContext};
 


### PR DESCRIPTION
HTMLFormElementTypeId, ElementNodeTypeID and Node are not used anymore in htmlformelement.rs

The compiler was giving a warning error about unused imports.
