### PR TITLE
Use the new style system

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -219,21 +219,21 @@ DONE_msg = $(B)src/components/msg/libmsg.dummy
 
 DEPS_msg = $(CRATE_msg) $(SRC_msg) $(DONE_SUBMODULES)
 
-RFLAGS_gfx = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/net -L $(B)src/components/msg
+RFLAGS_gfx = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/style -L $(B)src/components/net -L $(B)src/components/msg
 SRC_gfx = $(call rwildcard,$(S)src/components/gfx/,*.rs)
 CRATE_gfx = $(S)src/components/gfx/gfx.rc
 DONE_gfx = $(B)src/components/gfx/libgfx.dummy
 
-DEPS_gfx = $(CRATE_gfx) $(SRC_gfx) $(DONE_SUBMODULES) $(DONE_util) $(DONE_net) $(DONE_msg)
+DEPS_gfx = $(CRATE_gfx) $(SRC_gfx) $(DONE_SUBMODULES) $(DONE_util) $(DONE_style) $(DONE_net) $(DONE_msg)
 
-RFLAGS_script = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/net -L $(B)src/components/gfx -L $(B)src/components/msg
+RFLAGS_script = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/style -L $(B)src/components/net -L $(B)src/components/gfx -L $(B)src/components/msg
 WEBIDL_script = $(call rwildcard,$(S)src/components/script/,*.webidl)
 AUTOGEN_SRC_script = $(patsubst %.webidl, %Binding.rs, $(WEBIDL_script))
 SRC_script = $(call rwildcard,$(S)src/components/script/,*.rs) $(AUTOGEN_SRC_script)
 CRATE_script = $(S)src/components/script/script.rc
 DONE_script = $(B)src/components/script/libscript.dummy
 
-DEPS_script = $(CRATE_script) $(SRC_script) $(DONE_SUBMODULES) $(DONE_util) $(DONE_net) $(DONE_gfx) $(DONE_msg)
+DEPS_script = $(CRATE_script) $(SRC_script) $(DONE_SUBMODULES) $(DONE_util) $(DONE_style) $(DONE_net) $(DONE_gfx) $(DONE_msg)
 
 RFLAGS_style = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util
 MAKO_ZIP = $(S)src/components/style/Mako-0.8.1.zip

--- a/src/components/gfx/color.rs
+++ b/src/components/gfx/color.rs
@@ -8,15 +8,14 @@ use AzColor = azure::azure_hl::Color;
 pub type Color = AzColor;
 
 pub fn rgb(r: u8, g: u8, b: u8) -> AzColor {
-    rgba(r, g, b, 1.0)
-}
-
-pub fn rgba(r: u8, g: u8, b: u8, a: f64) -> AzColor {
     AzColor {
         r: (r as AzFloat) / (255.0 as AzFloat),
         g: (g as AzFloat) / (255.0 as AzFloat),
         b: (b as AzFloat) / (255.0 as AzFloat),
-        a: a as AzFloat
+        a: 1.0 as AzFloat
     }
 }
 
+pub fn rgba(r: AzFloat, g: AzFloat, b: AzFloat, a: AzFloat) -> AzColor {
+    AzColor { r: r, g: g, b: b, a: a }
+}

--- a/src/components/gfx/display_list.rs
+++ b/src/components/gfx/display_list.rs
@@ -16,7 +16,7 @@
 
 use color::Color;
 use servo_util::geometry::Au;
-use newcss::values::CSSBorderStyle;
+use style::computed_values::border_style;
 use render_context::RenderContext;
 use text::SendableTextRun;
 
@@ -25,8 +25,6 @@ use geom::{Point2D, Rect, Size2D, SideOffsets2D};
 use servo_net::image::base::Image;
 use servo_util::range::Range;
 use extra::arc::Arc;
