### PR TITLE
Short-term fixes for non-ASCII in JavaScript

### DIFF
--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -218,7 +218,13 @@ pub unsafe fn domstring_to_jsval(cx: *JSContext, string: &DOMString) -> JSVal {
     match string {
         &None => JSVAL_NULL,
         &Some(ref s) => do s.to_utf16().as_imm_buf |buf, len| {
-            RUST_STRING_TO_JSVAL(JS_NewUCStringCopyN(cx, buf, len as libc::size_t))
+            let jsstr = JS_NewUCStringCopyN(cx, buf, len as libc::size_t);
+            if jsstr.is_null() {
+                // FIXME: is there something else we should do on failure?
+                JSVAL_NULL
+            } else {
+                RUST_STRING_TO_JSVAL(jsstr)
+            }
         }
     }
 }

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -19,6 +19,7 @@ use std::cast;
 use std::cell::Cell;
 use std::comm;
 use std::comm::{Port, SharedChan};
+use std::str;
 use std::str::eq_slice;
 use std::task;
 use std::from_str::FromStr;
@@ -102,7 +103,7 @@ macro_rules! handle_element_base(
 
 
 pub struct JSFile {
-    data: ~[u8],
+    data: ~str,
     url: Url
 }
 
@@ -222,11 +223,11 @@ fn js_script_listener(to_parent: SharedChan<HtmlDiscoveryMessage>,
 
                 let bytes = result_port.recv();
                 if bytes.is_some() {
-                    result_vec.push(JSFile { data: bytes.unwrap(), url: url_clone });
+                    result_vec.push(JSFile { data: str::from_utf8(bytes.unwrap()), url: url_clone });
                 }
             }
             JSTaskNewInlineScript(data, url) => {
-                result_vec.push(JSFile { data: data.into_bytes(), url: url });
+                result_vec.push(JSFile { data: data, url: url });
             }
             JSTaskExit => {
                 break;

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -30,6 +30,7 @@ use std::comm;
 use std::comm::{Port, SharedChan};
 use std::io::read_whole_file;
 use std::ptr;
+use std::str;
 use std::task::{spawn_sched, SingleThreaded};
 use std::util::replace;
 use dom::window::TimerData;
@@ -578,7 +579,7 @@ impl ScriptTask {
             Ok(bytes) => {
                 compartment.define_functions(debug_fns);
                 cx.evaluate_script(compartment.global_obj,
-                                   bytes,
+                                   str::from_utf8(bytes),
                                    url.path.clone(),
                                    1);
             }

--- a/src/test/html/content/test_collections.html
+++ b/src/test/html/content/test_collections.html
@@ -24,8 +24,10 @@ function check_collection(obj, num, classes, name) {
     }
 }
 
-function check_tag(tagname, num, classes) {
-    check_collection(document.getElementsByTagName(tagname), num, classes, tagname.toUpperCase());
+function check_tag(tagname, num, classes, tagname_upper) {
+    if (tagname_upper === undefined)
+        tagname_upper = tagname.toUpperCase();
+    check_collection(document.getElementsByTagName(tagname), num, classes, tagname_upper);
 }
 
 check_collection(document.links,   1, [HTMLAnchorElement], "A");
@@ -73,8 +75,8 @@ check_tag("track",    1, [HTMLTrackElement]);
 check_tag("audio",    1, [HTMLMediaElement, HTMLAudioElement]);
 check_tag("video",    1, [HTMLMediaElement, HTMLVideoElement]);
 
-// FIXME: Test non-ASCII tag names
-check_tag("foo", 1, [HTMLUnknownElement]);
+// Test non-ASCII tag names.  The ASCII-only uppercasing matches Firefox's behavior.
+check_tag("foo-á", 1, [HTMLUnknownElement], "FOO-á");
 
 finish();
 </script>
@@ -134,7 +136,7 @@ finish();
   <track></track>
 </video>
 
-<foo>hi</foo>
+<foo-á>hi</foo-á>
 
 </body>
 </html>

--- a/src/test/html/content/test_collections.html
+++ b/src/test/html/content/test_collections.html
@@ -75,7 +75,8 @@ check_tag("track",    1, [HTMLTrackElement]);
 check_tag("audio",    1, [HTMLMediaElement, HTMLAudioElement]);
 check_tag("video",    1, [HTMLMediaElement, HTMLVideoElement]);
 
-// Test non-ASCII tag names.  The ASCII-only uppercasing matches Firefox's behavior.
+// Test non-ASCII tag names.  Uppercasing is ASCII-only per spec:
+// http://dom.spec.whatwg.org/#dom-element-tagname
 check_tag("foo-á", 1, [HTMLUnknownElement], "FOO-á");
 
 finish();


### PR DESCRIPTION
This doesn't resolve the big questions of how Servo will represent strings; it's just about doing the conversion correctly for our existing types.
