### PR TITLE
Fix font-weight propery

### DIFF
--- a/src/components/gfx/font.rs
+++ b/src/components/gfx/font.rs
@@ -15,7 +15,7 @@ use std::rc::RcMut;
 use servo_util::cache::{Cache, HashCache};
 use servo_util::range::Range;
 use servo_util::time::ProfilerChan;
-use style::computed_values::text_decoration;
+use style::computed_values::{text_decoration, font_weight};
 
 use color::Color;
 use font_context::FontContext;
@@ -41,7 +41,7 @@ pub trait FontHandleMethods {
     fn family_name(&self) -> ~str;
     fn face_name(&self) -> ~str;
     fn is_italic(&self) -> bool;
-    fn boldness(&self) -> CSSFontWeight;
+    fn boldness(&self) -> font_weight::T;
 
     fn clone_with_style(&self, fctx: &FontContextHandle, style: &UsedFontStyle)
                      -> Result<FontHandle, ()>;
@@ -90,29 +90,6 @@ pub struct FontMetrics {
     max_advance:      Au
 }
 
-// TODO(Issue #200): use enum from CSS bindings for 'font-weight'
-#[deriving(Clone, Eq)]
-pub enum CSSFontWeight {
-    FontWeight100,
-    FontWeight200,
-    FontWeight300,
-    FontWeight400,
-    FontWeight500,
-    FontWeight600,
-    FontWeight700,
-    FontWeight800,
-    FontWeight900,
-}
-
-impl CSSFontWeight {
-    pub fn is_bold(self) -> bool {
-        match self {
-            FontWeight900 | FontWeight800 | FontWeight700 | FontWeight600 => true,
-            _ => false
-        }
-    }
-}
-
 // TODO(Issue #179): eventually this will be split into the specified
 // and used font styles.  specified contains uninterpreted CSS font
 // property values, while 'used' is attached to gfx::Font to descript
@@ -122,7 +99,7 @@ impl CSSFontWeight {
 #[deriving(Clone, Eq)]
 pub struct FontStyle {
     pt_size: f64,
-    weight: CSSFontWeight,
+    weight: font_weight::T,
     italic: bool,
     oblique: bool,
     families: ~str,

--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -11,6 +11,7 @@ use servo_util::time::ProfilerChan;
 
 use platform::font::FontHandle;
 use platform::font_context::FontContextHandle;
+use style::computed_values::font_weight;
 
 use azure::azure_hl::BackendType;
 use std::hashmap::HashMap;
@@ -20,10 +21,9 @@ use std::rc::RcMut;
 // TODO(Rust #3934): creating lots of new dummy styles is a workaround
 // for not being able to store symbolic enums in top-level constants.
 pub fn dummy_style() -> FontStyle {
-    use font::FontWeight300;
     return FontStyle {
         pt_size: 20f64,
-        weight: FontWeight300,
+        weight: font_weight::Weight300,
         italic: false,
         oblique: false,
         families: ~"serif, sans-serif",

--- a/src/components/gfx/font_list.rs
+++ b/src/components/gfx/font_list.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use font::{CSSFontWeight, SpecifiedFontStyle};
+use font::SpecifiedFontStyle;
 use gfx_font::FontHandleMethods;
 use platform::font::FontHandle;
 use platform::font_context::FontContextHandle;
@@ -10,6 +10,7 @@ use platform::font_list::FontListHandle;
 use servo_util::time;
 use servo_util::time::profile;
 use servo_util::time::ProfilerChan;
+use style::computed_values::font_weight;
 
 use std::hashmap::HashMap;
 
@@ -132,7 +133,7 @@ impl<'self> FontFamily {
 /// standard four faces: Normal, Bold, Italic, BoldItalic.
 pub struct FontEntry {
     face_name: ~str,
-    priv weight: CSSFontWeight,
+    priv weight: font_weight::T,
     priv italic: bool,
     handle: FontHandle,
     // TODO: array of OpenType features, etc.

--- a/src/components/gfx/platform/android/font.rs
+++ b/src/components/gfx/platform/android/font.rs
@@ -4,15 +4,14 @@
 
 extern mod freetype;
 
-use font::{CSSFontWeight, FontHandleMethods, FontMetrics, FontTableMethods};
-use font::{FontTableTag, FractionalPixel, SpecifiedFontStyle, UsedFontStyle, FontWeight100};
-use font::{FontWeight200, FontWeight300, FontWeight400, FontWeight500, FontWeight600};
-use font::{FontWeight700, FontWeight800, FontWeight900};
+use font::{FontHandleMethods, FontMetrics, FontTableMethods};
+use font::{FontTableTag, FractionalPixel, SpecifiedFontStyle, UsedFontStyle};
 use servo_util::geometry::Au;
 use servo_util::geometry;
 use platform::font_context::FontContextHandle;
 use text::glyph::GlyphIndex;
 use text::util::{float_to_fixed, fixed_to_float};
+use style::computed_values::font_weight;
 
 use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
 use freetype::freetype::{FT_Load_Glyph, FT_Set_Char_Size};
@@ -140,8 +139,8 @@ impl FontHandleMethods for FontHandle {
         unsafe { (*self.face).style_flags & FT_STYLE_FLAG_ITALIC != 0 }
     }
     #[fixed_stack_segment]
-    fn boldness(&self) -> CSSFontWeight {
-        let default_weight = FontWeight400;
+    fn boldness(&self) -> font_weight::T {
+        let default_weight = font_weight::Weight400;
         if unsafe { (*self.face).style_flags & FT_STYLE_FLAG_BOLD == 0 } {
             default_weight
         } else {
@@ -151,15 +150,15 @@ impl FontHandleMethods for FontHandle {
                 if valid {
                     let weight =(*os2).usWeightClass;
                     match weight {
-                        1 | 100..199 => FontWeight100,
-                        2 | 200..299 => FontWeight200,
-                        3 | 300..399 => FontWeight300,
-                        4 | 400..499 => FontWeight400,
-                        5 | 500..599 => FontWeight500,
-                        6 | 600..699 => FontWeight600,
-                        7 | 700..799 => FontWeight700,
-                        8 | 800..899 => FontWeight800,
-                        9 | 900..999 => FontWeight900,
+                        1 | 100..199 => font_weight::Weight100,
+                        2 | 200..299 => font_weight::Weight200,
+                        3 | 300..399 => font_weight::Weight300,
+                        4 | 400..499 => font_weight::Weight400,
+                        5 | 500..599 => font_weight::Weight500,
+                        6 | 600..699 => font_weight::Weight600,
+                        7 | 700..799 => font_weight::Weight700,
+                        8 | 800..899 => font_weight::Weight800,
+                        9 | 900..999 => font_weight::Weight900,
                         _ => default_weight
                     }
                 } else {

--- a/src/components/gfx/platform/linux/font.rs
+++ b/src/components/gfx/platform/linux/font.rs
@@ -4,15 +4,14 @@
 
 extern mod freetype;
 
-use font::{CSSFontWeight, FontHandleMethods, FontMetrics, FontTableMethods};
-use font::{FontTableTag, FractionalPixel, SpecifiedFontStyle, UsedFontStyle, FontWeight100};
-use font::{FontWeight200, FontWeight300, FontWeight400, FontWeight500, FontWeight600};
-use font::{FontWeight700, FontWeight800, FontWeight900};
+use font::{FontHandleMethods, FontMetrics, FontTableMethods};
+use font::{FontTableTag, FractionalPixel, SpecifiedFontStyle, UsedFontStyle};
 use servo_util::geometry::Au;
 use servo_util::geometry;
 use platform::font_context::FontContextHandle;
 use text::glyph::GlyphIndex;
 use text::util::{float_to_fixed, fixed_to_float};
+use style::computed_values::font_weight;
 
 use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
 use freetype::freetype::{FT_Load_Glyph, FT_Set_Char_Size};
@@ -138,8 +137,8 @@ impl FontHandleMethods for FontHandle {
         unsafe { (*self.face).style_flags & FT_STYLE_FLAG_ITALIC != 0 }
     }
     #[fixed_stack_segment]
-    fn boldness(&self) -> CSSFontWeight {
-        let default_weight = FontWeight400;
+    fn boldness(&self) -> font_weight::T {
+        let default_weight = font_weight::Weight400;
         if unsafe { (*self.face).style_flags & FT_STYLE_FLAG_BOLD == 0 } {
             default_weight
         } else {
@@ -149,15 +148,15 @@ impl FontHandleMethods for FontHandle {
                 if valid {
                     let weight =(*os2).usWeightClass;
                     match weight {
-                        1 | 100..199 => FontWeight100,
-                        2 | 200..299 => FontWeight200,
-                        3 | 300..399 => FontWeight300,
-                        4 | 400..499 => FontWeight400,
-                        5 | 500..599 => FontWeight500,
-                        6 | 600..699 => FontWeight600,
-                        7 | 700..799 => FontWeight700,
-                        8 | 800..899 => FontWeight800,
-                        9 | 900..999 => FontWeight900,
+                        1 | 100..199 => font_weight::Weight100,
+                        2 | 200..299 => font_weight::Weight200,
+                        3 | 300..399 => font_weight::Weight300,
+                        4 | 400..499 => font_weight::Weight400,
+                        5 | 500..599 => font_weight::Weight500,
+                        6 | 600..699 => font_weight::Weight600,
+                        7 | 700..799 => font_weight::Weight700,
+                        8 | 800..899 => font_weight::Weight800,
+                        9 | 900..999 => font_weight::Weight900,
                         _ => default_weight
                     }
                 } else {

--- a/src/components/gfx/platform/macos/font.rs
+++ b/src/components/gfx/platform/macos/font.rs
@@ -8,14 +8,14 @@ extern mod core_foundation;
 extern mod core_graphics;
 extern mod core_text;
 
-use font::{CSSFontWeight, FontHandleMethods, FontMetrics, FontTableMethods};
-use font::{FontTableTag, FontWeight100, FontWeight200, FontWeight300, FontWeight400};
-use font::{FontWeight500, FontWeight600, FontWeight700, FontWeight800, FontWeight900};
+use font::{FontHandleMethods, FontMetrics, FontTableMethods};
+use font::FontTableTag;
 use font::{FractionalPixel, SpecifiedFontStyle};
 use servo_util::geometry::{Au, px_to_pt};
 use servo_util::geometry;
 use platform::macos::font_context::FontContextHandle;
 use text::glyph::GlyphIndex;
+use style::computed_values::font_weight;
 
 use core_foundation::base::CFIndex;
 use core_foundation::data::CFData;
@@ -104,20 +104,20 @@ impl FontHandleMethods for FontHandle {
         self.ctfont.symbolic_traits().is_italic()
     }
 
-    fn boldness(&self) -> CSSFontWeight {
+    fn boldness(&self) -> font_weight::T {
         // -1.0 to 1.0
         let normalized = self.ctfont.all_traits().normalized_weight();
         // 0.0 to 9.0
         let normalized = (normalized + 1.0) / 2.0 * 9.0;
-        if normalized < 1.0 { return FontWeight100; }
-        if normalized < 2.0 { return FontWeight200; }
-        if normalized < 3.0 { return FontWeight300; }
-        if normalized < 4.0 { return FontWeight400; }
-        if normalized < 5.0 { return FontWeight500; }
-        if normalized < 6.0 { return FontWeight600; }
-        if normalized < 7.0 { return FontWeight700; }
-        if normalized < 8.0 { return FontWeight800; }
-        return FontWeight900;
+        if normalized < 1.0 { return font_weight::Weight100; }
+        if normalized < 2.0 { return font_weight::Weight200; }
+        if normalized < 3.0 { return font_weight::Weight300; }
+        if normalized < 4.0 { return font_weight::Weight400; }
+        if normalized < 5.0 { return font_weight::Weight500; }
+        if normalized < 6.0 { return font_weight::Weight600; }
+        if normalized < 7.0 { return font_weight::Weight700; }
+        if normalized < 8.0 { return font_weight::Weight800; }
+        return font_weight::Weight900;
     }
 
     fn clone_with_style(&self, fctx: &FontContextHandle, style: &SpecifiedFontStyle)

--- a/src/components/main/layout/box.rs
+++ b/src/components/main/layout/box.rs
@@ -13,7 +13,8 @@ use gfx::display_list::{DisplayList, ImageDisplayItem, ImageDisplayItemClass};
 use gfx::display_list::{SolidColorDisplayItem, SolidColorDisplayItemClass, TextDisplayItem};
 use gfx::display_list::{TextDisplayItemClass, TextDisplayItemFlags, ClipDisplayItem};
 use gfx::display_list::{ClipDisplayItemClass};
-use gfx::font::{FontStyle, FontWeight300};
+use gfx::font::FontStyle;
+
 use gfx::text::text_run::TextRun;
 use servo_msg::constellation_msg::{FrameRectMsg, PipelineId, SubpageId};
 use servo_net::image::holder::ImageHolder;
@@ -415,9 +416,11 @@ impl Box {
             font_style::oblique => (false, true),
         };
 
+        let font_weight = my_style.Font.font_weight;
+
         FontStyle {
             pt_size: font_size,
-            weight: FontWeight300,
+            weight: font_weight,
             italic: italic,
             oblique: oblique,
             families: font_families,

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -554,6 +554,14 @@ pub mod longhands {
                     Weight${weight},
                 % endfor
             }
+            impl T {
+                pub fn is_bold(self) -> bool {
+                    match self {
+                        Weight900 | Weight800 | Weight700 | Weight600 => true,
+                        _ => false
+                    }
+                }
+            }
         }
         #[inline] pub fn get_initial_value() -> computed_value::T { Weight400 }  // normal
         pub fn to_computed_value(value: SpecifiedValue, context: &computed::Context)


### PR DESCRIPTION
Currently, hard coded value(FontWeight300) is used for font-weight property.
To display it properly, use parsed CSS font-weight value.
