### PR TITLE
Disable parallel builds at top level.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -378,3 +378,6 @@ backup-rust:
 
 restore-rust:
 	if [ -d ../$(CFG_TARGET_TRIPLES) ]; then rm -rf $(B)src/compiler/rust; mv ../$(CFG_TARGET_TRIPLES) $(B)src/compiler/rust; fi
+
+.NOTPARALLEL:
+


### PR DESCRIPTION
Sub-builds are still parallelized. This is a workaround for rustpkg
issues. See https://github.com/mozilla/rust/issues/9650
