### PR TITLE
Parallel selector matching

### DIFF
--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -20,7 +20,7 @@ use std::cast::transmute;
 use std::cell::Cell;
 use std::comm::{Port};
 use std::task;
-use extra::arc::Arc;
+use extra::arc::{Arc, RWArc};
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
@@ -65,7 +65,7 @@ struct LayoutTask {
 
     display_list: Option<Arc<DisplayList<AbstractNode<()>>>>,
 
-    stylist: Stylist,
+    stylist: RWArc<Stylist>,
     profiler_chan: ProfilerChan,
 }
 
@@ -240,7 +240,7 @@ impl LayoutTask {
 
             display_list: None,
             
-            stylist: new_stylist(),
+            stylist: RWArc::new(new_stylist()),
             profiler_chan: profiler_chan,
         }
     }
@@ -293,7 +293,10 @@ impl LayoutTask {
     }
 
     fn handle_add_stylesheet(&mut self, sheet: Stylesheet) {
-        self.stylist.add_stylesheet(sheet, AuthorOrigin);
+        let sheet = Cell::new(sheet);
+        do self.stylist.write |stylist| {
+            stylist.add_stylesheet(sheet.take(), AuthorOrigin)
+        }
     }
 
     /// The high-level routine that performs layout tasks.
@@ -335,7 +338,7 @@ impl LayoutTask {
             ReflowDocumentDamage => {}
             MatchSelectorsDocumentDamage => {
                 do profile(time::LayoutSelectorMatchCategory, self.profiler_chan.clone()) {
-                    node.match_subtree(&self.stylist);
+                    node.match_subtree(self.stylist.clone());
                     node.cascade_subtree(None);
                 }
             }


### PR DESCRIPTION
This an attempt to parallelize selector matching.

Approach
- Let the `match_subtree` spawn limited number of tasks.
- Each of them takes a list of nodes that is uniformly distributed
- And then each task does the selector matching for every single node in its list.

(Not sure if this is worthwhile for long term especially considering CSS optimizing techniques such as ancestor filter or style sharing)

Benchmark from my machine (LayoutSelectorMatchCategory) (intel i7 3.4GHz \* 8, linux x86_64)
- src/test/demo.html
  - original: 0.07ms
  - parallel: 0.20ms
- perf-rainbow.html
  - original: 485ms
  - parallel: 245ms
- A test page with 15000 nodes and 3000 CSS selector(including inline style).
  - original: 140ms
  - parallel: 60ms
