### PR TITLE
Ensure render and layout tasks get destructed before main thread finishes

### DIFF
--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -15,7 +15,7 @@ use layers::layers::TextureLayerKind;
 use layers::platform::surface::{NativeCompositingGraphicsContext, NativeSurfaceMethods};
 use layers::texturegl::{Texture, TextureTarget};
 #[cfg(target_os="macos")] use layers::texturegl::TextureTargetRectangle;
-use pipeline::Pipeline;
+use pipeline::CompositionPipeline;
 use script::dom::event::{ClickEvent, MouseDownEvent, MouseUpEvent};
 use script::script_task::SendEventMsg;
 use servo_msg::compositor_msg::{LayerBuffer, LayerBufferSet, Epoch, Tile};
@@ -34,7 +34,7 @@ use layers::texturegl::TextureTarget2D;
 /// Each layer can also have child layers.
 pub struct CompositorLayer {
     /// This layer's pipeline. BufferRequests and mouse events will be sent through this.
-    pipeline: Pipeline,
+    pipeline: CompositionPipeline,
 
     /// The size of the underlying page in page coordinates. This is an option
     /// because we may not know the size of the page until layout is finished completely.
@@ -104,7 +104,7 @@ enum ScrollBehavior {
 impl CompositorLayer {
     /// Creates a new CompositorLayer with an optional page size. If no page size is given,
     /// the layer is initially hidden and initialized without a quadtree.
-    pub fn new(pipeline: Pipeline,
+    pub fn new(pipeline: CompositionPipeline,
                page_size: Option<Size2D<f32>>,
                tile_size: uint,
                max_mem: Option<uint>,
@@ -669,7 +669,7 @@ impl CompositorLayer {
     }
     
     // Adds a child.
-    pub fn add_child(&mut self, pipeline: Pipeline, page_size: Option<Size2D<f32>>, tile_size: uint,
+    pub fn add_child(&mut self, pipeline: CompositionPipeline, page_size: Option<Size2D<f32>>, tile_size: uint,
                      max_mem: Option<uint>, clipping_rect: Rect<f32>) {
         let container = @mut ContainerLayer();
         container.scissor = Some(clipping_rect);

--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -4,8 +4,10 @@
 
 use compositing::compositor_layer::CompositorLayer;
 use compositing::*;
+
 use platform::{Application, Window};
-use windowing::{ApplicationMethods, WindowEvent, WindowMethods};
+
+use windowing::{WindowEvent, WindowMethods};
 use windowing::{IdleWindowEvent, ResizeWindowEvent, LoadUrlWindowEvent, MouseWindowEventClass};
 use windowing::{ScrollWindowEvent, ZoomWindowEvent, NavigationWindowEvent, FinishedWindowEvent};
 use windowing::{QuitWindowEvent, MouseWindowClickEvent, MouseWindowMouseDownEvent, MouseWindowMouseUpEvent};
@@ -34,9 +36,8 @@ use std::rt::io::timer::Timer;
 use std::vec;
 
 /// Starts the compositor, which listens for messages on the specified port.
-pub fn run_compositor(compositor: &CompositorTask) {
-    let app: Application = ApplicationMethods::new();
-    let window: @mut Window = WindowMethods::new(&app);
+pub fn run_compositor(compositor: &CompositorTask, app: &Application) {
+    let window: @mut Window = WindowMethods::new(app);
 
     // Create an initial layer tree.
     //
@@ -418,8 +419,6 @@ pub fn run_compositor(compositor: &CompositorTask) {
         }
 
     }
-
-    compositor.shutdown_chan.send(());
 
     // Clear out the compositor layers so that painting tasks can destroy the buffers.
     match compositor_layer {

--- a/src/components/main/compositing/run_headless.rs
+++ b/src/components/main/compositing/run_headless.rs
@@ -37,5 +37,4 @@ pub fn run_compositor(compositor: &CompositorTask) {
                 => ()
         }
     }
-    compositor.shutdown_chan.send(())
 }

--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -8,7 +8,7 @@ use extra::url::Url;
 use geom::rect::Rect;
 use geom::size::Size2D;
 use gfx::opts::Opts;
-use pipeline::Pipeline;
+use pipeline::{Pipeline, CompositionPipeline};
 use script::script_task::{ResizeMsg, ResizeInactiveMsg};
 use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, FailureMsg, FrameRectMsg};
 use servo_msg::constellation_msg::{IFrameSandboxState, IFrameUnsandboxed, InitLoadUrlMsg};
@@ -81,7 +81,7 @@ impl Clone for ChildFrameTree {
 }
 
 pub struct SendableFrameTree {
-    pipeline: Pipeline,
+    pipeline: CompositionPipeline,
     children: ~[SendableChildFrameTree],
 }
 
@@ -129,7 +129,7 @@ impl FrameTree {
 
     fn to_sendable(&self) -> SendableFrameTree {
         let sendable_frame_tree = SendableFrameTree {
-            pipeline: (*self.pipeline).clone(),
+            pipeline: self.pipeline.to_sendable(),
             children: self.children.iter().map(|frame_tree| frame_tree.to_sendable()).collect(),
         };
         sendable_frame_tree

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -207,18 +207,23 @@ impl LayoutTask {
                   render_chan: RenderChan<AbstractNode<()>>,
                   img_cache_task: ImageCacheTask,
                   opts: Opts,
-                  profiler_chan: ProfilerChan) {
+                  profiler_chan: ProfilerChan,
+                  shutdown_chan: Chan<()>) {
         spawn_with!(task::task(), [port, constellation_chan, script_chan,
-                                   render_chan, img_cache_task, profiler_chan], {
-            let mut layout = LayoutTask::new(id,
-                                             port,
-                                             constellation_chan,
-                                             script_chan,
-                                             render_chan,
-                                             img_cache_task,
-                                             &opts,
-                                             profiler_chan);
-            layout.start();
+                                   render_chan, img_cache_task, profiler_chan, shutdown_chan], {
+            { // Ensures LayoutTask gets destroyed before we send the shutdown message
+                let mut layout = LayoutTask::new(id,
+                                                 port,
+                                                 constellation_chan,
+                                                 script_chan,
+                                                 render_chan,
+                                                 img_cache_task,
+                                                 &opts,
+                                                 profiler_chan);
+                layout.start();
+            }
+
+            shutdown_chan.send(());
         });
     }
 

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -124,7 +124,7 @@ fn start(argc: int, argv: **u8) -> int {
 }
 
 fn run(opts: Opts) {
-    let (shutdown_port, shutdown_chan) = comm::stream();
+    let (exit_response_from_constellation, exit_chan) = comm::stream();
     let (profiler_port, profiler_chan) = special_stream!(ProfilerChan);
     let (compositor_port, compositor_chan) = special_stream!(CompositorChan);
     let (constellation_port, constellation_chan) = special_stream!(ConstellationChan);
@@ -158,24 +158,20 @@ fn run(opts: Opts) {
         for filename in opts.urls.iter() {
             constellation_chan.send(InitLoadUrlMsg(make_url(filename.clone(), None)))
         }
-
-        // Wait for the compositor to shut down.
-        shutdown_port.recv();
-
-        // Shut the constellation down.
-        debug!("master: Shut down");
-        let (exit_response_from_constellation, exit_chan) = comm::stream();
-        constellation_chan.send(ExitMsg(exit_chan));
-        exit_response_from_constellation.recv();
     }
 
     let compositor_task = CompositorTask::new(opts,
                                               compositor_port,
-                                              constellation_chan,
-                                              profiler_chan,
-                                              shutdown_chan);
+                                              constellation_chan.clone(),
+                                              profiler_chan);
 
     debug!("preparing to enter main loop");
     compositor_task.run();
+
+    // Constellation has to be shut down before the compositor goes out of
+    // scope, as the compositor manages setup/teardown of global subsystems
+    debug!("shutting down the constellation");
+    constellation_chan.send(ExitMsg(exit_chan));
+    exit_response_from_constellation.recv();
 }
 


### PR DESCRIPTION
Pipeline now blocks on `Pipeline.exit()` and waits for confirmation that RenderTask and LayoutTask were successfully destructed (they're created inside a block which ensures they go out of scope before the message is sent.

Other notable changes include:
- The blocking recv in main/servo.rc that waits for a constellation exit confirmation was moved out of the spawn and into the main thread.  `Constellation::start()` spawns a new task, so there's no need to block in that task once the ExitMsg is sent off.
- Application initialization was moved out of `run_compositor` and into `CompositorTask`, so it could be stored with the compositor task and not go out of scope until the program's main block finishes.

I had to use SharedPort<()> objects to work around the fact that pipelines get cloned, even though it feels like pipelines should probably be ref counted instead.  I went down that route for a few hours but got bogged down trying to wrap my head around some region/lifetime issues; I would be happy to work on that part again, but would need some mentoring to help me figure out what I was doing wrong and possibly why.  The current solution doesn't feel too bad though.

Fixes #1097.
