### PR TITLE
Make Document a Node

### DIFF
--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -21,7 +21,7 @@ use style::computed_values::display;
 use style::computed_values::float;
 use layout::float_context::{FloatLeft, FloatRight};
 use script::dom::node::{AbstractNode, CommentNodeTypeId, DoctypeNodeTypeId};
-use script::dom::node::{ElementNodeTypeId, LayoutView, TextNodeTypeId};
+use script::dom::node::{ElementNodeTypeId, LayoutView, TextNodeTypeId, DocumentNodeTypeId};
 use script::dom::node::DocumentFragmentNodeTypeId;
 use servo_util::range::Range;
 use servo_util::tree::{TreeNodeRef, TreeNode};
@@ -390,6 +390,7 @@ impl LayoutTreeBuilder {
                 ElementNodeTypeId(_) => display::inline,
                 TextNodeTypeId => display::inline,
                 DoctypeNodeTypeId |
+                DocumentNodeTypeId(_) |
                 DocumentFragmentNodeTypeId |
                 CommentNodeTypeId => return NoGenerator,
             }
@@ -430,11 +431,12 @@ impl LayoutTreeBuilder {
                 self.create_child_generator(node, parent_generator, Flow_Float(is_float.unwrap()))
             }
 
-            (display::block, & &BlockFlow(ref info), _) => match (info.is_root, node.parent_node().is_some()) {
+            (display::block, & &BlockFlow(ref info), _) => match (info.is_root, node.parent_node()) {
                 // If this is the root node, then use the root flow's
                 // context. Otherwise, make a child block context.
-                (true, true) => self.create_child_generator(node, parent_generator, Flow_Block),
-                (true, false) => { return ParentGenerator }
+                (true, Some(parent)) if !parent.is_document() =>
+                    self.create_child_generator(node, parent_generator, Flow_Block),
+                (true, None) | (true, Some(_)) => { return ParentGenerator }
                 (false, _)   => {
                     self.create_child_generator(node, parent_generator, Flow_Block)
                 }

--- a/src/components/script/dom/bindings/codegen/Document.webidl
+++ b/src/components/script/dom/bindings/codegen/Document.webidl
@@ -24,7 +24,7 @@ enum VisibilityState { "hidden", "visible" };
 
 /* http://dom.spec.whatwg.org/#interface-document */
 [Constructor]
-interface Document /*: Node*/ { //XXXjdm Requires servo/#623
+interface Document : Node {
   /*[Throws]
     readonly attribute DOMImplementation implementation;*/
   // readonly attribute DOMString URL;

--- a/src/components/script/dom/bindings/node.rs
+++ b/src/components/script/dom/bindings/node.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::utils::{Reflectable, Reflector, Traceable};
+use dom::document::{PlainDocumentTypeId, HTMLDocumentTypeId};
 use dom::element::*;
 use dom::types::*;
 use dom::node::{AbstractNode, ElementNodeTypeId, TextNodeTypeId, CommentNodeTypeId};
-use dom::node::{DoctypeNodeTypeId, DocumentFragmentNodeTypeId, ScriptView};
+use dom::node::{DoctypeNodeTypeId, DocumentFragmentNodeTypeId, ScriptView, DocumentNodeTypeId};
 
 use std::cast;
 use std::libc;
@@ -95,6 +96,8 @@ pub fn create(cx: *JSContext, node: &mut AbstractNode<ScriptView>) -> *JSObject 
         CommentNodeTypeId => generate_element!(Comment),
         DoctypeNodeTypeId => generate_element!(DocumentType),
         DocumentFragmentNodeTypeId => generate_element!(DocumentFragment),
+        DocumentNodeTypeId(PlainDocumentTypeId) => generate_element!(Document),
+        DocumentNodeTypeId(HTMLDocumentTypeId) => generate_element!(HTMLDocument),
         TextNodeTypeId => generate_element!(Text),
     }
 }

--- a/src/components/script/dom/domparser.rs
+++ b/src/components/script/dom/domparser.rs
@@ -4,13 +4,9 @@
 
 use dom::bindings::codegen::DOMParserBinding;
 use dom::bindings::codegen::DOMParserBinding::SupportedTypeValues::{Text_html, Text_xml};
-use dom::bindings::utils::{DOMString, Fallible, Reflector, Reflectable};
+use dom::bindings::utils::{DOMString, Fallible, Reflector, Reflectable, FailureUnknown};
 use dom::document::{AbstractDocument, Document, XML};
-use dom::element::HTMLHtmlElementTypeId;
 use dom::htmldocument::HTMLDocument;
-use dom::htmlelement::HTMLElement;
-use dom::htmlhtmlelement::HTMLHtmlElement;
-use dom::node::Node;
 use dom::window::Window;
 
 pub struct DOMParser {
@@ -41,25 +37,17 @@ impl DOMParser {
                            ty: DOMParserBinding::SupportedType)
                            -> Fallible<AbstractDocument> {
         let cx = self.owner.get_cx();
-        let document = match ty {
+        match ty {
             Text_html => {
-                HTMLDocument::new(self.owner)
+                Ok(HTMLDocument::new(self.owner))
             }
             Text_xml => {
-                AbstractDocument::as_abstract(cx, @mut Document::new(self.owner, XML))
+                Ok(AbstractDocument::as_abstract(cx, @mut Document::new(self.owner, XML)))
             }
             _ => {
-                fail!("unsupported document type")
+                Err(FailureUnknown)
             }
-        };
-
-        let root = @HTMLHtmlElement {
-            htmlelement: HTMLElement::new(HTMLHtmlElementTypeId, ~"html", document)
-        };
-        let root = unsafe { Node::as_abstract_node(cx, root) };
-        document.set_root(root);
-
-        Ok(document)
+        }
     }
 }
 

--- a/src/components/script/dom/htmldocument.rs
+++ b/src/components/script/dom/htmldocument.rs
@@ -35,6 +35,11 @@ impl ReflectableDocument for HTMLDocument {
     fn init_reflector(@mut self, cx: *JSContext) {
         self.wrap_object_shared(cx, ptr::null()); //XXXjdm a proper scope would be nice
     }
+
+    fn init_node(@mut self, doc: AbstractDocument) {
+        self.parent.node.set_owner_doc(doc);
+        self.parent.node.add_to_doc(AbstractNode::from_document(doc), doc);
+    }
 }
 
 impl HTMLDocument {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -9,7 +9,7 @@ use dom::bindings::utils::{Reflectable, Reflector};
 use dom::bindings::utils::{DOMString, null_str_as_empty};
 use dom::bindings::utils::{ErrorResult, Fallible, NotFound, HierarchyRequest};
 use dom::characterdata::CharacterData;
-use dom::document::AbstractDocument;
+use dom::document::{AbstractDocument, DocumentTypeId};
 use dom::documenttype::DocumentType;
 use dom::element::{Element, ElementTypeId, HTMLImageElementTypeId, HTMLIframeElementTypeId};
 use dom::element::{HTMLStyleElementTypeId};
@@ -88,7 +88,7 @@ pub struct Node<View> {
     prev_sibling: Option<AbstractNode<View>>,
 
     /// The document that this node belongs to.
-    priv owner_doc: AbstractDocument,
+    priv owner_doc: Option<AbstractDocument>,
 
     /// The live list of children return by .childNodes.
     child_list: Option<@mut NodeList>,
@@ -103,6 +103,7 @@ pub enum NodeTypeId {
     DoctypeNodeTypeId,
     DocumentFragmentNodeTypeId,
     CommentNodeTypeId,
+    DocumentNodeTypeId(DocumentTypeId),
     ElementNodeTypeId(ElementTypeId),
     TextNodeTypeId,
 }
@@ -197,6 +198,13 @@ impl<'self, View> AbstractNode<View> {
     pub fn from_box<T>(ptr: *mut Box<T>) -> AbstractNode<View> {
         AbstractNode {
             obj: ptr as *mut Box<Node<View>>
+        }
+    }
+
+    /// Allow consumers to upcast from derived classes.
+    pub fn from_document(doc: AbstractDocument) -> AbstractNode<View> {
+        unsafe {
+            cast::transmute(doc)
         }
     }
 
@@ -325,6 +333,13 @@ impl<'self, View> AbstractNode<View> {
             fail!(~"node is not text");
         }
         self.transmute_mut(f)
+    }
+
+    pub fn is_document(self) -> bool {
+        match self.type_id() {
+            DocumentNodeTypeId(*) => true,
+            _ => false
+        }
     }
 
     // FIXME: This should be doing dynamic borrow checking for safety.
@@ -463,11 +478,11 @@ impl<View> Iterator<AbstractNode<View>> for AbstractNodeChildrenIterator<View> {
 
 impl<View> Node<View> {
     pub fn owner_doc(&self) -> AbstractDocument {
-        self.owner_doc
+        self.owner_doc.unwrap()
     }
 
     pub fn set_owner_doc(&mut self, document: AbstractDocument) {
-        self.owner_doc = document;
+        self.owner_doc = Some(document);
     }
 }
 
@@ -508,6 +523,14 @@ impl Node<ScriptView> {
     }
 
     pub fn new(type_id: NodeTypeId, doc: AbstractDocument) -> Node<ScriptView> {
+        Node::new_(type_id, Some(doc))
+    }
+
+    pub fn new_without_doc(type_id: NodeTypeId) -> Node<ScriptView> {
+        Node::new_(type_id, None)
+    }
+
+    fn new_(type_id: NodeTypeId, doc: Option<AbstractDocument>) -> Node<ScriptView> {
         Node {
             reflector_: Reflector::new(),
             type_id: type_id,
@@ -526,24 +549,6 @@ impl Node<ScriptView> {
             layout_data: LayoutData::new(),
         }
     }
-
-    pub fn getNextSibling(&mut self) -> Option<&mut AbstractNode<ScriptView>> {
-        match self.next_sibling {
-            // transmute because the compiler can't deduce that the reference
-            // is safe outside of with_mut_base blocks.
-            Some(ref mut n) => Some(unsafe { cast::transmute(n) }),
-            None => None
-        }
-    }
-
-    pub fn getFirstChild(&mut self) -> Option<&mut AbstractNode<ScriptView>> {
-        match self.first_child {
-            // transmute because the compiler can't deduce that the reference
-            // is safe outside of with_mut_base blocks.
-            Some(ref mut n) => Some(unsafe { cast::transmute(n) }),
-            None => None
-        }
-    }
 }
 
 impl Node<ScriptView> {
@@ -552,6 +557,7 @@ impl Node<ScriptView> {
             ElementNodeTypeId(_) => 1,
             TextNodeTypeId       => 3,
             CommentNodeTypeId    => 8,
+            DocumentNodeTypeId(_)=> 9,
             DoctypeNodeTypeId    => 10,
             DocumentFragmentNodeTypeId => 11,
         }
@@ -572,6 +578,7 @@ impl Node<ScriptView> {
                 }
             },
             DocumentFragmentNodeTypeId => ~"#document-fragment",
+            DocumentNodeTypeId(_) => ~"#document"
         })
     }
 
