### PR TITLE
Remove no-op implementations from Document and HTMLDocument.

### DIFF
--- a/src/components/script/dom/bindings/codegen/Document.webidl
+++ b/src/components/script/dom/bindings/codegen/Document.webidl
@@ -27,11 +27,11 @@ enum VisibilityState { "hidden", "visible" };
 interface Document /*: Node*/ { //XXXjdm Requires servo/#623
   /*[Throws]
     readonly attribute DOMImplementation implementation;*/
-  readonly attribute DOMString URL;
-  readonly attribute DOMString documentURI;
-  readonly attribute DOMString compatMode;
-  readonly attribute DOMString characterSet;
-  readonly attribute DOMString contentType;
+  // readonly attribute DOMString URL;
+  // readonly attribute DOMString documentURI;
+  // readonly attribute DOMString compatMode;
+  // readonly attribute DOMString characterSet;
+  // readonly attribute DOMString contentType;
 
   //readonly attribute DocumentType? doctype;
   readonly attribute Element? documentElement;
@@ -42,8 +42,8 @@ interface Document /*: Node*/ { //XXXjdm Requires servo/#623
 
   [Creator, Throws]
   Element createElement(DOMString localName);
-  [Creator, Throws]
-  Element createElementNS(DOMString? namespace, DOMString qualifiedName);
+  // [Creator, Throws]
+  // Element createElementNS(DOMString? namespace, DOMString qualifiedName);
   [Creator]
   DocumentFragment createDocumentFragment();
   [Creator]
@@ -58,8 +58,8 @@ interface Document /*: Node*/ { //XXXjdm Requires servo/#623
   [Throws]
   Node adoptNode(Node node);*/
 
-  [Creator, Throws]
-  Event createEvent(DOMString interface_);
+  // [Creator, Throws]
+  // Event createEvent(DOMString interface_);
 
   /*[Creator, Throws]
     Range createRange();*/
@@ -83,23 +83,23 @@ interface Document /*: Node*/ { //XXXjdm Requires servo/#623
   Attr createAttribute(DOMString name);
   [Creator, Throws]
   Attr createAttributeNS(DOMString? namespace, DOMString name);*/
-  readonly attribute DOMString? inputEncoding;
+  // readonly attribute DOMString? inputEncoding;
 };
 
 // http://www.whatwg.org/specs/web-apps/current-work/#the-document-object
 partial interface Document {
   //[PutForwards=href, Unforgeable] readonly attribute Location? location;
   //(HTML only)         attribute DOMString domain;
-  readonly attribute DOMString referrer;
+  // readonly attribute DOMString referrer;
   //(HTML only)         attribute DOMString cookie;
-  readonly attribute DOMString lastModified;
-  readonly attribute DOMString readyState;
+  // readonly attribute DOMString lastModified;
+  // readonly attribute DOMString readyState;
 
   // DOM tree accessors
   //(Not proxy yet)getter object (DOMString name);
            [SetterThrows]
            attribute DOMString title;
-           attribute DOMString dir;
+  //          attribute DOMString dir;
   //(HTML only)         attribute HTMLElement? body;
   //(HTML only)readonly attribute HTMLHeadElement? head;
   //(HTML only)readonly attribute HTMLCollection images;
@@ -120,10 +120,10 @@ partial interface Document {
   //(HTML only)void writeln(DOMString... text);
 
   // user interaction
-  readonly attribute WindowProxy? defaultView;
-  readonly attribute Element? activeElement;
-  [Throws]
-  boolean hasFocus();
+  // readonly attribute WindowProxy? defaultView;
+  // readonly attribute Element? activeElement;
+  // [Throws]
+  // boolean hasFocus();
   //(HTML only)         attribute DOMString designMode;
   //(HTML only)boolean execCommand(DOMString commandId);
   //(HTML only)boolean execCommand(DOMString commandId, boolean showUI);
@@ -157,14 +157,14 @@ partial interface Document {
    *
    * @see <https://developer.mozilla.org/en/DOM/document.currentScript>
    */
-  readonly attribute Element? currentScript;
+  // readonly attribute Element? currentScript;
   /**
    * Release the current mouse capture if it is on an element within this
    * document.
    *
    * @see <https://developer.mozilla.org/en/DOM/document.releaseCapture>
    */
-  void releaseCapture();
+  // void releaseCapture();
   /**
    * Use the given DOM element as the source image of target |-moz-element()|.
    *
@@ -206,9 +206,9 @@ partial interface Document {
 partial interface Document {
   // Note: Per spec the 'S' in these two is lowercase, but the "Moz"
   // versions hve it uppercase.
-  readonly attribute boolean mozFullScreenEnabled;
-  [Throws]
-  readonly attribute Element? mozFullScreenElement;
+  // readonly attribute boolean mozFullScreenEnabled;
+  // [Throws]
+  // readonly attribute Element? mozFullScreenElement;
 
   //(Renamed?)void exitFullscreen();
 
@@ -219,8 +219,8 @@ partial interface Document {
 
 // http://dvcs.w3.org/hg/pointerlock/raw-file/default/index.html#extensions-to-the-document-interface
 partial interface Document {
-    readonly attribute Element? mozPointerLockElement;
-    void mozExitPointerLock ();
+    // readonly attribute Element? mozPointerLockElement;
+    // void mozExitPointerLock ();
 };
 
 //http://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html#dfn-document-register
@@ -231,27 +231,27 @@ partial interface Document {
 
 // http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/PageVisibility/Overview.html#sec-document-interface
 partial interface Document {
-  readonly attribute boolean hidden;
-  readonly attribute boolean mozHidden;
-  readonly attribute VisibilityState visibilityState;
-  readonly attribute VisibilityState mozVisibilityState;
+  // readonly attribute boolean hidden;
+  // readonly attribute boolean mozHidden;
+  // readonly attribute VisibilityState visibilityState;
+  // readonly attribute VisibilityState mozVisibilityState;
 };
 
 // http://dev.w3.org/csswg/cssom/#extensions-to-the-document-interface
 partial interface Document {
   /*[Constant]
     readonly attribute StyleSheetList styleSheets;*/
-    attribute DOMString? selectedStyleSheetSet;
-    readonly attribute DOMString? lastStyleSheetSet;
-    readonly attribute DOMString? preferredStyleSheetSet;
+    // attribute DOMString? selectedStyleSheetSet;
+    // readonly attribute DOMString? lastStyleSheetSet;
+    // readonly attribute DOMString? preferredStyleSheetSet;
   /*[Constant]
     readonly attribute DOMStringList styleSheetSets;*/
-    void enableStyleSheetsForSet (DOMString? name);
+    // void enableStyleSheetsForSet (DOMString? name);
 };
 
 // http://dev.w3.org/csswg/cssom-view/#extensions-to-the-document-interface
 partial interface Document {
-    Element? elementFromPoint (float x, float y);
+    // Element? elementFromPoint (float x, float y);
 
   //CaretPosition? caretPositionFromPoint (float x, float y);
 };
@@ -264,8 +264,8 @@ partial interface Document {
 
 // http://dev.w3.org/2006/webapi/selectors-api2/#interface-definitions
 partial interface Document {
-  [Throws]
-  Element?  querySelector(DOMString selectors);
+  // [Throws]
+  // Element?  querySelector(DOMString selectors);
   /*[Throws]
     NodeList  querySelectorAll(DOMString selectors);*/
 

--- a/src/components/script/dom/bindings/codegen/HTMLDocument.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLDocument.webidl
@@ -8,13 +8,13 @@ interface Selection;
 
 [OverrideBuiltins]
 interface HTMLDocument : Document {
-           [Throws]
-           attribute DOMString? domain;
-           [Throws]
-           attribute DOMString cookie;
+  //          [Throws]
+  //          attribute DOMString? domain;
+  //          [Throws]
+  //          attribute DOMString cookie;
   // DOM tree accessors
-  [Throws]
-  getter object (DOMString name);
+  // [Throws]
+  // getter object (DOMString name);
   /*[SetterThrows]
     attribute HTMLElement? body;*/
   readonly attribute HTMLHeadElement? head;
@@ -32,41 +32,41 @@ interface HTMLDocument : Document {
   Document open(optional DOMString type = "text/html", optional DOMString replace = "");
   [Throws]
   WindowProxy open(DOMString url, DOMString name, DOMString features, optional boolean replace = false);*/
-  [Throws]
-  void close();
+  // [Throws]
+  // void close();
   /*[Throws]
   void write(DOMString... text);
   [Throws]
   void writeln(DOMString... text);*/
 
-           [SetterThrows]
-           attribute DOMString designMode;
-  [Throws]
-  boolean execCommand(DOMString commandId, optional boolean showUI = false,
-                      optional DOMString value = "");
-  [Throws]
-  boolean queryCommandEnabled(DOMString commandId);
-  [Throws]
-  boolean queryCommandIndeterm(DOMString commandId);
-  [Throws]
-  boolean queryCommandState(DOMString commandId);
-  boolean queryCommandSupported(DOMString commandId);
-  [Throws]
-  DOMString queryCommandValue(DOMString commandId);
+  //          [SetterThrows]
+  //          attribute DOMString designMode;
+  // [Throws]
+  // boolean execCommand(DOMString commandId, optional boolean showUI = false,
+  //                     optional DOMString value = "");
+  // [Throws]
+  // boolean queryCommandEnabled(DOMString commandId);
+  // [Throws]
+  // boolean queryCommandIndeterm(DOMString commandId);
+  // [Throws]
+  // boolean queryCommandState(DOMString commandId);
+  // boolean queryCommandSupported(DOMString commandId);
+  // [Throws]
+  // DOMString queryCommandValue(DOMString commandId);
 
-  [TreatNullAs=EmptyString] attribute DOMString fgColor;
-  [TreatNullAs=EmptyString] attribute DOMString linkColor;
-  [TreatNullAs=EmptyString] attribute DOMString vlinkColor;
-  [TreatNullAs=EmptyString] attribute DOMString alinkColor;
-  [TreatNullAs=EmptyString] attribute DOMString bgColor;
+  // [TreatNullAs=EmptyString] attribute DOMString fgColor;
+  // [TreatNullAs=EmptyString] attribute DOMString linkColor;
+  // [TreatNullAs=EmptyString] attribute DOMString vlinkColor;
+  // [TreatNullAs=EmptyString] attribute DOMString alinkColor;
+  // [TreatNullAs=EmptyString] attribute DOMString bgColor;
 
   readonly attribute HTMLCollection anchors;
   readonly attribute HTMLCollection applets;
 
-  void clear();
+  // void clear();
 
-  [Throws]
-  readonly attribute object all;
+  // [Throws]
+  // readonly attribute object all;
 
   // https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#selections
   /*[Throws]

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -10,7 +10,6 @@ use dom::bindings::utils::{is_valid_element_name, InvalidCharacter, Traceable, n
 use dom::documentfragment::DocumentFragment;
 use dom::element::{Element};
 use dom::element::{HTMLHtmlElementTypeId, HTMLHeadElementTypeId, HTMLTitleElementTypeId};
-use dom::event::Event;
 use dom::htmlcollection::HTMLCollection;
 use dom::htmldocument::HTMLDocument;
 use dom::htmlelement::HTMLElement;
@@ -18,7 +17,6 @@ use dom::htmlhtmlelement::HTMLHtmlElement;
 use dom::node::{AbstractNode, ScriptView, Node, ElementNodeTypeId};
 use dom::text::Text;
 use dom::window::Window;
-use dom::windowproxy::WindowProxy;
 use dom::htmltitleelement::HTMLTitleElement;
 use html::hubbub_html_parser::build_element_from_tag;
 use js::jsapi::{JSObject, JSContext, JSVal};
@@ -212,26 +210,6 @@ impl Reflectable for Document {
 }
 
 impl Document {
-    pub fn URL(&self) -> DOMString {
-        None
-    }
-
-    pub fn DocumentURI(&self) -> DOMString {
-        None
-    }
-
-    pub fn CompatMode(&self) -> DOMString {
-        None
-    }
-
-    pub fn CharacterSet(&self) -> DOMString {
-        None
-    }
-
-    pub fn ContentType(&self) -> DOMString {
-        None
-    }
-
     pub fn GetDocumentElement(&self) -> Option<AbstractNode<ScriptView>> {
         self.root
     }
@@ -276,10 +254,6 @@ impl Document {
         Ok(build_element_from_tag(cx, local_name, abstract_self))
     }
 
-    pub fn CreateElementNS(&self, _namespace: &DOMString, _qualified_name: &DOMString) -> Fallible<AbstractNode<ScriptView>> {
-        fail!("stub")
-    }
-
     pub fn CreateDocumentFragment(&self, abstract_self: AbstractDocument) -> AbstractNode<ScriptView> {
         let cx = self.get_cx();
         let fragment = @DocumentFragment::new(abstract_self);
@@ -296,26 +270,6 @@ impl Document {
         let cx = self.get_cx();
         let comment = @Comment::new(null_str_as_word_null(data), abstract_self);
         unsafe { Node::as_abstract_node(cx, comment) }
-    }
-
-    pub fn CreateEvent(&self, _interface: &DOMString) -> Fallible<@mut Event> {
-        fail!("stub")
-    }
-
-    pub fn GetInputEncoding(&self) -> DOMString {
-        None
-    }
-
-    pub fn Referrer(&self) -> DOMString {
-        None
-    }
-
-    pub fn LastModified(&self) -> DOMString {
-        None
-    }
-
-    pub fn ReadyState(&self) -> DOMString {
-        None
     }
 
     pub fn Title(&self, _: AbstractDocument) -> DOMString {
@@ -395,89 +349,6 @@ impl Document {
             }
         }
         Ok(())
-    }
-
-    pub fn Dir(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetDir(&self, _dir: &DOMString) {
-    }
-
-    pub fn GetDefaultView(&self) -> Option<@mut WindowProxy> {
-        None
-    }
-
-    pub fn GetActiveElement(&self) -> Option<AbstractNode<ScriptView>> {
-        None
-    }
-
-    pub fn HasFocus(&self) -> Fallible<bool> {
-        Ok(false)
-    }
-
-    pub fn GetCurrentScript(&self) -> Option<AbstractNode<ScriptView>> {
-        None
-    }
-
-    pub fn ReleaseCapture(&self) {
-    }
-
-    pub fn MozFullScreenEnabled(&self) -> bool {
-        false
-    }
-
-    pub fn GetMozFullScreenElement(&self) -> Fallible<Option<AbstractNode<ScriptView>>> {
-        Ok(None)
-    }
-
-    pub fn GetMozPointerLockElement(&self) -> Option<AbstractNode<ScriptView>> {
-        None
-    }
-
-    pub fn MozExitPointerLock(&self) {
-    }
-
-    pub fn Hidden(&self) -> bool {
-        false
-    }
-
-    pub fn MozHidden(&self) -> bool {
-        self.Hidden()
-    }
-
-    pub fn VisibilityState(&self) -> DocumentBinding::VisibilityState {
-        DocumentBinding::VisibilityStateValues::Visible
-    }
-
-    pub fn MozVisibilityState(&self) -> DocumentBinding::VisibilityState {
-        self.VisibilityState()
-    }
-
-    pub fn GetSelectedStyleSheetSet(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetSelectedStyleSheetSet(&self, _sheet: &DOMString) {
-    }
-
-    pub fn GetLastStyleSheetSet(&self) -> DOMString {
-        None
-    }
-
-    pub fn GetPreferredStyleSheetSet(&self) -> DOMString {
-        None
-    }
-
-    pub fn EnableStyleSheetsForSet(&self, _name: &DOMString) {
-    }
-
-    pub fn ElementFromPoint(&self, _x: f32, _y: f32) -> Option<AbstractNode<ScriptView>> {
-        None
-    }
-
-    pub fn QuerySelector(&self, _selectors: &DOMString) -> Fallible<Option<AbstractNode<ScriptView>>> {
-        Ok(None)
     }
 
     pub fn GetElementsByName(&self, name: &DOMString) -> @mut HTMLCollection {

--- a/src/components/script/dom/htmldocument.rs
+++ b/src/components/script/dom/htmldocument.rs
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::HTMLDocumentBinding;
-use dom::bindings::utils::{DOMString, ErrorResult, Fallible, Traceable};
-use dom::bindings::utils::{Reflectable, Reflector};
+use dom::bindings::utils::{Reflectable, Reflector, Traceable};
 use dom::document::{AbstractDocument, Document, ReflectableDocument, HTML};
 use dom::element::HTMLHeadElementTypeId;
 use dom::htmlcollection::HTMLCollection;
@@ -15,7 +14,6 @@ use js::jsapi::{JSObject, JSContext, JSTracer};
 
 use servo_util::tree::{TreeNodeRef, ElementLike};
 
-use std::libc;
 use std::ptr;
 use std::str::eq_slice;
 
@@ -40,26 +38,6 @@ impl ReflectableDocument for HTMLDocument {
 }
 
 impl HTMLDocument {
-    pub fn NamedGetter(&self, _cx: *JSContext, _name: &DOMString, _found: &mut bool) -> Fallible<*JSObject> {
-        Ok(ptr::null())
-    }
-
-    pub fn GetDomain(&self) -> Fallible<DOMString> {
-        Ok(None)
-    }
-
-    pub fn SetDomain(&self, _domain: &DOMString) -> ErrorResult {
-        Ok(())
-    }
-
-    pub fn GetCookie(&self) -> Fallible<DOMString> {
-        Ok(None)
-    }
-
-    pub fn SetCookie(&self, _cookie: &DOMString) -> ErrorResult {
-        Ok(())
-    }
-
     pub fn GetHead(&self) -> Option<AbstractNode<ScriptView>> {
         match self.parent.GetDocumentElement() {
             None => None,
@@ -95,77 +73,6 @@ impl HTMLDocument {
         self.parent.createHTMLCollection(|elem| eq_slice(elem.tag_name, "script"))
     }
 
-    pub fn Close(&self) -> ErrorResult {
-        Ok(())
-    }
-
-    pub fn DesignMode(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetDesignMode(&self, _mode: &DOMString) -> ErrorResult {
-        Ok(())
-    }
-
-    pub fn ExecCommand(&self, _command_id: &DOMString, _show_ui: bool, _value: &DOMString) -> Fallible<bool> {
-        Ok(false)
-    }
-
-    pub fn QueryCommandEnabled(&self, _command_id: &DOMString) -> Fallible<bool> {
-        Ok(false)
-    }
-
-    pub fn QueryCommandIndeterm(&self, _command_id: &DOMString) -> Fallible<bool> {
-        Ok(false)
-    }
-
-    pub fn QueryCommandState(&self, _command_id: &DOMString) -> Fallible<bool> {
-        Ok(false)
-    }
-
-    pub fn QueryCommandSupported(&self, _command_id: &DOMString) -> bool {
-        false
-    }
-
-    pub fn QueryCommandValue(&self, _command_id: &DOMString) -> Fallible<DOMString> {
-        Ok(None)
-    }
-
-    pub fn FgColor(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetFgColor(&self, _color: &DOMString) {
-    }
-
-    pub fn LinkColor(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetLinkColor(&self, _color: &DOMString) {
-    }
-
-    pub fn VlinkColor(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetVlinkColor(&self, _color: &DOMString) {
-    }
-
-    pub fn AlinkColor(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetAlinkColor(&self, _color: &DOMString) {
-    }
-
-    pub fn BgColor(&self) -> DOMString {
-        None
-    }
-
-    pub fn SetBgColor(&self, _color: &DOMString) {
-    }
-
     pub fn Anchors(&self) -> @mut HTMLCollection {
         self.parent.createHTMLCollection(|elem|
             eq_slice(elem.tag_name, "a") && elem.get_attr("name").is_some())
@@ -174,13 +81,6 @@ impl HTMLDocument {
     pub fn Applets(&self) -> @mut HTMLCollection {
         // FIXME: This should be return OBJECT elements containing applets.
         self.parent.createHTMLCollection(|elem| eq_slice(elem.tag_name, "applet"))
-    }
-
-    pub fn Clear(&self) {
-    }
-
-    pub fn GetAll(&self, _cx: *JSContext) -> Fallible<*libc::c_void> {
-        Ok(ptr::null())
     }
 }
 


### PR DESCRIPTION
I don't think it's useful to keep those lying around, in particular because we should never even implement some of those (`mozHidden`, `mozVisibilityState`, …)
