### PR TITLE
Pseudo element ":before"

### DIFF
--- a/src/components/main/css/node_style.rs
+++ b/src/components/main/css/node_style.rs
@@ -13,6 +13,7 @@ use script::dom::node::{AbstractNode, LayoutView};
 /// Node mixin providing `style` method that returns a `NodeStyle`
 pub trait StyledNode {
     fn style(&self) -> &ComputedValues;
+    fn pseudo_style(&self) -> &ComputedValues;
     fn restyle_damage(&self) -> RestyleDamage;
 }
 
@@ -21,6 +22,11 @@ impl StyledNode for AbstractNode<LayoutView> {
         // FIXME(pcwalton): Is this assertion needed for memory safety? It's slow.
         //assert!(self.is_element()); // Only elements can have styles
         let results = self.get_css_select_results();
+        results
+    }
+
+    fn pseudo_style(&self) -> &ComputedValues {
+        let results = self.get_css_select_pseudo_results();
         results
     }
 

--- a/src/components/main/css/node_util.rs
+++ b/src/components/main/css/node_util.rs
@@ -13,6 +13,7 @@ use servo_util::tree::TreeNodeRef;
 
 pub trait NodeUtil<'self> {
     fn get_css_select_results(self) -> &'self ComputedValues;
+    fn get_css_select_pseudo_results(self) -> &'self ComputedValues;
     fn set_css_select_results(self, decl: ComputedValues);
     fn have_css_select_results(self) -> bool;
 
@@ -32,6 +33,15 @@ impl<'self> NodeUtil<'self> for AbstractNode<LayoutView> {
         do self.read_layout_data |layout_data| {
             match layout_data.style {
                 None => fail!(~"style() called on node without a style!"),
+                Some(ref style) => unsafe { cast::transmute_region(style) }
+            }
+        }
+    }
+
+    fn get_css_select_pseudo_results(self) -> &'self ComputedValues {
+        do self.read_layout_data |layout_data| {
+            match layout_data.pseudo_style {
+                None => fail!(~"pseudo_style() called on node without a style!"),
                 Some(ref style) => unsafe { cast::transmute_region(style) }
             }
         }

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -756,6 +756,11 @@ impl RenderBoxBase {
         self.node.style()
     }
 
+    #[inline(always)]
+    pub fn pseudo_style(&self) -> &'static ComputedValues {
+        self.node.pseudo_style()
+    }
+
     /// Returns the text alignment of the computed style of the nearest ancestor-or-self `Element`
     /// node.
     pub fn text_align(&self) -> text_align::T {

--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -145,14 +145,11 @@ impl<'self> BoxGenerator<'self> {
                                     let pseudo_node = unsafe { Node::as_abstract_node_layout(pseudo_text) };
                                     TreeNodeRef::<Node<LayoutView>>::set_parent_node(pseudo_node.mut_node(), Some(parent_node));
 
-                                    let parent_cell = Cell::new(pseudo_parent_element);
-                                    let pseudo_cell = Cell::new(pseudo_text);
+                                    // store pseudo_parent_element & pseudo_text
+                                    node.mut_node().pseudo_parent_element = Some(pseudo_parent_element);
+                                    node.mut_node().pseudo_text = Some(pseudo_text);
 
-                                    do p.write_layout_data |data| {
-                                        data.pseudo_parent_element = Some(parent_cell.take());
-                                        data.pseudo_text = Some(pseudo_cell.take());
-                                    }
-
+                                    // generate & push new box for pseudo element
                                     let before_box = BoxGenerator::make_box(ctx, box_type, pseudo_node, builder);
                                     inline.boxes.push(before_box);
                                 }

--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -21,6 +21,7 @@ use css::node_style::StyledNode;
 
 use style::computed_values::display;
 use style::computed_values::float;
+use style::computed_values::content;
 use layout::float_context::{FloatLeft, FloatRight};
 use script::dom::node::{AbstractNode, CommentNodeTypeId, DoctypeNodeTypeId};
 use script::dom::node::{ElementNodeTypeId, LayoutView, TextNodeTypeId, DocumentNodeTypeId};
@@ -417,7 +418,17 @@ impl LayoutTreeBuilder {
                     }
                     _ => { fail!("p should be element") }
                 };
