### PR TITLE
Add namespace info to elements

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -30,6 +30,7 @@ use std::ascii::StrAsciiExt;
 pub struct Element {
     node: Node<ScriptView>,
     tag_name: ~str,     // TODO: This should be an atom, not a ~str.
+    namespace: Namespace,
     attrs: HashMap<~str, ~[@mut Attr]>,
     attrs_insert_order: ~[(~str, Namespace)], // store an order of attributes.
     style_attribute: Option<style::PropertyDeclarationBlock>,
@@ -128,6 +129,10 @@ impl ElementLike for Element {
         self.tag_name.as_slice()
     }
 
+    fn get_namespace<'a>(&'a self) -> ~str {
+        self.namespace.to_str().unwrap_or(~"")
+    }
+
     fn get_attr(&self, name: &str) -> Option<~str> {
         self.get_attribute(None, name).map(|attr| attr.value.clone())
     }
@@ -146,10 +151,11 @@ impl ElementLike for Element {
 }
 
 impl<'self> Element {
-    pub fn new(type_id: ElementTypeId, tag_name: ~str, document: AbstractDocument) -> Element {
+    pub fn new(type_id: ElementTypeId, tag_name: ~str, namespace: Namespace, document: AbstractDocument) -> Element {
         Element {
             node: Node::new(ElementNodeTypeId(type_id), document),
             tag_name: tag_name,
+            namespace: namespace,
             attrs: HashMap::new(),
             attrs_insert_order: ~[],
             attr_list: None,

--- a/src/components/script/dom/htmlelement.rs
+++ b/src/components/script/dom/htmlelement.rs
@@ -9,6 +9,7 @@ use dom::element::{Element, ElementTypeId, HTMLElementTypeId};
 use dom::node::{AbstractNode, Node, ScriptView};
 use js::jsapi::{JSContext, JSVal};
 use js::JSVAL_NULL;
+use dom::namespace;
 
 pub struct HTMLElement {
     element: Element
@@ -17,7 +18,7 @@ pub struct HTMLElement {
 impl HTMLElement {
     pub fn new_inherited(type_id: ElementTypeId, tag_name: ~str, document: AbstractDocument) -> HTMLElement {
         HTMLElement {
-            element: Element::new(type_id, tag_name, document)
+            element: Element::new(type_id, tag_name, namespace::HTML, document)
         }
     }
 

--- a/src/components/util/tree.rs
+++ b/src/components/util/tree.rs
@@ -348,6 +348,7 @@ pub trait TreeNode<Ref: TreeNodeRef<Self>> {
 
 pub trait ElementLike {
     fn get_local_name<'a>(&'a self) -> &'a str;
+    fn get_namespace<'a>(&'a self) -> ~str;
     fn get_attr(&self, name: &str) -> Option<~str>;
     fn get_link(&self) -> Option<~str>;
 }


### PR DESCRIPTION
Add a namespace to elements. Sets by default the namespace to HTML for elements created by hubbub. Fixes :nth-of-type() and friends to match the namespace.

Note: prefix is not added by this PR because hubbub does not preserve it and I wanted to keep the patch as simple as possible.
