### PR TITLE
Implementation of node.parentNode/parentElement

### DIFF
--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -592,11 +592,11 @@ impl Node<ScriptView> {
     }
 
     pub fn GetParentNode(&self) -> Option<AbstractNode<ScriptView>> {
-        None
+        self.parent_node
     }
 
     pub fn GetParentElement(&self) -> Option<AbstractNode<ScriptView>> {
-        None
+        self.parent_node.filtered(|parent| parent.is_element())
     }
 
     pub fn HasChildNodes(&self) -> bool {

--- a/src/test/html/content/test_parentnodes.html
+++ b/src/test/html/content/test_parentnodes.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+  <title></title>
+  <script src="harness.js"></script>
+</head>
+<body>
+  <div id="div1"></div>
+  <script>
+    // FIXME: This should be HTMLDocument.
+    //isnot(document.documentElement.parentNode, null);
+    is(document.documentElement.parentElement, null);
+
+    var elem = document.createElement("p");
+    is(elem.parentNode, null);
+    is(elem.parentElement, null);
+    
+    var child = document.createElement("p");
+    elem.appendChild(child);
+
+    is(child.parentNode, elem);
+    is(child.parentElement, elem);
+
+    finish();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
In this implemantation `GetParentNode()` just returns `self.parent_node`.
But according to MDN(https://developer.mozilla.org/en-US/docs/Web/API/Node.parentNode), it says.
"parentNode returns null for the following node types: Attr, Document, DocumentFragment, Entity, and Notation."

should this be checked?

r? @jdm
