### PR TITLE
Avoid sending uninitialized data from the headless compositor.

### DIFF
--- a/src/components/main/compositing/run_headless.rs
+++ b/src/components/main/compositing/run_headless.rs
@@ -4,7 +4,7 @@
 
 use compositing::*;
 
-use std::unstable::intrinsics;
+use layers::platform::surface::NativeGraphicsMetadata;
 
 /// Starts the compositor, which listens for messages on the specified port.
 ///
@@ -16,9 +16,9 @@ pub fn run_compositor(compositor: &CompositorTask) {
             Exit => break,
 
              GetGraphicsMetadata(chan) => {
-                unsafe {
-                    chan.send(intrinsics::uninit());
-                }
+                chan.send(NativeGraphicsMetadata {
+                    display: ~"",
+                });
             }
 
             SetIds(_, response_chan, _) => {


### PR DESCRIPTION
This fixes `./servo -z` locally for me (Linux).
