### PR TITLE
layout: Change `RenderBox` to an enum and shorten its name in preparation for removing its `@`-ness.

### DIFF
--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! The `RenderBox` type, which represents the leaves of the layout tree.
+//! The `Box` type, which represents the leaves of the layout tree.
 
 use extra::url::Url;
 use geom::{Point2D, Rect, Size2D, SideOffsets2D};
+use gfx::color::rgb;
 use gfx::display_list::{BaseDisplayItem, BorderDisplayItem, BorderDisplayItemClass};
 use gfx::display_list::{DisplayList, ImageDisplayItem, ImageDisplayItemClass};
 use gfx::display_list::{SolidColorDisplayItem, SolidColorDisplayItemClass, TextDisplayItem};
 use gfx::display_list::{TextDisplayItemClass, ClipDisplayItem, ClipDisplayItemClass};
 use gfx::font::{FontStyle, FontWeight300};
 use gfx::text::text_run::TextRun;
-use gfx::color::rgb;
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_net::image::holder::ImageHolder;
 use servo_net::local_image_cache::LocalImageCache;
@@ -24,12 +24,10 @@ use std::cast;
 use std::cell::Cell;
 use std::cmp::ApproxEq;
 use std::num::Zero;
-use std::unstable::raw::Box;
 use style::ComputedValues;
-use style::computed_values::{
-    border_style, clear, float, font_family, font_style, line_height,
-    position, text_align, text_decoration, vertical_align, LengthOrPercentage,
-    overflow, visibility};
+use style::computed_values::{LengthOrPercentage, overflow};
+use style::computed_values::{border_style, clear, float, font_family, font_style, line_height};
+use style::computed_values::{position, text_align, text_decoration, vertical_align, visibility};
 
 use css::node_style::StyledNode;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData, ToGfxColor};
@@ -54,211 +52,62 @@ use layout::model::{MaybeAuto, specified};
 /// A box's type influences how its styles are interpreted during layout. For example, replaced
 /// content such as images are resized differently from tables, text, or other content. Different
 /// types of boxes may also contain custom data; for example, text boxes contain text.
