### PR TITLE
removing @ from flowtree. (but cloning boxes when creating a display lis...

### DIFF
--- a/src/components/gfx/display_list.rs
+++ b/src/components/gfx/display_list.rs
@@ -93,7 +93,7 @@ pub struct SolidColorDisplayItem<E> {
 /// Renders text.
 pub struct TextDisplayItem<E> {
     base: BaseDisplayItem<E>,
-    text_run: ~TextRun,
+    text_run: Arc<~TextRun>,
     range: Range,
     color: Color,
 }
@@ -163,7 +163,8 @@ impl<E> DisplayItem<E> {
                 debug!("Drawing text at {:?}.", text.base.bounds);
 
                 // FIXME(pcwalton): Allocating? Why?
-                let font = render_context.font_ctx.get_font_by_descriptor(&text.text_run.font_descriptor).unwrap();
+                let text_run = text.text_run.get();
+                let font = render_context.font_ctx.get_font_by_descriptor(&text_run.font_descriptor).unwrap();
 
                 let font_metrics = font.with_borrow( |font| {
                     font.metrics.clone()
@@ -172,7 +173,7 @@ impl<E> DisplayItem<E> {
                 let baseline_origin = Point2D(origin.x, origin.y + font_metrics.ascent);
                 font.with_mut_borrow( |font| {
                     font.draw_text_into_context(render_context,
-                                                &text.text_run,
+                                                text.text_run.get(),
                                                 &text.range,
                                                 baseline_origin,
                                                 text.color);
@@ -183,18 +184,18 @@ impl<E> DisplayItem<E> {
                 let strikeout_size = font_metrics.strikeout_size;
                 let strikeout_offset = font_metrics.strikeout_offset;
 
-                if text.text_run.decoration.underline {
+                if text_run.decoration.underline {
                     let underline_y = baseline_origin.y - underline_offset;
                     let underline_bounds = Rect(Point2D(baseline_origin.x, underline_y),
                                                 Size2D(width, underline_size));
                     render_context.draw_solid_color(&underline_bounds, text.color);
                 }
-                if text.text_run.decoration.overline {
+                if text_run.decoration.overline {
                     let overline_bounds = Rect(Point2D(baseline_origin.x, origin.y),
                                                Size2D(width, underline_size));
                     render_context.draw_solid_color(&overline_bounds, text.color);
                 }
-                if text.text_run.decoration.line_through {
+                if text_run.decoration.line_through {
                     let strikeout_y = baseline_origin.y - strikeout_offset;
                     let strikeout_bounds = Rect(Point2D(baseline_origin.x, strikeout_y),
                                                 Size2D(width, strikeout_size));

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -7,7 +7,7 @@
 //! Each step of the traversal considers the node and existing flow, if there is one. If a node is
 //! not dirty and an existing flow exists, then the traversal reuses that flow. Otherwise, it
 //! proceeds to construct either a flow or a `ConstructionItem`. A construction item is a piece of
-//! intermediate data that goes with a DOM node and hasn't found its "home" yet—maybe it's a box,
+//! intermediate data that goes with a DOM node and hasn't found its "home" yet-maybe it's a box,
 //! maybe it's an absolute or fixed position thing that hasn't found its containing block yet.
 //! Construction items bubble up the tree from children to parents until they find their homes.
 //!
@@ -70,7 +70,7 @@ struct InlineBoxesConstructionResult {
     splits: Option<~[InlineBlockSplit]>,
 
     /// Any boxes that succeed the {ib} splits.
-    boxes: ~[@Box],
+    boxes: ~[~Box],
 }
 
 /// Represents an {ib} split that has not yet found the containing block that it belongs to. This
@@ -99,7 +99,7 @@ struct InlineBlockSplit {
     /// The inline boxes that precede the flow.
     ///
     /// TODO(pcwalton): Small vector optimization.
-    predecessor_boxes: ~[@Box],
+    predecessor_boxes: ~[~Box],
 
     /// The flow that caused this {ib} split.
     flow: ~Flow:,
@@ -215,7 +215,7 @@ impl<'self> FlowConstructor<'self> {
     }
 
     /// Builds a `Box` for the given node.
-    fn build_box_for_node(&self, node: AbstractNode<LayoutView>) -> @Box {
+    fn build_box_for_node(&self, node: AbstractNode<LayoutView>) -> ~Box {
         let specific = match node.type_id() {
             ElementNodeTypeId(HTMLImageElementTypeId) => {
                 match self.build_box_info_for_image(node) {
@@ -226,7 +226,7 @@ impl<'self> FlowConstructor<'self> {
             TextNodeTypeId => UnscannedTextBox(UnscannedTextBoxInfo::new(&node)),
             _ => GenericBox,
         };
-        @Box::new(node, specific)
+        ~Box::new(node, specific)
     }
 
     /// Creates an inline flow from a set of inline boxes and adds it as a child of the given flow.
@@ -235,7 +235,7 @@ impl<'self> FlowConstructor<'self> {
     /// otherwise.
     #[inline(always)]
     fn flush_inline_boxes_to_flow(&self,
-                                  boxes: ~[@Box],
+                                  boxes: ~[~Box],
                                   flow: &mut ~Flow:,
                                   node: AbstractNode<LayoutView>) {
         if boxes.len() > 0 {
@@ -249,7 +249,7 @@ impl<'self> FlowConstructor<'self> {
     /// Creates an inline flow from a set of inline boxes, if present, and adds it as a child of
     /// the given flow.
     fn flush_inline_boxes_to_flow_if_necessary(&self,
-                                               opt_boxes: &mut Option<~[@Box]>,
+                                               opt_boxes: &mut Option<~[~Box]>,
                                                flow: &mut ~Flow:,
                                                node: AbstractNode<LayoutView>) {
         let opt_boxes = util::replace(opt_boxes, None);
@@ -564,7 +564,7 @@ impl NodeUtils for AbstractNode<LayoutView> {
 }
 
 /// Strips ignorable whitespace from the start of a list of boxes.
-fn strip_ignorable_whitespace_from_start(opt_boxes: &mut Option<~[@Box]>) {
+fn strip_ignorable_whitespace_from_start(opt_boxes: &mut Option<~[~Box]>) {
     match util::replace(opt_boxes, None) {
         None => return,
         Some(boxes) => {
@@ -586,7 +586,7 @@ fn strip_ignorable_whitespace_from_start(opt_boxes: &mut Option<~[@Box]>) {
 }
 
 /// Strips ignorable whitespace from the end of a list of boxes.
-fn strip_ignorable_whitespace_from_end(opt_boxes: &mut Option<~[@Box]>) {
+fn strip_ignorable_whitespace_from_end(opt_boxes: &mut Option<~[~Box]>) {
     match *opt_boxes {
         None => {}
         Some(ref mut boxes) => {

--- a/src/components/main/layout/display_list_builder.rs
+++ b/src/components/main/layout/display_list_builder.rs
@@ -16,13 +16,13 @@ use style;
 /// that nodes in this view shoud not really be touched. The idea is to
 /// store the nodes in the display list and have layout transmute them.
 pub trait ExtraDisplayListData {
-    fn new(box: &@Box) -> Self;
+    fn new(box: &Box) -> Self;
 }
 
 pub type Nothing = ();
 
 impl ExtraDisplayListData for AbstractNode<()> {
-    fn new(box: &@Box) -> AbstractNode<()> {
+    fn new(box: &Box) -> AbstractNode<()> {
         unsafe {
             transmute(box.node)
         }
@@ -30,7 +30,7 @@ impl ExtraDisplayListData for AbstractNode<()> {
 }
 
 impl ExtraDisplayListData for Nothing {
-    fn new(_: &@Box) -> Nothing {
+    fn new(_: &Box) -> Nothing {
         ()
     }
 }

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -56,7 +56,7 @@ impl ElementMapping {
         self.entries.iter().enumerate()
     }
 
-    pub fn repair_for_box_changes(&mut self, old_boxes: &[@Box], new_boxes: &[@Box]) {
+    pub fn repair_for_box_changes(&mut self, old_boxes: &[~Box], new_boxes: &[~Box]) {
         let entries = &mut self.entries;
 
         debug!("--- Old boxes: ---");

--- a/src/components/net/image/holder.rs
+++ b/src/components/net/image/holder.rs
@@ -17,6 +17,7 @@ use extra::arc::{Arc, MutexArc};
 
 /// A struct to store image data. The image will be loaded once the first time it is requested,
 /// and an Arc will be stored.  Clones of this Arc are given out on demand.
+#[deriving(Clone)]
 pub struct ImageHolder {
     url: Url,
     image: Option<Arc<~Image>>,
@@ -59,7 +60,7 @@ impl ImageHolder {
     pub fn size(&self) -> Size2D<int> {
         self.cached_size
     }
-    
+
     /// Query and update the current image size.
     pub fn get_size(&mut self) -> Option<Size2D<int>> {
         debug!("get_size() {}", self.url.to_str());


### PR DESCRIPTION
Removing all @ from flowtree to make it parallelism-ready.
The connection between displaylist and flowtree is removed, i.e., when displaylist is built, box is cloned.
Whether displaylist still needs to have boxes is a design decision to make.

Also thanks to @ksh8281
