### PR TITLE
Fix error during shutdown on OSX

### DIFF
--- a/src/components/main/platform/common/glfw_windowing.rs
+++ b/src/components/main/platform/common/glfw_windowing.rs
@@ -39,8 +39,8 @@ impl ApplicationMethods for Application {
 
 impl Drop for Application {
     fn drop(&self) {
-        glfw::terminate();
         drop_local_window();
+        glfw::terminate();
     }
 }
 


### PR DESCRIPTION
We were removing the Window from TLS and thus destroying it after terminating the windowing system, which caused an error due to calling a glfw function when it was not inititalized.