-pub trait RenderBox {
-    /// Returns the class of render box that this is.
-    fn class(&self) -> RenderBoxClass;
+///
+/// FIXME(pcwalton): This can be slimmed down quite a bit.
+pub struct Box {
+    /// The DOM node that this `Box` originates from.
+    node: AbstractNode<LayoutView>,
 
-    /// If this is an image render box, returns the underlying object. Fails otherwise.
+    /// The position of this box relative to its owning flow.
+    position: Slot<Rect<Au>>,
+
+    /// The border of the content box.
     ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_image_render_box(@self) -> @ImageRenderBox {
-        fail!("as_text_render_box() called on a non-text-render-box")
-    }
+    /// FIXME(pcwalton): This need not be stored in the box.
+    border: Slot<SideOffsets2D<Au>>,
 
-    /// If this is a text render box, returns the underlying object. Fails otherwise.
-    ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_text_render_box(@self) -> @TextRenderBox {
-        fail!("as_text_render_box() called on a non-text-render-box")
-    }
+    /// The padding of the content box.
+    padding: Slot<SideOffsets2D<Au>>,
 
-    /// If this is an unscanned text render box, returns the underlying object. Fails otherwise.
-    ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_unscanned_text_render_box(@self) -> @UnscannedTextRenderBox {
-        fail!("as_unscanned_text_render_box() called on a non-unscanned-text-render-box")
-    }
+    /// The margin of the content box.
+    margin: Slot<SideOffsets2D<Au>>,
 
-     /// If this is an unscanned text render box, returns the underlying object. Fails otherwise.
-    ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_generic_render_box(@self) -> @GenericRenderBox {
-        fail!("as_generic_render_box() called on a generic-render-box")
-    }
+    /// The width of the content box.
+    content_box_width: Au,
 
-    /// Cleans up all memory associated with this render box.
-    fn teardown(&self) {}
-
-    /// Returns true if this element is an unscanned text box that consists entirely of whitespace.
-    fn is_whitespace_only(&self) -> bool {
-        false
-    }
-
-    /// Attempts to split this box so that its width is no more than `max_width`. Fails if this box
-    /// is an unscanned text box.
-    fn split_to_width(@self, _: Au, _: bool) -> SplitBoxResult;
-
-    /// Determines whether this box can merge with another box.
-    fn can_merge_with_box(&self, _: &RenderBox) -> bool {
-        false
-    }
-
-    /// Returns the *minimum width* and *preferred width* of this render box as defined by CSS 2.1.
-    fn minimum_and_preferred_widths(&self) -> (Au, Au);
-
-    fn box_height(&self) -> Au;
-
-    /// Assigns the appropriate width.
-    fn assign_width(&self);
-
-    fn debug_str(&self) -> ~str {
-        ~"???"
-    }
+    /// Info specific to the kind of box. Keep this enum small.
+    specific: SpecificBoxInfo,
 }
 
-impl Clone for @RenderBox {
-    fn clone(&self) -> @RenderBox {
-        *self
-    }
+/// Info specific to the kind of box. Keep this enum small.
+pub enum SpecificBoxInfo {
+    GenericBox,
+    ImageBox(ImageBoxInfo),
+    ScannedTextBox(ScannedTextBoxInfo),
+    UnscannedTextBox(UnscannedTextBoxInfo),
 }
 
-// FIXME(pcwalton): These are botches and can be removed once Rust gets trait fields.
-
-pub trait RenderBoxUtils {
-    fn base<'a>(&'a self) -> &'a RenderBoxBase;
-
-    fn mut_base<'a>(&'a self) -> &'a mut RenderBoxBase;
-
-    /// Returns true if this element is replaced content. This is true for images, form elements,
-    /// and so on.
-    fn is_replaced(&self) -> bool;
-    
-    /// Returns true if this element can be split. This is true for text boxes.
-    fn can_split(&self) -> bool;
-    
-    /// Returns the amount of left and right "fringe" used by this box. This is based on margins,
-    /// borders, padding, and width.
-    fn get_used_width(&self) -> (Au, Au);
-    
-    /// Returns the amount of left and right "fringe" used by this box. This should be based on
-    /// margins, borders, padding, and width.
-    fn get_used_height(&self) -> (Au, Au);
-
-    /// Adds the display items necessary to paint the background of this render box to the display
-    /// list if necessary.
-    fn paint_background_if_applicable<E:ExtraDisplayListData>(
-                                      &self,
-                                      list: &Cell<DisplayList<E>>,
-                                      absolute_bounds: &Rect<Au>);
-
-    /// Adds the display items necessary to paint the borders of this render box to a display list
-    /// if necessary.
-    fn paint_borders_if_applicable<E:ExtraDisplayListData>(
-                                   &self,
-                                   list: &Cell<DisplayList<E>>,
-                                   abs_bounds: &Rect<Au>);
-
-    /// Adds the display items for this render box to the given display list.
-    ///
-    /// Arguments:
-    /// * `builder`: The display list builder, which manages the coordinate system and options.
-    /// * `dirty`: The dirty rectangle in the coordinate system of the owning flow.
-    /// * `origin`: The total offset from the display list root flow to the owning flow of this
-    ///   box.
-    /// * `list`: The display list to which items should be appended.
-    ///
-    /// TODO: To implement stacking contexts correctly, we need to create a set of display lists,
-    /// one per layer of the stacking context (CSS 2.1 § 9.9.1). Each box is passed the list set
-    /// representing the box's stacking context. When asked to construct its constituent display
-    /// items, each box puts its display items into the correct stack layer according to CSS 2.1
-    /// Appendix E. Finally, the builder flattens the list.
-    fn build_display_list<E:ExtraDisplayListData>(
-                          &self,
-                          _: &DisplayListBuilder,
-                          dirty: &Rect<Au>,
-                          offset: &Point2D<Au>,
-                          list: &Cell<DisplayList<E>>);
-}
-
-pub trait RenderBoxRefUtils<'self> {
-    fn base(self) -> &'self RenderBoxBase;
-    fn mut_base(self) -> &'self mut RenderBoxBase;
-}
-
-/// A box that represents a generic render box.
-pub struct GenericRenderBox {
-    base: RenderBoxBase,
-}
-
-impl GenericRenderBox {
-    pub fn new(base: RenderBoxBase) -> GenericRenderBox {
-        GenericRenderBox {
-            base: base,
-        }
-    }
-
-    fn need_clip(&self) -> bool {
-        if self.base.node.style().Box.overflow == overflow::hidden {
-            return true;
-        }
-        false
-    }
-}
-
-impl RenderBox for GenericRenderBox {
-    fn class(&self) -> RenderBoxClass {
-        GenericRenderBoxClass
-    }
-
-    fn as_generic_render_box(@self) -> @GenericRenderBox {
-        self
-    }
-
-    fn minimum_and_preferred_widths(&self) -> (Au, Au) {
-        let guessed_width = self.base.guess_width();
-        (guessed_width, guessed_width)
-    }
-
-    fn split_to_width(@self, _: Au, _: bool) -> SplitBoxResult {
-        CannotSplit(self as @RenderBox)
-    }
-
-    fn box_height(&self) -> Au {
-        Au::new(0)
-    }
-
-    fn assign_width(&self) {
-        // FIXME(pcwalton): This seems clownshoes; can we remove?
-        self.base.position.mutate().ptr.size.width = Au::from_px(45)
-    }
-
-    fn debug_str(&self) -> ~str {
-        ~"(generic)"
-    }
-}
-
-/// A box that represents a (replaced content) image and its accompanying borders, shadows, etc.
-pub struct ImageRenderBox {
-    base: RenderBoxBase,
+/// A box that represents a replaced content image and its accompanying borders, shadows, etc.
+pub struct ImageBoxInfo {
+    /// The image held within this box.
     image: Slot<ImageHolder>,
 }
 
-impl ImageRenderBox {
-    #[inline]
-    pub fn new(base: RenderBoxBase, image_url: Url, local_image_cache: @mut LocalImageCache)
-               -> ImageRenderBox {
-        assert!(base.node.is_image_element());
-
-        ImageRenderBox {
-            base: base,
+impl ImageBoxInfo {
+    /// Creates a new image box from the given URL and local image cache.
+    ///
+    /// FIXME(pcwalton): The fact that image boxes store the cache in the box makes little sense to
+    /// me.
+    pub fn new(image_url: Url, local_image_cache: @mut LocalImageCache) -> ImageBoxInfo {
+        ImageBoxInfo {
             image: Slot::init(ImageHolder::new(image_url, local_image_cache)),
         }
     }
 
     // Calculate the width of an image, accounting for the width attribute
     // TODO: This could probably go somewhere else
-    pub fn image_width(&self) -> Au {
-        let attr_width: Option<int> = do self.base.node.with_imm_element |elt| {
+    pub fn image_width(&self, base: &Box) -> Au {
+        let attr_width: Option<int> = do base.node.with_imm_element |elt| {
             match elt.get_attr("width") {
                 Some(width) => {
                     FromStr::from_str(width)
@@ -281,8 +130,8 @@ impl ImageRenderBox {
 
     // Calculate the height of an image, accounting for the height attribute
     // TODO: This could probably go somewhere else
-    pub fn image_height(&self) -> Au {
-        let attr_height: Option<int> = do self.base.node.with_imm_element |elt| {
+    pub fn image_height(&self, base: &Box) -> Au {
+        let attr_height: Option<int> = do base.node.with_imm_element |elt| {
             match elt.get_attr("height") {
                 Some(height) => {
                     FromStr::from_str(height)
@@ -302,381 +151,92 @@ impl ImageRenderBox {
 
         Au::from_px(px_height)
     }
-
-    /// If this is an image render box, returns the underlying object. Fails otherwise.
-    ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_image_render_box(@self) -> @ImageRenderBox {
-        self
-    }
-
-    fn debug_str(&self) -> ~str {
-        ~"(image)"
-    }
 }
 
-impl RenderBox for ImageRenderBox {
-    fn class(&self) -> RenderBoxClass {
-        ImageRenderBoxClass
-    }
-
-    fn split_to_width(@self, _: Au, _: bool) -> SplitBoxResult {
-        CannotSplit(self as @RenderBox)
-    }
-
-    fn minimum_and_preferred_widths(&self) -> (Au, Au) {
-        let guessed_width = self.base.guess_width();
-        let image_width = self.image_width();
-        (guessed_width + image_width, guessed_width + image_width)
-    }
-
-    fn box_height(&self) -> Au {
-        let size = self.image.mutate().ptr.get_size();
-        let height = Au::from_px(size.unwrap_or(Size2D(0, 0)).height);
-        self.base.position.mutate().ptr.size.height = height;
-        debug!("box_height: found image height: {}", height);
-        height
-    }
-
-    fn assign_width(&self) {
-        let width = self.image_width();
-        self.base.position.mutate().ptr.size.width = width;
-    }
-
-    /// If this is an image render box, returns the underlying object. Fails otherwise.
-    ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_image_render_box(@self) -> @ImageRenderBox {
-        self
-    }
-}
-
-/// A box representing a single run of text with a distinct style. A `TextRenderBox` may be split
-/// into two or more boxes across line breaks. Several `TextBox`es may correspond to a
-/// single DOM text node. Split text boxes are implemented by referring to subsets of a master
-/// `TextRun` object.
-pub struct TextRenderBox {
-    base: RenderBoxBase,
+/// A scanned text box represents a single run of text with a distinct style. A `TextBox` may be
+/// split into two or more boxes across line breaks. Several `TextBox`es may correspond to a single
+/// DOM text node. Split text boxes are implemented by referring to subsets of a single `TextRun`
+/// object.
+pub struct ScannedTextBoxInfo {
+    /// The text run that this represents.
     run: @TextRun,
+
+    /// The range within the above text run that this represents.
     range: Range,
 }
 
-impl TextRenderBox {
-    /// Creates a TextRenderBox from a base render box, a range, and a text run. The size of the
-    /// the base render box is ignored and becomes the size of the text run.
-    ///
-    /// FIXME(pcwalton): This API is confusing.
-    pub fn new(base: RenderBoxBase, run: @TextRun, range: Range) -> TextRenderBox {
-        debug!("Creating textbox with span: (strlen={:u}, off={:u}, len={:u}) of textrun ({:s}) (len={:u})",
-               run.char_len(),
-               range.begin(),
-               range.length(),
-               *run.text.get(),
-               run.char_len());
-
-        assert!(range.begin() < run.char_len());
-        assert!(range.end() <= run.char_len());
-        assert!(range.length() > 0);
-
-        let metrics = run.metrics_for_range(&range);
-
-        // FIXME(pcwalton): This block is necessary due to Rust #6248. If we don't have it, then
-        // the "currently borrowed" flag will be moved before the destructor runs, causing a
-        // (harmless) undefined memory write and a (very harmful) sticking of `position` in the
-        // "mutably borrowed" state, which will cause failures later.
-        {
-            base.position.mutate().ptr.size = metrics.bounding_box.size;
-        }
-
-        TextRenderBox {
-            base: base,
+impl ScannedTextBoxInfo {
+    /// Creates the information specific to a scanned text box from a range and a text run.
+    pub fn new(run: @TextRun, range: Range) -> ScannedTextBoxInfo {
+        ScannedTextBoxInfo {
             run: run,
             range: range,
         }
     }
 }
 
-impl RenderBox for TextRenderBox {
-    fn class(&self) -> RenderBoxClass {
-        TextRenderBoxClass
-    }
-
-    fn as_text_render_box(@self) -> @TextRenderBox {
-        self
-    }
-
-    fn teardown(&self) {
-        self.run.teardown();
-    }
-
-    fn minimum_and_preferred_widths(&self) -> (Au, Au) {
-        let guessed_width = self.base.guess_width();
-        let min_width = self.run.min_width_for_range(&self.range);
-
-        let mut max_line_width = Au::new(0);
-        for line_range in self.run.iter_natural_lines_for_range(&self.range) {
-            let line_metrics = self.run.metrics_for_range(&line_range);
-            max_line_width = Au::max(max_line_width, line_metrics.advance_width);
-        }
-
-        (guessed_width + min_width, guessed_width + max_line_width)
-    }
-
-    fn box_height(&self) -> Au {
-        let range = &self.range;
-        let run = &self.run;
-
-        // Compute the height based on the line-height and font size
-        let text_bounds = run.metrics_for_range(range).bounding_box;
-        let em_size = text_bounds.size.height;
-        let line_height = self.base.calculate_line_height(em_size);
-
-        line_height
-    }
-
-    fn assign_width(&self) {
-        // Text boxes are preinitialized.
-    }
-
-    /// Attempts to split this box so that its width is no more than `max_width`. Fails if this box
-    /// is an unscanned text box.
-    fn split_to_width(@self, max_width: Au, starts_line: bool) -> SplitBoxResult {
-        let mut pieces_processed_count: uint = 0;
-        let mut remaining_width: Au = max_width;
-        let mut left_range = Range::new(self.range.begin(), 0);
-        let mut right_range: Option<Range> = None;
-
-        debug!("split_to_width: splitting text box (strlen={:u}, range={}, avail_width={})",
-               self.run.text.get().len(),
-               self.range,
-               max_width);
-
-        for (glyphs, offset, slice_range) in self.run.iter_slices_for_range(&self.range) {
-            debug!("split_to_width: considering slice (offset={}, range={}, remain_width={})",
-                   offset,
-                   slice_range,
-                   remaining_width);
-
-            let metrics = self.run.metrics_for_slice(glyphs, &slice_range);
-            let advance = metrics.advance_width;
-            let should_continue: bool;
-
-            if advance <= remaining_width {
-                should_continue = true;
-
-                if starts_line && pieces_processed_count == 0 && glyphs.is_whitespace() {
-                    debug!("split_to_width: case=skipping leading trimmable whitespace");
-                    left_range.shift_by(slice_range.length() as int);
-                } else {
-                    debug!("split_to_width: case=enlarging span");
-                    remaining_width = remaining_width - advance;
-                    left_range.extend_by(slice_range.length() as int);
-                }
-            } else {    // The advance is more than the remaining width.
-                should_continue = false;
-                let slice_begin = offset + slice_range.begin();
-                let slice_end = offset + slice_range.end();
-
-                if glyphs.is_whitespace() {
-                    // If there are still things after the trimmable whitespace, create the
-                    // right chunk.
-                    if slice_end < self.range.end() {
-                        debug!("split_to_width: case=skipping trimmable trailing \
-                                whitespace, then split remainder");
-                        let right_range_end = self.range.end() - slice_end;
-                        right_range = Some(Range::new(slice_end, right_range_end));
-                    } else {
-                        debug!("split_to_width: case=skipping trimmable trailing \
-                                whitespace");
-                    }
-                } else if slice_begin < self.range.end() {
-                    // There are still some things left over at the end of the line. Create
-                    // the right chunk.
-                    let right_range_end = self.range.end() - slice_begin;
-                    right_range = Some(Range::new(slice_begin, right_range_end));
-                    debug!("split_to_width: case=splitting remainder with right range={:?}",
-                           right_range);
-                }
-            }
-
-            pieces_processed_count += 1;
-
-            if !should_continue {
-                break
-            }
-        }
-
-        let left_box = if left_range.length() > 0 {
-            let new_text_box = @TextRenderBox::new(self.base.clone(), self.run, left_range);
-            Some(new_text_box as @RenderBox)
-        } else {
-            None
-        };
-
-        let right_box = do right_range.map_default(None) |range: Range| {
-            let new_text_box = @TextRenderBox::new(self.base.clone(), self.run, range);
-            Some(new_text_box as @RenderBox)
-        };
-
-        if pieces_processed_count == 1 || left_box.is_none() {
-            SplitDidNotFit(left_box, right_box)
-        } else {
-            SplitDidFit(left_box, right_box)
-        }
-    }
-
-    fn debug_str(&self) -> ~str {
-        self.run.text.get().to_str()
-    }
-}
-
-/// The data for an unscanned text box.
-pub struct UnscannedTextRenderBox {
-    base: RenderBoxBase,
+/// Data for an unscanned text box. Unscanned text boxes are the results of flow construction that
+/// have not yet had their width determined.
+pub struct UnscannedTextBoxInfo {
+    /// The text inside the box.
     text: ~str,
-
-    // Cache font-style and text-decoration to check whether
-    // this box can merge with another render box.
-    font_style: Option<FontStyle>,
-    text_decoration: Option<text_decoration::T>,
 }
 
-impl UnscannedTextRenderBox {
-    /// Creates a new instance of `UnscannedTextRenderBox`.
-    #[inline(always)]
-    pub fn new(base: RenderBoxBase) -> UnscannedTextRenderBox {
-        assert!(base.node.is_text());
-
-        do base.node.with_imm_text |text_node| {
-            // FIXME: Don't copy text; atomically reference count it instead.
-            // FIXME(pcwalton): If we're just looking at node data, do we have to ensure this is
-            // a text node?
-            UnscannedTextRenderBox {
-                base: base.clone(),
+impl UnscannedTextBoxInfo {
+    /// Creates a new instance of `UnscannedTextBoxInfo` from the given DOM node.
+    pub fn new(node: &AbstractNode<LayoutView>) -> UnscannedTextBoxInfo {
+        node.with_imm_text(|text_node| {
+            // FIXME(pcwalton): Don't copy text; atomically reference count it instead.
+            UnscannedTextBoxInfo {
                 text: text_node.element.data.to_str(),
-                font_style: None,
-                text_decoration: None,
             }
-        }
+        })
     }
-
-    /// Copies out the text from an unscanned text box.
-    pub fn raw_text(&self) -> ~str {
-        self.text.clone()
-    }
-}
-
-impl RenderBox for UnscannedTextRenderBox {
-    fn class(&self) -> RenderBoxClass {
-        UnscannedTextRenderBoxClass
-    }
-
-    fn is_whitespace_only(&self) -> bool {
-        self.text.is_whitespace()
-    }
-
-    fn can_merge_with_box(&self, other: &RenderBox) -> bool {
-        if other.class() == UnscannedTextRenderBoxClass {
-            let this_base = &self.base;
-            let other_base = other.base();
-            return this_base.font_style() == other_base.font_style() &&
-                this_base.text_decoration() == other_base.text_decoration()
-        }
-        false
-    }
-
-    fn box_height(&self) -> Au {
-        fail!("can't get height of unscanned text box")
-    }
-
-    /// Attempts to split this box so that its width is no more than `max_width`. Fails if this box
-    /// is an unscanned text box.
-    fn split_to_width(@self, _: Au, _: bool) -> SplitBoxResult {
-        fail!("WAT: shouldn't be an unscanned text box here.")
-    }
-
-    /// Returns the *minimum width* and *preferred width* of this render box as defined by CSS 2.1.
-    fn minimum_and_preferred_widths(&self) -> (Au, Au) {
-        fail!("WAT: shouldn't be an unscanned text box here.")
-    }
-
-    fn assign_width(&self) {
-        fail!("WAT: shouldn't be an unscanned text box here.")
-    }
-
-    /// If this is an unscanned text render box, returns the underlying object. Fails otherwise.
-    ///
-    /// FIXME(pcwalton): Ugly. Replace with a real downcast operation.
-    fn as_unscanned_text_render_box(@self) -> @UnscannedTextRenderBox {
-        self
-    }
-
-    fn debug_str(&self) -> ~str {
-        self.text.clone()
-    }
-}
-
-#[deriving(Eq)]
-pub enum RenderBoxClass {
-    GenericRenderBoxClass,
-    ImageRenderBoxClass,
-    TextRenderBoxClass,
-    UnscannedTextRenderBoxClass,
 }
 
 /// Represents the outcome of attempting to split a box.
 pub enum SplitBoxResult {
-    CannotSplit(@RenderBox),
+    CannotSplit(@Box),
     // in general, when splitting the left or right side can
     // be zero length, due to leading/trailing trimmable whitespace
-    SplitDidFit(Option<@RenderBox>, Option<@RenderBox>),
-    SplitDidNotFit(Option<@RenderBox>, Option<@RenderBox>)
+    SplitDidFit(Option<@Box>, Option<@Box>),
+    SplitDidNotFit(Option<@Box>, Option<@Box>)
 }
 
-/// Data common to all boxes.
-#[deriving(Clone)]
-pub struct RenderBoxBase {
-    /// The DOM node that this `RenderBox` originates from.
-    node: AbstractNode<LayoutView>,
-
-    /// The position of this box relative to its owning flow.
-    position: Slot<Rect<Au>>,
-
-    /// A debug ID.
-    ///
-    /// TODO(#87) Make this only present in debug builds.
-    id: int,
-
-    /// the border of the content box.
-    border: SideOffsets2D<Au>,
-
-    /// the padding of the content box.
-    padding: SideOffsets2D<Au>,
-
-    /// the margin of the content box.
-    margin: SideOffsets2D<Au>,
-
-    /// The width of the content box.
-    content_box_width: Au,
-}
-
-impl RenderBoxBase {
-    /// Constructs a new `RenderBoxBase` instance.
-    pub fn new(node: AbstractNode<LayoutView>, id: int)
-               -> RenderBoxBase {
-        RenderBoxBase {
+impl Box {
+    /// Constructs a new `Box` instance.
+    pub fn new(node: AbstractNode<LayoutView>, specific: SpecificBoxInfo) -> Box {
+        Box {
             node: node,
             position: Slot::init(Au::zero_rect()),
-            id: id,
-            border: Zero::zero(),
-            padding: Zero::zero(),
-            margin: Zero::zero(),
+            border: Slot::init(Zero::zero()),
+            padding: Slot::init(Zero::zero()),
+            margin: Slot::init(Zero::zero()),
             content_box_width: Zero::zero(),
+            specific: specific,
         }
     }
 
-    pub fn id(&self) -> int {
-        0
+    /// Returns a debug ID of this box. This ID should not be considered stable across multiple
+    /// layouts or box manipulations.
+    pub fn debug_id(&self) -> uint {
+        unsafe {
+            cast::transmute(self)
+        }
+    }
+
+    /// Transforms this box into another box of the given type, with the given size, preserving all
+    /// the other data.
+    pub fn transform(&self, size: Size2D<Au>, specific: SpecificBoxInfo) -> Box {
+        Box {
+            node: self.node,
+            position: Slot::init(Rect(self.position.get().origin, size)),
+            border: Slot::init(self.border.get()),
+            padding: Slot::init(self.padding.get()),
+            margin: Slot::init(self.margin.get()),
+            content_box_width: self.content_box_width,
+            specific: specific,
+        }
     }
 
     fn guess_width(&self) -> Au {
@@ -694,8 +254,13 @@ impl RenderBoxBase {
         let padding_left = self.compute_padding_length(style.Padding.padding_left, Au::new(0));
         let padding_right = self.compute_padding_length(style.Padding.padding_right, Au::new(0));
 
-        width + margin_left + margin_right + padding_left + padding_right + self.border.left +
-            self.border.right
+        width + margin_left + margin_right + padding_left + padding_right +
+            self.border.get().left + self.border.get().right
+    }
+
+    /// Sets the size of this box.
+    fn set_size(&self, new_size: Size2D<Au>) {
+        self.position.set(Rect(self.position.get().origin, new_size))
     }
 
     pub fn calculate_line_height(&self, font_size: Au) -> Au { 
@@ -707,38 +272,43 @@ impl RenderBoxBase {
     }
 
     /// Populates the box model border parameters from the given computed style.
-    pub fn compute_borders(&mut self, style: &ComputedValues) {
-        self.border.top = style.Border.border_top_width;
-        self.border.right = style.Border.border_right_width;
-        self.border.bottom = style.Border.border_bottom_width;
-        self.border.left = style.Border.border_left_width;
+    ///
+    /// FIXME(pcwalton): This should not be necessary. Just go to the style.
+    pub fn compute_borders(&self, style: &ComputedValues) {
+        self.border.set(SideOffsets2D::new(style.Border.border_top_width,
+                                           style.Border.border_right_width,
+                                           style.Border.border_bottom_width,
+                                           style.Border.border_left_width))
     }
 
     /// Populates the box model padding parameters from the given computed style.
-    pub fn compute_padding(&mut self, style: &ComputedValues, containing_block_width: Au) {
-        self.padding.top = self.compute_padding_length(style.Padding.padding_top,
-                                                       containing_block_width);
-        self.padding.right = self.compute_padding_length(style.Padding.padding_right,
-                                                         containing_block_width);
-        self.padding.bottom = self.compute_padding_length(style.Padding.padding_bottom,
-                                                          containing_block_width);
-        self.padding.left = self.compute_padding_length(style.Padding.padding_left,
-                                                        containing_block_width);
+    pub fn compute_padding(&self, style: &ComputedValues, containing_block_width: Au) {
+        let padding = SideOffsets2D::new(self.compute_padding_length(style.Padding.padding_top,
+                                                                     containing_block_width),
+                                         self.compute_padding_length(style.Padding.padding_right,
+                                                                     containing_block_width),
+                                         self.compute_padding_length(style.Padding.padding_bottom,
+                                                                     containing_block_width),
+                                         self.compute_padding_length(style.Padding.padding_left,
+                                                                     containing_block_width));
+        self.padding.set(padding)
     }
 
-    pub fn compute_padding_length(&self, padding: LengthOrPercentage, content_box_width: Au) -> Au {
+    pub fn compute_padding_length(&self, padding: LengthOrPercentage, content_box_width: Au)
+                                  -> Au {
         specified(padding, content_box_width)
     }
 
     pub fn noncontent_width(&self) -> Au {
-        let left = self.margin.left + self.border.left + self.padding.left;
-        let right = self.margin.right + self.border.right + self.padding.right;
+        let left = self.margin.get().left + self.border.get().left + self.padding.get().left;
+        let right = self.margin.get().right + self.border.get().right + self.padding.get().right;
         left + right
     }
 
     pub fn noncontent_height(&self) -> Au {
-        let top = self.margin.top + self.border.top + self.padding.top;
-        let bottom = self.margin.bottom + self.border.bottom + self.padding.bottom;
+        let top = self.margin.get().top + self.border.get().top + self.padding.get().top;
+        let bottom = self.margin.get().bottom + self.border.get().bottom +
+            self.padding.get().bottom;
         top + bottom
     }
 
@@ -746,9 +316,10 @@ impl RenderBoxBase {
     /// the owning flow.
     pub fn content_box(&self) -> Rect<Au> {
         let position = self.position.get();
-        let origin = Point2D(position.origin.x + self.border.left + self.padding.left,
+        let origin = Point2D(position.origin.x + self.border.get().left + self.padding.get().left,
                              position.origin.y);
-        let noncontent_width = self.border.left + self.padding.left + self.border.right + self.padding.right;
+        let noncontent_width = self.border.get().left + self.padding.get().left +
+            self.border.get().right + self.padding.get().right;
         let size = Size2D(position.size.width - noncontent_width, position.size.height);
         Rect(origin, size)
     }
@@ -767,8 +338,7 @@ impl RenderBoxBase {
         self.content_box()
     }
 
-    /// Returns the nearest ancestor-or-self `Element` to the DOM node that this render box
-    /// represents.
+    /// Returns the nearest ancestor-or-self `Element` to the DOM node that this box represents.
     ///
     /// If there is no ancestor-or-self `Element` node, fails.
     pub fn nearest_ancestor_element(&self) -> AbstractNode<LayoutView> {
@@ -782,7 +352,9 @@ impl RenderBoxBase {
         node
     }
 
-    // Always inline for SCCP.
+    /// Always inline for SCCP.
+    ///
+    /// FIXME(pcwalton): Just replace with the clear type from the style module for speed?
     #[inline(always)]
     pub fn clear(&self) -> Option<ClearType> {
         let style = self.node.style();
@@ -795,6 +367,9 @@ impl RenderBoxBase {
     }
 
     /// Converts this node's computed style to a font style used for rendering.
+    ///
+    /// FIXME(pcwalton): This should not be necessary; just make the font part of style sharable
+    /// with the display list somehow. (Perhaps we should use an ARC.)
     pub fn font_style(&self) -> FontStyle {
         let my_style = self.nearest_ancestor_element().style();
 
@@ -877,101 +452,91 @@ impl RenderBoxBase {
                     None => text_decoration::none,
                     Some(parent) => get_propagated_text_decoration(parent),
                 }
-            }
-            else {
+            } else {
                 text_decoration
             }
         }
         get_propagated_text_decoration(self.nearest_ancestor_element())
     }
 
+    /// Returns the sum of margin, border, and padding on the left.
     pub fn offset(&self) -> Au {
-        self.margin.left + self.border.left + self.padding.left
+        self.margin.get().left + self.border.get().left + self.padding.get().left
     }
 
-}
-
-impl RenderBoxUtils for @RenderBox {
-    #[inline(always)]
-    fn base<'a>(&'a self) -> &'a RenderBoxBase {
-        unsafe {
-            let (_, box_ptr): (uint, *Box<RenderBoxBase>) = cast::transmute(*self);
-            cast::transmute(&(*box_ptr).data)
+    /// Returns true if this element is replaced content. This is true for images, form elements,
+    /// and so on.
+    pub fn is_replaced(&self) -> bool {
+        match self.specific {
+            ImageBox(*) => true,
+            _ => false,
         }
     }
 
-    fn mut_base<'a>(&'a self) -> &'a mut RenderBoxBase {
-        unsafe {
-            let (_, box_ptr): (uint, *Box<RenderBoxBase>) = cast::transmute(*self);
-            cast::transmute_mut(&(*box_ptr).data)
+    /// Returns true if this element can be split. This is true for text boxes.
+    pub fn can_split(&self) -> bool {
+        match self.specific {
+            ScannedTextBox(*) => true,
+            _ => false,
         }
-    }
-
-    fn is_replaced(&self) -> bool {
-        self.class() == ImageRenderBoxClass
-    }
-
-    fn can_split(&self) -> bool {
-        self.class() == TextRenderBoxClass
     }
 
     /// Returns the amount of left and right "fringe" used by this box. This is based on margins,
     /// borders, padding, and width.
-    fn get_used_width(&self) -> (Au, Au) {
+    pub fn get_used_width(&self) -> (Au, Au) {
         // TODO: This should actually do some computation! See CSS 2.1, Sections 10.3 and 10.4.
         (Au::new(0), Au::new(0))
     }
 
     /// Returns the amount of left and right "fringe" used by this box. This should be based on
     /// margins, borders, padding, and width.
-    fn get_used_height(&self) -> (Au, Au) {
+    pub fn get_used_height(&self) -> (Au, Au) {
         // TODO: This should actually do some computation! See CSS 2.1, Sections 10.5 and 10.6.
         (Au::new(0), Au::new(0))
     }
 
-    /// Adds the display items necessary to paint the background of this render box to the display
-    /// list if necessary.
-    fn paint_background_if_applicable<E:ExtraDisplayListData>(
-                                      &self,
-                                      list: &Cell<DisplayList<E>>,
-                                      absolute_bounds: &Rect<Au>) {
+    /// Adds the display items necessary to paint the background of this box to the display list if
+    /// necessary.
+    pub fn paint_background_if_applicable<E:ExtraDisplayListData>(
+                                          @self,
+                                          list: &Cell<DisplayList<E>>,
+                                          absolute_bounds: &Rect<Au>) {
         // FIXME: This causes a lot of background colors to be displayed when they are clearly not
         // needed. We could use display list optimization to clean this up, but it still seems
         // inefficient. What we really want is something like "nearest ancestor element that
-        // doesn't have a render box".
-        let nearest_ancestor_element = self.base().nearest_ancestor_element();
+        // doesn't have a box".
+        let nearest_ancestor_element = self.nearest_ancestor_element();
 
         let style = nearest_ancestor_element.style();
         let background_color = style.resolve_color(style.Background.background_color);
         if !background_color.alpha.approx_eq(&0.0) {
-            do list.with_mut_ref |list| {
+            list.with_mut_ref(|list| {
                 let solid_color_display_item = ~SolidColorDisplayItem {
                     base: BaseDisplayItem {
                         bounds: *absolute_bounds,
-                        extra: ExtraDisplayListData::new(self),
+                        extra: ExtraDisplayListData::new(&self),
                     },
                     color: background_color.to_gfx_color(),
                 };
 
                 list.append_item(SolidColorDisplayItemClass(solid_color_display_item))
-            }
+            })
         }
     }
 
-    /// Adds the display items necessary to paint the borders of this render box to a display list
-    /// if necessary.
-    fn paint_borders_if_applicable<E:ExtraDisplayListData>(
-                                   &self,
-                                   list: &Cell<DisplayList<E>>,
-                                   abs_bounds: &Rect<Au>) {
+    /// Adds the display items necessary to paint the borders of this box to a display list if
+    /// necessary.
+    pub fn paint_borders_if_applicable<E:ExtraDisplayListData>(
+                                       @self,
+                                       list: &Cell<DisplayList<E>>,
+                                       abs_bounds: &Rect<Au>) {
         // Fast path.
-        let base = self.base();
-        let border = base.border;
+        let border = self.border.get();
         if border.is_zero() {
             return
         }
 
-        let style = base.style();
+        let style = self.style();
         let top_color = style.resolve_color(style.Border.border_top_color);
         let right_color = style.resolve_color(style.Border.border_right_color);
         let bottom_color = style.resolve_color(style.Border.border_bottom_color);
@@ -986,12 +551,9 @@ impl RenderBoxUtils for @RenderBox {
             let border_display_item = ~BorderDisplayItem {
                 base: BaseDisplayItem {
                     bounds: *abs_bounds,
-                    extra: ExtraDisplayListData::new(self),
+                    extra: ExtraDisplayListData::new(&self),
                 },
-                border: SideOffsets2D::new(border.top,
-                                           border.right,
-                                           border.bottom,
-                                           border.left),
+                border: border,
                 color: SideOffsets2D::new(top_color.to_gfx_color(),
                                           right_color.to_gfx_color(),
                                           bottom_color.to_gfx_color(),
@@ -1006,7 +568,7 @@ impl RenderBoxUtils for @RenderBox {
         }
     }
 
-    /// Adds the display items for this render box to the given display list.
+    /// Adds the display items for this box to the given display list.
     ///
     /// Arguments:
     /// * `builder`: The display list builder, which manages the coordinate system and options.
@@ -1020,43 +582,40 @@ impl RenderBoxUtils for @RenderBox {
     /// representing the box's stacking context. When asked to construct its constituent display
     /// items, each box puts its display items into the correct stack layer according to CSS 2.1
     /// Appendix E. Finally, the builder flattens the list.
-    fn build_display_list<E:ExtraDisplayListData>(
-                          &self,
-                          _: &DisplayListBuilder,
-                          dirty: &Rect<Au>,
-                          offset: &Point2D<Au>,
-                          list: &Cell<DisplayList<E>>) {
-        let base = self.base();
-        let box_bounds = base.position.get();
+    pub fn build_display_list<E:ExtraDisplayListData>(
+                              @self,
+                              _: &DisplayListBuilder,
+                              dirty: &Rect<Au>,
+                              offset: &Point2D<Au>,
+                              list: &Cell<DisplayList<E>>) {
+        let box_bounds = self.position.get();
         let absolute_box_bounds = box_bounds.translate(offset);
-        debug!("RenderBox::build_display_list at rel={}, abs={}: {:s}",
+        debug!("Box::build_display_list at rel={}, abs={}: {:s}",
                box_bounds, absolute_box_bounds, self.debug_str());
-        debug!("RenderBox::build_display_list: dirty={}, offset={}", *dirty, *offset);
+        debug!("Box::build_display_list: dirty={}, offset={}", *dirty, *offset);
 
-        if base.nearest_ancestor_element().style().Box.visibility != visibility::visible {
+        if self.nearest_ancestor_element().style().Box.visibility != visibility::visible {
             return;
         }
 
         if absolute_box_bounds.intersects(dirty) {
-            debug!("RenderBox::build_display_list: intersected. Adding display item...");
+            debug!("Box::build_display_list: intersected. Adding display item...");
         } else {
-            debug!("RenderBox::build_display_list: Did not intersect...");
+            debug!("Box::build_display_list: Did not intersect...");
             return;
         }
 
-        match self.class() {
-            UnscannedTextRenderBoxClass => fail!("Shouldn't see unscanned boxes here."),
-            TextRenderBoxClass => {
-                let text_box = self.as_text_render_box();
+        // Add the background to the list, if applicable.
+        self.paint_background_if_applicable(list, &absolute_box_bounds);
 
-                // Add the background to the list, if applicable.
-                self.paint_background_if_applicable(list, &absolute_box_bounds);
-
+        match self.specific {
+            UnscannedTextBox(_) => fail!("Shouldn't see unscanned boxes here."),
+            ScannedTextBox(ref text_box) => {
                 do list.with_mut_ref |list| {
                     let item = ~ClipDisplayItem {
                         base: BaseDisplayItem {
                             bounds: absolute_box_bounds,
-                            extra: ExtraDisplayListData::new(self),
+                            extra: ExtraDisplayListData::new(&self),
                         },
                         child_list: ~[],
                         need_clip: false
@@ -1065,7 +624,7 @@ impl RenderBoxUtils for @RenderBox {
                 }
 
 
-                let nearest_ancestor_element = base.nearest_ancestor_element();
+                let nearest_ancestor_element = self.nearest_ancestor_element();
                 let color = nearest_ancestor_element.style().Color.color.to_gfx_color();
 
                 // Create the text box.
@@ -1073,7 +632,7 @@ impl RenderBoxUtils for @RenderBox {
                     let text_display_item = ~TextDisplayItem {
                         base: BaseDisplayItem {
                             bounds: absolute_box_bounds,
-                            extra: ExtraDisplayListData::new(self),
+                            extra: ExtraDisplayListData::new(&self),
                         },
                         // FIXME(pcwalton): Allocation? Why?!
                         text_run: ~text_box.run.serialize(),
@@ -1096,7 +655,7 @@ impl RenderBoxUtils for @RenderBox {
                         let border_display_item = ~BorderDisplayItem {
                             base: BaseDisplayItem {
                                 bounds: absolute_box_bounds,
-                                extra: ExtraDisplayListData::new(self),
+                                extra: ExtraDisplayListData::new(&self),
                             },
                             border: debug_border,
                             color: SideOffsets2D::new_all_same(rgb(0, 0, 200)),
@@ -1118,7 +677,7 @@ impl RenderBoxUtils for @RenderBox {
                         let border_display_item = ~BorderDisplayItem {
                             base: BaseDisplayItem {
                                 bounds: baseline,
-                                extra: ExtraDisplayListData::new(self),
+                                extra: ExtraDisplayListData::new(&self),
                             },
                             border: debug_border,
                             color: SideOffsets2D::new_all_same(rgb(0, 200, 0)),
@@ -1131,19 +690,15 @@ impl RenderBoxUtils for @RenderBox {
                     ()
                 });
             },
-            GenericRenderBoxClass => {
-                // Add the background to the list, if applicable.
-                self.paint_background_if_applicable(list, &absolute_box_bounds);
-
-                let generic_box = self.as_generic_render_box();
+            GenericBox => {
                 do list.with_mut_ref |list| {
                     let item = ~ClipDisplayItem {
                         base: BaseDisplayItem {
                             bounds: absolute_box_bounds,
-                            extra: ExtraDisplayListData::new(self),
+                            extra: ExtraDisplayListData::new(&self),
                         },
                         child_list: ~[],
-                        need_clip: generic_box.need_clip()
+                        need_clip: self.needs_clip()
                     };
                     list.append_item(ClipDisplayItemClass(item));
                 }
@@ -1157,7 +712,7 @@ impl RenderBoxUtils for @RenderBox {
                         let border_display_item = ~BorderDisplayItem {
                             base: BaseDisplayItem {
                                 bounds: absolute_box_bounds,
-                                extra: ExtraDisplayListData::new(self),
+                                extra: ExtraDisplayListData::new(&self),
                             },
                             border: debug_border,
                             color: SideOffsets2D::new_all_same(rgb(0, 0, 200)),
@@ -1170,23 +725,18 @@ impl RenderBoxUtils for @RenderBox {
                     ()
                 });
             },
-            ImageRenderBoxClass => {
-                // Add the background to the list, if applicable.
-                self.paint_background_if_applicable(list, &absolute_box_bounds);
-
+            ImageBox(ref image_box) => {
                 do list.with_mut_ref |list| {
                     let item = ~ClipDisplayItem {
                         base: BaseDisplayItem {
                             bounds: absolute_box_bounds,
-                            extra: ExtraDisplayListData::new(self),
+                            extra: ExtraDisplayListData::new(&self),
                         },
                         child_list: ~[],
                         need_clip: false
                     };
                     list.append_item(ClipDisplayItemClass(item));
                 }
-
-                let image_box = self.as_image_render_box();
 
                 match image_box.image.mutate().ptr.get_image() {
                     Some(image) => {
@@ -1197,7 +747,7 @@ impl RenderBoxUtils for @RenderBox {
                             let image_display_item = ~ImageDisplayItem {
                                 base: BaseDisplayItem {
                                     bounds: absolute_box_bounds,
-                                    extra: ExtraDisplayListData::new(self),
+                                    extra: ExtraDisplayListData::new(&self),
                                 },
                                 image: image.clone(),
                             };
@@ -1219,23 +769,218 @@ impl RenderBoxUtils for @RenderBox {
         // TODO: Outlines.
         self.paint_borders_if_applicable(list, &absolute_box_bounds);
     }
-}
 
-impl<'self> RenderBoxRefUtils<'self> for &'self RenderBox {
-    #[inline(always)]
-    fn base(self) -> &'self RenderBoxBase {
-        unsafe {
-            let (_, box_ptr): (uint, *RenderBoxBase) = cast::transmute(self);
-            cast::transmute(box_ptr)
+    /// Returns the *minimum width* and *preferred width* of this box as defined by CSS 2.1.
+    pub fn minimum_and_preferred_widths(&self) -> (Au, Au) {
+        let guessed_width = self.guess_width();
+        let (additional_minimum, additional_preferred) = match self.specific {
+            GenericBox => (Au(0), Au(0)),
+            ImageBox(ref image_box_info) => {
+                let image_width = image_box_info.image_width(self);
+                (image_width, image_width)
+            }
+            ScannedTextBox(ref text_box_info) => {
+                let range = &text_box_info.range;
+                let min_line_width = text_box_info.run.min_width_for_range(range);
+
+                let mut max_line_width = Au::new(0);
+                for line_range in text_box_info.run.iter_natural_lines_for_range(range) {
+                    let line_metrics = text_box_info.run.metrics_for_range(&line_range);
+                    max_line_width = Au::max(max_line_width, line_metrics.advance_width);
+                }
+
+                (min_line_width, max_line_width)
+            }
+            UnscannedTextBox(*) => fail!("Unscanned text boxes should have been scanned by now!"),
+        };
+        (guessed_width + additional_minimum, guessed_width + additional_preferred)
+    }
+
+    /// Returns, and computes, the height of this box.
+    ///
+    /// FIXME(pcwalton): Rename to just `height`?
+    /// FIXME(pcwalton): This function *mutates* the height? Gross! Refactor please.
+    pub fn box_height(&self) -> Au {
+        match self.specific {
+            GenericBox => Au(0),
+            ImageBox(ref image_box_info) => {
+                let size = image_box_info.image.mutate().ptr.get_size();
+                let height = Au::from_px(size.unwrap_or(Size2D(0, 0)).height);
+
+                // Eww. Refactor this.
+                self.position.mutate().ptr.size.height = height;
+                debug!("box_height: found image height: {}", height);
+
+                height
+            }
+            ScannedTextBox(ref text_box_info) => {
+                // Compute the height based on the line-height and font size.
+                let (range, run) = (&text_box_info.range, &text_box_info.run);
+                let text_bounds = run.metrics_for_range(range).bounding_box;
+                let em_size = text_bounds.size.height;
+                self.calculate_line_height(em_size)
+            }
+            UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }
     }
 
-    #[inline(always)]
-    fn mut_base(self) -> &'self mut RenderBoxBase {
-        unsafe {
-            let (_, box_ptr): (uint, *mut RenderBoxBase) = cast::transmute(self);
-            cast::transmute(box_ptr)
+    /// Attempts to split this box so that its width is no more than `max_width`.
+    pub fn split_to_width(@self, max_width: Au, starts_line: bool) -> SplitBoxResult {
+        match self.specific {
+            GenericBox | ImageBox(_) => CannotSplit(self),
+            UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
+            ScannedTextBox(ref text_box_info) => {
+                let mut pieces_processed_count: uint = 0;
+                let mut remaining_width: Au = max_width;
+                let mut left_range = Range::new(text_box_info.range.begin(), 0);
+                let mut right_range: Option<Range> = None;
+
+                debug!("split_to_width: splitting text box (strlen={:u}, range={}, \
+                                                            avail_width={})",
+                       text_box_info.run.text.get().len(),
+                       text_box_info.range,
+                       max_width);
+
+                for (glyphs, offset, slice_range) in text_box_info.run.iter_slices_for_range(
+                        &text_box_info.range) {
+                    debug!("split_to_width: considering slice (offset={}, range={}, \
+                                                               remain_width={})",
+                           offset,
+                           slice_range,
+                           remaining_width);
+
+                    let metrics = text_box_info.run.metrics_for_slice(glyphs, &slice_range);
+                    let advance = metrics.advance_width;
+
+                    let should_continue;
+                    if advance <= remaining_width {
+                        should_continue = true;
+
+                        if starts_line && pieces_processed_count == 0 && glyphs.is_whitespace() {
+                            debug!("split_to_width: case=skipping leading trimmable whitespace");
+                            left_range.shift_by(slice_range.length() as int);
+                        } else {
+                            debug!("split_to_width: case=enlarging span");
+                            remaining_width = remaining_width - advance;
+                            left_range.extend_by(slice_range.length() as int);
+                        }
+                    } else {
+                        // The advance is more than the remaining width.
+                        should_continue = false;
+                        let slice_begin = offset + slice_range.begin();
+                        let slice_end = offset + slice_range.end();
+
+                        if glyphs.is_whitespace() {
+                            // If there are still things after the trimmable whitespace, create the
+                            // right chunk.
+                            if slice_end < text_box_info.range.end() {
+                                debug!("split_to_width: case=skipping trimmable trailing \
+                                        whitespace, then split remainder");
+                                let right_range_end = text_box_info.range.end() - slice_end;
+                                right_range = Some(Range::new(slice_end, right_range_end));
+                            } else {
+                                debug!("split_to_width: case=skipping trimmable trailing \
+                                        whitespace");
+                            }
+                        } else if slice_begin < text_box_info.range.end() {
+                            // There are still some things left over at the end of the line. Create
+                            // the right chunk.
+                            let right_range_end = text_box_info.range.end() - slice_begin;
+                            right_range = Some(Range::new(slice_begin, right_range_end));
+                            debug!("split_to_width: case=splitting remainder with right range={:?}",
+                                   right_range);
+                        }
+                    }
+
+                    pieces_processed_count += 1;
+
+                    if !should_continue {
+                        break
+                    }
+                }
+
+                let left_box = if left_range.length() > 0 {
+                    let new_text_box_info = ScannedTextBoxInfo::new(text_box_info.run, left_range);
+                    let new_text_box = @Box::new(self.node, ScannedTextBox(new_text_box_info));
+                    let new_metrics = new_text_box_info.run.metrics_for_range(&left_range);
+                    new_text_box.set_size(new_metrics.bounding_box.size);
+                    Some(new_text_box)
+                } else {
+                    None
+                };
+
+                let right_box = right_range.map_default(None, |range: Range| {
+                    let new_text_box_info = ScannedTextBoxInfo::new(text_box_info.run, range);
+                    let new_text_box = @Box::new(self.node, ScannedTextBox(new_text_box_info));
+                    let new_metrics = new_text_box_info.run.metrics_for_range(&range);
+                    new_text_box.set_size(new_metrics.bounding_box.size);
+                    Some(new_text_box)
+                });
+
+                if pieces_processed_count == 1 || left_box.is_none() {
+                    SplitDidNotFit(left_box, right_box)
+                } else {
+                    SplitDidFit(left_box, right_box)
+                }
+            }
         }
+    }
+
+    /// Returns true if this box is an unscanned text box that consists entirely of whitespace.
+    pub fn is_whitespace_only(&self) -> bool {
+        match self.specific {
+            UnscannedTextBox(ref text_box_info) => text_box_info.text.is_whitespace(),
+            _ => false,
+        }
+    }
+
+    /// Assigns the appropriate width to this box.
+    pub fn assign_width(&self) {
+        match self.specific {
+            GenericBox => {
+                // FIXME(pcwalton): This seems clownshoes; can we remove?
+                self.position.mutate().ptr.size.width = Au::from_px(45)
+            }
+            ImageBox(ref image_box_info) => {
+                let image_width = image_box_info.image_width(self);
+                self.position.mutate().ptr.size.width = image_width
+            }
+            ScannedTextBox(_) => {
+                // Scanned text boxes will have already had their widths assigned by this point.
+            }
+            UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
+        }
+    }
+
+    /// Returns true if this box can merge with another adjacent box or false otherwise.
+    pub fn can_merge_with_box(&self, other: &Box) -> bool {
+        match (&self.specific, &other.specific) {
+            (&UnscannedTextBox(_), &UnscannedTextBox(_)) => {
+                self.font_style() == other.font_style() &&
+                    self.text_decoration() == other.text_decoration()
+            }
+            _ => false,
+        }
+    }
+
+    /// Cleans up all the memory associated with this box.
+    pub fn teardown(&self) {
+        match self.specific {
+            ScannedTextBox(ref text_box_info) => text_box_info.run.teardown(),
+            _ => {}
+        }
+    }
+
+    /// Returns true if the contents should be clipped (i.e. if `overflow` is `hidden`).
+    pub fn needs_clip(&self) -> bool {
+        self.node.style().Box.overflow == overflow::hidden
+    }
+
+    /// Returns a debugging string describing this box.
+    ///
+    /// TODO(pcwalton): Reimplement.
+    pub fn debug_str(&self) -> ~str {
+        ~"(Box)"
     }
 }
 

--- a/src/components/main/layout/display_list_builder.rs
+++ b/src/components/main/layout/display_list_builder.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! Constructs display lists from render boxes.
+//! Constructs display lists from boxes.
 
-use layout::box::{RenderBox, RenderBoxUtils};
+use layout::box::Box;
 use layout::context::LayoutContext;
 use std::cast::transmute;
 use script::dom::node::AbstractNode;
@@ -16,27 +16,27 @@ use style;
 /// that nodes in this view shoud not really be touched. The idea is to
 /// store the nodes in the display list and have layout transmute them.
 pub trait ExtraDisplayListData {
-    fn new(box: &@RenderBox) -> Self;
+    fn new(box: &@Box) -> Self;
 }
 
 pub type Nothing = ();
 
 impl ExtraDisplayListData for AbstractNode<()> {
-    fn new(box: &@RenderBox) -> AbstractNode<()> {
+    fn new(box: &@Box) -> AbstractNode<()> {
         unsafe {
-            transmute(box.base().node)
+            transmute(box.node)
         }
     }
 }
 
 impl ExtraDisplayListData for Nothing {
-    fn new(_: &@RenderBox) -> Nothing {
+    fn new(_: &@Box) -> Nothing {
         ()
     }
 }
 
-impl ExtraDisplayListData for @RenderBox {
-    fn new(box: &@RenderBox) -> @RenderBox {
+impl ExtraDisplayListData for @Box {
+    fn new(box: &@Box) -> @Box {
         *box
     }
 }

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -2,23 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! Servo's experimental layout system builds a tree of `Flow` and `RenderBox` objects and
-/// solves layout constraints to obtain positions and display attributes of tree nodes. Positions
-/// are computed in several tree traversals driven by the fundamental data dependencies required by
+//! Servo's experimental layout system builds a tree of `Flow` and `Box` objects and solves
+//! layout constraints to obtain positions and display attributes of tree nodes. Positions are
+//! computed in several tree traversals driven by the fundamental data dependencies required by
 /// inline and block layout.
 /// 
 /// Flows are interior nodes in the layout tree and correspond closely to *flow contexts* in the
-/// CSS specification. Flows are responsible for positioning their child flow contexts and render
-/// boxes. Flows have purpose-specific fields, such as auxiliary line box structs, out-of-flow
-/// child lists, and so on.
+/// CSS specification. Flows are responsible for positioning their child flow contexts and boxes.
+/// Flows have purpose-specific fields, such as auxiliary line box structs, out-of-flow child
+/// lists, and so on.
 ///
 /// Currently, the important types of flows are:
 /// 
 /// * `BlockFlow`: A flow that establishes a block context. It has several child flows, each of
 ///   which are positioned according to block formatting context rules (CSS block boxes). Block
 ///   flows also contain a single `GenericBox` to represent their rendered borders, padding, etc.
-///   (In the future, this render box may be folded into `BlockFlow` to save space.) The BlockFlow
-///   at the root of the tree has special behavior: it stretches to the boundaries of the viewport.
+///   (In the future, this box may be folded into `BlockFlow` to save space.) The BlockFlow at the
+///   root of the tree has special behavior: it stretches to the boundaries of the viewport.
 ///   
 /// * `InlineFlow`: A flow that establishes an inline context. It has a flat list of child
 ///   boxes/flows that are subject to inline layout and line breaking and structs to represent
@@ -27,7 +27,7 @@
 
 use css::node_style::StyledNode;
 use layout::block::BlockFlow;
-use layout::box::RenderBox;
+use layout::box::Box;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::float_context::{FloatContext, Invalid};
@@ -340,12 +340,12 @@ pub struct FlowData {
 }
 
 pub struct BoxIterator {
-    priv boxes: ~[@RenderBox],
+    priv boxes: ~[@Box],
     priv index: uint,
 }
 
-impl Iterator<@RenderBox> for BoxIterator {
-    fn next(&mut self) -> Option<@RenderBox> {
+impl Iterator<@Box> for BoxIterator {
+    fn next(&mut self) -> Option<@Box> {
         if self.index >= self.boxes.len() {
             None
         } else {

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use layout::box::{RenderBox, RenderBoxUtils};
+use layout::box::Box;
 use layout::construct::{ConstructionResult, NoConstructionResult};
 
 use extra::arc::Arc;
@@ -76,7 +76,7 @@ impl ElementMapping {
         self.entries.iter().enumerate()
     }
 
-    pub fn repair_for_box_changes(&mut self, old_boxes: &[@RenderBox], new_boxes: &[@RenderBox]) {
+    pub fn repair_for_box_changes(&mut self, old_boxes: &[@Box], new_boxes: &[@Box]) {
         let entries = &mut self.entries;
 
         debug!("--- Old boxes: ---");
@@ -118,8 +118,7 @@ impl ElementMapping {
                     repair_stack.push(item);
                     entries_k += 1;
                 }
-                while new_j < new_boxes.len() &&
-                        old_boxes[old_i].base().node != new_boxes[new_j].base().node {
+                while new_j < new_boxes.len() && old_boxes[old_i].node != new_boxes[new_j].node {
                     debug!("repair_for_box_changes: Slide through new box {:u}", new_j);
                     new_j += 1;
                 }


### PR DESCRIPTION
Also removes a few text copies that were taking place.

This sure does remove a lot of code!

r? @metajack
