### PR TITLE
Rename some 'new' functions to 'new_inherited'.

### DIFF
--- a/src/components/script/dom/characterdata.rs
+++ b/src/components/script/dom/characterdata.rs
@@ -15,9 +15,9 @@ pub struct CharacterData {
 }
 
 impl CharacterData {
-    pub fn new(id: NodeTypeId, data: ~str, document: AbstractDocument) -> CharacterData {
+    pub fn new_inherited(id: NodeTypeId, data: ~str, document: AbstractDocument) -> CharacterData {
         CharacterData {
-            node: Node::new(id, document),
+            node: Node::new_inherited(id, document),
             data: data
         }
     }

--- a/src/components/script/dom/comment.rs
+++ b/src/components/script/dom/comment.rs
@@ -17,7 +17,7 @@ pub struct Comment {
 impl Comment {
     pub fn new_inherited(text: ~str, document: AbstractDocument) -> Comment {
         Comment {
-            element: CharacterData::new(CommentNodeTypeId, text, document)
+            element: CharacterData::new_inherited(CommentNodeTypeId, text, document)
         }
     }
 

--- a/src/components/script/dom/documentfragment.rs
+++ b/src/components/script/dom/documentfragment.rs
@@ -17,7 +17,7 @@ impl DocumentFragment {
     /// Creates a new DocumentFragment.
     pub fn new_inherited(document: AbstractDocument) -> DocumentFragment {
         DocumentFragment {
-            node: Node::new(DocumentFragmentNodeTypeId, document),
+            node: Node::new_inherited(DocumentFragmentNodeTypeId, document),
         }
     }
 

--- a/src/components/script/dom/documenttype.rs
+++ b/src/components/script/dom/documenttype.rs
@@ -24,7 +24,7 @@ impl DocumentType {
                          document: AbstractDocument)
             -> DocumentType {
         DocumentType {
-            node: Node::new(DoctypeNodeTypeId, document),
+            node: Node::new_inherited(DoctypeNodeTypeId, document),
             name: name,
             public_id: public_id.unwrap_or(~""),
             system_id: system_id.unwrap_or(~""),

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -151,9 +151,9 @@ impl ElementLike for Element {
 }
 
 impl<'self> Element {
-    pub fn new(type_id: ElementTypeId, tag_name: ~str, namespace: Namespace, document: AbstractDocument) -> Element {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: ~str, namespace: Namespace, document: AbstractDocument) -> Element {
         Element {
-            node: Node::new(ElementNodeTypeId(type_id), document),
+            node: Node::new_inherited(ElementNodeTypeId(type_id), document),
             tag_name: tag_name,
             namespace: namespace,
             attrs: HashMap::new(),

--- a/src/components/script/dom/htmlelement.rs
+++ b/src/components/script/dom/htmlelement.rs
@@ -18,7 +18,7 @@ pub struct HTMLElement {
 impl HTMLElement {
     pub fn new_inherited(type_id: ElementTypeId, tag_name: ~str, document: AbstractDocument) -> HTMLElement {
         HTMLElement {
-            element: Element::new(type_id, tag_name, namespace::HTML, document)
+            element: Element::new_inherited(type_id, tag_name, namespace::HTML, document)
         }
     }
 

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -625,7 +625,7 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn new(type_id: NodeTypeId, doc: AbstractDocument) -> Node<ScriptView> {
+    pub fn new_inherited(type_id: NodeTypeId, doc: AbstractDocument) -> Node<ScriptView> {
         Node::new_(type_id, Some(doc))
     }
 

--- a/src/components/script/dom/text.rs
+++ b/src/components/script/dom/text.rs
@@ -17,7 +17,7 @@ pub struct Text {
 impl Text {
     pub fn new_inherited(text: ~str, document: AbstractDocument) -> Text {
         Text {
-            element: CharacterData::new(TextNodeTypeId, text, document)
+            element: CharacterData::new_inherited(TextNodeTypeId, text, document)
         }
     }
 


### PR DESCRIPTION
To match existing style for constructors that don't wrap.
