### PR TITLE
Implement 'leading' font metric for linux platform

### DIFF
--- a/src/components/gfx/platform/android/font.rs
+++ b/src/components/gfx/platform/android/font.rs
@@ -244,7 +244,7 @@ impl FontHandleMethods for FontHandle {
             }
         }
 
-        return FontMetrics {
+        let metrics = FontMetrics {
             underline_size:   underline_size,
             underline_offset: underline_offset,
             strikeout_size:   strikeout_size,
@@ -255,7 +255,10 @@ impl FontHandleMethods for FontHandle {
             ascent:           ascent,
             descent:          -descent, // linux font's seem to use the opposite sign from mac
             max_advance:      max_advance
-        }
+        };
+
+        debug!("Font metrics (@{:f} pt): {:?}", geometry::to_pt(em_size), metrics);
+        return metrics;
     }
 
     fn get_table_for_tag(&self, _: FontTableTag) -> Option<FontTable> {

--- a/src/components/gfx/platform/android/font.rs
+++ b/src/components/gfx/platform/android/font.rs
@@ -231,6 +231,15 @@ impl FontHandleMethods for FontHandle {
         let descent = self.font_units_to_au(face.descender as float);
         let max_advance = self.font_units_to_au(face.max_advance_width as float);
 
+        // 'leading' is supposed to be the vertical distance between two baselines,
+        // reflected by the height attibute in freetype.  On OS X (w/ CTFont),
+        // leading represents the distance between the bottom of a line descent to
+        // the top of the next line's ascent or: (line_height - ascent - descent),
+        // see http://stackoverflow.com/a/5635981 for CTFont implementation.
+        // Convert using a formular similar to what CTFont returns for consistency.
+        let height = self.font_units_to_au(face.height as float);
+        let leading = height - (ascent + descent);
+
         let mut strikeout_size = geometry::from_pt(0.0);
         let mut strikeout_offset = geometry::from_pt(0.0);
         let mut x_height = geometry::from_pt(0.0);
@@ -249,7 +258,7 @@ impl FontHandleMethods for FontHandle {
             underline_offset: underline_offset,
             strikeout_size:   strikeout_size,
             strikeout_offset: strikeout_offset,
-            leading:          geometry::from_pt(0.0), //FIXME
+            leading:          leading,
             x_height:         x_height,
             em_size:          em_size,
             ascent:           ascent,

--- a/src/components/gfx/platform/linux/font.rs
+++ b/src/components/gfx/platform/linux/font.rs
@@ -230,6 +230,15 @@ impl FontHandleMethods for FontHandle {
         let descent = self.font_units_to_au(face.descender as f64);
         let max_advance = self.font_units_to_au(face.max_advance_width as f64);
 
+        // 'leading' is supposed to be the vertical distance between two baselines,
+        // reflected by the height attibute in freetype.  On OS X (w/ CTFont),
+        // leading represents the distance between the bottom of a line descent to
+        // the top of the next line's ascent or: (line_height - ascent - descent),
+        // see http://stackoverflow.com/a/5635981 for CTFont implementation.
+        // Convert using a formular similar to what CTFont returns for consistency.
+        let height = self.font_units_to_au(face.height as f64);
+        let leading = height - (ascent + descent);
+
         let mut strikeout_size = geometry::from_pt(0.0);
         let mut strikeout_offset = geometry::from_pt(0.0);
         let mut x_height = geometry::from_pt(0.0);
@@ -248,7 +257,7 @@ impl FontHandleMethods for FontHandle {
             underline_offset: underline_offset,
             strikeout_size:   strikeout_size,
             strikeout_offset: strikeout_offset,
-            leading:          geometry::from_pt(0.0), //FIXME
+            leading:          leading,
             x_height:         x_height,
             em_size:          em_size,
             ascent:           ascent,

--- a/src/components/gfx/platform/linux/font.rs
+++ b/src/components/gfx/platform/linux/font.rs
@@ -243,7 +243,7 @@ impl FontHandleMethods for FontHandle {
             }
         }
 
-        return FontMetrics {
+        let metrics = FontMetrics {
             underline_size:   underline_size,
             underline_offset: underline_offset,
             strikeout_size:   strikeout_size,
@@ -254,7 +254,10 @@ impl FontHandleMethods for FontHandle {
             ascent:           ascent,
             descent:          -descent, // linux font's seem to use the opposite sign from mac
             max_advance:      max_advance
-        }
+        };
+
+        debug!("Font metrics (@{:f} pt): {:?}", geometry::to_pt(em_size), metrics);
+        return metrics;
     }
 
     fn get_table_for_tag(&self, _: FontTableTag) -> Option<FontTable> {

--- a/src/components/util/geometry.rs
+++ b/src/components/util/geometry.rs
@@ -9,6 +9,9 @@ use geom::size::Size2D;
 use std::num::{NumCast, One, Zero};
 use std::fmt;
 
+// An Au is an "App Unit" and represents 1/60th of a CSS pixel.  It was
+// originally proposed in 2002 as a standard unit of measure in Gecko.
+// See https://bugzilla.mozilla.org/show_bug.cgi?id=177805 for more info.
 pub struct Au(i32);
 
 // We don't use #[deriving] here for inlining.
@@ -223,5 +226,10 @@ pub fn to_frac_px(au: Au) -> f64 {
 // assumes 72 points per inch, and 96 px per inch
 pub fn from_pt(pt: f64) -> Au {
     from_px((pt / 72f64 * 96f64) as int)
+}
+
+// assumes 72 points per inch, and 96 px per inch
+pub fn to_pt(au: Au) -> f64 {
+    (*au as f64) / 60f64 * 72f64 / 96f64
 }
 


### PR DESCRIPTION
Fixes #76.

Implemented the only font metric remaining to resolve issue #76 for the Linux platform.

There are still some variations between Linux and OS X font metrics.  Looking at values for the "Times New Roman" font, the following metrics differed by over 10%:  `leading`, `x_height` and `max_advance`.  It was not obvious if this would create any major difference in rendering, or whether the discrepancies would be handled in platform specific ways during the rendering process.  Only `x_height` is being used by existing code.  The `leading` property under Linux is still an order of magnitude off from the OS X version, but they are computed with similar calculations.  Issue #1355 has been opened to further investigate the discrepancies.
#### Platform comparison of font metrics for "Times New Roman" between Linux and OS X:

**Au** is the raw metric values stored in the `FontMetrics` struct.  **% of em** is how large that value is relative to the raw `em_size` of the font as a percentage.  Linux reports the pt size differently than OS X, but this is probably because the linux platform uses hard-coded points-per-inch value (hard-coded in `src/components/util/geometry.rs`), whereas OS X uses the points-per-inch value provided by the font library.

```
+-----------------------------------+  +-----------------------------------+
| Linux (@14.25pt, 1.33em)          |  | OS X (@19.35pt, 1.0em)            |
+------------------+------+---------+  +------------------+------+---------+
| property         |   Au | % of em |  | property         |   Au | % of em |
+------------------+------+---------+  +------------------+------+---------+
| underline_size   |   55 |    4.82 |  | underline_size   |   60 |    5.17 |
| underline_offset | -151 |  -13.25 |  | underline_offset | -120 |  -10.34 |
| strikeout_size   |   56 |    4.91 |  | strikeout_size   |    0 |    0.00 |
| strikeout_offset |  295 |   25.88 |  | strikeout_offset |    0 |    0.00 |
| leading          |  541 |   47.45 |  | leading          |   60 |    5.17 |
| x_height         | 1015 |   89.04 |  | x_height         |  660 |   56.85 |
| em_size          | 1140 |  100.00 |  | em_size          | 1161 |  100.00 |
| ascent           | 1015 |   89.04 |  | ascent           |  893 |   76.92 |
| descent          |  246 |   21.58 |  | descent          |  203 |   17.48 |
| max_advance      | 1199 |  105.18 |  | max_advance      | 2820 |  242.89 |
+------------------+------+---------+  +------------------+------+---------+

+-----------------------------------+  +-----------------------------------+
| Linux (@24pt, 1.33em)             |  | OS X (@32.683333pt, 1.0em)        |
+------------------+------+---------+  +------------------+------+---------+
| property         |   Au | % of em |  | property         |   Au | % of em |
+------------------+------+---------+  +------------------+------+---------+
| underline_size   |   93 |    4.84 |  | underline_size   |  120 |    6.12 |
| underline_offset | -255 |  -13.28 |  | underline_offset | -240 |  -12.24 |
| strikeout_size   |   95 |    4.95 |  | strikeout_size   |    0 |    0.00 |
| strikeout_offset |  496 |   25.83 |  | strikeout_offset |    0 |    0.00 |
| leading          |  912 |   47.50 |  | leading          |   60 |    3.06 |
| x_height         | 1710 |   89.06 |  | x_height         | 1080 |   55.10 |
| em_size          | 1920 |  100.00 |  | em_size          | 1960 |  100.00 |
| ascent           | 1710 |   89.06 |  | ascent           | 1544 |   78.77 |
| descent          |  415 |   21.61 |  | descent          |  365 |   18.62 |
| max_advance      | 2020 |  105.21 |  | max_advance      | 4740 |  241.84 |
+------------------+------+---------+  +------------------+------+---------+

+-----------------------------------+  +-----------------------------------+
| Linux (@45pt, 1.33em)             |  | OS X (@60.833333pt, 1.0em)        |
+------------------+------+---------+  +------------------+------+---------+
| property         |   Au | % of em |  | property         |   Au | % of em |
+------------------+------+---------+  +------------------+------+---------+
| underline_size   |  175 |    4.86 |  | underline_size   |  180 |    4.93 |
| underline_offset | -479 |  -13.31 |  | underline_offset | -480 |  -13.15 |
| strikeout_size   |  179 |    4.97 |  | strikeout_size   |    0 |    0.00 |
| strikeout_offset |  931 |   25.86 |  | strikeout_offset |    0 |    0.00 |
| leading          | 1709 |   47.47 |  | leading          |  180 |    4.93 |
| x_height         | 3208 |   89.11 |  | x_height         | 2040 |   55.89 |
| em_size          | 3600 |  100.00 |  | em_size          | 3650 |  100.00 |
| ascent           | 3208 |   89.11 |  | ascent           | 2925 |   80.14 |
| descent          |  778 |   21.61 |  | descent          |  690 |   18.90 |
| max_advance      | 3788 |  105.22 |  | max_advance      | 8880 |  243.29 |
+------------------+------+---------+  +------------------+------+---------+

+-----------------------------------+  +-----------------------------------+
| Linux (@30.75pt, 1.33em)          |  | OS X (@41.9pt, 1.0em)             |
+------------------+------+---------+  +------------------+------+---------+
| property         |   Au | % of em |  | property         |   Au | % of em |
+------------------+------+---------+  +------------------+------+---------+
| underline_size   |  120 |    4.88 |  | underline_size   |  120 |    4.77 |
| underline_offset | -327 |  -13.29 |  | underline_offset | -360 |  -14.32 |
| strikeout_size   |  122 |    4.95 |  | strikeout_size   |    0 |    0.00 |
| strikeout_offset |  636 |   25.85 |  | strikeout_offset |    0 |    0.00 |
| leading          | 1168 |   47.47 |  | leading          |  120 |    4.77 |
| x_height         | 2192 |   89.11 |  | x_height         | 1440 |   57.27 |
| em_size          | 2460 |  100.00 |  | em_size          | 2514 |  100.00 |
| ascent           | 2192 |   89.11 |  | ascent           | 1991 |   79.20 |
| descent          |  532 |   21.63 |  | descent          |  487 |   19.37 |
| max_advance      | 2588 |  105.20 |  | max_advance      | 6120 |  243.44 |
+------------------+------+---------+  +------------------+------+---------+
```
