### PR TITLE
Harden layout

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -15,20 +15,20 @@ use css::node_style::StyledNode;
 use layout::incremental;
 use layout::util::LayoutDataAccess;
 
-use script::dom::node::{AbstractNode, LayoutView};
+use script::dom::node::LayoutNode;
 use style::{TNode, Stylist, cascade};
 
 pub trait MatchMethods {
     fn match_node(&self, stylist: &Stylist);
     fn match_subtree(&self, stylist: RWArc<Stylist>);
 
-    fn cascade_node(&self, parent: Option<AbstractNode<LayoutView>>);
-    fn cascade_subtree(&self, parent: Option<AbstractNode<LayoutView>>);
+    fn cascade_node(&self, parent: Option<LayoutNode>);
+    fn cascade_subtree(&self, parent: Option<LayoutNode>);
 }
 
-impl MatchMethods for AbstractNode<LayoutView> {
+impl MatchMethods for LayoutNode {
     fn match_node(&self, stylist: &Stylist) {
-        let applicable_declarations = do self.with_imm_element |element| {
+        let applicable_declarations = do self.with_element |element| {
             let style_attribute = match element.style_attribute {
                 None => None,
                 Some(ref style_attribute) => Some(style_attribute)
@@ -80,7 +80,7 @@ impl MatchMethods for AbstractNode<LayoutView> {
         }
     }
 
-    fn cascade_node(&self, parent: Option<AbstractNode<LayoutView>>) {
+    fn cascade_node(&self, parent: Option<LayoutNode>) {
         let parent_style = match parent {
             Some(ref parent) => Some(parent.style()),
             None => None
@@ -111,7 +111,7 @@ impl MatchMethods for AbstractNode<LayoutView> {
         }
     }
 
-    fn cascade_subtree(&self, parent: Option<AbstractNode<LayoutView>>) {
+    fn cascade_subtree(&self, parent: Option<LayoutNode>) {
         self.cascade_node(parent);
 
         for kid in self.children() {

--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -30,7 +30,7 @@ pub trait MatchMethods {
 impl<'self> MatchMethods for LayoutNode<'self> {
     fn match_node(&self, stylist: &Stylist) {
         let applicable_declarations = do self.with_element |element| {
-            let style_attribute = match element.style_attribute {
+            let style_attribute = match *element.style_attribute() {
                 None => None,
                 Some(ref style_attribute) => Some(style_attribute)
             };

--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -7,9 +7,9 @@
 use css::node_style::StyledNode;
 use layout::incremental;
 use layout::util::LayoutDataAccess;
+use layout::wrapper::LayoutNode;
 
 use extra::arc::{Arc, RWArc};
-use script::dom::node::LayoutNode;
 use std::cast;
 use std::cell::Cell;
 use std::comm;

--- a/src/components/main/css/node_style.rs
+++ b/src/components/main/css/node_style.rs
@@ -17,7 +17,7 @@ pub trait StyledNode {
     fn restyle_damage(&self) -> RestyleDamage;
 }
 
-impl StyledNode for LayoutNode {
+impl<'self> StyledNode for LayoutNode<'self> {
     #[inline]
     fn style<'a>(&'a self) -> &'a Arc<ComputedValues> {
         self.get_css_select_results()

--- a/src/components/main/css/node_style.rs
+++ b/src/components/main/css/node_style.rs
@@ -9,7 +9,7 @@ use layout::incremental::RestyleDamage;
 
 use extra::arc::Arc;
 use style::ComputedValues;
-use script::dom::node::{AbstractNode, LayoutView};
+use script::dom::node::LayoutNode;
 
 /// Node mixin providing `style` method that returns a `NodeStyle`
 pub trait StyledNode {
@@ -17,7 +17,7 @@ pub trait StyledNode {
     fn restyle_damage(&self) -> RestyleDamage;
 }
 
-impl StyledNode for AbstractNode<LayoutView> {
+impl StyledNode for LayoutNode {
     #[inline]
     fn style<'a>(&'a self) -> &'a Arc<ComputedValues> {
         self.get_css_select_results()

--- a/src/components/main/css/node_style.rs
+++ b/src/components/main/css/node_style.rs
@@ -6,10 +6,10 @@
 
 use css::node_util::NodeUtil;
 use layout::incremental::RestyleDamage;
+use layout::wrapper::LayoutNode;
 
 use extra::arc::Arc;
 use style::ComputedValues;
-use script::dom::node::LayoutNode;
 
 /// Node mixin providing `style` method that returns a `NodeStyle`
 pub trait StyledNode {

--- a/src/components/main/css/node_util.rs
+++ b/src/components/main/css/node_util.rs
@@ -8,7 +8,7 @@ use layout::util::LayoutDataAccess;
 use extra::arc::Arc;
 use std::cast;
 use style::{ComputedValues, TNode};
-use script::dom::node::{AbstractNode, LayoutView};
+use script::dom::node::LayoutNode;
 
 pub trait NodeUtil {
     fn get_css_select_results<'a>(&'a self) -> &'a Arc<ComputedValues>;
@@ -18,7 +18,7 @@ pub trait NodeUtil {
     fn set_restyle_damage(self, damage: RestyleDamage);
 }
 
-impl NodeUtil for AbstractNode<LayoutView> {
+impl NodeUtil for LayoutNode {
     /** 
      * Provides the computed style for the given node. If CSS selector
      * Returns the style results for the given node. If CSS selector

--- a/src/components/main/css/node_util.rs
+++ b/src/components/main/css/node_util.rs
@@ -18,7 +18,7 @@ pub trait NodeUtil {
     fn set_restyle_damage(self, damage: RestyleDamage);
 }
 
-impl NodeUtil for LayoutNode {
+impl<'self> NodeUtil for LayoutNode<'self> {
     /** 
      * Provides the computed style for the given node. If CSS selector
      * Returns the style results for the given node. If CSS selector

--- a/src/components/main/css/node_util.rs
+++ b/src/components/main/css/node_util.rs
@@ -4,11 +4,11 @@
 
 use layout::incremental::RestyleDamage;
 use layout::util::LayoutDataAccess;
+use layout::wrapper::LayoutNode;
 
 use extra::arc::Arc;
 use std::cast;
 use style::{ComputedValues, TNode};
-use script::dom::node::LayoutNode;
 
 pub trait NodeUtil {
     fn get_css_select_results<'a>(&'a self) -> &'a Arc<ComputedValues>;

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -15,7 +15,6 @@ use gfx::display_list::{TextDisplayItemClass, TextDisplayItemFlags, ClipDisplayI
 use gfx::display_list::{ClipDisplayItemClass};
 use gfx::font::{FontStyle, FontWeight300};
 use gfx::text::text_run::TextRun;
-use script::dom::node::LayoutNode;
 use servo_msg::constellation_msg::{FrameRectMsg, PipelineId, SubpageId};
 use servo_net::image::holder::ImageHolder;
 use servo_net::local_image_cache::LocalImageCache;
@@ -40,6 +39,7 @@ use layout::flow::Flow;
 use layout::flow;
 use layout::model::{MaybeAuto, specified};
 use layout::util::OpaqueNode;
+use layout::wrapper::LayoutNode;
 
 /// Boxes (`struct Box`) are the leaves of the layout tree. They cannot position themselves. In
 /// general, boxes do not have a simple correspondence with CSS boxes in the specification:

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -164,13 +164,11 @@ pub struct IframeBoxInfo {
 impl IframeBoxInfo {
     /// Creates the information specific to an iframe box.
     pub fn new(node: &LayoutNode) -> IframeBoxInfo {
-        node.with_iframe_element(|iframe_element| {
-            let size = iframe_element.size.unwrap();
-            IframeBoxInfo {
-                pipeline_id: size.pipeline_id,
-                subpage_id: size.subpage_id,
-            }
-        })
+        let (pipeline_id, subpage_id) = node.iframe_pipeline_and_subpage_ids();
+        IframeBoxInfo {
+            pipeline_id: pipeline_id,
+            subpage_id: subpage_id,
+        }
     }
 }
 
@@ -208,12 +206,10 @@ pub struct UnscannedTextBoxInfo {
 impl UnscannedTextBoxInfo {
     /// Creates a new instance of `UnscannedTextBoxInfo` from the given DOM node.
     pub fn new(node: &LayoutNode) -> UnscannedTextBoxInfo {
-        node.with_text(|text_node| {
-            // FIXME(pcwalton): Don't copy text; atomically reference count it instead.
-            UnscannedTextBoxInfo {
-                text: text_node.element.data.to_str(),
-            }
-        })
+        // FIXME(pcwalton): Don't copy text; atomically reference count it instead.
+        UnscannedTextBoxInfo {
+            text: node.text(),
+        }
     }
 }
 

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -528,7 +528,7 @@ trait NodeUtils {
     fn swap_out_construction_result(self) -> ConstructionResult;
 }
 
-impl NodeUtils for LayoutNode {
+impl<'self> NodeUtils for LayoutNode<'self> {
     fn is_replaced_content(self) -> bool {
         match self.type_id() {
             TextNodeTypeId |

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -30,11 +30,11 @@ use layout::flow::{Flow, FlowData, MutableFlowUtils};
 use layout::inline::InlineFlow;
 use layout::text::TextRunScanner;
 use layout::util::LayoutDataAccess;
+use layout::wrapper::{LayoutNode, PostorderNodeMutTraversal};
 
 use script::dom::element::{HTMLIframeElementTypeId, HTMLImageElementTypeId};
 use script::dom::node::{CommentNodeTypeId, DoctypeNodeTypeId, DocumentFragmentNodeTypeId};
-use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, LayoutNode};
-use script::dom::node::{PostorderNodeMutTraversal, TextNodeTypeId};
+use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, TextNodeTypeId};
 use servo_util::slot::Slot;
 use std::util;
 use style::computed_values::{display, float};

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -200,11 +200,7 @@ impl<'self> FlowConstructor<'self> {
     /// Builds the `ImageBoxInfo` for the given image. This is out of line to guide inlining.
     fn build_box_info_for_image(&mut self, node: LayoutNode) -> Option<ImageBoxInfo> {
         // FIXME(pcwalton): Don't copy URLs.
-        let url = node.with_image_element(|image_element| {
-            image_element.image.as_ref().map(|url| (*url).clone())
-        });
-
-        match url {
+        match node.image_url() {
             None => None,
             Some(url) => {
                 // FIXME(pcwalton): The fact that image boxes store the cache within them makes
@@ -530,10 +526,6 @@ trait NodeUtils {
     /// Replaces the flow construction result in a node with `NoConstructionResult` and returns the
     /// old value.
     fn swap_out_construction_result(self) -> ConstructionResult;
-
-    /// Returns true if this node consists entirely of ignorable whitespace and false otherwise.
-    /// Ignorable whitespace is defined as whitespace that would be removed per CSS 2.1 § 16.6.1.
-    fn is_ignorable_whitespace(self) -> bool;
 }
 
 impl NodeUtils for LayoutNode {
@@ -565,10 +557,6 @@ impl NodeUtils for LayoutNode {
             }
             None => fail!("no layout data"),
         }
-    }
-
-    fn is_ignorable_whitespace(self) -> bool {
-        self.is_text() && self.with_text(|text| text.element.data.is_whitespace())
     }
 }
 

--- a/src/components/main/layout/extra.rs
+++ b/src/components/main/layout/extra.rs
@@ -6,7 +6,7 @@
 
 use layout::util::{LayoutData, LayoutDataAccess};
 
-use script::dom::node::{AbstractNode, LayoutView};
+use script::dom::node::LayoutNode;
 
 /// Functionality useful for querying the layout-specific data on DOM nodes.
 pub trait LayoutAuxMethods {
@@ -14,7 +14,7 @@ pub trait LayoutAuxMethods {
     fn initialize_style_for_subtree(self);
 }
 
-impl LayoutAuxMethods for AbstractNode<LayoutView> {
+impl LayoutAuxMethods for LayoutNode {
     /// Resets layout data and styles for the node.
     ///
     /// FIXME(pcwalton): Do this as part of box building instead of in a traversal.

--- a/src/components/main/layout/extra.rs
+++ b/src/components/main/layout/extra.rs
@@ -5,8 +5,7 @@
 //! Code for managing the layout data in the DOM.
 
 use layout::util::{LayoutData, LayoutDataAccess};
-
-use script::dom::node::LayoutNode;
+use layout::wrapper::LayoutNode;
 
 /// Functionality useful for querying the layout-specific data on DOM nodes.
 pub trait LayoutAuxMethods {

--- a/src/components/main/layout/extra.rs
+++ b/src/components/main/layout/extra.rs
@@ -14,7 +14,7 @@ pub trait LayoutAuxMethods {
     fn initialize_style_for_subtree(self);
 }
 
-impl LayoutAuxMethods for LayoutNode {
+impl<'self> LayoutAuxMethods for LayoutNode<'self> {
     /// Resets layout data and styles for the node.
     ///
     /// FIXME(pcwalton): Do this as part of box building instead of in a traversal.

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -33,13 +33,13 @@ use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::float_context::{FloatContext, Invalid};
 use layout::incremental::RestyleDamage;
 use layout::inline::InlineFlow;
+use layout::wrapper::LayoutNode;
 
 use extra::dlist::{DList, DListIterator, MutDListIterator};
 use extra::container::Deque;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use gfx::display_list::{ClipDisplayItemClass, DisplayList};
-use script::dom::node::LayoutNode;
 use servo_util::geometry::Au;
 use std::cast;
 use std::cell::Cell;

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -39,7 +39,7 @@ use extra::container::Deque;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use gfx::display_list::{ClipDisplayItemClass, DisplayList};
-use script::dom::node::{AbstractNode, LayoutView};
+use script::dom::node::LayoutNode;
 use servo_util::geometry::Au;
 use std::cast;
 use std::cell::Cell;
@@ -382,7 +382,6 @@ impl FlowFlags {
 /// FIXME: We need a naming convention for pseudo-inheritance like this. How about
 /// `CommonFlowInfo`?
 pub struct FlowData {
-    node: AbstractNode<LayoutView>,
     restyle_damage: RestyleDamage,
 
     /// The children of this flow.
@@ -433,10 +432,9 @@ impl Iterator<@Box> for BoxIterator {
 
 impl FlowData {
     #[inline]
-    pub fn new(id: int, node: AbstractNode<LayoutView>) -> FlowData {
+    pub fn new(id: int, node: LayoutNode) -> FlowData {
         let style = node.style();
         FlowData {
-            node: node,
             restyle_damage: node.restyle_damage(),
 
             children: DList::new(),

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -441,10 +441,11 @@ pub struct InlineFlow {
     // these ranges are disjoint, and are the result of inline layout.
     // also some metadata used for positioning lines
     lines: ~[LineBox],
+
     // vec of ranges into boxes that represent elements. These ranges
     // must be well-nested, and are only related to the content of
     // boxes (not lines). Ranges are only kept for non-leaf elements.
-    elems: ElementMapping
+    elems: ElementMapping,
 }
 
 impl InlineFlow {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -17,6 +17,7 @@ use layout::flow::{PostorderFlowTraversal};
 use layout::flow;
 use layout::incremental::{RestyleDamage};
 use layout::util::{LayoutData, LayoutDataAccess, OpaqueNode};
+use layout::wrapper::LayoutNode;
 
 use extra::arc::{Arc, RWArc, MutexArc};
 use geom::point::Point2D;
@@ -28,7 +29,7 @@ use gfx::opts::Opts;
 use gfx::render_task::{RenderMsg, RenderChan, RenderLayer};
 use gfx::{render_task, color};
 use script::dom::event::ReflowEvent;
-use script::dom::node::{AbstractNode, ElementNodeTypeId, LayoutDataRef, LayoutNode};
+use script::dom::node::{AbstractNode, ElementNodeTypeId, LayoutDataRef};
 use script::dom::element::{HTMLBodyElementTypeId, HTMLHtmlElementTypeId};
 use script::layout_interface::{AddStylesheetMsg, ContentBoxQuery};
 use script::layout_interface::{ContentBoxesQuery, ContentBoxesResponse, ExitNowMsg, LayoutQuery};

--- a/src/components/main/layout/text.rs
+++ b/src/components/main/layout/text.rs
@@ -3,15 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! Text layout.
-use extra::arc::Arc;
+
 use layout::box::{Box, ScannedTextBox, ScannedTextBoxInfo, UnscannedTextBox};
 use layout::context::LayoutContext;
 use layout::flow::Flow;
 
+use extra::arc::Arc;
 use gfx::text::text_run::TextRun;
 use gfx::text::util::{CompressWhitespaceNewline, transform_text};
-use std::vec;
 use servo_util::range::Range;
+use std::vec;
 
 /// A stack-allocated object for scanning an inline flow into `TextRun`-containing `TextBox`es.
 struct TextRunScanner {

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -163,7 +163,7 @@ pub trait LayoutDataAccess {
     fn mutate_layout_data<'a>(&'a self) -> MutSlotRef<'a,Option<~LayoutData>>;
 }
 
-impl LayoutDataAccess for LayoutNode {
+impl<'self> LayoutDataAccess for LayoutNode<'self> {
     #[inline(always)]
     unsafe fn borrow_layout_data_unchecked<'a>(&'a self) -> &'a Option<~LayoutData> {
         cast::transmute(self.get().layout_data.borrow_unchecked())

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -4,9 +4,10 @@
 
 use layout::box::Box;
 use layout::construct::{ConstructionResult, NoConstructionResult};
+use layout::wrapper::LayoutNode;
 
 use extra::arc::Arc;
-use script::dom::node::{AbstractNode, LayoutNode};
+use script::dom::node::AbstractNode;
 use servo_util::range::Range;
 use servo_util::slot::{MutSlotRef, SlotRef};
 use std::cast;

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -1,0 +1,352 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A safe wrapper for DOM nodes that prevents layout from mutating the DOM, from letting DOM nodes
+//! escape, and from generally doing anything that it isn't supposed to. This is accomplished via
+//! a simple whitelist of allowed operations.
+//!
+//! As a security wrapper is only as good as its whitelist, be careful when adding operations to
+//! this list. The cardinal rules are:
+//!
+//! (1) Layout is not allowed to mutate the DOM.
+//!
+//! (2) Layout is not allowed to see anything with `Abstract` in the name, because it could hang
+//!     onto these objects and cause use-after-free.
+
+use extra::url::Url;
+use script::dom::element::Element;
+use script::dom::htmliframeelement::HTMLIFrameElement;
+use script::dom::htmlimageelement::HTMLImageElement;
+use script::dom::node::{AbstractNode, DocumentNodeTypeId, ElementNodeTypeId, LayoutView, Node};
+use script::dom::node::{NodeTypeId};
+use script::dom::text::Text;
+use servo_msg::constellation_msg::{PipelineId, SubpageId};
+use std::cast;
+use style::TNode;
+
+/// A wrapper so that layout can access only the methods that it should have access to. Layout must
+/// only ever see these and must never see instances of `AbstractNode`.
+#[deriving(Clone, Eq)]
+pub struct LayoutNode<'self> {
+    /// The wrapped node.
+    priv node: AbstractNode,
+
+    /// Being chained to a value prevents `LayoutNode`s from escaping.
+    priv chain: &'self (),
+}
+
+impl<'self> LayoutNode<'self> {
+    /// Creates a new layout node, scoped to the given closure.
+    pub unsafe fn with_layout_node<R>(node: AbstractNode, f: &fn<'a>(LayoutNode<'a>) -> R) -> R {
+        let heavy_iron_ball = ();
+        f(LayoutNode {
+            node: node,
+            chain: &heavy_iron_ball,
+        })
+    }
+
+    /// Creates a new layout node with the same lifetime as this layout node.
+    unsafe fn new_with_this_lifetime(&self, node: AbstractNode) -> LayoutNode<'self> {
+        LayoutNode {
+            node: node,
+            chain: self.chain,
+        }
+    }
+
+    /// Returns the interior of this node as a `Node`. This is highly unsafe for layout to call
+    /// and as such is marked `unsafe`.
+    pub unsafe fn get<'a>(&'a self) -> &'a Node<LayoutView> {
+        cast::transmute(self.node.node())
+    }
+
+    /// Returns the first child of this node.
+    pub fn first_child(&self) -> Option<LayoutNode<'self>> {
+        unsafe {
+            self.node.first_child().map(|node| self.new_with_this_lifetime(node))
+        }
+    }
+
+    /// Returns the first child of this node.
+    pub fn last_child(&self) -> Option<LayoutNode<'self>> {
+        unsafe {
+            self.node.last_child().map(|node| self.new_with_this_lifetime(node))
+        }
+    }
+
+    /// Iterates over this node and all its descendants, in preorder.
+    ///
+    /// FIXME(pcwalton): Terribly inefficient. We should use parallelism.
+    pub fn traverse_preorder(&self) -> LayoutTreeIterator<'self> {
+        let mut nodes = ~[];
+        gather_layout_nodes(self, &mut nodes, false);
+        LayoutTreeIterator::new(nodes)
+    }
+
+    /// Returns an iterator over this node's children.
+    pub fn children(&self) -> LayoutNodeChildrenIterator<'self> {
+        LayoutNodeChildrenIterator {
+            current_node: self.first_child(),
+        }
+    }
+
+    /// Returns the type ID of this node. Fails if this node is borrowed mutably.
+    pub fn type_id(&self) -> NodeTypeId {
+        self.node.type_id()
+    }
+
+    /// If this is an image element, returns its URL. If this is not an image element, fails.
+    ///
+    /// FIXME(pcwalton): Don't copy URLs.
+    pub fn image_url(&self) -> Option<Url> {
+        unsafe {
+            self.with_image_element(|image_element| {
+                image_element.image.as_ref().map(|url| (*url).clone())
+            })
+        }
+    }
+
+    /// Downcasts this node to an image element and calls the given closure.
+    ///
+    /// FIXME(pcwalton): RAII.
+    unsafe fn with_image_element<R>(self, f: &fn(&HTMLImageElement) -> R) -> R {
+        if !self.node.is_image_element() {
+            fail!(~"node is not an image element");
+        }
+        self.node.transmute(f)
+    }
+
+    /// If this node is an iframe element, returns its pipeline and subpage IDs. If this node is
+    /// not an iframe element, fails.
+    pub fn iframe_pipeline_and_subpage_ids(&self) -> (PipelineId, SubpageId) {
+        unsafe {
+            self.with_iframe_element(|iframe_element| {
+                let size = iframe_element.size.unwrap();
+                (size.pipeline_id, size.subpage_id)
+            })
+        }
+    }
+
+    /// Downcasts this node to an iframe element and calls the given closure.
+    ///
+    /// FIXME(pcwalton): RAII.
+    unsafe fn with_iframe_element<R>(self, f: &fn(&HTMLIFrameElement) -> R) -> R {
+        if !self.node.is_iframe_element() {
+            fail!(~"node is not an iframe element");
+        }
+        self.node.transmute(f)
+    }
+
+    /// Returns true if this node is a text node or false otherwise.
+    #[inline]
+    pub fn is_text(self) -> bool {
+        self.node.is_text()
+    }
+
+    /// Returns true if this node consists entirely of ignorable whitespace and false otherwise.
+    /// Ignorable whitespace is defined as whitespace that would be removed per CSS 2.1 § 16.6.1.
+    pub fn is_ignorable_whitespace(&self) -> bool {
+        unsafe {
+            self.is_text() && self.with_text(|text| text.element.data.is_whitespace())
+        }
+    }
+
+    /// If this is a text node, copies out the text. If this is not a text node, fails.
+    ///
+    /// FIXME(pcwalton): Don't copy text. Atomically reference count instead.
+    pub fn text(&self) -> ~str {
+        unsafe {
+            self.with_text(|text| text.element.data.to_str())
+        }
+    }
+
+    /// Downcasts this node to a text node and calls the given closure.
+    ///
+    /// FIXME(pcwalton): RAII.
+    unsafe fn with_text<R>(self, f: &fn(&Text) -> R) -> R {
+        self.node.with_imm_text(f)
+    }
+
+    /// Dumps this node tree, for debugging.
+    pub fn dump(&self) {
+        self.node.dump()
+    }
+
+    /// Returns a string that describes this node, for debugging.
+    pub fn debug_str(&self) -> ~str {
+        self.node.debug_str()
+    }
+
+    /// Traverses the tree in postorder.
+    ///
+    /// TODO(pcwalton): Offer a parallel version with a compatible API.
+    pub fn traverse_postorder<T:PostorderNodeTraversal>(self, traversal: &T) -> bool {
+        if traversal.should_prune(self) {
+            return true
+        }
+
+        let mut opt_kid = self.first_child();
+        loop {
+            match opt_kid {
+                None => break,
+                Some(kid) => {
+                    if !kid.traverse_postorder(traversal) {
+                        return false
+                    }
+                    opt_kid = kid.next_sibling()
+                }
+            }
+        }
+
+        traversal.process(self)
+    }
+
+    /// Traverses the tree in postorder.
+    ///
+    /// TODO(pcwalton): Offer a parallel version with a compatible API.
+    pub fn traverse_postorder_mut<T:PostorderNodeMutTraversal>(mut self, traversal: &mut T)
+                                  -> bool {
+        if traversal.should_prune(self) {
+            return true
+        }
+
+        let mut opt_kid = self.first_child();
+        loop {
+            match opt_kid {
+                None => break,
+                Some(kid) => {
+                    if !kid.traverse_postorder_mut(traversal) {
+                        return false
+                    }
+                    opt_kid = kid.next_sibling()
+                }
+            }
+        }
+
+        traversal.process(self)
+    }
+}
+
+impl<'self> TNode<Element> for LayoutNode<'self> {
+    fn parent_node(&self) -> Option<LayoutNode<'self>> {
+        unsafe {
+            self.node.node().parent_node.map(|node| self.new_with_this_lifetime(node))
+        }
+    }
+
+    fn prev_sibling(&self) -> Option<LayoutNode<'self>> {
+        unsafe {
+            self.node.node().prev_sibling.map(|node| self.new_with_this_lifetime(node))
+        }
+    }
+    
+    fn next_sibling(&self) -> Option<LayoutNode<'self>> {
+        unsafe {
+            self.node.node().next_sibling.map(|node| self.new_with_this_lifetime(node))
+        }
+    }
+
+    fn is_element(&self) -> bool {
+        match self.node.type_id() {
+            ElementNodeTypeId(*) => true,
+            _ => false
+        }
+    }
+
+    fn is_document(&self) -> bool {
+        match self.node.type_id() {
+            DocumentNodeTypeId(*) => true,
+            _ => false
+        }
+    }
+
+    /// FIXME(pcwalton): Unsafe!
+    #[inline]
+    fn with_element<R>(&self, f: &fn(&Element) -> R) -> R {
+        self.node.with_imm_element(f)
+    }
+}
+
+pub struct LayoutNodeChildrenIterator<'self> {
+    priv current_node: Option<LayoutNode<'self>>,
+}
+
+impl<'self> Iterator<LayoutNode<'self>> for LayoutNodeChildrenIterator<'self> {
+    fn next(&mut self) -> Option<LayoutNode<'self>> {
+        let node = self.current_node;
+        self.current_node = do self.current_node.and_then |node| {
+            node.next_sibling()
+        };
+        node
+    }
+}
+
+// FIXME: Do this without precomputing a vector of refs.
+// Easy for preorder; harder for postorder.
+//
+// FIXME(pcwalton): Parallelism! Eventually this should just be nuked.
+pub struct LayoutTreeIterator<'self> {
+    priv nodes: ~[LayoutNode<'self>],
+    priv index: uint,
+}
+
+impl<'self> LayoutTreeIterator<'self> {
+    fn new(nodes: ~[LayoutNode<'self>]) -> LayoutTreeIterator<'self> {
+        LayoutTreeIterator {
+            nodes: nodes,
+            index: 0,
+        }
+    }
+}
+
+impl<'self> Iterator<LayoutNode<'self>> for LayoutTreeIterator<'self> {
+    fn next(&mut self) -> Option<LayoutNode<'self>> {
+        if self.index >= self.nodes.len() {
+            None
+        } else {
+            let v = self.nodes[self.index].clone();
+            self.index += 1;
+            Some(v)
+        }
+    }
+}
+
+/// FIXME(pcwalton): This is super inefficient.
+fn gather_layout_nodes<'a>(cur: &LayoutNode<'a>, refs: &mut ~[LayoutNode<'a>], postorder: bool) {
+    if !postorder {
+        refs.push(cur.clone());
+    }
+    for kid in cur.children() {
+        gather_layout_nodes(&kid, refs, postorder)
+    }
+    if postorder {
+        refs.push(cur.clone());
+    }
+}
+
+/// A bottom-up, parallelizable traversal.
+pub trait PostorderNodeTraversal {
+    /// The operation to perform. Return true to continue or false to stop.
+    fn process<'a>(&'a self, node: LayoutNode<'a>) -> bool;
+
+    /// Returns true if this node should be pruned. If this returns true, we skip the operation
+    /// entirely and do not process any descendant nodes. This is called *before* child nodes are
+    /// visited. The default implementation never prunes any nodes.
+    fn should_prune<'a>(&'a self, _node: LayoutNode<'a>) -> bool {
+        false
+    }
+}
+
+/// A bottom-up, parallelizable traversal.
+pub trait PostorderNodeMutTraversal {
+    /// The operation to perform. Return true to continue or false to stop.
+    fn process<'a>(&'a mut self, node: LayoutNode<'a>) -> bool;
+
+    /// Returns true if this node should be pruned. If this returns true, we skip the operation
+    /// entirely and do not process any descendant nodes. This is called *before* child nodes are
+    /// visited. The default implementation never prunes any nodes.
+    fn should_prune<'a>(&'a self, _node: LayoutNode<'a>) -> bool {
+        false
+    }
+}
+

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -19,8 +19,7 @@ use script::dom::element::{Element, HTMLAreaElementTypeId, HTMLAnchorElementType
 use script::dom::element::{HTMLLinkElementTypeId};
 use script::dom::htmliframeelement::HTMLIFrameElement;
 use script::dom::htmlimageelement::HTMLImageElement;
-use script::dom::node::{AbstractNode, DocumentNodeTypeId, ElementNodeTypeId, LayoutView, Node};
-use script::dom::node::{NodeTypeId};
+use script::dom::node::{AbstractNode, DocumentNodeTypeId, ElementNodeTypeId, Node, NodeTypeId};
 use script::dom::text::Text;
 use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use std::cast;
@@ -57,7 +56,7 @@ impl<'self> LayoutNode<'self> {
 
     /// Returns the interior of this node as a `Node`. This is highly unsafe for layout to call
     /// and as such is marked `unsafe`.
-    pub unsafe fn get<'a>(&'a self) -> &'a Node<LayoutView> {
+    pub unsafe fn get<'a>(&'a self) -> &'a Node {
         cast::transmute(self.node.node())
     }
 

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -88,6 +88,7 @@ pub mod layout {
     pub mod text;
     pub mod util;
     pub mod incremental;
+    pub mod wrapper;
     mod extra;
 }
 

--- a/src/components/script/dom/attrlist.rs
+++ b/src/components/script/dom/attrlist.rs
@@ -5,18 +5,17 @@
 use dom::attr::Attr;
 use dom::bindings::codegen::AttrListBinding;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::{AbstractNode};
 use dom::window::Window;
 
 pub struct AttrList {
     reflector_: Reflector,
     window: @mut Window,
-    owner: AbstractNode<ScriptView>
+    owner: AbstractNode,
 }
 
 impl AttrList {
-        pub fn new_inherited(window: @mut Window,
-                             elem: AbstractNode<ScriptView>) -> AttrList {
+    pub fn new_inherited(window: @mut Window, elem: AbstractNode) -> AttrList {
         AttrList {
             reflector_: Reflector::new(),
             window: window,
@@ -24,7 +23,7 @@ impl AttrList {
         }
     }
 
-    pub fn new(window: @mut Window, elem: AbstractNode<ScriptView>) -> @mut AttrList {
+    pub fn new(window: @mut Window, elem: AbstractNode) -> @mut AttrList {
         reflect_dom_object(@mut AttrList::new_inherited(window, elem),
                            window, AttrListBinding::Wrap)
     }

--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -121,7 +121,7 @@ DOMInterfaces = {
 }],
 
 'CharacterData': {
-    'nativeType': 'AbstractNode<ScriptView>',
+    'nativeType': 'AbstractNode',
     'concreteType': 'CharacterData',
     'pointerType': ''
 },
@@ -182,7 +182,7 @@ DOMInterfaces = {
 }],
 
 'Element': {
-    'nativeType': 'AbstractNode<ScriptView>',
+    'nativeType': 'AbstractNode',
     'pointerType': '',
     'needsAbstract': ['getClientRects', 'getBoundingClientRect', 'setAttribute', 'setAttributeNS', 'id', 'attributes']
 },
@@ -239,7 +239,7 @@ DOMInterfaces = {
 },
 
 'HTMLFormElement': {
-    'nativeType': 'AbstractNode<ScriptView>',
+    'nativeType': 'AbstractNode',
     'pointerType': '',
     'register': False
 },
@@ -302,7 +302,7 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'nativeType': 'AbstractNode<ScriptView>',
+    'nativeType': 'AbstractNode',
     'concreteType': 'Node<ScriptView>',
     'pointerType': '',
     'needsAbstract': [
@@ -574,7 +574,7 @@ def addExternalIface(iface, nativeType=None, headerFile=None, pointerType=None):
 
 def addHTMLElement(element, concrete=None, needsAbstract=[]):
   DOMInterfaces[element] = {
-    'nativeType': 'AbstractNode<ScriptView>',
+    'nativeType': 'AbstractNode',
     'pointerType': '',
     'concreteType': concrete if concrete else element,
     'customTrace': 'trace',

--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -303,7 +303,7 @@ DOMInterfaces = {
 
 'Node': {
     'nativeType': 'AbstractNode',
-    'concreteType': 'Node<ScriptView>',
+    'concreteType': 'Node',
     'pointerType': '',
     'needsAbstract': [
         'appendChild',

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5161,7 +5161,7 @@ class CGBindingRoot(CGThing):
                           'dom::bindings::proxyhandler',
                           'dom::bindings::proxyhandler::*',
                           'dom::document::AbstractDocument',
-                          'dom::node::{AbstractNode, ScriptView}',
+                          'dom::node::AbstractNode',
                           'dom::eventtarget::AbstractEventTarget',
                           'dom::event::AbstractEvent',
                           'servo_util::vec::zip_copies',

--- a/src/components/script/dom/bindings/node.rs
+++ b/src/components/script/dom/bindings/node.rs
@@ -4,7 +4,7 @@
 
 use dom::bindings::utils::{Reflectable, Reflector, Traceable};
 use dom::types::*;
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 
 use std::cast;
 use std::libc;
@@ -21,7 +21,7 @@ impl Reflectable for AbstractNode {
     }
 }
 
-impl Traceable for Node<ScriptView> {
+impl Traceable for Node {
     fn trace(&self, tracer: *mut JSTracer) {
         #[fixed_stack_segment]
         fn trace_node(tracer: *mut JSTracer, node: Option<AbstractNode>, name: &str) {

--- a/src/components/script/dom/bindings/node.rs
+++ b/src/components/script/dom/bindings/node.rs
@@ -11,7 +11,7 @@ use std::libc;
 use std::ptr;
 use js::jsapi::{JSTracer, JSTRACE_OBJECT, JS_CallTracer};
 
-impl Reflectable for AbstractNode<ScriptView> {
+impl Reflectable for AbstractNode {
     fn reflector<'a>(&'a self) -> &'a Reflector {
         self.node().reflector()
     }
@@ -24,7 +24,7 @@ impl Reflectable for AbstractNode<ScriptView> {
 impl Traceable for Node<ScriptView> {
     fn trace(&self, tracer: *mut JSTracer) {
         #[fixed_stack_segment]
-        fn trace_node(tracer: *mut JSTracer, node: Option<AbstractNode<ScriptView>>, name: &str) {
+        fn trace_node(tracer: *mut JSTracer, node: Option<AbstractNode>, name: &str) {
             if node.is_none() {
                 return;
             }

--- a/src/components/script/dom/characterdata.rs
+++ b/src/components/script/dom/characterdata.rs
@@ -7,10 +7,10 @@
 use dom::bindings::utils::{DOMString, ErrorResult, Fallible};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::AbstractDocument;
-use dom::node::{Node, NodeTypeId, ScriptView};
+use dom::node::{Node, NodeTypeId};
 
 pub struct CharacterData {
-    node: Node<ScriptView>,
+    node: Node,
     data: ~str
 }
 

--- a/src/components/script/dom/comment.rs
+++ b/src/components/script/dom/comment.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::CommentBinding;
 use dom::bindings::utils::{DOMString, Fallible};
 use dom::characterdata::CharacterData;
 use dom::document::AbstractDocument;
-use dom::node::{AbstractNode, ScriptView, CommentNodeTypeId, Node};
+use dom::node::{AbstractNode, CommentNodeTypeId, Node};
 use dom::window::Window;
 
 /// An HTML comment.
@@ -21,12 +21,12 @@ impl Comment {
         }
     }
 
-    pub fn new(text: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(text: ~str, document: AbstractDocument) -> AbstractNode {
         let node = Comment::new_inherited(text, document);
         Node::reflect_node(@mut node, document, CommentBinding::Wrap)
     }
 
-    pub fn Constructor(owner: @mut Window, data: DOMString) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn Constructor(owner: @mut Window, data: DOMString) -> Fallible<AbstractNode> {
         Ok(Comment::new(data, owner.Document()))
     }
 }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -15,7 +15,7 @@ use dom::event::{AbstractEvent, Event};
 use dom::htmlcollection::HTMLCollection;
 use dom::htmldocument::HTMLDocument;
 use dom::mouseevent::MouseEvent;
-use dom::node::{AbstractNode, ScriptView, Node, ElementNodeTypeId, DocumentNodeTypeId};
+use dom::node::{AbstractNode, Node, ElementNodeTypeId, DocumentNodeTypeId};
 use dom::text::Text;
 use dom::uievent::UIEvent;
 use dom::window::Window;
@@ -86,7 +86,7 @@ pub enum DocumentType {
 }
 
 pub struct Document {
-    node: Node<ScriptView>,
+    node: Node,
     reflector_: Reflector,
     window: @mut Window,
     doctype: DocumentType,

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -92,7 +92,7 @@ pub struct Document {
     window: @mut Window,
     doctype: DocumentType,
     title: ~str,
-    idmap: HashMap<DOMString, AbstractNode<ScriptView>>
+    idmap: HashMap<DOMString, AbstractNode>
 }
 
 impl Document {
@@ -161,7 +161,7 @@ impl Reflectable for Document {
 }
 
 impl Document {
-    pub fn GetDocumentElement(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetDocumentElement(&self) -> Option<AbstractNode> {
         do self.node.children().find |c| {
             c.is_element()
         }
@@ -183,7 +183,7 @@ impl Document {
         HTMLCollection::new(self.window, ~[])
     }
 
-    pub fn GetElementById(&self, id: DOMString) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetElementById(&self, id: DOMString) -> Option<AbstractNode> {
         // TODO: "in tree order, within the context object's tree"
         // http://dom.spec.whatwg.org/#dom-document-getelementbyid.
         match self.idmap.find_equiv(&id) {
@@ -192,7 +192,8 @@ impl Document {
         }
     }
 
-    pub fn CreateElement(&self, abstract_self: AbstractDocument, local_name: DOMString) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn CreateElement(&self, abstract_self: AbstractDocument, local_name: DOMString)
+                         -> Fallible<AbstractNode> {
         if xml_name_type(local_name) == InvalidXMLName {
             debug!("Not a valid element name");
             return Err(InvalidCharacter);
@@ -201,15 +202,16 @@ impl Document {
         Ok(build_element_from_tag(local_name, abstract_self))
     }
 
-    pub fn CreateDocumentFragment(&self, abstract_self: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn CreateDocumentFragment(&self, abstract_self: AbstractDocument) -> AbstractNode {
         DocumentFragment::new(abstract_self)
     }
 
-    pub fn CreateTextNode(&self, abstract_self: AbstractDocument, data: DOMString) -> AbstractNode<ScriptView> {
+    pub fn CreateTextNode(&self, abstract_self: AbstractDocument, data: DOMString)
+                          -> AbstractNode {
         Text::new(data, abstract_self)
     }
 
-    pub fn CreateComment(&self, abstract_self: AbstractDocument, data: DOMString) -> AbstractNode<ScriptView> {
+    pub fn CreateComment(&self, abstract_self: AbstractDocument, data: DOMString) -> AbstractNode {
         Comment::new(data, abstract_self)
     }
 
@@ -330,15 +332,15 @@ impl Document {
         self.window.wait_until_safe_to_modify_dom();
     }
 
-    pub fn register_nodes_with_id(&mut self, root: &AbstractNode<ScriptView>) {
-        foreach_ided_elements(root, |id: &DOMString, abstract_node: &AbstractNode<ScriptView>| {
+    pub fn register_nodes_with_id(&mut self, root: &AbstractNode) {
+        foreach_ided_elements(root, |id: &DOMString, abstract_node: &AbstractNode| {
             // TODO: "in tree order, within the context object's tree"
             // http://dom.spec.whatwg.org/#dom-document-getelementbyid.
             self.idmap.find_or_insert(id.clone(), *abstract_node);
         });
     }
 
-    pub fn unregister_nodes_with_id(&mut self, root: &AbstractNode<ScriptView>) {
+    pub fn unregister_nodes_with_id(&mut self, root: &AbstractNode) {
         foreach_ided_elements(root, |id: &DOMString, _| {
             // TODO: "in tree order, within the context object's tree"
             // http://dom.spec.whatwg.org/#dom-document-getelementbyid.
@@ -347,7 +349,7 @@ impl Document {
     }
 
     pub fn update_idmap(&mut self,
-                        abstract_self: AbstractNode<ScriptView>,
+                        abstract_self: AbstractNode,
                         new_id: DOMString,
                         old_id: Option<DOMString>) {
         // remove old ids if the old ones are not same as the new one.
@@ -359,19 +361,17 @@ impl Document {
         }
 
         // TODO: support the case if multiple elements which haves same id are in the same document.
-        self.idmap.mangle(new_id, abstract_self,
-                         |_, new_node: AbstractNode<ScriptView>| -> AbstractNode<ScriptView> {
+        self.idmap.mangle(new_id, abstract_self, |_, new_node: AbstractNode| -> AbstractNode {
                              new_node
                          },
-                         |_, old_node: &mut AbstractNode<ScriptView>, new_node: AbstractNode<ScriptView>| {
+                         |_, old_node: &mut AbstractNode, new_node: AbstractNode| {
                              *old_node = new_node;
                          });
     }
 }
 
 #[inline(always)]
-fn foreach_ided_elements(root: &AbstractNode<ScriptView>,
-                         callback: &fn(&DOMString, &AbstractNode<ScriptView>)) {
+fn foreach_ided_elements(root: &AbstractNode, callback: &fn(&DOMString, &AbstractNode)) {
     for node in root.traverse_preorder() {
         if !node.is_element() {
             continue;

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -29,7 +29,6 @@ use std::cast;
 use std::hashmap::HashMap;
 use std::str::eq_slice;
 use std::unstable::raw::Box;
-use style::{TElement, TNode};
 
 #[deriving(Eq)]
 pub enum DocumentTypeId {

--- a/src/components/script/dom/documentfragment.rs
+++ b/src/components/script/dom/documentfragment.rs
@@ -21,14 +21,14 @@ impl DocumentFragment {
         }
     }
 
-    pub fn new(document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(document: AbstractDocument) -> AbstractNode {
         let node = DocumentFragment::new_inherited(document);
         Node::reflect_node(@mut node, document, DocumentFragmentBinding::Wrap)
     }
 }
 
 impl DocumentFragment {
-    pub fn Constructor(owner: @mut Window) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn Constructor(owner: @mut Window) -> Fallible<AbstractNode> {
         Ok(DocumentFragment::new(owner.Document()))
     }
 }

--- a/src/components/script/dom/documentfragment.rs
+++ b/src/components/script/dom/documentfragment.rs
@@ -5,12 +5,11 @@
 use dom::bindings::codegen::DocumentFragmentBinding;
 use dom::bindings::utils::Fallible;
 use dom::document::AbstractDocument;
-use dom::node::{ScriptView, Node, DocumentFragmentNodeTypeId};
-use dom::node::{AbstractNode};
+use dom::node::{AbstractNode, DocumentFragmentNodeTypeId, Node};
 use dom::window::Window;
 
 pub struct DocumentFragment {
-    node: Node<ScriptView>,
+    node: Node,
 }
 
 impl DocumentFragment {

--- a/src/components/script/dom/documenttype.rs
+++ b/src/components/script/dom/documenttype.rs
@@ -5,11 +5,11 @@
 use dom::bindings::codegen::DocumentTypeBinding;
 use dom::bindings::utils::DOMString;
 use dom::document::AbstractDocument;
-use dom::node::{AbstractNode, ScriptView, Node, DoctypeNodeTypeId};
+use dom::node::{AbstractNode, Node, DoctypeNodeTypeId};
 
 /// The `DOCTYPE` tag.
 pub struct DocumentType {
-    node: Node<ScriptView>,
+    node: Node,
     name: DOMString,
     public_id: DOMString,
     system_id: DOMString,

--- a/src/components/script/dom/documenttype.rs
+++ b/src/components/script/dom/documenttype.rs
@@ -36,7 +36,8 @@ impl DocumentType {
                public_id: Option<~str>,
                system_id: Option<~str>,
                force_quirks: bool,
-               document: AbstractDocument) -> AbstractNode<ScriptView> {
+               document: AbstractDocument)
+               -> AbstractNode {
         let documenttype = DocumentType::new_inherited(name,
                                                        public_id,
                                                        system_id,

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -4,6 +4,7 @@
 
 //! Element nodes.
 
+use dom::attr::Attr;
 use dom::attrlist::AttrList;
 use dom::bindings::utils::{Reflectable, DOMString, ErrorResult, Fallible, Reflector};
 use dom::bindings::utils::{null_str_as_empty, NamespaceError};
@@ -12,8 +13,7 @@ use dom::htmlcollection::HTMLCollection;
 use dom::clientrect::ClientRect;
 use dom::clientrectlist::ClientRectList;
 use dom::document::AbstractDocument;
-use dom::node::{ElementNodeTypeId, Node, ScriptView, AbstractNode};
-use dom::attr:: Attr;
+use dom::node::{AbstractNode, ElementNodeTypeId, Node};
 use dom::document;
 use dom::namespace;
 use dom::namespace::Namespace;
@@ -28,7 +28,7 @@ use std::str::{eq, eq_slice};
 use std::ascii::StrAsciiExt;
 
 pub struct Element {
-    node: Node<ScriptView>,
+    node: Node,
     tag_name: ~str,     // TODO: This should be an atom, not a ~str.
     namespace: Namespace,
     attrs: HashMap<~str, ~[@mut Attr]>,

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -187,15 +187,13 @@ impl<'self> Element {
         })
     }
 
-    pub fn set_attr(&mut self,
-                    abstract_self: AbstractNode<ScriptView>,
-                    name: DOMString,
-                    value: DOMString) -> ErrorResult {
+    pub fn set_attr(&mut self, abstract_self: AbstractNode, name: DOMString, value: DOMString)
+                    -> ErrorResult {
         self.set_attribute(abstract_self, namespace::Null, name, value)
     }
 
     pub fn set_attribute(&mut self,
-                         abstract_self: AbstractNode<ScriptView>,
+                         abstract_self: AbstractNode,
                          namespace: Namespace,
                          raw_name: DOMString,
                          value: DOMString) -> ErrorResult {
@@ -260,7 +258,7 @@ impl<'self> Element {
     }
 
     fn after_set_attr(&mut self,
-                      abstract_self: AbstractNode<ScriptView>,
+                      abstract_self: AbstractNode,
                       local_name: DOMString,
                       value: DOMString,
                       old_value: Option<DOMString>) {
@@ -309,18 +307,18 @@ impl Element {
         self.tag_name.to_ascii_upper()
     }
 
-    pub fn Id(&self, _abstract_self: AbstractNode<ScriptView>) -> DOMString {
+    pub fn Id(&self, _abstract_self: AbstractNode) -> DOMString {
         match self.get_attr(None, "id") {
             Some(x) => x,
             None => ~""
         }
     }
 
-    pub fn SetId(&mut self, abstract_self: AbstractNode<ScriptView>, id: DOMString) {
+    pub fn SetId(&mut self, abstract_self: AbstractNode, id: DOMString) {
         self.set_attribute(abstract_self, namespace::Null, ~"id", id);
     }
 
-    pub fn Attributes(&mut self, abstract_self: AbstractNode<ScriptView>) -> @mut AttrList {
+    pub fn Attributes(&mut self, abstract_self: AbstractNode) -> @mut AttrList {
         match self.attr_list {
             None => {
                 let window = self.node.owner_doc().document().window;
@@ -341,16 +339,14 @@ impl Element {
             .map(|attr| attr.value.clone())
     }
 
-    pub fn SetAttribute(&mut self,
-                        abstract_self: AbstractNode<ScriptView>,
-                        name: DOMString,
-                        value: DOMString) -> ErrorResult {
+    pub fn SetAttribute(&mut self, abstract_self: AbstractNode, name: DOMString, value: DOMString)
+                        -> ErrorResult {
         self.set_attr(abstract_self, name, value);
         Ok(())
     }
 
     pub fn SetAttributeNS(&mut self,
-                          abstract_self: AbstractNode<ScriptView>,
+                          abstract_self: AbstractNode,
                           namespace_url: Option<DOMString>,
                           name: DOMString,
                           value: DOMString) -> ErrorResult {
@@ -409,7 +405,7 @@ impl Element {
     pub fn MozRequestPointerLock(&self) {
     }
 
-    pub fn GetClientRects(&self, abstract_self: AbstractNode<ScriptView>) -> @mut ClientRectList {
+    pub fn GetClientRects(&self, abstract_self: AbstractNode) -> @mut ClientRectList {
         let win = self.node.owner_doc().document().window;
         let node = abstract_self;
         assert!(node.is_element());
@@ -431,7 +427,7 @@ impl Element {
         ClientRectList::new(win, rects)
     }
 
-    pub fn GetBoundingClientRect(&self, abstract_self: AbstractNode<ScriptView>) -> @mut ClientRect {
+    pub fn GetBoundingClientRect(&self, abstract_self: AbstractNode) -> @mut ClientRect {
         let win = self.node.owner_doc().document().window;
         let node = abstract_self;
         assert!(node.is_element());
@@ -509,7 +505,7 @@ impl Element {
         Ok(())
     }
 
-    pub fn QuerySelector(&self, _selectors: DOMString) -> Fallible<Option<AbstractNode<ScriptView>>> {
+    pub fn QuerySelector(&self, _selectors: DOMString) -> Fallible<Option<AbstractNode>> {
         Ok(None)
     }
 }

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -20,7 +20,6 @@ use dom::namespace::Namespace;
 use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery};
 use layout_interface::{ContentBoxesResponse, ContentChangedDocumentDamage};
 use layout_interface::{MatchSelectorsDocumentDamage};
-use style::{TElement, TNode};
 use style;
 
 use std::comm;
@@ -125,31 +124,6 @@ pub enum ElementTypeId {
 // Element methods
 //
 
-impl TElement for Element {
-    fn get_local_name<'a>(&'a self) -> &'a str {
-        self.tag_name.as_slice()
-    }
-
-    fn get_namespace_url<'a>(&'a self) -> &'a str {
-        self.namespace.to_str().unwrap_or("")
-    }
-
-    fn get_attr(&self, ns_url: Option<~str>, name: &str) -> Option<~str> {
-        self.get_attribute(ns_url, name).map(|attr| attr.value.clone())
-    }
-
-    fn get_link(&self) -> Option<~str>{
-        // FIXME: This is HTML only.
-        match self.node.type_id {
-            // http://www.whatwg.org/specs/web-apps/current-work/multipage/selectors.html#selector-link
-            ElementNodeTypeId(HTMLAnchorElementTypeId) |
-            ElementNodeTypeId(HTMLAreaElementTypeId) |
-            ElementNodeTypeId(HTMLLinkElementTypeId)
-            => self.get_attr(None, "href"),
-            _ => None,
-        }
-    }
-}
 
 impl<'self> Element {
     pub fn new_inherited(type_id: ElementTypeId, tag_name: ~str, namespace: Namespace, document: AbstractDocument) -> Element {
@@ -185,6 +159,11 @@ impl<'self> Element {
                 eq_slice(attr.local_name, name) && attr.namespace == namespace
             }.map(|x| *x)
         })
+    }
+
+    // FIXME(pcwalton): This is kind of confusingly named relative to the above...
+    pub fn get_attr(&self, ns_url: Option<~str>, name: &str) -> Option<~str> {
+        self.get_attribute(ns_url, name).map(|attr| attr.value.clone())
     }
 
     pub fn set_attr(&mut self, abstract_self: AbstractNode, name: DOMString, value: DOMString)

--- a/src/components/script/dom/eventtarget.rs
+++ b/src/components/script/dom/eventtarget.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::EventListenerBinding::EventListener;
 use dom::document::AbstractDocument;
 use dom::event::AbstractEvent;
 use dom::eventdispatcher::dispatch_event;
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 use dom::window::Window;
 
 use std::cast;
@@ -50,7 +50,7 @@ impl AbstractEventTarget {
         }
     }
 
-    pub fn from_node(node: AbstractNode<ScriptView>) -> AbstractEventTarget {
+    pub fn from_node(node: AbstractNode) -> AbstractEventTarget {
         unsafe {
             cast::transmute(node)
         }

--- a/src/components/script/dom/formdata.rs
+++ b/src/components/script/dom/formdata.rs
@@ -6,7 +6,7 @@ use dom::bindings::utils::{Fallible, Reflectable, Reflector, reflect_dom_object}
 use dom::bindings::utils::DOMString;
 use dom::bindings::codegen::FormDataBinding;
 use dom::blob::Blob;
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 use dom::window::Window;
 
 use std::hashmap::HashMap;
@@ -20,11 +20,11 @@ pub struct FormData {
     data: HashMap<~str, FormDatum>,
     reflector_: Reflector,
     window: @mut Window,
-    form: Option<AbstractNode<ScriptView>>
+    form: Option<AbstractNode>
 }
 
 impl FormData {
-    pub fn new_inherited(form: Option<AbstractNode<ScriptView>>, window: @mut Window) -> FormData {
+    pub fn new_inherited(form: Option<AbstractNode>, window: @mut Window) -> FormData {
         FormData {
             data: HashMap::new(),
             reflector_: Reflector::new(),
@@ -33,12 +33,12 @@ impl FormData {
         }
     }
 
-    pub fn new(form: Option<AbstractNode<ScriptView>>, window: @mut Window) -> @mut FormData {
+    pub fn new(form: Option<AbstractNode>, window: @mut Window) -> @mut FormData {
         reflect_dom_object(@mut FormData::new_inherited(form, window), window, FormDataBinding::Wrap)
     }
 
-    pub fn Constructor(window: @mut Window,
-                       form: Option<AbstractNode<ScriptView>>) -> Fallible<@mut FormData> {
+    pub fn Constructor(window: @mut Window, form: Option<AbstractNode>)
+                       -> Fallible<@mut FormData> {
         Ok(FormData::new(form, window))
     }
 

--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLAnchorElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLAnchorElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLAnchorElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLAnchorElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLAnchorElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlappletelement.rs
+++ b/src/components/script/dom/htmlappletelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLAppletElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLAppletElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLAppletElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLAppletElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLAppletElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLAreaElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLAreaElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLAreaElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLAreaElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLAreaElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlaudioelement.rs
+++ b/src/components/script/dom/htmlaudioelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLAudioElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLAudioElementTypeId;
 use dom::htmlmediaelement::HTMLMediaElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLAudioElement {
     htmlmediaelement: HTMLMediaElement
@@ -19,7 +19,7 @@ impl HTMLAudioElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLAudioElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLAudioElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlbaseelement.rs
+++ b/src/components/script/dom/htmlbaseelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLBaseElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLBaseElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLBaseElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLBaseElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLBaseElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlbodyelement.rs
+++ b/src/components/script/dom/htmlbodyelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLBodyElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLBodyElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLBodyElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLBodyElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLBodyElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlbrelement.rs
+++ b/src/components/script/dom/htmlbrelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLBRElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLBRElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLBRElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLBRElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLBRElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLButtonElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::validitystate::ValidityState;
 
 pub struct HTMLButtonElement {
@@ -21,7 +21,7 @@ impl HTMLButtonElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLButtonElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLButtonElementBinding::Wrap)
     }
@@ -44,7 +44,7 @@ impl HTMLButtonElement {
         Ok(())
     }
 
-    pub fn GetForm(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetForm(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/dom/htmlcanvaselement.rs
+++ b/src/components/script/dom/htmlcanvaselement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLCanvasElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLCanvasElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLCanvasElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLCanvasElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLCanvasElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -5,7 +5,7 @@
 use dom::bindings::codegen::HTMLCollectionBinding;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::utils::{DOMString, Fallible};
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 use dom::window::Window;
 
 use js::jsapi::{JSObject, JSContext};
@@ -13,14 +13,13 @@ use js::jsapi::{JSObject, JSContext};
 use std::ptr;
 
 pub struct HTMLCollection {
-    elements: ~[AbstractNode<ScriptView>],
+    elements: ~[AbstractNode],
     reflector_: Reflector,
     window: @mut Window,
 }
 
 impl HTMLCollection {
-    pub fn new_inherited(window: @mut Window,
-                         elements: ~[AbstractNode<ScriptView>]) -> HTMLCollection {
+    pub fn new_inherited(window: @mut Window, elements: ~[AbstractNode]) -> HTMLCollection {
         HTMLCollection {
             elements: elements,
             reflector_: Reflector::new(),
@@ -28,8 +27,7 @@ impl HTMLCollection {
         }
     }
 
-    pub fn new(window: @mut Window,
-               elements: ~[AbstractNode<ScriptView>]) -> @mut HTMLCollection {
+    pub fn new(window: @mut Window, elements: ~[AbstractNode]) -> @mut HTMLCollection {
         reflect_dom_object(@mut HTMLCollection::new_inherited(window, elements),
                            window, HTMLCollectionBinding::Wrap)
     }
@@ -38,7 +36,7 @@ impl HTMLCollection {
         self.elements.len() as u32
     }
 
-    pub fn Item(&self, index: u32) -> Option<AbstractNode<ScriptView>> {
+    pub fn Item(&self, index: u32) -> Option<AbstractNode> {
         if index < self.Length() {
             Some(self.elements[index])
         } else {
@@ -50,7 +48,7 @@ impl HTMLCollection {
         Ok(ptr::null())
     }
 
-    pub fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<AbstractNode<ScriptView>> {
+    pub fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<AbstractNode> {
         *found = true;
         self.Item(index)
     }

--- a/src/components/script/dom/htmldataelement.rs
+++ b/src/components/script/dom/htmldataelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLDataElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLDataElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLDataElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLDataElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLDataElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmldatalistelement.rs
+++ b/src/components/script/dom/htmldatalistelement.rs
@@ -7,7 +7,7 @@ use dom::document::AbstractDocument;
 use dom::element::HTMLDataListElementTypeId;
 use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLDataListElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLDataListElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLDataListElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLDataListElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmldirectoryelement.rs
+++ b/src/components/script/dom/htmldirectoryelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::ErrorResult;
 use dom::document::AbstractDocument;
 use dom::element::HTMLDirectoryElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLDirectoryElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLDirectoryElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLDirectoryElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLDirectoryElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmldivelement.rs
+++ b/src/components/script/dom/htmldivelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLDivElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLDivElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLDivElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLDivElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLDivElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmldlistelement.rs
+++ b/src/components/script/dom/htmldlistelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLDListElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLDListElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLDListElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLDListElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLDListElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmldocument.rs
+++ b/src/components/script/dom/htmldocument.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{Reflectable, Reflector, Traceable};
 use dom::document::{AbstractDocument, Document, HTML};
 use dom::element::HTMLHeadElementTypeId;
 use dom::htmlcollection::HTMLCollection;
-use dom::node::{AbstractNode, ScriptView, ElementNodeTypeId};
+use dom::node::{AbstractNode, ElementNodeTypeId};
 use dom::window::Window;
 
 use js::jsapi::JSTracer;
@@ -32,7 +32,7 @@ impl HTMLDocument {
 }
 
 impl HTMLDocument {
-    pub fn GetHead(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetHead(&self) -> Option<AbstractNode> {
         match self.parent.GetDocumentElement() {
             None => None,
             Some(root) => root.traverse_preorder().find(|child| {

--- a/src/components/script/dom/htmlelement.rs
+++ b/src/components/script/dom/htmlelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLElementBinding;
 use dom::bindings::utils::{DOMString, ErrorResult, Fallible};
 use dom::document::AbstractDocument;
 use dom::element::{Element, ElementTypeId, HTMLElementTypeId};
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use js::jsapi::{JSContext, JSVal};
 use js::JSVAL_NULL;
 use dom::namespace;
@@ -22,7 +22,7 @@ impl HTMLElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLElement::new_inherited(HTMLElementTypeId, localName, document);
         Node::reflect_node(@mut element, document, HTMLElementBinding::Wrap)
     }
@@ -133,7 +133,7 @@ impl HTMLElement {
     pub fn SetClassName(&self, _class: DOMString) {
     }
 
-    pub fn GetOffsetParent(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetOffsetParent(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/dom/htmlembedelement.rs
+++ b/src/components/script/dom/htmlembedelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLEmbedElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLEmbedElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLEmbedElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLEmbedElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLEmbedElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlfieldsetelement.rs
+++ b/src/components/script/dom/htmlfieldsetelement.rs
@@ -8,7 +8,7 @@ use dom::document::AbstractDocument;
 use dom::element::HTMLFieldSetElementTypeId;
 use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::validitystate::ValidityState;
 
 pub struct HTMLFieldSetElement {
@@ -22,7 +22,7 @@ impl HTMLFieldSetElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLFieldSetElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLFieldSetElementBinding::Wrap)
     }
@@ -37,7 +37,7 @@ impl HTMLFieldSetElement {
         Ok(())
     }
 
-    pub fn GetForm(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetForm(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/dom/htmlfontelement.rs
+++ b/src/components/script/dom/htmlfontelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLFontElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLFontElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLFontElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLFontElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLFontElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlformelement.rs
+++ b/src/components/script/dom/htmlformelement.rs
@@ -8,7 +8,7 @@ use dom::document::AbstractDocument;
 use dom::element::HTMLFormElementTypeId;
 use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLFormElement {
     htmlelement: HTMLElement
@@ -21,7 +21,7 @@ impl HTMLFormElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLFormElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLFormElementBinding::Wrap)
     }
@@ -120,7 +120,7 @@ impl HTMLFormElement {
         false
     }
 
-    pub fn IndexedGetter(&self, _index: u32, _found: &mut bool) -> AbstractNode<ScriptView> {
+    pub fn IndexedGetter(&self, _index: u32, _found: &mut bool) -> AbstractNode {
         fail!("Not implemented.")
     }
 }

--- a/src/components/script/dom/htmlframeelement.rs
+++ b/src/components/script/dom/htmlframeelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLFrameElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::windowproxy::WindowProxy;
 
 pub struct HTMLFrameElement {
@@ -21,7 +21,7 @@ impl HTMLFrameElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLFrameElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLFrameElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlframesetelement.rs
+++ b/src/components/script/dom/htmlframesetelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLFrameSetElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLFrameSetElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLFrameSetElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLFrameSetElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLFrameSetElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlheadelement.rs
+++ b/src/components/script/dom/htmlheadelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLHeadElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLHeadElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLHeadElement {
     htmlelement: HTMLElement
@@ -19,7 +19,7 @@ impl HTMLHeadElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLHeadElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLHeadElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlheadingelement.rs
+++ b/src/components/script/dom/htmlheadingelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::DOMString;
 use dom::document::AbstractDocument;
 use dom::element::HTMLHeadingElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub enum HeadingLevel {
     Heading1,
@@ -31,7 +31,7 @@ impl HTMLHeadingElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument, level: HeadingLevel) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument, level: HeadingLevel) -> AbstractNode {
         let element = HTMLHeadingElement::new_inherited(localName, document, level);
         Node::reflect_node(@mut element, document, HTMLHeadingElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlhrelement.rs
+++ b/src/components/script/dom/htmlhrelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLHRElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLHRElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLHRElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLHRElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLHRElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlhtmlelement.rs
+++ b/src/components/script/dom/htmlhtmlelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLHtmlElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLHtmlElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLHtmlElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLHtmlElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLHtmlElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLIframeElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::windowproxy::WindowProxy;
 
 use extra::url::Url;
@@ -52,7 +52,7 @@ impl HTMLIFrameElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLIFrameElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLIFrameElementBinding::Wrap)
     }
@@ -83,14 +83,14 @@ impl HTMLIFrameElement {
         Ok(())
     }
 
-    pub fn Sandbox(&self, _abstract_self: AbstractNode<ScriptView>) -> DOMString {
+    pub fn Sandbox(&self, _abstract_self: AbstractNode) -> DOMString {
         match self.htmlelement.element.GetAttribute(~"sandbox") {
             Some(s) => s.to_owned(),
             None => ~"",
         }
     }
 
-    pub fn SetSandbox(&mut self, abstract_self: AbstractNode<ScriptView>, sandbox: DOMString) {
+    pub fn SetSandbox(&mut self, abstract_self: AbstractNode, sandbox: DOMString) {
         self.htmlelement.element.SetAttribute(abstract_self, ~"sandbox", sandbox);
     }
 

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLImageElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use extra::url::Url;
 use servo_util::geometry::to_px;
 use layout_interface::{ContentBoxQuery, ContentBoxResponse};
@@ -29,7 +29,7 @@ impl HTMLImageElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLImageElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLImageElementBinding::Wrap)
     }
@@ -74,13 +74,11 @@ impl HTMLImageElement {
         Ok(())
     }
 
-    pub fn Src(&self, _abstract_self: AbstractNode<ScriptView>) -> DOMString {
+    pub fn Src(&self, _abstract_self: AbstractNode) -> DOMString {
         ~""
     }
 
-    pub fn SetSrc(&mut self,
-                  abstract_self: AbstractNode<ScriptView>,
-                  src: DOMString) -> ErrorResult {
+    pub fn SetSrc(&mut self, abstract_self: AbstractNode, src: DOMString) -> ErrorResult {
         let node = &mut self.htmlelement.element;
         node.set_attr(abstract_self, ~"src", src.clone());
         Ok(())
@@ -110,7 +108,7 @@ impl HTMLImageElement {
         Ok(())
     }
 
-    pub fn Width(&self, abstract_self: AbstractNode<ScriptView>) -> u32 {
+    pub fn Width(&self, abstract_self: AbstractNode) -> u32 {
         let node = &self.htmlelement.element.node;
         let page = node.owner_doc().document().window.page;
         let (port, chan) = stream();
@@ -121,15 +119,13 @@ impl HTMLImageElement {
         }
     }
 
-    pub fn SetWidth(&mut self,
-                    abstract_self: AbstractNode<ScriptView>,
-                    width: u32) -> ErrorResult {
+    pub fn SetWidth(&mut self, abstract_self: AbstractNode, width: u32) -> ErrorResult {
         let node = &mut self.htmlelement.element;
         node.set_attr(abstract_self, ~"width", width.to_str());
         Ok(())
     }
 
-    pub fn Height(&self, abstract_self: AbstractNode<ScriptView>) -> u32 {
+    pub fn Height(&self, abstract_self: AbstractNode) -> u32 {
         let node = &self.htmlelement.element.node;
         let page = node.owner_doc().document().window.page;
         let (port, chan) = stream();
@@ -140,9 +136,7 @@ impl HTMLImageElement {
         }
     }
 
-    pub fn SetHeight(&mut self,
-                     abstract_self: AbstractNode<ScriptView>,
-                     height: u32) -> ErrorResult {
+    pub fn SetHeight(&mut self, abstract_self: AbstractNode, height: u32) -> ErrorResult {
         let node = &mut self.htmlelement.element;
         node.set_attr(abstract_self, ~"height", height.to_str());
         Ok(())

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult, Fallible};
 use dom::document::AbstractDocument;
 use dom::element::HTMLInputElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLInputElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLInputElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLInputElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLInputElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmllabelelement.rs
+++ b/src/components/script/dom/htmllabelelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::DOMString;
 use dom::document::AbstractDocument;
 use dom::element::HTMLLabelElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLLabelElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLLabelElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLLabelElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLLabelElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmllegendelement.rs
+++ b/src/components/script/dom/htmllegendelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLLegendElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLLegendElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLLegendElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLLegendElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLLegendElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmllielement.rs
+++ b/src/components/script/dom/htmllielement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLLIElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLLIElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLLIElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLLIElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLLIElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLLinkElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLLinkElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLLinkElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLLinkElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLLinkElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlmainelement.rs
+++ b/src/components/script/dom/htmlmainelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLMainElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLMainElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLMainElement {
     htmlelement: HTMLElement
@@ -19,7 +19,7 @@ impl HTMLMainElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLMainElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLMainElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlmapelement.rs
+++ b/src/components/script/dom/htmlmapelement.rs
@@ -8,7 +8,7 @@ use dom::htmlcollection::HTMLCollection;
 use dom::document::AbstractDocument;
 use dom::element::HTMLMapElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLMapElement {
     htmlelement: HTMLElement
@@ -21,7 +21,7 @@ impl HTMLMapElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLMapElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLMapElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlmetaelement.rs
+++ b/src/components/script/dom/htmlmetaelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLMetaElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLMetaElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLMetaElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLMetaElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLMetaElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlmeterelement.rs
+++ b/src/components/script/dom/htmlmeterelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::ErrorResult;
 use dom::document::AbstractDocument;
 use dom::element::HTMLMeterElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLMeterElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLMeterElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLMeterElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLMeterElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlmodelement.rs
+++ b/src/components/script/dom/htmlmodelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLModElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLModElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLModElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLModElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLModElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLObjectElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::validitystate::ValidityState;
 use dom::windowproxy::WindowProxy;
 
@@ -22,7 +22,7 @@ impl HTMLObjectElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLObjectElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLObjectElementBinding::Wrap)
     }
@@ -61,7 +61,7 @@ impl HTMLObjectElement {
         Ok(())
     }
 
-    pub fn GetForm(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetForm(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/dom/htmlolistelement.rs
+++ b/src/components/script/dom/htmlolistelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLOListElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLOListElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLOListElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLOListElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLOListElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmloptgroupelement.rs
+++ b/src/components/script/dom/htmloptgroupelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLOptGroupElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLOptGroupElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLOptGroupElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLOptGroupElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLOptGroupElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLOptionElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLOptionElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLOptionElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLOptionElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLOptionElementBinding::Wrap)
     }
@@ -35,7 +35,7 @@ impl HTMLOptionElement {
         Ok(())
     }
 
-    pub fn GetForm(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetForm(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/dom/htmloutputelement.rs
+++ b/src/components/script/dom/htmloutputelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLOutputElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::validitystate::ValidityState;
 
 pub struct HTMLOutputElement {
@@ -21,14 +21,14 @@ impl HTMLOutputElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLOutputElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLOutputElementBinding::Wrap)
     }
 }
 
 impl HTMLOutputElement {
-    pub fn GetForm(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetForm(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/dom/htmlparagraphelement.rs
+++ b/src/components/script/dom/htmlparagraphelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLParagraphElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLParagraphElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLParagraphElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLParagraphElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLParagraphElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlparamelement.rs
+++ b/src/components/script/dom/htmlparamelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLParamElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLParamElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLParamElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLParamElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLParamElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlpreelement.rs
+++ b/src/components/script/dom/htmlpreelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLPreElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLPreElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLPreElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLPreElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLPreElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlprogresselement.rs
+++ b/src/components/script/dom/htmlprogresselement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{ErrorResult, Fallible};
 use dom::document::AbstractDocument;
 use dom::element::HTMLProgressElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLProgressElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLProgressElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLProgressElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLProgressElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlquoteelement.rs
+++ b/src/components/script/dom/htmlquoteelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLQuoteElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLQuoteElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLQuoteElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLQuoteElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLQuoteElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlscriptelement.rs
+++ b/src/components/script/dom/htmlscriptelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLScriptElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use style::TElement;
 
 pub struct HTMLScriptElement {
@@ -21,7 +21,7 @@ impl HTMLScriptElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLScriptElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLScriptElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLSelectElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 use dom::validitystate::ValidityState;
 
 pub struct HTMLSelectElement {
@@ -21,7 +21,7 @@ impl HTMLSelectElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLSelectElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLSelectElementBinding::Wrap)
     }
@@ -44,7 +44,7 @@ impl HTMLSelectElement {
         Ok(())
     }
 
-    pub fn GetForm(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetForm(&self) -> Option<AbstractNode> {
         None
     }
 
@@ -92,19 +92,19 @@ impl HTMLSelectElement {
         Ok(())
     }
 
-    pub fn Item(&self, _index: u32) -> Option<AbstractNode<ScriptView>> {
+    pub fn Item(&self, _index: u32) -> Option<AbstractNode> {
         None
     }
 
-    pub fn NamedItem(&self, _name: DOMString) -> Option<AbstractNode<ScriptView>> {
+    pub fn NamedItem(&self, _name: DOMString) -> Option<AbstractNode> {
         None
     }
 
-    pub fn IndexedGetter(&self, _index: u32, _found: &mut bool) -> Option<AbstractNode<ScriptView>> {
+    pub fn IndexedGetter(&self, _index: u32, _found: &mut bool) -> Option<AbstractNode> {
         None
     }
 
-    pub fn IndexedSetter(&mut self, _index: u32, _option: Option<AbstractNode<ScriptView>>) -> ErrorResult {
+    pub fn IndexedSetter(&mut self, _index: u32, _option: Option<AbstractNode>) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlsourceelement.rs
+++ b/src/components/script/dom/htmlsourceelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLSourceElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLSourceElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLSourceElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLSourceElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLSourceElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlspanelement.rs
+++ b/src/components/script/dom/htmlspanelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLSpanElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLSpanElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLSpanElement {
     htmlelement: HTMLElement
@@ -19,7 +19,7 @@ impl HTMLSpanElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLSpanElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLSpanElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLStyleElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLStyleElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLStyleElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLStyleElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLStyleElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltablecaptionelement.rs
+++ b/src/components/script/dom/htmltablecaptionelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableCaptionElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableCaptionElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLTableCaptionElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableCaptionElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableCaptionElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltablecolelement.rs
+++ b/src/components/script/dom/htmltablecolelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableColElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableColElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTableColElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableColElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableColElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltabledatacellelement.rs
+++ b/src/components/script/dom/htmltabledatacellelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLTableDataCellElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableDataCellElementTypeId;
 use dom::htmltablecellelement::HTMLTableCellElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableDataCellElement {
     htmltablecellelement: HTMLTableCellElement,
@@ -19,7 +19,7 @@ impl HTMLTableDataCellElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableDataCellElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableDataCellElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltableelement.rs
+++ b/src/components/script/dom/htmltableelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTableElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltableheadercellelement.rs
+++ b/src/components/script/dom/htmltableheadercellelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLTableHeaderCellElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableHeaderCellElementTypeId;
 use dom::htmltablecellelement::HTMLTableCellElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableHeaderCellElement {
     htmltablecellelement: HTMLTableCellElement,
@@ -19,7 +19,7 @@ impl HTMLTableHeaderCellElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableHeaderCellElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableHeaderCellElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltablerowelement.rs
+++ b/src/components/script/dom/htmltablerowelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableRowElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableRowElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTableRowElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableRowElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableRowElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltablesectionelement.rs
+++ b/src/components/script/dom/htmltablesectionelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTableSectionElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTableSectionElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTableSectionElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTableSectionElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTableSectionElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltemplateelement.rs
+++ b/src/components/script/dom/htmltemplateelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLTemplateElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLTemplateElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTemplateElement {
     htmlelement: HTMLElement,
@@ -19,7 +19,7 @@ impl HTMLTemplateElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTemplateElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTemplateElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult, Fallible};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTextAreaElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTextAreaElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTextAreaElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTextAreaElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTextAreaElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltimeelement.rs
+++ b/src/components/script/dom/htmltimeelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTimeElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTimeElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLTimeElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTimeElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTimeElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltitleelement.rs
+++ b/src/components/script/dom/htmltitleelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTitleElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTitleElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTitleElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTitleElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTitleElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmltrackelement.rs
+++ b/src/components/script/dom/htmltrackelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLTrackElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLTrackElement {
     htmlelement: HTMLElement,
@@ -20,7 +20,7 @@ impl HTMLTrackElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLTrackElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLTrackElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlulistelement.rs
+++ b/src/components/script/dom/htmlulistelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLUListElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLUListElement {
     htmlelement: HTMLElement
@@ -20,7 +20,7 @@ impl HTMLUListElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLUListElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLUListElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlunknownelement.rs
+++ b/src/components/script/dom/htmlunknownelement.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::HTMLUnknownElementBinding;
 use dom::document::AbstractDocument;
 use dom::element::HTMLUnknownElementTypeId;
 use dom::htmlelement::HTMLElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLUnknownElement {
     htmlelement: HTMLElement
@@ -19,7 +19,7 @@ impl HTMLUnknownElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLUnknownElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLUnknownElementBinding::Wrap)
     }

--- a/src/components/script/dom/htmlvideoelement.rs
+++ b/src/components/script/dom/htmlvideoelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::utils::{DOMString, ErrorResult};
 use dom::document::AbstractDocument;
 use dom::element::HTMLVideoElementTypeId;
 use dom::htmlmediaelement::HTMLMediaElement;
-use dom::node::{AbstractNode, Node, ScriptView};
+use dom::node::{AbstractNode, Node};
 
 pub struct HTMLVideoElement {
     htmlmediaelement: HTMLMediaElement
@@ -20,7 +20,7 @@ impl HTMLVideoElement {
         }
     }
 
-    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(localName: ~str, document: AbstractDocument) -> AbstractNode {
         let element = HTMLVideoElement::new_inherited(localName, document);
         Node::reflect_node(@mut element, document, HTMLVideoElementBinding::Wrap)
     }

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -14,212 +14,18 @@ use dom::documenttype::DocumentType;
 use dom::element::{Element, ElementTypeId, HTMLImageElementTypeId, HTMLIframeElementTypeId};
 use dom::element::{HTMLAnchorElementTypeId, HTMLStyleElementTypeId};
 use dom::eventtarget::{AbstractEventTarget, EventTarget, NodeTypeId};
-use dom::nodelist::{NodeList};
-use dom::htmlimageelement::HTMLImageElement;
 use dom::htmliframeelement::HTMLIFrameElement;
+use dom::htmlimageelement::HTMLImageElement;
+use dom::nodelist::{NodeList};
 use dom::text::Text;
 
-use extra::url::Url;
 use js::jsapi::{JSObject, JSContext};
-use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_util::slot::{MutSlotRef, Slot, SlotRef};
 use std::cast::transmute;
 use std::cast;
 use std::unstable::raw::Box;
 use std::util;
 use style::TNode;
-
-//
-// Layout's immutable, sanitized view of nodes.
-//
-
-/// A nonsense constant for layout nodes to point to just to establish a lifetime.
-///
-/// FIXME(pcwalton): Phantom lifetimes in Rust would be useful...
-static HEAVY_IRON_BALL: () = ();
-
-/// A wrapper so that layout can access only the methods that it should have access to. Layout must
-/// only ever see these and must never see instances of `AbstractNode`.
-#[deriving(Clone, Eq)]
-pub struct LayoutNode<'self> {
-    /// The wrapped node.
-    priv node: AbstractNode,
-
-    /// Being chained to a `HEAVY_IRON_BALL` prevents `LayoutNode`s from escaping.
-    priv chain: &'self (),
-}
-
-impl<'self> LayoutNode<'self> {
-    /// NB: Do not make this public.
-    ///
-    /// FIXME(pcwalton): Probably this should be marked `unsafe`.
-    /*PRIVATE-FOR-SECURITY-REASONS*/ fn new(node: AbstractNode) -> LayoutNode<'static> {
-        LayoutNode {
-            node: node,
-            chain: &HEAVY_IRON_BALL,
-        }
-    }
-
-    /// Returns the interior of this node as a `Node`. This is highly unsafe for layout to call
-    /// and as such is marked `unsafe`.
-    pub unsafe fn get<'a>(&'a self) -> &'a Node<LayoutView> {
-        cast::transmute(self.node.node())
-    }
-
-    /// Returns the first child of this node.
-    pub fn first_child(&self) -> Option<LayoutNode<'self>> {
-        self.node.first_child().map(|node| LayoutNode::new(node))
-    }
-
-    /// Returns the first child of this node.
-    pub fn last_child(&self) -> Option<LayoutNode<'self>> {
-        self.node.last_child().map(|node| LayoutNode::new(node))
-    }
-
-    /// Iterates over this node and all its descendants, in preorder.
-    ///
-    /// FIXME(pcwalton): Terribly inefficient. We should use parallelism.
-    pub fn traverse_preorder(&self) -> LayoutTreeIterator<'self> {
-        let mut nodes = ~[];
-        gather_layout_nodes(self, &mut nodes, false);
-        LayoutTreeIterator::new(nodes)
-    }
-
-    /// Returns an iterator over this node's children.
-    pub fn children(&self) -> LayoutNodeChildrenIterator<'self> {
-        LayoutNodeChildrenIterator {
-            current_node: self.first_child(),
-        }
-    }
-
-    /// Returns the type ID of this node. Fails if this node is borrowed mutably.
-    pub fn type_id(&self) -> NodeTypeId {
-        self.node.type_id()
-    }
-
-    /// If this is an image element, returns its URL. If this is not an image element, fails.
-    ///
-    /// FIXME(pcwalton): Don't copy URLs.
-    pub fn image_url(&self) -> Option<Url> {
-        self.with_image_element(|image_element| {
-            image_element.image.as_ref().map(|url| (*url).clone())
-        })
-    }
-
-    /// Downcasts this node to an image element and calls the given closure.
-    ///
-    /// NB: Do not make this public, as layout will be able to do unsafe things with `AbstractNode`
-    /// otherwise.
-    ///
-    /// FIXME(pcwalton): RAII.
-    /*PRIVATE-FOR-SECURITY-REASONS*/ fn with_image_element<R>(
-                                                           self,
-                                                           f: &fn(&HTMLImageElement) -> R)
-                                                           -> R {
-        if !self.node.is_image_element() {
-            fail!(~"node is not an image element");
-        }
-        self.node.transmute(f)
-    }
-
-    /// If this node is an iframe element, returns its pipeline and subpage IDs. If this node is
-    /// not an iframe element, fails.
-    pub fn iframe_pipeline_and_subpage_ids(&self) -> (PipelineId, SubpageId) {
-        self.with_iframe_element(|iframe_element| {
-            let size = iframe_element.size.unwrap();
-            (size.pipeline_id, size.subpage_id)
-        })
-    }
-
-    /// Downcasts this node to an iframe element and calls the given closure.
-    ///
-    /// NB: Do not make this public, as layout will be able to do unsafe things with `AbstractNode`
-    /// otherwise.
-    ///
-    /// FIXME(pcwalton): RAII.
-    /*PRIVATE-FOR-SECURITY-REASONS*/ fn with_iframe_element<R>(
-                                                            self,
-                                                            f: &fn(&HTMLIFrameElement) -> R)
-                                                            -> R {
-        if !self.node.is_iframe_element() {
-            fail!(~"node is not an iframe element");
-        }
-        self.node.transmute(f)
-    }
-
-    /// Returns true if this node is a text node or false otherwise.
-    #[inline]
-    pub fn is_text(self) -> bool {
-        self.node.is_text()
-    }
-
-    /// Returns true if this node consists entirely of ignorable whitespace and false otherwise.
-    /// Ignorable whitespace is defined as whitespace that would be removed per CSS 2.1 § 16.6.1.
-    pub fn is_ignorable_whitespace(&self) -> bool {
-        self.is_text() && self.with_text(|text| text.element.data.is_whitespace())
-    }
-
-    /// If this is a text node, copies out the text. If this is not a text node, fails.
-    ///
-    /// FIXME(pcwalton): Don't copy text. Atomically reference count instead.
-    pub fn text(&self) -> ~str {
-        self.with_text(|text| text.element.data.to_str())
-    }
-
-    /// Downcasts this node to a text node and calls the given closure.
-    ///
-    /// NB: Do not make this public, as layout will be able to do unsafe things with `AbstractNode`
-    /// otherwise.
-    ///
-    /// FIXME(pcwalton): RAII.
-    /*PRIVATE-FOR-SECURITY-REASONS*/ fn with_text<R>(self, f: &fn(&Text) -> R) -> R {
-        self.node.with_imm_text(f)
-    }
-
-    /// Dumps this node tree, for debugging.
-    pub fn dump(&self) {
-        self.node.dump()
-    }
-
-    /// Returns a string that describes this node, for debugging.
-    pub fn debug_str(&self) -> ~str {
-        self.node.debug_str()
-    }
-}
-
-impl<'self> TNode<Element> for LayoutNode<'self> {
-    fn parent_node(&self) -> Option<LayoutNode<'self>> {
-        self.node.node().parent_node.map(|node| LayoutNode::new(node))
-    }
-
-    fn prev_sibling(&self) -> Option<LayoutNode<'self>> {
-        self.node.node().prev_sibling.map(|node| LayoutNode::new(node))
-    }
-    
-    fn next_sibling(&self) -> Option<LayoutNode<'self>> {
-        self.node.node().next_sibling.map(|node| LayoutNode::new(node))
-    }
-
-    fn is_element(&self) -> bool {
-        match self.node.type_id() {
-            ElementNodeTypeId(*) => true,
-            _ => false
-        }
-    }
-
-    fn is_document(&self) -> bool {
-        match self.node.type_id() {
-            DocumentNodeTypeId(*) => true,
-            _ => false
-        }
-    }
-
-    /// FIXME(pcwalton): Unsafe!
-    #[inline]
-    fn with_element<R>(&self, f: &fn(&Element) -> R) -> R {
-        self.node.with_imm_element(f)
-    }
-}
 
 //
 // The basic Node structure
@@ -851,20 +657,6 @@ impl Iterator<AbstractNode> for AbstractNodeChildrenIterator {
     }
 }
 
-pub struct LayoutNodeChildrenIterator<'self> {
-    priv current_node: Option<LayoutNode<'self>>,
-}
-
-impl<'self> Iterator<LayoutNode<'self>> for LayoutNodeChildrenIterator<'self> {
-    fn next(&mut self) -> Option<LayoutNode<'self>> {
-        let node = self.current_node;
-        self.current_node = do self.current_node.and_then |node| {
-            node.next_sibling()
-        };
-        node
-    }
-}
-
 pub struct AncestorIterator {
     priv current: Option<AbstractNode>,
 }
@@ -916,49 +708,6 @@ fn gather_abstract_nodes(cur: &AbstractNode, refs: &mut ~[AbstractNode], postord
     }
     for kid in cur.children() {
         gather_abstract_nodes(&kid, refs, postorder)
-    }
-    if postorder {
-        refs.push(cur.clone());
-    }
-}
-
-// FIXME: Do this without precomputing a vector of refs.
-// Easy for preorder; harder for postorder.
-//
-// FIXME(pcwalton): Parallelism! Eventually this should just be nuked.
-pub struct LayoutTreeIterator<'self> {
-    priv nodes: ~[LayoutNode<'self>],
-    priv index: uint,
-}
-
-impl<'self> LayoutTreeIterator<'self> {
-    fn new(nodes: ~[LayoutNode<'self>]) -> LayoutTreeIterator<'self> {
-        LayoutTreeIterator {
-            nodes: nodes,
-            index: 0,
-        }
-    }
-}
-
-impl<'self> Iterator<LayoutNode<'self>> for LayoutTreeIterator<'self> {
-    fn next(&mut self) -> Option<LayoutNode<'self>> {
-        if self.index >= self.nodes.len() {
-            None
-        } else {
-            let v = self.nodes[self.index].clone();
-            self.index += 1;
-            Some(v)
-        }
-    }
-}
-
-/// FIXME(pcwalton): This is super inefficient.
-fn gather_layout_nodes<'a>(cur: &LayoutNode<'a>, refs: &mut ~[LayoutNode<'a>], postorder: bool) {
-    if !postorder {
-        refs.push(cur.clone());
-    }
-    for kid in cur.children() {
-        gather_layout_nodes(&kid, refs, postorder)
     }
     if postorder {
         refs.push(cur.clone());
@@ -1629,80 +1378,3 @@ impl Reflectable for Node<ScriptView> {
     }
 }
 
-/// A bottom-up, parallelizable traversal.
-pub trait PostorderNodeTraversal {
-    /// The operation to perform. Return true to continue or false to stop.
-    fn process<'a>(&'a self, node: LayoutNode<'a>) -> bool;
-
-    /// Returns true if this node should be pruned. If this returns true, we skip the operation
-    /// entirely and do not process any descendant nodes. This is called *before* child nodes are
-    /// visited. The default implementation never prunes any nodes.
-    fn should_prune<'a>(&'a self, _node: LayoutNode<'a>) -> bool {
-        false
-    }
-}
-
-/// A bottom-up, parallelizable traversal.
-pub trait PostorderNodeMutTraversal {
-    /// The operation to perform. Return true to continue or false to stop.
-    fn process<'a>(&'a mut self, node: LayoutNode<'a>) -> bool;
-
-    /// Returns true if this node should be pruned. If this returns true, we skip the operation
-    /// entirely and do not process any descendant nodes. This is called *before* child nodes are
-    /// visited. The default implementation never prunes any nodes.
-    fn should_prune<'a>(&'a self, _node: LayoutNode<'a>) -> bool {
-        false
-    }
-}
-
-impl<'self> LayoutNode<'self> {
-    /// Traverses the tree in postorder.
-    ///
-    /// TODO(pcwalton): Offer a parallel version with a compatible API.
-    pub fn traverse_postorder<T:PostorderNodeTraversal>(self, traversal: &T) -> bool {
-        if traversal.should_prune(self) {
-            return true
-        }
-
-        let mut opt_kid = self.first_child();
-        loop {
-            match opt_kid {
-                None => break,
-                Some(kid) => {
-                    if !kid.traverse_postorder(traversal) {
-                        return false
-                    }
-                    opt_kid = kid.next_sibling()
-                }
-            }
-        }
-
-        traversal.process(self)
-    }
-
-    /// Traverses the tree in postorder.
-    ///
-    /// TODO(pcwalton): Offer a parallel version with a compatible API.
-    pub fn traverse_postorder_mut<T:PostorderNodeMutTraversal>(mut self, traversal: &mut T)
-                                  -> bool {
-        if traversal.should_prune(self) {
-            return true
-        }
-
-        let mut opt_kid = self.first_child();
-        loop {
-            match opt_kid {
-                None => break,
-                Some(kid) => {
-                    if !kid.traverse_postorder_mut(traversal) {
-                        return false
-                    }
-                    opt_kid = kid.next_sibling()
-                }
-            }
-        }
-
-        traversal.process(self)
-    }
-
-}

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -31,36 +31,160 @@ use style::TNode;
 // The basic Node structure
 //
 
-/// A phantom type representing the script task's view of this node. Script is able to mutate
-/// nodes but may not access layout data.
-#[deriving(Eq)]
-pub struct ScriptView;
+/// A wrapper so that layout can access only the properties that it should have access to. Layout
+/// should only ever see this.
+#[deriving(Clone, Eq)]
+pub struct LayoutNode {
+    priv node: AbstractNode,
+}
 
-/// A phantom type representing the layout task's view of the node. Layout is not allowed to mutate
-/// nodes but may access layout data.
-#[deriving(Eq)]
-pub struct LayoutView;
+impl LayoutNode {
+    // NB: Do not make this public.
+    //
+    // FIXME(pcwalton): Probably this should be marked `unsafe`.
+    fn new(node: AbstractNode) -> LayoutNode {
+        LayoutNode {
+            node: node,
+        }
+    }
 
-// We shouldn't need Eq for ScriptView and LayoutView; see Rust #7671.
+    /// FIXME(pcwalton): This isn't safe, as it exposes guts, and should be deprecated.
+    pub fn get<'a>(&'a self) -> &'a Node<LayoutView> {
+        unsafe {
+            cast::transmute(self.node.node())
+        }
+    }
+
+    /// Returns the first child of this node.
+    pub fn first_child(&self) -> Option<LayoutNode> {
+        self.node.first_child().map(|node| LayoutNode::new(node))
+    }
+
+    /// Returns the first child of this node.
+    pub fn last_child(&self) -> Option<LayoutNode> {
+        self.node.last_child().map(|node| LayoutNode::new(node))
+    }
+
+    /// Iterates over this node and all its descendants, in preorder.
+    ///
+    /// FIXME(pcwalton): Terribly inefficient. We should use parallelism.
+    pub fn traverse_preorder(&self) -> LayoutTreeIterator {
+        let mut nodes = ~[];
+        gather_layout_nodes(self, &mut nodes, false);
+        LayoutTreeIterator::new(nodes)
+    }
+
+    /// Returns an iterator over this node's children.
+    pub fn children(&self) -> LayoutNodeChildrenIterator {
+        LayoutNodeChildrenIterator {
+            current_node: self.first_child(),
+        }
+    }
+
+    /// Returns the type ID of this node. Fails if this node is borrowed mutably.
+    pub fn type_id(&self) -> NodeTypeId {
+        self.node.type_id()
+    }
+
+    /// Downcasts this node to an image element and calls the given closure.
+    ///
+    /// FIXME(pcwalton): RAII.
+    /// FIXME(pcwalton): This isn't safe, as it allows layout to access `AbstractNode`s, and should
+    /// be deprecated.
+    pub fn with_image_element<R>(self, f: &fn(&HTMLImageElement) -> R) -> R {
+        if !self.node.is_image_element() {
+            fail!(~"node is not an image element");
+        }
+        self.node.transmute(f)
+    }
+
+    /// Downcasts this node to an iframe element and calls the given closure.
+    ///
+    /// FIXME(pcwalton): RAII.
+    /// FIXME(pcwalton): This isn't safe, as it allows layout to access `AbstractNode`s, and should
+    /// be deprecated.
+    pub fn with_iframe_element<R>(self, f: &fn(&HTMLIFrameElement) -> R) -> R {
+        if !self.node.is_iframe_element() {
+            fail!(~"node is not an iframe element");
+        }
+        self.node.transmute(f)
+    }
+
+    /// Returns true if this node is a text node or false otherwise.
+    #[inline]
+    pub fn is_text(self) -> bool {
+        self.node.is_text()
+    }
+
+    /// Downcasts this node to a text node and calls the given closure.
+    ///
+    /// FIXME(pcwalton): RAII.
+    /// FIXME(pcwalton): This isn't safe, as it allows layout to access `AbstractNode`s, and should
+    /// be deprecated.
+    pub fn with_text<R>(self, f: &fn(&Text) -> R) -> R {
+        self.node.with_imm_text(f)
+    }
+
+    /// Dumps this node tree, for debugging.
+    pub fn dump(&self) {
+        self.node.dump()
+    }
+
+    /// Returns a string that describes this node, for debugging.
+    pub fn debug_str(&self) -> ~str {
+        self.node.debug_str()
+    }
+}
+
+impl TNode<Element> for LayoutNode {
+    fn parent_node(&self) -> Option<LayoutNode> {
+        self.node.node().parent_node.map(|node| LayoutNode::new(node))
+    }
+
+    fn prev_sibling(&self) -> Option<LayoutNode> {
+        self.node.node().prev_sibling.map(|node| LayoutNode::new(node))
+    }
+    
+    fn next_sibling(&self) -> Option<LayoutNode> {
+        self.node.node().next_sibling.map(|node| LayoutNode::new(node))
+    }
+
+    fn is_element(&self) -> bool {
+        match self.node.type_id() {
+            ElementNodeTypeId(*) => true,
+            _ => false
+        }
+    }
+
+    fn is_document(&self) -> bool {
+        match self.node.type_id() {
+            DocumentNodeTypeId(*) => true,
+            _ => false
+        }
+    }
+
+    #[inline]
+    fn with_element<R>(&self, f: &fn(&Element) -> R) -> R {
+        self.node.with_imm_element(f)
+    }
+}
 
 /// This is what a Node looks like if you do not know what kind of node it is. To unpack it, use
 /// downcast().
 ///
 /// FIXME: This should be replaced with a trait once they can inherit from structs.
 #[deriving(Eq)]
-pub struct AbstractNode<View> {
-    priv obj: *mut Box<Node<View>>,
+pub struct AbstractNode {
+    priv obj: *mut Box<Node<ScriptView>>,
 }
 
-pub struct AbstractNodeChildrenIterator<View> {
-    priv current_node: Option<AbstractNode<View>>,
-}
+/// The script task's mutable view of a node.
+pub struct ScriptView;
+
+/// The layout task's mutable view of a node.
+pub struct LayoutView;
 
 /// An HTML node.
-///
-/// `View` describes extra data associated with this node that this task has access to. For
-/// the script task, this is the unit type `()`. For the layout task, this is
-/// `LayoutData`.
 pub struct Node<View> {
     /// The JavaScript reflector for this node.
     eventtarget: EventTarget,
@@ -68,22 +192,22 @@ pub struct Node<View> {
     /// The type of node that this is.
     type_id: NodeTypeId,
 
-    abstract: Option<AbstractNode<View>>,
+    abstract: Option<AbstractNode>,
 
     /// The parent of this node.
-    parent_node: Option<AbstractNode<View>>,
+    parent_node: Option<AbstractNode>,
 
     /// The first child of this node.
-    first_child: Option<AbstractNode<View>>,
+    first_child: Option<AbstractNode>,
 
     /// The last child of this node.
-    last_child: Option<AbstractNode<View>>,
+    last_child: Option<AbstractNode>,
 
     /// The next sibling of this node.
-    next_sibling: Option<AbstractNode<View>>,
+    next_sibling: Option<AbstractNode>,
 
     /// The previous sibling of this node.
-    prev_sibling: Option<AbstractNode<View>>,
+    prev_sibling: Option<AbstractNode>,
 
     /// The document that this node belongs to.
     priv owner_doc: Option<AbstractDocument>,
@@ -204,68 +328,53 @@ pub enum NodeTypeId {
     TextNodeTypeId,
 }
 
-impl<View> Clone for AbstractNode<View> {
-    fn clone(&self) -> AbstractNode<View> {
+impl Clone for AbstractNode {
+    fn clone(&self) -> AbstractNode {
         *self
     }
 }
 
-impl<View> TNode<Element> for AbstractNode<View> {
-    fn parent_node(&self) -> Option<AbstractNode<View>> {
+impl AbstractNode {
+    pub fn node<'a>(&'a self) -> &'a Node<ScriptView> {
+        unsafe {
+            &(*self.obj).data
+        }
+    }
+
+    pub fn mut_node<'a>(&'a self) -> &'a mut Node<ScriptView> {
+        unsafe {
+            &mut (*self.obj).data
+        }
+    }
+
+    pub fn parent_node(&self) -> Option<AbstractNode> {
         self.node().parent_node
     }
 
-    fn prev_sibling(&self) -> Option<AbstractNode<View>> {
-        self.node().prev_sibling
-    }
-    
-    fn next_sibling(&self) -> Option<AbstractNode<View>> {
-        self.node().next_sibling
+    pub fn first_child(&self) -> Option<AbstractNode> {
+        self.node().first_child
     }
 
-    fn is_element(&self) -> bool {
+    pub fn last_child(&self) -> Option<AbstractNode> {
+        self.node().last_child
+    }
+
+    pub fn is_element(&self) -> bool {
         match self.type_id() {
             ElementNodeTypeId(*) => true,
             _ => false
         }
     }
 
-    fn is_document(&self) -> bool {
+    pub fn is_document(&self) -> bool {
         match self.type_id() {
             DocumentNodeTypeId(*) => true,
             _ => false
         }
     }
-
-    #[inline]
-    fn with_element<R>(&self, f: &fn(&Element) -> R) -> R {
-        self.with_imm_element(f)
-    }
 }
 
-impl<View> AbstractNode<View> {
-    pub fn node<'a>(&'a self) -> &'a Node<View> {
-        unsafe {
-            &(*self.obj).data
-        }
-    }
-
-    pub fn mut_node<'a>(&'a self) -> &'a mut Node<View> {
-        unsafe {
-            &mut (*self.obj).data
-        }
-    }
-
-    pub fn first_child(&self) -> Option<AbstractNode<View>> {
-        self.node().first_child
-    }
-
-    pub fn last_child(&self) -> Option<AbstractNode<View>> {
-        self.node().last_child
-    }
-}
-
-impl<'self, View> AbstractNode<View> {
+impl<'self> AbstractNode {
     // Unsafe accessors
 
     pub unsafe fn as_cacheable_wrapper(&self) -> @mut Reflectable {
@@ -283,20 +392,22 @@ impl<'self, View> AbstractNode<View> {
     /// Allow consumers to recreate an AbstractNode from the raw boxed type.
     /// Must only be used in situations where the boxed type is in the inheritance
     /// chain for nodes.
-    pub fn from_box<T>(ptr: *mut Box<T>) -> AbstractNode<View> {
+    ///
+    /// FIXME(pcwalton): Mark unsafe?
+    pub fn from_box<T>(ptr: *mut Box<T>) -> AbstractNode {
         AbstractNode {
-            obj: ptr as *mut Box<Node<View>>
+            obj: ptr as *mut Box<Node<ScriptView>>
         }
     }
 
     /// Allow consumers to upcast from derived classes.
-    pub fn from_document(doc: AbstractDocument) -> AbstractNode<View> {
+    pub fn from_document(doc: AbstractDocument) -> AbstractNode {
         unsafe {
             cast::transmute(doc)
         }
     }
 
-    pub fn from_eventtarget(target: AbstractEventTarget) -> AbstractNode<View> {
+    pub fn from_eventtarget(target: AbstractEventTarget) -> AbstractNode {
         assert!(target.is_node());
         unsafe {
             cast::transmute(target)
@@ -311,12 +422,12 @@ impl<'self, View> AbstractNode<View> {
     }
 
     /// Returns the previous sibling of this node. Fails if this node is borrowed mutably.
-    pub fn prev_sibling(self) -> Option<AbstractNode<View>> {
+    pub fn prev_sibling(self) -> Option<AbstractNode> {
         self.node().prev_sibling
     }
 
     /// Returns the next sibling of this node. Fails if this node is borrowed mutably.
-    pub fn next_sibling(self) -> Option<AbstractNode<View>> {
+    pub fn next_sibling(self) -> Option<AbstractNode> {
         self.node().next_sibling
     }
 
@@ -326,7 +437,7 @@ impl<'self, View> AbstractNode<View> {
 
     pub fn transmute<T, R>(self, f: &fn(&T) -> R) -> R {
         unsafe {
-            let node_box: *mut Box<Node<View>> = transmute(self.obj);
+            let node_box: *mut Box<Node<ScriptView>> = transmute(self.obj);
             let node = &mut (*node_box).data;
             let old = node.abstract;
             node.abstract = Some(self);
@@ -339,7 +450,7 @@ impl<'self, View> AbstractNode<View> {
 
     pub fn transmute_mut<T, R>(self, f: &fn(&mut T) -> R) -> R {
         unsafe {
-            let node_box: *mut Box<Node<View>> = transmute(self.obj);
+            let node_box: *mut Box<Node<ScriptView>> = transmute(self.obj);
             let node = &mut (*node_box).data;
             let old = node.abstract;
             node.abstract = Some(self);
@@ -446,13 +557,6 @@ impl<'self, View> AbstractNode<View> {
         }
     }
 
-    pub fn with_imm_image_element<R>(self, f: &fn(&HTMLImageElement) -> R) -> R {
-        if !self.is_image_element() {
-            fail!(~"node is not an image element");
-        }
-        self.transmute(f)
-    }
-
     pub fn with_mut_image_element<R>(self, f: &fn(&mut HTMLImageElement) -> R) -> R {
         if !self.is_image_element() {
             fail!(~"node is not an image element");
@@ -462,13 +566,6 @@ impl<'self, View> AbstractNode<View> {
 
     pub fn is_iframe_element(self) -> bool {
         self.type_id() == ElementNodeTypeId(HTMLIframeElementTypeId)
-    }
-
-    pub fn with_imm_iframe_element<R>(self, f: &fn(&HTMLIFrameElement) -> R) -> R {
-        if !self.is_iframe_element() {
-            fail!(~"node is not an iframe element");
-        }
-        self.transmute(f)
     }
 
     pub fn with_mut_iframe_element<R>(self, f: &fn(&mut HTMLIFrameElement) -> R) -> R {
@@ -486,11 +583,11 @@ impl<'self, View> AbstractNode<View> {
         self.type_id() == ElementNodeTypeId(HTMLAnchorElementTypeId)
     }
 
-    pub unsafe fn raw_object(self) -> *mut Box<Node<View>> {
+    pub unsafe fn raw_object(self) -> *mut Box<Node<ScriptView>> {
         self.obj
     }
 
-    pub fn from_raw(raw: *mut Box<Node<View>>) -> AbstractNode<View> {
+    pub fn from_raw(raw: *mut Box<Node<ScriptView>>) -> AbstractNode {
         AbstractNode {
             obj: raw
         }
@@ -530,7 +627,7 @@ impl<'self, View> AbstractNode<View> {
         self.first_child().is_none()
     }
 
-    pub fn children(&self) -> AbstractNodeChildrenIterator<View> {
+    pub fn children(&self) -> AbstractNodeChildrenIterator {
         self.node().children()
     }
 
@@ -539,12 +636,12 @@ impl<'self, View> AbstractNode<View> {
     }
 }
 
-impl AbstractNode<ScriptView> {
-    pub fn AppendChild(self, node: AbstractNode<ScriptView>) -> Fallible<AbstractNode<ScriptView>> {
+impl AbstractNode {
+    pub fn AppendChild(self, node: AbstractNode) -> Fallible<AbstractNode> {
         self.node().AppendChild(self, node)
     }
 
-    pub fn RemoveChild(self, node: AbstractNode<ScriptView>) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn RemoveChild(self, node: AbstractNode) -> Fallible<AbstractNode> {
         self.node().RemoveChild(self, node)
     }
 
@@ -577,9 +674,7 @@ impl AbstractNode<ScriptView> {
     /// Adds a new child to the end of this node's list of children.
     ///
     /// Fails unless `new_child` is disconnected from the tree.
-    fn add_child(&self,
-                 new_child: AbstractNode<ScriptView>,
-                 before: Option<AbstractNode<ScriptView>>) {
+    fn add_child(&self, new_child: AbstractNode, before: Option<AbstractNode>) {
         let this_node = self.mut_node();
         let new_child_node = new_child.mut_node();
         assert!(new_child_node.parent_node.is_none());
@@ -626,7 +721,7 @@ impl AbstractNode<ScriptView> {
     /// Removes the given child from this node's list of children.
     ///
     /// Fails unless `child` is a child of this node. (FIXME: This is not yet checked.)
-    fn remove_child(&self, child: AbstractNode<ScriptView>) {
+    fn remove_child(&self, child: AbstractNode) {
         let this_node = self.mut_node();
         let child_node = child.mut_node();
         assert!(child_node.parent_node.is_some());
@@ -656,27 +751,27 @@ impl AbstractNode<ScriptView> {
     // Low-level pointer stitching wrappers
     //
 
-    fn set_parent_node(&self, new_parent_node: Option<AbstractNode<ScriptView>>) {
+    fn set_parent_node(&self, new_parent_node: Option<AbstractNode>) {
         let node = self.mut_node();
         node.set_parent_node(new_parent_node)
     }
 
-    fn set_first_child(&self, new_first_child: Option<AbstractNode<ScriptView>>) {
+    fn set_first_child(&self, new_first_child: Option<AbstractNode>) {
         let node = self.mut_node();
         node.set_first_child(new_first_child)
     }
 
-    fn set_last_child(&self, new_last_child: Option<AbstractNode<ScriptView>>) {
+    fn set_last_child(&self, new_last_child: Option<AbstractNode>) {
         let node = self.mut_node();
         node.set_last_child(new_last_child)
     }
     
-    fn set_prev_sibling(&self, new_prev_sibling: Option<AbstractNode<ScriptView>>) {
+    fn set_prev_sibling(&self, new_prev_sibling: Option<AbstractNode>) {
         let node = self.mut_node();
         node.set_prev_sibling(new_prev_sibling)
     }
     
-    fn set_next_sibling(&self, new_next_sibling: Option<AbstractNode<ScriptView>>) {
+    fn set_next_sibling(&self, new_next_sibling: Option<AbstractNode>) {
         let node = self.mut_node();
         node.set_next_sibling(new_next_sibling)
     }
@@ -686,8 +781,12 @@ impl AbstractNode<ScriptView> {
 // Iteration and traversal
 //
 
-impl<View> Iterator<AbstractNode<View>> for AbstractNodeChildrenIterator<View> {
-    fn next(&mut self) -> Option<AbstractNode<View>> {
+pub struct AbstractNodeChildrenIterator {
+    priv current_node: Option<AbstractNode>,
+}
+
+impl Iterator<AbstractNode> for AbstractNodeChildrenIterator {
+    fn next(&mut self) -> Option<AbstractNode> {
         let node = self.current_node;
         self.current_node = do self.current_node.and_then |node| {
             node.next_sibling()
@@ -696,12 +795,26 @@ impl<View> Iterator<AbstractNode<View>> for AbstractNodeChildrenIterator<View> {
     }
 }
 
-pub struct AncestorIterator<View> {
-    priv current: Option<AbstractNode<View>>,
+pub struct LayoutNodeChildrenIterator {
+    priv current_node: Option<LayoutNode>,
 }
 
-impl<View> Iterator<AbstractNode<View>> for AncestorIterator<View> {
-    fn next(&mut self) -> Option<AbstractNode<View>> {
+impl Iterator<LayoutNode> for LayoutNodeChildrenIterator {
+    fn next(&mut self) -> Option<LayoutNode> {
+        let node = self.current_node;
+        self.current_node = do self.current_node.and_then |node| {
+            node.next_sibling()
+        };
+        node
+    }
+}
+
+pub struct AncestorIterator {
+    priv current: Option<AbstractNode>,
+}
+
+impl Iterator<AbstractNode> for AncestorIterator {
+    fn next(&mut self) -> Option<AbstractNode> {
         if self.current.is_none() {
             return None;
         }
@@ -715,13 +828,13 @@ impl<View> Iterator<AbstractNode<View>> for AncestorIterator<View> {
 
 // FIXME: Do this without precomputing a vector of refs.
 // Easy for preorder; harder for postorder.
-pub struct TreeIterator<View> {
-    priv nodes: ~[AbstractNode<View>],
+pub struct TreeIterator {
+    priv nodes: ~[AbstractNode],
     priv index: uint,
 }
 
-impl<View> TreeIterator<View> {
-    fn new(nodes: ~[AbstractNode<View>]) -> TreeIterator<View> {
+impl TreeIterator {
+    fn new(nodes: ~[AbstractNode]) -> TreeIterator {
         TreeIterator {
             nodes: nodes,
             index: 0,
@@ -729,8 +842,8 @@ impl<View> TreeIterator<View> {
     }
 }
 
-impl<View> Iterator<AbstractNode<View>> for TreeIterator<View> {
-    fn next(&mut self) -> Option<AbstractNode<View>> {
+impl Iterator<AbstractNode> for TreeIterator {
+    fn next(&mut self) -> Option<AbstractNode> {
         if self.index >= self.nodes.len() {
             None
         } else {
@@ -741,37 +854,80 @@ impl<View> Iterator<AbstractNode<View>> for TreeIterator<View> {
     }
 }
 
-fn gather<View>(cur: &AbstractNode<View>, refs: &mut ~[AbstractNode<View>], postorder: bool) {
+fn gather_abstract_nodes(cur: &AbstractNode, refs: &mut ~[AbstractNode], postorder: bool) {
     if !postorder {
         refs.push(cur.clone());
     }
     for kid in cur.children() {
-        gather(&kid, refs, postorder)
+        gather_abstract_nodes(&kid, refs, postorder)
     }
     if postorder {
         refs.push(cur.clone());
     }
 }
 
-impl<View> AbstractNode<View> {
+// FIXME: Do this without precomputing a vector of refs.
+// Easy for preorder; harder for postorder.
+//
+// FIXME(pcwalton): Parallelism! Eventually this should just be nuked.
+pub struct LayoutTreeIterator {
+    priv nodes: ~[LayoutNode],
+    priv index: uint,
+}
+
+impl LayoutTreeIterator {
+    fn new(nodes: ~[LayoutNode]) -> LayoutTreeIterator {
+        LayoutTreeIterator {
+            nodes: nodes,
+            index: 0,
+        }
+    }
+}
+
+impl Iterator<LayoutNode> for LayoutTreeIterator {
+    fn next(&mut self) -> Option<LayoutNode> {
+        if self.index >= self.nodes.len() {
+            None
+        } else {
+            let v = self.nodes[self.index].clone();
+            self.index += 1;
+            Some(v)
+        }
+    }
+}
+
+/// FIXME(pcwalton): This is super inefficient.
+fn gather_layout_nodes(cur: &LayoutNode, refs: &mut ~[LayoutNode], postorder: bool) {
+    if !postorder {
+        refs.push(cur.clone());
+    }
+    for kid in cur.children() {
+        gather_layout_nodes(&kid, refs, postorder)
+    }
+    if postorder {
+        refs.push(cur.clone());
+    }
+}
+
+impl AbstractNode {
     /// Iterates over all ancestors of this node.
-    pub fn ancestors(&self) -> AncestorIterator<View> {
+    pub fn ancestors(&self) -> AncestorIterator {
         AncestorIterator {
             current: self.parent_node(),
         }
     }
 
     /// Iterates over this node and all its descendants, in preorder.
-    pub fn traverse_preorder(&self) -> TreeIterator<View> {
+    pub fn traverse_preorder(&self) -> TreeIterator {
         let mut nodes = ~[];
-        gather(self, &mut nodes, false);
+        gather_abstract_nodes(self, &mut nodes, false);
         TreeIterator::new(nodes)
     }
 
     /// Iterates over this node and all its descendants, in postorder.
-    pub fn sequential_traverse_postorder(&self) -> TreeIterator<View> {
+    pub fn sequential_traverse_postorder(&self) -> TreeIterator {
         let mut nodes = ~[];
-        gather(self, &mut nodes, true);
+        gather_abstract_nodes(self, &mut nodes, true);
         TreeIterator::new(nodes)
     }
 }
@@ -780,24 +936,24 @@ impl<View> Node<View> {
     pub fn owner_doc(&self) -> AbstractDocument {
         self.owner_doc.unwrap()
     }
+}
 
+impl Node<ScriptView> {
     pub fn set_owner_doc(&mut self, document: AbstractDocument) {
         self.owner_doc = Some(document);
     }
 
-    pub fn children(&self) -> AbstractNodeChildrenIterator<View> {
+    pub fn children(&self) -> AbstractNodeChildrenIterator {
         AbstractNodeChildrenIterator {
             current_node: self.first_child,
         }
     }
-}
 
-impl Node<ScriptView> {
     pub fn reflect_node<N: Reflectable>
             (node:      @mut N,
              document:  AbstractDocument,
              wrap_fn:   extern "Rust" fn(*JSContext, *JSObject, @mut N) -> *JSObject)
-             -> AbstractNode<ScriptView> {
+             -> AbstractNode {
         assert!(node.reflector().get_jsobject().is_null());
         let node = reflect_dom_object(node, document.document().window, wrap_fn);
         assert!(node.reflector().get_jsobject().is_not_null());
@@ -860,7 +1016,7 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn NodeName(&self, abstract_self: AbstractNode<ScriptView>) -> DOMString {
+    pub fn NodeName(&self, abstract_self: AbstractNode) -> DOMString {
         match self.type_id {
             ElementNodeTypeId(*) => {
                 do abstract_self.with_imm_element |element| {
@@ -894,11 +1050,11 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn GetParentNode(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetParentNode(&self) -> Option<AbstractNode> {
         self.parent_node
     }
 
-    pub fn GetParentElement(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetParentElement(&self) -> Option<AbstractNode> {
         self.parent_node.filtered(|parent| parent.is_element())
     }
 
@@ -906,23 +1062,23 @@ impl Node<ScriptView> {
         self.first_child.is_some()
     }
 
-    pub fn GetFirstChild(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetFirstChild(&self) -> Option<AbstractNode> {
         self.first_child
     }
 
-    pub fn GetLastChild(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetLastChild(&self) -> Option<AbstractNode> {
         self.last_child
     }
 
-    pub fn GetPreviousSibling(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetPreviousSibling(&self) -> Option<AbstractNode> {
         self.prev_sibling
     }
 
-    pub fn GetNextSibling(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetNextSibling(&self) -> Option<AbstractNode> {
         self.next_sibling
     }
 
-    pub fn GetNodeValue(&self, abstract_self: AbstractNode<ScriptView>) -> Option<DOMString> {
+    pub fn GetNodeValue(&self, abstract_self: AbstractNode) -> Option<DOMString> {
         match self.type_id {
             // ProcessingInstruction
             CommentNodeTypeId | TextNodeTypeId => {
@@ -936,11 +1092,12 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn SetNodeValue(&mut self, _abstract_self: AbstractNode<ScriptView>, _val: Option<DOMString>) -> ErrorResult {
+    pub fn SetNodeValue(&mut self, _abstract_self: AbstractNode, _val: Option<DOMString>)
+                        -> ErrorResult {
         Ok(())
     }
 
-    pub fn GetTextContent(&self, abstract_self: AbstractNode<ScriptView>) -> Option<DOMString> {
+    pub fn GetTextContent(&self, abstract_self: AbstractNode) -> Option<DOMString> {
         match self.type_id {
           DocumentFragmentNodeTypeId | ElementNodeTypeId(*) => {
             let mut content = ~"";
@@ -964,7 +1121,7 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn ChildNodes(&mut self, abstract_self: AbstractNode<ScriptView>) -> @mut NodeList {
+    pub fn ChildNodes(&mut self, abstract_self: AbstractNode) -> @mut NodeList {
         match self.child_list {
             None => {
                 let window = self.owner_doc().document().window;
@@ -977,7 +1134,7 @@ impl Node<ScriptView> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-adopt
-    fn adopt(node: AbstractNode<ScriptView>, document: AbstractDocument) {
+    fn adopt(node: AbstractNode, document: AbstractDocument) {
         // Step 1.
         match node.parent_node() {
             Some(parent) => Node::remove(node, parent, false),
@@ -996,11 +1153,9 @@ impl Node<ScriptView> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-pre-insert
-    fn pre_insert(node: AbstractNode<ScriptView>,
-                  parent: AbstractNode<ScriptView>,
-                  child: Option<AbstractNode<ScriptView>>) -> Fallible<AbstractNode<ScriptView>> {
-        fn is_inclusive_ancestor_of(node: AbstractNode<ScriptView>,
-                                    parent: AbstractNode<ScriptView>) -> bool {
+    fn pre_insert(node: AbstractNode, parent: AbstractNode, child: Option<AbstractNode>)
+                  -> Fallible<AbstractNode> {
+        fn is_inclusive_ancestor_of(node: AbstractNode, parent: AbstractNode) -> bool {
             node == parent || parent.ancestors().any(|ancestor| ancestor == node)
         }
 
@@ -1060,7 +1215,7 @@ impl Node<ScriptView> {
         // Step 6.
         match parent.type_id() {
             DocumentNodeTypeId(_) => {
-                fn inclusively_followed_by_doctype(child: Option<AbstractNode<ScriptView>>) -> bool{
+                fn inclusively_followed_by_doctype(child: Option<AbstractNode>) -> bool{
                     match child {
                         Some(child) if child.is_doctype() => true,
                         Some(child) => {
@@ -1159,9 +1314,9 @@ impl Node<ScriptView> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-insert
-    fn insert(node: AbstractNode<ScriptView>,
-              parent: AbstractNode<ScriptView>,
-              child: Option<AbstractNode<ScriptView>>,
+    fn insert(node: AbstractNode,
+              parent: AbstractNode,
+              child: Option<AbstractNode>,
               suppress_observers: bool) {
         // XXX assert owner_doc
         // Step 1-3: ranges.
@@ -1198,8 +1353,7 @@ impl Node<ScriptView> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-replace-all
-    pub fn replace_all(node: Option<AbstractNode<ScriptView>>,
-                       parent: AbstractNode<ScriptView>) {
+    pub fn replace_all(node: Option<AbstractNode>, parent: AbstractNode) {
         // Step 1.
         match node {
             Some(node) => Node::adopt(node, parent.node().owner_doc()),
@@ -1207,7 +1361,7 @@ impl Node<ScriptView> {
         }
 
         // Step 2.
-        let removedNodes: ~[AbstractNode<ScriptView>] = parent.children().collect();
+        let removedNodes: ~[AbstractNode] = parent.children().collect();
 
         // Step 3.
         let addedNodes = match node {
@@ -1241,8 +1395,7 @@ impl Node<ScriptView> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-pre-remove
-    fn pre_remove(child: AbstractNode<ScriptView>,
-                  parent: AbstractNode<ScriptView>) -> Fallible<AbstractNode<ScriptView>> {
+    fn pre_remove(child: AbstractNode, parent: AbstractNode) -> Fallible<AbstractNode> {
         // Step 1.
         if child.parent_node() != Some(parent) {
             return Err(NotFound);
@@ -1256,9 +1409,7 @@ impl Node<ScriptView> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-remove
-    fn remove(node: AbstractNode<ScriptView>,
-              parent: AbstractNode<ScriptView>,
-              suppress_observers: bool) {
+    fn remove(node: AbstractNode, parent: AbstractNode, suppress_observers: bool) {
         assert!(node.parent_node() == Some(parent));
 
         // Step 1-5: ranges.
@@ -1273,9 +1424,8 @@ impl Node<ScriptView> {
         }
     }
 
-    pub fn SetTextContent(&mut self,
-                          abstract_self: AbstractNode<ScriptView>,
-                          value: Option<DOMString>) -> ErrorResult {
+    pub fn SetTextContent(&mut self, abstract_self: AbstractNode, value: Option<DOMString>)
+                          -> ErrorResult {
         let value = null_str_as_empty(&value);
         match self.type_id {
           DocumentFragmentNodeTypeId | ElementNodeTypeId(*) => {
@@ -1305,9 +1455,8 @@ impl Node<ScriptView> {
         Ok(())
     }
 
-    pub fn InsertBefore(&self,
-                        node: AbstractNode<ScriptView>,
-                        child: Option<AbstractNode<ScriptView>>) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn InsertBefore(&self, node: AbstractNode, child: Option<AbstractNode>)
+                        -> Fallible<AbstractNode> {
         Node::pre_insert(node, node, child)
     }
 
@@ -1316,38 +1465,37 @@ impl Node<ScriptView> {
         document.document().wait_until_safe_to_modify_dom();
     }
 
-    pub fn AppendChild(&self,
-                       abstract_self: AbstractNode<ScriptView>,
-                       node: AbstractNode<ScriptView>) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn AppendChild(&self, abstract_self: AbstractNode, node: AbstractNode)
+                       -> Fallible<AbstractNode> {
         Node::pre_insert(node, abstract_self, None)
     }
 
-    pub fn ReplaceChild(&mut self, _node: AbstractNode<ScriptView>, _child: AbstractNode<ScriptView>) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn ReplaceChild(&mut self, _node: AbstractNode, _child: AbstractNode)
+                        -> Fallible<AbstractNode> {
         fail!("stub")
     }
 
-    pub fn RemoveChild(&self,
-                       abstract_self: AbstractNode<ScriptView>,
-                       node: AbstractNode<ScriptView>) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn RemoveChild(&self, abstract_self: AbstractNode, node: AbstractNode)
+                       -> Fallible<AbstractNode> {
         Node::pre_remove(node, abstract_self)
     }
 
     pub fn Normalize(&mut self) {
     }
 
-    pub fn CloneNode(&self, _deep: bool) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn CloneNode(&self, _deep: bool) -> Fallible<AbstractNode> {
         fail!("stub")
     }
 
-    pub fn IsEqualNode(&self, _node: Option<AbstractNode<ScriptView>>) -> bool {
+    pub fn IsEqualNode(&self, _node: Option<AbstractNode>) -> bool {
         false
     }
 
-    pub fn CompareDocumentPosition(&self, _other: AbstractNode<ScriptView>) -> u16 {
+    pub fn CompareDocumentPosition(&self, _other: AbstractNode) -> u16 {
         0
     }
 
-    pub fn Contains(&self, _other: Option<AbstractNode<ScriptView>>) -> bool {
+    pub fn Contains(&self, _other: Option<AbstractNode>) -> bool {
         false
     }
 
@@ -1384,31 +1532,31 @@ impl Node<ScriptView> {
     // Low-level pointer stitching
     //
 
-    pub fn set_parent_node(&mut self, new_parent_node: Option<AbstractNode<ScriptView>>) {
+    pub fn set_parent_node(&mut self, new_parent_node: Option<AbstractNode>) {
         let doc = self.owner_doc();
         doc.document().wait_until_safe_to_modify_dom();
         self.parent_node = new_parent_node
     }
 
-    pub fn set_first_child(&mut self, new_first_child: Option<AbstractNode<ScriptView>>) {
+    pub fn set_first_child(&mut self, new_first_child: Option<AbstractNode>) {
         let doc = self.owner_doc();
         doc.document().wait_until_safe_to_modify_dom();
         self.first_child = new_first_child
     }
 
-    pub fn set_last_child(&mut self, new_last_child: Option<AbstractNode<ScriptView>>) {
+    pub fn set_last_child(&mut self, new_last_child: Option<AbstractNode>) {
         let doc = self.owner_doc();
         doc.document().wait_until_safe_to_modify_dom();
         self.last_child = new_last_child
     }
 
-    pub fn set_prev_sibling(&mut self, new_prev_sibling: Option<AbstractNode<ScriptView>>) {
+    pub fn set_prev_sibling(&mut self, new_prev_sibling: Option<AbstractNode>) {
         let doc = self.owner_doc();
         doc.document().wait_until_safe_to_modify_dom();
         self.prev_sibling = new_prev_sibling
     }
 
-    pub fn set_next_sibling(&mut self, new_next_sibling: Option<AbstractNode<ScriptView>>) {
+    pub fn set_next_sibling(&mut self, new_next_sibling: Option<AbstractNode>) {
         let doc = self.owner_doc();
         doc.document().wait_until_safe_to_modify_dom();
         self.next_sibling = new_next_sibling
@@ -1428,12 +1576,12 @@ impl Reflectable for Node<ScriptView> {
 /// A bottom-up, parallelizable traversal.
 pub trait PostorderNodeTraversal {
     /// The operation to perform. Return true to continue or false to stop.
-    fn process(&self, node: AbstractNode<LayoutView>) -> bool;
+    fn process(&self, node: LayoutNode) -> bool;
 
     /// Returns true if this node should be pruned. If this returns true, we skip the operation
     /// entirely and do not process any descendant nodes. This is called *before* child nodes are
     /// visited. The default implementation never prunes any nodes.
-    fn should_prune(&self, _node: AbstractNode<LayoutView>) -> bool {
+    fn should_prune(&self, _node: LayoutNode) -> bool {
         false
     }
 }
@@ -1441,18 +1589,17 @@ pub trait PostorderNodeTraversal {
 /// A bottom-up, parallelizable traversal.
 pub trait PostorderNodeMutTraversal {
     /// The operation to perform. Return true to continue or false to stop.
-    fn process(&mut self, node: AbstractNode<LayoutView>) -> bool;
+    fn process(&mut self, node: LayoutNode) -> bool;
 
     /// Returns true if this node should be pruned. If this returns true, we skip the operation
     /// entirely and do not process any descendant nodes. This is called *before* child nodes are
     /// visited. The default implementation never prunes any nodes.
-    fn should_prune(&self, _node: AbstractNode<LayoutView>) -> bool {
+    fn should_prune(&self, _node: LayoutNode) -> bool {
         false
     }
 }
 
-
-impl AbstractNode<LayoutView> {
+impl LayoutNode {
     /// Traverses the tree in postorder.
     ///
     /// TODO(pcwalton): Offer a parallel version with a compatible API.

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -25,7 +25,6 @@ use std::cast::transmute;
 use std::cast;
 use std::unstable::raw::Box;
 use std::util;
-use style::TNode;
 
 //
 // The basic Node structure

--- a/src/components/script/dom/nodelist.rs
+++ b/src/components/script/dom/nodelist.rs
@@ -4,12 +4,12 @@
 
 use dom::bindings::codegen::NodeListBinding;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 use dom::window::Window;
 
 enum NodeListType {
-    Simple(~[AbstractNode<ScriptView>]),
-    Children(AbstractNode<ScriptView>)
+    Simple(~[AbstractNode]),
+    Children(AbstractNode)
 }
 
 pub struct NodeList {
@@ -34,11 +34,11 @@ impl NodeList {
                            window, NodeListBinding::Wrap)
     }
 
-    pub fn new_simple_list(window: @mut Window, elements: ~[AbstractNode<ScriptView>]) -> @mut NodeList {
+    pub fn new_simple_list(window: @mut Window, elements: ~[AbstractNode]) -> @mut NodeList {
         NodeList::new(window, Simple(elements))
     }
 
-    pub fn new_child_list(window: @mut Window, node: AbstractNode<ScriptView>) -> @mut NodeList {
+    pub fn new_child_list(window: @mut Window, node: AbstractNode) -> @mut NodeList {
         NodeList::new(window, Children(node))
     }
 
@@ -49,7 +49,7 @@ impl NodeList {
         }
     }
 
-    pub fn Item(&self, index: u32) -> Option<AbstractNode<ScriptView>> {
+    pub fn Item(&self, index: u32) -> Option<AbstractNode> {
         match self.list_type {
             _ if index >= self.Length() => None,
             Simple(ref elems) => Some(elems[index]),
@@ -57,7 +57,7 @@ impl NodeList {
         }
     }
 
-    pub fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<AbstractNode<ScriptView>> {
+    pub fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<AbstractNode> {
         let item = self.Item(index);
         *found = item.is_some();
         item

--- a/src/components/script/dom/text.rs
+++ b/src/components/script/dom/text.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::TextBinding;
 use dom::bindings::utils::{DOMString, Fallible};
 use dom::characterdata::CharacterData;
 use dom::document::AbstractDocument;
-use dom::node::{AbstractNode, ScriptView, Node, TextNodeTypeId};
+use dom::node::{AbstractNode, Node, TextNodeTypeId};
 use dom::window::Window;
 
 /// An HTML text node.
@@ -21,16 +21,16 @@ impl Text {
         }
     }
 
-    pub fn new(text: ~str, document: AbstractDocument) -> AbstractNode<ScriptView> {
+    pub fn new(text: ~str, document: AbstractDocument) -> AbstractNode {
         let node = Text::new_inherited(text, document);
         Node::reflect_node(@mut node, document, TextBinding::Wrap)
     }
 
-    pub fn Constructor(owner: @mut Window, text: DOMString) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn Constructor(owner: @mut Window, text: DOMString) -> Fallible<AbstractNode> {
         Ok(Text::new(text.clone(), owner.Document()))
     }
 
-    pub fn SplitText(&self, _offset: u32) -> Fallible<AbstractNode<ScriptView>> {
+    pub fn SplitText(&self, _offset: u32) -> Fallible<AbstractNode> {
         fail!("unimplemented")
     }
 

--- a/src/components/script/dom/uievent.rs
+++ b/src/components/script/dom/uievent.rs
@@ -5,7 +5,7 @@
 use dom::bindings::codegen::UIEventBinding;
 use dom::bindings::utils::{DOMString, Fallible};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 use dom::event::{AbstractEvent, Event, EventTypeId, UIEventTypeId};
 use dom::window::Window;
 use dom::windowproxy::WindowProxy;
@@ -85,7 +85,7 @@ impl UIEvent {
         0
     }
 
-    pub fn GetRangeParent(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetRangeParent(&self) -> Option<AbstractNode> {
         //TODO
         None
     }

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -8,7 +8,7 @@ use dom::bindings::utils::{trace_option, trace_reflector};
 use dom::bindings::utils::DOMString;
 use dom::document::AbstractDocument;
 use dom::eventtarget::{EventTarget, WindowTypeId};
-use dom::node::{AbstractNode, ScriptView};
+use dom::node::AbstractNode;
 use dom::location::Location;
 use dom::navigator::Navigator;
 
@@ -114,7 +114,7 @@ impl Window {
     pub fn Blur(&self) {
     }
 
-    pub fn GetFrameElement(&self) -> Option<AbstractNode<ScriptView>> {
+    pub fn GetFrameElement(&self) -> Option<AbstractNode> {
         None
     }
 

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -6,7 +6,7 @@
 /// coupling between these two components, and enables the DOM to be placed in a separate crate
 /// from layout.
 
-use dom::node::{AbstractNode, LayoutDataRef, LayoutView, ScriptView};
+use dom::node::{AbstractNode, LayoutDataRef};
 
 use extra::url::Url;
 use geom::point::Point2D;
@@ -51,16 +51,16 @@ pub enum Msg {
 /// Synchronous messages that script can send to layout.
 pub enum LayoutQuery {
     /// Requests the dimensions of the content box, as in the `getBoundingClientRect()` call.
-    ContentBoxQuery(AbstractNode<ScriptView>, Chan<ContentBoxResponse>),
+    ContentBoxQuery(AbstractNode, Chan<ContentBoxResponse>),
     /// Requests the dimensions of all the content boxes, as in the `getClientRects()` call.
-    ContentBoxesQuery(AbstractNode<ScriptView>, Chan<ContentBoxesResponse>),
+    ContentBoxesQuery(AbstractNode, Chan<ContentBoxesResponse>),
     /// Requests the node containing the point of interest
-    HitTestQuery(AbstractNode<ScriptView>, Point2D<f32>, Chan<Result<HitTestResponse, ()>>),
+    HitTestQuery(AbstractNode, Point2D<f32>, Chan<Result<HitTestResponse, ()>>),
 }
 
 pub struct ContentBoxResponse(Rect<Au>);
 pub struct ContentBoxesResponse(~[Rect<Au>]);
-pub struct HitTestResponse(AbstractNode<LayoutView>);
+pub struct HitTestResponse(AbstractNode);
 
 /// Determines which part of the 
 #[deriving(Eq, Ord)]
@@ -85,7 +85,7 @@ impl DocumentDamageLevel {
 /// Note that this is fairly coarse-grained and is separate from layout's notion of the document
 pub struct DocumentDamage {
     /// The topmost node in the tree that has changed.
-    root: AbstractNode<ScriptView>,
+    root: AbstractNode,
     /// The amount of damage that occurred.
     level: DocumentDamageLevel,
 }
@@ -102,7 +102,7 @@ pub enum ReflowGoal {
 /// Information needed for a reflow.
 pub struct Reflow {
     /// The document node.
-    document_root: AbstractNode<ScriptView>,
+    document_root: AbstractNode,
     /// The style changes that need to be done.
     damage: DocumentDamage,
     /// The goal of reflow: either to render to the screen or to flush layout info for script.

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -52,7 +52,6 @@ use std::ptr;
 use std::str::eq_slice;
 use std::task::{spawn_sched, SingleThreaded};
 use std::util::replace;
-use style::{TElement, TNode};
 
 /// Messages used to control the script task.
 pub enum ScriptMsg {

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -26,7 +26,6 @@ use layout_interface::{Reflow, ReflowDocumentDamage, ReflowForDisplay, ReflowGoa
 use layout_interface::ContentChangedDocumentDamage;
 use layout_interface;
 
-use dom::node::ScriptView;
 use extra::url::Url;
 use geom::point::Point2D;
 use geom::size::Size2D;
@@ -133,7 +132,7 @@ pub struct Page {
     resize_event: Option<Size2D<uint>>,
 
     /// Pending scroll to fragment event, if any
-    fragment_node: Option<AbstractNode<ScriptView>>
+    fragment_node: Option<AbstractNode>
 }
 
 pub struct PageTree {
@@ -804,7 +803,7 @@ impl ScriptTask {
         page.fragment_node = fragment.map_default(None, |fragid| self.find_fragment_node(page, fragid));
     }
 
-    fn find_fragment_node(&self, page: &mut Page, fragid: ~str) -> Option<AbstractNode<ScriptView>> {
+    fn find_fragment_node(&self, page: &mut Page, fragid: ~str) -> Option<AbstractNode> {
         let document = page.frame.expect("root frame is None").document; 
         match document.document().GetElementById(fragid.to_owned()) {
             Some(node) => Some(node),
@@ -823,7 +822,7 @@ impl ScriptTask {
         }
     }
 
-    fn scroll_fragment_point(&self, pipeline_id: PipelineId, page: &mut Page, node: AbstractNode<ScriptView>) {
+    fn scroll_fragment_point(&self, pipeline_id: PipelineId, page: &mut Page, node: AbstractNode) {
         let (port, chan) = comm::stream();
         match page.query_layout(ContentBoxQuery(node, chan), port) {
             ContentBoxResponse(rect) => {

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! Traits that nodes must implement. Breaks the otherwise-cyclic dependency between script and
+//! Traits that nodes must implement. Breaks the otherwise-cyclic dependency between layout and
 //! style.
 
-/// FIXME(pcwalton): Should not require `Clone` and should instead return references. When this
-/// happens this will need to only be implemented for `AbstractNode<LayoutView>`.
 pub trait TNode<E:TElement> : Clone {
     fn parent_node(&self) -> Option<Self>;
     fn prev_sibling(&self) -> Option<Self>;


### PR DESCRIPTION
This changeset gets rid of the `FooView` phantom type in favor of a more brute force approach that just whitelists methods that layout is allowed to call. The set is surprisingly small now that layout isn't going to the DOM for much.

If this approach turns out not to scale, we can do something fancier, but I'd rather just have it be safe and secure first and then refactor later for programmer happiness.

r? @kmcallister
