### PR TITLE
Fix #1435: em units in font-size

### DIFF
--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -1140,7 +1140,12 @@ pub fn cascade(applicable_declarations: &[Arc<~[PropertyDeclaration]>],
         % for style_struct, longhands in LONGHANDS_PER_STYLE_STRUCT:
             ${style_struct}: style_structs::${style_struct} {
                 % for longhand in longhands:
-                    ${longhand.ident}: get_computed!(${style_struct}, ${longhand.ident}),
+                    ${longhand.ident}:
+                    % if longhand.ident == 'font_size':
+                        context.font_size,
+                    % else:
+                        get_computed!(${style_struct}, ${longhand.ident}),
+                    % endif
                 % endfor
             },
         % endfor

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -20,3 +20,4 @@
 == text_decoration_propagation_a.html text_decoration_propagation_b.html
 == inline_text_align_a.html inline_text_align_b.html
 == font_size_em.html font_size_em_ref.html
+== font_size_percentage.html font_size_em_ref.html

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -19,3 +19,4 @@
 == acid1_a.html acid1_b.html
 == text_decoration_propagation_a.html text_decoration_propagation_b.html
 == inline_text_align_a.html inline_text_align_b.html
+== font_size_em.html font_size_em_ref.html

--- a/src/test/ref/font_size_em.html
+++ b/src/test/ref/font_size_em.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>font-size: 2em (Bug #1435)</title>
+    <style type="text/css">
+      body { font-size: 20px; }
+      p { font-size: 2em; }
+    </style>
+  </head>
+  <body>
+    <p>This text should be 40px high.</p>
+  </body>
+</html>

--- a/src/test/ref/font_size_em_ref.html
+++ b/src/test/ref/font_size_em_ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>font-size: 2em (Bug #1435)</title>
+    <style type="text/css">
+      p { font-size: 40px; }
+    </style>
+  </head>
+  <body>
+    <p>This text should be 40px high.</p>
+  </body>
+</html>

--- a/src/test/ref/font_size_percentage.html
+++ b/src/test/ref/font_size_percentage.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>font-size: 200% (Bug #1435)</title>
+    <style type="text/css">
+      body { font-size: 20px }
+      p { font-size: 200%; }
+    </style>
+  </head>
+  <body>
+    <p>This text should be 40px high.</p>
+  </body>
+</html>


### PR DESCRIPTION
Font-based units in the font-size property refer to the font-size of the parent, not itself.
