### PR TITLE
Remove Document's unused 'title'

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -87,7 +87,6 @@ pub struct Document {
     reflector_: Reflector,
     window: @mut Window,
     doctype: DocumentType,
-    title: ~str,
     idmap: HashMap<DOMString, AbstractNode>,
     implementation: Option<@mut DOMImplementation>
 }
@@ -120,7 +119,6 @@ impl Document {
             reflector_: Reflector::new(),
             window: window,
             doctype: doctype,
-            title: ~"",
             idmap: HashMap::new(),
             implementation: None
         }


### PR DESCRIPTION
There is no current use for this variable.

This is a subtask for #1428.
