### PR TITLE
Don't use a separate channel to communicate window size to the constellation

### DIFF
--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -93,7 +93,6 @@ impl RenderListener for CompositorChan {
 }
 
 impl CompositorChan {
-
     pub fn new(chan: Chan<Msg>) -> CompositorChan {
         CompositorChan {
             chan: SharedChan::new(chan),
@@ -103,20 +102,12 @@ impl CompositorChan {
     pub fn send(&self, msg: Msg) {
         self.chan.send(msg);
     }
-
-    pub fn get_size(&self) -> Size2D<int> {
-        let (port, chan) = comm::stream();
-        self.chan.send(GetSize(chan));
-        port.recv()
-    }
 }
 
-/// Messages to the compositor.
+/// Messages from the painting task and the constellation task to the compositor task.
 pub enum Msg {
     /// Requests that the compositor shut down.
     Exit,
-    /// Requests the window size
-    GetSize(Chan<Size2D<int>>),
     /// Requests the compositor's graphics metadata. Graphics metadata is what the renderer needs
     /// to create surfaces that the compositor can see. On Linux this is the X display; on Mac this
     /// is the pixel format.

--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -111,12 +111,14 @@ pub fn run_compositor(compositor: &CompositorTask) {
                     }
 
                     compositor_layer = Some(layer);
-                    constellation_chan = Some(new_constellation_chan);
-                }
 
-                GetSize(chan) => {
-                    let size = window.size();
-                    chan.send(Size2D(size.width as int, size.height as int));
+                    // Initialize the new constellation channel by sending it the root window size.
+                    let window_size = window.size();
+                    let window_size = Size2D(window_size.width as uint,
+                                             window_size.height as uint);
+                    new_constellation_chan.send(ResizedWindowMsg(window_size));
+
+                    constellation_chan = Some(new_constellation_chan);
                 }
 
                 GetGraphicsMetadata(chan) => chan.send(azure_hl::current_graphics_metadata()),

--- a/src/components/main/compositing/run_headless.rs
+++ b/src/components/main/compositing/run_headless.rs
@@ -4,7 +4,6 @@
 
 use compositing::*;
 
-use geom::size::Size2D;
 use std::unstable::intrinsics;
 
 /// Starts the compositor, which listens for messages on the specified port.
@@ -15,10 +14,6 @@ pub fn run_compositor(compositor: &CompositorTask) {
     loop {
         match compositor.port.recv() {
             Exit => break,
-
-            GetSize(chan) => {
-                chan.send(Size2D(500, 500));
-            }
 
             GetGraphicsMetadata(chan) => {
                 unsafe {

--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -40,6 +40,7 @@ pub struct Constellation {
     pending_frames: ~[FrameChange],
     pending_sizes: HashMap<(PipelineId, SubpageId), Rect<f32>>,
     profiler_chan: ProfilerChan,
+    window_size: Size2D<uint>,
     opts: Opts,
 }
 
@@ -254,7 +255,6 @@ impl Constellation {
                  image_cache_task: ImageCacheTask,
                  profiler_chan: ProfilerChan)
                  -> ConstellationChan {
-            
         let (constellation_port, constellation_chan) = special_stream!(ConstellationChan);
         do spawn_with((constellation_port, constellation_chan.clone(),
                        compositor_chan, resource_task, image_cache_task,
@@ -273,6 +273,7 @@ impl Constellation {
                 pending_frames: ~[],
                 pending_sizes: HashMap::new(),
                 profiler_chan: profiler_chan,
+                window_size: Size2D(500u, 500u),
                 opts: opts
             };
             constellation.run();
@@ -375,10 +376,7 @@ impl Constellation {
                                              self.resource_task.clone(),
                                              self.profiler_chan.clone(),
                                              self.opts.clone(),
-                                             {
-                                                let size = self.compositor_chan.get_size();
-                                                Future::from_value(Size2D(size.width as uint, size.height as uint))
-                                             });
+                                             Future::from_value(self.window_size));
         let failure = ~"about:failure";
         let url = make_url(failure, None);
         pipeline.load(url);
@@ -400,10 +398,7 @@ impl Constellation {
                                              self.resource_task.clone(),
                                              self.profiler_chan.clone(),
                                              self.opts.clone(),
-                                             {
-                                                 let size = self.compositor_chan.get_size();
-                                                 Future::from_value(Size2D(size.width as uint, size.height as uint))
-                                             });
+                                             Future::from_value(self.window_size));
         pipeline.load(url);
 
         self.pending_frames.push(FrameChange{
@@ -746,6 +741,7 @@ impl Constellation {
                 already_seen.insert(pipeline.id);
             }
         }
+        self.window_size = new_size;
     }
 
     // Close all pipelines at and beneath a given frame

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -13,6 +13,7 @@ use geom::rect::Rect;
 
 #[deriving(Clone)]
 pub struct ConstellationChan(SharedChan<Msg>);
+
 impl ConstellationChan {
     pub fn new(chan: Chan<Msg>) -> ConstellationChan {
         ConstellationChan(SharedChan::new(chan))
@@ -25,6 +26,7 @@ pub enum IFrameSandboxState {
     IFrameUnsandboxed
 }
 
+/// Messages from the compositor to the constellation.
 pub enum Msg {
     ExitMsg(Chan<()>),
     FailureMsg(PipelineId, Option<SubpageId>),


### PR DESCRIPTION
This will make sandboxing much easier since we won't need a
separate Unix pipe just for this.
