### PR TITLE
Make Element::set_attribute not lower-case the name argument.

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -162,17 +162,18 @@ impl<'self> Element {
 
     pub fn set_attr(&mut self, abstract_self: AbstractNode, name: DOMString, value: DOMString)
                     -> ErrorResult {
+        // FIXME: HTML-in-HTML only.
+        let name = name.to_ascii_lower();
         self.set_attribute(abstract_self, namespace::Null, name, value)
     }
 
     pub fn set_attribute(&mut self,
                          abstract_self: AbstractNode,
                          namespace: Namespace,
-                         raw_name: DOMString,
+                         name: DOMString,
                          value: DOMString) -> ErrorResult {
         //FIXME: Throw for XML-invalid names
         //FIXME: Throw for XMLNS-invalid names
-        let name = raw_name.to_ascii_lower();
         let (prefix, local_name) = if name.contains(":")  {
             let parts: ~[&str] = name.splitn_iter(':', 1).collect();
             (Some(parts[0].to_owned()), parts[1].to_owned())
@@ -279,6 +280,7 @@ impl Element {
     }
     pub fn set_string_attribute(&mut self, abstract_self: AbstractNode,
                                 name: &str, value: DOMString) {
+        assert!(name == name.to_ascii_lower());
         self.set_attribute(abstract_self, Null, name.to_owned(), value);
     }
 }

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -8,7 +8,6 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlheadingelement::{Heading1, Heading2, Heading3, Heading4, Heading5, Heading6};
 use dom::htmliframeelement::IFrameSize;
 use dom::htmlformelement::HTMLFormElement;
-use dom::namespace;
 use dom::namespace::Null;
 use dom::node::{AbstractNode, ElementNodeTypeId};
 use dom::types::*;
@@ -336,10 +335,9 @@ pub fn parse_html(cx: *JSContext,
             debug!("-- attach attrs");
             do node.as_mut_element |element| {
                 for attr in tag.attributes.iter() {
-                    element.set_attribute(node,
-                                          namespace::Null,
-                                          attr.name.clone(),
-                                          attr.value.clone());
+                    element.set_attr(node,
+                                     attr.name.clone(),
+                                     attr.value.clone());
                 }
             }
 


### PR DESCRIPTION
In particular, for SetAttributeNS, we should not change the case.
