### PR TITLE
Fix to avoid attribute name clash between Document/HTMLDocument

### DIFF
--- a/src/components/script/dom/bindings/codegen/HTMLDocument.webidl
+++ b/src/components/script/dom/bindings/codegen/HTMLDocument.webidl
@@ -17,7 +17,7 @@ interface HTMLDocument : Document {
   // getter object (DOMString name);
   /*[SetterThrows]
     attribute HTMLElement? body;*/
-  readonly attribute HTMLHeadElement? head;
+  // readonly attribute HTMLHeadElement? head;
   readonly attribute HTMLCollection images;
   readonly attribute HTMLCollection embeds;
   readonly attribute HTMLCollection plugins;

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -306,12 +306,13 @@ impl Document {
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-head
     pub fn GetHead(&self) -> Option<AbstractNode> {
         self.get_html_element().and_then(|root| {
-            root.traverse_preorder().find(|child| {
+            root.children().find(|child| {
                 child.type_id() == ElementNodeTypeId(HTMLHeadElementTypeId)
             })
         })
     }
 
+    // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-body
     pub fn GetBody(&self, _: AbstractDocument) -> Option<AbstractNode> {
         match self.get_html_element() {
             None => None,

--- a/src/components/script/dom/htmldocument.rs
+++ b/src/components/script/dom/htmldocument.rs
@@ -33,14 +33,6 @@ impl HTMLDocument {
 }
 
 impl HTMLDocument {
-    pub fn GetHead(&self) -> Option<AbstractNode> {
-        self.parent.GetDocumentElement().and_then(|root| {
-            root.traverse_preorder().find(|child| {
-                child.type_id() == ElementNodeTypeId(HTMLHeadElementTypeId)
-            })
-        })
-    }
-
     pub fn Images(&self) -> @mut HTMLCollection {
         self.parent.createHTMLCollection(|elem| eq_slice(elem.tag_name, "img"))
     }

--- a/src/test/html/content/test_document_head.html
+++ b/src/test/html/content/test_document_head.html
@@ -29,6 +29,17 @@
                 is(new_document.head, new_head, "test2-4, append head to a new document");
             }
 
+            // test3: head's parent should be document element
+            {
+                let new_document = new Document();
+                let html = new_document.createElement("html");
+                let foo = new_document.createElement("foo");
+                let head = new_document.createElement("head");
+                new_document.appendChild(html);
+                html.appendChild(foo);
+                foo.appendChild(head);
+                is(new_document.head, null, "test3-0, head's parent should be document element");
+            }
             finish();
         </script>
     </body>


### PR DESCRIPTION
Use children() instead of traverse_preorder(), and avoid having
GetHead() in both Document and HTMLDocument.

Closes #1465.