-                let pseudo_text = @Text::new(p.pseudo_style().Content.content.clone(), document);
+                let content = match p.pseudo_style().Content.content {
+                    content::SpecifiedContentList(ref value) => {
+                        let iter = &mut value.clone().move_iter().peekable();
+                        match iter.next() {
+                            Some(content::StringContent(str)) => str,
+                            _ => ~"",
+                        }
+                    }
+                    _ => ~"",
+                };
+                let pseudo_text = @Text::new_inherited(content, document);
 
                 // create parent abstract node for pseudo abstract node
                 let pseudo_parent_ab_node = unsafe { Node::as_abstract_node_layout(pseudo_parent_element) };

--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -21,7 +21,6 @@ use css::node_style::StyledNode;
 
 use style::computed_values::display;
 use style::computed_values::float;
-use style::selectors::Before;
 use layout::float_context::{FloatLeft, FloatRight};
 use script::dom::node::{AbstractNode, CommentNodeTypeId, DoctypeNodeTypeId};
 use script::dom::node::{ElementNodeTypeId, LayoutView, TextNodeTypeId, DocumentNodeTypeId};
@@ -30,7 +29,7 @@ use script::dom::node::Node;
 use script::dom::element::{Element, HTMLUnknownElementTypeId};
 use script::dom::text::Text;
 use servo_util::range::Range;
-use servo_util::tree::{TreeNodeRef, TreeNode};
+use servo_util::tree::{TreeNodeRef, TreeNode, Before};
 use std::cast;
 use std::cell::Cell;
 
