### PR TITLE
Fix white-space property(pre)

### DIFF
--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -1283,14 +1283,12 @@ impl Box {
                 let right_range = Range::new(text_box_info.range.begin() + cur_new_line_pos + 1, text_box_info.range.length() - (cur_new_line_pos + 1));
 
                 // Left box is for left text of first founded new-line character.
-                let left_box = if left_range.length() > 0 {
+                let left_box = {
                     let new_text_box_info = ScannedTextBoxInfo::new(text_box_info.run.clone(), left_range);
                     let new_metrics = new_text_box_info.run.get().metrics_for_range(&left_range);
                     let mut new_box = self.transform(new_metrics.bounding_box.size, ScannedTextBox(new_text_box_info));
                     new_box.new_line_pos = ~[];
                     Some(new_box)
-                } else {
-                    None
                 };
 
                 // Right box is for right text of first founded new-line character.

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -327,10 +327,7 @@ impl LineboxScanner {
                         (Some(left_box), None) => {
                             self.push_box_to_line(left_box);
                         }
-                        (None, Some(right_box)) => {
-                            self.work_list.push_front(right_box);
-                        }
-                        (None, None) => error!("LineboxScanner: This split case makes no sense!"),
+                        _ => error!("LineboxScanner: This split case makes no sense!"),
                     }
                 }
                 _ => {}


### PR DESCRIPTION
If html has empty line, it is not handled currently.
Because pending line is empty in such case, flushing current line doesn't care empty line.
For example, below html has two empty line(line 2 and line 4)

<div>
test1

test2

</div>


To handle empty line, added empty box to pending line.
