### PR TITLE
Add glfw window_refresh_callback, windows now redraw on linux

### DIFF
--- a/src/components/main/compositing/run.rs
+++ b/src/components/main/compositing/run.rs
@@ -9,6 +9,7 @@ use windowing::{ApplicationMethods, WindowEvent, WindowMethods};
 use windowing::{IdleWindowEvent, ResizeWindowEvent, LoadUrlWindowEvent, MouseWindowEventClass};
 use windowing::{ScrollWindowEvent, ZoomWindowEvent, NavigationWindowEvent, FinishedWindowEvent};
 use windowing::{QuitWindowEvent, MouseWindowClickEvent, MouseWindowMouseDownEvent, MouseWindowMouseUpEvent};
+use windowing::RefreshWindowEvent;
 
 use azure::azure_hl::SourceSurfaceMethods;
 use azure::azure_hl;
@@ -240,6 +241,10 @@ pub fn run_compositor(compositor: &CompositorTask) {
     let check_for_window_messages: &fn(WindowEvent) = |event| {
         match event {
             IdleWindowEvent => {}
+
+            RefreshWindowEvent => {
+                recomposite = true;
+            }
 
             ResizeWindowEvent(width, height) => {
                 let new_size = Size2D(width, height);

--- a/src/components/main/platform/common/glfw_windowing.rs
+++ b/src/components/main/platform/common/glfw_windowing.rs
@@ -8,6 +8,7 @@ use windowing::{ApplicationMethods, WindowEvent, WindowMethods};
 use windowing::{IdleWindowEvent, ResizeWindowEvent, LoadUrlWindowEvent, MouseWindowEventClass};
 use windowing::{ScrollWindowEvent, ZoomWindowEvent, NavigationWindowEvent, FinishedWindowEvent};
 use windowing::{QuitWindowEvent, MouseWindowClickEvent, MouseWindowMouseDownEvent, MouseWindowMouseUpEvent};
+use windowing::RefreshWindowEvent;
 use windowing::{Forward, Back};
 
 use alert::{Alert, AlertMethods};
@@ -91,6 +92,9 @@ impl WindowMethods<Application> for Window {
         // Register event handlers.
         do window.glfw_window.set_framebuffer_size_callback |_win, width, height| {
             local_window().event_queue.push(ResizeWindowEvent(width as uint, height as uint))
+        }
+        do window.glfw_window.set_refresh_callback |_win| {
+            local_window().event_queue.push(RefreshWindowEvent)
         }
         do window.glfw_window.set_key_callback |_win, key, _scancode, action, mods| {
             if action == glfw::Press {

--- a/src/components/main/windowing.rs
+++ b/src/components/main/windowing.rs
@@ -26,6 +26,8 @@ pub enum WindowEvent {
     /// FIXME: This is a bogus event and is only used because we don't have the new
     /// scheduler integrated with the platform event loop.
     IdleWindowEvent,
+    /// Sent when part of the window is marked dirty and needs to be redrawn.
+    RefreshWindowEvent,
     /// Sent when the window is resized.
     ResizeWindowEvent(uint, uint),
     /// Sent when a new URL is to be loaded.


### PR DESCRIPTION
Moving another window on top of servo window, or switching screen would result in a blank window until the app was resized.  This was due to a missing glfw callback.

Fixes #941.
