### PR TITLE
fix #1211: change for display of table-related elements

### DIFF
--- a/src/components/main/layout/box_builder.rs
+++ b/src/components/main/layout/box_builder.rs
@@ -388,6 +388,11 @@ impl LayoutTreeBuilder {
         let display = match node.type_id() {
             ElementNodeTypeId(_) => match node.style().Box.display {
                 display::none => return NoGenerator,
+                display::table | display::inline_table | display::table_row_group
+                    | display::table_header_group | display::table_footer_group
+                    | display::table_row | display::table_column_group
+                    | display::table_column | display::table_cell | display::table_caption
+                    => display::block,
                 display => display,
             },
             TextNodeTypeId => display::inline,

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -225,10 +225,11 @@ pub mod longhands {
 
     // TODO: don't parse values we don't support
     <%self:single_keyword_computed name="display"
-            values="inline block inline-block none">
+            values="inline block inline-block 
+            table inline-table table-row-group table-header-group table-footer-group
+            table-row table-column-group table-column table-cell table-caption
+            none">
 //        list-item
-//        table inline-table table-row-group table-header-group table-footer-group
-//        table-row table-column-group table-column table-cell table-caption
         pub fn to_computed_value(value: SpecifiedValue, context: &computed::Context)
                               -> computed_value::T {
 //            if context.is_root_element && value == list_item {


### PR DESCRIPTION
In order to fix the wikipedia error, I temporarily change the display property of table-related elements to 'block' instead of 'inline'.
When table is implemented, it should be changed to proper value.

@sonwow
@brson
