### PR TITLE
Stop passing DOMStrings via borrowed pointer.

### DIFF
--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -66,8 +66,8 @@ impl Attr {
         self.value.clone()
     }
 
-    pub fn SetValue(&mut self, value: &DOMString) {
-        self.value = value.clone();
+    pub fn SetValue(&mut self, value: DOMString) {
+        self.value = value;
     }
 
     pub fn Name(&self) -> DOMString {

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1584,9 +1584,9 @@ for (uint32_t i = 0; i < length; ++i) {
 
     if type.isString():
         if type.nullable():
-            return (wrapAndSetPtr("*${jsvalPtr} = domstring_to_jsval(cx, &%s)" % result), False)
+            return (wrapAndSetPtr("*${jsvalPtr} = domstring_to_jsval(cx, %s)" % result), False)
         else:
-            return (wrapAndSetPtr("*${jsvalPtr} = str_to_jsval(cx, &%s)" % result), False)
+            return (wrapAndSetPtr("*${jsvalPtr} = str_to_jsval(cx, %s)" % result), False)
 
     if type.isEnum():
         if type.nullable():
@@ -2961,9 +2961,7 @@ class CGCallGenerator(CGThing):
             if a.type.isObject() and not a.type.nullable() and not a.optional:
                 name = "(JSObject&)" + name
             #XXXjdm Perhaps we should pass all nontrivial types by borrowed pointer
-            # Aoid passing Option<Option<DOMString>> by reference. If only one of optional or
-            # defaultValue are truthy we pass an Option, otherwise it's a concrete Option<DOMString>.
-            if a.type.isDictionary() or (a.type.isString() and not (bool(a.defaultValue) ^ a.optional)):
+            if a.type.isDictionary():
                 name = "&" + name
             args.append(CGGeneric(name))
 

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -111,7 +111,7 @@ extern fn InterfaceObjectToString(cx: *JSContext, _argc: c_uint, vp: *mut JSVal)
     assert!(jsval::is_string(v));
     let name = jsstring_to_str(cx, jsval::to_string(v));
     let retval = Some(~"function " + name + "() {\n    [native code]\n}");
-    *vp = domstring_to_jsval(cx, &retval);
+    *vp = domstring_to_jsval(cx, retval);
     return 1;
   }
 }
@@ -273,7 +273,7 @@ pub fn jsval_to_domstring(cx: *JSContext, v: JSVal) -> Result<Option<DOMString>,
 }
 
 #[fixed_stack_segment]