@@ -126,8 +125,8 @@ impl<'self> BoxGenerator<'self> {
 
                 // if a leaf, make a box.
                 if node.is_leaf() {
-                    match *node.pseudo_element() {
-                        Before => {
+                    match node.pseudo_element() {
+                        Some(&Before) => {
                             match node.parent_node() {
                                 Some(p) => {
                                     // Create TextNode

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -24,7 +24,6 @@ use std::unstable::raw::Box;
 use extra::arc::Arc;
 use js::jsapi::{JSObject, JSContext};
 use style::{ComputedValues, PropertyDeclaration};
-use style::selectors::{PseudoElement, none};
 use servo_util::tree::{TreeNode, TreeNodeRef, TreeNodeRefAsElement, PseudoElement};
 use servo_util::range::Range;
 use gfx::display_list::DisplayList;
@@ -182,14 +181,12 @@ impl<View> TreeNodeRefAsElement<Node<View>, Element> for AbstractNode<View> {
     fn with_imm_element_like<R>(&self, f: &fn(&Element) -> R) -> R {
         self.with_imm_element(f)
     }
-
     fn set_pseudo_element(&mut self, pseudo_element: Option<PseudoElement>) {
         do self.write_layout_data_view |data| {
             data.pseudo_element = pseudo_element
         }
     }
 }
-
 
 impl<View> TreeNode<AbstractNode<View>> for Node<View> { }
 
@@ -495,7 +492,9 @@ impl AbstractNode<ScriptView> {
 
         document.document().content_changed();
     }
+}
 
+impl<View> AbstractNode<View> {
     pub fn write_layout_data_view<R>(self, blk: &fn(data: &mut LayoutData) -> R) -> R {
         blk(&mut self.mut_node().layout_data)
     }
@@ -522,15 +521,6 @@ impl<View> Node<View> {
 }
 
 impl Node<ScriptView> {
-    pub unsafe fn as_abstract_node<N>(cx: *JSContext, node: @N) -> AbstractNode<ScriptView> {
-        // This surrenders memory management of the node!
-        let mut node = AbstractNode {
-            obj: transmute(node),
-        };
-        node::create(cx, &mut node);
-        node
-    }
-
     pub unsafe fn as_abstract_node_layout<N>(node: @N) -> AbstractNode<LayoutView> {
         // This surrenders memory management of the node!
         let node = AbstractNode {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -24,7 +24,7 @@ use std::unstable::raw::Box;
 use extra::arc::Arc;
 use js::jsapi::{JSObject, JSContext};
 use style::{ComputedValues, PropertyDeclaration};
-use style::selectors::PseudoElement;
+use style::selectors::{PseudoElement, none};
 use servo_util::tree::{TreeNode, TreeNodeRef, TreeNodeRefAsElement};
 use servo_util::range::Range;
 use gfx::display_list::DisplayList;
@@ -516,6 +516,23 @@ impl<View> Node<View> {
 }
 
 impl Node<ScriptView> {
+    pub unsafe fn as_abstract_node<N>(cx: *JSContext, node: @N) -> AbstractNode<ScriptView> {
+        // This surrenders memory management of the node!
+        let mut node = AbstractNode {
+            obj: transmute(node),
+        };
+        node::create(cx, &mut node);
+        node
+    }
+
+    pub unsafe fn as_abstract_node_layout<N>(node: @N) -> AbstractNode<LayoutView> {
+        // This surrenders memory management of the node!
+        let node = AbstractNode {
+            obj: transmute(node),
+        };
+        node
+    }
+
     pub fn reflect_node<N: Reflectable>
             (node:      @mut N,
              document:  AbstractDocument,
@@ -1094,6 +1111,12 @@ pub struct LayoutData {
     /// The enum value of pseudo element
     pseudo_element: Option<PseudoElement>,
 
+    /// Text for pseudo element
+    pseudo_text: Option<@Text>,
+
+    /// Parent element to style text for pseudo element
+    pseudo_parent_element: Option<@Element>,
+
     /// Description of how to account for recent style changes.
     restyle_damage: Option<int>,
 
@@ -1110,7 +1133,9 @@ impl LayoutData {
             pseudo_applicable_declarations: ~[],
             style: None,
             pseudo_style: None,
-            pseudo_element: None,
+            pseudo_element: Some(none),
+            pseudo_text: None,
+            pseudo_parent_element: None,
             restyle_damage: None,
             boxes: DisplayBoxes {
                 display_list: None,
@@ -1124,7 +1149,7 @@ impl LayoutData {
 // we can have memory unsafety, which usually manifests as shutdown crashes.
 fn assert_is_sendable<T:Send>(_: T) {}
 fn assert_layout_data_is_sendable() {
-    assert_is_sendable(LayoutData::new())
+    //assert_is_sendable(LayoutData::new())
 }
 
 impl AbstractNode<LayoutView> {
@@ -1138,5 +1163,14 @@ impl AbstractNode<LayoutView> {
 
     pub fn write_layout_data<R>(self, blk: &fn(data: &mut LayoutData) -> R) -> R {
         blk(&mut self.mut_node().layout_data)
+    }
+
+    pub fn pseudo_element(self) -> &PseudoElement {
+        do self.read_layout_data |layout_data| {
+            match layout_data.pseudo_element {
+                None => fail!(~"pseudo_element() called on node without a pseudo_element"),
+                Some(ref s) => unsafe { cast::transmute_region(s)}
+            }
+        }
     }
 }

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -25,7 +25,7 @@ use extra::arc::Arc;
 use js::jsapi::{JSObject, JSContext};
 use style::{ComputedValues, PropertyDeclaration};
 use style::selectors::{PseudoElement, none};
-use servo_util::tree::{TreeNode, TreeNodeRef, TreeNodeRefAsElement};
+use servo_util::tree::{TreeNode, TreeNodeRef, TreeNodeRefAsElement, PseudoElement};
 use servo_util::range::Range;
 use gfx::display_list::DisplayList;
 
@@ -177,7 +177,7 @@ impl<View> TreeNodeRef<Node<View>> for AbstractNode<View> {
     }
 }
 
-impl<View> TreeNodeRefAsElement<Node<View>, Element, PseudoElement> for AbstractNode<View> {
+impl<View> TreeNodeRefAsElement<Node<View>, Element> for AbstractNode<View> {
     #[inline]
     fn with_imm_element_like<R>(&self, f: &fn(&Element) -> R) -> R {
         self.with_imm_element(f)
@@ -1136,7 +1136,7 @@ impl LayoutData {
             pseudo_applicable_declarations: ~[],
             style: None,
             pseudo_style: None,
-            pseudo_element: Some(none),
+            pseudo_element: None,
             restyle_damage: None,
             boxes: DisplayBoxes {
                 display_list: None,
@@ -1166,11 +1166,13 @@ impl AbstractNode<LayoutView> {
         blk(&mut self.mut_node().layout_data)
     }
 
-    pub fn pseudo_element(self) -> &PseudoElement {
+    pub fn pseudo_element(self) -> Option<&PseudoElement> {
         do self.read_layout_data |layout_data| {
             match layout_data.pseudo_element {
-                None => fail!(~"pseudo_element() called on node without a pseudo_element"),
-                Some(ref s) => unsafe { cast::transmute_region(s)}
+                Some(ref s) => {
+                    unsafe { Some(cast::transmute_region(s)) }
+                }
+                None => None,
             }
         }
     }

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -95,6 +95,12 @@ pub struct Node<View> {
 
     /// Layout information. Only the layout task may touch this data.
     priv layout_data: LayoutData,
+
+    /// Text for pseudo element
+    pseudo_text: Option<@Text>,
+
+    /// Parent element to style text for pseudo element
+    pseudo_parent_element: Option<@Element>,
 }
 
 /// The different types of nodes.
@@ -572,6 +578,9 @@ impl Node<ScriptView> {
             child_list: None,
 
             layout_data: LayoutData::new(),
+
+            pseudo_text: None,
+            pseudo_parent_element: None,
         }
     }
 }
@@ -1111,12 +1120,6 @@ pub struct LayoutData {
     /// The enum value of pseudo element
     pseudo_element: Option<PseudoElement>,
 
-    /// Text for pseudo element
-    pseudo_text: Option<@Text>,
-
-    /// Parent element to style text for pseudo element
-    pseudo_parent_element: Option<@Element>,
-
     /// Description of how to account for recent style changes.
     restyle_damage: Option<int>,
 
@@ -1134,8 +1137,6 @@ impl LayoutData {
             style: None,
             pseudo_style: None,
             pseudo_element: Some(none),
-            pseudo_text: None,
-            pseudo_parent_element: None,
             restyle_damage: None,
             boxes: DisplayBoxes {
                 display_list: None,
@@ -1149,7 +1150,7 @@ impl LayoutData {
 // we can have memory unsafety, which usually manifests as shutdown crashes.
 fn assert_is_sendable<T:Send>(_: T) {}
 fn assert_layout_data_is_sendable() {
-    //assert_is_sendable(LayoutData::new())
+    assert_is_sendable(LayoutData::new())
 }
 
 impl AbstractNode<LayoutView> {

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -376,21 +376,34 @@ pub mod longhands {
 
     <%self:raw_longhand name="content" inherited="False">
             pub use to_computed_value = super::computed_as_specified;
-            pub type SpecifiedValue = ~str;
             pub mod computed_value {
-                pub type T = super::SpecifiedValue;
+                #[deriving(Eq, Clone)]
+                pub enum Content {
+                    StringContent(~str),
+                }
+                #[deriving(Eq, Clone)]
+                pub enum T {
+		    SpecifiedNormal,
+		    SpecifiedNone,
+		    SpecifiedContentList(~[Content]),
+		}
             }
-            #[inline] pub fn get_initial_value() -> computed_value::T  { ~"" }
+            pub type SpecifiedValue = computed_value::T;
+            #[inline] pub fn get_initial_value() -> computed_value::T  { SpecifiedNormal }
             pub fn parse_specified(input: &[ComponentValue]) -> Option<DeclaredValue<SpecifiedValue>> {
                 let mut iter = input.skip_whitespace();
-                match iter.next() {
-                    Some(&String(ref value)) => Some(SpecifiedValue(value.to_owned())),
-                    Some(_) => { 
-                        // TODO impl other properties
-                        None
-                    },
-                    None => None
+                let mut content_list = ~[];
+                loop {
+                    match iter.next() {
+                        Some(&String(ref value)) => content_list.push(StringContent(value.to_owned())),
+                        Some(_) => {
+                            // TODO impl other properties
+                            break
+                        }
+                        None => break,
+                    }
                 }
+                Some(SpecifiedValue(SpecifiedContentList(content_list)))
             }
     </%self:raw_longhand>
     // CSS 2.1, Section 13 - Paged media

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -372,7 +372,27 @@ pub mod longhands {
     // CSS 2.1, Section 11 - Visual effects
 
     // CSS 2.1, Section 12 - Generated content, automatic numbering, and lists
+    ${new_style_struct("Content")}
 
+    <%self:raw_longhand name="content" inherited="False">
+            pub use to_computed_value = super::computed_as_specified;
+            pub type SpecifiedValue = ~str;
+            pub mod computed_value {
+                pub type T = super::SpecifiedValue;
+            }
+            #[inline] pub fn get_initial_value() -> computed_value::T  { ~"" }
+            pub fn parse_specified(input: &[ComponentValue]) -> Option<DeclaredValue<SpecifiedValue>> {
+                let mut iter = input.skip_whitespace();
+                match iter.next() {
+                    Some(&String(ref value)) => Some(SpecifiedValue(value.to_owned())),
+                    Some(_) => { 
+                        // TODO impl other properties
+                        None
+                    },
+                    None => None
+                }
+            }
+    </%self:raw_longhand>
     // CSS 2.1, Section 13 - Paged media
 
     // CSS 2.1, Section 14 - Colors and Backgrounds

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -80,7 +80,8 @@ impl Stylist {
     pub fn get_applicable_declarations<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
             &self, element: &T, style_attribute: Option<&PropertyDeclarationBlock>) -> (~[Arc<~[PropertyDeclaration]>], ~[Arc<~[PropertyDeclaration]>]) {
         assert!(element.is_element())
-        assert!(style_attribute.is_none(), "Style attributes do not apply to pseudo-elements")
+        //assert!(style_attribute.is_none() || pseudo_element.is_none(), 
+        //        "Style attributes do not apply to pseudo-elements")
         let mut applicable_declarations = ~[];  // TODO: use an iterator?
         let mut pseudo_applicable_declarations = ~[];
 

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -10,7 +10,7 @@ use selectors::*;
 use stylesheets::{Stylesheet, iter_style_rules};
 use media_queries::{Device, Screen};
 use properties::{PropertyDeclaration, PropertyDeclarationBlock};
-use servo_util::tree::{TreeNodeRefAsElement, TreeNode, ElementLike};
+use servo_util::tree::{TreeNodeRefAsElement, TreeNode, ElementLike, Before};
 
 
 pub enum StylesheetOrigin {
@@ -77,7 +77,7 @@ impl Stylist {
         }
     }
 
-    pub fn get_applicable_declarations<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
+    pub fn get_applicable_declarations<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E>, E: ElementLike>(
             &self, element: &T, style_attribute: Option<&PropertyDeclarationBlock>) -> (~[Arc<~[PropertyDeclaration]>], ~[Arc<~[PropertyDeclaration]>]) {
         assert!(element.is_element())
         //assert!(style_attribute.is_none() || pseudo_element.is_none(), 
@@ -156,12 +156,12 @@ impl Ord for Rule {
 
 
 #[inline]
-fn matches_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
+fn matches_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E>, E: ElementLike>(
         selector: &Selector, element: &T) -> bool {
     matches_compound_selector::<N, T, E>(&selector.compound_selectors, element)
 }
 
-fn matches_compound_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
+fn matches_compound_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E>, E: ElementLike>(
         selector: &CompoundSelector, element: &T) -> bool {
     if !do selector.simple_selectors.iter().all |simple_selector| {
             matches_simple_selector(simple_selector, element)
@@ -201,7 +201,7 @@ fn matches_compound_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, Pseud
 }
 
 #[inline]
-fn matches_simple_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
+fn matches_simple_selector<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E>, E: ElementLike>(
         selector: &SimpleSelector, element: &T) -> bool {
     static WHITESPACE: &'static [char] = &'static [' ', '\t', '\n', '\r', '\x0C'];
 
@@ -290,7 +290,7 @@ fn url_is_visited(_url: &str) -> bool {
 }
 
 #[inline]
-fn matches_first_child<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
+fn matches_first_child<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E>, E: ElementLike>(
         element: &T) -> bool {
     let mut node = element.clone();
     loop {
@@ -307,7 +307,7 @@ fn matches_first_child<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoEleme
 }
 
 #[inline]
-fn match_attribute<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E, PseudoElement>, E: ElementLike>(
+fn match_attribute<N: TreeNode<T>, T: TreeNodeRefAsElement<N, E>, E: ElementLike>(
         attr: &AttrSelector, element: &T, f: &fn(&str)-> bool) -> bool {
     do element.with_imm_element_like |element: &E| {
         match attr.namespace {

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -24,6 +24,7 @@ pub enum PseudoElement {
     After,
     FirstLine,
     FirstLetter,
+    none,
 }
 
 

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -6,6 +6,7 @@ use std::{vec, iter};
 use std::ascii::StrAsciiExt;
 use cssparser::ast::*;
 use namespaces::NamespaceMap;
+use servo_util::tree::{PseudoElement, Before, After, FirstLine, FirstLetter};
 
 
 #[deriving(Eq, Clone)]
@@ -16,17 +17,6 @@ pub struct Selector {
 }
 
 pub static STYLE_ATTRIBUTE_SPECIFICITY: u32 = 1 << 31;
-
-
-#[deriving(Eq, Clone)]
-pub enum PseudoElement {
-    Before,
-    After,
-    FirstLine,
-    FirstLetter,
-    none,
-}
-
 
 #[deriving(Eq, Clone)]
 pub struct CompoundSelector {

--- a/src/components/util/tree.rs
+++ b/src/components/util/tree.rs
@@ -5,6 +5,14 @@
 
 //! Helper functions for garbage collected doubly-linked trees.
 
+#[deriving(Eq, Clone)]
+pub enum PseudoElement {
+    Before,
+    After,
+    FirstLine,
+    FirstLetter,
+}
+
 // Macros to make add_child etc. less painful to write.
 // Code outside this module should instead implement TreeNode
 // and use its default methods.
@@ -267,7 +275,7 @@ pub trait TreeNodeRef<Node>: Clone {
     fn is_root(&self) -> bool;
 }
 
-pub trait TreeNodeRefAsElement<Node, E: ElementLike, PseudoElement>: TreeNodeRef<Node> {
+pub trait TreeNodeRefAsElement<Node, E: ElementLike>: TreeNodeRef<Node> {
     fn with_imm_element_like<R>(&self, f: &fn(&E) -> R) -> R;
 
     fn set_pseudo_element(&mut self, pseudo_element: Option<PseudoElement>);

--- a/src/components/util/tree.rs
+++ b/src/components/util/tree.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+
 //! Helper functions for garbage collected doubly-linked trees.
 
 // Macros to make add_child etc. less painful to write.
@@ -266,8 +267,10 @@ pub trait TreeNodeRef<Node>: Clone {
     fn is_root(&self) -> bool;
 }
 
-pub trait TreeNodeRefAsElement<Node, E: ElementLike>: TreeNodeRef<Node> {
+pub trait TreeNodeRefAsElement<Node, E: ElementLike, PseudoElement>: TreeNodeRef<Node> {
     fn with_imm_element_like<R>(&self, f: &fn(&E) -> R) -> R;
+
+    fn set_pseudo_element(&mut self, pseudo_element: Option<PseudoElement>);
 }
 
 fn gather<Node, Ref: TreeNodeRef<Node>>(cur: &Ref, refs: &mut ~[Ref],
@@ -344,7 +347,6 @@ pub trait TreeNode<Ref: TreeNodeRef<Self>> {
         TreeNodeRef::<Self>::set_next_sibling(self, new_next_sibling)
     }
 }
-
 
 pub trait ElementLike {
     fn get_local_name<'a>(&'a self) -> &'a str;


### PR DESCRIPTION
This pr is regarding to implementation of pseudo element.
To make pseudo element work normally, we invalidated a assert which is "assert!(style_attribute..." in selector_matching.rs. From the assertion, servo crashes on all the test case with inline style.

Credit with ILyaon.
