### PR TITLE
main: Disable parallel selector matching due to races.

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -46,7 +46,9 @@ impl MatchMethods for AbstractNode<LayoutView> {
         }
     }
     fn match_subtree(&self, stylist: RWArc<Stylist>) {
-        let num_tasks = rt::default_sched_threads() * 2;
+        // FIXME(pcwalton): Racy. Parallel CSS selector matching is disabled.
+        //let num_tasks = rt::default_sched_threads() * 2;
+        let num_tasks = 1;
         let mut node_count = 0;
         let mut nodes_per_task = vec::from_elem(num_tasks, ~[]);
 


### PR DESCRIPTION
To verify, turn ON optimizations and go to:

http://en.wikipedia.org/wiki/Yellow_River

r? @metajack
