### PR TITLE
Return None from get_graphics_metadata in headless compositor

### DIFF
--- a/src/components/gfx/gfx.rc
+++ b/src/components/gfx/gfx.rc
@@ -8,7 +8,7 @@
        url = "http://servo.org/")];
 #[crate_type = "lib"];
 
-#[feature(globs, managed_boxes)];
+#[feature(globs, managed_boxes, macro_rules)];
 
 extern mod azure;
 extern mod extra;

--- a/src/components/main/compositing/mod.rs
+++ b/src/components/main/compositing/mod.rs
@@ -61,7 +61,7 @@ impl ScriptListener for CompositorChan {
 
 /// Implementation of the abstract `RenderListener` interface.
 impl RenderListener for CompositorChan {
-    fn get_graphics_metadata(&self) -> NativeGraphicsMetadata {
+    fn get_graphics_metadata(&self) -> Option<NativeGraphicsMetadata> {
         let (port, chan) = comm::stream();
         self.chan.send(GetGraphicsMetadata(chan));
         port.recv()
@@ -117,7 +117,9 @@ pub enum Msg {
     /// Requests the compositor's graphics metadata. Graphics metadata is what the renderer needs
     /// to create surfaces that the compositor can see. On Linux this is the X display; on Mac this
     /// is the pixel format.
-    GetGraphicsMetadata(Chan<NativeGraphicsMetadata>),
+    ///
+    /// The headless compositor returns `None`.
+    GetGraphicsMetadata(Chan<Option<NativeGraphicsMetadata>>),
 
     /// Alerts the compositor that there is a new layer to be rendered.
     NewLayer(PipelineId, Size2D<f32>),

--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -131,7 +131,7 @@ pub fn run_compositor(compositor: &CompositorTask) {
                     constellation_chan = Some(new_constellation_chan);
                 }
 
-                GetGraphicsMetadata(chan) => chan.send(azure_hl::current_graphics_metadata()),
+                GetGraphicsMetadata(chan) => chan.send(Some(azure_hl::current_graphics_metadata())),
 
                 NewLayer(_id, new_size) => {
                     // FIXME: This should create an additional layer instead of replacing the current one.

--- a/src/components/main/compositing/run_headless.rs
+++ b/src/components/main/compositing/run_headless.rs
@@ -4,8 +4,6 @@
 
 use compositing::*;
 
-use std::unstable::intrinsics;
-
 /// Starts the compositor, which listens for messages on the specified port.
 ///
 /// This is the null compositor which doesn't draw anything to the screen.
@@ -15,10 +13,8 @@ pub fn run_compositor(compositor: &CompositorTask) {
         match compositor.port.recv() {
             Exit => break,
 
-             GetGraphicsMetadata(chan) => {
-                unsafe {
-                    chan.send(intrinsics::uninit());
-                }
+            GetGraphicsMetadata(chan) => {
+                chan.send(None);
             }
 
             SetIds(_, response_chan, _) => {

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -76,7 +76,7 @@ impl Epoch {
 /// The interface used by the renderer to acquire draw targets for each render frame and
 /// submit them to be drawn to the display.
 pub trait RenderListener {
-    fn get_graphics_metadata(&self) -> NativeGraphicsMetadata;
+    fn get_graphics_metadata(&self) -> Option<NativeGraphicsMetadata>;
     fn new_layer(&self, PipelineId, Size2D<uint>);
     fn set_layer_page_size_and_color(&self, PipelineId, Size2D<uint>, Epoch, Color);
     fn set_layer_clip_rect(&self, PipelineId, Rect<uint>);


### PR DESCRIPTION
This fixes `servo -z`.

Alternative to #1338.
