### PR TITLE
layout: Remove `DisplayBoxes` to save memory and as one step toward an

### DIFF
--- a/src/components/main/layout/display_list_builder.rs
+++ b/src/components/main/layout/display_list_builder.rs
@@ -35,12 +35,6 @@ impl ExtraDisplayListData for Nothing {
     }
 }
 
-impl ExtraDisplayListData for @Box {
-    fn new(box: &@Box) -> @Box {
-        *box
-    }
-}
-
 /// A builder object that manages display list builder should mainly hold information about the
 /// initial request and desired result--for example, whether the `DisplayList` is to be used for
 /// painting or hit testing. This can affect which boxes are created.

--- a/src/components/main/layout/extra.rs
+++ b/src/components/main/layout/extra.rs
@@ -4,7 +4,7 @@
 
 //! Code for managing the layout data in the DOM.
 
-use layout::util::{DisplayBoxes, LayoutData, LayoutDataAccess};
+use layout::util::{LayoutData, LayoutDataAccess};
 
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_util::tree::TreeNodeRef;
@@ -17,11 +17,13 @@ pub trait LayoutAuxMethods {
 
 impl LayoutAuxMethods for AbstractNode<LayoutView> {
     /// Resets layout data and styles for the node.
+    ///
+    /// FIXME(pcwalton): Do this as part of box building instead of in a traversal.
     fn initialize_layout_data(self) {
         let layout_data_handle = self.mutate_layout_data();
         match *layout_data_handle.ptr {
             None => *layout_data_handle.ptr = Some(~LayoutData::new()),
-            Some(ref mut layout_data) => layout_data.boxes = DisplayBoxes::init(),
+            Some(_) => {}
         }
     }
 

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -6,7 +6,6 @@ use layout::box::Box;
 use layout::construct::{ConstructionResult, NoConstructionResult};
 
 use extra::arc::Arc;
-use gfx::display_list::DisplayList;
 use script::dom::node::{AbstractNode, LayoutView};
 use servo_util::range::Range;
 use servo_util::slot::{MutSlotRef, SlotRef};
@@ -15,25 +14,6 @@ use std::cast;
 use std::iter::Enumerate;
 use std::vec::VecIterator;
 use style::{ComputedValues, PropertyDeclaration};
-use geom::rect::Rect;
-use servo_util::geometry::Au;
-
-/// The boxes associated with a node.
-pub struct DisplayBoxes {
-    display_list: Option<Arc<DisplayList<AbstractNode<()>>>>,
-    display_bound_list: Option<~[Rect<Au>]>,
-    display_bound: Option<Rect<Au>>
-}
-
-impl DisplayBoxes {
-    pub fn init() -> DisplayBoxes {
-        DisplayBoxes {
-            display_list: None,
-            display_bound_list: None,
-            display_bound: None,
-        }
-    }
-}
 
 /// A range of nodes.
 pub struct NodeRange {
@@ -152,10 +132,6 @@ pub struct LayoutData {
     /// Description of how to account for recent style changes.
     restyle_damage: Option<int>,
 
-    /// The boxes assosiated with this flow.
-    /// Used for getBoundingClientRect and friends.
-    boxes: DisplayBoxes,
-
     /// The current results of flow construction for this node. This is either a flow or a
     /// `ConstructionItem`. See comments in `construct.rs` for more details.
     flow_construction_result: ConstructionResult,
@@ -168,7 +144,6 @@ impl LayoutData {
             applicable_declarations: ~[],
             style: None,
             restyle_damage: None,
-            boxes: DisplayBoxes::init(),
             flow_construction_result: NoConstructionResult,
         }
     }


### PR DESCRIPTION
`@`-free layout

r? @larsbergstrom
