### PR TITLE
layout: Make "height" relative to the initial containing block for the root.

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -323,6 +323,10 @@ impl BlockFlow {
 
 
         let mut height = if self.is_root {
+            // FIXME(pcwalton): The max is taken here so that you can scroll the page, but this is
+            // not correct behavior according to CSS 2.1 § 10.5. Instead I think we should treat
+            // the root element as having `overflow: scroll` and use the layers-based scrolling
+            // infrastructure to make it scrollable.
             Au::max(ctx.screen_size.size.height, cur_y)
         } else {
             cur_y - top_offset - collapsing
@@ -330,7 +334,11 @@ impl BlockFlow {
 
         for &box in self.box.iter() {
             let style = box.style();
-            height = match MaybeAuto::from_style(style.Box.height, Au::new(0)) {
+
+            // At this point, `height` is the height of the containing block, so passing `height`
+            // as the second argument here effectively makes percentages relative to the containing
+            // block per CSS 2.1 § 10.5.
+            height = match MaybeAuto::from_style(style.Box.height, height) {
                 Auto => height,
                 Specified(value) => value
             };

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -13,3 +13,4 @@
 == last_of_type_pseudo_a.html last_of_type_pseudo_b.html
 == only_of_type_pseudo_a.html only_of_type_pseudo_b.html
 == visibility_hidden.html visibility_hidden_ref.html
+== root_height_a.html root_height_b.html

--- a/src/test/ref/root_height_a.html
+++ b/src/test/ref/root_height_a.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>Aliens was a really good movie. But Alien 3 sucked.</title>
+<style>
+html {
+    height: 100%;
+    background-color: maroon;
+}
+</style>
+</head>
+<body>
+</body>
+</html>
+

--- a/src/test/ref/root_height_b.html
+++ b/src/test/ref/root_height_b.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<title>Aliens was a really good movie. But Alien 3 sucked.</title>
+<style>
+html {
+    background-color: maroon;
+}
+</style>
+</head>
+<body>
+</body>
+</html>
+


### PR DESCRIPTION
Fixes Wikipedia.

r? @metajack
