### PR TITLE
Make hubbub depend on libparserutils.

### DIFF
--- a/mk/sub.mk
+++ b/mk/sub.mk
@@ -38,6 +38,10 @@ NATIVE_BUILDS += \
 
 # NB. This should not be a problem once a real package system exists.
 
+DEPS_hubbub += \
+	libparserutils \
+	$(NULL)
+
 DEPS_rust-azure += \
 	rust-opengles \
 	rust-layers \


### PR DESCRIPTION
This fixes a parallel build issue where hubbub is built before libparserutils.
