### PR TITLE
Fix infinite recursion in Au formatting

### DIFF
--- a/src/components/util/geometry.rs
+++ b/src/components/util/geometry.rs
@@ -21,7 +21,8 @@ impl Clone for Au {
 
 impl fmt::Default for Au {
     fn fmt(obj: &Au, f: &mut fmt::Formatter) {
-        write!(f.buf, "Au({})", *obj);
+        let Au(n) = *obj;
+        write!(f.buf, "Au({})", n);
     }
 }
 


### PR DESCRIPTION
Polymorphism strikes again.  This should have been **obj but let's switch to an
explicit pattern match to be safe.

Fixes #1172.

r? @larsbergstrom
