### PR TITLE
Replace DOM nodes in reflow with opaque nodes

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -585,11 +585,13 @@ impl Flow for BlockFlow {
     /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
     /// contexts.
     fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_widths_float: assigning width for flow {}",  self.base.id);
-        } else {
-            debug!("assign_widths_block: assigning width for flow {}",  self.base.id);
-        }
+        debug!("assign_widths({}): assigning width for flow {}",
+               if self.is_float() {
+                   "float"
+               } else {
+                   "block"
+               },
+               self.base.id);
 
         if self.is_root {
             debug!("Setting root position");
@@ -612,6 +614,9 @@ impl Flow for BlockFlow {
 
         for box in self.box.iter() {
             let style = box.style();
+
+            // The text alignment of a block flow is the text alignment of its box's style.
+            self.base.flags.set_text_align(style.Text.text_align);
 
             // Can compute padding here since we know containing block width.
             box.compute_padding(style, remaining_width);
@@ -672,7 +677,9 @@ impl Flow for BlockFlow {
             // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
             //
             // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-            child_base.flags.propagate_text_decoration_from_parent(self.base.flags)
+            child_base.flags.propagate_text_decoration_from_parent(self.base.flags);
+
+            child_base.flags.propagate_text_alignment_from_parent(self.base.flags)
         }
     }
 

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -40,6 +40,7 @@ use layout::float_context::{ClearType, ClearLeft, ClearRight, ClearBoth};
 use layout::flow::Flow;
 use layout::flow;
 use layout::model::{MaybeAuto, specified};
+use layout::util::OpaqueNode;
 
 /// Boxes (`struct Box`) are the leaves of the layout tree. They cannot position themselves. In
 /// general, boxes do not have a simple correspondence with CSS boxes in the specification:
@@ -63,8 +64,8 @@ use layout::model::{MaybeAuto, specified};
 /// FIXME(pcwalton): This can be slimmed down quite a bit.
 #[deriving(Clone)]
 pub struct Box {
-    /// The DOM node that this `Box` originates from.
-    node: AbstractNode<LayoutView>,
+    /// An opaque reference to the DOM node that this `Box` originates from.
+    node: OpaqueNode,
 
     /// The CSS style of this box.
     style: Arc<ComputedValues>,
@@ -250,7 +251,7 @@ impl Box {
         }
 
         Box {
-            node: node,
+            node: OpaqueNode::from_node(&node),
             style: (*nearest_ancestor_element.style()).clone(),
             position: Slot::init(Au::zero_rect()),
             border: Slot::init(Zero::zero()),
@@ -288,7 +289,7 @@ impl Box {
     /// CSS 2.1.
     fn guess_width(&self) -> Au {
         match self.specific {
-            GenericBox | ImageBox(_) => {}
+            GenericBox | IframeBox(_) | ImageBox(_) => {}
             ScannedTextBox(_) | UnscannedTextBox(_) => return Au(0),
         }
 

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -284,9 +284,12 @@ impl Box {
         }
     }
 
+    /// Returns the shared part of the width for computation of minimum and preferred width per
+    /// CSS 2.1.
     fn guess_width(&self) -> Au {
-        if !self.node.is_element() {
-            return Au(0)
+        match self.specific {
+            GenericBox | ImageBox(_) => {}
+            ScannedTextBox(_) | UnscannedTextBox(_) => return Au(0),
         }
 
         let style = self.style();

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -924,9 +924,8 @@ impl Box {
                 let left_box = if left_range.length() > 0 {
                     let new_text_box_info = ScannedTextBoxInfo::new(text_box_info.run.clone(), left_range);
                     let new_metrics = new_text_box_info.run.get().metrics_for_range(&left_range);
-                    let new_text_box = Box::new(self.node, ScannedTextBox(new_text_box_info));
-                    new_text_box.set_size(new_metrics.bounding_box.size);
-                    Some(new_text_box)
+                    Some(self.transform(new_metrics.bounding_box.size,
+                                        ScannedTextBox(new_text_box_info)))
                 } else {
                     None
                 };
@@ -934,9 +933,8 @@ impl Box {
                 let right_box = right_range.map_default(None, |range: Range| {
                     let new_text_box_info = ScannedTextBoxInfo::new(text_box_info.run.clone(), range);
                     let new_metrics = new_text_box_info.run.get().metrics_for_range(&range);
-                    let new_text_box = Box::new(self.node, ScannedTextBox(new_text_box_info));
-                    new_text_box.set_size(new_metrics.bounding_box.size);
-                    Some(new_text_box)
+                    Some(self.transform(new_metrics.bounding_box.size,
+                                        ScannedTextBox(new_text_box_info)))
                 });
 
                 if pieces_processed_count == 1 || left_box.is_none() {

--- a/src/components/main/layout/display_list_builder.rs
+++ b/src/components/main/layout/display_list_builder.rs
@@ -6,26 +6,20 @@
 
 use layout::box::Box;
 use layout::context::LayoutContext;
-use std::cast::transmute;
-use script::dom::node::AbstractNode;
+use layout::util::OpaqueNode;
 
 use gfx;
 use style;
 
-/// Display list data is usually an AbstractNode with view () to indicate
-/// that nodes in this view shoud not really be touched. The idea is to
-/// store the nodes in the display list and have layout transmute them.
 pub trait ExtraDisplayListData {
     fn new(box: &Box) -> Self;
 }
 
 pub type Nothing = ();
 
-impl ExtraDisplayListData for AbstractNode<()> {
-    fn new(box: &Box) -> AbstractNode<()> {
-        unsafe {
-            transmute(box.node)
-        }
+impl ExtraDisplayListData for OpaqueNode {
+    fn new(box: &Box) -> OpaqueNode {
+        box.node
     }
 }
 

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -785,17 +785,15 @@ impl Flow for InlineFlow {
                 // parent's content area.
 
                 // We should calculate the distance from baseline to the top of parent's content
-                // area. But for now we assume it's the parent's font size.
-                let mut parent_text_top;
+                // area. But for now we assume it's the font size.
+                //
+                // The spec does not state which font to use. Previous versions of the code used
+                // the parent's font; this code uses the current font.
+                let parent_text_top = cur_box.style().Font.font_size;
 
                 // We should calculate the distance from baseline to the bottom of the parent's
                 // content area. But for now we assume it's zero.
                 let parent_text_bottom = Au::new(0);
-
-                let parent = cur_box.node.parent_node().unwrap();
-                let parent_style = parent.style();
-                let font_size = parent_style.get().Font.font_size;
-                parent_text_top = font_size;
 
                 // Calculate a relative offset from the baseline.
                 //

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -9,7 +9,7 @@ use extra::url::Url;
 use gfx::opts::Opts;
 use gfx::render_task::{PaintPermissionGranted, PaintPermissionRevoked};
 use gfx::render_task::{RenderChan, RenderTask};
-use script::dom::node::AbstractNode;
+use layout::util::OpaqueNode;
 use script::layout_interface::LayoutChan;
 use script::script_task::LoadMsg;
 use script::script_task::{AttachLayoutMsg, NewLayoutInfo, ScriptTask, ScriptChan};
@@ -27,19 +27,19 @@ pub struct Pipeline {
     subpage_id: Option<SubpageId>,
     script_chan: ScriptChan,
     layout_chan: LayoutChan,
-    render_chan: RenderChan<AbstractNode<()>>,
+    render_chan: RenderChan<OpaqueNode>,
     layout_shutdown_port: Port<()>,
     render_shutdown_port: Port<()>,
     /// The most recently loaded url
     url: Option<Url>,
 }
 
-/// A subset of the Pipeline nthat is eeded for layer composition
+/// The subset of the pipeline that is needed for layer composition.
 #[deriving(Clone)]
 pub struct CompositionPipeline {
     id: PipelineId,
     script_chan: ScriptChan,
-    render_chan: RenderChan<AbstractNode<()>>,
+    render_chan: RenderChan<OpaqueNode>,
 }
 
 impl Pipeline {
@@ -182,7 +182,7 @@ impl Pipeline {
                subpage_id: Option<SubpageId>,
                script_chan: ScriptChan,
                layout_chan: LayoutChan,
-               render_chan: RenderChan<AbstractNode<()>>,
+               render_chan: RenderChan<OpaqueNode>,
                layout_shutdown_port: Port<()>,
                render_shutdown_port: Port<()>)
                -> Pipeline {

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -106,7 +106,7 @@ pub mod longhands {
         <%self:single_component_value name="${name}" inherited="${inherited}">
             ${caller.body()}
             pub mod computed_value {
-                #[deriving(Eq, Clone)]
+                #[deriving(Eq, Clone, FromPrimitive)]
                 pub enum T {
                     % for value in values.split():
                         ${to_rust_ident(value)},


### PR DESCRIPTION
This shuts off all layout access to the DOM after flow tree construction, which will allow us to run script concurrently with layout during reflow and display list construction—even without the COW DOM. It also gets us closer to making `AbstractNode` noncopyable, which is important for safety because the JS GC will not trace layout.

r? @kmcallister
