### PR TITLE
Changes to CanvasRenderingContext2D and HTMLCanvasElement

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -105,19 +105,6 @@ DOMInterfaces = {
 
 'CanvasRenderingContext2D': [
 {
-    'nativeType': 'nsCanvasRenderingContext2DAzure',
-    # Making this non-prefable requires that we ensure that nothing takes this
-    # type as an argument or that the non-Azure variant is removed.
-    'prefable': True,
-    'implicitJSContext': [
-        'createImageData', 'getImageData', 'putImageData', 'strokeStyle',
-        'fillStyle', 'mozDash'
-    ],
-    'resultNotAddRefed': [ 'canvas' ],
-    'binaryNames': {
-        'mozImageSmoothingEnabled': 'imageSmoothingEnabled',
-        'mozFillRule': 'fillRule'
-    }
 }],
 
 'CharacterData': {

--- a/src/components/script/dom/bindings/codegen/CanvasRenderingContext2D.webidl
+++ b/src/components/script/dom/bindings/codegen/CanvasRenderingContext2D.webidl
@@ -1,0 +1,356 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * http://www.whatwg.org/specs/web-apps/current-work/
+ *
+ * © Copyright 2004-2011 Apple Computer, Inc., Mozilla Foundation, and
+ * Opera Software ASA. You are granted a license to use, reproduce
+ * and create derivative works of this document.
+ */
+
+//interface HitRegionOptions;
+//interface Window;
+
+enum CanvasWindingRule { "nonzero", "evenodd" };
+
+interface CanvasRenderingContext2D {
+
+  // back-reference to the canvas.  Might be null if we're not
+  // associated with a canvas.
+  //readonly attribute HTMLCanvasElement? canvas;
+
+   // state
+  //void save(); // push state on state stack
+  //void restore(); // pop state stack and restore state
+
+  // transformations (default transform is the identity matrix)
+  // NOT IMPLEMENTED           attribute SVGMatrix currentTransform;
+  //[Throws, LenientFloat]
+  //void scale(double x, double y);
+  //[Throws, LenientFloat]
+  //void rotate(double angle);
+  //[Throws, LenientFloat]
+  //void translate(double x, double y);
+  //[Throws, LenientFloat]
+  //void transform(double a, double b, double c, double d, double e, double f);
+  //[Throws, LenientFloat]
+  //void setTransform(double a, double b, double c, double d, double e, double f);
+// NOT IMPLEMENTED  void resetTransform();
+
+  // compositing
+           // attribute unrestricted double globalAlpha; // (default 1.0)
+    ///       [Throws]
+   ///   attribute DOMString globalCompositeOperation; // (default source-over)
+
+  // colors and styles (see also the CanvasDrawingStyles interface)
+      //   attribute (DOMString or CanvasGradient or CanvasPattern) strokeStyle; // (default black)
+       // attribute (DOMString or CanvasGradient or CanvasPattern) fillStyle; // (default black)
+  
+/*[Creator]
+  CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1);
+  [Creator, Throws]
+  CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);
+  [Creator, Throws]
+  CanvasPattern createPattern((HTMLImageElement or HTMLCanvasElement or HTMLVideoElement) image, [TreatNullAs=EmptyString] DOMString repetition);
+*/
+
+  // shadows
+      ///     [LenientFloat]
+       ///    attribute double shadowOffsetX; // (default 0)
+        ///   [LenientFloat]
+         ///  attribute double shadowOffsetY; // (default 0)
+          /// [LenientFloat]
+          /// attribute double shadowBlur; // (default 0)
+          /// attribute DOMString shadowColor; // (default transparent black)
+
+  // rects
+  
+/*
+
+*/
+
+  long Width();
+  [LenientFloat]
+  void FillRect(float x, float y, float w, float h);
+  [LenientFloat]
+  void StrokeRect(float x, float y, float w, float h);
+  void StrokeLine(float x, float y, float x1, float y1);
+  [LenientFloat]
+  void ClearRect(float x, float y, float w, float h);
+  void SetWidth(long width);
+  void SetHeight(long height);
+  long Height(); 
+/*
+  [LenientFloat]
+  void strokeRect(double x, double y, double w, double h);
+/*
+*/
+  // path API (see also CanvasPathMethods)
+  //void beginPath();
+//  void fill([TreatUndefinedAs=Missing] optional CanvasWindingRule winding = "nonzero");
+// NOT IMPLEMENTED  void fill(Path path);
+  //void stroke();
+// NOT IMPLEMENTED  void stroke(Path path);
+// NOT IMPLEMENTED  void drawSystemFocusRing(Element element);
+// NOT IMPLEMENTED  void drawSystemFocusRing(Path path, Element element);
+// NOT IMPLEMENTED  boolean drawCustomFocusRing(Element element);
+// NOT IMPLEMENTED  boolean drawCustomFocusRing(Path path, Element element);
+// NOT IMPLEMENTED  void scrollPathIntoView();
+// NOT IMPLEMENTED  void scrollPathIntoView(Path path);
+//  void clip([TreatUndefinedAs=Missing] optional CanvasWindingRule winding = "nonzero");
+// NOT IMPLEMENTED  void clip(Path path);
+// NOT IMPLEMENTED  void resetClip();
+//  boolean isPointInPath(unrestricted double x, unrestricted double y, [TreatUndefinedAs=Missing] optional CanvasWindingRule winding = "nonzero");
+// NOT IMPLEMENTED  boolean isPointInPath(Path path, unrestricted double x, unrestricted double y);
+  //boolean isPointInStroke(double x, double y);
+
+  // text (see also the CanvasDrawingStyles interface)
+  //[Throws, LenientFloat]
+  //void fillText(DOMString text, double x, double y, optional double maxWidth);
+  //[Throws, LenientFloat]
+  //void strokeText(DOMString text, double x, double y, optional double maxWidth);
+/*  
+[Creator, Throws]
+  TextMetrics measureText(DOMString text);
+*/
+  // drawing images
+// NOT IMPLEMENTED           attribute boolean imageSmoothingEnabled; // (default true)
+ /* 
+ [Throws, LenientFloat]
+  void drawImage((HTMLImageElement or HTMLCanvasElement or HTMLVideoElement) image, double dx, double dy);
+  [Throws, LenientFloat]
+  void drawImage((HTMLImageElement or HTMLCanvasElement or HTMLVideoElement) image, double dx, double dy, double dw, double dh);
+  [Throws, LenientFloat]
+  void drawImage((HTMLImageElement or HTMLCanvasElement or HTMLVideoElement) image, double sx, double sy, double sw, double sh, double dx, double dy, double dw, double dh);
+*/
+  // hit regions
+// NOT IMPLEMENTED  void addHitRegion(HitRegionOptions options);
+
+  // pixel manipulation
+  /*  
+  [Creator, Throws]
+  ImageData createImageData(double sw, double sh);
+  [Creator, Throws]
+  ImageData createImageData(ImageData imagedata);
+  [Creator, Throws]
+  ImageData getImageData(double sx, double sy, double sw, double sh);
+  [Throws]
+  void putImageData(ImageData imagedata, double dx, double dy);
+  [Throws]
+  void putImageData(ImageData imagedata, double dx, double dy, double dirtyX, double dirtyY, double dirtyWidth, double dirtyHeight);
+  */
+  // Mozilla-specific stuff
+  // FIXME Bug 768048 mozCurrentTransform/mozCurrentTransformInverse should return a WebIDL array.
+  /*[Throws]
+  attribute object mozCurrentTransform; // [ m11, m12, m21, m22, dx, dy ], i.e. row major
+  [Throws]
+  attribute object mozCurrentTransformInverse;
+*/
+
+///  attribute DOMString mozFillRule; /* "evenodd", "nonzero" (default) */
+
+ /// [Throws]
+ /// attribute any mozDash; /* default |null| */
+
+///  [LenientFloat]
+ /// attribute double mozDashOffset; /* default 0.0 */
+
+ /// [SetterThrows]
+ /// attribute DOMString mozTextStyle;
+
+  // image smoothing mode -- if disabled, images won't be smoothed
+  // if scaled.
+  ///attribute boolean mozImageSmoothingEnabled;
+
+  // Show the caret if appropriate when drawing
+ /// [ChromeOnly]
+  ///const unsigned long DRAWWINDOW_DRAW_CARET   = 0x01;
+  // Don't flush pending layout notifications that could otherwise
+  // be batched up
+  
+
+
+///[ChromeOnly]
+ /// const unsigned long DRAWWINDOW_DO_NOT_FLUSH = 0x02;
+  // Draw scrollbars and scroll the viewport if they are present
+  ///[ChromeOnly]
+ /// const unsigned long DRAWWINDOW_DRAW_VIEW    = 0x04;
+  // Use the widget layer manager if available. This means hardware
+  // acceleration may be used, but it might actually be slower or
+  // lower quality than normal. It will however more accurately reflect
+  // the pixels rendered to the screen.
+  ///[ChromeOnly]
+  ///const unsigned long DRAWWINDOW_USE_WIDGET_LAYERS = 0x08;
+  // Don't synchronously decode images - draw what we have
+  ///[ChromeOnly]
+  ///const unsigned long DRAWWINDOW_ASYNC_DECODE_IMAGES = 0x10;
+
+
+  /**
+   * Renders a region of a window into the canvas.  The contents of
+   * the window's viewport are rendered, ignoring viewport clipping
+   * and scrolling.
+   *
+   * @param x
+   * @param y
+   * @param w
+   * @param h specify the area of the window to render, in CSS
+   * pixels.
+   *
+   * @param backgroundColor the canvas is filled with this color
+   * before we render the window into it. This color may be
+   * transparent/translucent. It is given as a CSS color string
+   * (e.g., rgb() or rgba()).
+   *
+   * @param flags Used to better control the drawWindow call.
+   * Flags can be ORed together.
+   *
+   * Of course, the rendering obeys the current scale, transform and
+   * globalAlpha values.
+   *
+   * Hints:
+   * -- If 'rgba(0,0,0,0)' is used for the background color, the
+   * drawing will be transparent wherever the window is transparent.
+   * -- Top-level browsed documents are usually not transparent
+   * because the user's background-color preference is applied,
+   * but IFRAMEs are transparent if the page doesn't set a background.
+   * -- If an opaque color is used for the background color, rendering
+   * will be faster because we won't have to compute the window's
+   * transparency.
+   *
+   * This API cannot currently be used by Web content. It is chrome
+   * only.
+   */
+  /*
+  [Throws, ChromeOnly]
+  void drawWindow(Window window, double x, double y, double w, double h,
+                  DOMString bgColor, optional unsigned long flags = 0);
+  */
+  /*[Throws, ChromeOnly]
+  void asyncDrawXULElement(XULElement elem, double x, double y, double w,
+                           double h, DOMString bgColor,
+                           optional unsigned long flags = 0);
+  */
+  /**
+   * This causes a context that is currently using a hardware-accelerated
+   * backend to fallback to a software one. All state should be preserved.
+   */
+  //[ChromeOnly]
+  //void demote();
+
+
+};
+
+/*CanvasRenderingContext2D implements CanvasDrawingStyles;
+//CanvasRenderingContext2D implements CanvasPathMethods;
+
+[NoInterfaceObject]
+interface CanvasDrawingStyles {
+
+
+  // line caps/joins
+           [LenientFloat]
+           attribute double lineWidth; // (default 1)
+           attribute DOMString lineCap; // "butt", "round", "square" (default "butt")
+           [GetterThrows]
+           attribute DOMString lineJoin; // "round", "bevel", "miter" (default "miter")
+           [LenientFloat]
+           attribute double miterLimit; // (default 10)
+
+  // dashed lines
+// NOT IMPLEMENTED    [LenientFloat] void setLineDash(sequence<double> segments); // default empty
+// NOT IMPLEMENTED    sequence<double> getLineDash();
+// NOT IMPLEMENTED             [LenientFloat] attribute double lineDashOffset;
+
+  // text
+           [SetterThrows]
+           attribute DOMString font; // (default 10px sans-serif)
+           attribute DOMString textAlign; // "start", "end", "left", "right", "center" (default: "start")
+           attribute DOMString textBaseline; // "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" (default: "alphabetic")
+
+
+};
+
+
+/*
+[NoInterfaceObject]
+interface CanvasPathMethods {
+  // shared path API methods
+  void closePath();
+  [LenientFloat]
+  void moveTo(double x, double y);
+  [LenientFloat]
+  void lineTo(double x, double y);
+  [LenientFloat]
+  void quadraticCurveTo(double cpx, double cpy, double x, double y);
+
+  [LenientFloat]
+  void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
+
+  [Throws, LenientFloat]
+  void arcTo(double x1, double y1, double x2, double y2, double radius); 
+// NOT IMPLEMENTED  [LenientFloat] void arcTo(double x1, double y1, double x2, double y2, double radiusX, double radiusY, double rotation);
+
+  [LenientFloat]
+  void rect(double x, double y, double w, double h);
+
+  [Throws, LenientFloat]
+  void arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false); 
+// NOT IMPLEMENTED  [LenientFloat] void ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, boolean anticlockwise);
+
+};
+*/
+/*
+
+interface CanvasGradient {
+  // opaque object
+  [Throws]
+  // addColorStop should take a double
+  void addColorStop(float offset, DOMString color);
+};
+
+*/
+
+/*
+interface CanvasPattern {
+  // opaque object
+  // void setTransform(SVGMatrix transform);
+};
+*/
+
+//interface TextMetrics {
+
+  // x-direction
+  //readonly attribute double width; // advance width
+
+  /*
+   * NOT IMPLEMENTED YET
+
+  readonly attribute double actualBoundingBoxLeft;
+  readonly attribute double actualBoundingBoxRight;
+
+  // y-direction
+  readonly attribute double fontBoundingBoxAscent;
+  readonly attribute double fontBoundingBoxDescent;
+  readonly attribute double actualBoundingBoxAscent;
+  readonly attribute double actualBoundingBoxDescent;
+  readonly attribute double emHeightAscent;
+  readonly attribute double emHeightDescent;
+  readonly attribute double hangingBaseline;
+  readonly attribute double alphabeticBaseline;
+  readonly attribute double ideographicBaseline;
+  */
+/*
+};
+*/
+/*
+class CanvasRenderingContext2D 
+{
+
+void fillRect(int32_t aNumber,int32_t abNumber,int32_t acNumber,int32_t adNumber);
+
+}
+*/

--- a/src/components/script/dom/bindings/codegen/HTMLCanvasElement.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLCanvasElement.webidl
@@ -13,7 +13,6 @@
 // import from http://mxr.mozilla.org/mozilla-central/source/dom/webidl/HTMLCanvasElement.webidl
 
 interface CanvasRenderingContext2D;
-//interface Window;
 
 interface HTMLCanvasElement : HTMLElement {
   [Pure, SetterThrows]

--- a/src/components/script/dom/bindings/codegen/HTMLCanvasElement.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLCanvasElement.webidl
@@ -12,24 +12,26 @@
 
 // import from http://mxr.mozilla.org/mozilla-central/source/dom/webidl/HTMLCanvasElement.webidl
 
-/*
+
 interface Blob;
 interface FileCallback;
 interface nsIInputStreamCallback;
 interface nsISupports;
 interface PrintCallback;
 interface Variant;
-*/
+interface CanvasRenderingContext2D;
+//interface Window;
 
 interface HTMLCanvasElement : HTMLElement {
   [Pure, SetterThrows]
            attribute unsigned long width;
   [Pure, SetterThrows]
            attribute unsigned long height;
-/*
-  [Throws]
-  nsISupports? getContext(DOMString contextId, optional any contextOptions = null);
 
+  CanvasRenderingContext2D GetContext(DOMString contextId);
+
+//  void setContext(CanvasRenderingContext2D context);
+/*
   [Throws]
   DOMString toDataURL(optional DOMString type = "",
                       optional any encoderOptions);

--- a/src/components/script/dom/bindings/codegen/HTMLCanvasElement.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLCanvasElement.webidl
@@ -12,13 +12,6 @@
 
 // import from http://mxr.mozilla.org/mozilla-central/source/dom/webidl/HTMLCanvasElement.webidl
 
-
-interface Blob;
-interface FileCallback;
-interface nsIInputStreamCallback;
-interface nsISupports;
-interface PrintCallback;
-interface Variant;
 interface CanvasRenderingContext2D;
 //interface Window;
 

--- a/src/components/script/dom/canvasrenderingcontext2d.rs
+++ b/src/components/script/dom/canvasrenderingcontext2d.rs
@@ -38,7 +38,7 @@ impl CanvasRenderingContext2D {
     */
      pub fn FillRect(&self, x: f32, y: f32, width: f32, height: f32) {  
       let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
-      let Azrect=Rect(Point2D(x,y), Size2D(width,height));
+      let Azrect = Rect(Point2D(x,y), Size2D(width,height));
       let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
       drawtarget.fill_rect(&Azrect, &colorpattern); 	
     }
@@ -49,7 +49,7 @@ impl CanvasRenderingContext2D {
     */
      pub fn ClearRect(&self, x: f32, y: f32, width: f32, height: f32) {
 
-      let Azrect=Rect(Point2D(x,y), Size2D(width,height));
+      let Azrect = Rect(Point2D(x,y), Size2D(width,height));
       let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
       drawtarget.clear_rect(&Azrect);
     }
@@ -59,7 +59,7 @@ impl CanvasRenderingContext2D {
     */
     pub fn StrokeRect(&self, x: f32, y: f32, width: f32, height: f32) {
       let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
-      let Azrect=Rect(Point2D(x,y), Size2D(width,height));
+      let Azrect = Rect(Point2D(x,y), Size2D(width,height));
       let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
       let strokeopts = StrokeOptions(10.0, 10.0); 
       let drawopts = DrawOptions(1.0, 0);  

--- a/src/components/script/dom/canvasrenderingcontext2d.rs
+++ b/src/components/script/dom/canvasrenderingcontext2d.rs
@@ -84,16 +84,16 @@ impl CanvasRenderingContext2D {
         self.width
     }
 
-    pub fn SetWidth(&mut self, _width: i32) {
-        self.width = _width
+    pub fn SetWidth(&mut self, width: i32) {
+        self.width = width
     }
 
     pub fn Height(&self) -> i32 {                
         self.height
     }
 
-    pub fn SetHeight(&mut self, _height: i32) {
-        self.height = _height
+    pub fn SetHeight(&mut self, height: i32) {
+        self.height = height
     }
 
 }

--- a/src/components/script/dom/canvasrenderingcontext2d.rs
+++ b/src/components/script/dom/canvasrenderingcontext2d.rs
@@ -1,17 +1,11 @@
 use dom::bindings::utils::{DOMString, Reflectable, Reflector, reflect_dom_object};
-use dom::bindings::utils::Fallible;
 use dom::bindings::codegen::CanvasRenderingContext2DBinding;
 use dom::window::Window;
-use dom::bindings::utils::{ErrorResult};
-use std::libc::*;
-use dom::htmlcanvaselement::HTMLCanvasElement;
-use geom::rect::Rect;
-use azure::azure_hl::{DrawTarget, Color, Drop, BackendType, B8G8R8A8, SkiaBackend, StrokeOptions, DrawOptions};
+use azure::azure_hl::{DrawTarget, Color, B8G8R8A8, SkiaBackend, StrokeOptions, DrawOptions};
 use geom::rect::Rect;
 use azure::azure_hl::{ColorPattern};
 use geom::point::Point2D;
 use geom::size::Size2D;
-use azure::{AzBackendType, AzDrawTargetRef, AzSourceSurfaceRef, AzDataSourceSurfaceRef};
 
 
 pub struct CanvasRenderingContext2D {
@@ -35,22 +29,35 @@ impl CanvasRenderingContext2D {
         reflect_dom_object(@mut CanvasRenderingContext2D::new_inherited(window), window, CanvasRenderingContext2DBinding::Wrap)
     }
 
-    pub fn FillRect(&self, x: f32, y: f32, width: f32, height: f32) {  
+
+
+    /* 
+      fn FillRect - It takes the (x,y)co-ordinates and height , weight as parameters of the rectangle to be filled.
+	            The rectangle will be filled with the color specified by colorPattern variable that holds a default color(r,g,b,a).
+		    We have used Color(1.0, 0.0, 0.0, 0.0) i.e Red      	
+    */
+     pub fn FillRect(&self, x: f32, y: f32, width: f32, height: f32) {  
       let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
       let Azrect=Rect(Point2D(x,y), Size2D(width,height));
       let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
       drawtarget.fill_rect(&Azrect, &colorpattern); 	
     }
 
-    pub fn ClearRect(&self, x: f32, y: f32, width: f32, height: f32) {
+    
+    /*
+     fn clearRect - It takes (x,y) co-ordinates and widht, height as parameters and clears the specified pixels of the rectangle.
+    */
+     pub fn ClearRect(&self, x: f32, y: f32, width: f32, height: f32) {
 
       let Azrect=Rect(Point2D(x,y), Size2D(width,height));
       let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
       drawtarget.clear_rect(&Azrect);
     }
 
+    /*
+     fn strokeRect - It takes (x,y) co-ordinates and widht, height as parameters of the rectangle to be created i.e no fill
+    */
     pub fn StrokeRect(&self, x: f32, y: f32, width: f32, height: f32) {
-  
       let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
       let Azrect=Rect(Point2D(x,y), Size2D(width,height));
       let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
@@ -59,6 +66,9 @@ impl CanvasRenderingContext2D {
       drawtarget.stroke_rect(&Azrect, &colorpattern, &strokeopts, &drawopts);
     }	
 
+    /*
+     fn strokeLine - It strokes the line from the start and end points provided as parameters.
+    */
     pub fn StrokeLine(&self, x: f32, y: f32, x1: f32, y1: f32) {
   
       let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));

--- a/src/components/script/dom/canvasrenderingcontext2d.rs
+++ b/src/components/script/dom/canvasrenderingcontext2d.rs
@@ -45,7 +45,7 @@ impl CanvasRenderingContext2D {
 
     
     /*
-     fn clearRect - It takes (x,y) co-ordinates and widht, height as parameters and clears the specified pixels of the rectangle.
+     fn clearRect - It takes (x,y) co-ordinates and width, height as parameters and clears the specified pixels of the rectangle.
     */
      pub fn ClearRect(&self, x: f32, y: f32, width: f32, height: f32) {
 
@@ -55,7 +55,7 @@ impl CanvasRenderingContext2D {
     }
 
     /*
-     fn strokeRect - It takes (x,y) co-ordinates and widht, height as parameters of the rectangle to be created i.e no fill
+     fn strokeRect - It takes (x,y) co-ordinates and width, height as parameters of the rectangle to be created i.e no fill
     */
     pub fn StrokeRect(&self, x: f32, y: f32, width: f32, height: f32) {
       let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));

--- a/src/components/script/dom/canvasrenderingcontext2d.rs
+++ b/src/components/script/dom/canvasrenderingcontext2d.rs
@@ -1,0 +1,99 @@
+use dom::bindings::utils::{DOMString, Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::Fallible;
+use dom::bindings::codegen::CanvasRenderingContext2DBinding;
+use dom::window::Window;
+use dom::bindings::utils::{ErrorResult};
+use std::libc::*;
+use dom::htmlcanvaselement::HTMLCanvasElement;
+use geom::rect::Rect;
+use azure::azure_hl::{DrawTarget, Color, Drop, BackendType, B8G8R8A8, SkiaBackend, StrokeOptions, DrawOptions};
+use geom::rect::Rect;
+use azure::azure_hl::{ColorPattern};
+use geom::point::Point2D;
+use geom::size::Size2D;
+use azure::{AzBackendType, AzDrawTargetRef, AzSourceSurfaceRef, AzDataSourceSurfaceRef};
+
+
+pub struct CanvasRenderingContext2D {
+    reflector_: Reflector,
+    window: @mut Window,
+    width: i32,
+    height: i32,
+}
+
+impl CanvasRenderingContext2D {
+    pub fn new_inherited(window: @mut Window) -> CanvasRenderingContext2D {
+        CanvasRenderingContext2D {
+            reflector_: Reflector::new(),
+            window: window,
+	    width: 0,
+            height: 0,
+        }
+    }
+	
+    pub fn new(window: @mut Window) -> @mut CanvasRenderingContext2D {
+        reflect_dom_object(@mut CanvasRenderingContext2D::new_inherited(window), window, CanvasRenderingContext2DBinding::Wrap)
+    }
+
+    pub fn FillRect(&self, x: f32, y: f32, width: f32, height: f32) {  
+      let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
+      let Azrect=Rect(Point2D(x,y), Size2D(width,height));
+      let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
+      drawtarget.fill_rect(&Azrect, &colorpattern); 	
+    }
+
+    pub fn ClearRect(&self, x: f32, y: f32, width: f32, height: f32) {
+
+      let Azrect=Rect(Point2D(x,y), Size2D(width,height));
+      let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
+      drawtarget.clear_rect(&Azrect);
+    }
+
+    pub fn StrokeRect(&self, x: f32, y: f32, width: f32, height: f32) {
+  
+      let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
+      let Azrect=Rect(Point2D(x,y), Size2D(width,height));
+      let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
+      let strokeopts = StrokeOptions(10.0, 10.0); 
+      let drawopts = DrawOptions(1.0, 0);  
+      drawtarget.stroke_rect(&Azrect, &colorpattern, &strokeopts, &drawopts);
+    }	
+
+    pub fn StrokeLine(&self, x: f32, y: f32, x1: f32, y1: f32) {
+  
+      let colorpattern = ColorPattern(Color(1.0, 0.0, 0.0, 0.0));
+      let pt1 = Point2D(x,y);
+      let pt2 = Point2D(x1,y1);
+      let drawtarget = DrawTarget::new(SkiaBackend, Size2D(100 as i32,100 as i32), B8G8R8A8);
+      let strokeopts = StrokeOptions(10.0, 10.0); 
+      let drawopts = DrawOptions(1.0, 0);  
+      drawtarget.stroke_line(pt1, pt2, &colorpattern, &strokeopts, &drawopts);
+    }	 
+
+    pub fn Width(&self) -> i32 {                    
+        self.width
+    }
+
+    pub fn SetWidth(&mut self, _width: i32) {
+        self.width = _width
+    }
+
+    pub fn Height(&self) -> i32 {                
+        self.height
+    }
+
+    pub fn SetHeight(&mut self, _height: i32) {
+        self.height = _height
+    }
+
+}
+
+impl Reflectable for CanvasRenderingContext2D {
+    fn reflector<'a>(&'a self) -> &'a Reflector {
+        &self.reflector_
+    }
+
+    fn mut_reflector<'a>(&'a mut self) -> &'a mut Reflector {
+        &mut self.reflector_
+    }
+}

--- a/src/components/script/dom/htmlcanvaselement.rs
+++ b/src/components/script/dom/htmlcanvaselement.rs
@@ -4,18 +4,14 @@
 
 use dom::bindings::codegen::HTMLCanvasElementBinding;
 use dom::bindings::codegen::CanvasRenderingContext2DBinding;
-use std::libc::*;
 use dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use dom::window::Window;
-use dom::bindings::utils::{ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLCanvasElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::bindings::utils::{DOMString, ErrorResult, Fallible};
-use dom::node::{ElementNodeTypeId, Node, ScriptView, AbstractNode};
-use dom::element::Element;
+use dom::bindings::utils::{DOMString, ErrorResult};
+use dom::node::{Node, ScriptView, AbstractNode};
 use dom::element::ElementTypeId;
-use dom::element::{Element, ElementTypeId};
 
 pub struct HTMLCanvasElement {
     htmlelement: HTMLElement,
@@ -51,9 +47,15 @@ impl HTMLCanvasElement {
         Ok(())
     }
   
-    pub fn GetContext(&self, _id: DOMString) -> @mut CanvasRenderingContext2D {
     
+    /*
+	fn GetContext() - returns a CanvasRenderingContext2D object that can be used to call the methods implemented in 
+	canvasrenderingcontext2D.rs file .
+    */
+     pub fn GetContext(&self, _id: DOMString) -> @mut CanvasRenderingContext2D {
+   
           let canvas = CanvasRenderingContext2D::new(self.htmlelement.element.node.owner_doc().document().window);
 	  canvas
      }
+
 }

--- a/src/components/script/dom/htmlcanvaselement.rs
+++ b/src/components/script/dom/htmlcanvaselement.rs
@@ -3,25 +3,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::HTMLCanvasElementBinding;
+use dom::bindings::codegen::CanvasRenderingContext2DBinding;
+use std::libc::*;
+use dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
+use dom::window::Window;
 use dom::bindings::utils::{ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLCanvasElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::bindings::utils::{DOMString, ErrorResult, Fallible};
+use dom::node::{ElementNodeTypeId, Node, ScriptView, AbstractNode};
+use dom::element::Element;
+use dom::element::ElementTypeId;
+use dom::element::{Element, ElementTypeId};
 
 pub struct HTMLCanvasElement {
     htmlelement: HTMLElement,
-}
+  }
 
 impl HTMLCanvasElement {
-    pub fn new_inherited(localName: ~str, document: AbstractDocument) -> HTMLCanvasElement {
+    pub fn new_inherited(type_id: ElementTypeId, localName: ~str, document: AbstractDocument) -> HTMLCanvasElement {
         HTMLCanvasElement {
-            htmlelement: HTMLElement::new_inherited(HTMLCanvasElementTypeId, localName, document)
-        }
+            htmlelement: HTMLElement::new_inherited(HTMLCanvasElementTypeId, localName, document),
+       }
     }
 
     pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
-        let element = HTMLCanvasElement::new_inherited(localName, document);
+        let element = HTMLCanvasElement::new_inherited(HTMLCanvasElementTypeId, localName, document);
         Node::reflect_node(@mut element, document, HTMLCanvasElementBinding::Wrap)
     }
 }
@@ -42,4 +50,10 @@ impl HTMLCanvasElement {
     pub fn SetHeight(&mut self, _height: u32) -> ErrorResult {
         Ok(())
     }
+  
+    pub fn GetContext(&self, _id: DOMString) -> @mut CanvasRenderingContext2D {
+    
+          let canvas = CanvasRenderingContext2D::new(self.htmlelement.element.node.owner_doc().document().window);
+	  canvas
+     }
 }

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -21,6 +21,7 @@ extern mod servo_util (name = "util");
 extern mod style;
 extern mod servo_msg (name = "msg");
 extern mod extra;
+extern mod azure;
 
 pub mod dom {
     pub mod bindings {
@@ -46,6 +47,7 @@ pub mod dom {
     pub mod attr;
     pub mod attrlist;
     pub mod blob;
+    pub mod canvasrenderingcontext2d;
     pub mod characterdata;
     pub mod clientrect;
     pub mod clientrectlist;

--- a/src/test/html/NewFile.html
+++ b/src/test/html/NewFile.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+<meta charset="ISO-8859-1">
+<title>Insert title here</title>
+</head>
+<body>
+ <canvas id="tutorial" style="border:1px solid #d3d3d3"> </canvas>
+ <div id="a">
+
+</div>
+  
+<script type="text/javascript">
+
+canvas = document.getElementById('tutorial');
+
+var ctx = canvas.GetContext('2d');
+ctx.SetWidth(5000);
+ctx.SetHeight(1000);
+var width = ctx.Width();
+var height = ctx.Height();
+ctx.FillRect(10.0,10.0,100.0,100.0);
+ctx.StrokeRect(20.0,40.0,80.0,80.0);
+ctx.ClearRect(10.0,10.0,100.0,100.0);
+ctx.StrokeLine(10.0,20.0,50.0,70.0);
+print("hello");
+
+
+alert(width);
+alert(height);
+//ctx.fillRect(10,10,50,50);
+/*
+ctx.fillStyle = "#ff0000";  
+ctx.fillRect(10, 10, 55, 50); 
+*/
+
+
+</script>
+ hello world!
+
+  
+</body>
+</html>

--- a/src/test/html/NewFile.html
+++ b/src/test/html/NewFile.html
@@ -24,7 +24,7 @@ ctx.FillRect(10.0,10.0,100.0,100.0);
 ctx.StrokeRect(20.0,40.0,80.0,80.0);
 ctx.ClearRect(10.0,10.0,100.0,100.0);
 ctx.StrokeLine(10.0,20.0,50.0,70.0);
-print("hello");
+
 
 
 alert(width);

--- a/src/test/html/NewFile.html
+++ b/src/test/html/NewFile.html
@@ -29,12 +29,6 @@ ctx.StrokeLine(10.0,20.0,50.0,70.0);
 
 alert(width);
 alert(height);
-//ctx.fillRect(10,10,50,50);
-/*
-ctx.fillStyle = "#ff0000";  
-ctx.fillRect(10, 10, 55, 50); 
-*/
-
 
 </script>
  hello world!

--- a/src/test/html/NewFile.html
+++ b/src/test/html/NewFile.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-<meta charset="ISO-8859-1">
+<meta charset="UTF-8">
 <title>Insert title here</title>
 </head>
 <body>


### PR DESCRIPTION
Our contribution involves implementing the various canvas 2D API calls like GetContext, FillRect, ClearRect, StrokeRect and StrokeLine.

This contribution is a part of deliverables to the CSC 517 semester project: M803 for North Carolina State University. 
