### PR TITLE
Silence CSS errors in the user-agent stylesheet.

### DIFF
--- a/src/components/main/css/select.rs
+++ b/src/components/main/css/select.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use style::Stylesheet;
-use style::Stylist;
-use style::UserAgentOrigin;
+use style::{Stylesheet, Stylist, UserAgentOrigin, with_errors_silenced};
+
 
 pub fn new_stylist() -> Stylist {
     let mut stylist = Stylist::new();
-    let ua_stylesheet = Stylesheet::from_str(include_str!("user-agent.css"));
+    let ua_stylesheet = with_errors_silenced(
+        || Stylesheet::from_str(include_str!("user-agent.css")));
     stylist.add_stylesheet(ua_stylesheet, UserAgentOrigin);
     stylist
 }

--- a/src/components/style/errors.rs
+++ b/src/components/style/errors.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::local_data;
 use cssparser::ast::{SyntaxError, SourceLocation};
 
 
@@ -20,7 +21,19 @@ impl<T, I: Iterator<Result<T, SyntaxError>>> Iterator<T> for ErrorLoggerIterator
 }
 
 
+local_data_key!(silence_errors: ())
+
 pub fn log_css_error(location: SourceLocation, message: &str) {
     // TODO eventually this will got into a "web console" or something.
-    error!("{:u}:{:u} {:s}", location.line, location.column, message)
+    if local_data::get(silence_errors, |silenced| silenced.is_none()) {
+        error!("{:u}:{:u} {:s}", location.line, location.column, message)
+    }
+}
+
+
+pub fn with_errors_silenced<T>(f: &fn() -> T) -> T {
+    local_data::set(silence_errors, ());
+    let result = f();
+    local_data::pop(silence_errors);
+    result
 }

--- a/src/components/style/style.rc
+++ b/src/components/style/style.rc
@@ -23,6 +23,7 @@ pub use stylesheets::Stylesheet;
 pub use selector_matching::{Stylist, StylesheetOrigin, UserAgentOrigin, AuthorOrigin, UserOrigin};
 pub use properties::{cascade, PropertyDeclaration, ComputedValues, computed_values};
 pub use properties::{PropertyDeclarationBlock, parse_style_attribute};  // Style attributes
+pub use errors::with_errors_silenced;
 
 mod stylesheets;
 mod errors;


### PR DESCRIPTION
Alternatively, we could comment the parts of that stylesheet that we don’t support yet. (But we’d have to remember to uncomment them when we do!)
