### PR TITLE
Implement Node::replaceChild()

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -308,6 +308,7 @@ DOMInterfaces = {
     'pointerType': '',
     'needsAbstract': [
         'appendChild',
+        'replaceChild',
         'nodeName',
         'nodeValue',
         'removeChild',

--- a/src/test/html/content/test_document_body.html
+++ b/src/test/html/content/test_document_body.html
@@ -11,7 +11,6 @@
                 is(document.body && document.body.tagName, "BODY", "test1-2, existing document's body");
             }
 
-            /* TODO: Depends on https://github.com/mozilla/servo/issues/1430
             // test2: replace document's body with new body
             {
                 let new_body = document.createElement("body");
@@ -27,7 +26,6 @@
                 document.body = new_frameset;
                 is(new_frameset, document.body, "test2-1, replace document's body with new frameset");
             }
-            */
 
             // test4: append an invalid element to a new document
             {

--- a/src/test/html/content/test_node_replaceChild.html
+++ b/src/test/html/content/test_node_replaceChild.html
@@ -1,0 +1,31 @@
+<html>
+    <head>
+        <script src="harness.js"></script>
+    </head>
+    <body>
+        <script>
+            // test1: 1-to-1
+            {
+                var root = document.createElement("div");
+                var elem = document.createElement("div");
+                var foo = document.createTextNode("foo");
+                var bar = document.createTextNode("bar");
+
+                elem.appendChild(bar);
+                elem.replaceChild(bar, bar);
+                is(elem.childNodes[0], bar, "test1-0, 1-to-1");
+
+                root.appendChild(foo);
+                root.replaceChild(bar, foo);
+                is(elem.childNodes.length, 0, "test1-1, 1-to-1");
+                is(root.childNodes[0], bar, "test1-2, 1-to-1");
+
+                elem.appendChild(foo);
+                root.replaceChild(elem, bar);
+                is(root.childNodes[0].childNodes[0], foo, "test1-3, 1-to-1");
+            }
+
+            finish();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Implements Node:replaceChild() according to spec below:
http://dom.spec.whatwg.org/#concept-node-replace

This patch is for:
https://github.com/mozilla/servo/issues/1430
