### PR TITLE
Acid1 fix (fixed FloatFlow refactory)

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -558,7 +558,6 @@ impl Flow for BlockFlow {
     min/pref widths based on child context widths and dimensions of
     any boxes it is responsible for flowing.  */
 
-    /* TODO: floats */
     /* TODO: absolute contexts */
     /* TODO: inline-blocks */
     fn bubble_widths(&mut self, _: &mut LayoutContext) {
@@ -587,10 +586,8 @@ impl Flow for BlockFlow {
            these widths will not include child elements, just padding etc. */
         for box in self.box.iter() {
             {
-                let mut_base = box.mut_base();
-                let base = box.base();
                 // Can compute border width here since it doesn't depend on anything.
-                mut_base.compute_borders(base.style())
+                box.mut_base().compute_borders(box.base().style());
             }
 
             let (this_minimum_width, this_preferred_width) = box.minimum_and_preferred_widths();
@@ -627,6 +624,8 @@ impl Flow for BlockFlow {
         let mut x_offset = Au::new(0);
 
         if self.is_float() {
+            self.float.get_mut_ref().containing_width = remaining_width;
+
             // Parent usually sets this, but floats are never inorder
             self.base.is_inorder = false;
         }


### PR DESCRIPTION
While doing the FloatFlow refactory, I forgot to transpose a variable
assignment in assign_widths(). Also did a minor change in
bubble_widths() to avoid creating temporary variables in an iteration
loop.

This patch is for:
https://github.com/mozilla/servo/issues/1335
