### PR TITLE
Log CSS errors on stderr, with serialized bits of CSS.

### DIFF
--- a/src/components/style/errors.rs
+++ b/src/components/style/errors.rs
@@ -22,5 +22,5 @@ impl<T, I: Iterator<Result<T, SyntaxError>>> Iterator<T> for ErrorLoggerIterator
 
 pub fn log_css_error(location: SourceLocation, message: &str) {
     // TODO eventually this will got into a "web console" or something.
-    info!("{:u}:{:u} {:s}", location.line, location.column, message)
+    error!("{:u}:{:u} {:s}", location.line, location.column, message)
 }

--- a/src/components/style/stylesheets.rs
+++ b/src/components/style/stylesheets.rs
@@ -112,12 +112,15 @@ impl Stylesheet {
 pub fn parse_style_rule(rule: QualifiedRule, parent_rules: &mut ~[CSSRule],
                         namespaces: &NamespaceMap) {
     let QualifiedRule{location: location, prelude: prelude, block: block} = rule;
+    // FIXME: avoid doing this for valid selectors
+    let serialized = prelude.iter().to_css();
     match selectors::parse_selector_list(prelude, namespaces) {
         Some(selectors) => parent_rules.push(CSSStyleRule(StyleRule{
             selectors: selectors,
             declarations: properties::parse_property_declaration_list(block.move_iter())
         })),
-        None => log_css_error(location, "Unsupported CSS selector."),
+        None => log_css_error(location, format!(
+            "Invalid/unsupported selector: {}", serialized)),
     }
 }
 


### PR DESCRIPTION
(Ab)using `error!()` because it’s enabled by default.
