### PR TITLE
Add a spec-incompliant load event.

### DIFF
--- a/src/components/script/dom/eventdispatcher.rs
+++ b/src/components/script/dom/eventdispatcher.rs
@@ -9,12 +9,14 @@ use dom::node::AbstractNode;
 use servo_util::tree::{TreeNodeRef};
 
 // See http://dom.spec.whatwg.org/#concept-event-dispatch for the full dispatch algorithm
-pub fn dispatch_event(target: AbstractEventTarget, event: AbstractEvent) -> bool {
+pub fn dispatch_event(target: AbstractEventTarget,
+                      pseudo_target: Option<AbstractEventTarget>,
+                      event: AbstractEvent) -> bool {
     assert!(!event.event().dispatching);
 
     {
         let event = event.mut_event();
-        event.target = Some(target);
+        event.target = Some(pseudo_target.unwrap_or(target));
         event.dispatching = true;
     }
 

--- a/src/components/script/dom/eventtarget.rs
+++ b/src/components/script/dom/eventtarget.rs
@@ -5,9 +5,11 @@
 use dom::bindings::utils::{Reflectable, Reflector, DOMString, Fallible};
 use dom::bindings::utils::{null_str_as_word_null, InvalidState};
 use dom::bindings::codegen::EventListenerBinding::EventListener;
+use dom::document::AbstractDocument;
 use dom::event::AbstractEvent;
 use dom::eventdispatcher::dispatch_event;
 use dom::node::{AbstractNode, ScriptView};
+use dom::window::Window;
 
 use std::cast;
 use std::hashmap::HashMap;
@@ -51,6 +53,18 @@ impl AbstractEventTarget {
     pub fn from_node(node: AbstractNode<ScriptView>) -> AbstractEventTarget {
         unsafe {
             cast::transmute(node)
+        }
+    }
+
+    pub fn from_window(window: @mut Window) -> AbstractEventTarget {
+        AbstractEventTarget {
+            eventtarget: unsafe { cast::transmute(window) }
+        }
+    }
+
+    pub fn from_document(document: AbstractDocument) -> AbstractEventTarget {
+        unsafe {
+            cast::transmute(document)
         }
     }
 
@@ -164,10 +178,17 @@ impl EventTarget {
     }
 
     pub fn DispatchEvent(&self, abstract_self: AbstractEventTarget, event: AbstractEvent) -> Fallible<bool> {
+        self.dispatch_event_with_target(abstract_self, None, event)
+    }
+
+    pub fn dispatch_event_with_target(&self,
+                                      abstract_self: AbstractEventTarget,
+                                      abstract_target: Option<AbstractEventTarget>,
+                                      event: AbstractEvent) -> Fallible<bool> {
         if event.event().dispatching || !event.event().initialized {
             return Err(InvalidState);
         }
-        Ok(dispatch_event(abstract_self, event))
+        Ok(dispatch_event(abstract_self, abstract_target, event))
     }
 }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -12,6 +12,8 @@ use dom::bindings::utils::{Reflectable, GlobalStaticData};
 use dom::document::AbstractDocument;
 use dom::element::Element;
 use dom::event::{Event_, ResizeEvent, ReflowEvent, ClickEvent, MouseDownEvent, MouseUpEvent};
+use dom::event::{Event, HTMLEventTypeId};
+use dom::eventtarget::AbstractEventTarget;
 use dom::htmldocument::HTMLDocument;
 use dom::window::Window;
 use layout_interface::{AddStylesheetMsg, DocumentDamage};
@@ -765,6 +767,15 @@ impl ScriptTask {
                                        file.url.to_str(),
                                        1);
         }
+
+        // We have no concept of a document loader right now, so just dispatch the
+        // "load" event as soon as we've finished executing all scripts parsed during
+        // the initial load.
+        let event = Event::new(window, HTMLEventTypeId);
+        event.mut_event().InitEvent(&Some(~"load"), false, false);
+        let doctarget = AbstractEventTarget::from_document(document);
+        let wintarget = AbstractEventTarget::from_window(window);
+        window.eventtarget.dispatch_event_with_target(wintarget, Some(doctarget), event);
     }
 
     /// This is the main entry point for receiving and dispatching DOM events.

--- a/src/test/html/content/test_load_event.html
+++ b/src/test/html/content/test_load_event.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<script src="harness.js"></script>
+</head>
+<body>
+<script>
+  addEventListener("load", function(ev) {
+    is_a(ev, Event);
+    ev.preventDefault();
+    is(ev.defaultPrevented, false);
+    is(ev.target, document);
+    is(ev.currentTarget, window);
+    finish();
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
It's good enough for now, since we don't track document resources at all. Should be good enough for #841.
