### PR TITLE
unrendered content uses doc's background color

### DIFF
--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -4,7 +4,7 @@
 
 // The task that handles all rendering/painting.
 
-use azure::azure_hl::{B8G8R8A8, DrawTarget, StolenGLResources};
+use azure::azure_hl::{B8G8R8A8, Color, DrawTarget, StolenGLResources};
 use azure::AzFloat;
 use geom::matrix2d::Matrix2D;
 use geom::rect::Rect;
@@ -31,7 +31,8 @@ use render_context::RenderContext;
 
 pub struct RenderLayer<T> {
     display_list: Arc<DisplayList<T>>,
-    size: Size2D<uint>
+    size: Size2D<uint>,
+    color: Color
 }
 
 pub enum Msg<T> {
@@ -178,7 +179,7 @@ impl<C: RenderListener + Send,T:Send+Freeze> RenderTask<C,T> {
                 RenderMsg(render_layer) => {
                     if self.paint_permission {
                         self.epoch.next();
-                        self.compositor.set_layer_page_size(self.id, render_layer.size, self.epoch);
+                        self.compositor.set_layer_page_size_and_color(self.id, render_layer.size, self.epoch, render_layer.color);
                     } else {
                         self.constellation_chan.send(RendererReadyMsg(self.id));
                     }
@@ -202,7 +203,7 @@ impl<C: RenderListener + Send,T:Send+Freeze> RenderTask<C,T> {
                     match self.render_layer {
                         Some(ref render_layer) => {
                             self.epoch.next();
-                            self.compositor.set_layer_page_size(self.id, render_layer.size, self.epoch);
+                            self.compositor.set_layer_page_size_and_color(self.id, render_layer.size, self.epoch, render_layer.color);
                         }
                         None => {}
                     }

--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -23,6 +23,8 @@ use servo_msg::constellation_msg::PipelineId;
 use std::cell::Cell;
 use windowing::{MouseWindowEvent, MouseWindowClickEvent, MouseWindowMouseDownEvent};
 use windowing::{MouseWindowMouseUpEvent};
+use azure::azure_hl::Color;
+use gfx;
 
 #[cfg(not(target_os="macos"))]
 use layers::texturegl::TextureTarget2D;
@@ -69,6 +71,9 @@ pub struct CompositorLayer {
 
     /// True if CPU rendering is enabled, false if we're using GPU rendering.
     cpu_painting: bool,
+
+    /// The color to use for the unrendered-content void
+    unrendered_color: Color
 }
 
 /// Helper struct for keeping CompositorLayer children organized.
@@ -122,6 +127,7 @@ impl CompositorLayer {
             epoch: Epoch(0),
             scroll_behavior: Scroll,
             cpu_painting: cpu_painting,
+            unrendered_color: gfx::color::rgba(0.0, 0.0, 0.0, 0.0),
         }
     }
     

--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -7,7 +7,7 @@ pub use windowing;
 use constellation::SendableFrameTree;
 use windowing::WindowMethods;
 
-use azure::azure_hl::SourceSurfaceMethods;
+use azure::azure_hl::{SourceSurfaceMethods, Color};
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
@@ -71,10 +71,12 @@ impl RenderListener for CompositorChan {
         let Size2D { width, height } = page_size;
         self.chan.send(NewLayer(id, Size2D(width as f32, height as f32)))
     }
-    fn set_layer_page_size(&self, id: PipelineId, page_size: Size2D<uint>, epoch: Epoch) {
+    fn set_layer_page_size_and_color(&self, id: PipelineId, page_size: Size2D<uint>, epoch: Epoch, color: Color) {
         let Size2D { width, height } = page_size;
+        self.chan.send(SetUnRenderedColor(id, color));
         self.chan.send(SetLayerPageSize(id, Size2D(width as f32, height as f32), epoch))
     }
+
     fn set_layer_clip_rect(&self, id: PipelineId, new_rect: Rect<uint>) {
         let new_rect = Rect(Point2D(new_rect.origin.x as f32,
                                     new_rect.origin.y as f32),
@@ -132,6 +134,8 @@ pub enum Msg {
     ChangeRenderState(RenderState),
     /// Sets the channel to the current layout and render tasks, along with their id
     SetIds(SendableFrameTree, Chan<()>, ConstellationChan),
+
+    SetUnRenderedColor(PipelineId, Color),
 }
 
 pub struct CompositorTask {

--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -89,6 +89,16 @@ pub fn run_compositor(compositor: &CompositorTask) {
                 ChangeReadyState(ready_state) => window.set_ready_state(ready_state),
                 ChangeRenderState(render_state) => window.set_render_state(render_state),
 
+                SetUnRenderedColor(id, color) => {
+                  match compositor_layer {
+                      Some(ref mut layer) => {
+                          layer.unrendered_color = color;
+                      }
+                      None => {}
+                  }
+                }
+
+
                 SetIds(frame_tree, response_chan, new_constellation_chan) => {
                     response_chan.send(());
 
@@ -332,8 +342,16 @@ pub fn run_compositor(compositor: &CompositorTask) {
             debug!("compositor: compositing");
             // Adjust the layer dimensions as necessary to correspond to the size of the window.
             scene.size = window.size();
-
             // Render the scene.
+            match compositor_layer {
+                Some(ref mut layer) => {
+                    scene.background_color.r = layer.unrendered_color.r;
+                    scene.background_color.g = layer.unrendered_color.g;
+                    scene.background_color.b = layer.unrendered_color.b;
+                    scene.background_color.a = layer.unrendered_color.a;
+                }
+                None => {}
+            }
             rendergl::render_scene(context, &scene);
         }
 

--- a/src/components/main/compositing/run_headless.rs
+++ b/src/components/main/compositing/run_headless.rs
@@ -15,7 +15,7 @@ pub fn run_compositor(compositor: &CompositorTask) {
         match compositor.port.recv() {
             Exit => break,
 
-            GetGraphicsMetadata(chan) => {
+             GetGraphicsMetadata(chan) => {
                 unsafe {
                     chan.send(intrinsics::uninit());
                 }
@@ -30,7 +30,8 @@ pub fn run_compositor(compositor: &CompositorTask) {
             // SetIds.
 
             NewLayer(*) | SetLayerPageSize(*) | SetLayerClipRect(*) | DeleteLayer(*) |
-            Paint(*) | InvalidateRect(*) | ChangeReadyState(*) | ChangeRenderState(*)
+            Paint(*) | InvalidateRect(*) | ChangeReadyState(*) | ChangeRenderState(*)|
+            SetUnRenderedColor(*)
                 => ()
         }
     }

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -4,6 +4,7 @@
 
 use geom::rect::Rect;
 use geom::size::Size2D;
+use azure::azure_hl::Color;
 use layers::platform::surface::{NativeGraphicsMetadata, NativePaintingGraphicsContext};
 use layers::platform::surface::{NativeSurface, NativeSurfaceMethods};
 
@@ -76,7 +77,7 @@ impl Epoch {
 pub trait RenderListener {
     fn get_graphics_metadata(&self) -> NativeGraphicsMetadata;
     fn new_layer(&self, PipelineId, Size2D<uint>);
-    fn set_layer_page_size(&self, PipelineId, Size2D<uint>, Epoch);
+    fn set_layer_page_size_and_color(&self, PipelineId, Size2D<uint>, Epoch, Color);
     fn set_layer_clip_rect(&self, PipelineId, Rect<uint>);
     fn delete_layer(&self, PipelineId);
     fn paint(&self, id: PipelineId, layer_buffer_set: ~LayerBufferSet, Epoch);

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -8,6 +8,7 @@
 use std::comm::{Chan, SharedChan};
 use extra::url::Url;
 use extra::future::Future;
+use azure::azure_hl::Color;
 use geom::size::Size2D;
 use geom::rect::Rect;
 


### PR DESCRIPTION
fixes #140

This shouldn't be merged until the appropriate change is made in rust layers (https://github.com/mozilla-servo/rust-layers/pull/37). I'm making a pull request anyway to start getting some feedback. 
