### PR TITLE
Remove unused import for fix compile warning

### DIFF
--- a/src/components/gfx/platform/macos/font_list.rs
+++ b/src/components/gfx/platform/macos/font_list.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use font::FontHandleMethods;
-use font_context::FontContextHandleMethods;
 use font_list::{FontEntry, FontFamily, FontFamilyMap};
 use platform::macos::font::FontHandle;
 use platform::macos::font_context::FontContextHandle;


### PR DESCRIPTION
Fix this warning:

```
servo/src/components/gfx/platform/macos/font_list.rs:6:4: 6:42 warning: unused import, #[warn(unused_imports)] on by default
servo/src/components/gfx/platform/macos/font_list.rs:6 use font_context::FontContextHandleMethods;
```
