### PR TITLE
Add the Rust crate map to the servo library and dependency on libuv

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -328,7 +328,7 @@ servo:	$(DEPS_servo)
 else
 servo:  $(DEPS_servo)
 	@$(call E, compile: $@)
-	$(Q)$(RUSTC) $(RFLAGS_servo) -o $@ $< --lib
+	$(Q)$(RUSTC) $(RFLAGS_servo) -o -Z gen-crate-map $@ $< --lib
 endif
 
 # Darwin app packaging

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -20,6 +20,8 @@ extern mod js;
 extern mod layers;
 extern mod opengles;
 extern mod png;
+#[cfg(target_os="android")]
+extern mod rustuv;
 extern mod script;
 extern mod servo_net = "net";
 extern mod servo_msg = "msg";


### PR DESCRIPTION
These two fixes are required for Android. We need to generate a toplevel crate map because it is used by both debugging and the libuv stuff. We also need to manually link against rustuv because we cannot dynamically inject it on Android.

r? @metajack
