### PR TITLE
Use `Any` for the layout data.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -226,14 +226,14 @@ DONE_gfx = $(B)src/components/gfx/libgfx.dummy
 
 DEPS_gfx = $(CRATE_gfx) $(SRC_gfx) $(DONE_SUBMODULES) $(DONE_util) $(DONE_style) $(DONE_net) $(DONE_msg)
 
-RFLAGS_script = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/style -L $(B)src/components/net -L $(B)src/components/gfx -L $(B)src/components/msg
+RFLAGS_script = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/style -L $(B)src/components/net -L $(B)src/components/msg
 WEBIDL_script = $(call rwildcard,$(S)src/components/script/,*.webidl)
 AUTOGEN_SRC_script = $(patsubst %.webidl, %Binding.rs, $(WEBIDL_script))
 SRC_script = $(call rwildcard,$(S)src/components/script/,*.rs) $(AUTOGEN_SRC_script)
 CRATE_script = $(S)src/components/script/script.rc
 DONE_script = $(B)src/components/script/libscript.dummy
 
-DEPS_script = $(CRATE_script) $(SRC_script) $(DONE_SUBMODULES) $(DONE_util) $(DONE_style) $(DONE_net) $(DONE_gfx) $(DONE_msg)
+DEPS_script = $(CRATE_script) $(SRC_script) $(DONE_SUBMODULES) $(DONE_util) $(DONE_style) $(DONE_net) $(DONE_msg)
 
 RFLAGS_style = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util
 MAKO_ZIP = $(S)src/components/style/Mako-0.8.1.zip

--- a/src/components/main/layout/aux.rs
+++ b/src/components/main/layout/aux.rs
@@ -4,8 +4,11 @@
 
 //! Code for managing the layout data in the DOM.
 
+use layout::util::{DisplayBoxes, LayoutData, LayoutDataAccess};
+
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_util::tree::TreeNodeRef;
+use std::cast;
 
 /// Functionality useful for querying the layout-specific data on DOM nodes.
 pub trait LayoutAuxMethods {
@@ -15,10 +18,16 @@ pub trait LayoutAuxMethods {
 
 impl LayoutAuxMethods for AbstractNode<LayoutView> {
     /// Resets layout data and styles for the node.
+    ///
+    /// FIXME(pcwalton): Do this as part of box building instead of in a traversal.
     fn initialize_layout_data(self) {
-        do self.write_layout_data |data| {
-            data.boxes.display_list = None;
-            data.boxes.range = None;
+        unsafe {
+            let node = cast::transmute_mut(self.node());
+            if node.layout_data.is_none() {
+                node.layout_data = Some(~LayoutData::new() as ~Any)
+            } else {
+                self.layout_data().boxes.set(DisplayBoxes::init());
+            }
         }
     }
 

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -3,12 +3,34 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use layout::box::{RenderBox, RenderBoxUtils};
+
+use extra::arc::Arc;
+use gfx::display_list::DisplayList;
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_util::range::Range;
-
+use servo_util::slot::Slot;
+use servo_util::tree::TreeNodeRef;
+use std::any::AnyRefExt;
 use std::iter::Enumerate;
 use std::vec::VecIterator;
+use style::{ComputedValues, PropertyDeclaration};
 
+/// The boxes associated with a node.
+pub struct DisplayBoxes {
+    display_list: Option<Arc<DisplayList<AbstractNode<()>>>>,
+    range: Option<Range>,
+}
+
+impl DisplayBoxes {
+    pub fn init() -> DisplayBoxes {
+        DisplayBoxes {
+            display_list: None,
+            range: None,
+        }
+    }
+}
+
+/// A range of nodes.
 pub struct NodeRange {
     node: AbstractNode<LayoutView>,
     range: Range,
@@ -16,7 +38,10 @@ pub struct NodeRange {
 
 impl NodeRange {
     pub fn new(node: AbstractNode<LayoutView>, range: &Range) -> NodeRange {
-        NodeRange { node: node, range: (*range).clone() }
+        NodeRange {
+            node: node,
+            range: (*range).clone()
+        }
     }
 }
 
@@ -111,3 +136,51 @@ impl ElementMapping {
         debug!("----------------------------------");
     }
 }
+
+/// Data that layout associates with a node.
+pub struct LayoutData {
+    /// The results of CSS matching for this node.
+    applicable_declarations: Slot<~[Arc<~[PropertyDeclaration]>]>,
+
+    /// The results of CSS styling for this node.
+    style: Slot<Option<ComputedValues>>,
+
+    /// Description of how to account for recent style changes.
+    restyle_damage: Slot<Option<int>>,
+
+    /// The boxes assosiated with this flow.
+    /// Used for getBoundingClientRect and friends.
+    boxes: Slot<DisplayBoxes>,
+}
+
+impl LayoutData {
+    /// Creates new layout data.
+    pub fn new() -> LayoutData {
+        LayoutData {
+            applicable_declarations: Slot::init(~[]),
+            style: Slot::init(None),
+            restyle_damage: Slot::init(None),
+            boxes: Slot::init(DisplayBoxes::init()),
+        }
+    }
+}
+
+// This serves as a static assertion that layout data remains sendable. If this is not done, then
+// we can have memory unsafety, which usually manifests as shutdown crashes.
+fn assert_is_sendable<T:Send>(_: T) {}
+fn assert_layout_data_is_sendable() {
+    assert_is_sendable(LayoutData::new())
+}
+
+/// A trait that allows access to the layout data of a DOM node.
+pub trait LayoutDataAccess {
+    fn layout_data<'a>(&'a self) -> &'a LayoutData;
+}
+
+impl LayoutDataAccess for AbstractNode<LayoutView> {
+    #[inline(always)]
+    fn layout_data<'a>(&'a self) -> &'a LayoutData {
+        self.node().layout_data.as_ref().unwrap().as_ref().unwrap()
+    }
+}
+

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -21,12 +21,8 @@ use dom::text::Text;
 use std::cast;
 use std::cast::transmute;
 use std::unstable::raw::Box;
-use extra::arc::Arc;
 use js::jsapi::{JSObject, JSContext};
-use style::{ComputedValues, PropertyDeclaration};
 use servo_util::tree::{TreeNode, TreeNodeRef, TreeNodeRefAsElement};
-use servo_util::range::Range;
-use gfx::display_list::DisplayList;
 
 //
 // The basic Node structure
@@ -93,7 +89,7 @@ pub struct Node<View> {
     child_list: Option<@mut NodeList>,
 
     /// Layout information. Only the layout task may touch this data.
-    priv layout_data: LayoutData,
+    layout_data: Option<~Any>,
 }
 
 /// The different types of nodes.
@@ -543,7 +539,7 @@ impl Node<ScriptView> {
             owner_doc: doc,
             child_list: None,
 
-            layout_data: LayoutData::new(),
+            layout_data: None,
         }
     }
 }
