### PR TITLE
Fix content tests for buildbot

### DIFF
--- a/src/test/harness/contenttest/contenttest.rs
+++ b/src/test/harness/contenttest/contenttest.rs
@@ -27,7 +27,9 @@ fn main() {
     let config = parse_config(args);
     let opts = test_options(config.clone());
     let tests = find_tests(config);
-    run_tests_console(&opts, tests);
+    if !run_tests_console(&opts, tests) {
+        os::set_exit_status(1);
+    }
 }
 
 fn parse_config(args: ~[~str]) -> Config {


### PR DESCRIPTION
**This build is expected to fail** at first, because `test_img_width_height` is broken on `master`. It's the simplest way I know to check that with this change, buildbot will indeed catch failing content tests.

After that happens I'll push the commits to fix `test_img_width_height` and request a re-review.
