### PR TITLE
Make the HTML parser parse into the document rather than an element.

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -77,17 +77,6 @@ impl AbstractDocument {
             document: ptr as *mut Box<Document>
         }
     }
-
-    pub fn set_root(&self, root: AbstractNode<ScriptView>) {
-        assert!(do root.traverse_preorder().all |node| {
-            node.node().owner_doc() == *self
-        });
-
-        let document = self.mut_document();
-        document.node.AppendChild(AbstractNode::from_document(*self), root);
-        // Register elements having "id" attribute to the owner doc.
-        document.register_nodes_with_id(&root);
-    }
 }
 
 #[deriving(Eq)]
@@ -173,7 +162,9 @@ impl Reflectable for Document {
 
 impl Document {
     pub fn GetDocumentElement(&self) -> Option<AbstractNode<ScriptView>> {
-        self.node.first_child
+        do self.node.children().find |c| {
+            c.is_element()
+        }
     }
 
     fn get_cx(&self) -> *JSContext {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -441,9 +441,7 @@ impl<'self, View> AbstractNode<View> {
     }
 
     pub fn children(&self) -> AbstractNodeChildrenIterator<View> {
-        AbstractNodeChildrenIterator {
-            current_node: self.first_child(),
-        }
+        self.node().children()
     }
 
     // Issue #1030: should not walk the tree
@@ -497,6 +495,12 @@ impl<View> Node<View> {
 
     pub fn set_owner_doc(&mut self, document: AbstractDocument) {
         self.owner_doc = Some(document);
+    }
+
+    pub fn children(&self) -> AbstractNodeChildrenIterator<View> {
+        AbstractNodeChildrenIterator {
+            current_node: self.first_child,
+        }
     }
 }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -701,7 +701,7 @@ impl ScriptTask {
                                                                  self.constellation_chan.clone());
 
 
-        let HtmlParserResult {root, discovery_port} = html_parsing_result;
+        let HtmlParserResult {discovery_port} = html_parsing_result;
 
         // Create the root frame.
         page.frame = Some(Frame {
@@ -741,11 +741,8 @@ impl ScriptTask {
             }
         }
 
-        // Tie the root into the document. This will kick off the initial reflow
-        // of the page.
-        // FIXME: We have no way to ensure that the first reflow performed is a
-        //        ReflowForDisplay operation.
-        document.set_root(root);
+        // Kick off the initial reflow of the page.
+        document.document().content_changed();
 
         // No more reflow required
         page.url = Some((url, false));

--- a/src/test/html/content/test_documentElement.html
+++ b/src/test/html/content/test_documentElement.html
@@ -4,7 +4,7 @@
 <script>
 is_a(window, Window);
 is_a(document.documentElement, HTMLHtmlElement);
-is_a(document.documentElement.firstChild, HTMLHtmlElement);
+is_a(document.documentElement.firstChild, HTMLHeadElement);
 is(document.documentElement.nextSibling, null);
 is_a(document, HTMLDocument);
 is_a(document, Document);


### PR DESCRIPTION
This removes the duplicate html element.
