### PR TITLE
Make Node.owner_doc private.

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -90,7 +90,7 @@ impl AbstractDocument {
     pub fn set_root(&self, root: AbstractNode<ScriptView>) {
         assert!(root.traverse_preorder().all(|node| {
             do node.with_base |node| {
-                node.owner_doc == *self
+                node.owner_doc() == *self
             }
         }));
         self.with_mut_base(|document| {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -193,7 +193,7 @@ impl<'self> Element {
         }
 
         if abstract_self.is_in_doc() {
-            do self.node.owner_doc.with_base |owner| {
+            do self.node.owner_doc().with_base |owner| {
                 owner.content_changed();
             }
         }
@@ -280,7 +280,7 @@ impl Element {
     }
 
     pub fn GetClientRects(&self, abstract_self: AbstractNode<ScriptView>) -> @mut ClientRectList {
-        let document = self.node.owner_doc;
+        let document = self.node.owner_doc();
         let win = document.with_base(|doc| doc.window);
         let node = abstract_self;
         assert!(node.is_element());
@@ -307,7 +307,7 @@ impl Element {
     }
 
     pub fn GetBoundingClientRect(&self, abstract_self: AbstractNode<ScriptView>) -> @mut ClientRect {
-        let document = self.node.owner_doc;
+        let document = self.node.owner_doc();
         let win = document.with_base(|doc| doc.window);
         let node = abstract_self;
         assert!(node.is_element());

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -43,7 +43,7 @@ impl HTMLImageElement {
     pub fn AfterSetAttr(&mut self, name: &DOMString, _value: &DOMString) {
         let name = null_str_as_empty(name);
         if "src" == name {
-            let doc = self.htmlelement.element.node.owner_doc;
+            let doc = self.htmlelement.element.node.owner_doc();
             do doc.with_base |doc| {
                 let window = doc.window;
                 let url = window.page.url.map(|&(ref url, _)| url.clone());
@@ -100,7 +100,7 @@ impl HTMLImageElement {
 
     pub fn Width(&self, abstract_self: AbstractNode<ScriptView>) -> u32 {
         let node = &self.htmlelement.element.node;
-        let page = node.owner_doc.with_base(|doc| doc.window).page;
+        let page = node.owner_doc().with_base(|doc| doc.window).page;
         let (port, chan) = stream();
         match page.query_layout(ContentBoxQuery(abstract_self, chan), port) {
             ContentBoxResponse(rect) => {
@@ -121,7 +121,7 @@ impl HTMLImageElement {
 
     pub fn Height(&self, abstract_self: AbstractNode<ScriptView>) -> u32 {
         let node = &self.htmlelement.element.node;
-        let page = node.owner_doc.with_base(|doc| doc.window).page;
+        let page = node.owner_doc().with_base(|doc| doc.window).page;
         let (port, chan) = stream();
         match page.query_layout(ContentBoxQuery(abstract_self, chan), port) {
             ContentBoxResponse(rect) => {


### PR DESCRIPTION
When `Document` is a `Node`, we can only set its `owner_doc` after creating the `AbstractDocument`, and thus the `Document`, and thus the `Node`; i.e., when creating the `Node`, the `AbstractDocument` can't exist yet. That means that we'll need to turn `owner_doc` back into an `Option`. We don't want to expose that to everyone, though, so this adds encapsulation so we'll be able to just `unwrap` in the `owner_doc()` function rather than at all call sites.
