### PR TITLE
Move backup related stuff to its own Makefile.

### DIFF
--- a/Makefile.backup
+++ b/Makefile.backup
@@ -1,0 +1,17 @@
+# Build commands for backing up and restoring the Rust build.
+# Because Rust takes a very long time to build and changes infrequently,
+# the bots want to reuse it between builds. They can do so by running
+# `make backup-rust` and `make restore-rust`.
+#
+# backup-rust is run before the build directory is cleaned. if it fails, that's ok.
+#
+# restore-rust is run after configure and before invoking make. if it fails, we must abort.
+
+include config.mk
+
+.PHONY: backup-rust restore-rust
+backup-rust:
+	-mv $(CFG_BUILD_DIR)src/compiler/rust ../$(CFG_TARGET_TRIPLES)
+
+restore-rust:
+	if [ -d ../$(CFG_TARGET_TRIPLES) ]; then rm -rf $(CFG_BUILD_DIR)src/compiler/rust; mv ../$(CFG_TARGET_TRIPLES) $(CFG_BUILD_DIR)src/compiler/rust; fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -363,21 +363,13 @@ package:
 
 endif
 
-# Build commands for backing up and restoring the Rust build.
-# Because Rust takes a very long time to build and changes infrequently,
-# the bots want to reuse it between builds. They can do so by running
-# `make backup-rust` and `make restore-rust`.
-#
-# backup-rust is run before the build directory is cleaned. if it fails, that's ok.
-#
-# restore-rust is run after configure and before invoking make. if it fails, we must abort.
+# Backup targets. These axist until build slaves are using Makefile.backup directly.
 
 .PHONY: backup-rust restore-rust
 backup-rust:
-	-mv $(B)src/compiler/rust ../$(CFG_TARGET_TRIPLES)
+	$(MAKE) -f $(S)Makefile.backup $@
 
 restore-rust:
-	if [ -d ../$(CFG_TARGET_TRIPLES) ]; then rm -rf $(B)src/compiler/rust; mv ../$(CFG_TARGET_TRIPLES) $(B)src/compiler/rust; fi
+	$(MAKE) -f $(S)Makefile.backup $@
 
 .NOTPARALLEL:
-


### PR DESCRIPTION
This will prevent Makefile errors from affecting backups. This happens when
different branches include Makefile helpers other branches don't have. This
should be more reliable.
