### PR TITLE
Issue #1071 - Ensure that Documents always have a non-null Window.

### DIFF
--- a/src/components/script/dom/domparser.rs
+++ b/src/components/script/dom/domparser.rs
@@ -43,10 +43,10 @@ impl DOMParser {
         let cx = self.owner.get_cx();
         let document = match ty {
             Text_html => {
-                HTMLDocument::new(None)
+                HTMLDocument::new(self.owner)
             }
             Text_xml => {
-                AbstractDocument::as_abstract(cx, @mut Document::new(None, XML))
+                AbstractDocument::as_abstract(cx, @mut Document::new(self.owner, XML))
             }
             _ => {
                 fail!("unsupported document type")

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -274,7 +274,7 @@ impl Element {
 
     pub fn GetClientRects(&self, abstract_self: AbstractNode<ScriptView>) -> @mut ClientRectList {
         let document = self.node.owner_doc;
-        let win = document.with_base(|doc| doc.window).expect("no window");
+        let win = document.with_base(|doc| doc.window);
         let node = abstract_self;
         assert!(node.is_element());
         let (port, chan) = comm::stream();
@@ -301,7 +301,7 @@ impl Element {
 
     pub fn GetBoundingClientRect(&self, abstract_self: AbstractNode<ScriptView>) -> @mut ClientRect {
         let document = self.node.owner_doc;
-        let win = document.with_base(|doc| doc.window).expect("no window");
+        let win = document.with_base(|doc| doc.window);
         let node = abstract_self;
         assert!(node.is_element());
         let (port, chan) = comm::stream();

--- a/src/components/script/dom/htmldocument.rs
+++ b/src/components/script/dom/htmldocument.rs
@@ -24,12 +24,12 @@ pub struct HTMLDocument {
 }
 
 impl HTMLDocument {
-    pub fn new(window: Option<@mut Window>) -> AbstractDocument {
+    pub fn new(window: @mut Window) -> AbstractDocument {
         let doc = @mut HTMLDocument {
             parent: Document::new(window, HTML)
         };
 
-        AbstractDocument::as_abstract(window.get_ref().get_cx(), doc)
+        AbstractDocument::as_abstract(window.get_cx(), doc)
     }
 }
 

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -44,10 +44,9 @@ impl HTMLImageElement {
         if "src" == name {
             let doc = self.htmlelement.element.node.owner_doc;
             do doc.with_base |doc| {
-                for window in doc.window.iter() {
-                    let url = window.page.url.map(|&(ref url, _)| url.clone());
-                    self.update_image(window.image_cache_task.clone(), url);
-                }
+                let window = doc.window;
+                let url = window.page.url.map(|&(ref url, _)| url.clone());
+                self.update_image(window.image_cache_task.clone(), url);
             }
         }
     }
@@ -100,19 +99,11 @@ impl HTMLImageElement {
 
     pub fn Width(&self, abstract_self: AbstractNode<ScriptView>) -> u32 {
         let node = &self.htmlelement.element.node;
-        match node.owner_doc.with_base(|doc| doc.window) {
-            Some(win) => {
-                let page = win.page;
-                let (port, chan) = stream();
-                match page.query_layout(ContentBoxQuery(abstract_self, chan), port) {
-                    ContentBoxResponse(rect) => {
-                        to_px(rect.size.width) as u32
-                    }
-                }
-            }
-            None => {
-                debug!("no window");
-                0
+        let page = node.owner_doc.with_base(|doc| doc.window).page;
+        let (port, chan) = stream();
+        match page.query_layout(ContentBoxQuery(abstract_self, chan), port) {
+            ContentBoxResponse(rect) => {
+                to_px(rect.size.width) as u32
             }
         }
     }
@@ -129,19 +120,11 @@ impl HTMLImageElement {
 
     pub fn Height(&self, abstract_self: AbstractNode<ScriptView>) -> u32 {
         let node = &self.htmlelement.element.node;
-        match node.owner_doc.with_base(|doc| doc.window) {
-            Some(win) => {
-                let page = win.page;
-                let (port, chan) = stream();
-                match page.query_layout(ContentBoxQuery(abstract_self, chan), port) {
-                    ContentBoxResponse(rect) => {
-                        to_px(rect.size.height) as u32
-                    }
-                }
-            }
-            None => {
-                debug!("no window");
-                0
+        let page = node.owner_doc.with_base(|doc| doc.window).page;
+        let (port, chan) = stream();
+        match page.query_layout(ContentBoxQuery(abstract_self, chan), port) {
+            ContentBoxResponse(rect) => {
+                to_px(rect.size.height) as u32
             }
         }
     }

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -664,7 +664,7 @@ impl Node<ScriptView> {
     }
 
     pub fn get_scope_and_cx(&self) -> (*JSObject, *JSContext) {
-        let win = self.owner_doc.with_base(|doc| doc.window.unwrap());
+        let win = self.owner_doc.with_base(|doc| doc.window);
         (win.reflector().get_jsobject(), win.get_cx())
     }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -717,7 +717,7 @@ impl ScriptTask {
         // Parse HTML.
         //
         // Note: We can parse the next document in parallel with any previous documents.
-        let document = HTMLDocument::new(Some(window));
+        let document = HTMLDocument::new(window);
 
         let html_parsing_result = hubbub_html_parser::parse_html(cx.ptr,
                                                                  document,


### PR DESCRIPTION
Turns out that documents without a window `fail!` a lot, because we need the `cx` all over.
