### PR TITLE
Make Node::is_in_doc O(1)

### DIFF
--- a/src/components/script/macros.rs
+++ b/src/components/script/macros.rs
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[macro_escape];
+
+macro_rules! bitfield(
+    ($bitfieldname:ident, $getter:ident, $setter:ident, $value:expr) => (
+        impl $bitfieldname {
+            #[inline]
+            pub fn $getter(self) -> bool {
+                (*self & $value) != 0
+            }
+
+            #[inline]
+            pub fn $setter(&mut self, value: bool) {
+                *self = $bitfieldname((**self & !$value) | (if value { $value } else { 0 }))
+            }
+        }
+    )
+)
+

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -23,6 +23,9 @@ extern mod style;
 extern mod servo_msg (name = "msg");
 extern mod extra;
 
+// Macros
+mod macros;
+
 pub mod dom {
     pub mod bindings {
         pub mod element;


### PR DESCRIPTION
Added a flags variable inside Node to represent boolean flags, with
is_in_doc being the first of them. It is updated whenever a node is
appended or removed from a parent.

This patch is for:
https://github.com/mozilla/servo/issues/1030