@@ -586,7 +593,7 @@ impl Node<ScriptView> {
             TextNodeTypeId |
             DoctypeNodeTypeId |
             DocumentFragmentNodeTypeId => Some(self.owner_doc()),
-            // DocumentNodeTypeId => None
+            DocumentNodeTypeId(_) => None
         }
     }
 
@@ -655,7 +662,7 @@ impl Node<ScriptView> {
                 characterdata.Data()
             }
           }
-          DoctypeNodeTypeId => {
+          DoctypeNodeTypeId | DocumentNodeTypeId(_) => {
             None
           }
         }
@@ -722,7 +729,7 @@ impl Node<ScriptView> {
                 document.document().content_changed();
             }
           }
-          DoctypeNodeTypeId => {}
+          DoctypeNodeTypeId | DocumentNodeTypeId(_) => {}
         }
         Ok(())
     }
@@ -744,10 +751,9 @@ impl Node<ScriptView> {
             if new_child.is_doctype() {
                 return true;
             }
-            if !this_node.is_element() {
-                // FIXME: This should also work for Document and DocumentFragments when they inherit from node.
-                // per jgraham
-                return true;
+            match this_node.type_id() {
+                DocumentNodeTypeId(*) | ElementNodeTypeId(*) => (),
+                _ => return true
             }
             if this_node == new_child {
                 return true;
@@ -798,7 +804,8 @@ impl Node<ScriptView> {
 
         // Unregister elements having "id' from the owner doc.
         // This need be called before target nodes are removed from tree.
-        self.owner_doc.mut_document().unregister_nodes_with_id(&abstract_self);
+        let owner_doc = self.owner_doc();
+        owner_doc.mut_document().unregister_nodes_with_id(&abstract_self);
 
         abstract_self.remove_child(node);
         // Signal the document that it needs to update its display.

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -274,7 +274,7 @@ impl Page {
     /// This function fails if there is no root frame.
     fn reflow(&mut self, goal: ReflowGoal, script_chan: ScriptChan, compositor: @ScriptListener) {
         let root = match self.frame {
-            None => fail!(~"Tried to relayout with no root frame!"),
+            None => return,
             Some(ref frame) => {
                 frame.document.document().GetDocumentElement()
             }

--- a/src/test/html/content/test_parentnodes.html
+++ b/src/test/html/content/test_parentnodes.html
@@ -6,8 +6,7 @@
 <body>
   <div id="div1"></div>
   <script>
-    // FIXME: This should be HTMLDocument.
-    //isnot(document.documentElement.parentNode, null);
+    is_a(document.documentElement.parentNode, HTMLDocument);
     is(document.documentElement.parentElement, null);
 
     var elem = document.createElement("p");

--- a/src/test/html/content/test_prototypes.html
+++ b/src/test/html/content/test_prototypes.html
@@ -5,6 +5,9 @@
 <body>
   <foo-á>foo</foo-á>
 <script>
+gc(); // ensure that our document rooting works; subsequent accesses should be valid.
+is_a(window.document, Node);
+is(window.document.nodeType, Node.DOCUMENT_NODE);
 is_a(window.document.documentElement, Node);
 is_a(window.document.documentElement, Element);
 is_a(window.document.documentElement, HTMLElement);


### PR DESCRIPTION
The bit I don't like about these changes is that I ended up hiding the document node from the CSS selecting/matching code, so it continues thinking of the document's first child as the root. When I tried to send the full tree including the document node to layout, the layout code refused to create any child flows. When I sent the document's first child without hiding the document, it saw inherited values for properties like font-family, and later tried to treat the document node as an Element when searching for named nodes.
