### PR TITLE
Build start libparserutils before hubbub.

### DIFF
--- a/configure
+++ b/configure
@@ -484,10 +484,10 @@ CFG_SUBMODULES="\
     support/geom/rust-geom \
     support/harfbuzz/rust-harfbuzz \
     support/http/rust-http \
+    support/libparserutils/libparserutils \
     support/hubbub/libhubbub \
     support/hubbub/rust-hubbub \
     support/layers/rust-layers \
-    support/libparserutils/libparserutils \
     support/nss/nspr \
     support/nss/nss \
     support/opengles/rust-opengles \


### PR DESCRIPTION
On clean build, `hubbub` modules would fail build because libparserutils isn't built before it.

@metajack r?