@@ -1058,62 +1054,41 @@ impl Reflectable for Node<ScriptView> {
     }
 }
 
-// This stuff is notionally private to layout, but we put it here because it needs
-// to be stored in a Node, and we can't have cross-crate cyclic dependencies.
+/// A bottom-up, parallelizable traversal.
+pub trait PostorderNodeTraversal {
+    /// The operation to perform. Return true to continue or false to stop.
+    fn process(&mut self, node: AbstractNode<LayoutView>) -> bool;
 
-pub struct DisplayBoxes {
-    display_list: Option<Arc<DisplayList<AbstractNode<()>>>>,
-    range: Option<Range>,
-}
-
-/// Data that layout associates with a node.
-pub struct LayoutData {
-    /// The results of CSS matching for this node.
-    applicable_declarations: ~[Arc<~[PropertyDeclaration]>],
-
-    /// The results of CSS styling for this node.
-    style: Option<ComputedValues>,
-
-    /// Description of how to account for recent style changes.
-    restyle_damage: Option<int>,
-
-    /// The boxes assosiated with this flow.
-    /// Used for getBoundingClientRect and friends.
-    boxes: DisplayBoxes,
-}
-
-impl LayoutData {
-    /// Creates new layout data.
-    pub fn new() -> LayoutData {
-        LayoutData {
-            applicable_declarations: ~[],
-            style: None,
-            restyle_damage: None,
-            boxes: DisplayBoxes {
-                display_list: None,
-                range: None,
-            },
-        }
+    /// Returns true if this node should be pruned. If this returns true, we skip the operation
+    /// entirely and do not process any descendant nodes. This is called *before* child nodes are
+    /// visited. The default implementation never prunes any nodes.
+    fn should_prune(&mut self, _node: AbstractNode<LayoutView>) -> bool {
+        false
     }
-}
-
-// This serves as a static assertion that layout data remains sendable. If this is not done, then
-// we can have memory unsafety, which usually manifests as shutdown crashes.
-fn assert_is_sendable<T:Send>(_: T) {}
-fn assert_layout_data_is_sendable() {
-    assert_is_sendable(LayoutData::new())
 }
 
 impl AbstractNode<LayoutView> {
-    // These accessors take a continuation rather than returning a reference, because
-    // an AbstractNode doesn't have a lifetime parameter relating to the underlying
-    // Node.  Also this makes it easier to switch to RWArc if we decide that is
-    // necessary.
-    pub fn read_layout_data<R>(self, blk: &fn(data: &LayoutData) -> R) -> R {
-        blk(&self.node().layout_data)
-    }
+    /// Traverses the tree in postorder.
+    ///
+    /// TODO(pcwalton): Offer a parallel version with a compatible API.
+    pub fn traverse_postorder<T:PostorderNodeTraversal>(self, traversal: &mut T) -> bool {
+        if traversal.should_prune(self) {
+            return true
+        }
 
-    pub fn write_layout_data<R>(self, blk: &fn(data: &mut LayoutData) -> R) -> R {
-        blk(&mut self.mut_node().layout_data)
+        let mut opt_kid = self.first_child();
+        loop {
+            match opt_kid {
+                None => break,
+                Some(kid) => {
+                    if !kid.traverse_postorder(traversal) {
+                        return false
+                    }
+                    opt_kid = kid.next_sibling()
+                }
+            }
+        }
+
+        traversal.process(self)
     }
 }

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -14,7 +14,6 @@
 #[feature(globs, macro_rules, struct_variant, managed_boxes)];
 
 extern mod geom;
-extern mod gfx (name = "gfx");
 extern mod hubbub;
 extern mod js;
 extern mod servo_net (name = "net");


### PR DESCRIPTION
Breaks the dependency between `gfx` and `script`, which is nice.

This exposed some performance issues with Rust's `Any` type, which I've filed:

https://github.com/mozilla/rust/issues/10382
