### PR TITLE
Restore restyle damage computation but disable reflow pruning for now

### DIFF
--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -120,6 +120,7 @@ impl PreorderFlowTraversal for PropagateDamageTraversal {
         if self.all_style_damage {
             flow::mut_base(flow).restyle_damage.union_in_place(RestyleDamage::all())
         }
+        debug!("restyle damage = {:?}", flow::base(flow).restyle_damage);
 
         let prop = flow::base(flow).restyle_damage.propagate_down();
         if prop.is_nonempty() {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -100,7 +100,7 @@ impl PostorderFlowTraversal for ComputeDamageTraversal {
     fn process(&mut self, flow: &mut Flow) -> bool {
         let mut damage = flow::base(flow).restyle_damage;
         for child in flow::child_iter(flow) {
-            damage.union_in_place(flow::base(*child).restyle_damage)
+            damage.union_in_place(flow::base(*child).restyle_damage.propagate_up())
         }
         flow::mut_base(flow).restyle_damage = damage;
         true

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -23,6 +23,7 @@ use dom::htmltitleelement::HTMLTitleElement;
 use html::hubbub_html_parser::build_element_from_tag;
 use js::jsapi::{JSObject, JSContext, JSTracer};
 use servo_util::tree::{TreeNodeRef, ElementLike};
+use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage};
 
 use std::hashmap::HashMap;
 
@@ -319,7 +320,11 @@ impl Document {
     }
 
     pub fn content_changed(&self) {
-        self.window.content_changed();
+        self.damage_and_reflow(ContentChangedDocumentDamage);
+    }
+
+    pub fn damage_and_reflow(&self, damage: DocumentDamageLevel) {
+        self.window.damage_and_reflow(damage);
     }
 
     pub fn wait_until_safe_to_modify_dom(&self) {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -18,7 +18,8 @@ use dom::document;
 use dom::namespace;
 use dom::namespace::Namespace;
 use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery};
-use layout_interface::{ContentBoxesResponse};
+use layout_interface::{ContentBoxesResponse, ContentChangedDocumentDamage};
+use layout_interface::{MatchSelectorsDocumentDamage};
 use style;
 use servo_util::tree::{TreeNodeRef, ElementLike};
 
@@ -293,8 +294,12 @@ impl<'self> Element {
         }
 
         if abstract_self.is_in_doc() {
+            let damage = match local_name.as_slice() {
+                "style" | "id" | "class" => MatchSelectorsDocumentDamage,
+                _ => ContentChangedDocumentDamage
+            };
             let document = self.node.owner_doc();
-            document.document().content_changed();
+            document.document().damage_and_reflow(damage);
         }
     }
 }

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -252,19 +252,20 @@ impl<'self> Element {
                               }
                           });
 
-        self.after_set_attr(abstract_self, &namespace, local_name, value, old_raw_value);
+        if namespace == namespace::Null {
+            self.after_set_attr(abstract_self, local_name, value, old_raw_value);
+        }
         Ok(())
     }
 
     fn after_set_attr(&mut self,
                       abstract_self: AbstractNode<ScriptView>,
-                      namespace: &Namespace,
                       local_name: DOMString,
                       value: DOMString,
                       old_value: Option<DOMString>) {
 
         match local_name.as_slice() {
-            "style" if *namespace == namespace::Null => {
+            "style" => {
                 self.style_attribute = Some(style::parse_style_attribute(value))
             }
             "id" => {

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -12,7 +12,7 @@ use dom::node::{AbstractNode, ScriptView};
 use dom::location::Location;
 use dom::navigator::Navigator;
 
-use layout_interface::{ReflowForDisplay, ContentChangedDocumentDamage};
+use layout_interface::{ReflowForDisplay, DocumentDamageLevel};
 use script_task::{ExitWindowMsg, FireTimerMsg, Page, ScriptChan};
 use servo_msg::compositor_msg::ScriptListener;
 use servo_net::image_cache_task::ImageCacheTask;
@@ -185,11 +185,11 @@ impl Window {
         self.active_timers.remove(&handle);
     }
 
-    pub fn content_changed(&self) {
+    pub fn damage_and_reflow(&self, damage: DocumentDamageLevel) {
         // FIXME This should probably be ReflowForQuery, not Display. All queries currently
         // currently rely on the display list, which means we can't destroy it by
         // doing a query reflow.
-        self.page.damage(ContentChangedDocumentDamage);
+        self.page.damage(damage);
         self.page.reflow(ReflowForDisplay, self.script_chan.clone(), self.compositor);
     }
 

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -12,7 +12,7 @@ use dom::node::{AbstractNode, ScriptView};
 use dom::location::Location;
 use dom::navigator::Navigator;
 
-use layout_interface::ReflowForDisplay;
+use layout_interface::{ReflowForDisplay, ContentChangedDocumentDamage};
 use script_task::{ExitWindowMsg, FireTimerMsg, Page, ScriptChan};
 use servo_msg::compositor_msg::ScriptListener;
 use servo_net::image_cache_task::ImageCacheTask;
@@ -189,7 +189,8 @@ impl Window {
         // FIXME This should probably be ReflowForQuery, not Display. All queries currently
         // currently rely on the display list, which means we can't destroy it by
         // doing a query reflow.
-        self.page.reflow_all(ReflowForDisplay, self.script_chan.clone(), self.compositor);
+        self.page.damage(ContentChangedDocumentDamage);
+        self.page.reflow(ReflowForDisplay, self.script_chan.clone(), self.compositor);
     }
 
     pub fn wait_until_safe_to_modify_dom(&self) {

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -588,9 +588,6 @@ impl ScriptTask {
                                  &rval);
 
         }
-        // We don't know what the script changed, so for now we will do a total redisplay.
-        page.damage(ContentChangedDocumentDamage);
-        page.reflow(ReflowForDisplay, self.chan.clone(), self.compositor);
     }
 
     /// Handles a notification that reflow completed.


### PR DESCRIPTION
This fixes the computation of restyle damage on `color-change-text.html`, which can be seen with `RUST_LOG=servo::layout::layout_task`.

However we can't prune the layout traversals yet, because we don't reuse `Flow` objects between reflows, so we have no old values to fall back to.

I think this used to work because `FlowContexts` (as they were called then) were stored in a DOM node's `LayoutData` and reused.  But it's possible that it never really worked, and my testing when I landed the restyle damage code was insufficient (I didn't understand the layout code nearly as well back then).

r? @pcwalton
