### PR TITLE
Move glfw::terminate() out of destructor, is hanging app under linux

### DIFF
--- a/src/components/main/platform/common/glfw_windowing.rs
+++ b/src/components/main/platform/common/glfw_windowing.rs
@@ -37,13 +37,6 @@ impl ApplicationMethods for Application {
     }
 }
 
-impl Drop for Application {
-    fn drop(&mut self) {
-        drop_local_window();
-        glfw::terminate();
-    }
-}
-
 /// The type of a window.
 pub struct Window {
     glfw_window: glfw::Window,
@@ -145,6 +138,8 @@ impl WindowMethods<Application> for Window {
         glfw::poll_events();
 
         if self.glfw_window.should_close() {
+            drop_local_window();
+            glfw::terminate();
             QuitWindowEvent
         } else if !self.event_queue.is_empty() {
             self.event_queue.shift()


### PR DESCRIPTION
There's a race condition between tasks (or something along those lines) that causes glfw::terminate() to hang if called in the destructor.  Moving it out of the destructor fixes the issue under linux.

It might be worth having someone more familiar with the rust internals look at why this was happening eventually.

Fixes #1097.
