### PR TITLE
Add DOMImplementation skeleton

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -160,6 +160,10 @@ DOMInterfaces = {
     ],
 },
 
+'DOMImplementation': {
+    'nativeType': 'DOMImplementation',
+},
+
 'DOMParser': {
     'nativeType': 'DOMParser',
 },

--- a/src/components/script/dom/bindings/codegen/DOMImplementation.webidl
+++ b/src/components/script/dom/bindings/codegen/DOMImplementation.webidl
@@ -1,0 +1,26 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * http://dom.spec.whatwg.org/#interface-domimplementation
+ *
+ * Copyright:
+ * To the extent possible under law, the editors have waived all copyright and
+ * related or neighboring rights to this work.
+ */
+
+interface DOMImplementation {
+  /*boolean hasFeature(DOMString feature,
+                     [TreatNullAs=EmptyString] DOMString version);*/
+  /*[Throws]
+  DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId,
+                                  DOMString systemId);*/
+  /*[Throws]
+  Document createDocument(DOMString? namespace,
+                          [TreatNullAs=EmptyString] DOMString qualifiedName,
+                          optional DocumentType? doctype = null);*/
+  /*[Throws]
+  Document createHTMLDocument(optional DOMString title);*/
+};

--- a/src/components/script/dom/bindings/codegen/Document.webidl
+++ b/src/components/script/dom/bindings/codegen/Document.webidl
@@ -25,8 +25,7 @@ enum VisibilityState { "hidden", "visible" };
 /* http://dom.spec.whatwg.org/#interface-document */
 [Constructor]
 interface Document : Node {
-  /*[Throws]
-    readonly attribute DOMImplementation implementation;*/
+  readonly attribute DOMImplementation implementation;
   // readonly attribute DOMString URL;
   // readonly attribute DOMString documentURI;
   // readonly attribute DOMString compatMode;

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -9,6 +9,7 @@ use dom::bindings::utils::{ErrorResult, Fallible, NotSupported, InvalidCharacter
 use dom::bindings::utils::DOMString;
 use dom::bindings::utils::{xml_name_type, InvalidXMLName};
 use dom::documentfragment::DocumentFragment;
+use dom::domimplementation::DOMImplementation;
 use dom::element::{Element};
 use dom::element::{HTMLHtmlElementTypeId, HTMLHeadElementTypeId, HTMLTitleElementTypeId, HTMLBodyElementTypeId, HTMLFrameSetElementTypeId};
 use dom::event::{AbstractEvent, Event};
@@ -87,7 +88,8 @@ pub struct Document {
     window: @mut Window,
     doctype: DocumentType,
     title: ~str,
-    idmap: HashMap<DOMString, AbstractNode>
+    idmap: HashMap<DOMString, AbstractNode>,
+    implementation: Option<@mut DOMImplementation>
 }
 
 impl Document {
@@ -119,7 +121,8 @@ impl Document {
             window: window,
             doctype: doctype,
             title: ~"",
-            idmap: HashMap::new()
+            idmap: HashMap::new(),
+            implementation: None
         }
     }
 
@@ -156,6 +159,13 @@ impl Reflectable for Document {
 }
 
 impl Document {
+    pub fn Implementation(&mut self) -> @mut DOMImplementation {
+        if self.implementation.is_none() {
+            self.implementation = Some(DOMImplementation::new(self.window));
+        }
+        self.implementation.unwrap()
+    }
+
     pub fn GetDoctype(&self) -> Option<AbstractNode> {
         self.node.children().find(|child| child.is_doctype())
     }

--- a/src/components/script/dom/domimplementation.rs
+++ b/src/components/script/dom/domimplementation.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::DOMImplementationBinding;
+use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};
+use dom::window::Window;
+
+pub struct DOMImplementation {
+    owner: @mut Window,
+    reflector_: Reflector
+}
+
+impl DOMImplementation {
+    pub fn new_inherited(owner: @mut Window) -> DOMImplementation {
+        DOMImplementation {
+            owner: owner,
+            reflector_: Reflector::new()
+        }
+    }
+
+    pub fn new(owner: @mut Window) -> @mut DOMImplementation {
+        reflect_dom_object(@mut DOMImplementation::new_inherited(owner), owner,
+                           DOMImplementationBinding::Wrap)
+    }
+}
+
+impl Reflectable for DOMImplementation {
+    fn reflector<'a>(&'a self) -> &'a Reflector {
+        &self.reflector_
+    }
+
+    fn mut_reflector<'a>(&'a mut self) -> &'a mut Reflector {
+        &mut self.reflector_
+    }
+}

--- a/src/components/script/script.rc
+++ b/src/components/script/script.rc
@@ -55,6 +55,7 @@ pub mod dom {
     pub mod document;
     pub mod documentfragment;
     pub mod documenttype;
+    pub mod domimplementation;
     pub mod domparser;
     pub mod element;
     pub mod event;

--- a/src/test/html/content/test_document_implementation.html
+++ b/src/test/html/content/test_document_implementation.html
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <script src="harness.js"></script>
+        <script>
+            // test1: basic test
+            {
+                isnot(document.implementation, null, "test1-0, basic test");
+                is_a(document.implementation, DOMImplementation, "test1-1, basic test");
+
+                var implementation = document.implementation;
+                is(document.implementation, implementation, "test1-2, basic test");
+            }
+
+            finish();
+        </script>
+    </head>
+</html>


### PR DESCRIPTION
Creates a DOMImplementation struct corresponding to DOMImplementation
WebIDL. Also implements a getter for Document::implementation.

Closes #1486.
