### PR TITLE
add support for transparant png

### DIFF
--- a/src/components/gfx/gfx.rc
+++ b/src/components/gfx/gfx.rc
@@ -15,6 +15,7 @@ extern mod extra;
 extern mod geom;
 extern mod layers;
 extern mod stb_image;
+extern mod png;
 extern mod servo_net (name = "net");
 extern mod servo_util (name = "util");
 extern mod style;

--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -359,7 +359,7 @@ pub fn run_compositor(compositor: &CompositorTask) {
             let img = png::Image {
                 width: width as u32,
                 height: height as u32,
-                color_type: png::RGB8,
+                color_type: png::RGBA8,
                 pixels: pixels,
             };
             let res = png::store_png(&img, &path);

--- a/src/components/net/image/base.rs
+++ b/src/components/net/image/base.rs
@@ -4,14 +4,19 @@
 
 use std::vec;
 use stb_image = stb_image::image;
+use png;
 
 // FIXME: Images must not be copied every frame. Instead we should atomically
 // reference count them.
+pub type Image = png::Image;
 
-pub type Image = stb_image::Image<u8>;
-
-pub fn Image(width: uint, height: uint, depth: uint, data: ~[u8]) -> Image {
-    stb_image::new_image(width, height, depth, data)
+pub fn Image(width: u32, height: u32, color_type: png::ColorType, data: ~[u8]) -> Image {
+    png::Image {
+        width: width,
+        height: height,
+        color_type: color_type,
+        pixels: data,
+    }
 }
 
 static TEST_IMAGE: &'static [u8] = include_bin!("test.jpeg");
@@ -21,30 +26,38 @@ pub fn test_image_bin() -> ~[u8] {
 }
 
 pub fn load_from_memory(buffer: &[u8]) -> Option<Image> {
-    // Can't remember why we do this. Maybe it's what cairo wants
-    static FORCE_DEPTH: uint = 4;
-
-    match stb_image::load_from_memory_with_depth(buffer, FORCE_DEPTH, true) {
-        stb_image::ImageU8(image) => {
-            assert!(image.depth == 4);
-            // Do color space conversion :(
-            let data = do vec::from_fn(image.width * image.height * 4) |i| {
-                let color = i % 4;
-                let pixel = i / 4;
-                match color {
-                    0 => image.data[pixel * 4 + 2],
-                    1 => image.data[pixel * 4 + 1],
-                    2 => image.data[pixel * 4 + 0],
-                    3 => 0xffu8,
-                    _ => fail!()
-                }
-            };
-
-            assert!(image.data.len() == data.len());
-
-            Some(Image(image.width, image.height, image.depth, data))
+    if png::is_png(buffer) {
+        match png::load_png_from_memory(buffer) {
+            Ok(png_image) => Some(png_image),
+            Err(_err) => None,
         }
-        stb_image::ImageF32(_image) => fail!(~"HDR images not implemented"),
-        stb_image::Error => None
+    } else {
+        // For non-png images, we use stb_image
+        // Can't remember why we do this. Maybe it's what cairo wants
+        static FORCE_DEPTH: uint = 4;
+
+        match stb_image::load_from_memory_with_depth(buffer, FORCE_DEPTH, true) {
+            stb_image::ImageU8(image) => {
+                assert!(image.depth == 4);
+                // Do color space conversion :(
+                let data = do vec::from_fn(image.width * image.height * 4) |i| {
+                    let color = i % 4;
+                    let pixel = i / 4;
+                    match color {
+                        0 => image.data[pixel * 4 + 2],
+                        1 => image.data[pixel * 4 + 1],
+                        2 => image.data[pixel * 4 + 0],
+                        3 => 0xffu8,
+                        _ => fail!()
+                    }
+                };
+
+                assert!(image.data.len() == data.len());
+
+                Some(Image(image.width as u32, image.height as u32, png::RGBA8, data))
+            }
+            stb_image::ImageF32(_image) => fail!(~"HDR images not implemented"),
+            stb_image::Error => None
+        }
     }
 }

--- a/src/components/net/net.rc
+++ b/src/components/net/net.rc
@@ -15,6 +15,7 @@ extern mod http;
 extern mod servo_util (name = "util");
 extern mod stb_image;
 extern mod extra;
+extern mod png;
 
 /// Image handling.
 ///


### PR DESCRIPTION
Modified to use libpng to read .png files. We use stb_image to read all other image files.
This requires updated submodule: https://github.com/mozilla-servo/rust-png/pull/13

This patch is for:
https://github.com/mozilla/servo/issues/1279
