### PR TITLE
Report exceptions to JS when the DOM implementation fails.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3107,11 +3107,10 @@ class CGPerSignatureCall(CGThing):
                              self.idlNode.identifier.name))
 
     def getErrorReport(self):
-        #return CGGeneric('return ThrowMethodFailedWithDetails<%s>(cx, rv, "%s", "%s");'
-        #                 % (toStringBool(not self.descriptor.workers),
-        #                    self.descriptor.interface.identifier.name,
-        #                    self.idlNode.identifier.name))
-        return CGGeneric('return 0'); #XXXjdm
+        return CGGeneric(
+            'return throw_method_failed_with_details(cx, result_fallible, "%s", "%s");' %
+                (self.descriptor.interface.identifier.name,
+                 self.idlNode.identifier.name))
 
     def define(self):
         return (self.cgRoot.define() + "\n" + self.wrap_return_value())

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -194,6 +194,7 @@ impl Document {
 
     pub fn CreateElement(&self, abstract_self: AbstractDocument, local_name: DOMString) -> Fallible<AbstractNode<ScriptView>> {
         if xml_name_type(local_name) == InvalidXMLName {
+            debug!("Not a valid element name");
             return Err(InvalidCharacter);
         }
         let local_name = local_name.to_ascii_lower();

--- a/src/test/html/content/test_exception.html
+++ b/src/test/html/content/test_exception.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<script src="harness.js"></script>
+<script>
+try {
+  document.createElement("1foo");
+  is(true, false, "No exception thrown");
+} catch (e) {
+  is(true, true, "Exception caught");
+}
+finish();
+</script>


### PR DESCRIPTION
As a bonus, adds some debugging statements.

This is better than the status-quo–uncatchable exceptions–but we should also implement `DOMException` soonish.
