### PR TITLE
Move servo-android-glue submodule to mozilla-servo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -115,4 +115,4 @@
 	url = https://github.com/mozilla-servo/rust-egl.git
 [submodule "src/platform/android/servo-android-glue"]
 	path = src/platform/android/servo-android-glue
-	url = https://github.com/webconvforge/servo-android-glue.git
+	url = https://github.com/mozilla-servo/servo-android-glue.git


### PR DESCRIPTION
For some reason the webconvforge organization is the cause of many API
failures. They seem to be sporadic but no one has any idea why it
happens.
