### PR TITLE
layout: Destroy flows properly under `display: none`.

### DIFF
--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -12,8 +12,8 @@ use layout::construct::{FlowConstructionResult, FlowConstructor, NoConstructionR
 use layout::context::{LayoutContext, SharedLayoutInfo};
 use layout::display_list_builder::{DisplayListBuilder, ToGfxColor};
 use layout::extra::LayoutAuxMethods;
-use layout::flow::{Flow, ImmutableFlowUtils, LeafSet, MutableFlowUtils, PreorderFlowTraversal};
-use layout::flow::{PostorderFlowTraversal};
+use layout::flow::{Flow, ImmutableFlowUtils, LeafSet, MutableFlowUtils, MutableOwnedFlowUtils};
+use layout::flow::{PreorderFlowTraversal, PostorderFlowTraversal};
 use layout::flow;
 use layout::incremental::RestyleDamage;
 use layout::parallel::{AssignHeightsAndStoreOverflowTraversalKind, BubbleWidthsTraversalKind};
@@ -590,10 +590,7 @@ impl LayoutTask {
             });
         }
 
-        // FIXME(pcwalton): Hack because we don't yet reference count flows. When we do reference
-        // count them, then the destructor should remove the flow from the leaf set once the count
-        // hits zero.
-        self.leaf_set.access(|leaf_set| leaf_set.clear());
+        self.leaf_set.access(|leaf_set| layout_root.destroy(leaf_set));
 
         // Tell script that we're done.
         //


### PR DESCRIPTION
Fixes a crash on http://en.wikipedia.org/wiki/South_China_Sea

It plants a destructor bomb on flows so that this can't happen again.

r? @larsbergstrom