-
-use newcss::values::{CSSTextDecorationUnderline, CSSTextDecorationOverline, CSSTextDecorationLineThrough};
 
 /// A list of rendering operations to be performed.
 pub struct DisplayList<E> {
@@ -110,7 +108,7 @@ pub struct BorderDisplayItem<E> {
     color: SideOffsets2D<Color>,
 
     /// The border styles.
-    style: SideOffsets2D<CSSBorderStyle>
+    style: SideOffsets2D<border_style::T>
 }
 
 impl<E> DisplayItem<E> {
@@ -143,25 +141,22 @@ impl<E> DisplayItem<E> {
                 let strikeout_size = font.metrics.strikeout_size;
                 let strikeout_offset = font.metrics.strikeout_offset;
 
-                match new_run.decoration {
-                    CSSTextDecorationUnderline => {
-                        let underline_y = baseline_origin.y - underline_offset;
-                        let underline_bounds = Rect(Point2D(baseline_origin.x, underline_y),
-                                                    Size2D(width, underline_size));
-                        render_context.draw_solid_color(&underline_bounds, text.color);
-                    },
-                    CSSTextDecorationOverline => {
-                        let overline_bounds = Rect(Point2D(baseline_origin.x, origin.y),
-                                                   Size2D(width, underline_size));
-                        render_context.draw_solid_color(&overline_bounds, text.color);
-                    },
-                    CSSTextDecorationLineThrough => {
-                        let strikeout_y = baseline_origin.y - strikeout_offset;
-                        let strikeout_bounds = Rect(Point2D(baseline_origin.x, strikeout_y),
-                                                    Size2D(width, strikeout_size));
-                        render_context.draw_solid_color(&strikeout_bounds, text.color);
-                    },
-                    _ => ()
+                if new_run.decoration.underline {
+                    let underline_y = baseline_origin.y - underline_offset;
+                    let underline_bounds = Rect(Point2D(baseline_origin.x, underline_y),
+                                                Size2D(width, underline_size));
+                    render_context.draw_solid_color(&underline_bounds, text.color);
+                }
+                if new_run.decoration.overline {
+                    let overline_bounds = Rect(Point2D(baseline_origin.x, origin.y),
+                                               Size2D(width, underline_size));
+                    render_context.draw_solid_color(&overline_bounds, text.color);
+                }
+                if new_run.decoration.line_through {
+                    let strikeout_y = baseline_origin.y - strikeout_offset;
+                    let strikeout_bounds = Rect(Point2D(baseline_origin.x, strikeout_y),
+                                                Size2D(width, strikeout_size));
+                    render_context.draw_solid_color(&strikeout_bounds, text.color);
                 }
             }
 

--- a/src/components/gfx/font.rs
+++ b/src/components/gfx/font.rs
@@ -28,7 +28,7 @@ use servo_util::time;
 use servo_util::time::profile;
 use servo_util::time::ProfilerChan;
 
-use newcss::values::CSSTextDecoration;
+use style::computed_values::text_decoration;
 
 // FontHandle encapsulates access to the platform's font API,
 // e.g. quartz, FreeType. It provides access to metrics and tables
@@ -195,7 +195,7 @@ impl FontGroup {
         self.fonts = ~[];
     }
 
-    pub fn create_textrun(&self, text: ~str, decoration: CSSTextDecoration) -> TextRun {
+    pub fn create_textrun(&self, text: ~str, decoration: text_decoration::T) -> TextRun {
         assert!(self.fonts.len() > 0);
 
         // TODO(Issue #177): Actually fall back through the FontGroup when a font is unsuitable.

--- a/src/components/gfx/gfx.rc
+++ b/src/components/gfx/gfx.rc
@@ -17,6 +17,7 @@ extern mod stb_image;
 extern mod extra;
 extern mod servo_net (name = "net");
 extern mod servo_util (name = "util");
+extern mod style;
 extern mod servo_msg (name = "msg");
 
 // Eventually we would like the shaper to be pluggable, as many operating systems have their own

--- a/src/components/gfx/render_context.rs
+++ b/src/components/gfx/render_context.rs
@@ -5,8 +5,7 @@
 use servo_msg::compositor_msg::LayerBuffer;
 use servo_util::geometry::Au;
 use font_context::FontContext;
-use newcss::values::CSSBorderStyle;
-use newcss::values::{CSSBorderStyleNone, CSSBorderStyleHidden, CSSBorderStyleDotted, CSSBorderStyleDashed, CSSBorderStyleSolid, CSSBorderStyleDouble, CSSBorderStyleGroove, CSSBorderStyleRidge, CSSBorderStyleInset, CSSBorderStyleOutset};
+use style::computed_values::border_style;
 use opts::Opts;
 
 use azure::azure_hl::{B8G8R8A8, Color, ColorPattern, DrawOptions};
@@ -44,7 +43,7 @@ impl<'self> RenderContext<'self>  {
                        bounds: &Rect<Au>,
                        border: SideOffsets2D<Au>,
                        color: SideOffsets2D<Color>,
-                       style: SideOffsets2D<CSSBorderStyle>) {
+                       style: SideOffsets2D<border_style::T>) {
         let draw_opts = DrawOptions(1 as AzFloat, 0 as uint16_t);
         let rect = bounds.to_azure_rect();
         let border = border.to_float_px();
@@ -113,14 +112,14 @@ impl<'self> RenderContext<'self>  {
         self.canvas.draw_target.fill_rect(&rect, &pattern);
     }
 
-    fn apply_border_style(style: CSSBorderStyle, border_width: AzFloat, dash: &mut [AzFloat], stroke_opts: &mut StrokeOptions){
+    fn apply_border_style(style: border_style::T, border_width: AzFloat, dash: &mut [AzFloat], stroke_opts: &mut StrokeOptions){
         match style{
-            CSSBorderStyleNone => {
+            border_style::none => {
             }
-            CSSBorderStyleHidden => {
+            border_style::hidden => {
             }
             //FIXME(sammykim): This doesn't work with dash_pattern and cap_style well. I referred firefox code.
-            CSSBorderStyleDotted => {
+            border_style::dotted => {
                 stroke_opts.line_width = border_width;
                 
                 if border_width > 2.0 {
@@ -135,7 +134,7 @@ impl<'self> RenderContext<'self>  {
                 stroke_opts.mDashPattern = vec::raw::to_ptr(dash);
                 stroke_opts.mDashLength = dash.len() as size_t;
             }
-            CSSBorderStyleDashed => {
+            border_style::dashed => {
                 stroke_opts.set_cap_style(AZ_CAP_BUTT as u8);
                 stroke_opts.line_width = border_width;
                 dash[0] = border_width*3 as AzFloat;
@@ -144,28 +143,14 @@ impl<'self> RenderContext<'self>  {
                 stroke_opts.mDashLength = dash.len() as size_t;
             }
             //FIXME(sammykim): BorderStyleSolid doesn't show proper join-style with comparing firefox.
-            CSSBorderStyleSolid => {
+            border_style::solid => {
                 stroke_opts.set_cap_style(AZ_CAP_BUTT as u8);
                 stroke_opts.set_join_style(AZ_JOIN_BEVEL as u8);
                 stroke_opts.line_width = border_width; 
                 stroke_opts.mDashLength = 0 as size_t;
             }            
             //FIXME(sammykim): Five more styles should be implemented.
-            CSSBorderStyleDouble => {
-
-            }
-            CSSBorderStyleGroove => {
-
-            }
-            CSSBorderStyleRidge => {
-
-            }
-            CSSBorderStyleInset => {
-
-            }
-            CSSBorderStyleOutset => {
-
-            }
+            //double, groove, ridge, inset, outset
         }
     }
 }

--- a/src/components/gfx/text/text_run.rs
+++ b/src/components/gfx/text/text_run.rs
@@ -10,13 +10,13 @@ use text::glyph::GlyphStore;
 use font::{Font, FontDescriptor, RunMetrics};
 use servo_util::range::Range;
 use extra::arc::Arc;
-use newcss::values::CSSTextDecoration;
+use style::computed_values::text_decoration;
 
 /// A text run.
 pub struct TextRun {
     text: ~str,
     font: @mut Font,
-    decoration: CSSTextDecoration,
+    decoration: text_decoration::T,
     glyphs: ~[Arc<GlyphStore>],
 }
 
@@ -24,7 +24,7 @@ pub struct TextRun {
 pub struct SendableTextRun {
     text: ~str,
     font: FontDescriptor,
-    decoration: CSSTextDecoration,
+    decoration: text_decoration::T,
     priv glyphs: ~[Arc<GlyphStore>],
 }
 
@@ -117,7 +117,7 @@ impl<'self> Iterator<Range> for LineIterator<'self> {
 }
 
 impl<'self> TextRun {
-    pub fn new(font: @mut Font, text: ~str, decoration: CSSTextDecoration) -> TextRun {
+    pub fn new(font: @mut Font, text: ~str, decoration: text_decoration::T) -> TextRun {
         let glyphs = TextRun::break_and_shape(font, text);
 
         let run = TextRun {

--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -4,72 +4,66 @@
 
 // High-level interface to CSS selector matching.
 
-use css::node_util::NodeUtil;
-use css::select_handler::NodeSelectHandler;
-use layout::incremental;
+use std::cell::Cell;
+use css::node_style::StyledNode;
 
 use script::dom::node::{AbstractNode, LayoutView};
-use newcss::complete::CompleteSelectResults;
-use newcss::select::{SelectCtx, SelectResults};
+use style::Stylist;
+use style::cascade;
 use servo_util::tree::TreeNodeRef;
 
 pub trait MatchMethods {
-    fn restyle_subtree(&self, select_ctx: &SelectCtx);
+    fn match_node(&self, stylist: &Stylist);
+    fn match_subtree(&self, stylist: &Stylist);
+
+    fn cascade_node(&self, parent: Option<AbstractNode<LayoutView>>);
+    fn cascade_subtree(&self, parent: Option<AbstractNode<LayoutView>>);
 }
 
 impl MatchMethods for AbstractNode<LayoutView> {
-    /**
-     * Performs CSS selector matching on a subtree.
-     *
-     * This is, importantly, the function that updates the layout data for
-     * the node (the reader-auxiliary box in the COW model) with the
-     * computed style.
-     */
-    fn restyle_subtree(&self, select_ctx: &SelectCtx) {
-        // Only elements have styles
-        if self.is_element() {
-            do self.with_imm_element |elem| {
-                let inline_style = match elem.style_attribute {
-                    None => None,
-                    Some(ref sheet) => Some(sheet),
-                };
-                let select_handler = NodeSelectHandler { node: *self };
-                let incomplete_results = select_ctx.select_style(self, inline_style, &select_handler);
-                // Combine this node's results with its parent's to resolve all inherited values
-                let complete_results = compose_results(*self, incomplete_results);
-
-                // If there was an existing style, compute the damage that
-                // incremental layout will need to fix.
-                if self.have_css_select_results() {
-                    let damage = incremental::compute_damage(self, self.get_css_select_results(), &complete_results);
-                    self.set_restyle_damage(damage);
-                }
-                self.set_css_select_results(complete_results);
+    fn match_node(&self, stylist: &Stylist) {
+        let applicable_declarations = do self.with_imm_element |element| {
+            let style_attribute = match element.style_attribute {
+                None => None,
+                Some(ref style_attribute) => Some(style_attribute)
             };
+            stylist.get_applicable_declarations(self, style_attribute, None)
+        };
+        let cell = Cell::new(applicable_declarations);
+        do self.write_layout_data |data| {
+            data.applicable_declarations = cell.take();
         }
+    }
+    fn match_subtree(&self, stylist: &Stylist) {
+        self.match_node(stylist);
 
         for kid in self.children() {
-            kid.restyle_subtree(select_ctx); 
+            if kid.is_element() {
+                kid.match_subtree(stylist); 
+            }
+        }
+    }
+
+    fn cascade_node(&self, parent: Option<AbstractNode<LayoutView>>) {
+        let parent_style = match parent {
+            Some(parent) => Some(parent.style()),
+            None => None
+        };
+        let computed_values = do self.read_layout_data |data| {
+            cascade(data.applicable_declarations, parent_style)
+        };
+        let cell = Cell::new(computed_values);
+        do self.write_layout_data |data| {
+            data.style = Some(cell.take());
+        }
+    }
+    fn cascade_subtree(&self, parent: Option<AbstractNode<LayoutView>>) {
+        self.cascade_node(parent);
+
+        for kid in self.children() {
+            if kid.is_element() {
+                kid.cascade_subtree(Some(*self));
+            }
         }
     }
 }
-
-fn compose_results(node: AbstractNode<LayoutView>, results: SelectResults)
-                   -> CompleteSelectResults {
-    match find_parent_element_node(node) {
-        None => CompleteSelectResults::new_root(results),
-        Some(parent_node) => {
-            let parent_results = parent_node.get_css_select_results();
-            CompleteSelectResults::new_from_parent(parent_results, results)
-        }
-    }    
-}
-
-fn find_parent_element_node(node: AbstractNode<LayoutView>) -> Option<AbstractNode<LayoutView>> {
-    match node.parent_node() {
-        Some(parent) if parent.is_element() => Some(parent),
-        Some(parent) => find_parent_element_node(parent),
-        None => None,
-    }
-}
-

--- a/src/components/main/css/node_style.rs
+++ b/src/components/main/css/node_style.rs
@@ -7,22 +7,22 @@
 use css::node_util::NodeUtil;
 use layout::incremental::RestyleDamage;
 
-use newcss::complete::CompleteStyle;
+use style::ComputedValues;
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_util::tree::TreeNodeRef;
 
 
 /// Node mixin providing `style` method that returns a `NodeStyle`
 pub trait StyledNode {
-    fn style(&self) -> CompleteStyle;
+    fn style(&self) -> &ComputedValues;
     fn restyle_damage(&self) -> RestyleDamage;
 }
 
 impl StyledNode for AbstractNode<LayoutView> {
-    fn style(&self) -> CompleteStyle {
+    fn style(&self) -> &ComputedValues {
         assert!(self.is_element()); // Only elements can have styles
         let results = self.get_css_select_results();
-        results.computed_style()
+        results
     }
 
     fn restyle_damage(&self) -> RestyleDamage {

--- a/src/components/main/css/node_util.rs
+++ b/src/components/main/css/node_util.rs
@@ -6,14 +6,14 @@ use layout::incremental::RestyleDamage;
 
 use std::cast;
 use std::cell::Cell;
-use newcss::complete::CompleteSelectResults;
+use style::ComputedValues;
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_util::tree::TreeNodeRef;
 
 
 pub trait NodeUtil<'self> {
-    fn get_css_select_results(self) -> &'self CompleteSelectResults;
-    fn set_css_select_results(self, decl: CompleteSelectResults);
+    fn get_css_select_results(self) -> &'self ComputedValues;
+    fn set_css_select_results(self, decl: ComputedValues);
     fn have_css_select_results(self) -> bool;
 
     fn get_restyle_damage(self) -> RestyleDamage;
@@ -28,7 +28,7 @@ impl<'self> NodeUtil<'self> for AbstractNode<LayoutView> {
      * FIXME: This isn't completely memory safe since the style is
      * stored in a box that can be overwritten
      */
-    fn get_css_select_results(self) -> &'self CompleteSelectResults {
+    fn get_css_select_results(self) -> &'self ComputedValues {
         do self.read_layout_data |layout_data| {
             match layout_data.style {
                 None => fail!(~"style() called on node without a style!"),
@@ -43,7 +43,7 @@ impl<'self> NodeUtil<'self> for AbstractNode<LayoutView> {
     }
 
     /// Update the computed style of an HTML element with a style specified by CSS.
-    fn set_css_select_results(self, decl: CompleteSelectResults) {
+    fn set_css_select_results(self, decl: ComputedValues) {
         let cell = Cell::new(decl);
         self.write_layout_data(|data| data.style = Some(cell.take()));
     }

--- a/src/components/main/css/select.rs
+++ b/src/components/main/css/select.rs
@@ -4,26 +4,24 @@
 
 use extra::url::Url;
 use std::cell::Cell;
-use newcss::stylesheet::Stylesheet;
-use newcss::select::SelectCtx;
-use newcss::types::OriginUA;
+use style::Stylesheet;
+use style::Stylist;
+use style::selector_matching::UserAgentOrigin;
 use newcss::util::DataStream;
 
-pub fn new_css_select_ctx() -> SelectCtx {
-    let mut ctx = SelectCtx::new();
-    ctx.append_sheet(html4_default_style(), OriginUA);
-    ctx.append_sheet(servo_default_style(), OriginUA);
-    return ctx;
+pub fn new_stylist() -> Stylist {
+    let mut stylist = Stylist::new();
+    stylist.add_stylesheet(html4_default_style(), UserAgentOrigin);
+    stylist.add_stylesheet(servo_default_style(), UserAgentOrigin);
+    stylist
 }
 
 fn html4_default_style() -> Stylesheet {
-    Stylesheet::new(default_url("html4_style"),
-                    style_stream(html4_default_style_str()))
+    Stylesheet::from_str(html4_default_style_str())
 }
 
 fn servo_default_style() -> Stylesheet {
-    Stylesheet::new(default_url("servo_style"),
-                    style_stream(servo_default_style_str()))
+    Stylesheet::from_str(servo_default_style_str())
 }
 
 fn default_url(name: &str) -> Url {

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -199,17 +199,15 @@ impl BlockFlowData {
                 let available_width = remaining_width - model.noncontent_width();
 
                 // Top and bottom margins for blocks are 0 if auto.
-                let margin_top = MaybeAuto::from_margin(style.margin_top(),
-                                                        remaining_width,
-                                                        style.font_size()).specified_or_zero();
-                let margin_bottom = MaybeAuto::from_margin(style.margin_bottom(),
-                                                           remaining_width,
-                                                           style.font_size()).specified_or_zero();
+                let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
+                                                       remaining_width).specified_or_zero();
+                let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
+                                                          remaining_width).specified_or_zero();
 
                 let (width, margin_left, margin_right) =
-                    (MaybeAuto::from_width(style.width(), remaining_width, style.font_size()),
-                     MaybeAuto::from_margin(style.margin_left(), remaining_width, style.font_size()),
-                     MaybeAuto::from_margin(style.margin_right(), remaining_width, style.font_size()));
+                    (MaybeAuto::from_style(style.Box.width, remaining_width),
+                     MaybeAuto::from_style(style.Margin.margin_left, remaining_width),
+                     MaybeAuto::from_style(style.Margin.margin_right, remaining_width));
 
                 let (width, margin_left, margin_right) = self.compute_horiz(width,
                                                                             margin_left,
@@ -403,7 +401,7 @@ impl BlockFlowData {
 
         for &box in self.box.iter() {
             let style = box.style();
-            let maybe_height = MaybeAuto::from_height(style.height(), Au(0), style.font_size());
+            let maybe_height = MaybeAuto::from_style(style.Box.height, Au(0));
             let maybe_height = maybe_height.specified_or_zero();
             height = geometry::max(height, maybe_height);
         }

--- a/src/components/main/layout/display_list_builder.rs
+++ b/src/components/main/layout/display_list_builder.rs
@@ -10,7 +10,7 @@ use std::cast::transmute;
 use script::dom::node::AbstractNode;
 
 use gfx;
-use newcss;
+use style;
 
 /// Display list data is usually an AbstractNode with view () to indicate
 /// that nodes in this view shoud not really be touched. The idea is to
@@ -61,9 +61,9 @@ pub trait ToGfxColor {
     fn to_gfx_color(&self) -> gfx::color::Color;
 }
 
-impl ToGfxColor for newcss::color::Color {
+impl ToGfxColor for style::properties::RGBA {
     fn to_gfx_color(&self) -> gfx::color::Color {
-        gfx::color::rgba(self.red, self.green, self.blue, self.alpha as f64)
+        gfx::color::rgba(self.red, self.green, self.blue, self.alpha)
     }
 }
 

--- a/src/components/main/layout/float.rs
+++ b/src/components/main/layout/float.rs
@@ -113,18 +113,14 @@ impl FloatFlowData {
                 model.compute_padding(style, remaining_width);
 
                 // Margins for floats are 0 if auto.
-                let margin_top = MaybeAuto::from_margin(style.margin_top(),
-                                                        remaining_width,
-                                                        style.font_size()).specified_or_zero();
-                let margin_bottom = MaybeAuto::from_margin(style.margin_bottom(),
-                                                           remaining_width,
-                                                           style.font_size()).specified_or_zero();
-                let margin_left = MaybeAuto::from_margin(style.margin_left(),
-                                                         remaining_width,
-                                                         style.font_size()).specified_or_zero();
-                let margin_right = MaybeAuto::from_margin(style.margin_right(),
-                                                          remaining_width,
-                                                          style.font_size()).specified_or_zero();
+                let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
+                                                        remaining_width).specified_or_zero();
+                let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
+                                                          remaining_width).specified_or_zero();
+                let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
+                                                        remaining_width).specified_or_zero();
+                let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
+                                                         remaining_width).specified_or_zero();
 
 
 
@@ -133,9 +129,8 @@ impl FloatFlowData {
                                                                 remaining_width));
 
 
-                let width = MaybeAuto::from_width(style.width(), 
-                                                  remaining_width,
-                                                  style.font_size()).specified_or_default(shrink_to_fit);
+                let width = MaybeAuto::from_style(style.Box.width,
+                                                  remaining_width).specified_or_default(shrink_to_fit);
                 debug!("assign_widths_float -- width: %?", width);
 
                 model.margin.top = margin_top;
@@ -274,9 +269,8 @@ impl FloatFlowData {
         //TODO(eatkinson): compute heights properly using the 'height' property.
         for &box in self.box.iter() {
             let height_prop = 
-                MaybeAuto::from_height(box.style().height(),
-                                       Au(0),
-                                       box.style().font_size()).specified_or_zero();
+                MaybeAuto::from_style(box.style().Box.height,
+                                      Au(0)).specified_or_zero();
 
             height = geometry::max(height, height_prop) + noncontent_height;
             debug!("assign_height_float -- height: %?", height);

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -31,6 +31,7 @@ extern mod script;
 extern mod servo_net (name = "net");
 extern mod servo_msg (name = "msg");
 extern mod servo_util (name = "util");
+extern mod style;
 extern mod sharegl;
 extern mod stb_image;
 extern mod extra;

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -13,7 +13,7 @@ use dom::document::AbstractDocument;
 use dom::node::{ElementNodeTypeId, Node, ScriptView, AbstractNode};
 use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery};
 use layout_interface::{ContentBoxesResponse};
-use newcss::stylesheet::Stylesheet;
+use style;
 use servo_util::tree::{TreeNodeRef, ElementLike};
 
 use js::jsapi::{JSContext, JSObject};
@@ -27,7 +27,7 @@ pub struct Element {
     tag_name: ~str,     // TODO: This should be an atom, not a ~str.
     attrs: HashMap<~str, ~str>,
     attrs_list: ~[~str], // store an order of attributes.
-    style_attribute: Option<Stylesheet>,
+    style_attribute: Option<style::PropertyDeclarationBlock>,
 }
 
 impl Reflectable for Element {
@@ -173,10 +173,8 @@ impl<'self> Element {
                           });
 
         if "style" == name {
-            self.style_attribute = Some(
-                Stylesheet::from_attribute(
-                    FromStr::from_str("http://www.example.com/").unwrap(),
-                    null_str_as_empty_ref(raw_value)));
+            self.style_attribute = Some(style::parse_style_attribute(
+                null_str_as_empty_ref(raw_value)));
         }
 
         // TODO: update owner document's id hashmap for `document.getElementById()`

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -25,7 +25,8 @@ use std::unstable::raw::Box;
 use extra::arc::Arc;
 use js::jsapi::{JSObject, JSContext};
 use netsurfcss::util::VoidPtrLike;
-use newcss::complete::CompleteSelectResults;
+use style::ComputedValues;
+use style::properties::PropertyDeclaration;
 use servo_util::tree::{TreeNode, TreeNodeRef, TreeNodeRefAsElement};
 use servo_util::range::Range;
 use gfx::display_list::DisplayList;
@@ -904,8 +905,11 @@ pub struct DisplayBoxes {
 
 /// Data that layout associates with a node.
 pub struct LayoutData {
+    /// The results of CSS matching for this node.
+    applicable_declarations: ~[@[PropertyDeclaration]],
+
     /// The results of CSS styling for this node.
-    style: Option<CompleteSelectResults>,
+    style: Option<ComputedValues>,
 
     /// Description of how to account for recent style changes.
     restyle_damage: Option<int>,
@@ -919,6 +923,7 @@ impl LayoutData {
     /// Creates new layout data.
     pub fn new() -> LayoutData {
         LayoutData {
+            applicable_declarations: ~[],
             style: None,
             restyle_damage: None,
             boxes: DisplayBoxes { display_list: None, range: None },

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -12,7 +12,7 @@ use dom::node::{AbstractNode, ElementNodeTypeId, Node, ScriptView};
 use dom::types::*;
 use html::cssparse::{InlineProvenance, StylesheetProvenance, UrlProvenance, spawn_css_parser};
 use js::jsapi::JSContext;
-use newcss::stylesheet::Stylesheet;
+use style::Stylesheet;
 use script_task::page_from_context;
 
 use std::cast;

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -13,7 +13,7 @@ use geom::rect::Rect;
 use geom::size::Size2D;
 use geom::point::Point2D;
 use servo_util::geometry::Au;
-use newcss::stylesheet::Stylesheet;
+use style::Stylesheet;
 use extra::url::Url;
 
 /// Asynchronous messages that script can send to layout.

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -21,6 +21,7 @@ extern mod netsurfcss;
 extern mod newcss (name = "css");
 extern mod servo_net (name = "net");
 extern mod servo_util (name = "util");
+extern mod style;
 extern mod servo_msg (name = "msg");
 extern mod extra;
 

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -371,7 +371,7 @@ pub mod longhands {
     <%self:longhand name="font-family" inherited="True">
         pub use to_computed_value = super::computed_as_specified;
         #[deriving(Eq, Clone)]
-        enum FontFamily {
+        pub enum FontFamily {
             FamilyName(~str),
             // Generic
 //            Serif,
@@ -563,9 +563,10 @@ pub mod longhands {
         }
         pub mod computed_value {
             pub type T = super::SpecifiedValue;
+            pub static none: T = super::SpecifiedValue { underline: false, overline: false, line_through: false };
         }
         #[inline] pub fn get_initial_value() -> computed_value::T {
-            SpecifiedValue { underline: false, overline: false, line_through: false }  // none
+            none
         }
         /// none | [ underline || overline || line-through || blink ]
         pub fn parse(input: &[ComponentValue]) -> Option<SpecifiedValue> {
@@ -978,7 +979,7 @@ fn get_initial_values() -> ComputedValues {
 
 
 // Most specific/important declarations last
-pub fn cascade(applicable_declarations: &[~[PropertyDeclaration]],
+pub fn cascade(applicable_declarations: &[@[PropertyDeclaration]],
                parent_style: Option< &ComputedValues>)
             -> ComputedValues {
     let initial_keep_alive;

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -90,7 +90,9 @@ pub fn parse_selector_list(input: ~[ComponentValue], namespaces: &NamespaceMap)
         skip_whitespace(iter);
         match iter.peek() {
             None => break,  // EOF
-            Some(&Comma) => (),
+            Some(&Comma) => {
+                iter.next();
+            }
             _ => return None,
         }
         match parse_selector(iter, namespaces) {
@@ -116,6 +118,7 @@ fn parse_selector(iter: &mut Iter, namespaces: &NamespaceMap)
         let any_whitespace = skip_whitespace(iter);
         let combinator = match iter.peek() {
             None => break,  // EOF
+            Some(&Comma) => break,
             Some(&Delim('>')) => { iter.next(); Child },
             Some(&Delim('+')) => { iter.next(); NextSibling },
             Some(&Delim('~')) => { iter.next(); LaterSibling },
@@ -356,6 +359,7 @@ fn parse_qualified_name(iter: &mut Iter, allow_universal: bool, namespaces: &Nam
             }
         },
         Some(&Delim('|')) => explicit_namespace(iter, allow_universal, Some(~"")),
+        Some(&IDHash(*)) => default_namespace(namespaces, None),
         _ => return None,
     }
 }


### PR DESCRIPTION
Regressions are:
- Incremental layout is broken
- `:link` is broken
- Source URL is not passed to CSS parser
- `text-decoration` propagation for block containers establishing an inline formatting context is not handled

This also does not remove NetSurf libcss from the build. That can be done in a followup.

This was a team effort. Credits to Deokjin Kim, Ilyong Cho, Jaeman Park, Junyoung Cho, Ryan Choi, Sangeun Kim, Yongjin Kim, Youngmin Yoo, Youngsoo Son.
