### PR TITLE
Adjust PNG encoder color type to match what's read from gl2

### DIFF
--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -373,7 +373,7 @@ pub fn run_compositor(compositor: &CompositorTask) {
             let img = png::Image {
                 width: width as u32,
                 height: height as u32,
-                color_type: png::RGBA8,
+                color_type: png::RGB8,
                 pixels: pixels,
             };
             let res = png::store_png(&img, &path);


### PR DESCRIPTION
This should fix images produced by the -o flag.

The gl2::read_pixels call was asking for pixel data in RGB8 but was then telling the PNG encoder that the data was RGBA8.  The value was originally set correctly, but was changed when support was added for drawing transparent PNGs.

We could instead adjust the gl2::read_pixels call to return RGBA8 so we can write transparent screenshots, but I'm not sure if there's a use case for that.
