### PR TITLE
configure: Refuse to do anything if a submodule has a dirty working tree

### DIFF
--- a/configure
+++ b/configure
@@ -308,6 +308,11 @@ CFG_SELF=${CFG_SRC_DIR}$(basename $0)
 CFG_CONFIGURE_ARGS="$@"
 CFG_PATH=$PATH
 
+if git status $CFG_SRC_DIR/src/compiler $CFG_SRC_DIR/src/support $CFG_SRC_DIR/src/platform \
+    | grep -q 'modified:.*modified content'; then
+    err "Some submodule has a dirty working tree.  See 'git status'."
+fi
+
 OPTIONS=""
 HELP=0
 if [ "$1" = "--help" ]


### PR DESCRIPTION
This isn't a full fix for #522 / #835 but it prevents the unrecoverable loss of work without changing the behavior of configure generally.

If configure drops committed local work, it can be recovered from the reflog.
