### PR TITLE
Re-enable parallel selector matching.

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -8,6 +8,7 @@ use std::cell::Cell;
 use std::comm;
 use std::task;
 use std::vec;
+use std::rt;
 use extra::arc::{Arc, RWArc};
 
 use css::node_style::StyledNode;
@@ -43,9 +44,7 @@ impl MatchMethods for AbstractNode<LayoutView> {
         }
     }
     fn match_subtree(&self, stylist: RWArc<Stylist>) {
-        // FIXME(pcwalton): Racy. Parallel CSS selector matching is disabled.
-        //let num_tasks = rt::default_sched_threads() * 2;
-        let num_tasks = 1;
+        let num_tasks = rt::default_sched_threads() * 2;
         let mut node_count = 0;
         let mut nodes_per_task = vec::from_elem(num_tasks, ~[]);
 


### PR DESCRIPTION
The problems that were caused because of Yellow River seem to be fixed.

(See #1319).