-pub unsafe fn str_to_jsval(cx: *JSContext, string: &DOMString) -> JSVal {
+pub unsafe fn str_to_jsval(cx: *JSContext, string: DOMString) -> JSVal {
     do string.to_utf16().as_imm_buf |buf, len| {
         let jsstr = JS_NewUCStringCopyN(cx, buf, len as libc::size_t);
         if jsstr.is_null() {
@@ -286,10 +286,10 @@ pub unsafe fn str_to_jsval(cx: *JSContext, string: &DOMString) -> JSVal {
 }
 
 #[fixed_stack_segment]
-pub unsafe fn domstring_to_jsval(cx: *JSContext, string: &Option<DOMString>) -> JSVal {
+pub unsafe fn domstring_to_jsval(cx: *JSContext, string: Option<DOMString>) -> JSVal {
     match string {
-        &None => JSVAL_NULL,
-        &Some(ref s) => str_to_jsval(cx, s),
+        None => JSVAL_NULL,
+        Some(s) => str_to_jsval(cx, s),
     }
 }
 

--- a/src/components/script/dom/characterdata.rs
+++ b/src/components/script/dom/characterdata.rs
@@ -26,8 +26,8 @@ impl CharacterData {
         self.data.clone()
     }
 
-    pub fn SetData(&mut self, arg: &DOMString) -> ErrorResult {
-        self.data = arg.clone();
+    pub fn SetData(&mut self, arg: DOMString) -> ErrorResult {
+        self.data = arg;
         Ok(())
     }
 
@@ -39,12 +39,12 @@ impl CharacterData {
         Ok(self.data.slice(offset as uint, count as uint).to_str())
     }
 
-    pub fn AppendData(&mut self, arg: &DOMString) -> ErrorResult {
-        self.data.push_str(*arg);
+    pub fn AppendData(&mut self, arg: DOMString) -> ErrorResult {
+        self.data.push_str(arg);
         Ok(())
     }
 
-    pub fn InsertData(&mut self, _offset: u32, _arg: &DOMString) -> ErrorResult {
+    pub fn InsertData(&mut self, _offset: u32, _arg: DOMString) -> ErrorResult {
         fail!("CharacterData::InsertData() is unimplemented")
     }
 
@@ -52,7 +52,7 @@ impl CharacterData {
         fail!("CharacterData::DeleteData() is unimplemented")
     }
 
-    pub fn ReplaceData(&mut self, _offset: u32, _count: u32, _arg: &DOMString) -> ErrorResult {
+    pub fn ReplaceData(&mut self, _offset: u32, _count: u32, _arg: DOMString) -> ErrorResult {
         fail!("CharacterData::ReplaceData() is unimplemented")
     }
 }

--- a/src/components/script/dom/comment.rs
+++ b/src/components/script/dom/comment.rs
@@ -26,7 +26,7 @@ impl Comment {
         Node::reflect_node(@mut node, document, CommentBinding::Wrap)
     }
 
-    pub fn Constructor(owner: @mut Window, data: &DOMString) -> Fallible<AbstractNode<ScriptView>> {
-        Ok(Comment::new(data.clone(), owner.Document()))
+    pub fn Constructor(owner: @mut Window, data: DOMString) -> Fallible<AbstractNode<ScriptView>> {
+        Ok(Comment::new(data, owner.Document()))
     }
 }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -180,29 +180,29 @@ impl Document {
         self.window.get_cx()
     }
 
-    pub fn GetElementsByTagName(&self, tag: &DOMString) -> @mut HTMLCollection {
-        self.createHTMLCollection(|elem| eq_slice(elem.tag_name, *tag))
+    pub fn GetElementsByTagName(&self, tag: DOMString) -> @mut HTMLCollection {
+        self.createHTMLCollection(|elem| eq_slice(elem.tag_name, tag))
     }
 
-    pub fn GetElementsByTagNameNS(&self, _ns: &Option<DOMString>, _tag: &DOMString) -> @mut HTMLCollection {
+    pub fn GetElementsByTagNameNS(&self, _ns: Option<DOMString>, _tag: DOMString) -> @mut HTMLCollection {
         HTMLCollection::new(self.window, ~[])
     }
 
-    pub fn GetElementsByClassName(&self, _class: &DOMString) -> @mut HTMLCollection {
+    pub fn GetElementsByClassName(&self, _class: DOMString) -> @mut HTMLCollection {
         HTMLCollection::new(self.window, ~[])
     }
 
-    pub fn GetElementById(&self, id: &DOMString) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetElementById(&self, id: DOMString) -> Option<AbstractNode<ScriptView>> {
         // TODO: "in tree order, within the context object's tree"
         // http://dom.spec.whatwg.org/#dom-document-getelementbyid.
-        match self.idmap.find_equiv(id) {
+        match self.idmap.find_equiv(&id) {
             None => None,
             Some(node) => Some(*node),
         }
     }
 
-    pub fn CreateElement(&self, abstract_self: AbstractDocument, local_name: &DOMString) -> Fallible<AbstractNode<ScriptView>> {
-        if xml_name_type(*local_name) == InvalidXMLName {
+    pub fn CreateElement(&self, abstract_self: AbstractDocument, local_name: DOMString) -> Fallible<AbstractNode<ScriptView>> {
+        if xml_name_type(local_name) == InvalidXMLName {
             return Err(InvalidCharacter);
         }
         let local_name = local_name.to_ascii_lower();
@@ -213,15 +213,15 @@ impl Document {
         DocumentFragment::new(abstract_self)
     }
 
-    pub fn CreateTextNode(&self, abstract_self: AbstractDocument, data: &DOMString) -> AbstractNode<ScriptView> {
-        Text::new(data.clone(), abstract_self)
+    pub fn CreateTextNode(&self, abstract_self: AbstractDocument, data: DOMString) -> AbstractNode<ScriptView> {
+        Text::new(data, abstract_self)
     }
 
-    pub fn CreateComment(&self, abstract_self: AbstractDocument, data: &DOMString) -> AbstractNode<ScriptView> {
-        Comment::new(data.clone(), abstract_self)
+    pub fn CreateComment(&self, abstract_self: AbstractDocument, data: DOMString) -> AbstractNode<ScriptView> {
+        Comment::new(data, abstract_self)
     }
 
-    pub fn CreateEvent(&self, interface: &DOMString) -> Fallible<AbstractEvent> {
+    pub fn CreateEvent(&self, interface: DOMString) -> Fallible<AbstractEvent> {
         match interface.as_slice() {
             "UIEvents" => Ok(UIEvent::new(self.window, UIEventTypeId)),
             "MouseEvents" => Ok(MouseEvent::new(self.window)),
@@ -263,7 +263,7 @@ impl Document {
         title
     }
 
-    pub fn SetTitle(&self, abstract_self: AbstractDocument, title: &DOMString) -> ErrorResult {
+    pub fn SetTitle(&self, abstract_self: AbstractDocument, title: DOMString) -> ErrorResult {
         match self.doctype {
             SVG => {
                 fail!("no SVG document yet")
@@ -285,12 +285,12 @@ impl Document {
                                 for title_child in child.children() {
                                     child.remove_child(title_child);
                                 }
-                                child.AppendChild(self.CreateTextNode(abstract_self, title));
+                                child.AppendChild(self.CreateTextNode(abstract_self, title.clone()));
                                 break;
                             }
                             if !has_title {
                                 let new_title = HTMLTitleElement::new(~"title", abstract_self);
-                                new_title.AppendChild(self.CreateTextNode(abstract_self, title));
+                                new_title.AppendChild(self.CreateTextNode(abstract_self, title.clone()));
                                 node.AppendChild(new_title);
                             }
                             break;
@@ -302,9 +302,9 @@ impl Document {
         Ok(())
     }
 
-    pub fn GetElementsByName(&self, name: &DOMString) -> @mut HTMLCollection {
+    pub fn GetElementsByName(&self, name: DOMString) -> @mut HTMLCollection {
         self.createHTMLCollection(|elem|
-            elem.get_attr("name").is_some() && eq_slice(elem.get_attr("name").unwrap(), *name))
+            elem.get_attr("name").is_some() && eq_slice(elem.get_attr("name").unwrap(), name))
     }
 
     pub fn createHTMLCollection(&self, callback: &fn(elem: &Element) -> bool) -> @mut HTMLCollection {

--- a/src/components/script/dom/domparser.rs
+++ b/src/components/script/dom/domparser.rs
@@ -33,7 +33,7 @@ impl DOMParser {
     }
 
     pub fn ParseFromString(&self,
-                           _s: &DOMString,
+                           _s: DOMString,
                            ty: DOMParserBinding::SupportedType)
                            -> Fallible<AbstractDocument> {
         match ty {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -129,7 +129,7 @@ impl ElementLike for Element {
     }
 
     fn get_attr(&self, name: &str) -> Option<~str> {
-        self.get_attribute(&None, name).map(|attr| attr.value.clone())
+        self.get_attribute(None, name).map(|attr| attr.value.clone())
     }
 
     fn get_link(&self) -> Option<~str>{
@@ -157,18 +157,18 @@ impl<'self> Element {
         }
     }
 
-    pub fn normalize_attr_name(&self, name: &Option<DOMString>) -> ~str {
+    pub fn normalize_attr_name(&self, name: Option<DOMString>) -> ~str {
         //FIXME: Throw for XML-invalid names
         let owner = self.node.owner_doc();
         if owner.document().doctype == document::HTML { // && self.namespace == Namespace::HTML
-            null_str_as_empty(name).to_ascii_lower()
+            null_str_as_empty(&name).to_ascii_lower()
         } else {
-            null_str_as_empty(name)
+            null_str_as_empty(&name)
         }
     }
 
     pub fn get_attribute<'a>(&'a self,
-                         namespace_url: &Option<DOMString>,
+                         namespace_url: Option<DOMString>,
                          name: &str) -> Option<@mut Attr> {
         let namespace = Namespace::from_str(namespace_url);
         // FIXME: only case-insensitive in the HTML namespace (as opposed to SVG, etc.)
@@ -264,12 +264,12 @@ impl<'self> Element {
         match abstract_self.type_id() {
             ElementNodeTypeId(HTMLImageElementTypeId) => {
                 do abstract_self.with_mut_image_element |image| {
-                    image.AfterSetAttr(&local_name, &value);
+                    image.AfterSetAttr(local_name.clone(), value.clone());
                 }
             }
             ElementNodeTypeId(HTMLIframeElementTypeId) => {
                 do abstract_self.with_mut_iframe_element |iframe| {
-                    iframe.AfterSetAttr(&local_name, &value);
+                    iframe.AfterSetAttr(local_name.clone(), value.clone());
                 }
             }
             _ => ()
@@ -294,8 +294,8 @@ impl Element {
         }
     }
 
-    pub fn SetId(&mut self, abstract_self: AbstractNode<ScriptView>, id: &DOMString) {
-        self.set_attribute(abstract_self, namespace::Null, ~"id", id.clone());
+    pub fn SetId(&mut self, abstract_self: AbstractNode<ScriptView>, id: DOMString) {
+        self.set_attribute(abstract_self, namespace::Null, ~"id", id);
     }
 
     pub fn Attributes(&mut self, abstract_self: AbstractNode<ScriptView>) -> @mut AttrList {
@@ -310,29 +310,29 @@ impl Element {
         }
     }
 
-    pub fn GetAttribute(&self, name: &DOMString) -> Option<DOMString> {
-        self.get_attr(*name).map(|s| s.to_owned())
+    pub fn GetAttribute(&self, name: DOMString) -> Option<DOMString> {
+        self.get_attr(name).map(|s| s.to_owned())
     }
 
-    pub fn GetAttributeNS(&self, namespace: &Option<DOMString>, local_name: &DOMString) -> Option<DOMString> {
-        self.get_attribute(namespace, *local_name)
+    pub fn GetAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) -> Option<DOMString> {
+        self.get_attribute(namespace, local_name)
             .map(|attr| attr.value.clone())
     }
 
     pub fn SetAttribute(&mut self,
                         abstract_self: AbstractNode<ScriptView>,
-                        name: &DOMString,
-                        value: &DOMString) -> ErrorResult {
-        self.set_attr(abstract_self, name.clone(), value.clone());
+                        name: DOMString,
+                        value: DOMString) -> ErrorResult {
+        self.set_attr(abstract_self, name, value);
         Ok(())
     }
 
     pub fn SetAttributeNS(&mut self,
                           abstract_self: AbstractNode<ScriptView>,
-                          namespace_url: &Option<DOMString>,
-                          name: &DOMString,
-                          value: &DOMString) -> ErrorResult {
-        let name_type = xml_name_type(*name);
+                          namespace_url: Option<DOMString>,
+                          name: DOMString,
+                          value: DOMString) -> ErrorResult {
+        let name_type = xml_name_type(name);
         match name_type {
             InvalidXMLName => return Err(InvalidCharacter),
             Name => return Err(NamespaceError),
@@ -340,38 +340,38 @@ impl Element {
         }
 
         let namespace = Namespace::from_str(namespace_url);
-        self.set_attribute(abstract_self, namespace, name.clone(), value.clone())
+        self.set_attribute(abstract_self, namespace, name, value)
     }
 
-    pub fn RemoveAttribute(&self, _name: &DOMString) -> ErrorResult {
+    pub fn RemoveAttribute(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
-    pub fn RemoveAttributeNS(&self, _namespace: &Option<DOMString>, _localname: &DOMString) -> ErrorResult {
+    pub fn RemoveAttributeNS(&self, _namespace: Option<DOMString>, _localname: DOMString) -> ErrorResult {
         Ok(())
     }
 
-    pub fn HasAttribute(&self, name: &DOMString) -> bool {
+    pub fn HasAttribute(&self, name: DOMString) -> bool {
         self.GetAttribute(name).is_some()
     }
 
-    pub fn HasAttributeNS(&self, namespace: &Option<DOMString>, local_name: &DOMString) -> bool {
+    pub fn HasAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) -> bool {
         self.GetAttributeNS(namespace, local_name).is_some()
     }
 
-    pub fn GetElementsByTagName(&self, _localname: &DOMString) -> @mut HTMLCollection {
+    pub fn GetElementsByTagName(&self, _localname: DOMString) -> @mut HTMLCollection {
         HTMLCollection::new(self.node.owner_doc().document().window, ~[])
     }
 
-    pub fn GetElementsByTagNameNS(&self, _namespace: &Option<DOMString>, _localname: &DOMString) -> Fallible<@mut HTMLCollection> {
+    pub fn GetElementsByTagNameNS(&self, _namespace: Option<DOMString>, _localname: DOMString) -> Fallible<@mut HTMLCollection> {
         Ok(HTMLCollection::new(self.node.owner_doc().document().window, ~[]))
     }
 
-    pub fn GetElementsByClassName(&self, _names: &DOMString) -> @mut HTMLCollection {
+    pub fn GetElementsByClassName(&self, _names: DOMString) -> @mut HTMLCollection {
         HTMLCollection::new(self.node.owner_doc().document().window, ~[])
     }
 
-    pub fn MozMatchesSelector(&self, _selector: &DOMString) -> Fallible<bool> {
+    pub fn MozMatchesSelector(&self, _selector: DOMString) -> Fallible<bool> {
         Ok(false)
     }
 
@@ -471,7 +471,7 @@ impl Element {
         Ok(~"")
     }
 
-    pub fn SetInnerHTML(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetInnerHTML(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -479,15 +479,15 @@ impl Element {
         Ok(~"")
     }
 
-    pub fn SetOuterHTML(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetOuterHTML(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
-    pub fn InsertAdjacentHTML(&mut self, _position: &DOMString, _text: &DOMString) -> ErrorResult {
+    pub fn InsertAdjacentHTML(&mut self, _position: DOMString, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 
-    pub fn QuerySelector(&self, _selectors: &DOMString) -> Fallible<Option<AbstractNode<ScriptView>>> {
+    pub fn QuerySelector(&self, _selectors: DOMString) -> Fallible<Option<AbstractNode<ScriptView>>> {
         Ok(None)
     }
 }

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -225,10 +225,10 @@ impl Event {
     }
 
     pub fn InitEvent(&mut self,
-                     type_: &DOMString,
+                     type_: DOMString,
                      bubbles: bool,
                      cancelable: bool) -> ErrorResult {
-        self.type_ = type_.clone();
+        self.type_ = type_;
         self.cancelable = cancelable;
         self.bubbles = bubbles;
         self.initialized = true;
@@ -240,7 +240,7 @@ impl Event {
     }
 
     pub fn Constructor(global: @mut Window,
-                       type_: &DOMString,
+                       type_: DOMString,
                        init: &EventBinding::EventInit) -> Fallible<AbstractEvent> {
         let ev = Event::new(global, HTMLEventTypeId);
         ev.mut_event().InitEvent(type_, init.bubbles, init.cancelable);

--- a/src/components/script/dom/eventtarget.rs
+++ b/src/components/script/dom/eventtarget.rs
@@ -141,7 +141,7 @@ impl EventTarget {
     }
 
     pub fn AddEventListener(&mut self,
-                            ty: &DOMString,
+                            ty: DOMString,
                             listener: Option<EventListener>,
                             capture: bool) {
         for &listener in listener.iter() {
@@ -158,11 +158,11 @@ impl EventTarget {
     }
 
     pub fn RemoveEventListener(&mut self,
-                               ty: &DOMString,
+                               ty: DOMString,
                                listener: Option<EventListener>,
                                capture: bool) {
         for &listener in listener.iter() {
-            let mut entry = self.handlers.find_mut(ty);
+            let mut entry = self.handlers.find_mut(&ty);
             for entry in entry.mut_iter() {
                 let phase = if capture { Capturing } else { Bubbling };
                 let old_entry = EventListenerEntry {

--- a/src/components/script/dom/formdata.rs
+++ b/src/components/script/dom/formdata.rs
@@ -34,7 +34,7 @@ impl FormData {
         reflect_dom_object(@mut FormData::new_inherited(window), window, FormDataBinding::Wrap)
     }
 
-    pub fn Append(&mut self, name: &DOMString, value: @mut Blob, filename: Option<DOMString>) {
+    pub fn Append(&mut self, name: DOMString, value: @mut Blob, filename: Option<DOMString>) {
         let blob = BlobData {
             blob: value,
             name: filename.unwrap_or(~"default")
@@ -42,8 +42,8 @@ impl FormData {
         self.data.insert(name.clone(), blob);
     }
 
-    pub fn Append_(&mut self, name: &DOMString, value: &DOMString) {
-        self.data.insert(name.clone(), StringData((*value).clone()));
+    pub fn Append_(&mut self, name: DOMString, value: DOMString) {
+        self.data.insert(name, StringData(value));
     }
 }
 

--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -31,7 +31,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetHref(&mut self, _href: &DOMString) -> ErrorResult {
+    pub fn SetHref(&mut self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetTarget(&self, _target: &DOMString) -> ErrorResult {
+    pub fn SetTarget(&self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetDownload(&self, _download: &DOMString) -> ErrorResult {
+    pub fn SetDownload(&self, _download: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetPing(&self, _ping: &DOMString) -> ErrorResult {
+    pub fn SetPing(&self, _ping: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetRel(&self, _rel: &DOMString) -> ErrorResult {
+    pub fn SetRel(&self, _rel: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetHreflang(&self, _href_lang: &DOMString) -> ErrorResult {
+    pub fn SetHreflang(&self, _href_lang: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -79,7 +79,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -87,7 +87,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetText(&mut self, _text: &DOMString) -> ErrorResult {
+    pub fn SetText(&mut self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -95,7 +95,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetCoords(&mut self, _coords: &DOMString) -> ErrorResult {
+    pub fn SetCoords(&mut self, _coords: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -103,7 +103,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetCharset(&mut self, _charset: &DOMString) -> ErrorResult {
+    pub fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -111,7 +111,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -119,7 +119,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetRev(&mut self, _rev: &DOMString) -> ErrorResult {
+    pub fn SetRev(&mut self, _rev: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -127,7 +127,7 @@ impl HTMLAnchorElement {
         ~""
     }
 
-    pub fn SetShape(&mut self, _shape: &DOMString) -> ErrorResult {
+    pub fn SetShape(&mut self, _shape: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlappletelement.rs
+++ b/src/components/script/dom/htmlappletelement.rs
@@ -31,7 +31,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetAlt(&self, _alt: &DOMString) -> ErrorResult {
+    pub fn SetAlt(&self, _alt: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetArchive(&self, _archive: &DOMString) -> ErrorResult {
+    pub fn SetArchive(&self, _archive: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetCode(&self, _code: &DOMString) -> ErrorResult {
+    pub fn SetCode(&self, _code: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetCodeBase(&self, _code_base: &DOMString) -> ErrorResult {
+    pub fn SetCodeBase(&self, _code_base: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetHeight(&self, _height: &DOMString) -> ErrorResult {
+    pub fn SetHeight(&self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -87,7 +87,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -95,7 +95,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetObject(&mut self, _object: &DOMString) -> ErrorResult {
+    pub fn SetObject(&mut self, _object: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -111,7 +111,7 @@ impl HTMLAppletElement {
         ~""
     }
 
-    pub fn SetWidth(&mut self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -31,7 +31,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetAlt(&self, _alt: &DOMString) -> ErrorResult {
+    pub fn SetAlt(&self, _alt: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetCoords(&self, _coords: &DOMString) -> ErrorResult {
+    pub fn SetCoords(&self, _coords: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetShape(&self, _shape: &DOMString) -> ErrorResult {
+    pub fn SetShape(&self, _shape: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetHref(&self, _href: &DOMString) -> ErrorResult {
+    pub fn SetHref(&self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetTarget(&self, _target: &DOMString) -> ErrorResult {
+    pub fn SetTarget(&self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetDownload(&self, _download: &DOMString) -> ErrorResult {
+    pub fn SetDownload(&self, _download: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -79,7 +79,7 @@ impl HTMLAreaElement {
         ~""
     }
 
-    pub fn SetPing(&self, _ping: &DOMString) -> ErrorResult {
+    pub fn SetPing(&self, _ping: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlbaseelement.rs
+++ b/src/components/script/dom/htmlbaseelement.rs
@@ -31,7 +31,7 @@ impl HTMLBaseElement {
         ~""
     }
 
-    pub fn SetHref(&self, _href: &DOMString) -> ErrorResult {
+    pub fn SetHref(&self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLBaseElement {
         ~""
     }
 
-    pub fn SetTarget(&self, _target: &DOMString) -> ErrorResult {
+    pub fn SetTarget(&self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlbodyelement.rs
+++ b/src/components/script/dom/htmlbodyelement.rs
@@ -31,7 +31,7 @@ impl HTMLBodyElement {
         ~""
     }
 
-    pub fn SetText(&mut self, _text: &DOMString) -> ErrorResult {
+    pub fn SetText(&mut self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLBodyElement {
         ~""
     }
 
-    pub fn SetLink(&self, _link: &DOMString) -> ErrorResult {
+    pub fn SetLink(&self, _link: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLBodyElement {
         ~""
     }
 
-    pub fn SetVLink(&self, _v_link: &DOMString) -> ErrorResult {
+    pub fn SetVLink(&self, _v_link: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLBodyElement {
         ~""
     }
 
-    pub fn SetALink(&self, _a_link: &DOMString) -> ErrorResult {
+    pub fn SetALink(&self, _a_link: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLBodyElement {
         ~""
     }
 
-    pub fn SetBgColor(&self, _bg_color: &DOMString) -> ErrorResult {
+    pub fn SetBgColor(&self, _bg_color: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLBodyElement {
         ~""
     }
 
-    pub fn SetBackground(&self, _background: &DOMString) -> ErrorResult {
+    pub fn SetBackground(&self, _background: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlbrelement.rs
+++ b/src/components/script/dom/htmlbrelement.rs
@@ -31,7 +31,7 @@ impl HTMLBRElement {
         ~""
     }
 
-    pub fn SetClear(&mut self, _text: &DOMString) -> ErrorResult {
+    pub fn SetClear(&mut self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -52,7 +52,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetFormAction(&mut self, _formaction: &DOMString) -> ErrorResult {
+    pub fn SetFormAction(&mut self, _formaction: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -60,7 +60,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetFormEnctype(&mut self, _formenctype: &DOMString) -> ErrorResult {
+    pub fn SetFormEnctype(&mut self, _formenctype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -68,7 +68,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetFormMethod(&mut self, _formmethod: &DOMString) -> ErrorResult {
+    pub fn SetFormMethod(&mut self, _formmethod: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -84,7 +84,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetFormTarget(&mut self, _formtarget: &DOMString) -> ErrorResult {
+    pub fn SetFormTarget(&mut self, _formtarget: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -92,7 +92,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
     
@@ -100,7 +100,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -108,7 +108,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -131,7 +131,7 @@ impl HTMLButtonElement {
         ~""
     }
 
-    pub fn SetValidationMessage(&mut self, _message: &DOMString) -> ErrorResult {
+    pub fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -139,6 +139,6 @@ impl HTMLButtonElement {
         true
     }
 
-    pub fn SetCustomValidity(&mut self, _error: &DOMString) {
+    pub fn SetCustomValidity(&mut self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -46,7 +46,7 @@ impl HTMLCollection {
         }
     }
 
-    pub fn NamedItem(&self, _cx: *JSContext, _name: &DOMString) -> Fallible<*JSObject> {
+    pub fn NamedItem(&self, _cx: *JSContext, _name: DOMString) -> Fallible<*JSObject> {
         Ok(ptr::null())
     }
 
@@ -55,7 +55,7 @@ impl HTMLCollection {
         self.Item(index)
     }
 
-    pub fn NamedGetter(&self, _cx: *JSContext, _name: &Option<DOMString>, _found: &mut bool) -> Fallible<*JSObject> {
+    pub fn NamedGetter(&self, _cx: *JSContext, _name: Option<DOMString>, _found: &mut bool) -> Fallible<*JSObject> {
         Ok(ptr::null())
     }
 }

--- a/src/components/script/dom/htmldataelement.rs
+++ b/src/components/script/dom/htmldataelement.rs
@@ -31,7 +31,7 @@ impl HTMLDataElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmldivelement.rs
+++ b/src/components/script/dom/htmldivelement.rs
@@ -31,7 +31,7 @@ impl HTMLDivElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmldlistelement.rs
+++ b/src/components/script/dom/htmldlistelement.rs
@@ -39,7 +39,7 @@ impl HTMLDListElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlelement.rs
+++ b/src/components/script/dom/htmlelement.rs
@@ -32,21 +32,21 @@ impl HTMLElement {
         ~""
     }
 
-    pub fn SetTitle(&mut self, _title: &DOMString) {
+    pub fn SetTitle(&mut self, _title: DOMString) {
     }
 
     pub fn Lang(&self) -> DOMString {
         ~""
     }
 
-    pub fn SetLang(&mut self, _lang: &DOMString) {
+    pub fn SetLang(&mut self, _lang: DOMString) {
     }
 
     pub fn Dir(&self) -> DOMString {
         ~""
     }
 
-    pub fn SetDir(&mut self, _dir: &DOMString) -> ErrorResult {
+    pub fn SetDir(&mut self, _dir: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl HTMLElement {
         ~""
     }
 
-    pub fn SetAccessKey(&self, _key: &DOMString) -> ErrorResult {
+    pub fn SetAccessKey(&self, _key: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -109,7 +109,7 @@ impl HTMLElement {
         ~""
     }
 
-    pub fn SetContentEditable(&mut self, _val: &DOMString) -> ErrorResult {
+    pub fn SetContentEditable(&mut self, _val: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -129,7 +129,7 @@ impl HTMLElement {
         ~""
     }
 
-    pub fn SetClassName(&self, _class: &DOMString) {
+    pub fn SetClassName(&self, _class: DOMString) {
     }
 
     pub fn GetOffsetParent(&self) -> Option<AbstractNode<ScriptView>> {

--- a/src/components/script/dom/htmlembedelement.rs
+++ b/src/components/script/dom/htmlembedelement.rs
@@ -31,7 +31,7 @@ impl HTMLEmbedElement {
         ~""
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLEmbedElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLEmbedElement {
         ~""
     }
 
-    pub fn SetWidth(&mut self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLEmbedElement {
         ~""
     }
 
-    pub fn SetHeight(&mut self, _height: &DOMString) -> ErrorResult {
+    pub fn SetHeight(&mut self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLEmbedElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLEmbedElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlfieldsetelement.rs
+++ b/src/components/script/dom/htmlfieldsetelement.rs
@@ -45,7 +45,7 @@ impl HTMLFieldSetElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -75,6 +75,6 @@ impl HTMLFieldSetElement {
         false
     }
 
-    pub fn SetCustomValidity(&mut self, _error: &DOMString) {
+    pub fn SetCustomValidity(&mut self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlfontelement.rs
+++ b/src/components/script/dom/htmlfontelement.rs
@@ -31,7 +31,7 @@ impl HTMLFontElement {
         ~""
     }
 
-    pub fn SetColor(&mut self, _color: &DOMString) -> ErrorResult {
+    pub fn SetColor(&mut self, _color: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLFontElement {
         ~""
     }
 
-    pub fn SetFace(&mut self, _face: &DOMString) -> ErrorResult {
+    pub fn SetFace(&mut self, _face: DOMString) -> ErrorResult {
         Ok(())
     }
     
@@ -47,7 +47,7 @@ impl HTMLFontElement {
         ~""
     }
 
-    pub fn SetSize(&mut self, _size: &DOMString) -> ErrorResult {
+    pub fn SetSize(&mut self, _size: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlformelement.rs
+++ b/src/components/script/dom/htmlformelement.rs
@@ -32,7 +32,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetAcceptCharset(&mut self, _accept_charset: &DOMString) -> ErrorResult {
+    pub fn SetAcceptCharset(&mut self, _accept_charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -40,7 +40,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetAction(&mut self, _action: &DOMString) -> ErrorResult {
+    pub fn SetAction(&mut self, _action: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -48,7 +48,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetAutocomplete(&mut self, _autocomplete: &DOMString) -> ErrorResult {
+    pub fn SetAutocomplete(&mut self, _autocomplete: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -56,7 +56,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetEnctype(&mut self, _enctype: &DOMString) -> ErrorResult {
+    pub fn SetEnctype(&mut self, _enctype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -64,7 +64,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetEncoding(&mut self, _encoding: &DOMString) -> ErrorResult {
+    pub fn SetEncoding(&mut self, _encoding: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -72,7 +72,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetMethod(&mut self, _method: &DOMString) -> ErrorResult {
+    pub fn SetMethod(&mut self, _method: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl HTMLFormElement {
         ~""
     }
 
-    pub fn SetTarget(&mut self, _target: &DOMString) -> ErrorResult {
+    pub fn SetTarget(&mut self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlframeelement.rs
+++ b/src/components/script/dom/htmlframeelement.rs
@@ -32,7 +32,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -40,7 +40,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetScrolling(&mut self, _scrolling: &DOMString) -> ErrorResult {
+    pub fn SetScrolling(&mut self, _scrolling: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -48,7 +48,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -56,7 +56,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetFrameBorder(&mut self, _frameborder: &DOMString) -> ErrorResult {
+    pub fn SetFrameBorder(&mut self, _frameborder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -64,7 +64,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetLongDesc(&mut self, _longdesc: &DOMString) -> ErrorResult {
+    pub fn SetLongDesc(&mut self, _longdesc: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetMarginHeight(&mut self, _height: &DOMString) -> ErrorResult {
+    pub fn SetMarginHeight(&mut self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl HTMLFrameElement {
         ~""
     }
 
-    pub fn SetMarginWidth(&mut self, _height: &DOMString) -> ErrorResult {
+    pub fn SetMarginWidth(&mut self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlframesetelement.rs
+++ b/src/components/script/dom/htmlframesetelement.rs
@@ -31,7 +31,7 @@ impl HTMLFrameSetElement {
         ~""
     }
 
-    pub fn SetCols(&mut self, _cols: &DOMString) -> ErrorResult {
+    pub fn SetCols(&mut self, _cols: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLFrameSetElement {
         ~""
     }
 
-    pub fn SetRows(&mut self, _rows: &DOMString) -> ErrorResult {
+    pub fn SetRows(&mut self, _rows: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlheadingelement.rs
+++ b/src/components/script/dom/htmlheadingelement.rs
@@ -42,6 +42,6 @@ impl HTMLHeadingElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) {
+    pub fn SetAlign(&mut self, _align: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlhrelement.rs
+++ b/src/components/script/dom/htmlhrelement.rs
@@ -31,7 +31,7 @@ impl HTMLHRElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLHRElement {
         ~""
     }
 
-    pub fn SetColor(&mut self, _color: &DOMString) -> ErrorResult {
+    pub fn SetColor(&mut self, _color: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLHRElement {
         ~""
     }
 
-    pub fn SetSize(&mut self, _size: &DOMString) -> ErrorResult {
+    pub fn SetSize(&mut self, _size: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLHRElement {
         ~""
     }
 
-    pub fn SetWidth(&mut self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlhtmlelement.rs
+++ b/src/components/script/dom/htmlhtmlelement.rs
@@ -31,7 +31,7 @@ impl HTMLHtmlElement {
         ~""
     }
 
-    pub fn SetVersion(&mut self, _version: &DOMString) -> ErrorResult {
+    pub fn SetVersion(&mut self, _version: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -81,7 +81,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetSrcdoc(&mut self, _srcdoc: &DOMString) -> ErrorResult {
+    pub fn SetSrcdoc(&mut self, _srcdoc: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -97,23 +97,23 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
     pub fn Sandbox(&self, _abstract_self: AbstractNode<ScriptView>) -> DOMString {
-        match self.htmlelement.element.GetAttribute(&~"sandbox") {
+        match self.htmlelement.element.GetAttribute(~"sandbox") {
             Some(s) => s.to_owned(),
             None => ~"",
         }
     }
 
-    pub fn SetSandbox(&mut self, abstract_self: AbstractNode<ScriptView>, sandbox: &DOMString) {
-        self.htmlelement.element.SetAttribute(abstract_self, &~"sandbox", sandbox);
+    pub fn SetSandbox(&mut self, abstract_self: AbstractNode<ScriptView>, sandbox: DOMString) {
+        self.htmlelement.element.SetAttribute(abstract_self, ~"sandbox", sandbox);
     }
 
-    pub fn AfterSetAttr(&mut self, name: &DOMString, value: &DOMString) {
-        if "sandbox" == *name {
+    pub fn AfterSetAttr(&mut self, name: DOMString, value: DOMString) {
+        if "sandbox" == name {
             let mut modes = AllowNothing as u8;
             for word in value.split_iter(' ') {
                 modes |= match word.to_ascii_lower().as_slice() {
@@ -142,7 +142,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetWidth(&mut self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -150,7 +150,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetHeight(&mut self, _height: &DOMString) -> ErrorResult {
+    pub fn SetHeight(&mut self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -166,7 +166,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -174,7 +174,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetScrolling(&mut self, _scrolling: &DOMString) -> ErrorResult {
+    pub fn SetScrolling(&mut self, _scrolling: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -182,7 +182,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetFrameBorder(&mut self, _frameborder: &DOMString) -> ErrorResult {
+    pub fn SetFrameBorder(&mut self, _frameborder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -190,7 +190,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetLongDesc(&mut self, _longdesc: &DOMString) -> ErrorResult {
+    pub fn SetLongDesc(&mut self, _longdesc: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -198,7 +198,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetMarginHeight(&mut self, _marginheight: &DOMString) -> ErrorResult {
+    pub fn SetMarginHeight(&mut self, _marginheight: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -206,7 +206,7 @@ impl HTMLIFrameElement {
         ~""
     }
 
-    pub fn SetMarginWidth(&mut self, _marginwidth: &DOMString) -> ErrorResult {
+    pub fn SetMarginWidth(&mut self, _marginwidth: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -57,8 +57,8 @@ impl HTMLImageElement {
         }
     }
 
-    pub fn AfterSetAttr(&mut self, name: &DOMString, _value: &DOMString) {
-        if "src" == *name {
+    pub fn AfterSetAttr(&mut self, name: DOMString, _value: DOMString) {
+        if "src" == name {
             let document = self.htmlelement.element.node.owner_doc();
             let window = document.document().window;
             let url = window.page.url.as_ref().map(|&(ref url, _)| url.clone());
@@ -70,7 +70,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetAlt(&mut self, _alt: &DOMString) -> ErrorResult {
+    pub fn SetAlt(&mut self, _alt: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl HTMLImageElement {
 
     pub fn SetSrc(&mut self,
                   abstract_self: AbstractNode<ScriptView>,
-                  src: &DOMString) -> ErrorResult {
+                  src: DOMString) -> ErrorResult {
         let node = &mut self.htmlelement.element;
         node.set_attr(abstract_self, ~"src", src.clone());
         Ok(())
@@ -90,7 +90,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetCrossOrigin(&mut self, _cross_origin: &DOMString) -> ErrorResult {
+    pub fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -98,7 +98,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetUseMap(&mut self, _use_map: &DOMString) -> ErrorResult {
+    pub fn SetUseMap(&mut self, _use_map: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -164,7 +164,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -172,7 +172,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -196,7 +196,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetLongDesc(&mut self, _longdesc: &DOMString) -> ErrorResult {
+    pub fn SetLongDesc(&mut self, _longdesc: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -204,7 +204,7 @@ impl HTMLImageElement {
         ~""
     }
 
-    pub fn SetBorder(&mut self, _border: &DOMString) -> ErrorResult {
+    pub fn SetBorder(&mut self, _border: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -31,7 +31,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetAccept(&mut self, _accept: &DOMString) -> ErrorResult {
+    pub fn SetAccept(&mut self, _accept: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetAlt(&mut self, _alt: &DOMString) -> ErrorResult {
+    pub fn SetAlt(&mut self, _alt: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetAutocomplete(&mut self, _autocomple: &DOMString) -> ErrorResult {
+    pub fn SetAutocomplete(&mut self, _autocomple: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -86,7 +86,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetFormAction(&mut self, _form_action: &DOMString) -> ErrorResult {
+    pub fn SetFormAction(&mut self, _form_action: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetFormEnctype(&mut self, _form_enctype: &DOMString) -> ErrorResult {
+    pub fn SetFormEnctype(&mut self, _form_enctype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -102,7 +102,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetFormMethod(&mut self, _form_method: &DOMString) -> ErrorResult {
+    pub fn SetFormMethod(&mut self, _form_method: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -118,7 +118,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetFormTarget(&mut self, _form_target: &DOMString) -> ErrorResult {
+    pub fn SetFormTarget(&mut self, _form_target: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -141,7 +141,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetInputMode(&mut self, _input_mode: &DOMString) -> ErrorResult {
+    pub fn SetInputMode(&mut self, _input_mode: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -149,7 +149,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetMax(&mut self, _max: &DOMString) -> ErrorResult {
+    pub fn SetMax(&mut self, _max: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -165,7 +165,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetMin(&mut self, _min: &DOMString) -> ErrorResult {
+    pub fn SetMin(&mut self, _min: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -181,7 +181,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -189,7 +189,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetPattern(&mut self, _pattern: &DOMString) -> ErrorResult {
+    pub fn SetPattern(&mut self, _pattern: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -197,7 +197,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetPlaceholder(&mut self, _placeholder: &DOMString) -> ErrorResult {
+    pub fn SetPlaceholder(&mut self, _placeholder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -229,7 +229,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -237,7 +237,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetStep(&mut self, _step: &DOMString) -> ErrorResult {
+    pub fn SetStep(&mut self, _step: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -245,7 +245,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -253,7 +253,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetDefaultValue(&mut self, _default_value: &DOMString) -> ErrorResult {
+    pub fn SetDefaultValue(&mut self, _default_value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -261,7 +261,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -287,7 +287,7 @@ impl HTMLInputElement {
         false
     }
 
-    pub fn SetCustomValidity(&self, _error: &DOMString) {
+    pub fn SetCustomValidity(&self, _error: DOMString) {
     }
 
     pub fn Select(&self) {
@@ -313,7 +313,7 @@ impl HTMLInputElement {
         Ok(~"")
     }
 
-    pub fn SetSelectionDirection(&mut self, _selection_direction: &DOMString) -> ErrorResult {
+    pub fn SetSelectionDirection(&mut self, _selection_direction: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -321,7 +321,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -329,7 +329,7 @@ impl HTMLInputElement {
         ~""
     }
 
-    pub fn SetUseMap(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetUseMap(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmllabelelement.rs
+++ b/src/components/script/dom/htmllabelelement.rs
@@ -31,6 +31,6 @@ impl HTMLLabelElement {
         ~""
     }
 
-    pub fn SetHtmlFor(&mut self, _html_for: &DOMString) {
+    pub fn SetHtmlFor(&mut self, _html_for: DOMString) {
     }
 }

--- a/src/components/script/dom/htmllegendelement.rs
+++ b/src/components/script/dom/htmllegendelement.rs
@@ -31,7 +31,7 @@ impl HTMLLegendElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmllielement.rs
+++ b/src/components/script/dom/htmllielement.rs
@@ -39,7 +39,7 @@ impl HTMLLIElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -38,7 +38,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetHref(&mut self, _href: &DOMString) -> ErrorResult {
+    pub fn SetHref(&mut self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -46,7 +46,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetCrossOrigin(&mut self, _cross_origin: &DOMString) -> ErrorResult {
+    pub fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -54,7 +54,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetRel(&mut self, _rel: &DOMString) -> ErrorResult {
+    pub fn SetRel(&mut self, _rel: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -62,7 +62,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetMedia(&mut self, _media: &DOMString) -> ErrorResult {
+    pub fn SetMedia(&mut self, _media: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -70,7 +70,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetHreflang(&mut self, _href: &DOMString) -> ErrorResult {
+    pub fn SetHreflang(&mut self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -78,7 +78,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -86,7 +86,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetCharset(&mut self, _charset: &DOMString) -> ErrorResult {
+    pub fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetRev(&mut self, _rev: &DOMString) -> ErrorResult {
+    pub fn SetRev(&mut self, _rev: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -102,7 +102,7 @@ impl HTMLLinkElement {
         ~""
     }
 
-    pub fn SetTarget(&mut self, _target: &DOMString) -> ErrorResult {
+    pub fn SetTarget(&mut self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlmapelement.rs
+++ b/src/components/script/dom/htmlmapelement.rs
@@ -32,7 +32,7 @@ impl HTMLMapElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlmediaelement.rs
+++ b/src/components/script/dom/htmlmediaelement.rs
@@ -24,7 +24,7 @@ impl HTMLMediaElement {
         ~""
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -36,7 +36,7 @@ impl HTMLMediaElement {
         ~""
     }
 
-    pub fn SetCrossOrigin(&mut self, _cross_origin: &DOMString) -> ErrorResult {
+    pub fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -44,14 +44,14 @@ impl HTMLMediaElement {
         ~""
     }
 
-    pub fn SetPreload(&mut self, _preload: &DOMString) -> ErrorResult {
+    pub fn SetPreload(&mut self, _preload: DOMString) -> ErrorResult {
         Ok(())
     }
 
     pub fn Load(&self) {
     }
 
-    pub fn CanPlayType(&self, _type: &DOMString) -> DOMString {
+    pub fn CanPlayType(&self, _type: DOMString) -> DOMString {
         ~""
     }
 

--- a/src/components/script/dom/htmlmetaelement.rs
+++ b/src/components/script/dom/htmlmetaelement.rs
@@ -31,7 +31,7 @@ impl HTMLMetaElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLMetaElement {
         ~""
     }
 
-    pub fn SetHttpEquiv(&mut self, _http_equiv: &DOMString) -> ErrorResult {
+    pub fn SetHttpEquiv(&mut self, _http_equiv: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLMetaElement {
         ~""
     }
 
-    pub fn SetContent(&mut self, _content: &DOMString) -> ErrorResult {
+    pub fn SetContent(&mut self, _content: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLMetaElement {
         ~""
     }
 
-    pub fn SetScheme(&mut self, _scheme: &DOMString) -> ErrorResult {
+    pub fn SetScheme(&mut self, _scheme: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlmodelement.rs
+++ b/src/components/script/dom/htmlmodelement.rs
@@ -31,7 +31,7 @@ impl HTMLModElement {
         ~""
     }
 
-    pub fn SetCite(&mut self, _cite: &DOMString) -> ErrorResult {
+    pub fn SetCite(&mut self, _cite: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLModElement {
         ~""
     }
 
-    pub fn SetDateTime(&mut self, _datetime: &DOMString) -> ErrorResult {
+    pub fn SetDateTime(&mut self, _datetime: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -33,7 +33,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetData(&mut self, _data: &DOMString) -> ErrorResult {
+    pub fn SetData(&mut self, _data: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -41,7 +41,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -49,7 +49,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetUseMap(&mut self, _use_map: &DOMString) -> ErrorResult {
+    pub fn SetUseMap(&mut self, _use_map: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -69,7 +69,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetWidth(&mut self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -77,7 +77,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetHeight(&mut self, _height: &DOMString) -> ErrorResult {
+    pub fn SetHeight(&mut self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -106,14 +106,14 @@ impl HTMLObjectElement {
         false
     }
 
-    pub fn SetCustomValidity(&mut self, _error: &DOMString) {
+    pub fn SetCustomValidity(&mut self, _error: DOMString) {
     }
 
     pub fn Align(&self) -> DOMString {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -121,7 +121,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetArchive(&mut self, _archive: &DOMString) -> ErrorResult {
+    pub fn SetArchive(&mut self, _archive: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -129,7 +129,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetCode(&mut self, _code: &DOMString) -> ErrorResult {
+    pub fn SetCode(&mut self, _code: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -153,7 +153,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetStandby(&mut self, _standby: &DOMString) -> ErrorResult {
+    pub fn SetStandby(&mut self, _standby: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -169,7 +169,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetCodeBase(&mut self, _codebase: &DOMString) -> ErrorResult {
+    pub fn SetCodeBase(&mut self, _codebase: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -177,7 +177,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetCodeType(&mut self, _codetype: &DOMString) -> ErrorResult {
+    pub fn SetCodeType(&mut self, _codetype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -185,7 +185,7 @@ impl HTMLObjectElement {
         ~""
     }
 
-    pub fn SetBorder(&mut self, _border: &DOMString) -> ErrorResult {
+    pub fn SetBorder(&mut self, _border: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlolistelement.rs
+++ b/src/components/script/dom/htmlolistelement.rs
@@ -47,7 +47,7 @@ impl HTMLOListElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmloptgroupelement.rs
+++ b/src/components/script/dom/htmloptgroupelement.rs
@@ -39,7 +39,7 @@ impl HTMLOptGroupElement {
         ~""
     }
 
-    pub fn SetLabel(&mut self, _label: &DOMString) -> ErrorResult {
+    pub fn SetLabel(&mut self, _label: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -43,7 +43,7 @@ impl HTMLOptionElement {
         ~""
     }
 
-    pub fn SetLabel(&mut self, _label: &DOMString) -> ErrorResult {
+    pub fn SetLabel(&mut self, _label: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -67,7 +67,7 @@ impl HTMLOptionElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -75,7 +75,7 @@ impl HTMLOptionElement {
         ~""
     }
 
-    pub fn SetText(&mut self, _text: &DOMString) -> ErrorResult {
+    pub fn SetText(&mut self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmloutputelement.rs
+++ b/src/components/script/dom/htmloutputelement.rs
@@ -36,7 +36,7 @@ impl HTMLOutputElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -48,7 +48,7 @@ impl HTMLOutputElement {
         ~""
     }
 
-    pub fn SetDefaultValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetDefaultValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -56,7 +56,7 @@ impl HTMLOutputElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -79,7 +79,7 @@ impl HTMLOutputElement {
         ~""
     }
 
-    pub fn SetValidationMessage(&mut self, _message: &DOMString) -> ErrorResult {
+    pub fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -87,6 +87,6 @@ impl HTMLOutputElement {
         true
     }
 
-    pub fn SetCustomValidity(&mut self, _error: &DOMString) {
+    pub fn SetCustomValidity(&mut self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlparagraphelement.rs
+++ b/src/components/script/dom/htmlparagraphelement.rs
@@ -31,7 +31,7 @@ impl HTMLParagraphElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlparamelement.rs
+++ b/src/components/script/dom/htmlparamelement.rs
@@ -31,7 +31,7 @@ impl HTMLParamElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLParamElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) -> ErrorResult {
+    pub fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLParamElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLParamElement {
         ~""
     }
 
-    pub fn SetValueType(&mut self, _value_type: &DOMString) -> ErrorResult {
+    pub fn SetValueType(&mut self, _value_type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlquoteelement.rs
+++ b/src/components/script/dom/htmlquoteelement.rs
@@ -31,7 +31,7 @@ impl HTMLQuoteElement {
         ~""
     }
 
-    pub fn SetCite(&self, _cite: &DOMString) -> ErrorResult {
+    pub fn SetCite(&self, _cite: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlscriptelement.rs
+++ b/src/components/script/dom/htmlscriptelement.rs
@@ -35,7 +35,7 @@ impl HTMLScriptElement {
         }
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -43,7 +43,7 @@ impl HTMLScriptElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl HTMLScriptElement {
         ~""
     }
 
-    pub fn SetCharset(&mut self, _charset: &DOMString) -> ErrorResult {
+    pub fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -75,7 +75,7 @@ impl HTMLScriptElement {
         ~""
     }
 
-    pub fn SetCrossOrigin(&mut self, _cross_origin: &DOMString) -> ErrorResult {
+    pub fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -83,7 +83,7 @@ impl HTMLScriptElement {
         ~""
     }
 
-    pub fn SetText(&mut self, _text: &DOMString) -> ErrorResult {
+    pub fn SetText(&mut self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -91,7 +91,7 @@ impl HTMLScriptElement {
         ~""
     }
 
-    pub fn SetEvent(&mut self, _event: &DOMString) -> ErrorResult {
+    pub fn SetEvent(&mut self, _event: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -99,7 +99,7 @@ impl HTMLScriptElement {
         ~""
     }
 
-    pub fn SetHtmlFor(&mut self, _html_for: &DOMString) -> ErrorResult {
+    pub fn SetHtmlFor(&mut self, _html_for: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -60,7 +60,7 @@ impl HTMLSelectElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl HTMLSelectElement {
         None
     }
 
-    pub fn NamedItem(&self, _name: &DOMString) -> Option<AbstractNode<ScriptView>> {
+    pub fn NamedItem(&self, _name: DOMString) -> Option<AbstractNode<ScriptView>> {
         None
     }
 
@@ -126,7 +126,7 @@ impl HTMLSelectElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) {
+    pub fn SetValue(&mut self, _value: DOMString) {
     }
 
     pub fn WillValidate(&self) -> bool {
@@ -148,7 +148,7 @@ impl HTMLSelectElement {
         ~""
     }
 
-    pub fn SetValidationMessage(&mut self, _message: &DOMString) -> ErrorResult {
+    pub fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -156,6 +156,6 @@ impl HTMLSelectElement {
         true
     }
 
-    pub fn SetCustomValidity(&mut self, _error: &DOMString) {
+    pub fn SetCustomValidity(&mut self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlsourceelement.rs
+++ b/src/components/script/dom/htmlsourceelement.rs
@@ -31,7 +31,7 @@ impl HTMLSourceElement {
         ~""
     }
     
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLSourceElement {
         ~""
     }
     
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLSourceElement {
         ~""
     }
     
-    pub fn SetMedia(&mut self, _media: &DOMString) -> ErrorResult {
+    pub fn SetMedia(&mut self, _media: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -38,7 +38,7 @@ impl HTMLStyleElement {
         ~""
     }
 
-    pub fn SetMedia(&mut self, _media: &DOMString) -> ErrorResult {
+    pub fn SetMedia(&mut self, _media: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -46,7 +46,7 @@ impl HTMLStyleElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmltablecaptionelement.rs
+++ b/src/components/script/dom/htmltablecaptionelement.rs
@@ -31,7 +31,7 @@ impl HTMLTableCaptionElement {
         ~""
     }
     
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltablecellelement.rs
+++ b/src/components/script/dom/htmltablecellelement.rs
@@ -40,7 +40,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetHeaders(&self, _headers: &DOMString) -> ErrorResult {
+    pub fn SetHeaders(&self, _headers: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -56,7 +56,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetAbbr(&self, _abbr: &DOMString) -> ErrorResult {
+    pub fn SetAbbr(&self, _abbr: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -64,7 +64,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetScope(&self, _abbr: &DOMString) -> ErrorResult {
+    pub fn SetScope(&self, _abbr: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -72,7 +72,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetAlign(&self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetAxis(&self, _axis: &DOMString) -> ErrorResult {
+    pub fn SetAxis(&self, _axis: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetHeight(&self, _height: &DOMString) -> ErrorResult {
+    pub fn SetHeight(&self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetWidth(&self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -104,7 +104,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetCh(&self, _ch: &DOMString) -> ErrorResult {
+    pub fn SetCh(&self, _ch: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -112,7 +112,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetChOff(&self, _ch_off: &DOMString) -> ErrorResult {
+    pub fn SetChOff(&self, _ch_off: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -128,7 +128,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetVAlign(&self, _valign: &DOMString) -> ErrorResult {
+    pub fn SetVAlign(&self, _valign: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -136,7 +136,7 @@ impl HTMLTableCellElement {
         ~""
     }
 
-    pub fn SetBgColor(&self, _bg_color: &DOMString) -> ErrorResult {
+    pub fn SetBgColor(&self, _bg_color: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltablecolelement.rs
+++ b/src/components/script/dom/htmltablecolelement.rs
@@ -39,7 +39,7 @@ impl HTMLTableColElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLTableColElement {
         ~""
     }
 
-    pub fn SetCh(&mut self, _ch: &DOMString) -> ErrorResult {
+    pub fn SetCh(&mut self, _ch: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLTableColElement {
         ~""
     }
 
-    pub fn SetChOff(&mut self, _ch_off: &DOMString) -> ErrorResult {
+    pub fn SetChOff(&mut self, _ch_off: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl HTMLTableColElement {
         ~""
     }
 
-    pub fn SetVAlign(&mut self, _v_align: &DOMString) -> ErrorResult {
+    pub fn SetVAlign(&mut self, _v_align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLTableColElement {
         ~""
     }
 
-    pub fn SetWidth(&mut self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltableelement.rs
+++ b/src/components/script/dom/htmltableelement.rs
@@ -54,7 +54,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetAlign(&self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -62,7 +62,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetBorder(&self, _border: &DOMString) -> ErrorResult {
+    pub fn SetBorder(&self, _border: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -70,7 +70,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetFrame(&self, _frame: &DOMString) -> ErrorResult {
+    pub fn SetFrame(&self, _frame: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -78,7 +78,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetRules(&self, _rules: &DOMString) -> ErrorResult {
+    pub fn SetRules(&self, _rules: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -86,7 +86,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetSummary(&self, _summary: &DOMString) -> ErrorResult {
+    pub fn SetSummary(&self, _summary: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetWidth(&self, _width: &DOMString) -> ErrorResult {
+    pub fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -102,7 +102,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetBgColor(&self, _bg_color: &DOMString) -> ErrorResult {
+    pub fn SetBgColor(&self, _bg_color: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -110,7 +110,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetCellPadding(&self, _cell_padding: &DOMString) -> ErrorResult {
+    pub fn SetCellPadding(&self, _cell_padding: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -118,7 +118,7 @@ impl HTMLTableElement {
         ~""
     }
 
-    pub fn SetCellSpacing(&self, _cell_spacing: &DOMString) -> ErrorResult {
+    pub fn SetCellSpacing(&self, _cell_spacing: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltablerowelement.rs
+++ b/src/components/script/dom/htmltablerowelement.rs
@@ -51,7 +51,7 @@ impl HTMLTableRowElement {
         ~""
     }
 
-    pub fn SetAlign(&self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -59,7 +59,7 @@ impl HTMLTableRowElement {
         ~""
     }
 
-    pub fn SetCh(&self, _ch: &DOMString) -> ErrorResult {
+    pub fn SetCh(&self, _ch: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -67,7 +67,7 @@ impl HTMLTableRowElement {
         ~""
     }
 
-    pub fn SetChOff(&self, _ch_off: &DOMString) -> ErrorResult {
+    pub fn SetChOff(&self, _ch_off: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -75,7 +75,7 @@ impl HTMLTableRowElement {
         ~""
     }
 
-    pub fn SetVAlign(&self, _v_align: &DOMString) -> ErrorResult {
+    pub fn SetVAlign(&self, _v_align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -83,7 +83,7 @@ impl HTMLTableRowElement {
         ~""
     }
 
-    pub fn SetBgColor(&self, _bg_color: &DOMString) -> ErrorResult {
+    pub fn SetBgColor(&self, _bg_color: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltablesectionelement.rs
+++ b/src/components/script/dom/htmltablesectionelement.rs
@@ -35,7 +35,7 @@ impl HTMLTableSectionElement {
         ~""
     }
 
-    pub fn SetAlign(&mut self, _align: &DOMString) -> ErrorResult {
+    pub fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -43,7 +43,7 @@ impl HTMLTableSectionElement {
         ~""
     }
 
-    pub fn SetCh(&mut self, _ch: &DOMString) -> ErrorResult {
+    pub fn SetCh(&mut self, _ch: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl HTMLTableSectionElement {
         ~""
     }
 
-    pub fn SetChOff(&mut self, _ch_off: &DOMString) -> ErrorResult {
+    pub fn SetChOff(&mut self, _ch_off: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -59,7 +59,7 @@ impl HTMLTableSectionElement {
         ~""
     }
 
-    pub fn SetVAlign(&mut self, _v_align: &DOMString) -> ErrorResult {
+    pub fn SetVAlign(&mut self, _v_align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -63,7 +63,7 @@ impl HTMLTextAreaElement {
         ~""
     }
 
-    pub fn SetName(&mut self, _name: &DOMString) -> ErrorResult {
+    pub fn SetName(&mut self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl HTMLTextAreaElement {
         ~""
     }
 
-    pub fn SetPlaceholder(&mut self, _placeholder: &DOMString) -> ErrorResult {
+    pub fn SetPlaceholder(&mut self, _placeholder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -103,7 +103,7 @@ impl HTMLTextAreaElement {
         ~""
     }
 
-    pub fn SetWrap(&mut self, _wrap: &DOMString) -> ErrorResult {
+    pub fn SetWrap(&mut self, _wrap: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -111,14 +111,14 @@ impl HTMLTextAreaElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) {
+    pub fn SetType(&mut self, _type: DOMString) {
     }
 
     pub fn DefaultValue(&self) -> DOMString {
         ~""
     }
 
-    pub fn SetDefaultValue(&mut self, _default_value: &DOMString) -> ErrorResult {
+    pub fn SetDefaultValue(&mut self, _default_value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -126,7 +126,7 @@ impl HTMLTextAreaElement {
         ~""
     }
 
-    pub fn SetValue(&mut self, _value: &DOMString) {
+    pub fn SetValue(&mut self, _value: DOMString) {
     }
 
     pub fn TextLength(&self) -> u32 {
@@ -153,7 +153,7 @@ impl HTMLTextAreaElement {
         false
     }
 
-    pub fn SetCustomValidity(&self, _error: &DOMString) {
+    pub fn SetCustomValidity(&self, _error: DOMString) {
     }
 
     pub fn Select(&self) {
@@ -179,10 +179,10 @@ impl HTMLTextAreaElement {
         Ok(~"")
     }
 
-    pub fn SetSelectionDirection(&self, _selection_direction: &DOMString) -> ErrorResult {
+    pub fn SetSelectionDirection(&self, _selection_direction: DOMString) -> ErrorResult {
         Ok(())
     }
 
-    pub fn SetRangeText(&self, _replacement: &DOMString) {
+    pub fn SetRangeText(&self, _replacement: DOMString) {
     }
 }

--- a/src/components/script/dom/htmltimeelement.rs
+++ b/src/components/script/dom/htmltimeelement.rs
@@ -31,7 +31,7 @@ impl HTMLTimeElement {
         ~""
     }
     
-    pub fn SetDateTime(&mut self, _dateTime: &DOMString) -> ErrorResult {
+    pub fn SetDateTime(&mut self, _dateTime: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltitleelement.rs
+++ b/src/components/script/dom/htmltitleelement.rs
@@ -31,7 +31,7 @@ impl HTMLTitleElement {
         ~""
     }
 
-    pub fn SetText(&mut self, _text: &DOMString) -> ErrorResult {
+    pub fn SetText(&mut self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltrackelement.rs
+++ b/src/components/script/dom/htmltrackelement.rs
@@ -31,7 +31,7 @@ impl HTMLTrackElement {
         ~""
     }
 
-    pub fn SetKind(&mut self, _kind: &DOMString) -> ErrorResult {
+    pub fn SetKind(&mut self, _kind: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -39,7 +39,7 @@ impl HTMLTrackElement {
         ~""
     }
 
-    pub fn SetSrc(&mut self, _src: &DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl HTMLTrackElement {
         ~""
     }
 
-    pub fn SetSrclang(&mut self, _srclang: &DOMString) -> ErrorResult {
+    pub fn SetSrclang(&mut self, _srclang: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -55,7 +55,7 @@ impl HTMLTrackElement {
         ~""
     }
 
-    pub fn SetLabel(&mut self, _label: &DOMString) -> ErrorResult {
+    pub fn SetLabel(&mut self, _label: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlulistelement.rs
+++ b/src/components/script/dom/htmlulistelement.rs
@@ -39,7 +39,7 @@ impl HTMLUListElement {
         ~""
     }
 
-    pub fn SetType(&mut self, _type: &DOMString) -> ErrorResult {
+    pub fn SetType(&mut self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlvideoelement.rs
+++ b/src/components/script/dom/htmlvideoelement.rs
@@ -55,7 +55,7 @@ impl HTMLVideoElement {
         ~""
     }
 
-    pub fn SetPoster(&mut self, _poster: &DOMString) -> ErrorResult {
+    pub fn SetPoster(&mut self, _poster: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/mouseevent.rs
+++ b/src/components/script/dom/mouseevent.rs
@@ -49,7 +49,7 @@ impl MouseEvent {
     }
 
     pub fn Constructor(owner: @mut Window,
-                       type_: &DOMString,
+                       type_: DOMString,
                        init: &MouseEventBinding::MouseEventInit) -> Fallible<AbstractEvent> {
         let ev = MouseEvent::new(owner);
         ev.mut_mouseevent().InitMouseEvent(type_, init.bubbles, init.cancelable, init.view,
@@ -105,13 +105,13 @@ impl MouseEvent {
         self.related_target
     }
 
-    pub fn GetModifierState(&self, _keyArg: &DOMString) -> bool {
+    pub fn GetModifierState(&self, _keyArg: DOMString) -> bool {
         //TODO
         false
     }
 
     pub fn InitMouseEvent(&mut self,
-                          typeArg: &DOMString,
+                          typeArg: DOMString,
                           canBubbleArg: bool,
                           cancelableArg: bool,
                           viewArg: Option<@mut WindowProxy>,

--- a/src/components/script/dom/namespace.rs
+++ b/src/components/script/dom/namespace.rs
@@ -17,8 +17,8 @@ pub enum Namespace {
 }
 
 impl Namespace {
-    pub fn from_str(url: &Option<DOMString>) -> Namespace {
-        match null_str_as_empty_ref(url) {
+    pub fn from_str(url: Option<DOMString>) -> Namespace {
+        match null_str_as_empty_ref(&url) {
             &"http://www.w3.org/1999/xhtml" => HTML,
             &"http://www.w3.org/XML/1998/namespace" => XML,
             &"http://www.w3.org/2000/xmlns/" => XMLNS,

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -633,7 +633,7 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn SetNodeValue(&mut self, _abstract_self: AbstractNode<ScriptView>, _val: &Option<DOMString>) -> ErrorResult {
+    pub fn SetNodeValue(&mut self, _abstract_self: AbstractNode<ScriptView>, _val: Option<DOMString>) -> ErrorResult {
         Ok(())
     }
 
@@ -970,10 +970,10 @@ impl Node<ScriptView> {
 
     pub fn SetTextContent(&mut self,
                           abstract_self: AbstractNode<ScriptView>,
-                          value: &Option<DOMString>) -> ErrorResult {
+                          value: Option<DOMString>) -> ErrorResult {
         self.wait_until_safe_to_modify_dom();
 
-        let value = null_str_as_empty(value);
+        let value = null_str_as_empty(&value);
         match self.type_id {
           DocumentFragmentNodeTypeId | ElementNodeTypeId(*) => {
             // Step 1-2.
@@ -981,7 +981,7 @@ impl Node<ScriptView> {
                 None
             } else {
                 let document = self.owner_doc();
-                Some(document.document().CreateTextNode(document, &value))
+                Some(document.document().CreateTextNode(document, value))
             };
             // Step 3.
             Node::replace_all(node, abstract_self);
@@ -1049,15 +1049,15 @@ impl Node<ScriptView> {
         false
     }
 
-    pub fn LookupPrefix(&self, _prefix: &Option<DOMString>) -> Option<DOMString> {
+    pub fn LookupPrefix(&self, _prefix: Option<DOMString>) -> Option<DOMString> {
         None
     }
 
-    pub fn LookupNamespaceURI(&self, _namespace: &Option<DOMString>) -> Option<DOMString> {
+    pub fn LookupNamespaceURI(&self, _namespace: Option<DOMString>) -> Option<DOMString> {
         None
     }
 
-    pub fn IsDefaultNamespace(&self, _namespace: &Option<DOMString>) -> bool {
+    pub fn IsDefaultNamespace(&self, _namespace: Option<DOMString>) -> bool {
         false
     }
 

--- a/src/components/script/dom/text.rs
+++ b/src/components/script/dom/text.rs
@@ -26,7 +26,7 @@ impl Text {
         Node::reflect_node(@mut node, document, TextBinding::Wrap)
     }
 
-    pub fn Constructor(owner: @mut Window, text: &DOMString) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn Constructor(owner: @mut Window, text: DOMString) -> Fallible<AbstractNode<ScriptView>> {
         Ok(Text::new(text.clone(), owner.Document()))
     }
 

--- a/src/components/script/dom/uievent.rs
+++ b/src/components/script/dom/uievent.rs
@@ -33,7 +33,7 @@ impl UIEvent {
     }
 
     pub fn Constructor(owner: @mut Window,
-                       type_: &DOMString,
+                       type_: DOMString,
                        init: &UIEventBinding::UIEventInit) -> Fallible<AbstractEvent> {
         let ev = UIEvent::new(owner, UIEventTypeId);
         ev.mut_uievent().InitUIEvent(type_, init.parent.bubbles, init.parent.cancelable,
@@ -50,7 +50,7 @@ impl UIEvent {
     }
 
     pub fn InitUIEvent(&mut self,
-                       type_: &DOMString,
+                       type_: DOMString,
                        can_bubble: bool,
                        cancelable: bool,
                        view: Option<@mut WindowProxy>,

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -72,9 +72,9 @@ pub struct TimerData {
 }
 
 impl Window {
-    pub fn Alert(&self, s: &DOMString) {
+    pub fn Alert(&self, s: DOMString) {
         // Right now, just print to the console
-        println(format!("ALERT: {:s}", *s));
+        println(format!("ALERT: {:s}", s));
     }
 
     pub fn Close(&self) {
@@ -89,14 +89,14 @@ impl Window {
         ~""
     }
 
-    pub fn SetName(&self, _name: &DOMString) {
+    pub fn SetName(&self, _name: DOMString) {
     }
 
     pub fn Status(&self) -> DOMString {
         ~""
     }
 
-    pub fn SetStatus(&self, _status: &DOMString) {
+    pub fn SetStatus(&self, _status: DOMString) {
     }
 
     pub fn Closed(&self) -> bool {
@@ -123,18 +123,18 @@ impl Window {
         self.navigator.unwrap()
     }
 
-    pub fn Confirm(&self, _message: &DOMString) -> bool {
+    pub fn Confirm(&self, _message: DOMString) -> bool {
         false
     }
 
-    pub fn Prompt(&self, _message: &DOMString, _default: &DOMString) -> Option<DOMString> {
+    pub fn Prompt(&self, _message: DOMString, _default: DOMString) -> Option<DOMString> {
         None
     }
 
     pub fn Print(&self) {
     }
 
-    pub fn ShowModalDialog(&self, _cx: *JSContext, _url: &DOMString, _argument: JSVal) -> JSVal {
+    pub fn ShowModalDialog(&self, _cx: *JSContext, _url: DOMString, _argument: JSVal) -> JSVal {
         JSVAL_NULL
     }
 }

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -772,7 +772,7 @@ impl ScriptTask {
         // "load" event as soon as we've finished executing all scripts parsed during
         // the initial load.
         let event = Event::new(window, HTMLEventTypeId);
-        event.mut_event().InitEvent(&~"load", false, false);
+        event.mut_event().InitEvent(~"load", false, false);
         let doctarget = AbstractEventTarget::from_document(document);
         let wintarget = AbstractEventTarget::from_window(window);
         window.eventtarget.dispatch_event_with_target(wintarget, Some(doctarget), event);


### PR DESCRIPTION
This will fix #1201.
This maybe the work in progress.

@jdm:
- Should we pass `DOMString` directly to `dom::utils::null_str_as_...`?
- Do you have any good idea to update the comment in `CodegenRust.py`?
