### PR TITLE
Added recognition of positioned offsets: top, bottom, right, and left

### DIFF
--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -85,6 +85,9 @@ pub struct Box {
 
     /// Info specific to the kind of box. Keep this enum small.
     specific: SpecificBoxInfo,
+
+    /// positioned box offsets
+    position_offsets: Slot<SideOffsets2D<Au>>,
 }
 
 /// Info specific to the kind of box. Keep this enum small.
@@ -254,6 +257,7 @@ impl Box {
             padding: Slot::init(Zero::zero()),
             margin: Slot::init(Zero::zero()),
             specific: specific,
+            position_offsets: Slot::init(Zero::zero()),
         }
     }
 
@@ -276,6 +280,7 @@ impl Box {
             padding: Slot::init(self.padding.get()),
             margin: Slot::init(self.margin.get()),
             specific: specific,
+            position_offsets: Slot::init(Zero::zero())
         }
     }
 
@@ -332,6 +337,14 @@ impl Box {
                                                  style.Border.border_bottom_style),
                                            width(style.Border.border_left_width,
                                                  style.Border.border_left_style)))
+    }
+
+    pub fn compute_positioned_offset(&self, style: &ComputedValues) {
+        self.position_offsets.set(SideOffsets2D::new(
+                MaybeAuto::from_style(style.PositionOffsets.top, Au::new(0)).specified_or_zero(),
+                MaybeAuto::from_style(style.PositionOffsets.right, Au::new(0)).specified_or_zero(),
+                MaybeAuto::from_style(style.PositionOffsets.bottom, Au::new(0)).specified_or_zero(),
+                MaybeAuto::from_style(style.PositionOffsets.left, Au::new(0)).specified_or_zero()));
     }
 
     /// Populates the box model padding parameters from the given computed style.

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -223,6 +223,13 @@ pub mod longhands {
         </%self:longhand>
     % endfor
 
+    ${new_style_struct("PositionOffsets")}
+
+    % for side in ["top", "right", "bottom", "left"]:
+        ${predefined_type(side, "LengthOrPercentageOrAuto",
+                          "computed::LPA_Auto")}
+    % endfor
+
     // CSS 2.1, Section 9 - Visual formatting model
 
     ${new_style_struct("Box")}
@@ -278,6 +285,7 @@ pub mod longhands {
     ${predefined_type("max-width", "LengthOrPercentageOrNone",
                       "computed::LPN_None",
                       "parse_non_negative")}
+
 
     <%self:single_component_value name="line-height">
         #[deriving(Clone)]


### PR DESCRIPTION
For #1406

Not really sure about some of my naming conventions, but offset was kinda taken in box.rs :/

Also this doesn't fully implement the offsets, but I'll do that alongside #782.
