### PR TITLE
Supporting preliminary fixed-layout table

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -578,7 +578,7 @@ impl Flow for BlockFlow {
 
         /* find max width from child block contexts */
         for child_ctx in self.base.child_iter() {
-            assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow() || child_ctx.starts_table_flow());
+            assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow() || child_ctx.is_table_kind());
 
             let child_base = flow::mut_base(*child_ctx);
             min_width = geometry::max(min_width, child_base.min_width);
@@ -709,7 +709,7 @@ impl Flow for BlockFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -288,7 +288,7 @@ impl BlockFlow {
                                    margin_top: &mut Au,
                                    margin_bottom: &mut Au,
                                    top_margin_collapsible: bool,
-                                   bottom_margin_collapsible: bool) {
+                                   bottom_margin_collapsible: bool) -> Au {
         let mut first_in_flow = true;
         let mut collapsing = Au::new(0);
         let mut collapsible = if top_margin_collapsible {
@@ -321,7 +321,7 @@ impl BlockFlow {
             Au::new(0)
         };
 
-        *cur_y = *cur_y - collapsing;
+        collapsing
     }
 
     /// In case of inorder assign_height traversal, 'assign_height's of all children are visited.
@@ -436,12 +436,12 @@ impl BlockFlow {
 
         let mut cur_y = top_offset;
         let mut top_offset = top_offset;
-        self.compute_margin_collapse(&mut cur_y,
-                                     &mut top_offset,
-                                     &mut margin_top,
-                                     &mut margin_bottom,
-                                     top_margin_collapsible,
-                                     bottom_margin_collapsible);
+        let collapsing = self.compute_margin_collapse(&mut cur_y,
+                                                      &mut top_offset,
+                                                      &mut margin_top,
+                                                      &mut margin_bottom,
+                                                      top_margin_collapsible,
+                                                      bottom_margin_collapsible);
 
         // TODO: A box's own margins collapse if the 'min-height' property is zero, and it has neither
         // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
@@ -456,7 +456,7 @@ impl BlockFlow {
             // infrastructure to make it scrollable.
             Au::max(screen_height, cur_y)
         } else {
-            cur_y - top_offset
+            cur_y - top_offset - collapsing
         };
 
         let mut border_and_padding = Au::new(0);

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -545,19 +545,14 @@ impl Box {
             }
         }
 
-        match self.specific {
-            GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableColumnBox(_) | TableCellBox |
-            TableRowBox | TableWrapperBox | ScannedTextBox(_) | UnscannedTextBox(_) => {
-                self.border.set(SideOffsets2D::new(width(style.Border.border_top_width,
-                                                         style.Border.border_top_style),
-                                                   width(style.Border.border_right_width,
-                                                         style.Border.border_right_style),
-                                                   width(style.Border.border_bottom_width,
-                                                         style.Border.border_bottom_style),
-                                                   width(style.Border.border_left_width,
-                                                         style.Border.border_left_style)))
-            }
-        }
+        self.border.set(SideOffsets2D::new(width(style.Border.border_top_width,
+                                                 style.Border.border_top_style),
+                                           width(style.Border.border_right_width,
+                                                 style.Border.border_right_style),
+                                           width(style.Border.border_bottom_width,
+                                                 style.Border.border_bottom_style),
+                                           width(style.Border.border_left_width,
+                                                 style.Border.border_left_style)))
     }
 
     pub fn compute_positioned_offsets(&self, style: &ComputedValues, containing_width: Au, containing_height: Au) {

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -546,8 +546,7 @@ impl Box {
         }
 
         match self.specific {
-            TableColumnBox(_) => {}
-            GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
+            GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableColumnBox(_) | TableCellBox |
             TableRowBox | TableWrapperBox | ScannedTextBox(_) | UnscannedTextBox(_) => {
                 self.border.set(SideOffsets2D::new(width(style.Border.border_top_width,
                                                          style.Border.border_top_style),
@@ -1522,10 +1521,7 @@ impl Box {
     pub fn assign_width(&self,container_width: Au) {
         match self.specific {
             GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
-            TableWrapperBox => {
-                // FIXME(pcwalton): This seems clownshoes; can we remove?
-                self.position.borrow_mut().get().size.width = Au::from_px(45)
-            }
+            TableWrapperBox => {}
             ImageBox(ref image_box_info) => {
                 // TODO(ksh8281): compute border,margin,padding
                 let width = ImageBoxInfo::style_length(self.style().Box.width,
@@ -1563,7 +1559,7 @@ impl Box {
                 position.get().size.width = position.get().size.width + self.noncontent_width() +
                     self.noncontent_inline_left() + self.noncontent_inline_right();
             }
-            TableColumnBox(_) => fail!("Table column boxes do not have wdith"),
+            TableColumnBox(_) => fail!("Table column boxes do not have width"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }
     }

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -366,6 +366,36 @@ impl Box {
         }
     }
 
+    /// Constructs a new `Box` instance for an anonymous table object.
+    pub fn new_anonymous_table_box(node: LayoutNode, specific: SpecificBoxInfo) -> Box {
+        // The `node` is the nearest ancestor element of the anonymous table object.
+        // Take its inherited style.
+        // CSS 2.1 § 17.2.1 This is for non-inherited properties on anonymous table boxes
+        // example:
+        //
+        //     <div style="display: table">
+        //         Foo
+        //     </div>
+        //
+        // Anonymous table boxes, TableRowBox and TableCellBox, are generated around `Foo`, but it shouldn't inherit the border.
+
+        let node_style = Arc::new(cascade(&[Arc::new(~[])],
+                                          Some(node.style().get())));
+
+        Box {
+            node: OpaqueNode::from_layout_node(&node),
+            style: node_style,
+            position: RefCell::new(Au::zero_rect()),
+            border: RefCell::new(Zero::zero()),
+            padding: RefCell::new(Zero::zero()),
+            margin: RefCell::new(Zero::zero()),
+            specific: specific,
+            position_offsets: RefCell::new(Zero::zero()),
+            inline_info: RefCell::new(None),
+            new_line_pos: ~[],
+        }
+    }
+
     /// Returns a debug ID of this box. This ID should not be considered stable across multiple
     /// layouts or box manipulations.
     pub fn debug_id(&self) -> uint {

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -532,6 +532,13 @@ impl Box {
         }
     }
 
+    pub fn compute_borders_if_necessary(&self, style: &ComputedValues) {
+        match self.specific {
+            TableWrapperBox | TableColumnBox(_) => {},
+            _ => self.compute_borders(style)
+        }
+    }
+
     /// Populates the box model border parameters from the given computed style.
     ///
     /// FIXME(pcwalton): This should not be necessary. Just go to the style.
@@ -599,19 +606,43 @@ impl Box {
     }
 
     pub fn noncontent_left(&self) -> Au {
-        self.margin.get().left + self.border.get().left + self.padding.get().left
+        match self.specific {
+            TableWrapperBox => self.margin.get().left,
+            TableBox | TableCellBox => self.border.get().left + self.padding.get().left,
+            TableRowBox => self.border.get().left,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().left + self.border.get().left + self.padding.get().left
+        }
     }
 
     pub fn noncontent_right(&self) -> Au {
-        self.margin.get().right + self.border.get().right + self.padding.get().right
+        match self.specific {
+            TableWrapperBox => self.margin.get().right,
+            TableBox | TableCellBox => self.border.get().right + self.padding.get().right,
+            TableRowBox => self.border.get().right,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().right + self.border.get().right + self.padding.get().right
+        }
     }
 
     pub fn noncontent_top(&self) -> Au {
-        self.margin.get().top + self.border.get().top + self.padding.get().top
+        match self.specific {
+            TableWrapperBox => self.margin.get().top,
+            TableBox | TableCellBox => self.border.get().top + self.padding.get().top,
+            TableRowBox => self.border.get().top,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().top + self.border.get().top + self.padding.get().top
+        }
     }
 
     pub fn noncontent_bottom(&self) -> Au {
-        self.margin.get().bottom + self.border.get().bottom + self.padding.get().bottom
+        match self.specific {
+            TableWrapperBox => self.margin.get().bottom,
+            TableBox | TableCellBox => self.border.get().bottom + self.padding.get().bottom,
+            TableRowBox => self.border.get().bottom,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().bottom + self.border.get().bottom + self.padding.get().bottom
+        }
     }
 
     pub fn noncontent_inline_left(&self) -> Au {
@@ -827,7 +858,13 @@ impl Box {
 
     /// Returns the sum of margin, border, and padding on the left.
     pub fn offset(&self) -> Au {
-        self.margin.get().left + self.border.get().left + self.padding.get().left
+        match self.specific {
+            TableWrapperBox => self.margin.get().left,
+            TableBox | TableCellBox => self.border.get().left + self.padding.get().left,
+            TableRowBox => self.border.get().left,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().left + self.border.get().left + self.padding.get().left
+        }
     }
 
     /// Returns true if this element is replaced content. This is true for images, form elements,

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -23,8 +23,8 @@
 use css::node_style::StyledNode;
 use layout::block::BlockFlow;
 use layout::box_::{Box, GenericBox, IframeBox, IframeBoxInfo, ImageBox, ImageBoxInfo};
+use layout::box_::{TableCellBox, TableColumnBox, TableColumnBoxInfo, TableRowBox};
 use layout::box_::{UnscannedTextBox, UnscannedTextBoxInfo, InlineInfo, InlineParentInfo};
-use layout::box_::{TableColBox, TableColBoxInfo};
 use layout::context::LayoutContext;
 use layout::float_context::FloatType;
 use layout::flow::{BaseFlow, Flow, LeafSet, MutableOwnedFlowUtils, ImmutableFlowUtils};
@@ -40,7 +40,10 @@ use layout::util::{LayoutDataAccess, OpaqueNode};
 use layout::wrapper::{LayoutNode, PostorderNodeMutTraversal};
 
 use gfx::font_context::FontContext;
-use script::dom::element::{HTMLIframeElementTypeId, HTMLImageElementTypeId, HTMLTableColElementTypeId};
+use script::dom::element::{HTMLIframeElementTypeId, HTMLImageElementTypeId};
+use script::dom::element::{HTMLTableDataCellElementTypeId};
+use script::dom::element::{HTMLTableHeaderCellElementTypeId, HTMLTableColElementTypeId};
+use script::dom::element::{HTMLTableRowElementTypeId, HTMLTableSectionElementTypeId};
 use script::dom::node::{CommentNodeTypeId, DoctypeNodeTypeId, DocumentFragmentNodeTypeId};
 use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, TextNodeTypeId};
 use style::computed_values::{display, position, float};
@@ -263,7 +266,11 @@ impl<'fc> FlowConstructor<'fc> {
                 }
             }
             ElementNodeTypeId(HTMLIframeElementTypeId) => IframeBox(IframeBoxInfo::new(&node)),
-            ElementNodeTypeId(HTMLTableColElementTypeId) => TableColBox(TableColBoxInfo::new(&node)),
+            ElementNodeTypeId(HTMLTableColElementTypeId) => TableColumnBox(TableColumnBoxInfo::new(&node)),
+            ElementNodeTypeId(HTMLTableDataCellElementTypeId) |
+            ElementNodeTypeId(HTMLTableHeaderCellElementTypeId) => TableCellBox,
+            ElementNodeTypeId(HTMLTableRowElementTypeId) |
+            ElementNodeTypeId(HTMLTableSectionElementTypeId) => TableRowBox,
             TextNodeTypeId => UnscannedTextBox(UnscannedTextBoxInfo::new(&node)),
             _ => GenericBox,
         };
@@ -735,8 +742,8 @@ impl<'fc> FlowConstructor<'fc> {
             }
         }
         if col_boxes.is_empty() {
-            debug!("add TableColBox for empty colgroup");
-            let specific = TableColBox(TableColBoxInfo::new(&node));
+            debug!("add TableColumnBox for empty colgroup");
+            let specific = TableColumnBox(TableColumnBoxInfo::new(&node));
             col_boxes.push( Box::new(node, specific) );
         }
         let flow = ~TableColGroupFlow::from_box(base, box_, col_boxes) as ~Flow;

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -812,7 +812,7 @@ impl<'fc> FlowConstructor<'fc> {
 
         let table_base = BaseFlow::new(self.next_flow_id(), node);
         let table_box_ = Box::new(node, TableBox);
-        let mut table_flow = ~TableFlow::from_box(table_base, table_box_, is_fixed) as ~Flow;
+        let mut table_flow = ~TableFlow::from_box(table_base, table_box_) as ~Flow;
         self.layout_context.leaf_set.access(|leaf_set| leaf_set.insert(&table_flow));
 
         // We first populate the TableFlow with other flows than TableCaptionFlow.

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -24,6 +24,7 @@ use css::node_style::StyledNode;
 use layout::block::BlockFlow;
 use layout::box_::{Box, GenericBox, IframeBox, IframeBoxInfo, ImageBox, ImageBoxInfo};
 use layout::box_::{UnscannedTextBox, UnscannedTextBoxInfo, InlineInfo, InlineParentInfo};
+use layout::box_::{TableColBox, TableColBoxInfo};
 use layout::context::LayoutContext;
 use layout::float_context::FloatType;
 use layout::flow::{BaseFlow, Flow, LeafSet, MutableOwnedFlowUtils};
@@ -261,6 +262,7 @@ impl<'fc> FlowConstructor<'fc> {
                 }
             }
             ElementNodeTypeId(HTMLIframeElementTypeId) => IframeBox(IframeBoxInfo::new(&node)),
+            ElementNodeTypeId(HTMLTableColElementTypeId) => TableColBox(TableColBoxInfo::new(&node)),
             TextNodeTypeId => UnscannedTextBox(UnscannedTextBoxInfo::new(&node)),
             _ => GenericBox,
         };
@@ -700,7 +702,8 @@ impl<'fc> FlowConstructor<'fc> {
         }
         if col_boxes.is_empty() {
             debug!("add TableColBox for empty colgroup");
-            col_boxes.push( Box::new(node, GenericBox) );
+            let specific = TableColBox(TableColBoxInfo::new(&node));
+            col_boxes.push( Box::new(node, specific) );
         }
         let flow = ~TableColGroupFlow::from_box(base, box_, col_boxes) as ~Flow;
 

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -727,6 +727,7 @@ impl<'fc> FlowConstructor<'fc> {
                     if flow.need_anonymous_flow(kid_flow) {
                         consecutive_siblings.push(kid_flow);
                     } else {
+                        strip_ignorable_whitespace_from_end(&mut opt_boxes_for_inline_flow);
                         self.flush_inline_boxes_to_flow_list_if_necessary(&mut opt_boxes_for_inline_flow,
                                                                           &mut consecutive_siblings,
                                                                           node);

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -98,8 +98,7 @@ impl ConstructionItem {
                     }
                 }
             }
-            TableColumnBoxConstructionItem(_) => {
-            }
+            TableColumnBoxConstructionItem(_) => {}
         }
     }
 }

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -480,7 +480,7 @@ impl<'fc> FlowConstructor<'fc> {
                                                   -> ConstructionResult {
         let mut opt_inline_block_splits = None;
         let mut opt_box_accumulator = None;
- 
+
         // Concatenate all the boxes of our kids, creating {ib} splits as necessary.
         for kid in node.children() {
             match kid.swap_out_construction_result() {
@@ -833,10 +833,10 @@ impl<'fc> FlowConstructor<'fc> {
 
     /// Builds a flow for a node with `display: table-caption`. This yields a `TableCaptionFlow`
     /// with possibly other `BlockFlow`s or `InlineFlow`s underneath it.
-    fn build_flow_for_table_caption(&mut self, node: LayoutNode, is_fixed: bool) -> ~Flow {
+    fn build_flow_for_table_caption(&mut self, node: LayoutNode) -> ~Flow {
         let base = BaseFlow::new(self.next_flow_id(), node);
         let box_ = self.build_box_for_node(node);
-        let mut flow = ~TableCaptionFlow::from_box(base, box_, is_fixed) as ~Flow;
+        let mut flow = ~TableCaptionFlow::from_box(base, box_) as ~Flow;
 
         self.layout_context.leaf_set.access(|leaf_set| leaf_set.insert(&flow));
 
@@ -846,10 +846,10 @@ impl<'fc> FlowConstructor<'fc> {
 
     /// Builds a flow for a node with `display: table-row-group`. This yields a `TableRowGroupFlow`
     /// with possibly other `TableRowFlow`s underneath it.
-    fn build_flow_for_table_rowgroup(&mut self, node: LayoutNode, is_fixed: bool) -> ~Flow {
+    fn build_flow_for_table_rowgroup(&mut self, node: LayoutNode) -> ~Flow {
         let base = BaseFlow::new(self.next_flow_id(), node);
         let box_ = Box::new(node, TableRowBox);
-        let mut flow = ~TableRowGroupFlow::from_box(base, box_, is_fixed) as ~Flow;
+        let mut flow = ~TableRowGroupFlow::from_box(base, box_) as ~Flow;
 
         self.layout_context.leaf_set.access(|leaf_set| leaf_set.insert(&flow));
 
@@ -859,10 +859,10 @@ impl<'fc> FlowConstructor<'fc> {
 
     /// Builds a flow for a node with `display: table-row`. This yields a `TableRowFlow` with
     /// possibly other `TableCellFlow`s underneath it.
-    fn build_flow_for_table_row(&mut self, node: LayoutNode, is_fixed: bool) -> ~Flow {
+    fn build_flow_for_table_row(&mut self, node: LayoutNode) -> ~Flow {
         let base = BaseFlow::new(self.next_flow_id(), node);
         let box_ = Box::new(node, TableRowBox);
-        let mut flow = ~TableRowFlow::from_box(base, box_, is_fixed) as ~Flow;
+        let mut flow = ~TableRowFlow::from_box(base, box_) as ~Flow;
 
         self.layout_context.leaf_set.access(|leaf_set| leaf_set.insert(&flow));
 
@@ -872,10 +872,10 @@ impl<'fc> FlowConstructor<'fc> {
 
     /// Builds a flow for a node with `display: table-cell`. This yields a `TableCellFlow` with
     /// possibly other `BlockFlow`s or `InlineFlow`s underneath it.
-    fn build_flow_for_table_cell(&mut self, node: LayoutNode, is_fixed: bool) -> ~Flow {
+    fn build_flow_for_table_cell(&mut self, node: LayoutNode) -> ~Flow {
         let base = BaseFlow::new(self.next_flow_id(), node);
         let box_ = Box::new(node, TableCellBox);
-        let mut flow = ~TableCellFlow::from_box(base, box_, is_fixed) as ~Flow;
+        let mut flow = ~TableCellFlow::from_box(base, box_) as ~Flow;
 
         self.layout_context.leaf_set.access(|leaf_set| leaf_set.insert(&flow));
 
@@ -974,7 +974,7 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
 
             // Table items contribute table flow construction results.
             (display::table_caption, _, _) => {
-                let flow = self.build_flow_for_table_caption(node, false);
+                let flow = self.build_flow_for_table_caption(node);
                 node.set_flow_construction_result(FlowConstructionResult(flow))
             }
 
@@ -993,19 +993,19 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
             // Table items contribute table flow construction results.
             (display::table_row_group, _, _) | (display::table_header_group, _, _) |
             (display::table_footer_group, _, _) => {
-                let flow = self.build_flow_for_table_rowgroup(node, false);
+                let flow = self.build_flow_for_table_rowgroup(node);
                 node.set_flow_construction_result(FlowConstructionResult(flow))
             }
 
             // Table items contribute table flow construction results.
             (display::table_row, _, _) => {
-                let flow = self.build_flow_for_table_row(node, false);
+                let flow = self.build_flow_for_table_row(node);
                 node.set_flow_construction_result(FlowConstructionResult(flow))
             }
 
             // Table items contribute table flow construction results.
             (display::table_cell, _, _) => {
-                let flow = self.build_flow_for_table_cell(node, false);
+                let flow = self.build_flow_for_table_cell(node);
                 node.set_flow_construction_result(FlowConstructionResult(flow))
             }
 

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -680,11 +680,11 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
         match self.class() {
             TableFlowClass | TableRowGroupFlowClass => {
                 let box_ = Box::new_anonymous_table_box(node, TableRowBox);
-                ~TableRowFlow::from_box(base, box_, false) as ~Flow
+                ~TableRowFlow::from_box(base, box_) as ~Flow
             },
             TableRowFlowClass => {
                 let box_ = Box::new_anonymous_table_box(node, TableCellBox);
-                ~TableCellFlow::from_box(base, box_, false) as ~Flow
+                ~TableCellFlow::from_box(base, box_) as ~Flow
             },
             _ => {
                 fail!("no need to generate a missing child")

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -200,6 +200,12 @@ pub trait ImmutableFlowUtils {
     /// Returns true if this flow is a child of table flow.
     fn is_child_of_table_flow(self) -> bool;
 
+    /// Returns true if this flow is a table colgroup flow.
+    fn is_table_colgroup(self) -> bool;
+
+    /// Returns true if this flow is a table rowgroup flow.
+    fn is_table_rowgroup(self) -> bool;
+
     /// Returns true if this flow has no children.
     fn is_leaf(self) -> bool;
 
@@ -639,6 +645,22 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
         match self.class() {
             TableColGroupFlowClass | TableRowGroupFlowClass => true,
             BlockFlowClass | InlineFlowClass | TableWrapperFlowClass |
+                TableFlowClass | TableRowFlowClass | TableCellFlowClass => false,
+        }
+    }
+
+    fn is_table_colgroup(self) -> bool {
+        match self.class() {
+            TableColGroupFlowClass => true,
+            BlockFlowClass | InlineFlowClass | TableWrapperFlowClass |
+                TableFlowClass | TableRowFlowClass | TableRowGroupFlowClass | TableCellFlowClass => false,
+        }
+    }
+
+    fn is_table_rowgroup(self) -> bool {
+        match self.class() {
+            TableRowGroupFlowClass => true,
+            BlockFlowClass | InlineFlowClass | TableColGroupFlowClass | TableWrapperFlowClass |
                 TableFlowClass | TableRowFlowClass | TableCellFlowClass => false,
         }
     }

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -885,12 +885,12 @@ impl<'a> MutableFlowUtils for &'a mut Flow {
         match self.class() {
             BlockFlowClass => self.as_block().build_display_list_block(builder, dirty, list),
             InlineFlowClass => self.as_inline().build_display_list_inline(builder, dirty, list),
-            TableWrapperFlowClass => self.as_table_wrapper().build_display_list_table(builder, dirty, list),
+            TableWrapperFlowClass => self.as_table_wrapper().build_display_list_table_wrapper(builder, dirty, list),
             TableFlowClass => self.as_table().build_display_list_table(builder, dirty, list),
-            TableRowGroupFlowClass => self.as_table_rowgroup().build_display_list_table(builder, dirty, list),
-            TableRowFlowClass => self.as_table_row().build_display_list_table(builder, dirty, list),
-            TableCaptionFlowClass => self.as_table_caption().build_display_list_table(builder, dirty, list),
-            TableCellFlowClass => self.as_table_cell().build_display_list_table(builder, dirty, list),
+            TableRowGroupFlowClass => self.as_table_rowgroup().build_display_list_table_rowgroup(builder, dirty, list),
+            TableRowFlowClass => self.as_table_row().build_display_list_table_row(builder, dirty, list),
+            TableCaptionFlowClass => self.as_table_caption().build_display_list_table_caption(builder, dirty, list),
+            TableCellFlowClass => self.as_table_cell().build_display_list_table_cell(builder, dirty, list),
             TableColGroupFlowClass => false,
         };
 

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use css::node_style::StyledNode;
-use layout::box_::{Box, CannotSplit, GenericBox, IframeBox, ImageBox, ScannedTextBox, SplitDidFit};
+use layout::box_::{Box, CannotSplit, GenericBox, IframeBox, ImageBox, ScannedTextBox, SplitDidFit, TableColBox};
 use layout::box_::{SplitDidNotFit, UnscannedTextBox, InlineInfo};
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
@@ -774,7 +774,7 @@ impl Flow for InlineFlow {
 
                         (text_offset, line_height - text_offset, text_ascent)
                     },
-                    GenericBox | IframeBox(_) => {
+                    GenericBox | IframeBox(_) | TableColBox(_) => {
                         let height = cur_box.position.get().size.height;
                         (height, Au::new(0), height)
                     },

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -4,8 +4,8 @@
 
 use css::node_style::StyledNode;
 use layout::box_::{Box, CannotSplit, GenericBox, IframeBox, InlineInfo, ImageBox};
-use layout::box_::{ScannedTextBox, SplitDidFit, SplitDidNotFit};
-use layout::box_::{TableCellBox, TableColumnBox, TableRowBox, UnscannedTextBox};
+use layout::box_::{ScannedTextBox, SplitDidFit, SplitDidNotFit, TableBox, TableCellBox};
+use layout::box_::{TableColumnBox, TableRowBox, TableWrapperBox, UnscannedTextBox};
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, FlowClass, Flow, InlineFlowClass};
@@ -775,7 +775,8 @@ impl Flow for InlineFlow {
 
                         (text_offset, line_height - text_offset, text_ascent)
                     },
-                    GenericBox | IframeBox(_) | TableCellBox | TableRowBox => {
+                    GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
+                    TableWrapperBox => {
                         let height = cur_box.position.get().size.height;
                         (height, Au::new(0), height)
                     },

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use css::node_style::StyledNode;
-use layout::box_::{Box, CannotSplit, GenericBox, IframeBox, ImageBox, ScannedTextBox, SplitDidFit, TableColBox};
-use layout::box_::{SplitDidNotFit, UnscannedTextBox, InlineInfo};
+use layout::box_::{Box, CannotSplit, GenericBox, IframeBox, InlineInfo, ImageBox};
+use layout::box_::{ScannedTextBox, SplitDidFit, SplitDidNotFit};
+use layout::box_::{TableCellBox, TableColumnBox, TableRowBox, UnscannedTextBox};
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, FlowClass, Flow, InlineFlowClass};
@@ -774,10 +775,11 @@ impl Flow for InlineFlow {
 
                         (text_offset, line_height - text_offset, text_ascent)
                     },
-                    GenericBox | IframeBox(_) | TableColBox(_) => {
+                    GenericBox | IframeBox(_) | TableCellBox | TableRowBox => {
                         let height = cur_box.position.get().size.height;
                         (height, Au::new(0), height)
                     },
+                    TableColumnBox(_) => fail!("Table column boxes do not have height"),
                     UnscannedTextBox(_) => {
                         fail!("Unscanned text boxes should have been scanned by now.")
                     }

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -248,7 +248,7 @@ impl LayoutTask {
            chan: LayoutChan,
            constellation_chan: ConstellationChan,
            script_chan: ScriptChan,
-           render_chan: RenderChan<OpaqueNode>, 
+           render_chan: RenderChan<OpaqueNode>,
            image_cache_task: ImageCacheTask,
            opts: &Opts,
            profiler_chan: ProfilerChan)
@@ -370,7 +370,7 @@ impl LayoutTask {
     /// crash.
     fn exit_now(&mut self) {
         let (response_port, response_chan) = Chan::new();
-        
+
         match self.parallel_traversal {
             None => {}
             Some(ref mut traversal) => traversal.shutdown(),
@@ -581,7 +581,7 @@ impl LayoutTask {
                 let mut color = color::rgba(255.0, 255.0, 255.0, 255.0);
 
                 for child in node.traverse_preorder() {
-                    if child.type_id() == ElementNodeTypeId(HTMLHtmlElementTypeId) || 
+                    if child.type_id() == ElementNodeTypeId(HTMLHtmlElementTypeId) ||
                             child.type_id() == ElementNodeTypeId(HTMLBodyElementTypeId) {
                         let element_bg_color = child.style()
                                                     .get()

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -564,7 +564,6 @@ impl LayoutTask {
                 }
             }
         });
-        debug!("{:?}", layout_root.dump());
 
         // Build the display list if necessary, and send it to the renderer.
         if data.goal == ReflowForDisplay {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -564,6 +564,7 @@ impl LayoutTask {
                 }
             }
         });
+        debug!("{:?}", layout_root.dump());
 
         // Build the display list if necessary, and send it to the renderer.
         if data.goal == ReflowForDisplay {

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -9,12 +9,12 @@ use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
+use layout::model::{MaybeAuto, Specified, Auto};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
 
 use std::cell::RefCell;
 use style::computed_values::table_layout;
-use geom::{Point2D, Rect, SideOffsets2D};
+use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
@@ -127,115 +127,6 @@ impl TableFlow {
         }
         self.box_ = None;
         self.float = None;
-    }
-
-    /// Computes left and right margins and width based on CSS 2.1 section 10.3.3.
-    /// Requires borders and padding to already be computed.
-    fn compute_horiz(&self,
-                     width: MaybeAuto,
-                     left_margin: MaybeAuto,
-                     right_margin: MaybeAuto,
-                     available_width: Au)
-                     -> (Au, Au, Au) {
-        // If width is not 'auto', and width + margins > available_width, all 'auto' margins are
-        // treated as 0.
-        let (left_margin, right_margin) = match width {
-            Auto => (left_margin, right_margin),
-            Specified(width) => {
-                let left = left_margin.specified_or_zero();
-                let right = right_margin.specified_or_zero();
-
-                if((left + right + width) > available_width) {
-                    (Specified(left), Specified(right))
-                } else {
-                    (left_margin, right_margin)
-                }
-            }
-        };
-
-        //Invariant: left_margin_Au + width_Au + right_margin_Au == available_width
-        let (left_margin_Au, width_Au, right_margin_Au) = match (left_margin, width, right_margin) {
-            //If all have a computed value other than 'auto', the system is over-constrained and we need to discard a margin.
-            //if direction is ltr, ignore the specified right margin and solve for it. If it is rtl, ignore the specified
-            //left margin. FIXME(eatkinson): this assumes the direction is ltr
-            (Specified(margin_l), Specified(width), Specified(_margin_r)) => (margin_l, width, available_width - (margin_l + width )),
-
-            //If exactly one value is 'auto', solve for it
-            (Auto, Specified(width), Specified(margin_r)) => (available_width - (width + margin_r), width, margin_r),
-            (Specified(margin_l), Auto, Specified(margin_r)) => (margin_l, available_width - (margin_l + margin_r), margin_r),
-            (Specified(margin_l), Specified(width), Auto) => (margin_l, width, available_width - (margin_l + width)),
-
-            //If width is set to 'auto', any other 'auto' value becomes '0', and width is solved for
-            (Auto, Auto, Specified(margin_r)) => (Au::new(0), available_width - margin_r, margin_r),
-            (Specified(margin_l), Auto, Auto) => (margin_l, available_width - margin_l, Au::new(0)),
-            (Auto, Auto, Auto) => (Au::new(0), available_width, Au::new(0)),
-
-            //If left and right margins are auto, they become equal
-            (Auto, Specified(width), Auto) => {
-                let margin = (available_width - width).scale_by(0.5);
-                (margin, width, margin)
-            }
-
-        };
-        //return values in same order as params
-        (width_Au, left_margin_Au, right_margin_Au)
-    }
-
-    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
-                             -> (Au, Au, Au) {
-        let style = box_.style();
-
-        let (width, maybe_margin_left, maybe_margin_right) =
-            (MaybeAuto::from_style(style.Box.width, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_left, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_right, remaining_width));
-
-        let (width, margin_left, margin_right) = self.compute_horiz(width,
-                                                                    maybe_margin_left,
-                                                                    maybe_margin_right,
-                                                                    available_width);
-
-        // If the tentative used width is greater than 'max-width', width should be recalculated,
-        // but this time using the computed value of 'max-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            match specified_or_none(style.Box.max_width, remaining_width) {
-                Some(value) if value < width => self.compute_horiz(Specified(value),
-                                                                   maybe_margin_left,
-                                                                   maybe_margin_right,
-                                                                   available_width),
-                _ => (width, margin_left, margin_right)
-            }
-        };
-
-        // If the resulting width is smaller than 'min-width', width should be recalculated,
-        // but this time using the value of 'min-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            let computed_min_width = specified(style.Box.min_width, remaining_width);
-            if computed_min_width > width {
-                self.compute_horiz(Specified(computed_min_width),
-                                   maybe_margin_left,
-                                   maybe_margin_right,
-                                   available_width)
-            } else {
-                (width, margin_left, margin_right)
-            }
-        };
-
-        return (width, margin_left, margin_right);
-    }
-
-    fn compute_float_margins(&self, box_: &Box, remaining_width: Au) -> (Au, Au, Au) {
-        let style = box_.style();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
-                                                remaining_width).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
-                                                 remaining_width).specified_or_zero();
-        let shrink_to_fit = geometry::min(self.base.pref_width,
-                                          geometry::max(self.base.min_width, remaining_width));
-        let width = MaybeAuto::from_style(style.Box.width,
-                                          remaining_width).specified_or_default(shrink_to_fit);
-        debug!("assign_widths_float -- width: {}", width);
-        return (width, margin_left, margin_right);
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
@@ -667,6 +558,8 @@ impl Flow for TableFlow {
             self.base.flags_info.flags.set_inorder(false);
         }
 
+        let mut padding_and_borders = Au::new(0);
+
         for box_ in self.box_.iter() {
             let style = box_.style();
 
@@ -676,51 +569,32 @@ impl Flow for TableFlow {
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
-            // Margins are 0 right now so base.noncontent_width() is just borders + padding.
-            let available_width = remaining_width - box_.noncontent_width();
-
-            // Top and bottom margins for blocks are 0 if auto.
-            let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
-                                                   remaining_width).specified_or_zero();
-            let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
-                                                      remaining_width).specified_or_zero();
-
-            let (width, margin_left, margin_right) = if self.is_float() {
-                self.compute_float_margins(box_, remaining_width)
-            } else {
-                self.compute_table_margins(box_, remaining_width, available_width)
-            };
-
-            box_.margin.set(SideOffsets2D::new(margin_top,
-                                              margin_right,
-                                              margin_bottom,
-                                              margin_left));
-
             let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height, 
-                                                                 width, 
-                                                                 box_.offset(), 
+            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
+                                                                 screen_size.height,
+                                                                 remaining_width,
+                                                                 box_.offset(),
                                                                  self.is_fixed);
             x_offset = x;
-            remaining_width = geometry::max( fix_cell_width, w );
+            padding_and_borders = box_.padding.get().left + box_.padding.get().right +
+                                  box_.border.get().left + box_.border.get().right;
+            remaining_width = geometry::max(fix_cell_width + padding_and_borders, w);
 
             // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
             if self.is_fixed {
-                position_ref.get().origin.x = x_offset + box_.margin.get().left;
+                position_ref.get().origin.x = x_offset;
                 x_offset = x_offset + box_.padding.get().left;
-            } else {
-                position_ref.get().origin.x = box_.margin.get().left;
             }
-            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-            position_ref.get().size.width = remaining_width + padding_and_borders;
+                                  
+            position_ref.get().size.width = remaining_width;
         }
 
         if self.is_float() {
             self.base.position.size.width = remaining_width;
         }
+        
+        remaining_width = remaining_width - padding_and_borders; 
 
         let default_cell_width = if fix_cell_width >= remaining_width {
             self.base.position.size.width = remaining_width;

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! CSS block formatting contexts.
+//! CSS table formatting contexts.
 
 use layout::box_::Box;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
-use layout::flow::{BaseFlow, BlockFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow::{BaseFlow, TableFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
@@ -19,7 +19,7 @@ use servo_util::geometry::Au;
 use servo_util::geometry;
 
 /// Information specific to floated blocks.
-pub struct FloatedBlockInfo {
+pub struct FloatedTableInfo {
     containing_width: Au,
 
     /// Offset relative to where the parent tried to position this flow
@@ -35,9 +35,9 @@ pub struct FloatedBlockInfo {
     float_type: FloatType
 }
 
-impl FloatedBlockInfo {
-    pub fn new(float_type: FloatType) -> FloatedBlockInfo {
-        FloatedBlockInfo {
+impl FloatedTableInfo {
+    pub fn new(float_type: FloatType) -> FloatedTableInfo {
+        FloatedTableInfo {
             containing_width: Au(0),
             rel_pos: Point2D(Au(0), Au(0)),
             index: None,
@@ -47,72 +47,56 @@ impl FloatedBlockInfo {
     }
 }
 
-/// A block formatting context.
-pub struct BlockFlow {
+/// A table formatting context.
+pub struct TableFlow {
     /// Data common to all flows.
     base: BaseFlow,
 
     /// The associated box.
     box_: Option<Box>,
 
-    //TODO: is_fixed and is_root should be bit fields to conserve memory.
-    /// Whether this block flow is the root flow.
-    is_root: bool,
-
+    //TODO: is_fixed should be bit fields to conserve memory.
+    /// Position property
     is_fixed: bool,
 
     /// Additional floating flow members.
-    float: Option<~FloatedBlockInfo>
+    float: Option<~FloatedTableInfo>
 }
 
-impl BlockFlow {
-    pub fn new(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+impl TableFlow {
+    pub fn new(base: BaseFlow) -> TableFlow {
+        TableFlow {
             base: base,
             box_: None,
-            is_root: false,
             is_fixed: false,
             float: None
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> BlockFlow {
-        BlockFlow {
+    pub fn from_box(base: BaseFlow, is_fixed: bool) -> TableFlow {
+        TableFlow {
             base: base,
-            box_: Some(box_),
-            is_root: false,
+            box_: None,
             is_fixed: is_fixed,
             float: None
         }
     }
 
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> BlockFlow {
-        BlockFlow {
+    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableFlow {
+        TableFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
-    pub fn new_root(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableFlow {
+        TableFlow {
             base: base,
             box_: None,
-            is_root: true,
             is_fixed: false,
-            float: None
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> BlockFlow {
-        BlockFlow {
-            base: base,
-            box_: None,
-            is_root: false,
-            is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
@@ -180,7 +164,7 @@ impl BlockFlow {
         (width_Au, left_margin_Au, right_margin_Au)
     }
 
-    fn compute_block_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
+    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
                              -> (Au, Au, Au) {
         let style = box_.style();
 
@@ -240,7 +224,7 @@ impl BlockFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_block_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
@@ -288,11 +272,11 @@ impl BlockFlow {
         let mut bottom_margin_collapsible = false;
         let mut first_in_flow = true;
         for box_ in self.box_.iter() {
-            if !self.is_root && box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
+            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
                 collapsible = box_.margin.get().top;
                 top_margin_collapsible = true;
             }
-            if !self.is_root && box_.border.get().bottom == Au(0) &&
+            if box_.border.get().bottom == Au(0) &&
                     box_.padding.get().bottom == Au(0) {
                 bottom_margin_collapsible = true;
             }
@@ -329,17 +313,8 @@ impl BlockFlow {
         // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
         // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
 
-        let screen_height = ctx.screen_size.height;
 
-        let mut height = if self.is_root {
-            // FIXME(pcwalton): The max is taken here so that you can scroll the page, but this is
-            // not correct behavior according to CSS 2.1 § 10.5. Instead I think we should treat
-            // the root element as having `overflow: scroll` and use the layers-based scrolling
-            // infrastructure to make it scrollable.
-            Au::max(screen_height, cur_y)
-        } else {
-            cur_y - top_offset - collapsing
-        };
+        let mut height = cur_y - top_offset - collapsing;
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -354,6 +329,7 @@ impl BlockFlow {
         }
 
         let mut noncontent_height = Au::new(0);
+        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
             let mut margin = box_.margin.get();
@@ -366,10 +342,9 @@ impl BlockFlow {
                 box_.border.get().top + box_.border.get().bottom;
 
             let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                  height,
-                                                                  clearance + margin.top,
+                                                                  height, 
+                                                                  clearance + margin.top, 
                                                                   self.is_fixed);
-
             position.origin.y = y;
             height = h;
 
@@ -492,7 +467,7 @@ impl BlockFlow {
         box_.position.set(position);
     }
 
-    pub fn build_display_list_block<E:ExtraDisplayListData>(
+    pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -507,9 +482,9 @@ impl BlockFlow {
             return true;
         }
 
-        debug!("build_display_list_block: adding display element");
+        debug!("build_display_list_table[TABLE]: adding display element");
 
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
         }
@@ -536,7 +511,7 @@ impl BlockFlow {
         }
 
         let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
         }
@@ -554,12 +529,12 @@ impl BlockFlow {
     }
 }
 
-impl Flow for BlockFlow {
+impl Flow for TableFlow {
     fn class(&self) -> FlowClass {
-        BlockFlowClass
+        TableFlowClass
     }
 
-    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+    fn as_table<'a>(&'a mut self) -> &'a mut TableFlow {
         self
     }
 
@@ -578,7 +553,7 @@ impl Flow for BlockFlow {
 
         /* find max width from child block contexts */
         for child_ctx in self.base.child_iter() {
-            assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow() || child_ctx.starts_table_flow());
+            if !child_ctx.starts_table_flow() { continue; }
 
             let child_base = flow::mut_base(*child_ctx);
             min_width = geometry::max(min_width, child_base.min_width);
@@ -620,17 +595,9 @@ impl Flow for BlockFlow {
                if self.is_float() {
                    "float"
                } else {
-                   "block"
+                   "table"
                },
                self.base.id);
-
-        if self.is_root {
-            debug!("Setting root position");
-            self.base.position.origin = Au::zero_point();
-            self.base.position.size.width = ctx.screen_size.width;
-            self.base.floats_in = FloatContext::new(self.base.num_floats);
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         // The position was set to the containing block by the flow's parent.
         let mut remaining_width = self.base.position.size.width;
@@ -646,10 +613,9 @@ impl Flow for BlockFlow {
         for box_ in self.box_.iter() {
             let style = box_.style();
 
-            // The text alignment of a block flow is the text alignment of its box's style.
+            // The text alignment of a table flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            box_.assign_width(remaining_width);
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
@@ -665,21 +631,20 @@ impl Flow for BlockFlow {
             let (width, margin_left, margin_right) = if self.is_float() {
                 self.compute_float_margins(box_, remaining_width)
             } else {
-                self.compute_block_margins(box_, remaining_width, available_width)
+                self.compute_table_margins(box_, remaining_width, available_width)
             };
 
             box_.margin.set(SideOffsets2D::new(margin_top,
-                                               margin_right,
-                                               margin_bottom,
-                                               margin_left));
+                                              margin_right,
+                                              margin_bottom,
+                                              margin_left));
 
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height,
-                                                                 width,
-                                                                 box_.offset(),
+                                                                 screen_size.height, 
+                                                                 width, 
+                                                                 box_.offset(), 
                                                                  self.is_fixed);
-
             x_offset = x;
             remaining_width = w;
 
@@ -709,7 +674,7 @@ impl Flow for BlockFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            if !kid.starts_table_flow() { continue; }
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;
@@ -723,8 +688,8 @@ impl Flow for BlockFlow {
             // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
             //
             // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-
             child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
+
             child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
         }
     }
@@ -734,29 +699,18 @@ impl Flow for BlockFlow {
             debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
             self.assign_height_float_inorder();
         } else {
-            debug!("assign_height_inorder: assigning height for block {}", self.base.id);
-            self.assign_height_block_base(ctx, true);
+            debug!("assign_height_inorder: assigning height for table {}", self.base.id);
+            self.assign_height_table_base(ctx, true);
         }
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        //assign height for box
-        for box_ in self.box_.iter() {
-            box_.assign_height();
-        }
-
         if self.is_float() {
             debug!("assign_height_float: assigning height for float {}", self.base.id);
             self.assign_height_float(ctx);
         } else {
-            debug!("assign_height: assigning height for block {}", self.base.id);
-            // This is the only case in which a block flow can start an inorder
-            // subtraversal.
-            if self.is_root && self.base.num_floats > 0 {
-                self.assign_height_inorder(ctx);
-                return;
-            }
-            self.assign_height_block_base(ctx, false);
+            debug!("assign_height: assigning height for table {}", self.base.id);
+            self.assign_height_table_base(ctx, false);
         }
     }
 
@@ -796,17 +750,11 @@ impl Flow for BlockFlow {
         *first_in_flow = false;
     }
 
-    fn mark_as_root(&mut self) {
-        self.is_root = true
-    }
-
     fn debug_str(&self) -> ~str {
         let txt = if self.is_float() {
             ~"FloatFlow: "
-        } else if self.is_root {
-            ~"RootFlow: "
         } else {
-            ~"BlockFlow: "
+            ~"TableFlow: "
         };
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -552,10 +552,10 @@ impl Flow for TableFlow {
         let mut num_floats = 0;
 
         /* find max width from child block contexts */
-        for child_ctx in self.base.child_iter() {
-            if !child_ctx.starts_table_flow() { continue; }
+        for kid in self.base.child_iter() {
+            if !kid.starts_table_flow() { continue; }
 
-            let child_base = flow::mut_base(*child_ctx);
+            let child_base = flow::mut_base(*kid);
             min_width = geometry::max(min_width, child_base.min_width);
             pref_width = geometry::max(pref_width, child_base.pref_width);
             num_floats = num_floats + child_base.num_floats;

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -9,8 +9,7 @@ use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto};
-use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
+use layout::float_context::{FloatContext, Invalid};
 
 use std::cell::RefCell;
 use style::computed_values::table_layout;
@@ -19,49 +18,15 @@ use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
 
-/// Information specific to floated blocks.
-pub struct FloatedTableInfo {
-    containing_width: Au,
-
-    /// Offset relative to where the parent tried to position this flow
-    rel_pos: Point2D<Au>,
-
-    /// Index into the box list for inline floats
-    index: Option<uint>,
-
-    /// Number of floated children
-    floated_children: uint,
-
-    /// Left or right?
-    float_type: FloatType
-}
-
-impl FloatedTableInfo {
-    pub fn new(float_type: FloatType) -> FloatedTableInfo {
-        FloatedTableInfo {
-            containing_width: Au(0),
-            rel_pos: Point2D(Au(0), Au(0)),
-            index: None,
-            floated_children: 0,
-            float_type: float_type
-        }
-    }
-}
-
-/// A table formatting context.
+/// A table flow corresponded to the table's internal table box under a table wrapper flow.
+/// The properties `position`, `float`, and `margin-*` are used on the table wrapper box,
+/// not table box per CSS 2.1 § 10.5.
 pub struct TableFlow {
     /// Data common to all flows.
     base: BaseFlow,
 
     /// The associated box.
     box_: Option<Box>,
-
-    //TODO: is_fixed should be bit fields to conserve memory.
-    /// Position property
-    is_fixed: bool,
-
-    /// Additional floating flow members.
-    float: Option<~FloatedTableInfo>,
 
     /// Column widths
     col_widths: ~[Au],
@@ -75,50 +40,19 @@ impl TableFlow {
         TableFlow {
             base: base,
             box_: None,
-            is_fixed: false,
-            float: None,
             col_widths: ~[],
             is_fixed_table_layout: false,
-
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableFlow {
+    pub fn from_box(base: BaseFlow, box_: Box) -> TableFlow {
         let is_fixed_table_layout = box_.style().Table.table_layout == table_layout::fixed;
         TableFlow {
             base: base,
             box_: Some(box_),
-            is_fixed: is_fixed,
-            float: None,
             col_widths: ~[],
             is_fixed_table_layout: is_fixed_table_layout,
         }
-    }
-
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableFlow {
-        TableFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-            col_widths: ~[],
-            is_fixed_table_layout: false,
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableFlow {
-        TableFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-            col_widths: ~[],
-            is_fixed_table_layout: false,
-        }
-    }
-
-    pub fn is_float(&self) -> bool {
-        self.float.is_some()
     }
 
     pub fn teardown(&mut self) {
@@ -126,7 +60,6 @@ impl TableFlow {
             box_.teardown();
         }
         self.box_ = None;
-        self.float = None;
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
@@ -134,26 +67,16 @@ impl TableFlow {
     #[inline(always)]
     fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
-        let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
         let mut bottom_offset = Au::new(0);
         let mut left_offset = Au::new(0);
         let mut float_ctx = Invalid;
 
         for box_ in self.box_.iter() {
-            clearance = match box_.clear() {
-                None => Au::new(0),
-                Some(clear) => {
-                    self.base.floats_in.clearance(clear)
-                }
-            };
-
-            top_offset = clearance + box_.margin.get().top + box_.border.get().top +
-                box_.padding.get().top;
+            top_offset = box_.noncontent_top();
             cur_y = cur_y + top_offset;
-            bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
-                box_.padding.get().bottom;
-            left_offset = box_.offset();
+            bottom_offset = box_.noncontent_bottom();
+            left_offset = box_.noncontent_left();
         }
 
         if inorder {
@@ -172,114 +95,27 @@ impl TableFlow {
             }
         }
 
-        let mut collapsible = Au::new(0);
-        let mut collapsing = Au::new(0);
-        let mut margin_top = Au::new(0);
-        let mut margin_bottom = Au::new(0);
-        let mut top_margin_collapsible = false;
-        let mut bottom_margin_collapsible = false;
-        let mut first_in_flow = true;
-        for box_ in self.box_.iter() {
-            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
-                collapsible = box_.margin.get().top;
-                top_margin_collapsible = true;
-            }
-            if box_.border.get().bottom == Au(0) &&
-                    box_.padding.get().bottom == Au(0) {
-                bottom_margin_collapsible = true;
-            }
-            margin_top = box_.margin.get().top;
-            margin_bottom = box_.margin.get().bottom;
-        }
-
         for kid in self.base.child_iter() {
-            kid.collapse_margins(top_margin_collapsible,
-                                 &mut first_in_flow,
-                                 &mut margin_top,
-                                 &mut top_offset,
-                                 &mut collapsing,
-                                 &mut collapsible);
-
             let child_node = flow::mut_base(*kid);
-            cur_y = cur_y - collapsing;
             child_node.position.origin.y = cur_y;
             cur_y = cur_y + child_node.position.size.height;
         }
 
-        // The bottom margin collapses with its last in-flow block-level child's bottom margin
-        // if the parent has no bottom boder, no bottom padding.
-        collapsing = if bottom_margin_collapsible {
-            if margin_bottom < collapsible {
-                margin_bottom = collapsible;
-            }
-            collapsible
-        } else {
-            Au::new(0)
-        };
-
-        // TODO: A box's own margins collapse if the 'min-height' property is zero, and it has neither
-        // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
-        // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
-
-
-        let mut height = cur_y - top_offset - collapsing;
-
-        for box_ in self.box_.iter() {
-            let style = box_.style();
-
-            // At this point, `height` is the height of the containing block, so passing `height`
-            // as the second argument here effectively makes percentages relative to the containing
-            // block per CSS 2.1 § 10.5.
-            height = match MaybeAuto::from_style(style.Box.height, height) {
-                Auto => height,
-                Specified(value) => value
-            };
-        }
+        let height = cur_y - top_offset;
 
         let mut noncontent_height = Au::new(0);
-        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
-            let mut margin = box_.margin.get();
 
-            // The associated box is the border box of this flow.
-            margin.top = margin_top;
-            margin.bottom = margin_bottom;
+            noncontent_height = box_.noncontent_height();
 
-            noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-                box_.border.get().top + box_.border.get().bottom;
-
-            let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                  height,
-                                                                  clearance + margin.top,
-                                                                  self.is_fixed);
-            position.origin.y = y;
-            height = h;
-
-            if self.is_fixed {
-                for kid in self.base.child_iter() {
-                    let child_node = flow::mut_base(*kid);
-                    child_node.position.origin.y = position.origin.y + top_offset;
-                }
-            }
-
-            position.size.height = if self.is_fixed {
-                height
-            } else {
-                height + noncontent_height
-            };
-
-            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
+            position.origin.y = Au(0);
+            position.size.height = height + noncontent_height;
 
             box_.position.set(position);
-            box_.margin.set(margin);
         }
 
-        self.base.position.size.height = if self.is_fixed {
-            height
-        } else {
-            height + noncontent_height
-        };
+        self.base.position.size.height = height + noncontent_height;
 
         if inorder {
             let extra_height = height - (cur_y - top_offset) + bottom_offset;
@@ -289,102 +125,12 @@ impl TableFlow {
         }
     }
 
-    fn assign_height_float_inorder(&mut self) {
-        // assign_height_float was already called by the traversal function
-        // so this is well-defined
-
-        let mut height = Au(0);
-        let mut clearance = Au(0);
-        let mut full_noncontent_width = Au(0);
-        let mut margin_height = Au(0);
-
-        for box_ in self.box_.iter() {
-            height = box_.position.get().size.height;
-            clearance = match box_.clear() {
-                None => Au(0),
-                Some(clear) => self.base.floats_in.clearance(clear),
-            };
-
-            let noncontent_width = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-
-            full_noncontent_width = noncontent_width + box_.margin.get().left +
-                box_.margin.get().right;
-            margin_height = box_.margin.get().top + box_.margin.get().bottom;
-        }
-
-        let info = PlacementInfo {
-            width: self.base.position.size.width + full_noncontent_width,
-            height: height + margin_height,
-            ceiling: clearance,
-            max_width: self.float.get_ref().containing_width,
-            f_type: self.float.get_ref().float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.base.floats_out = self.base.floats_in.add_float(&info);
-        self.float.get_mut_ref().rel_pos = self.base.floats_out.last_float_pos();
-    }
-
-    fn assign_height_float(&mut self, ctx: &mut LayoutContext) {
-        // Now that we've determined our height, propagate that out.
-        let has_inorder_children = self.base.num_floats > 0;
-        if has_inorder_children {
-            let mut float_ctx = FloatContext::new(self.float.get_ref().floated_children);
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-        let mut cur_y = Au(0);
-        let mut top_offset = Au(0);
-
-        for box_ in self.box_.iter() {
-            top_offset = box_.margin.get().top + box_.border.get().top + box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-        }
-
-        for kid in self.base.child_iter() {
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.y = cur_y;
-            cur_y = cur_y + child_base.position.size.height;
-        }
-
-        let mut height = cur_y - top_offset;
-
-        let mut noncontent_height;
-        let box_ = self.box_.as_ref().unwrap();
-        let mut position = box_.position.get();
-
-        // The associated box is the border box of this flow.
-        position.origin.y = box_.margin.get().top;
-
-        noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-            box_.border.get().top + box_.border.get().bottom;
-
-        //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
-                                                Au::new(0)).specified_or_zero();
-
-        height = geometry::max(height, height_prop) + noncontent_height;
-        debug!("assign_height_float -- height: {}", height);
-
-        position.size.height = height;
-        box_.position.set(position);
-    }
-
     pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        if self.is_float() {
-            return self.build_display_list_float(builder, dirty, list);
-        }
-
         let abs_rect = Rect(self.base.abs_position, self.base.position.size);
         if !abs_rect.intersects(dirty) {
             return true;
@@ -402,35 +148,6 @@ impl TableFlow {
         for child in self.base.child_iter() {
             let child_base = flow::mut_base(*child);
             child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
-    }
-
-    pub fn build_display_list_float<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true
-        }
-
-        let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
-        }
-
-
-        // TODO: handle any out-of-flow elements
-
-        // go deeper into the flow tree
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = offset + child_base.position.origin;
         }
 
         false
@@ -499,12 +216,7 @@ impl Flow for TableFlow {
             num_floats = num_floats + child_base.num_floats;
         }
 
-        if self.is_float() {
-            self.base.num_floats = 1;
-            self.float.get_mut_ref().floated_children = num_floats;
-        } else {
-            self.base.num_floats = num_floats;
-        }
+        self.base.num_floats = num_floats;
 
         for box_ in self.box_.iter() {
             {
@@ -523,14 +235,8 @@ impl Flow for TableFlow {
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
     /// on this context, the context has had its width set by the parent context.
-    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}",
-               if self.is_float() {
-                   "float"
-               } else {
-                   "table"
-               },
-               self.base.id);
+    fn assign_widths(&mut self, _: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow {}", "table", self.base.id);
 
         // The position was set to the containing block by the flow's parent.
         let mut remaining_width = self.base.position.size.width;
@@ -546,13 +252,6 @@ impl Flow for TableFlow {
             }
         }
 
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = remaining_width;
-
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
-
         let mut padding_and_borders = Au::new(0);
 
         for box_ in self.box_.iter() {
@@ -564,27 +263,12 @@ impl Flow for TableFlow {
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
-            let screen_size = ctx.screen_size;
-            let (x, _w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
-                                                                  screen_size.height,
-                                                                  remaining_width,
-                                                                  box_.offset(),
-                                                                  self.is_fixed);
-            x_offset = x;
+            x_offset = box_.padding.get().left + box_.border.get().left;
             padding_and_borders = box_.padding.get().left + box_.padding.get().right +
                                   box_.border.get().left + box_.border.get().right;
 
             let mut position_ref = box_.position.borrow_mut();
-            if self.is_fixed {
-                position_ref.get().origin.x = x_offset;
-                x_offset = x_offset + box_.padding.get().left;
-            }
-
             position_ref.get().size.width = remaining_width;
-        }
-
-        if self.is_float() {
-            self.base.position.size.width = remaining_width;
         }
 
         remaining_width = remaining_width - padding_and_borders;
@@ -602,11 +286,7 @@ impl Flow for TableFlow {
             Au(0)
         };
 
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
+        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
@@ -645,67 +325,29 @@ impl Flow for TableFlow {
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
-            self.assign_height_float_inorder();
-        } else {
-            debug!("assign_height_inorder: assigning height for table {}", self.base.id);
-            self.assign_height_table_base(ctx, true);
-        }
+        debug!("assign_height_inorder: assigning height for table {}", self.base.id);
+        self.assign_height_table_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
-            self.assign_height_float(ctx);
-        } else {
-            debug!("assign_height: assigning height for table {}", self.base.id);
-            self.assign_height_table_base(ctx, false);
-        }
+        debug!("assign_height: assigning height for table {}", self.base.id);
+        self.assign_height_table_base(ctx, false);
     }
 
     fn collapse_margins(&mut self,
-                        top_margin_collapsible: bool,
-                        first_in_flow: &mut bool,
-                        margin_top: &mut Au,
-                        top_offset: &mut Au,
+                        _: bool,
+                        _: &mut bool,
+                        _: &mut Au,
+                        _: &mut Au,
                         collapsing: &mut Au,
                         collapsible: &mut Au) {
-        if self.is_float() {
-            // Margins between a floated box and any other box do not collapse.
-            *collapsing = Au::new(0);
-            return;
-        }
-
-        for box_ in self.box_.iter() {
-            // The top margin collapses with its first in-flow block-level child's
-            // top margin if the parent has no top border, no top padding.
-            if *first_in_flow && top_margin_collapsible {
-                // If top-margin of parent is less than top-margin of its first child,
-                // the parent box goes down until its top is aligned with the child.
-                if *margin_top < box_.margin.get().top {
-                    // TODO: The position of child floats should be updated and this
-                    // would influence clearance as well. See #725
-                    let extra_margin = box_.margin.get().top - *margin_top;
-                    *top_offset = *top_offset + extra_margin;
-                    *margin_top = box_.margin.get().top;
-                }
-            }
-            // The bottom margin of an in-flow block-level element collapses
-            // with the top margin of its next in-flow block-level sibling.
-            *collapsing = geometry::min(box_.margin.get().top, *collapsible);
-            *collapsible = box_.margin.get().bottom;
-        }
-
-        *first_in_flow = false;
+        // `margin` is not used on table box.
+        *collapsing = Au::new(0);
+        *collapsible = Au::new(0);
     }
 
     fn debug_str(&self) -> ~str {
-        let txt = if self.is_float() {
-            ~"FloatFlow: "
-        } else {
-            ~"TableFlow: "
-        };
+        let txt = ~"TableFlow: ";
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -241,6 +241,11 @@ impl Flow for TableFlow {
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        //assign height for box
+        for box_ in self.block_flow.box_.iter() {
+            box_.assign_height();
+        }
+
         debug!("assign_height: assigning height for table {}", self.block_flow.base.id);
         self.assign_height_table_base(ctx, false);
     }

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -5,11 +5,11 @@
 //! CSS table formatting contexts.
 
 use layout::box_::Box;
+use layout::block::BlockFlow;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::float_context::{FloatContext, Invalid};
 use layout::table_wrapper::{TableLayout, FixedLayout, AutoLayout};
 
 use std::cell::RefCell;
@@ -17,17 +17,12 @@ use style::computed_values::table_layout;
 use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
-use servo_util::geometry;
 
 /// A table flow corresponded to the table's internal table box under a table wrapper flow.
 /// The properties `position`, `float`, and `margin-*` are used on the table wrapper box,
 /// not table box per CSS 2.1 § 10.5.
 pub struct TableFlow {
-    /// Data common to all flows.
-    base: BaseFlow,
-
-    /// The associated box.
-    box_: Option<Box>,
+    block_flow: BlockFlow,
 
     /// Column widths
     col_widths: ~[Au],
@@ -39,8 +34,7 @@ pub struct TableFlow {
 impl TableFlow {
     pub fn new(base: BaseFlow) -> TableFlow {
         TableFlow {
-            base: base,
-            box_: None,
+            block_flow: BlockFlow::new(base),
             col_widths: ~[],
             table_layout: AutoLayout,
         }
@@ -53,54 +47,30 @@ impl TableFlow {
             AutoLayout
         };
         TableFlow {
-            base: base,
-            box_: Some(box_),
+            block_flow: BlockFlow::from_box(base, box_, false),
             col_widths: ~[],
             table_layout: table_layout,
         }
     }
 
     pub fn teardown(&mut self) {
-        for box_ in self.box_.iter() {
-            box_.teardown();
-        }
-        self.box_ = None;
+        self.block_flow.teardown();
+        self.col_widths = ~[];
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
     fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let mut cur_y = Au::new(0);
-        let mut top_offset = Au::new(0);
-        let mut bottom_offset = Au::new(0);
-        let mut left_offset = Au::new(0);
-        let mut float_ctx = Invalid;
 
-        for box_ in self.box_.iter() {
-            top_offset = box_.noncontent_top();
-            cur_y = cur_y + top_offset;
-            bottom_offset = box_.noncontent_bottom();
-            left_offset = box_.noncontent_left();
-        }
+        let (_, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offset(true);
 
-        if inorder {
-            // Floats for blocks work like this:
-            // self.floats_in -> child[0].floats_in
-            // visit child[0]
-            // child[i-1].floats_out -> child[i].floats_in
-            // visit child[i]
-            // repeat until all children are visited.
-            // last_child.floats_out -> self.floats_out (done at the end of this method)
-            float_ctx = self.base.floats_in.translate(Point2D(-left_offset, -top_offset));
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
+        let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx,
+                                                                              Point2D(-left_offset, -top_offset),
+                                                                              inorder);
 
-        for kid in self.base.child_iter() {
+        let mut cur_y = top_offset;
+        for kid in self.block_flow.base.child_iter() {
             let child_node = flow::mut_base(*kid);
             child_node.position.origin.y = cur_y;
             cur_y = cur_y + child_node.position.size.height;
@@ -109,7 +79,7 @@ impl TableFlow {
         let height = cur_y - top_offset;
 
         let mut noncontent_height = Au::new(0);
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let mut position = box_.position.get();
 
             noncontent_height = box_.noncontent_height();
@@ -120,14 +90,10 @@ impl TableFlow {
             box_.position.set(position);
         }
 
-        self.base.position.size.height = height + noncontent_height;
+        self.block_flow.base.position.size.height = height + noncontent_height;
 
-        if inorder {
-            let extra_height = height - (cur_y - top_offset) + bottom_offset;
-            self.base.floats_out = float_ctx.translate(Point2D(left_offset, -extra_height));
-        } else {
-            self.base.floats_out = self.base.floats_in.clone();
-        }
+        self.block_flow.set_floats_out(&mut float_ctx, height, cur_y, top_offset,
+                                       bottom_offset, left_offset, inorder);
     }
 
     pub fn build_display_list_table<E:ExtraDisplayListData>(
@@ -136,26 +102,8 @@ impl TableFlow {
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true;
-        }
-
-        debug!("build_display_list_table[TABLE]: adding display element");
-
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
-        }
-        // TODO: handle any out-of-flow elements
-        let this_position = self.base.abs_position;
-
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
+        debug!("build_display_list_table: same process as block flow");
+        self.block_flow.build_display_list_block(builder, dirty, list)
     }
 }
 
@@ -171,14 +119,11 @@ impl Flow for TableFlow {
     /// This function finds the specified column widths from column group and the first row.
     /// Those are used in fixed table layout calculation.
     /* FIXME: automatic table layout calculation */
-    fn bubble_widths(&mut self, _: &mut LayoutContext) {
-        let mut min_width = Au::new(0);
-        let mut pref_width = Au::new(0);
-        let mut num_floats = 0;
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
         let mut did_first_row = false;
 
         /* find max width from child block contexts */
-        for kid in self.base.child_iter() {
+        for kid in self.block_flow.base.child_iter() {
             assert!(kid.is_proper_table_child());
 
             if kid.is_table_colgroup() {
@@ -210,21 +155,6 @@ impl Flow for TableFlow {
                     },
                     _ => {}
                 }
-                /*
-                if self.table_layout == FixedLayout && !did_first_row {
-                    did_first_row = true;
-                    let mut child_widths = kid_col_widths.iter();
-                    for col_width in self.col_widths.mut_iter() {
-                        match child_widths.next() {
-                            Some(child_width) => {
-                                if *col_width == Au::new(0) {
-                                    *col_width = *child_width;
-                                }
-                            },
-                            None => break
-                        }
-                    }
-                }*/
                 let num_child_cols = kid_col_widths.len();
                 let num_cols = self.col_widths.len();
                 debug!("colgroup has {} column(s) and child has {} column(s)", num_cols, num_child_cols);
@@ -232,37 +162,17 @@ impl Flow for TableFlow {
                     self.col_widths.push( kid_col_widths[i] );
                 }
             }
-
-            let child_base = flow::mut_base(*kid);
-            min_width = geometry::max(min_width, child_base.min_width);
-            pref_width = geometry::max(pref_width, child_base.pref_width);
-            num_floats = num_floats + child_base.num_floats;
         }
-
-        self.base.num_floats = num_floats;
-
-        for box_ in self.box_.iter() {
-            {
-                // Can compute border width here since it doesn't depend on anything.
-                box_.compute_borders(box_.style())
-            }
-
-            let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
-            min_width = min_width + this_minimum_width;
-            pref_width = pref_width + this_preferred_width;
-        }
-
-        self.base.min_width = min_width;
-        self.base.pref_width = pref_width;
+        self.block_flow.bubble_widths(ctx);
     }
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
     /// on this context, the context has had its width set by the parent context.
     fn assign_widths(&mut self, _: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}", "table", self.base.id);
+        debug!("assign_widths({}): assigning width for flow {}", "table", self.block_flow.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let mut remaining_width = self.base.position.size.width;
+        let mut remaining_width = self.block_flow.base.position.size.width;
         let mut x_offset = Au::new(0);
 
         let mut num_unspecified_widths = 0;
@@ -275,26 +185,19 @@ impl Flow for TableFlow {
             }
         }
 
-        let mut padding_and_borders = Au::new(0);
-
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let style = box_.style();
 
             // The text alignment of a table_wrapper flow is the text alignment of its box's style.
-            self.base.flags_info.flags.set_text_align(style.Text.text_align);
-
-            // Can compute padding here since we know containing block width.
-            box_.compute_padding(style, remaining_width);
+            self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
+            self.block_flow.initial_box_setting(box_, style, remaining_width, true, false);
+            self.block_flow.set_box_x_and_width(box_, Au(0), remaining_width);
 
             x_offset = box_.padding.get().left + box_.border.get().left;
-            padding_and_borders = box_.padding.get().left + box_.padding.get().right +
-                                  box_.border.get().left + box_.border.get().right;
-
-            let mut position_ref = box_.position.borrow_mut();
-            position_ref.get().size.width = remaining_width;
+            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
+                                      box_.border.get().left + box_.border.get().right;
+            remaining_width = remaining_width - padding_and_borders;
         }
-
-        remaining_width = remaining_width - padding_and_borders;
 
         // In fixed table layout, we distribute extra space among the unspecified columns if there are
         // any, or among all the columns if all are specified.
@@ -311,13 +214,9 @@ impl Flow for TableFlow {
             Au(0)
         };
 
-        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
-
-        // FIXME(ksh8281): avoid copy
-        let flags_info = self.base.flags_info.clone();
-        for kid in self.base.child_iter() {
+        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width);
+        for kid in self.block_flow.base.child_iter() {
             assert!(kid.is_proper_table_child());
-
             if kid.is_table_colgroup() {
                 continue;
             }
@@ -333,32 +232,16 @@ impl Flow for TableFlow {
             } else if kid.is_table_row() {
                 kid.as_table_row().col_widths = final_col_widths;
             }
-
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.x = x_offset;
-            child_base.position.size.width = remaining_width;
-            child_base.flags_info.flags.set_inorder(has_inorder_children);
-
-            if !child_base.flags_info.flags.inorder() {
-                child_base.floats_in = FloatContext::new(0);
-            }
-
-            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
-            //
-            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
-
-            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
         }
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_height_inorder: assigning height for table {}", self.base.id);
+        debug!("assign_height_inorder: assigning height for table {}", self.block_flow.base.id);
         self.assign_height_table_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_height: assigning height for table {}", self.base.id);
+        debug!("assign_height: assigning height for table {}", self.block_flow.base.id);
         self.assign_height_table_base(ctx, false);
     }
 
@@ -376,7 +259,7 @@ impl Flow for TableFlow {
 
     fn debug_str(&self) -> ~str {
         let txt = ~"TableFlow: ";
-        txt.append(match self.box_ {
+        txt.append(match self.block_flow.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",
         })

--- a/src/components/main/layout/table_caption.rs
+++ b/src/components/main/layout/table_caption.rs
@@ -163,12 +163,10 @@ impl TableCaptionFlow {
                 }
             };
 
-            top_offset = clearance + box_.margin.get().top + box_.border.get().top +
-                box_.padding.get().top;
+            top_offset = clearance + box_.noncontent_top();
             cur_y = cur_y + top_offset;
-            bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
-                box_.padding.get().bottom;
-            left_offset = box_.offset();
+            bottom_offset = box_.noncontent_bottom();
+            left_offset = box_.noncontent_left();
         }
 
         if inorder {

--- a/src/components/main/layout/table_caption.rs
+++ b/src/components/main/layout/table_caption.rs
@@ -346,7 +346,7 @@ impl TableCaptionFlow {
             position.origin.y = y;
             height = h;
 
-            if self.is_fixed { 
+            if self.is_fixed {
                 for kid in self.base.child_iter() {
                     let child_node = flow::mut_base(*kid);
                     child_node.position.origin.y = position.origin.y + top_offset;
@@ -549,7 +549,7 @@ impl Flow for TableCaptionFlow {
 
         /* find max width from child block contexts */
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
 
             let child_base = flow::mut_base(*kid);
             min_width = geometry::max(min_width, child_base.min_width);
@@ -637,10 +637,10 @@ impl Flow for TableCaptionFlow {
                                               margin_left));
 
             let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height, 
-                                                                 width, 
-                                                                 box_.offset(), 
+            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
+                                                                 screen_size.height,
+                                                                 width,
+                                                                 box_.offset(),
                                                                  self.is_fixed);
             x_offset = x;
             remaining_width = w;
@@ -671,8 +671,8 @@ impl Flow for TableCaptionFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
-            
+            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
+
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;
             child_base.position.size.width = remaining_width;

--- a/src/components/main/layout/table_caption.rs
+++ b/src/components/main/layout/table_caption.rs
@@ -147,7 +147,7 @@ impl TableCaptionFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_caption_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
@@ -280,7 +280,7 @@ impl TableCaptionFlow {
         }
     }
 
-    pub fn build_display_list_table<E:ExtraDisplayListData>(
+    pub fn build_display_list_table_caption<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -435,12 +435,12 @@ impl Flow for TableCaptionFlow {
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height_inorder: assigning height for table_caption {}", self.base.id);
-        self.assign_height_table_base(ctx, true);
+        self.assign_height_table_caption_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height: assigning height for table_caption {}", self.base.id);
-        self.assign_height_table_base(ctx, false);
+        self.assign_height_table_caption_base(ctx, false);
     }
 
     fn collapse_margins(&mut self,

--- a/src/components/main/layout/table_caption.rs
+++ b/src/components/main/layout/table_caption.rs
@@ -10,42 +10,13 @@ use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableCaptionFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
-use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
+use layout::float_context::{FloatContext, Invalid};
 
 use std::cell::RefCell;
 use geom::{Point2D, Rect, SideOffsets2D};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
-
-/// Information specific to floated blocks.
-pub struct FloatedTableInfo {
-    containing_width: Au,
-
-    /// Offset relative to where the parent tried to position this flow
-    rel_pos: Point2D<Au>,
-
-    /// Index into the box list for inline floats
-    index: Option<uint>,
-
-    /// Number of floated children
-    floated_children: uint,
-
-    /// Left or right?
-    float_type: FloatType
-}
-
-impl FloatedTableInfo {
-    pub fn new(float_type: FloatType) -> FloatedTableInfo {
-        FloatedTableInfo {
-            containing_width: Au(0),
-            rel_pos: Point2D(Au(0), Au(0)),
-            index: None,
-            floated_children: 0,
-            float_type: float_type
-        }
-    }
-}
 
 /// A table formatting context.
 pub struct TableCaptionFlow {
@@ -54,13 +25,6 @@ pub struct TableCaptionFlow {
 
     /// The associated box.
     box_: Option<Box>,
-
-    //TODO: is_fixed should be bit fields to conserve memory.
-    /// Position property
-    is_fixed: bool,
-
-    /// Additional floating flow members.
-    float: Option<~FloatedTableInfo>,
 }
 
 impl TableCaptionFlow {
@@ -68,40 +32,14 @@ impl TableCaptionFlow {
         TableCaptionFlow {
             base: base,
             box_: None,
-            is_fixed: false,
-            float: None,
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableCaptionFlow {
+    pub fn from_box(base: BaseFlow, box_: Box) -> TableCaptionFlow {
         TableCaptionFlow {
             base: base,
             box_: Some(box_),
-            is_fixed: is_fixed,
-            float: None,
         }
-    }
-
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableCaptionFlow {
-        TableCaptionFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableCaptionFlow {
-        TableCaptionFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-        }
-    }
-
-    pub fn is_float(&self) -> bool {
-        self.float.is_some()
     }
 
     pub fn teardown(&mut self) {
@@ -109,7 +47,6 @@ impl TableCaptionFlow {
             box_.teardown();
         }
         self.box_ = None;
-        self.float = None;
     }
 
     /// Computes left and right margins and width based on CSS 2.1 section 10.3.3.
@@ -204,20 +141,6 @@ impl TableCaptionFlow {
             }
         };
 
-        return (width, margin_left, margin_right);
-    }
-
-    fn compute_float_margins(&self, box_: &Box, remaining_width: Au) -> (Au, Au, Au) {
-        let style = box_.style();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
-                                                remaining_width).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
-                                                 remaining_width).specified_or_zero();
-        let shrink_to_fit = geometry::min(self.base.pref_width,
-                                          geometry::max(self.base.min_width, remaining_width));
-        let width = MaybeAuto::from_style(style.Box.width,
-                                          remaining_width).specified_or_default(shrink_to_fit);
-        debug!("assign_widths_float -- width: {}", width);
         return (width, margin_left, margin_right);
     }
 
@@ -329,7 +252,6 @@ impl TableCaptionFlow {
         }
 
         let mut noncontent_height = Au::new(0);
-        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
             let mut margin = box_.margin.get();
@@ -341,23 +263,8 @@ impl TableCaptionFlow {
             noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
                 box_.border.get().top + box_.border.get().bottom;
 
-            let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                 height, clearance + margin.top, self.is_fixed);
-            position.origin.y = y;
-            height = h;
-
-            if self.is_fixed {
-                for kid in self.base.child_iter() {
-                    let child_node = flow::mut_base(*kid);
-                    child_node.position.origin.y = position.origin.y + top_offset;
-                }
-            }
-
-            position.size.height = if self.is_fixed {
-                height
-            } else {
-                height + noncontent_height
-            };
+            position.origin.y = clearance + margin.top;
+            position.size.height = height + noncontent_height;
 
             noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
 
@@ -365,11 +272,7 @@ impl TableCaptionFlow {
             box_.margin.set(margin);
         }
 
-        self.base.position.size.height = if self.is_fixed {
-            height
-        } else {
-            height + noncontent_height
-        };
+        self.base.position.size.height = height + noncontent_height;
 
         if inorder {
             let extra_height = height - (cur_y - top_offset) + bottom_offset;
@@ -379,102 +282,12 @@ impl TableCaptionFlow {
         }
     }
 
-    fn assign_height_float_inorder(&mut self) {
-        // assign_height_float was already called by the traversal function
-        // so this is well-defined
-
-        let mut height = Au(0);
-        let mut clearance = Au(0);
-        let mut full_noncontent_width = Au(0);
-        let mut margin_height = Au(0);
-
-        for box_ in self.box_.iter() {
-            height = box_.position.get().size.height;
-            clearance = match box_.clear() {
-                None => Au(0),
-                Some(clear) => self.base.floats_in.clearance(clear),
-            };
-
-            let noncontent_width = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-
-            full_noncontent_width = noncontent_width + box_.margin.get().left +
-                box_.margin.get().right;
-            margin_height = box_.margin.get().top + box_.margin.get().bottom;
-        }
-
-        let info = PlacementInfo {
-            width: self.base.position.size.width + full_noncontent_width,
-            height: height + margin_height,
-            ceiling: clearance,
-            max_width: self.float.get_ref().containing_width,
-            f_type: self.float.get_ref().float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.base.floats_out = self.base.floats_in.add_float(&info);
-        self.float.get_mut_ref().rel_pos = self.base.floats_out.last_float_pos();
-    }
-
-    fn assign_height_float(&mut self, ctx: &mut LayoutContext) {
-        // Now that we've determined our height, propagate that out.
-        let has_inorder_children = self.base.num_floats > 0;
-        if has_inorder_children {
-            let mut float_ctx = FloatContext::new(self.float.get_ref().floated_children);
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-        let mut cur_y = Au(0);
-        let mut top_offset = Au(0);
-
-        for box_ in self.box_.iter() {
-            top_offset = box_.margin.get().top + box_.border.get().top + box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-        }
-
-        for kid in self.base.child_iter() {
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.y = cur_y;
-            cur_y = cur_y + child_base.position.size.height;
-        }
-
-        let mut height = cur_y - top_offset;
-
-        let mut noncontent_height;
-        let box_ = self.box_.as_ref().unwrap();
-        let mut position = box_.position.get();
-
-        // The associated box is the border box of this flow.
-        position.origin.y = box_.margin.get().top;
-
-        noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-            box_.border.get().top + box_.border.get().bottom;
-
-        //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
-                                                Au::new(0)).specified_or_zero();
-
-        height = geometry::max(height, height_prop) + noncontent_height;
-        debug!("assign_height_float -- height: {}", height);
-
-        position.size.height = height;
-        box_.position.set(position);
-    }
-
     pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        if self.is_float() {
-            return self.build_display_list_float(builder, dirty, list);
-        }
-
         let abs_rect = Rect(self.base.abs_position, self.base.position.size);
         if !abs_rect.intersects(dirty) {
             return true;
@@ -492,35 +305,6 @@ impl TableCaptionFlow {
         for child in self.base.child_iter() {
             let child_base = flow::mut_base(*child);
             child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
-    }
-
-    pub fn build_display_list_float<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true
-        }
-
-        let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
-        }
-
-
-        // TODO: handle any out-of-flow elements
-
-        // go deeper into the flow tree
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = offset + child_base.position.origin;
         }
 
         false
@@ -557,12 +341,7 @@ impl Flow for TableCaptionFlow {
             num_floats = num_floats + child_base.num_floats;
         }
 
-        if self.is_float() {
-            self.base.num_floats = 1;
-            self.float.get_mut_ref().floated_children = num_floats;
-        } else {
-            self.base.num_floats = num_floats;
-        }
+        self.base.num_floats = num_floats;
 
         /* if not an anonymous block context, add in block box's widths.
            these widths will not include child elements, just padding etc. */
@@ -586,25 +365,12 @@ impl Flow for TableCaptionFlow {
     ///
     /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
     /// contexts.
-    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}",
-               if self.is_float() {
-                   "float"
-               } else {
-                   "table_caption"
-               },
-               self.base.id);
+    fn assign_widths(&mut self, _: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow {}", "table_caption", self.base.id);
 
         // The position was set to the containing block by the flow's parent.
         let mut remaining_width = self.base.position.size.width;
         let mut x_offset = Au::new(0);
-
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = remaining_width;
-
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -625,48 +391,26 @@ impl Flow for TableCaptionFlow {
             let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
                                                       remaining_width).specified_or_zero();
 
-            let (width, margin_left, margin_right) = if self.is_float() {
-                self.compute_float_margins(box_, remaining_width)
-            } else {
-                self.compute_table_margins(box_, remaining_width, available_width)
-            };
+            let (width, margin_left, margin_right) = self.compute_table_margins(box_,
+                                                                                remaining_width, available_width);
 
             box_.margin.set(SideOffsets2D::new(margin_top,
                                               margin_right,
                                               margin_bottom,
                                               margin_left));
 
-            let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
-                                                                 screen_size.height,
-                                                                 width,
-                                                                 box_.offset(),
-                                                                 self.is_fixed);
-            x_offset = x;
-            remaining_width = w;
+            x_offset = box_.offset();
+            remaining_width = width;
 
             // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
-            if self.is_fixed {
-                position_ref.get().origin.x = x_offset + box_.margin.get().left;
-                x_offset = x_offset + box_.padding.get().left;
-            } else {
-                position_ref.get().origin.x = box_.margin.get().left;
-            }
+            position_ref.get().origin.x = box_.margin.get().left;
             let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
                 box_.border.get().left + box_.border.get().right;
             position_ref.get().size.width = remaining_width + padding_and_borders;
         }
 
-        if self.is_float() {
-            self.base.position.size.width = remaining_width;
-        }
-
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
+        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
@@ -692,23 +436,13 @@ impl Flow for TableCaptionFlow {
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
-            self.assign_height_float_inorder();
-        } else {
-            debug!("assign_height_inorder: assigning height for table_caption {}", self.base.id);
-            self.assign_height_table_base(ctx, true);
-        }
+        debug!("assign_height_inorder: assigning height for table_caption {}", self.base.id);
+        self.assign_height_table_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
-            self.assign_height_float(ctx);
-        } else {
-            debug!("assign_height: assigning height for table_caption {}", self.base.id);
-            self.assign_height_table_base(ctx, false);
-        }
+        debug!("assign_height: assigning height for table_caption {}", self.base.id);
+        self.assign_height_table_base(ctx, false);
     }
 
     fn collapse_margins(&mut self,
@@ -718,12 +452,6 @@ impl Flow for TableCaptionFlow {
                         top_offset: &mut Au,
                         collapsing: &mut Au,
                         collapsible: &mut Au) {
-        if self.is_float() {
-            // Margins between a floated box and any other box do not collapse.
-            *collapsing = Au::new(0);
-            return;
-        }
-
         for box_ in self.box_.iter() {
             // The top margin collapses with its first in-flow block-level child's
             // top margin if the parent has no top border, no top padding.
@@ -748,11 +476,7 @@ impl Flow for TableCaptionFlow {
     }
 
     fn debug_str(&self) -> ~str {
-        let txt = if self.is_float() {
-            ~"FloatFlow: "
-        } else {
-            ~"TableCaptionFlow: "
-        };
+        let txt = ~"TableCaptionFlow: ";
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! CSS block formatting contexts.
+//! CSS table formatting contexts.
 
 use layout::box_::Box;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
-use layout::flow::{BaseFlow, BlockFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow::{BaseFlow, TableCellFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
@@ -19,7 +19,7 @@ use servo_util::geometry::Au;
 use servo_util::geometry;
 
 /// Information specific to floated blocks.
-pub struct FloatedBlockInfo {
+pub struct FloatedTableInfo {
     containing_width: Au,
 
     /// Offset relative to where the parent tried to position this flow
@@ -35,9 +35,9 @@ pub struct FloatedBlockInfo {
     float_type: FloatType
 }
 
-impl FloatedBlockInfo {
-    pub fn new(float_type: FloatType) -> FloatedBlockInfo {
-        FloatedBlockInfo {
+impl FloatedTableInfo {
+    pub fn new(float_type: FloatType) -> FloatedTableInfo {
+        FloatedTableInfo {
             containing_width: Au(0),
             rel_pos: Point2D(Au(0), Au(0)),
             index: None,
@@ -47,72 +47,56 @@ impl FloatedBlockInfo {
     }
 }
 
-/// A block formatting context.
-pub struct BlockFlow {
+/// A table formatting context.
+pub struct TableCellFlow {
     /// Data common to all flows.
     base: BaseFlow,
 
     /// The associated box.
     box_: Option<Box>,
 
-    //TODO: is_fixed and is_root should be bit fields to conserve memory.
-    /// Whether this block flow is the root flow.
-    is_root: bool,
-
+    //TODO: is_fixed should be bit fields to conserve memory.
+    /// Position property
     is_fixed: bool,
 
     /// Additional floating flow members.
-    float: Option<~FloatedBlockInfo>
+    float: Option<~FloatedTableInfo>
 }
 
-impl BlockFlow {
-    pub fn new(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+impl TableCellFlow {
+    pub fn new(base: BaseFlow) -> TableCellFlow {
+        TableCellFlow {
             base: base,
             box_: None,
-            is_root: false,
             is_fixed: false,
             float: None
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> BlockFlow {
-        BlockFlow {
+    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableCellFlow {
+        TableCellFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: is_fixed,
             float: None
         }
     }
 
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> BlockFlow {
-        BlockFlow {
+    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableCellFlow {
+        TableCellFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
-    pub fn new_root(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableCellFlow {
+        TableCellFlow {
             base: base,
             box_: None,
-            is_root: true,
             is_fixed: false,
-            float: None
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> BlockFlow {
-        BlockFlow {
-            base: base,
-            box_: None,
-            is_root: false,
-            is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
@@ -180,7 +164,7 @@ impl BlockFlow {
         (width_Au, left_margin_Au, right_margin_Au)
     }
 
-    fn compute_block_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
+    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
                              -> (Au, Au, Au) {
         let style = box_.style();
 
@@ -240,7 +224,7 @@ impl BlockFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_block_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
@@ -274,6 +258,7 @@ impl BlockFlow {
             // last_child.floats_out -> self.floats_out (done at the end of this method)
             float_ctx = self.base.floats_in.translate(Point2D(-left_offset, -top_offset));
             for kid in self.base.child_iter() {
+                println!("{:?}", float_ctx);
                 flow::mut_base(*kid).floats_in = float_ctx.clone();
                 kid.assign_height_inorder(ctx);
                 float_ctx = flow::mut_base(*kid).floats_out.clone();
@@ -288,11 +273,11 @@ impl BlockFlow {
         let mut bottom_margin_collapsible = false;
         let mut first_in_flow = true;
         for box_ in self.box_.iter() {
-            if !self.is_root && box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
+            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
                 collapsible = box_.margin.get().top;
                 top_margin_collapsible = true;
             }
-            if !self.is_root && box_.border.get().bottom == Au(0) &&
+            if box_.border.get().bottom == Au(0) &&
                     box_.padding.get().bottom == Au(0) {
                 bottom_margin_collapsible = true;
             }
@@ -329,17 +314,8 @@ impl BlockFlow {
         // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
         // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
 
-        let screen_height = ctx.screen_size.height;
 
-        let mut height = if self.is_root {
-            // FIXME(pcwalton): The max is taken here so that you can scroll the page, but this is
-            // not correct behavior according to CSS 2.1 § 10.5. Instead I think we should treat
-            // the root element as having `overflow: scroll` and use the layers-based scrolling
-            // infrastructure to make it scrollable.
-            Au::max(screen_height, cur_y)
-        } else {
-            cur_y - top_offset - collapsing
-        };
+        let mut height = cur_y - top_offset - collapsing;
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -354,6 +330,7 @@ impl BlockFlow {
         }
 
         let mut noncontent_height = Au::new(0);
+        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
             let mut margin = box_.margin.get();
@@ -366,10 +343,7 @@ impl BlockFlow {
                 box_.border.get().top + box_.border.get().bottom;
 
             let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                  height,
-                                                                  clearance + margin.top,
-                                                                  self.is_fixed);
-
+                                                                 height, clearance + margin.top, self.is_fixed);
             position.origin.y = y;
             height = h;
 
@@ -492,7 +466,7 @@ impl BlockFlow {
         box_.position.set(position);
     }
 
-    pub fn build_display_list_block<E:ExtraDisplayListData>(
+    pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -507,9 +481,9 @@ impl BlockFlow {
             return true;
         }
 
-        debug!("build_display_list_block: adding display element");
+        debug!("build_display_list_table: adding display element");
 
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
         }
@@ -536,7 +510,7 @@ impl BlockFlow {
         }
 
         let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
         }
@@ -554,12 +528,12 @@ impl BlockFlow {
     }
 }
 
-impl Flow for BlockFlow {
+impl Flow for TableCellFlow {
     fn class(&self) -> FlowClass {
-        BlockFlowClass
+        TableCellFlowClass
     }
 
-    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+    fn as_table_cell<'a>(&'a mut self) -> &'a mut TableCellFlow {
         self
     }
 
@@ -620,17 +594,9 @@ impl Flow for BlockFlow {
                if self.is_float() {
                    "float"
                } else {
-                   "block"
+                   "table_cell"
                },
                self.base.id);
-
-        if self.is_root {
-            debug!("Setting root position");
-            self.base.position.origin = Au::zero_point();
-            self.base.position.size.width = ctx.screen_size.width;
-            self.base.floats_in = FloatContext::new(self.base.num_floats);
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         // The position was set to the containing block by the flow's parent.
         let mut remaining_width = self.base.position.size.width;
@@ -646,10 +612,9 @@ impl Flow for BlockFlow {
         for box_ in self.box_.iter() {
             let style = box_.style();
 
-            // The text alignment of a block flow is the text alignment of its box's style.
+            // The text alignment of a table_cell flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            box_.assign_width(remaining_width);
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
@@ -665,21 +630,20 @@ impl Flow for BlockFlow {
             let (width, margin_left, margin_right) = if self.is_float() {
                 self.compute_float_margins(box_, remaining_width)
             } else {
-                self.compute_block_margins(box_, remaining_width, available_width)
+                self.compute_table_margins(box_, remaining_width, available_width)
             };
 
             box_.margin.set(SideOffsets2D::new(margin_top,
-                                               margin_right,
-                                               margin_bottom,
-                                               margin_left));
+                                              margin_right,
+                                              margin_bottom,
+                                              margin_left));
 
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height,
-                                                                 width,
-                                                                 box_.offset(),
+                                                                 screen_size.height, 
+                                                                 width, 
+                                                                 box_.offset(), 
                                                                  self.is_fixed);
-
             x_offset = x;
             remaining_width = w;
 
@@ -723,8 +687,8 @@ impl Flow for BlockFlow {
             // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
             //
             // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-
             child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
+
             child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
         }
     }
@@ -734,29 +698,18 @@ impl Flow for BlockFlow {
             debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
             self.assign_height_float_inorder();
         } else {
-            debug!("assign_height_inorder: assigning height for block {}", self.base.id);
-            self.assign_height_block_base(ctx, true);
+            debug!("assign_height_inorder: assigning height for table_cell {}", self.base.id);
+            self.assign_height_table_base(ctx, true);
         }
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        //assign height for box
-        for box_ in self.box_.iter() {
-            box_.assign_height();
-        }
-
         if self.is_float() {
             debug!("assign_height_float: assigning height for float {}", self.base.id);
             self.assign_height_float(ctx);
         } else {
-            debug!("assign_height: assigning height for block {}", self.base.id);
-            // This is the only case in which a block flow can start an inorder
-            // subtraversal.
-            if self.is_root && self.base.num_floats > 0 {
-                self.assign_height_inorder(ctx);
-                return;
-            }
-            self.assign_height_block_base(ctx, false);
+            debug!("assign_height: assigning height for table_cell {}", self.base.id);
+            self.assign_height_table_base(ctx, false);
         }
     }
 
@@ -796,17 +749,11 @@ impl Flow for BlockFlow {
         *first_in_flow = false;
     }
 
-    fn mark_as_root(&mut self) {
-        self.is_root = true
-    }
-
     fn debug_str(&self) -> ~str {
         let txt = if self.is_float() {
             ~"FloatFlow: "
-        } else if self.is_root {
-            ~"RootFlow: "
         } else {
-            ~"BlockFlow: "
+            ~"TableCellFlow: "
         };
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -51,7 +51,7 @@ impl TableCellFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_cell_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let mut top_offset = Au::new(0);
         let mut bottom_offset = Au::new(0);
@@ -127,7 +127,7 @@ impl TableCellFlow {
         }
     }
 
-    pub fn build_display_list_table<E:ExtraDisplayListData>(
+    pub fn build_display_list_table_cell<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -138,7 +138,7 @@ impl TableCellFlow {
             return true;
         }
 
-        debug!("build_display_list_table: adding display element");
+        debug!("build_display_list_table_cell: adding display element");
 
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
@@ -206,7 +206,7 @@ impl Flow for TableCellFlow {
     fn assign_widths(&mut self, _: &mut LayoutContext) {
         debug!("assign_widths({}): assigning width for flow {}", "table_cell", self.base.id);
 
-        // The position was set to the containing block by the flow's parent.
+        // The position was set to the column width by the parent flow, table row flow.
         let mut remaining_width = self.base.position.size.width;
         let mut x_offset = Au::new(0);
 
@@ -257,14 +257,16 @@ impl Flow for TableCellFlow {
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height_inorder: assigning height for table_cell {}", self.base.id);
-        self.assign_height_table_base(ctx, true);
+        self.assign_height_table_cell_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height: assigning height for table_cell {}", self.base.id);
-        self.assign_height_table_base(ctx, false);
+        self.assign_height_table_cell_base(ctx, false);
     }
 
+    /// TableCellBox and their parents(TableRowBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
     fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
                         _: &mut Au, _: &mut Au, _: &mut Au) {
     }

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -9,11 +9,11 @@ use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableCellFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
+use layout::model::{MaybeAuto, Specified, Auto};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
 
 use std::cell::RefCell;
-use geom::{Point2D, Rect, SideOffsets2D};
+use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
@@ -110,115 +110,6 @@ impl TableCellFlow {
         }
         self.box_ = None;
         self.float = None;
-    }
-
-    /// Computes left and right margins and width based on CSS 2.1 section 10.3.3.
-    /// Requires borders and padding to already be computed.
-    fn compute_horiz(&self,
-                     width: MaybeAuto,
-                     left_margin: MaybeAuto,
-                     right_margin: MaybeAuto,
-                     available_width: Au)
-                     -> (Au, Au, Au) {
-        // If width is not 'auto', and width + margins > available_width, all 'auto' margins are
-        // treated as 0.
-        let (left_margin, right_margin) = match width {
-            Auto => (left_margin, right_margin),
-            Specified(width) => {
-                let left = left_margin.specified_or_zero();
-                let right = right_margin.specified_or_zero();
-
-                if((left + right + width) > available_width) {
-                    (Specified(left), Specified(right))
-                } else {
-                    (left_margin, right_margin)
-                }
-            }
-        };
-
-        //Invariant: left_margin_Au + width_Au + right_margin_Au == available_width
-        let (left_margin_Au, width_Au, right_margin_Au) = match (left_margin, width, right_margin) {
-            //If all have a computed value other than 'auto', the system is over-constrained and we need to discard a margin.
-            //if direction is ltr, ignore the specified right margin and solve for it. If it is rtl, ignore the specified
-            //left margin. FIXME(eatkinson): this assumes the direction is ltr
-            (Specified(margin_l), Specified(width), Specified(_margin_r)) => (margin_l, width, available_width - (margin_l + width )),
-
-            //If exactly one value is 'auto', solve for it
-            (Auto, Specified(width), Specified(margin_r)) => (available_width - (width + margin_r), width, margin_r),
-            (Specified(margin_l), Auto, Specified(margin_r)) => (margin_l, available_width - (margin_l + margin_r), margin_r),
-            (Specified(margin_l), Specified(width), Auto) => (margin_l, width, available_width - (margin_l + width)),
-
-            //If width is set to 'auto', any other 'auto' value becomes '0', and width is solved for
-            (Auto, Auto, Specified(margin_r)) => (Au::new(0), available_width - margin_r, margin_r),
-            (Specified(margin_l), Auto, Auto) => (margin_l, available_width - margin_l, Au::new(0)),
-            (Auto, Auto, Auto) => (Au::new(0), available_width, Au::new(0)),
-
-            //If left and right margins are auto, they become equal
-            (Auto, Specified(width), Auto) => {
-                let margin = (available_width - width).scale_by(0.5);
-                (margin, width, margin)
-            }
-
-        };
-        //return values in same order as params
-        (width_Au, left_margin_Au, right_margin_Au)
-    }
-
-    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
-                             -> (Au, Au, Au) {
-        let style = box_.style();
-
-        let (width, maybe_margin_left, maybe_margin_right) =
-            (MaybeAuto::from_style(style.Box.width, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_left, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_right, remaining_width));
-
-        let (width, margin_left, margin_right) = self.compute_horiz(width,
-                                                                    maybe_margin_left,
-                                                                    maybe_margin_right,
-                                                                    available_width);
-
-        // If the tentative used width is greater than 'max-width', width should be recalculated,
-        // but this time using the computed value of 'max-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            match specified_or_none(style.Box.max_width, remaining_width) {
-                Some(value) if value < width => self.compute_horiz(Specified(value),
-                                                                   maybe_margin_left,
-                                                                   maybe_margin_right,
-                                                                   available_width),
-                _ => (width, margin_left, margin_right)
-            }
-        };
-
-        // If the resulting width is smaller than 'min-width', width should be recalculated,
-        // but this time using the value of 'min-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            let computed_min_width = specified(style.Box.min_width, remaining_width);
-            if computed_min_width > width {
-                self.compute_horiz(Specified(computed_min_width),
-                                   maybe_margin_left,
-                                   maybe_margin_right,
-                                   available_width)
-            } else {
-                (width, margin_left, margin_right)
-            }
-        };
-
-        return (width, margin_left, margin_right);
-    }
-
-    fn compute_float_margins(&self, box_: &Box, remaining_width: Au) -> (Au, Au, Au) {
-        let style = box_.style();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
-                                                remaining_width).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
-                                                 remaining_width).specified_or_zero();
-        let shrink_to_fit = geometry::min(self.base.pref_width,
-                                          geometry::max(self.base.min_width, remaining_width));
-        let width = MaybeAuto::from_style(style.Box.width,
-                                          remaining_width).specified_or_default(shrink_to_fit);
-        debug!("assign_widths_float -- width: {}", width);
-        return (width, margin_left, margin_right);
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
@@ -616,46 +507,22 @@ impl Flow for TableCellFlow {
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
-            // Margins are 0 right now so base.noncontent_width() is just borders + padding.
-            let available_width = remaining_width - box_.noncontent_width();
-
-            // Top and bottom margins for blocks are 0 if auto.
-            let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
-                                                   remaining_width).specified_or_zero();
-            let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
-                                                      remaining_width).specified_or_zero();
-
-            let (width, margin_left, margin_right) = if self.is_float() {
-                self.compute_float_margins(box_, remaining_width)
-            } else {
-                self.compute_table_margins(box_, remaining_width, available_width)
-            };
-
-            box_.margin.set(SideOffsets2D::new(margin_top,
-                                              margin_right,
-                                              margin_bottom,
-                                              margin_left));
-
             let screen_size = ctx.screen_size;
             let (x, _w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
                                                                  screen_size.height, 
-                                                                 width, 
+                                                                 remaining_width, 
                                                                  box_.offset(), 
                                                                  self.is_fixed);
             x_offset = x;
-            //remaining_width = w;
 
             // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
             if self.is_fixed {
-                position_ref.get().origin.x = x_offset + box_.margin.get().left;
+                position_ref.get().origin.x = x_offset;
                 x_offset = x_offset + box_.padding.get().left;
-            } else {
-                position_ref.get().origin.x = box_.margin.get().left;
             }
-            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-            position_ref.get().size.width = remaining_width + padding_and_borders;
+
+            position_ref.get().size.width = remaining_width;
         }
 
         if self.is_float() {

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -543,18 +543,16 @@ impl Flow for TableCellFlow {
     min/pref widths based on child context widths and dimensions of
     any boxes it is responsible for flowing.  */
 
-    /* TODO: absolute contexts */
-    /* TODO: inline-blocks */
     fn bubble_widths(&mut self, _: &mut LayoutContext) {
         let mut min_width = Au::new(0);
         let mut pref_width = Au::new(0);
         let mut num_floats = 0;
 
         /* find max width from child block contexts */
-        for child_ctx in self.base.child_iter() {
-            assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow() || child_ctx.starts_table_flow());
+        for kid in self.base.child_iter() {
+            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
 
-            let child_base = flow::mut_base(*child_ctx);
+            let child_base = flow::mut_base(*kid);
             min_width = geometry::max(min_width, child_base.min_width);
             pref_width = geometry::max(pref_width, child_base.pref_width);
             num_floats = num_floats + child_base.num_floats;
@@ -599,7 +597,7 @@ impl Flow for TableCellFlow {
                self.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let mut remaining_width = self.base.position.size.width;
+        let remaining_width = self.base.position.size.width;
         let mut x_offset = Au::new(0);
 
         if self.is_float() {
@@ -639,13 +637,13 @@ impl Flow for TableCellFlow {
                                               margin_left));
 
             let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
+            let (x, _w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
                                                                  screen_size.height, 
                                                                  width, 
                                                                  box_.offset(), 
                                                                  self.is_fixed);
             x_offset = x;
-            remaining_width = w;
+            //remaining_width = w;
 
             // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -149,7 +149,6 @@ impl TableCellFlow {
             // last_child.floats_out -> self.floats_out (done at the end of this method)
             float_ctx = self.base.floats_in.translate(Point2D(-left_offset, -top_offset));
             for kid in self.base.child_iter() {
-                println!("{:?}", float_ctx);
                 flow::mut_base(*kid).floats_in = float_ctx.clone();
                 kid.assign_height_inorder(ctx);
                 float_ctx = flow::mut_base(*kid).floats_out.clone();

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -237,7 +237,7 @@ impl TableCellFlow {
             position.origin.y = y;
             height = h;
 
-            if self.is_fixed { 
+            if self.is_fixed {
                 for kid in self.base.child_iter() {
                     let child_node = flow::mut_base(*kid);
                     child_node.position.origin.y = position.origin.y + top_offset;
@@ -440,7 +440,7 @@ impl Flow for TableCellFlow {
 
         /* find max width from child block contexts */
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
 
             let child_base = flow::mut_base(*kid);
             min_width = geometry::max(min_width, child_base.min_width);
@@ -507,10 +507,10 @@ impl Flow for TableCellFlow {
             box_.compute_padding(style, remaining_width);
 
             let screen_size = ctx.screen_size;
-            let (x, _w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height, 
-                                                                 remaining_width, 
-                                                                 box_.offset(), 
+            let (x, _w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
+                                                                 screen_size.height,
+                                                                 remaining_width,
+                                                                 box_.offset(),
                                                                  self.is_fixed);
             x_offset = x;
 
@@ -537,7 +537,7 @@ impl Flow for TableCellFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -9,43 +9,13 @@ use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableCellFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto};
-use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
+use layout::float_context::{FloatContext, Invalid};
 
 use std::cell::RefCell;
 use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
-
-/// Information specific to floated blocks.
-pub struct FloatedTableInfo {
-    containing_width: Au,
-
-    /// Offset relative to where the parent tried to position this flow
-    rel_pos: Point2D<Au>,
-
-    /// Index into the box list for inline floats
-    index: Option<uint>,
-
-    /// Number of floated children
-    floated_children: uint,
-
-    /// Left or right?
-    float_type: FloatType
-}
-
-impl FloatedTableInfo {
-    pub fn new(float_type: FloatType) -> FloatedTableInfo {
-        FloatedTableInfo {
-            containing_width: Au(0),
-            rel_pos: Point2D(Au(0), Au(0)),
-            index: None,
-            floated_children: 0,
-            float_type: float_type
-        }
-    }
-}
 
 /// A table formatting context.
 pub struct TableCellFlow {
@@ -54,13 +24,6 @@ pub struct TableCellFlow {
 
     /// The associated box.
     box_: Option<Box>,
-
-    //TODO: is_fixed should be bit fields to conserve memory.
-    /// Position property
-    is_fixed: bool,
-
-    /// Additional floating flow members.
-    float: Option<~FloatedTableInfo>
 }
 
 impl TableCellFlow {
@@ -68,40 +31,14 @@ impl TableCellFlow {
         TableCellFlow {
             base: base,
             box_: None,
-            is_fixed: false,
-            float: None
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableCellFlow {
+    pub fn from_box(base: BaseFlow, box_: Box) -> TableCellFlow {
         TableCellFlow {
             base: base,
             box_: Some(box_),
-            is_fixed: is_fixed,
-            float: None
         }
-    }
-
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableCellFlow {
-        TableCellFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type))
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableCellFlow {
-        TableCellFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type))
-        }
-    }
-
-    pub fn is_float(&self) -> bool {
-        self.float.is_some()
     }
 
     pub fn teardown(&mut self) {
@@ -109,7 +46,6 @@ impl TableCellFlow {
             box_.teardown();
         }
         self.box_ = None;
-        self.float = None;
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
@@ -117,26 +53,16 @@ impl TableCellFlow {
     #[inline(always)]
     fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
-        let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
         let mut bottom_offset = Au::new(0);
         let mut left_offset = Au::new(0);
         let mut float_ctx = Invalid;
 
         for box_ in self.box_.iter() {
-            clearance = match box_.clear() {
-                None => Au::new(0),
-                Some(clear) => {
-                    self.base.floats_in.clearance(clear)
-                }
-            };
-
-            top_offset = clearance + box_.margin.get().top + box_.border.get().top +
-                box_.padding.get().top;
+            top_offset = box_.border.get().top + box_.padding.get().top;
             cur_y = cur_y + top_offset;
-            bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
-                box_.padding.get().bottom;
-            left_offset = box_.offset();
+            bottom_offset = box_.border.get().bottom + box_.padding.get().bottom;
+            left_offset = box_.border.get().left + box_.padding.get().left;
         }
 
         if inorder {
@@ -155,112 +81,30 @@ impl TableCellFlow {
             }
         }
 
-        let mut collapsible = Au::new(0);
-        let mut collapsing = Au::new(0);
-        let mut margin_top = Au::new(0);
-        let mut margin_bottom = Au::new(0);
-        let mut top_margin_collapsible = false;
-        let mut bottom_margin_collapsible = false;
-        let mut first_in_flow = true;
-        for box_ in self.box_.iter() {
-            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
-                collapsible = box_.margin.get().top;
-                top_margin_collapsible = true;
-            }
-            if box_.border.get().bottom == Au(0) &&
-                    box_.padding.get().bottom == Au(0) {
-                bottom_margin_collapsible = true;
-            }
-            margin_top = box_.margin.get().top;
-            margin_bottom = box_.margin.get().bottom;
-        }
-
         for kid in self.base.child_iter() {
-            kid.collapse_margins(top_margin_collapsible,
-                                 &mut first_in_flow,
-                                 &mut margin_top,
-                                 &mut top_offset,
-                                 &mut collapsing,
-                                 &mut collapsible);
-
             let child_node = flow::mut_base(*kid);
-            cur_y = cur_y - collapsing;
             child_node.position.origin.y = cur_y;
             cur_y = cur_y + child_node.position.size.height;
         }
 
-        // The bottom margin collapses with its last in-flow block-level child's bottom margin
-        // if the parent has no bottom boder, no bottom padding.
-        collapsing = if bottom_margin_collapsible {
-            if margin_bottom < collapsible {
-                margin_bottom = collapsible;
-            }
-            collapsible
-        } else {
-            Au::new(0)
-        };
+        // CSS 2.1 § 17.5.3. Table cell box height is the minimum height required by the content.
+        let height = cur_y - top_offset;
 
-        // TODO: A box's own margins collapse if the 'min-height' property is zero, and it has neither
-        // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
-        // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
-
-
-        let mut height = cur_y - top_offset - collapsing;
-
-        for box_ in self.box_.iter() {
-            let style = box_.style();
-
-            // At this point, `height` is the height of the containing block, so passing `height`
-            // as the second argument here effectively makes percentages relative to the containing
-            // block per CSS 2.1 § 10.5.
-            height = match MaybeAuto::from_style(style.Box.height, height) {
-                Auto => height,
-                Specified(value) => value
-            };
-        }
-
+        // TODO(june0cho): vertical-align of table-cell should be calculated.
         let mut noncontent_height = Au::new(0);
-        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
-            let mut margin = box_.margin.get();
-
-            // The associated box is the border box of this flow.
-            margin.top = margin_top;
-            margin.bottom = margin_bottom;
 
             noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-                box_.border.get().top + box_.border.get().bottom;
+                                box_.border.get().top + box_.border.get().bottom;
 
-            let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                 height, clearance + margin.top, self.is_fixed);
-            position.origin.y = y;
-            height = h;
-
-            if self.is_fixed {
-                for kid in self.base.child_iter() {
-                    let child_node = flow::mut_base(*kid);
-                    child_node.position.origin.y = position.origin.y + top_offset;
-                }
-            }
-
-            position.size.height = if self.is_fixed {
-                height
-            } else {
-                height + noncontent_height
-            };
-
-            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
+            position.origin.y = Au(0);
+            position.size.height = height + noncontent_height;
 
             box_.position.set(position);
-            box_.margin.set(margin);
         }
 
-        self.base.position.size.height = if self.is_fixed {
-            height
-        } else {
-            height + noncontent_height
-        };
+        self.base.position.size.height = height + noncontent_height;
 
         if inorder {
             let extra_height = height - (cur_y - top_offset) + bottom_offset;
@@ -270,102 +114,12 @@ impl TableCellFlow {
         }
     }
 
-    fn assign_height_float_inorder(&mut self) {
-        // assign_height_float was already called by the traversal function
-        // so this is well-defined
-
-        let mut height = Au(0);
-        let mut clearance = Au(0);
-        let mut full_noncontent_width = Au(0);
-        let mut margin_height = Au(0);
-
-        for box_ in self.box_.iter() {
-            height = box_.position.get().size.height;
-            clearance = match box_.clear() {
-                None => Au(0),
-                Some(clear) => self.base.floats_in.clearance(clear),
-            };
-
-            let noncontent_width = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-
-            full_noncontent_width = noncontent_width + box_.margin.get().left +
-                box_.margin.get().right;
-            margin_height = box_.margin.get().top + box_.margin.get().bottom;
-        }
-
-        let info = PlacementInfo {
-            width: self.base.position.size.width + full_noncontent_width,
-            height: height + margin_height,
-            ceiling: clearance,
-            max_width: self.float.get_ref().containing_width,
-            f_type: self.float.get_ref().float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.base.floats_out = self.base.floats_in.add_float(&info);
-        self.float.get_mut_ref().rel_pos = self.base.floats_out.last_float_pos();
-    }
-
-    fn assign_height_float(&mut self, ctx: &mut LayoutContext) {
-        // Now that we've determined our height, propagate that out.
-        let has_inorder_children = self.base.num_floats > 0;
-        if has_inorder_children {
-            let mut float_ctx = FloatContext::new(self.float.get_ref().floated_children);
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-        let mut cur_y = Au(0);
-        let mut top_offset = Au(0);
-
-        for box_ in self.box_.iter() {
-            top_offset = box_.margin.get().top + box_.border.get().top + box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-        }
-
-        for kid in self.base.child_iter() {
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.y = cur_y;
-            cur_y = cur_y + child_base.position.size.height;
-        }
-
-        let mut height = cur_y - top_offset;
-
-        let mut noncontent_height;
-        let box_ = self.box_.as_ref().unwrap();
-        let mut position = box_.position.get();
-
-        // The associated box is the border box of this flow.
-        position.origin.y = box_.margin.get().top;
-
-        noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-            box_.border.get().top + box_.border.get().bottom;
-
-        //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
-                                                Au::new(0)).specified_or_zero();
-
-        height = geometry::max(height, height_prop) + noncontent_height;
-        debug!("assign_height_float -- height: {}", height);
-
-        position.size.height = height;
-        box_.position.set(position);
-    }
-
     pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        if self.is_float() {
-            return self.build_display_list_float(builder, dirty, list);
-        }
-
         let abs_rect = Rect(self.base.abs_position, self.base.position.size);
         if !abs_rect.intersects(dirty) {
             return true;
@@ -373,7 +127,6 @@ impl TableCellFlow {
 
         debug!("build_display_list_table: adding display element");
 
-        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
         }
@@ -383,35 +136,6 @@ impl TableCellFlow {
         for child in self.base.child_iter() {
             let child_base = flow::mut_base(*child);
             child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
-    }
-
-    pub fn build_display_list_float<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true
-        }
-
-        let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
-        }
-
-
-        // TODO: handle any out-of-flow elements
-
-        // go deeper into the flow tree
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = offset + child_base.position.origin;
         }
 
         false
@@ -427,12 +151,11 @@ impl Flow for TableCellFlow {
         self
     }
 
-    /* Recursively (bottom-up) determine the context's preferred and
-    minimum widths.  When called on this context, all child contexts
-    have had their min/pref widths set. This function must decide
-    min/pref widths based on child context widths and dimensions of
-    any boxes it is responsible for flowing.  */
-
+    /// Recursively (bottom-up) determines the context's preferred and minimum widths. When called
+    /// on this context, all child contexts have had their min/pref widths set. This function must
+    /// decide min/pref widths based on child context widths and dimensions of any boxes it is
+    /// responsible for flowing.
+    /// Min/pref widths set by this function are used in automatic table layout calculation.
     fn bubble_widths(&mut self, _: &mut LayoutContext) {
         let mut min_width = Au::new(0);
         let mut pref_width = Au::new(0);
@@ -448,15 +171,8 @@ impl Flow for TableCellFlow {
             num_floats = num_floats + child_base.num_floats;
         }
 
-        if self.is_float() {
-            self.base.num_floats = 1;
-            self.float.get_mut_ref().floated_children = num_floats;
-        } else {
-            self.base.num_floats = num_floats;
-        }
+        self.base.num_floats = num_floats;
 
-        /* if not an anonymous block context, add in block box's widths.
-           these widths will not include child elements, just padding etc. */
         for box_ in self.box_.iter() {
             {
                 // Can compute border width here since it doesn't depend on anything.
@@ -473,29 +189,13 @@ impl Flow for TableCellFlow {
     }
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
-    /// on this context, the context has had its width set by the parent context.
-    ///
-    /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
-    /// contexts.
-    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}",
-               if self.is_float() {
-                   "float"
-               } else {
-                   "table_cell"
-               },
-               self.base.id);
+    /// on this context, the context has had its width set by the parent table row.
+    fn assign_widths(&mut self, _: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow {}", "table_cell", self.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let remaining_width = self.base.position.size.width;
+        let mut remaining_width = self.base.position.size.width;
         let mut x_offset = Au::new(0);
-
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = remaining_width;
-
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -506,33 +206,18 @@ impl Flow for TableCellFlow {
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
-            let screen_size = ctx.screen_size;
-            let (x, _w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
-                                                                 screen_size.height,
-                                                                 remaining_width,
-                                                                 box_.offset(),
-                                                                 self.is_fixed);
-            x_offset = x;
+            x_offset = box_.padding.get().left + box_.border.get().left;
 
             // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
-            if self.is_fixed {
-                position_ref.get().origin.x = x_offset;
-                x_offset = x_offset + box_.padding.get().left;
-            }
-
             position_ref.get().size.width = remaining_width;
+
+            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
+                                      box_.border.get().left + box_.border.get().right;
+            remaining_width = remaining_width - padding_and_borders;
         }
 
-        if self.is_float() {
-            self.base.position.size.width = remaining_width;
-        }
-
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
+        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
@@ -558,67 +243,21 @@ impl Flow for TableCellFlow {
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
-            self.assign_height_float_inorder();
-        } else {
-            debug!("assign_height_inorder: assigning height for table_cell {}", self.base.id);
-            self.assign_height_table_base(ctx, true);
-        }
+        debug!("assign_height_inorder: assigning height for table_cell {}", self.base.id);
+        self.assign_height_table_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
-            self.assign_height_float(ctx);
-        } else {
-            debug!("assign_height: assigning height for table_cell {}", self.base.id);
-            self.assign_height_table_base(ctx, false);
-        }
+        debug!("assign_height: assigning height for table_cell {}", self.base.id);
+        self.assign_height_table_base(ctx, false);
     }
 
-    fn collapse_margins(&mut self,
-                        top_margin_collapsible: bool,
-                        first_in_flow: &mut bool,
-                        margin_top: &mut Au,
-                        top_offset: &mut Au,
-                        collapsing: &mut Au,
-                        collapsible: &mut Au) {
-        if self.is_float() {
-            // Margins between a floated box and any other box do not collapse.
-            *collapsing = Au::new(0);
-            return;
-        }
-
-        for box_ in self.box_.iter() {
-            // The top margin collapses with its first in-flow block-level child's
-            // top margin if the parent has no top border, no top padding.
-            if *first_in_flow && top_margin_collapsible {
-                // If top-margin of parent is less than top-margin of its first child,
-                // the parent box goes down until its top is aligned with the child.
-                if *margin_top < box_.margin.get().top {
-                    // TODO: The position of child floats should be updated and this
-                    // would influence clearance as well. See #725
-                    let extra_margin = box_.margin.get().top - *margin_top;
-                    *top_offset = *top_offset + extra_margin;
-                    *margin_top = box_.margin.get().top;
-                }
-            }
-            // The bottom margin of an in-flow block-level element collapses
-            // with the top margin of its next in-flow block-level sibling.
-            *collapsing = geometry::min(box_.margin.get().top, *collapsible);
-            *collapsible = box_.margin.get().bottom;
-        }
-
-        *first_in_flow = false;
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
     }
 
     fn debug_str(&self) -> ~str {
-        let txt = if self.is_float() {
-            ~"FloatFlow: "
-        } else {
-            ~"TableCellFlow: "
-        };
+        let txt = ~"TableCellFlow: ";
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -141,6 +141,11 @@ impl Flow for TableCellFlow {
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        //assign height for box
+        for box_ in self.block_flow.box_.iter() {
+            box_.assign_height();
+        }
+
         debug!("assign_height: assigning height for table_cell {}", self.block_flow.base.id);
         self.assign_height_table_cell_base(ctx, false);
     }

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -5,108 +5,69 @@
 //! CSS table formatting contexts.
 
 use layout::box_::Box;
+use layout::block::BlockFlow;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
-use layout::flow::{BaseFlow, TableCellFlowClass, FlowClass, Flow, ImmutableFlowUtils};
-use layout::flow;
-use layout::float_context::{FloatContext, Invalid};
+use layout::flow::{BaseFlow, TableCellFlowClass, FlowClass, Flow};
 
 use std::cell::RefCell;
 use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
-use servo_util::geometry;
 
 /// A table formatting context.
 pub struct TableCellFlow {
     /// Data common to all flows.
-    base: BaseFlow,
-
-    /// The associated box.
-    box_: Option<Box>,
+    block_flow: BlockFlow,
 }
 
 impl TableCellFlow {
     pub fn new(base: BaseFlow) -> TableCellFlow {
         TableCellFlow {
-            base: base,
-            box_: None,
+            block_flow: BlockFlow::new(base),
         }
     }
 
     pub fn from_box(base: BaseFlow, box_: Box) -> TableCellFlow {
         TableCellFlow {
-            base: base,
-            box_: Some(box_),
+            block_flow: BlockFlow::from_box(base, box_, false),
         }
     }
 
     pub fn teardown(&mut self) {
-        for box_ in self.box_.iter() {
-            box_.teardown();
-        }
-        self.box_ = None;
+        self.block_flow.teardown()
+    }
+
+    pub fn box_<'a>(&'a mut self) -> &'a Option<Box>{
+        &self.block_flow.box_
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
     fn assign_height_table_cell_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let mut cur_y = Au::new(0);
-        let mut top_offset = Au::new(0);
-        let mut bottom_offset = Au::new(0);
-        let mut left_offset = Au::new(0);
-        let mut float_ctx = Invalid;
+        let (_, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offset(true);
 
-        for box_ in self.box_.iter() {
-            top_offset = box_.noncontent_top();
-            cur_y = cur_y + top_offset;
-            bottom_offset = box_.noncontent_bottom();
-            left_offset = box_.noncontent_left();
-        }
-
-        if inorder {
-            // Floats for blocks work like this:
-            // self.floats_in -> child[0].floats_in
-            // visit child[0]
-            // child[i-1].floats_out -> child[i].floats_in
-            // visit child[i]
-            // repeat until all children are visited.
-            // last_child.floats_out -> self.floats_out (done at the end of this method)
-            float_ctx = self.base.floats_in.translate(Point2D(-left_offset, -top_offset));
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-
-        let mut collapsible = Au::new(0);
-        let mut collapsing = Au::new(0);
-        let mut first_in_flow = true;
-
-        for kid in self.base.child_iter() {
-            // Since table cell does not have `margin`, the first child's top margin and
-            // the last child's bottom margin do not collapse.
-            kid.collapse_margins(false,
-                                 &mut first_in_flow,
-                                 &mut Au(0),
-                                 &mut top_offset,
-                                 &mut collapsing,
-                                 &mut collapsible);
-
-            let child_node = flow::mut_base(*kid);
-            cur_y = cur_y - collapsing;
-            child_node.position.origin.y = cur_y;
-            cur_y = cur_y + child_node.position.size.height;
-        }
+        let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx,
+                                                                   Point2D(-left_offset, -top_offset),
+                                                                   inorder);
+        let mut cur_y = top_offset;
+        let mut top_offset = top_offset;
+        // Since table cell does not have `margin`, the first child's top margin and
+        // the last child's bottom margin do not collapse.
+        self.block_flow.compute_margin_collapse(&mut cur_y,
+                                                &mut top_offset,
+                                                Au(0),
+                                                Au(0),
+                                                false,
+                                                false);
 
         // CSS 2.1 § 17.5.3. Table cell box height is the minimum height required by the content.
         let height = cur_y - top_offset;
 
         // TODO(june0cho): vertical-align of table-cell should be calculated.
         let mut noncontent_height = Au::new(0);
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let mut position = box_.position.get();
 
             noncontent_height = box_.noncontent_height();
@@ -117,14 +78,10 @@ impl TableCellFlow {
             box_.position.set(position);
         }
 
-        self.base.position.size.height = height + noncontent_height;
+        self.block_flow.base.position.size.height = height + noncontent_height;
 
-        if inorder {
-            let extra_height = height - (cur_y - top_offset) + bottom_offset;
-            self.base.floats_out = float_ctx.translate(Point2D(left_offset, -extra_height));
-        } else {
-            self.base.floats_out = self.base.floats_in.clone();
-        }
+        self.block_flow.set_floats_out(&mut float_ctx, height, cur_y, top_offset,
+                                       bottom_offset, left_offset, inorder);
     }
 
     pub fn build_display_list_table_cell<E:ExtraDisplayListData>(
@@ -133,25 +90,8 @@ impl TableCellFlow {
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true;
-        }
-
-        debug!("build_display_list_table_cell: adding display element");
-
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
-        }
-        // TODO: handle any out-of-flow elements
-        let this_position = self.base.abs_position;
-
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
+        debug!("build_display_list_table_cell: same process as block flow");
+        self.block_flow.build_display_list_block(builder, dirty, list)
     }
 }
 
@@ -164,104 +104,44 @@ impl Flow for TableCellFlow {
         self
     }
 
-    /// Recursively (bottom-up) determines the context's preferred and minimum widths. When called
-    /// on this context, all child contexts have had their min/pref widths set. This function must
-    /// decide min/pref widths based on child context widths and dimensions of any boxes it is
-    /// responsible for flowing.
-    /// Min/pref widths set by this function are used in automatic table layout calculation.
-    fn bubble_widths(&mut self, _: &mut LayoutContext) {
-        let mut min_width = Au::new(0);
-        let mut pref_width = Au::new(0);
-        let mut num_floats = 0;
-
-        /* find max width from child block contexts */
-        for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
-
-            let child_base = flow::mut_base(*kid);
-            min_width = geometry::max(min_width, child_base.min_width);
-            pref_width = geometry::max(pref_width, child_base.pref_width);
-            num_floats = num_floats + child_base.num_floats;
-        }
-
-        self.base.num_floats = num_floats;
-
-        for box_ in self.box_.iter() {
-            {
-                // Can compute border width here since it doesn't depend on anything.
-                box_.compute_borders(box_.style())
-            }
-
-            let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
-            min_width = min_width + this_minimum_width;
-            pref_width = pref_width + this_preferred_width;
-        }
-
-        self.base.min_width = min_width;
-        self.base.pref_width = pref_width;
+    /// Minimum/preferred widths set by this function are used in automatic table layout calculation.
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        self.block_flow.bubble_widths(ctx);
     }
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
     /// on this context, the context has had its width set by the parent table row.
     fn assign_widths(&mut self, _: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}", "table_cell", self.base.id);
+        debug!("assign_widths({}): assigning width for flow {}", "table_cell", self.block_flow.base.id);
 
         // The position was set to the column width by the parent flow, table row flow.
-        let mut remaining_width = self.base.position.size.width;
+        let mut remaining_width = self.block_flow.base.position.size.width;
         let mut x_offset = Au::new(0);
 
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let style = box_.style();
 
             // The text alignment of a table_cell flow is the text alignment of its box's style.
-            self.base.flags_info.flags.set_text_align(style.Text.text_align);
+            self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
+            self.block_flow.initial_box_setting(box_, style, remaining_width, true, false);
+            self.block_flow.set_box_x_and_width(box_, Au(0), remaining_width);
 
-            // Can compute padding here since we know containing block width.
-            box_.compute_padding(style, remaining_width);
-
-            x_offset = box_.padding.get().left + box_.border.get().left;
-
-            // The associated box is the border box of this flow.
-            let mut position_ref = box_.position.borrow_mut();
-            position_ref.get().size.width = remaining_width;
-
+            x_offset = box_.offset();
             let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
                                       box_.border.get().left + box_.border.get().right;
             remaining_width = remaining_width - padding_and_borders;
         }
 
-        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
-
-        // FIXME(ksh8281): avoid copy
-        let flags_info = self.base.flags_info.clone();
-        for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.is_table_kind());
-
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.x = x_offset;
-            child_base.position.size.width = remaining_width;
-            child_base.flags_info.flags.set_inorder(has_inorder_children);
-
-            if !child_base.flags_info.flags.inorder() {
-                child_base.floats_in = FloatContext::new(0);
-            }
-
-            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
-            //
-            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
-
-            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
-        }
+        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width);
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_height_inorder: assigning height for table_cell {}", self.base.id);
+        debug!("assign_height_inorder: assigning height for table_cell {}", self.block_flow.base.id);
         self.assign_height_table_cell_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_height: assigning height for table_cell {}", self.base.id);
+        debug!("assign_height: assigning height for table_cell {}", self.block_flow.base.id);
         self.assign_height_table_cell_base(ctx, false);
     }
 
@@ -273,10 +153,9 @@ impl Flow for TableCellFlow {
 
     fn debug_str(&self) -> ~str {
         let txt = ~"TableCellFlow: ";
-        txt.append(match self.box_ {
+        txt.append(match self.block_flow.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",
         })
     }
 }
-

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -46,7 +46,7 @@ impl TableCellFlow {
     // methods
     #[inline(always)]
     fn assign_height_table_cell_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let (_, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offset(true);
+        let (_, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offsets(true);
 
         let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx,
                                                                    Point2D(-left_offset, -top_offset),
@@ -57,8 +57,8 @@ impl TableCellFlow {
         // the last child's bottom margin do not collapse.
         self.block_flow.compute_margin_collapse(&mut cur_y,
                                                 &mut top_offset,
-                                                Au(0),
-                                                Au(0),
+                                                &mut Au(0),
+                                                &mut Au(0),
                                                 false,
                                                 false);
 
@@ -123,7 +123,7 @@ impl Flow for TableCellFlow {
 
             // The text alignment of a table_cell flow is the text alignment of its box's style.
             self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
-            self.block_flow.initial_box_setting(box_, style, remaining_width, true, false);
+            self.block_flow.compute_padding_and_margin_if_exists(box_, style, remaining_width, true, false);
             self.block_flow.set_box_x_and_width(box_, Au(0), remaining_width);
 
             x_offset = box_.offset();
@@ -132,7 +132,7 @@ impl Flow for TableCellFlow {
             remaining_width = remaining_width - padding_and_borders;
         }
 
-        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width);
+        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width, None);
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {

--- a/src/components/main/layout/table_colgroup.rs
+++ b/src/components/main/layout/table_colgroup.rs
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::Box;
+use layout::context::LayoutContext;
+use layout::flow::{BaseFlow, TableColGroupFlowClass, FlowClass, Flow};
+use servo_util::geometry::Au;
+
+/// A table formatting context.
+pub struct TableColGroupFlow {
+    /// Data common to all flows.
+    base: BaseFlow,
+
+    /// The associated box.
+    box_: Option<Box>,
+
+    /// The table column boxes
+    cols: ~[Box],
+}
+
+impl TableColGroupFlow {
+    pub fn new(base: BaseFlow) -> TableColGroupFlow {
+        TableColGroupFlow {
+            base: base,
+            box_: None,
+            cols: ~[],
+        }
+    }
+
+    pub fn from_box(base: BaseFlow, box_: Box, boxes: ~[Box]) -> TableColGroupFlow {
+        TableColGroupFlow {
+            base: base,
+            box_: Some(box_),
+            cols: boxes,
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        for box_ in self.box_.iter() {
+            box_.teardown();
+        }
+        self.box_ = None;
+        self.cols = ~[];
+    }
+}
+
+impl Flow for TableColGroupFlow {
+    fn class(&self) -> FlowClass {
+        TableColGroupFlowClass
+    }
+
+    fn as_table_colgroup<'a>(&'a mut self) -> &'a mut TableColGroupFlow {
+        self
+    }
+
+    /* Recursively (bottom-up) determine the context's preferred and
+    minimum widths.  When called on this context, all child contexts
+    have had their min/pref widths set. This function must decide
+    min/pref widths based on child context widths and dimensions of
+    any boxes it is responsible for flowing.  */
+
+    /* TODO: absolute contexts */
+    /* TODO: inline-blocks */
+    fn bubble_widths(&mut self, _: &mut LayoutContext) {
+    }
+
+    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
+    /// on this context, the context has had its width set by the parent context.
+    ///
+    /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
+    /// contexts.
+    fn assign_widths(&mut self, _ctx: &mut LayoutContext) {
+    }
+
+    fn assign_height(&mut self, _ctx: &mut LayoutContext) {
+    }
+
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableColGroupFlow: ";
+        txt.append(match self.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}

--- a/src/components/main/layout/table_colgroup.rs
+++ b/src/components/main/layout/table_colgroup.rs
@@ -68,7 +68,7 @@ impl Flow for TableColGroupFlow {
             // get the specified value from width property
             let width = MaybeAuto::from_style(box_.style().Box.width, Au::new(0)).specified_or_zero();
 
-            let span:int = match box_.specific {
+            let span: int = match box_.specific {
                 TableColumnBox(col_box) => col_box.span.unwrap_or(1),
                 _ => fail!("Other box come out in TableColGroupFlow. {:?}", box_.specific)
             };
@@ -78,17 +78,17 @@ impl Flow for TableColGroupFlow {
         }
     }
 
-    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
-    /// on this context, the context has had its width set by the parent context.
-    ///
-    /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
-    /// contexts.
+    /// Table column widths are assigned in table flow and propagated to table row or rowgroup flow.
+    /// Therefore, table colgroup flow does not need to assign its width.
     fn assign_widths(&mut self, _ctx: &mut LayoutContext) {
     }
 
+    /// Table column do not have height.
     fn assign_height(&mut self, _ctx: &mut LayoutContext) {
     }
 
+    /// TableColumnBox and their parents(TableBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
     fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
                         _: &mut Au, _: &mut Au, _: &mut Au) {
     }

--- a/src/components/main/layout/table_colgroup.rs
+++ b/src/components/main/layout/table_colgroup.rs
@@ -4,7 +4,7 @@
 
 //! CSS table formatting contexts.
 
-use layout::box_::{Box, TableColBox};
+use layout::box_::{Box, TableColumnBox};
 use layout::context::LayoutContext;
 use layout::flow::{BaseFlow, TableColGroupFlowClass, FlowClass, Flow};
 use layout::model::{MaybeAuto};
@@ -69,7 +69,7 @@ impl Flow for TableColGroupFlow {
             let width = MaybeAuto::from_style(box_.style().Box.width, Au::new(0)).specified_or_zero();
 
             let span:int = match box_.specific {
-                TableColBox(col_box) => col_box.span.unwrap_or(1),
+                TableColumnBox(col_box) => col_box.span.unwrap_or(1),
                 _ => fail!("Other box come out in TableColGroupFlow. {:?}", box_.specific)
             };
             for _ in range(0, span) {

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -10,42 +10,13 @@ use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableRowFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto};
-use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
+use layout::float_context::{FloatContext, Invalid};
 
 use std::cell::RefCell;
 use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
-
-/// Information specific to floated blocks.
-pub struct FloatedTableInfo {
-    containing_width: Au,
-
-    /// Offset relative to where the parent tried to position this flow
-    rel_pos: Point2D<Au>,
-
-    /// Index into the box list for inline floats
-    index: Option<uint>,
-
-    /// Number of floated children
-    floated_children: uint,
-
-    /// Left or right?
-    float_type: FloatType
-}
-
-impl FloatedTableInfo {
-    pub fn new(float_type: FloatType) -> FloatedTableInfo {
-        FloatedTableInfo {
-            containing_width: Au(0),
-            rel_pos: Point2D(Au(0), Au(0)),
-            index: None,
-            floated_children: 0,
-            float_type: float_type
-        }
-    }
-}
 
 /// A table formatting context.
 pub struct TableRowFlow {
@@ -54,13 +25,6 @@ pub struct TableRowFlow {
 
     /// The associated box.
     box_: Option<Box>,
-
-    //TODO: is_fixed should be bit fields to conserve memory.
-    /// Position property
-    is_fixed: bool,
-
-    /// Additional floating flow members.
-    float: Option<~FloatedTableInfo>,
 
     /// Column widths.
     col_widths: ~[Au],
@@ -71,44 +35,16 @@ impl TableRowFlow {
         TableRowFlow {
             base: base,
             box_: None,
-            is_fixed: false,
-            float: None,
             col_widths: ~[],
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableRowFlow {
+    pub fn from_box(base: BaseFlow, box_: Box) -> TableRowFlow {
         TableRowFlow {
             base: base,
             box_: Some(box_),
-            is_fixed: is_fixed,
-            float: None,
             col_widths: ~[],
         }
-    }
-
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableRowFlow {
-        TableRowFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-            col_widths: ~[],
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableRowFlow {
-        TableRowFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-            col_widths: ~[],
-        }
-    }
-
-    pub fn is_float(&self) -> bool {
-        self.float.is_some()
     }
 
     pub fn teardown(&mut self) {
@@ -116,7 +52,6 @@ impl TableRowFlow {
             box_.teardown();
         }
         self.box_ = None;
-        self.float = None;
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
@@ -124,27 +59,13 @@ impl TableRowFlow {
     #[inline(always)]
     fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
-        let mut clearance = Au::new(0);
-        let mut top_offset = Au::new(0);
-        let mut bottom_offset = Au::new(0);
-        let mut left_offset = Au::new(0);
+        let top_offset = Au::new(0);
+        let bottom_offset = Au::new(0);
+        let left_offset = Au::new(0);
         let mut float_ctx = Invalid;
 
-        for box_ in self.box_.iter() {
-            clearance = match box_.clear() {
-                None => Au::new(0),
-                Some(clear) => {
-                    self.base.floats_in.clearance(clear)
-                }
-            };
-
-            top_offset = clearance + box_.margin.get().top + box_.border.get().top +
-                box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-            bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
-                box_.padding.get().bottom;
-            left_offset = box_.offset();
-        }
+        // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
+        // should be updated. Currently, they are set as Au(0).
 
         if inorder {
             // Floats for blocks work like this:
@@ -162,114 +83,46 @@ impl TableRowFlow {
             }
         }
 
-        let mut collapsible = Au::new(0);
-        let mut collapsing = Au::new(0);
-        let mut margin_top = Au::new(0);
-        let mut margin_bottom = Au::new(0);
-        let mut top_margin_collapsible = false;
-        let mut bottom_margin_collapsible = false;
-        let mut first_in_flow = true;
-        for box_ in self.box_.iter() {
-            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
-                collapsible = box_.margin.get().top;
-                top_margin_collapsible = true;
-            }
-            if box_.border.get().bottom == Au(0) &&
-                    box_.padding.get().bottom == Au(0) {
-                bottom_margin_collapsible = true;
-            }
-            margin_top = box_.margin.get().top;
-            margin_bottom = box_.margin.get().bottom;
-        }
-
         let mut max_y = Au::new(0);
         for kid in self.base.child_iter() {
-            kid.collapse_margins(top_margin_collapsible,
-                                 &mut first_in_flow,
-                                 &mut margin_top,
-                                 &mut top_offset,
-                                 &mut collapsing,
-                                 &mut collapsible);
-
             let child_node = flow::mut_base(*kid);
-            cur_y = cur_y - collapsing;
             child_node.position.origin.y = cur_y;
             max_y = geometry::max(max_y, child_node.position.size.height);
         }
         cur_y = cur_y + max_y;
 
-        // The bottom margin collapses with its last in-flow block-level child's bottom margin
-        // if the parent has no bottom boder, no bottom padding.
-        collapsing = if bottom_margin_collapsible {
-            if margin_bottom < collapsible {
-                margin_bottom = collapsible;
-            }
-            collapsible
-        } else {
-            Au::new(0)
-        };
-
-        // TODO: A box's own margins collapse if the 'min-height' property is zero, and it has neither
-        // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
-        // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
-
-
-        let mut height = cur_y - top_offset - collapsing;
-
+        let mut height = max_y;
         for box_ in self.box_.iter() {
             let style = box_.style();
 
-            // At this point, `height` is the height of the containing block, so passing `height`
-            // as the second argument here effectively makes percentages relative to the containing
-            // block per CSS 2.1 § 10.5.
-            height = match MaybeAuto::from_style(style.Box.height, height) {
+            // TODO: Percentage height
+            height = match MaybeAuto::from_style(style.Box.height, Au(0)) {
                 Auto => height,
-                Specified(value) => value
+                Specified(value) => geometry::max(value, height)
             };
         }
 
-        let mut noncontent_height = Au::new(0);
-        let screen_height = ctx.screen_size.height;
+        // TODO: Table height should be correctly calculated. Child cells' 'height' property
+        // should be considered.
+
+        // Assign the height of own box
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
-            let mut margin = box_.margin.get();
-
-            // The associated box is the border box of this flow.
-            margin.top = margin_top;
-            margin.bottom = margin_bottom;
-
-            noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-                box_.border.get().top + box_.border.get().bottom;
-
-            let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                 height, clearance + margin.top, self.is_fixed);
-            position.origin.y = y;
-            height = h;
-
-            if self.is_fixed {
-                for kid in self.base.child_iter() {
-                    let child_node = flow::mut_base(*kid);
-                    child_node.position.origin.y = position.origin.y + top_offset;
-                }
-            }
-
-            position.size.height = if self.is_fixed {
-                height
-            } else {
-                height + noncontent_height
-            };
-
-            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
-
+            position.size.height = height;
             box_.position.set(position);
-            box_.margin.set(margin);
         }
+        self.base.position.size.height = height;
 
-        self.base.position.size.height = if self.is_fixed {
-            height
-        } else {
-            height + noncontent_height
-        };
+        // Assign the height of kid boxes, which is the same value as own height.
+        for kid in self.base.child_iter() {
+            for kid_box_ in kid.as_table_cell().box_.iter() {
+                let mut position = kid_box_.position.get();
+                position.size.height = height;
+                kid_box_.position.set(position);
+            }
+            let child_node = flow::mut_base(*kid);
+            child_node.position.size.height = height;
+        }
 
         if inorder {
             let extra_height = height - (cur_y - top_offset) + bottom_offset;
@@ -279,102 +132,12 @@ impl TableRowFlow {
         }
     }
 
-    fn assign_height_float_inorder(&mut self) {
-        // assign_height_float was already called by the traversal function
-        // so this is well-defined
-
-        let mut height = Au(0);
-        let mut clearance = Au(0);
-        let mut full_noncontent_width = Au(0);
-        let mut margin_height = Au(0);
-
-        for box_ in self.box_.iter() {
-            height = box_.position.get().size.height;
-            clearance = match box_.clear() {
-                None => Au(0),
-                Some(clear) => self.base.floats_in.clearance(clear),
-            };
-
-            let noncontent_width = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-
-            full_noncontent_width = noncontent_width + box_.margin.get().left +
-                box_.margin.get().right;
-            margin_height = box_.margin.get().top + box_.margin.get().bottom;
-        }
-
-        let info = PlacementInfo {
-            width: self.base.position.size.width + full_noncontent_width,
-            height: height + margin_height,
-            ceiling: clearance,
-            max_width: self.float.get_ref().containing_width,
-            f_type: self.float.get_ref().float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.base.floats_out = self.base.floats_in.add_float(&info);
-        self.float.get_mut_ref().rel_pos = self.base.floats_out.last_float_pos();
-    }
-
-    fn assign_height_float(&mut self, ctx: &mut LayoutContext) {
-        // Now that we've determined our height, propagate that out.
-        let has_inorder_children = self.base.num_floats > 0;
-        if has_inorder_children {
-            let mut float_ctx = FloatContext::new(self.float.get_ref().floated_children);
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-        let mut cur_y = Au(0);
-        let mut top_offset = Au(0);
-
-        for box_ in self.box_.iter() {
-            top_offset = box_.margin.get().top + box_.border.get().top + box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-        }
-
-        for kid in self.base.child_iter() {
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.y = cur_y;
-            cur_y = cur_y + child_base.position.size.height;
-        }
-
-        let mut height = cur_y - top_offset;
-
-        let mut noncontent_height;
-        let box_ = self.box_.as_ref().unwrap();
-        let mut position = box_.position.get();
-
-        // The associated box is the border box of this flow.
-        position.origin.y = box_.margin.get().top;
-
-        noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-            box_.border.get().top + box_.border.get().bottom;
-
-        //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
-                                                Au::new(0)).specified_or_zero();
-
-        height = geometry::max(height, height_prop) + noncontent_height;
-        debug!("assign_height_float -- height: {}", height);
-
-        position.size.height = height;
-        box_.position.set(position);
-    }
-
     pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        if self.is_float() {
-            return self.build_display_list_float(builder, dirty, list);
-        }
-
         let abs_rect = Rect(self.base.abs_position, self.base.position.size);
         if !abs_rect.intersects(dirty) {
             return true;
@@ -396,35 +159,6 @@ impl TableRowFlow {
 
         false
     }
-
-    pub fn build_display_list_float<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true
-        }
-
-        let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
-        }
-
-
-        // TODO: handle any out-of-flow elements
-
-        // go deeper into the flow tree
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = offset + child_base.position.origin;
-        }
-
-        false
-    }
 }
 
 impl Flow for TableRowFlow {
@@ -436,18 +170,19 @@ impl Flow for TableRowFlow {
         self
     }
 
-    /* Recursively (bottom-up) determine the context's preferred and
-    minimum widths.  When called on this context, all child contexts
-    have had their min/pref widths set. This function must decide
-    min/pref widths based on child context widths and dimensions of
-    any boxes it is responsible for flowing.  */
-
+    /// Recursively (bottom-up) determines the context's preferred and minimum widths. When called
+    /// on this context, all child contexts have had their min/pref widths set. This function must
+    /// decide min/pref widths based on child context widths and dimensions of any boxes it is
+    /// responsible for flowing.
+    /// Min/pref widths set by this function are used in automatic table layout calculation.
+    /// Also, this function collects the specified column widths of children cells. Those are used
+    /// in fixed table layout calculation
     fn bubble_widths(&mut self, _: &mut LayoutContext) {
         let mut min_width = Au::new(0);
         let mut pref_width = Au::new(0);
         let mut num_floats = 0;
 
-        /* find max width from child block contexts */
+        /* find the specified widths from child table-cell contexts */
         for kid in self.base.child_iter() {
             assert!(kid.is_table_cell());
 
@@ -463,15 +198,9 @@ impl Flow for TableRowFlow {
             num_floats = num_floats + child_base.num_floats;
         }
 
-        if self.is_float() {
-            self.base.num_floats = 1;
-            self.float.get_mut_ref().floated_children = num_floats;
-        } else {
-            self.base.num_floats = num_floats;
-        }
+        self.base.num_floats = num_floats;
 
-        /* if not an anonymous block context, add in block box's widths.
-           these widths will not include child elements, just padding etc. */
+        // FIXME: automatic table layout calculation
         for box_ in self.box_.iter() {
             let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
             min_width = min_width + this_minimum_width;
@@ -484,28 +213,12 @@ impl Flow for TableRowFlow {
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
     /// on this context, the context has had its width set by the parent context.
-    ///
-    /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
-    /// contexts.
-    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}",
-               if self.is_float() {
-                   "float"
-               } else {
-                   "table_row"
-               },
-               self.base.id);
+    fn assign_widths(&mut self, _: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow {}", "table_row", self.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let mut remaining_width = self.base.position.size.width;
+        let remaining_width = self.base.position.size.width;
         let mut x_offset = Au::new(0);
-
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = remaining_width;
-
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -513,32 +226,14 @@ impl Flow for TableRowFlow {
             // The text alignment of a table_row flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
-                                                                 screen_size.height,
-                                                                 remaining_width,
-                                                                 box_.offset(),
-                                                                 self.is_fixed);
-            x_offset = x;
-            remaining_width = w;
+            // In case of border-collapse: collapse, x_offset should be border-left
+            x_offset = Au(0);
 
-            // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
-            if self.is_fixed {
-                position_ref.get().origin.x = x_offset;
-            }
             position_ref.get().size.width = remaining_width;
         }
 
-        if self.is_float() {
-            self.base.position.size.width = remaining_width;
-        }
-
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
+        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
@@ -568,67 +263,21 @@ impl Flow for TableRowFlow {
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
-            self.assign_height_float_inorder();
-        } else {
-            debug!("assign_height_inorder: assigning height for table_row {}", self.base.id);
-            self.assign_height_table_base(ctx, true);
-        }
+        debug!("assign_height_inorder: assigning height for table_row {}", self.base.id);
+        self.assign_height_table_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
-            self.assign_height_float(ctx);
-        } else {
-            debug!("assign_height: assigning height for table_row {}", self.base.id);
-            self.assign_height_table_base(ctx, false);
-        }
+        debug!("assign_height: assigning height for table_row {}", self.base.id);
+        self.assign_height_table_base(ctx, false);
     }
 
-    fn collapse_margins(&mut self,
-                        top_margin_collapsible: bool,
-                        first_in_flow: &mut bool,
-                        margin_top: &mut Au,
-                        top_offset: &mut Au,
-                        collapsing: &mut Au,
-                        collapsible: &mut Au) {
-        if self.is_float() {
-            // Margins between a floated box and any other box do not collapse.
-            *collapsing = Au::new(0);
-            return;
-        }
-
-        for box_ in self.box_.iter() {
-            // The top margin collapses with its first in-flow block-level child's
-            // top margin if the parent has no top border, no top padding.
-            if *first_in_flow && top_margin_collapsible {
-                // If top-margin of parent is less than top-margin of its first child,
-                // the parent box goes down until its top is aligned with the child.
-                if *margin_top < box_.margin.get().top {
-                    // TODO: The position of child floats should be updated and this
-                    // would influence clearance as well. See #725
-                    let extra_margin = box_.margin.get().top - *margin_top;
-                    *top_offset = *top_offset + extra_margin;
-                    *margin_top = box_.margin.get().top;
-                }
-            }
-            // The bottom margin of an in-flow block-level element collapses
-            // with the top margin of its next in-flow block-level sibling.
-            *collapsing = geometry::min(box_.margin.get().top, *collapsible);
-            *collapsible = box_.margin.get().bottom;
-        }
-
-        *first_in_flow = false;
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
     }
 
     fn debug_str(&self) -> ~str {
-        let txt = if self.is_float() {
-            ~"FloatFlow: "
-        } else {
-            ~"TableRowFlow: "
-        };
+        let txt = ~"TableRowFlow: ";
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -57,7 +57,7 @@ impl TableRowFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_row_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let top_offset = Au::new(0);
         let bottom_offset = Au::new(0);
@@ -134,7 +134,7 @@ impl TableRowFlow {
         }
     }
 
-    pub fn build_display_list_table<E:ExtraDisplayListData>(
+    pub fn build_display_list_table_row<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -239,8 +239,7 @@ impl Flow for TableRowFlow {
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
-        let mut i = 0;
-        for kid in self.base.child_iter() {
+        for (i, kid) in self.base.child_iter().enumerate() {
             assert!(kid.is_table_cell());
 
             let child_base = flow::mut_base(*kid);
@@ -249,7 +248,6 @@ impl Flow for TableRowFlow {
             child_base.flags_info.flags.set_inorder(has_inorder_children);
 
             x_offset = x_offset + self.col_widths[i];
-            i += 1;
 
             if !child_base.flags_info.flags.inorder() {
                 child_base.floats_in = FloatContext::new(0);
@@ -266,14 +264,16 @@ impl Flow for TableRowFlow {
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height_inorder: assigning height for table_row {}", self.base.id);
-        self.assign_height_table_base(ctx, true);
+        self.assign_height_table_row_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height: assigning height for table_row {}", self.base.id);
-        self.assign_height_table_base(ctx, false);
+        self.assign_height_table_row_base(ctx, false);
     }
 
+    /// TableRowBox and their parents(TableBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
     fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
                         _: &mut Au, _: &mut Au, _: &mut Au) {
     }

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -246,7 +246,7 @@ impl TableRowFlow {
             position.origin.y = y;
             height = h;
 
-            if self.is_fixed { 
+            if self.is_fixed {
                 for kid in self.base.child_iter() {
                     let child_node = flow::mut_base(*kid);
                     child_node.position.origin.y = position.origin.y + top_offset;
@@ -452,7 +452,7 @@ impl Flow for TableRowFlow {
             assert!(kid.starts_table_flow());
 
             for child_box in kid.as_table_cell().box_.iter() {
-                let child_specified_width = MaybeAuto::from_style(child_box.style().Box.width, 
+                let child_specified_width = MaybeAuto::from_style(child_box.style().Box.width,
                                                                   Au::new(0)).specified_or_zero();
                 self.col_widths.push(child_specified_width);
             }
@@ -514,10 +514,10 @@ impl Flow for TableRowFlow {
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
             let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height, 
-                                                                 remaining_width, 
-                                                                 box_.offset(), 
+            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
+                                                                 screen_size.height,
+                                                                 remaining_width,
+                                                                 box_.offset(),
                                                                  self.is_fixed);
             x_offset = x;
             remaining_width = w;
@@ -542,17 +542,17 @@ impl Flow for TableRowFlow {
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
-        let mut idx = 0;
+        let mut i = 0;
         for kid in self.base.child_iter() {
             assert!(kid.starts_table_flow());
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;
-            child_base.position.size.width = self.col_widths[idx];
+            child_base.position.size.width = self.col_widths[i];
             child_base.flags_info.flags.set_inorder(has_inorder_children);
 
-            x_offset = x_offset + self.col_widths[idx];
-            idx = idx + 1;
+            x_offset = x_offset + self.col_widths[i];
+            i += 1;
 
             if !child_base.flags_info.flags.inorder() {
                 child_base.floats_in = FloatContext::new(0);

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -449,7 +449,7 @@ impl Flow for TableRowFlow {
 
         /* find max width from child block contexts */
         for kid in self.base.child_iter() {
-            assert!(kid.starts_table_flow());
+            assert!(kid.is_table_cell());
 
             for child_box in kid.as_table_cell().box_.iter() {
                 let child_specified_width = MaybeAuto::from_style(child_box.style().Box.width,
@@ -544,7 +544,7 @@ impl Flow for TableRowFlow {
         let flags_info = self.base.flags_info.clone();
         let mut i = 0;
         for kid in self.base.child_iter() {
-            assert!(kid.starts_table_flow());
+            assert!(kid.is_table_cell());
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -5,12 +5,13 @@
 //! CSS table formatting contexts.
 
 use layout::box_::Box;
+use layout::block::BlockFlow;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableRowFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto};
-use layout::float_context::{FloatContext, Invalid};
+use layout::float_context::{FloatContext};
 
 use std::cell::RefCell;
 use geom::{Point2D, Rect};
@@ -20,11 +21,7 @@ use servo_util::geometry;
 
 /// A table formatting context.
 pub struct TableRowFlow {
-    /// Data common to all flows.
-    base: BaseFlow,
-
-    /// The associated box.
-    box_: Option<Box>,
+    block_flow: BlockFlow,
 
     /// Column widths.
     col_widths: ~[Au],
@@ -33,60 +30,46 @@ pub struct TableRowFlow {
 impl TableRowFlow {
     pub fn new(base: BaseFlow) -> TableRowFlow {
         TableRowFlow {
-            base: base,
-            box_: None,
+            block_flow: BlockFlow::new(base),
             col_widths: ~[],
         }
     }
 
     pub fn from_box(base: BaseFlow, box_: Box) -> TableRowFlow {
         TableRowFlow {
-            base: base,
-            box_: Some(box_),
+            block_flow: BlockFlow::from_box(base, box_, false),
             col_widths: ~[],
         }
     }
 
     pub fn teardown(&mut self) {
-        for box_ in self.box_.iter() {
-            box_.teardown();
-        }
-        self.box_ = None;
+        self.block_flow.teardown();
+        self.col_widths = ~[];
+    }
+
+    pub fn box_<'a>(&'a mut self) -> &'a Option<Box>{
+        &self.block_flow.box_
+    }
+
+    fn initialize_offset(&mut self) -> (Au, Au, Au) {
+        // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
+        // should be updated. Currently, they are set as Au(0).
+        (Au(0), Au(0), Au(0))
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
     fn assign_height_table_row_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let mut cur_y = Au::new(0);
-        let top_offset = Au::new(0);
-        let bottom_offset = Au::new(0);
-        let left_offset = Au::new(0);
-        let mut float_ctx = Invalid;
+        let (top_offset, bottom_offset, left_offset) = self.initialize_offset();
 
-        // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
-        // should be updated. Currently, they are set as Au(0).
-
-        if inorder {
-            // Floats for blocks work like this:
-            // self.floats_in -> child[0].floats_in
-            // visit child[0]
-            // child[i-1].floats_out -> child[i].floats_in
-            // visit child[i]
-            // repeat until all children are visited.
-            // last_child.floats_out -> self.floats_out (done at the end of this method)
-            float_ctx = self.base.floats_in.translate(Point2D(-left_offset, -top_offset));
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
+        let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx, Point2D(-left_offset, -top_offset), inorder);
+        let mut cur_y = top_offset;
 
         // Per CSS 2.1 § 17.5.3, find max_y = max( computed `height`, minimum height of all cells )
         let mut max_y = Au::new(0);
-        for kid in self.base.child_iter() {
-            for child_box in kid.as_table_cell().box_.iter() {
+        for kid in self.block_flow.base.child_iter() {
+            for child_box in kid.as_table_cell().box_().iter() {
                 // TODO: Percentage height
                 let child_specified_height = MaybeAuto::from_style(child_box.style().Box.height,
                                                                    Au::new(0)).specified_or_zero();
@@ -99,7 +82,7 @@ impl TableRowFlow {
         cur_y = cur_y + max_y;
 
         let mut height = max_y;
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             // TODO: Percentage height
             height = match MaybeAuto::from_style(box_.style().Box.height, Au(0)) {
                 Auto => height,
@@ -108,16 +91,16 @@ impl TableRowFlow {
         }
 
         // Assign the height of own box
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let mut position = box_.position.get();
             position.size.height = height;
             box_.position.set(position);
         }
-        self.base.position.size.height = height;
+        self.block_flow.base.position.size.height = height;
 
         // Assign the height of kid boxes, which is the same value as own height.
-        for kid in self.base.child_iter() {
-            for kid_box_ in kid.as_table_cell().box_.iter() {
+        for kid in self.block_flow.base.child_iter() {
+            for kid_box_ in kid.as_table_cell().box_().iter() {
                 let mut position = kid_box_.position.get();
                 position.size.height = height;
                 kid_box_.position.set(position);
@@ -126,40 +109,46 @@ impl TableRowFlow {
             child_node.position.size.height = height;
         }
 
-        if inorder {
-            let extra_height = height - (cur_y - top_offset) + bottom_offset;
-            self.base.floats_out = float_ctx.translate(Point2D(left_offset, -extra_height));
-        } else {
-            self.base.floats_out = self.base.floats_in.clone();
+        self.block_flow.set_floats_out(&mut float_ctx, height, cur_y, top_offset,
+                                       bottom_offset, left_offset, inorder);
+    }
+
+    pub fn propagate_assigned_width_to_children(&mut self, x_offset: Au) {
+        let mut x_offset = x_offset;
+        let has_inorder_children = self.block_flow.base.flags_info.flags.inorder() || 
+                                   self.block_flow.base.num_floats > 0;
+
+        // FIXME(ksh8281): avoid copy
+        let flags_info = self.block_flow.base.flags_info.clone();
+        for (i, kid) in self.block_flow.base.child_iter().enumerate() {
+            assert!(kid.is_table_cell());
+
+            let child_base = flow::mut_base(*kid);
+            child_base.position.origin.x = x_offset;
+            child_base.position.size.width = self.col_widths[i];
+            x_offset = x_offset + self.col_widths[i];
+            child_base.flags_info.flags.set_inorder(has_inorder_children);
+
+            if !child_base.flags_info.flags.inorder() {
+                child_base.floats_in = FloatContext::new(0);
+            }
+
+            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
+            //
+            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
+            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
+            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
         }
     }
 
     pub fn build_display_list_table_row<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true;
-        }
-
-        debug!("build_display_list_table: adding display element");
-
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
-        }
-        // TODO: handle any out-of-flow elements
-        let this_position = self.base.abs_position;
-
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
+                                        &mut self,
+                                        builder: &DisplayListBuilder,
+                                        dirty: &Rect<Au>,
+                                        list: &RefCell<DisplayList<E>>)
+                                        -> bool {
+        debug!("build_display_list_table_row: same process as block flow");
+        self.block_flow.build_display_list_block(builder, dirty, list)
     }
 }
 
@@ -179,96 +168,51 @@ impl Flow for TableRowFlow {
     /// Min/pref widths set by this function are used in automatic table layout calculation.
     /// Also, this function collects the specified column widths of children cells. Those are used
     /// in fixed table layout calculation
-    fn bubble_widths(&mut self, _: &mut LayoutContext) {
-        let mut min_width = Au::new(0);
-        let mut pref_width = Au::new(0);
-        let mut num_floats = 0;
-
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
         /* find the specified widths from child table-cell contexts */
-        for kid in self.base.child_iter() {
+        for kid in self.block_flow.base.child_iter() {
             assert!(kid.is_table_cell());
 
-            for child_box in kid.as_table_cell().box_.iter() {
+            for child_box in kid.as_table_cell().box_().iter() {
                 let child_specified_width = MaybeAuto::from_style(child_box.style().Box.width,
                                                                   Au::new(0)).specified_or_zero();
                 self.col_widths.push(child_specified_width);
             }
-
-            let child_base = flow::mut_base(*kid);
-            min_width = geometry::max(min_width, child_base.min_width);
-            pref_width = geometry::max(pref_width, child_base.pref_width);
-            num_floats = num_floats + child_base.num_floats;
         }
 
-        self.base.num_floats = num_floats;
-
-        // FIXME: automatic table layout calculation
-        for box_ in self.box_.iter() {
-            let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
-            min_width = min_width + this_minimum_width;
-            pref_width = pref_width + this_preferred_width;
-        }
-
-        self.base.min_width = min_width;
-        self.base.pref_width = pref_width;
+        // TODO: calculate min_width & pref_width for automatic table layout calculation
+        self.block_flow.bubble_widths(ctx);
     }
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
     /// on this context, the context has had its width set by the parent context.
     fn assign_widths(&mut self, _: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}", "table_row", self.base.id);
+        debug!("assign_widths({}): assigning width for flow {}", "table_row", self.block_flow.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let remaining_width = self.base.position.size.width;
-        let mut x_offset = Au::new(0);
+        let remaining_width = self.block_flow.base.position.size.width;
+        // In case of border-collapse: collapse, x_offset should be border-left
+        let x_offset = Au::new(0);
 
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let style = box_.style();
 
             // The text alignment of a table_row flow is the text alignment of its box's style.
-            self.base.flags_info.flags.set_text_align(style.Text.text_align);
-
-            // In case of border-collapse: collapse, x_offset should be border-left
-            x_offset = Au(0);
-
-            let mut position_ref = box_.position.borrow_mut();
-            position_ref.get().size.width = remaining_width;
+            self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
+            self.block_flow.initial_box_setting(box_, style, remaining_width, false, false);
+            self.block_flow.set_box_x_and_width(box_, Au(0), remaining_width);
         }
 
-        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
-
-        // FIXME(ksh8281): avoid copy
-        let flags_info = self.base.flags_info.clone();
-        for (i, kid) in self.base.child_iter().enumerate() {
-            assert!(kid.is_table_cell());
-
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.x = x_offset;
-            child_base.position.size.width = self.col_widths[i];
-            child_base.flags_info.flags.set_inorder(has_inorder_children);
-
-            x_offset = x_offset + self.col_widths[i];
-
-            if !child_base.flags_info.flags.inorder() {
-                child_base.floats_in = FloatContext::new(0);
-            }
-
-            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
-            //
-            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
-
-            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
-        }
+        self.propagate_assigned_width_to_children(x_offset);
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_height_inorder: assigning height for table_row {}", self.base.id);
+        debug!("assign_height_inorder: assigning height for table_row {}", self.block_flow.base.id);
         self.assign_height_table_row_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_height: assigning height for table_row {}", self.base.id);
+        debug!("assign_height: assigning height for table_row {}", self.block_flow.base.id);
         self.assign_height_table_row_base(ctx, false);
     }
 
@@ -280,7 +224,7 @@ impl Flow for TableRowFlow {
 
     fn debug_str(&self) -> ~str {
         let txt = ~"TableRowFlow: ";
-        txt.append(match self.box_ {
+        txt.append(match self.block_flow.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",
         })

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -212,6 +212,11 @@ impl Flow for TableRowFlow {
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        //assign height for box
+        for box_ in self.block_flow.box_.iter() {
+            box_.assign_height();
+        }
+
         debug!("assign_height: assigning height for table_row {}", self.block_flow.base.id);
         self.assign_height_table_row_base(ctx, false);
     }

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -62,7 +62,7 @@ pub struct TableRowGroupFlow {
     /// Additional floating flow members.
     float: Option<~FloatedTableInfo>,
 
-    /// Column widths 
+    /// Column widths
     col_widths: ~[Au],
 }
 
@@ -245,7 +245,7 @@ impl TableRowGroupFlow {
             position.origin.y = y;
             height = h;
 
-            if self.is_fixed { 
+            if self.is_fixed {
                 for kid in self.base.child_iter() {
                     let child_node = flow::mut_base(*kid);
                     child_node.position.origin.y = position.origin.y + top_offset;
@@ -450,7 +450,7 @@ impl Flow for TableRowGroupFlow {
         for kid in self.base.child_iter() {
             assert!(kid.starts_table_flow());
             if self.col_widths.is_empty() {
-                self.col_widths = kid.as_table_row().col_widths.slice_from(0).to_owned();
+                self.col_widths = kid.as_table_row().col_widths.clone();
             } else {
                 let num_cols = self.col_widths.len();
                 let num_child_cols = kid.as_table_row().col_widths.len();
@@ -460,7 +460,7 @@ impl Flow for TableRowGroupFlow {
                     0
                 };
                 for _ in range(0, diff) {
-                    self.col_widths.push ( Au::new(0) );
+                    self.col_widths.push (Au::new(0));
                 }
             }
 
@@ -521,10 +521,10 @@ impl Flow for TableRowGroupFlow {
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
             let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height, 
-                                                                 remaining_width, 
-                                                                 box_.offset(), 
+            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
+                                                                 screen_size.height,
+                                                                 remaining_width,
+                                                                 box_.offset(),
                                                                  self.is_fixed);
             x_offset = x;
             remaining_width = w;
@@ -552,7 +552,7 @@ impl Flow for TableRowGroupFlow {
         for kid in self.base.child_iter() {
             assert!(kid.starts_table_flow());
 
-            kid.as_table_row().col_widths = self.col_widths.slice_from(0).to_owned();
+            kid.as_table_row().col_widths = self.col_widths.clone();
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -57,7 +57,7 @@ impl TableRowGroupFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_rowgroup_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let top_offset = Au::new(0);
         let bottom_offset = Au::new(0);
@@ -106,7 +106,7 @@ impl TableRowGroupFlow {
         }
     }
 
-    pub fn build_display_list_table<E:ExtraDisplayListData>(
+    pub fn build_display_list_table_rowgroup<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -238,14 +238,16 @@ impl Flow for TableRowGroupFlow {
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height_inorder: assigning height for table_rowgroup {}", self.base.id);
-        self.assign_height_table_base(ctx, true);
+        self.assign_height_table_rowgroup_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
         debug!("assign_height: assigning height for table_rowgroup {}", self.base.id);
-        self.assign_height_table_base(ctx, false);
+        self.assign_height_table_rowgroup_base(ctx, false);
     }
 
+    /// TableRowBox and their parents(TableBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
     fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
                         _: &mut Au, _: &mut Au, _: &mut Au) {
     }

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -9,43 +9,13 @@ use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableRowGroupFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto};
-use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
+use layout::float_context::{FloatContext, Invalid};
 
 use std::cell::RefCell;
 use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
-
-/// Information specific to floated blocks.
-pub struct FloatedTableInfo {
-    containing_width: Au,
-
-    /// Offset relative to where the parent tried to position this flow
-    rel_pos: Point2D<Au>,
-
-    /// Index into the box list for inline floats
-    index: Option<uint>,
-
-    /// Number of floated children
-    floated_children: uint,
-
-    /// Left or right?
-    float_type: FloatType
-}
-
-impl FloatedTableInfo {
-    pub fn new(float_type: FloatType) -> FloatedTableInfo {
-        FloatedTableInfo {
-            containing_width: Au(0),
-            rel_pos: Point2D(Au(0), Au(0)),
-            index: None,
-            floated_children: 0,
-            float_type: float_type
-        }
-    }
-}
 
 /// A table formatting context.
 pub struct TableRowGroupFlow {
@@ -54,13 +24,6 @@ pub struct TableRowGroupFlow {
 
     /// The associated box.
     box_: Option<Box>,
-
-    //TODO: is_fixed should be bit fields to conserve memory.
-    /// Position property
-    is_fixed: bool,
-
-    /// Additional floating flow members.
-    float: Option<~FloatedTableInfo>,
 
     /// Column widths
     col_widths: ~[Au],
@@ -71,44 +34,16 @@ impl TableRowGroupFlow {
         TableRowGroupFlow {
             base: base,
             box_: None,
-            is_fixed: false,
-            float: None,
             col_widths: ~[],
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableRowGroupFlow {
+    pub fn from_box(base: BaseFlow, box_: Box) -> TableRowGroupFlow {
         TableRowGroupFlow {
             base: base,
             box_: Some(box_),
-            is_fixed: is_fixed,
-            float: None,
             col_widths: ~[],
         }
-    }
-
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableRowGroupFlow {
-        TableRowGroupFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-            col_widths: ~[],
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableRowGroupFlow {
-        TableRowGroupFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: Some(~FloatedTableInfo::new(float_type)),
-            col_widths: ~[],
-        }
-    }
-
-    pub fn is_float(&self) -> bool {
-        self.float.is_some()
     }
 
     pub fn teardown(&mut self) {
@@ -116,7 +51,6 @@ impl TableRowGroupFlow {
             box_.teardown();
         }
         self.box_ = None;
-        self.float = None;
         self.col_widths = ~[];
     }
 
@@ -125,27 +59,13 @@ impl TableRowGroupFlow {
     #[inline(always)]
     fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
-        let mut clearance = Au::new(0);
-        let mut top_offset = Au::new(0);
-        let mut bottom_offset = Au::new(0);
-        let mut left_offset = Au::new(0);
+        let top_offset = Au::new(0);
+        let bottom_offset = Au::new(0);
+        let left_offset = Au::new(0);
         let mut float_ctx = Invalid;
 
-        for box_ in self.box_.iter() {
-            clearance = match box_.clear() {
-                None => Au::new(0),
-                Some(clear) => {
-                    self.base.floats_in.clearance(clear)
-                }
-            };
-
-            top_offset = clearance + box_.margin.get().top + box_.border.get().top +
-                box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-            bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
-                box_.padding.get().bottom;
-            left_offset = box_.offset();
-        }
+        // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
+        // should be updated. Currently, they are set as Au(0).
 
         if inorder {
             // Floats for blocks work like this:
@@ -163,112 +83,20 @@ impl TableRowGroupFlow {
             }
         }
 
-        let mut collapsible = Au::new(0);
-        let mut collapsing = Au::new(0);
-        let mut margin_top = Au::new(0);
-        let mut margin_bottom = Au::new(0);
-        let mut top_margin_collapsible = false;
-        let mut bottom_margin_collapsible = false;
-        let mut first_in_flow = true;
-        for box_ in self.box_.iter() {
-            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
-                collapsible = box_.margin.get().top;
-                top_margin_collapsible = true;
-            }
-            if box_.border.get().bottom == Au(0) &&
-                    box_.padding.get().bottom == Au(0) {
-                bottom_margin_collapsible = true;
-            }
-            margin_top = box_.margin.get().top;
-            margin_bottom = box_.margin.get().bottom;
-        }
-
         for kid in self.base.child_iter() {
-            kid.collapse_margins(top_margin_collapsible,
-                                 &mut first_in_flow,
-                                 &mut margin_top,
-                                 &mut top_offset,
-                                 &mut collapsing,
-                                 &mut collapsible);
-
             let child_node = flow::mut_base(*kid);
-            cur_y = cur_y - collapsing;
             child_node.position.origin.y = cur_y;
             cur_y = cur_y + child_node.position.size.height;
         }
 
-        // The bottom margin collapses with its last in-flow block-level child's bottom margin
-        // if the parent has no bottom boder, no bottom padding.
-        collapsing = if bottom_margin_collapsible {
-            if margin_bottom < collapsible {
-                margin_bottom = collapsible;
-            }
-            collapsible
-        } else {
-            Au::new(0)
-        };
+        let height = cur_y - top_offset;
 
-        // TODO: A box's own margins collapse if the 'min-height' property is zero, and it has neither
-        // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
-        // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
-
-
-        let mut height = cur_y - top_offset - collapsing;
-
-        for box_ in self.box_.iter() {
-            let style = box_.style();
-
-            // At this point, `height` is the height of the containing block, so passing `height`
-            // as the second argument here effectively makes percentages relative to the containing
-            // block per CSS 2.1 § 10.5.
-            height = match MaybeAuto::from_style(style.Box.height, height) {
-                Auto => height,
-                Specified(value) => value
-            };
-        }
-
-        let mut noncontent_height = Au::new(0);
-        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
-            let mut margin = box_.margin.get();
-
-            // The associated box is the border box of this flow.
-            margin.top = margin_top;
-            margin.bottom = margin_bottom;
-
-            noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-                box_.border.get().top + box_.border.get().bottom;
-
-            let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                 height, clearance + margin.top, self.is_fixed);
-            position.origin.y = y;
-            height = h;
-
-            if self.is_fixed {
-                for kid in self.base.child_iter() {
-                    let child_node = flow::mut_base(*kid);
-                    child_node.position.origin.y = position.origin.y + top_offset;
-                }
-            }
-
-            position.size.height = if self.is_fixed {
-                height
-            } else {
-                height + noncontent_height
-            };
-
-            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
-
+            position.size.height = height;
             box_.position.set(position);
-            box_.margin.set(margin);
         }
-
-        self.base.position.size.height = if self.is_fixed {
-            height
-        } else {
-            height + noncontent_height
-        };
+        self.base.position.size.height = height;
 
         if inorder {
             let extra_height = height - (cur_y - top_offset) + bottom_offset;
@@ -278,102 +106,12 @@ impl TableRowGroupFlow {
         }
     }
 
-    fn assign_height_float_inorder(&mut self) {
-        // assign_height_float was already called by the traversal function
-        // so this is well-defined
-
-        let mut height = Au(0);
-        let mut clearance = Au(0);
-        let mut full_noncontent_width = Au(0);
-        let mut margin_height = Au(0);
-
-        for box_ in self.box_.iter() {
-            height = box_.position.get().size.height;
-            clearance = match box_.clear() {
-                None => Au(0),
-                Some(clear) => self.base.floats_in.clearance(clear),
-            };
-
-            let noncontent_width = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-
-            full_noncontent_width = noncontent_width + box_.margin.get().left +
-                box_.margin.get().right;
-            margin_height = box_.margin.get().top + box_.margin.get().bottom;
-        }
-
-        let info = PlacementInfo {
-            width: self.base.position.size.width + full_noncontent_width,
-            height: height + margin_height,
-            ceiling: clearance,
-            max_width: self.float.get_ref().containing_width,
-            f_type: self.float.get_ref().float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.base.floats_out = self.base.floats_in.add_float(&info);
-        self.float.get_mut_ref().rel_pos = self.base.floats_out.last_float_pos();
-    }
-
-    fn assign_height_float(&mut self, ctx: &mut LayoutContext) {
-        // Now that we've determined our height, propagate that out.
-        let has_inorder_children = self.base.num_floats > 0;
-        if has_inorder_children {
-            let mut float_ctx = FloatContext::new(self.float.get_ref().floated_children);
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-        let mut cur_y = Au(0);
-        let mut top_offset = Au(0);
-
-        for box_ in self.box_.iter() {
-            top_offset = box_.margin.get().top + box_.border.get().top + box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-        }
-
-        for kid in self.base.child_iter() {
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.y = cur_y;
-            cur_y = cur_y + child_base.position.size.height;
-        }
-
-        let mut height = cur_y - top_offset;
-
-        let mut noncontent_height;
-        let box_ = self.box_.as_ref().unwrap();
-        let mut position = box_.position.get();
-
-        // The associated box is the border box of this flow.
-        position.origin.y = box_.margin.get().top;
-
-        noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-            box_.border.get().top + box_.border.get().bottom;
-
-        //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
-                                                Au::new(0)).specified_or_zero();
-
-        height = geometry::max(height, height_prop) + noncontent_height;
-        debug!("assign_height_float -- height: {}", height);
-
-        position.size.height = height;
-        box_.position.set(position);
-    }
-
     pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        if self.is_float() {
-            return self.build_display_list_float(builder, dirty, list);
-        }
-
         let abs_rect = Rect(self.base.abs_position, self.base.position.size);
         if !abs_rect.intersects(dirty) {
             return true;
@@ -395,35 +133,6 @@ impl TableRowGroupFlow {
 
         false
     }
-
-    pub fn build_display_list_float<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true
-        }
-
-        let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
-        }
-
-
-        // TODO: handle any out-of-flow elements
-
-        // go deeper into the flow tree
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = offset + child_base.position.origin;
-        }
-
-        false
-    }
 }
 
 impl Flow for TableRowGroupFlow {
@@ -435,18 +144,20 @@ impl Flow for TableRowGroupFlow {
         self
     }
 
-    /* Recursively (bottom-up) determine the context's preferred and
-    minimum widths.  When called on this context, all child contexts
-    have had their min/pref widths set. This function must decide
-    min/pref widths based on child context widths and dimensions of
-    any boxes it is responsible for flowing.  */
-
+    /// Recursively (bottom-up) determines the context's preferred and minimum widths. When called
+    /// on this context, all child contexts have had their min/pref widths set. This function must
+    /// decide min/pref widths based on child context widths and dimensions of any boxes it is
+    /// responsible for flowing.
+    /// Min/pref widths set by this function are used in automatic table layout calculation.
+    /// Also, this function finds the specified column widths from the first row.
+    /// Those are used in fixed table layout calculation
     fn bubble_widths(&mut self, _: &mut LayoutContext) {
         let mut min_width = Au::new(0);
         let mut pref_width = Au::new(0);
         let mut num_floats = 0;
 
-        /* find max width from child block contexts */
+        /* find the specified column widths from the first table-row.
+           update the number of column widths from other table-rows. */
         for kid in self.base.child_iter() {
             assert!(kid.is_table_row());
             if self.col_widths.is_empty() {
@@ -464,15 +175,9 @@ impl Flow for TableRowGroupFlow {
             num_floats = num_floats + child_base.num_floats;
         }
 
-        if self.is_float() {
-            self.base.num_floats = 1;
-            self.float.get_mut_ref().floated_children = num_floats;
-        } else {
-            self.base.num_floats = num_floats;
-        }
+        self.base.num_floats = num_floats;
 
-        /* if not an anonymous block context, add in block box's widths.
-           these widths will not include child elements, just padding etc. */
+        // FIXME: automatic table layout calculation
         for box_ in self.box_.iter() {
             let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
             min_width = min_width + this_minimum_width;
@@ -485,28 +190,12 @@ impl Flow for TableRowGroupFlow {
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
     /// on this context, the context has had its width set by the parent context.
-    ///
-    /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
-    /// contexts.
-    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}",
-               if self.is_float() {
-                   "float"
-               } else {
-                   "table_rowgroup"
-               },
-               self.base.id);
+    fn assign_widths(&mut self, _: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow {}", "table_rowgroup", self.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let mut remaining_width = self.base.position.size.width;
+        let remaining_width = self.base.position.size.width;
         let mut x_offset = Au::new(0);
-
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = remaining_width;
-
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -514,32 +203,13 @@ impl Flow for TableRowGroupFlow {
             // The text alignment of a table_rowgroup flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
-                                                                 screen_size.height,
-                                                                 remaining_width,
-                                                                 box_.offset(),
-                                                                 self.is_fixed);
-            x_offset = x;
-            remaining_width = w;
+            x_offset = Au(0);
 
-            // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
-            if self.is_fixed {
-                position_ref.get().origin.x = x_offset;
-            }
             position_ref.get().size.width = remaining_width;
         }
 
-        if self.is_float() {
-            self.base.position.size.width = remaining_width;
-        }
-
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
+        let has_inorder_children = self.base.flags_info.flags.inorder() || self.base.num_floats > 0;
 
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
@@ -567,67 +237,21 @@ impl Flow for TableRowGroupFlow {
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
-            self.assign_height_float_inorder();
-        } else {
-            debug!("assign_height_inorder: assigning height for table_rowgroup {}", self.base.id);
-            self.assign_height_table_base(ctx, true);
-        }
+        debug!("assign_height_inorder: assigning height for table_rowgroup {}", self.base.id);
+        self.assign_height_table_base(ctx, true);
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
-            self.assign_height_float(ctx);
-        } else {
-            debug!("assign_height: assigning height for table_rowgroup {}", self.base.id);
-            self.assign_height_table_base(ctx, false);
-        }
+        debug!("assign_height: assigning height for table_rowgroup {}", self.base.id);
+        self.assign_height_table_base(ctx, false);
     }
 
-    fn collapse_margins(&mut self,
-                        top_margin_collapsible: bool,
-                        first_in_flow: &mut bool,
-                        margin_top: &mut Au,
-                        top_offset: &mut Au,
-                        collapsing: &mut Au,
-                        collapsible: &mut Au) {
-        if self.is_float() {
-            // Margins between a floated box and any other box do not collapse.
-            *collapsing = Au::new(0);
-            return;
-        }
-
-        for box_ in self.box_.iter() {
-            // The top margin collapses with its first in-flow block-level child's
-            // top margin if the parent has no top border, no top padding.
-            if *first_in_flow && top_margin_collapsible {
-                // If top-margin of parent is less than top-margin of its first child,
-                // the parent box goes down until its top is aligned with the child.
-                if *margin_top < box_.margin.get().top {
-                    // TODO: The position of child floats should be updated and this
-                    // would influence clearance as well. See #725
-                    let extra_margin = box_.margin.get().top - *margin_top;
-                    *top_offset = *top_offset + extra_margin;
-                    *margin_top = box_.margin.get().top;
-                }
-            }
-            // The bottom margin of an in-flow block-level element collapses
-            // with the top margin of its next in-flow block-level sibling.
-            *collapsing = geometry::min(box_.margin.get().top, *collapsible);
-            *collapsible = box_.margin.get().bottom;
-        }
-
-        *first_in_flow = false;
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
     }
 
     fn debug_str(&self) -> ~str {
-        let txt = if self.is_float() {
-            ~"FloatFlow: "
-        } else {
-            ~"TableRowGroupFlow: "
-        };
+        let txt = ~"TableRowGroupFlow: ";
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -9,11 +9,11 @@ use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableRowGroupFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
+use layout::model::{MaybeAuto, Specified, Auto};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
 
 use std::cell::RefCell;
-use geom::{Point2D, Rect, SideOffsets2D};
+use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
@@ -118,115 +118,6 @@ impl TableRowGroupFlow {
         self.box_ = None;
         self.float = None;
         self.col_widths = ~[];
-    }
-
-    /// Computes left and right margins and width based on CSS 2.1 section 10.3.3.
-    /// Requires borders and padding to already be computed.
-    fn compute_horiz(&self,
-                     width: MaybeAuto,
-                     left_margin: MaybeAuto,
-                     right_margin: MaybeAuto,
-                     available_width: Au)
-                     -> (Au, Au, Au) {
-        // If width is not 'auto', and width + margins > available_width, all 'auto' margins are
-        // treated as 0.
-        let (left_margin, right_margin) = match width {
-            Auto => (left_margin, right_margin),
-            Specified(width) => {
-                let left = left_margin.specified_or_zero();
-                let right = right_margin.specified_or_zero();
-
-                if((left + right + width) > available_width) {
-                    (Specified(left), Specified(right))
-                } else {
-                    (left_margin, right_margin)
-                }
-            }
-        };
-
-        //Invariant: left_margin_Au + width_Au + right_margin_Au == available_width
-        let (left_margin_Au, width_Au, right_margin_Au) = match (left_margin, width, right_margin) {
-            //If all have a computed value other than 'auto', the system is over-constrained and we need to discard a margin.
-            //if direction is ltr, ignore the specified right margin and solve for it. If it is rtl, ignore the specified
-            //left margin. FIXME(eatkinson): this assumes the direction is ltr
-            (Specified(margin_l), Specified(width), Specified(_margin_r)) => (margin_l, width, available_width - (margin_l + width )),
-
-            //If exactly one value is 'auto', solve for it
-            (Auto, Specified(width), Specified(margin_r)) => (available_width - (width + margin_r), width, margin_r),
-            (Specified(margin_l), Auto, Specified(margin_r)) => (margin_l, available_width - (margin_l + margin_r), margin_r),
-            (Specified(margin_l), Specified(width), Auto) => (margin_l, width, available_width - (margin_l + width)),
-
-            //If width is set to 'auto', any other 'auto' value becomes '0', and width is solved for
-            (Auto, Auto, Specified(margin_r)) => (Au::new(0), available_width - margin_r, margin_r),
-            (Specified(margin_l), Auto, Auto) => (margin_l, available_width - margin_l, Au::new(0)),
-            (Auto, Auto, Auto) => (Au::new(0), available_width, Au::new(0)),
-
-            //If left and right margins are auto, they become equal
-            (Auto, Specified(width), Auto) => {
-                let margin = (available_width - width).scale_by(0.5);
-                (margin, width, margin)
-            }
-
-        };
-        //return values in same order as params
-        (width_Au, left_margin_Au, right_margin_Au)
-    }
-
-    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
-                             -> (Au, Au, Au) {
-        let style = box_.style();
-
-        let (width, maybe_margin_left, maybe_margin_right) =
-            (MaybeAuto::from_style(style.Box.width, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_left, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_right, remaining_width));
-
-        let (width, margin_left, margin_right) = self.compute_horiz(width,
-                                                                    maybe_margin_left,
-                                                                    maybe_margin_right,
-                                                                    available_width);
-
-        // If the tentative used width is greater than 'max-width', width should be recalculated,
-        // but this time using the computed value of 'max-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            match specified_or_none(style.Box.max_width, remaining_width) {
-                Some(value) if value < width => self.compute_horiz(Specified(value),
-                                                                   maybe_margin_left,
-                                                                   maybe_margin_right,
-                                                                   available_width),
-                _ => (width, margin_left, margin_right)
-            }
-        };
-
-        // If the resulting width is smaller than 'min-width', width should be recalculated,
-        // but this time using the value of 'min-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            let computed_min_width = specified(style.Box.min_width, remaining_width);
-            if computed_min_width > width {
-                self.compute_horiz(Specified(computed_min_width),
-                                   maybe_margin_left,
-                                   maybe_margin_right,
-                                   available_width)
-            } else {
-                (width, margin_left, margin_right)
-            }
-        };
-
-        return (width, margin_left, margin_right);
-    }
-
-    fn compute_float_margins(&self, box_: &Box, remaining_width: Au) -> (Au, Au, Au) {
-        let style = box_.style();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
-                                                remaining_width).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
-                                                 remaining_width).specified_or_zero();
-        let shrink_to_fit = geometry::min(self.base.pref_width,
-                                          geometry::max(self.base.min_width, remaining_width));
-        let width = MaybeAuto::from_style(style.Box.width,
-                                          remaining_width).specified_or_default(shrink_to_fit);
-        debug!("assign_widths_float -- width: {}", width);
-        return (width, margin_left, margin_right);
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
@@ -589,11 +480,6 @@ impl Flow for TableRowGroupFlow {
         /* if not an anonymous block context, add in block box's widths.
            these widths will not include child elements, just padding etc. */
         for box_ in self.box_.iter() {
-            {
-                // Can compute border width here since it doesn't depend on anything.
-                box_.compute_borders(box_.style())
-            }
-
             let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
             min_width = min_width + this_minimum_width;
             pref_width = pref_width + this_preferred_width;
@@ -634,33 +520,10 @@ impl Flow for TableRowGroupFlow {
             // The text alignment of a table_rowgroup flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            // Can compute padding here since we know containing block width.
-            box_.compute_padding(style, remaining_width);
-
-            // Margins are 0 right now so base.noncontent_width() is just borders + padding.
-            let available_width = remaining_width - box_.noncontent_width();
-
-            // Top and bottom margins for blocks are 0 if auto.
-            let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
-                                                   remaining_width).specified_or_zero();
-            let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
-                                                      remaining_width).specified_or_zero();
-
-            let (width, margin_left, margin_right) = if self.is_float() {
-                self.compute_float_margins(box_, remaining_width)
-            } else {
-                self.compute_table_margins(box_, remaining_width, available_width)
-            };
-
-            box_.margin.set(SideOffsets2D::new(margin_top,
-                                              margin_right,
-                                              margin_bottom,
-                                              margin_left));
-
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
                                                                  screen_size.height, 
-                                                                 width, 
+                                                                 remaining_width, 
                                                                  box_.offset(), 
                                                                  self.is_fixed);
             x_offset = x;
@@ -669,14 +532,9 @@ impl Flow for TableRowGroupFlow {
             // The associated box is the border box of this flow.
             let mut position_ref = box_.position.borrow_mut();
             if self.is_fixed {
-                position_ref.get().origin.x = x_offset + box_.margin.get().left;
-                x_offset = x_offset + box_.padding.get().left;
-            } else {
-                position_ref.get().origin.x = box_.margin.get().left;
+                position_ref.get().origin.x = x_offset;
             }
-            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-            position_ref.get().size.width = remaining_width + padding_and_borders;
+            position_ref.get().size.width = remaining_width;
         }
 
         if self.is_float() {

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! CSS block formatting contexts.
+//! CSS table formatting contexts.
 
 use layout::box_::Box;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
-use layout::flow::{BaseFlow, BlockFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow::{BaseFlow, TableRowGroupFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
@@ -19,7 +19,7 @@ use servo_util::geometry::Au;
 use servo_util::geometry;
 
 /// Information specific to floated blocks.
-pub struct FloatedBlockInfo {
+pub struct FloatedTableInfo {
     containing_width: Au,
 
     /// Offset relative to where the parent tried to position this flow
@@ -35,9 +35,9 @@ pub struct FloatedBlockInfo {
     float_type: FloatType
 }
 
-impl FloatedBlockInfo {
-    pub fn new(float_type: FloatType) -> FloatedBlockInfo {
-        FloatedBlockInfo {
+impl FloatedTableInfo {
+    pub fn new(float_type: FloatType) -> FloatedTableInfo {
+        FloatedTableInfo {
             containing_width: Au(0),
             rel_pos: Point2D(Au(0), Au(0)),
             index: None,
@@ -47,72 +47,56 @@ impl FloatedBlockInfo {
     }
 }
 
-/// A block formatting context.
-pub struct BlockFlow {
+/// A table formatting context.
+pub struct TableRowGroupFlow {
     /// Data common to all flows.
     base: BaseFlow,
 
     /// The associated box.
     box_: Option<Box>,
 
-    //TODO: is_fixed and is_root should be bit fields to conserve memory.
-    /// Whether this block flow is the root flow.
-    is_root: bool,
-
+    //TODO: is_fixed should be bit fields to conserve memory.
+    /// Position property
     is_fixed: bool,
 
     /// Additional floating flow members.
-    float: Option<~FloatedBlockInfo>
+    float: Option<~FloatedTableInfo>
 }
 
-impl BlockFlow {
-    pub fn new(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+impl TableRowGroupFlow {
+    pub fn new(base: BaseFlow) -> TableRowGroupFlow {
+        TableRowGroupFlow {
             base: base,
             box_: None,
-            is_root: false,
             is_fixed: false,
             float: None
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> BlockFlow {
-        BlockFlow {
+    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableRowGroupFlow {
+        TableRowGroupFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: is_fixed,
             float: None
         }
     }
 
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> BlockFlow {
-        BlockFlow {
+    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableRowGroupFlow {
+        TableRowGroupFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
-    pub fn new_root(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableRowGroupFlow {
+        TableRowGroupFlow {
             base: base,
             box_: None,
-            is_root: true,
             is_fixed: false,
-            float: None
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> BlockFlow {
-        BlockFlow {
-            base: base,
-            box_: None,
-            is_root: false,
-            is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
@@ -180,7 +164,7 @@ impl BlockFlow {
         (width_Au, left_margin_Au, right_margin_Au)
     }
 
-    fn compute_block_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
+    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
                              -> (Au, Au, Au) {
         let style = box_.style();
 
@@ -240,7 +224,7 @@ impl BlockFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_block_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
@@ -288,11 +272,11 @@ impl BlockFlow {
         let mut bottom_margin_collapsible = false;
         let mut first_in_flow = true;
         for box_ in self.box_.iter() {
-            if !self.is_root && box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
+            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
                 collapsible = box_.margin.get().top;
                 top_margin_collapsible = true;
             }
-            if !self.is_root && box_.border.get().bottom == Au(0) &&
+            if box_.border.get().bottom == Au(0) &&
                     box_.padding.get().bottom == Au(0) {
                 bottom_margin_collapsible = true;
             }
@@ -329,17 +313,8 @@ impl BlockFlow {
         // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
         // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
 
-        let screen_height = ctx.screen_size.height;
 
-        let mut height = if self.is_root {
-            // FIXME(pcwalton): The max is taken here so that you can scroll the page, but this is
-            // not correct behavior according to CSS 2.1 § 10.5. Instead I think we should treat
-            // the root element as having `overflow: scroll` and use the layers-based scrolling
-            // infrastructure to make it scrollable.
-            Au::max(screen_height, cur_y)
-        } else {
-            cur_y - top_offset - collapsing
-        };
+        let mut height = cur_y - top_offset - collapsing;
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -354,6 +329,7 @@ impl BlockFlow {
         }
 
         let mut noncontent_height = Au::new(0);
+        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
             let mut margin = box_.margin.get();
@@ -366,10 +342,7 @@ impl BlockFlow {
                 box_.border.get().top + box_.border.get().bottom;
 
             let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                  height,
-                                                                  clearance + margin.top,
-                                                                  self.is_fixed);
-
+                                                                 height, clearance + margin.top, self.is_fixed);
             position.origin.y = y;
             height = h;
 
@@ -492,7 +465,7 @@ impl BlockFlow {
         box_.position.set(position);
     }
 
-    pub fn build_display_list_block<E:ExtraDisplayListData>(
+    pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -507,9 +480,9 @@ impl BlockFlow {
             return true;
         }
 
-        debug!("build_display_list_block: adding display element");
+        debug!("build_display_list_table[RowGroup]: adding display element");
 
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
         }
@@ -536,7 +509,7 @@ impl BlockFlow {
         }
 
         let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
         }
@@ -554,12 +527,12 @@ impl BlockFlow {
     }
 }
 
-impl Flow for BlockFlow {
+impl Flow for TableRowGroupFlow {
     fn class(&self) -> FlowClass {
-        BlockFlowClass
+        TableRowGroupFlowClass
     }
 
-    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+    fn as_table_rowgroup<'a>(&'a mut self) -> &'a mut TableRowGroupFlow {
         self
     }
 
@@ -578,7 +551,7 @@ impl Flow for BlockFlow {
 
         /* find max width from child block contexts */
         for child_ctx in self.base.child_iter() {
-            assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow() || child_ctx.starts_table_flow());
+            assert!(child_ctx.starts_table_flow());
 
             let child_base = flow::mut_base(*child_ctx);
             min_width = geometry::max(min_width, child_base.min_width);
@@ -620,17 +593,9 @@ impl Flow for BlockFlow {
                if self.is_float() {
                    "float"
                } else {
-                   "block"
+                   "table_rowgroup"
                },
                self.base.id);
-
-        if self.is_root {
-            debug!("Setting root position");
-            self.base.position.origin = Au::zero_point();
-            self.base.position.size.width = ctx.screen_size.width;
-            self.base.floats_in = FloatContext::new(self.base.num_floats);
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         // The position was set to the containing block by the flow's parent.
         let mut remaining_width = self.base.position.size.width;
@@ -646,10 +611,9 @@ impl Flow for BlockFlow {
         for box_ in self.box_.iter() {
             let style = box_.style();
 
-            // The text alignment of a block flow is the text alignment of its box's style.
+            // The text alignment of a table_rowgroup flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            box_.assign_width(remaining_width);
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
@@ -665,21 +629,20 @@ impl Flow for BlockFlow {
             let (width, margin_left, margin_right) = if self.is_float() {
                 self.compute_float_margins(box_, remaining_width)
             } else {
-                self.compute_block_margins(box_, remaining_width, available_width)
+                self.compute_table_margins(box_, remaining_width, available_width)
             };
 
             box_.margin.set(SideOffsets2D::new(margin_top,
-                                               margin_right,
-                                               margin_bottom,
-                                               margin_left));
+                                              margin_right,
+                                              margin_bottom,
+                                              margin_left));
 
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height,
-                                                                 width,
-                                                                 box_.offset(),
+                                                                 screen_size.height, 
+                                                                 width, 
+                                                                 box_.offset(), 
                                                                  self.is_fixed);
-
             x_offset = x;
             remaining_width = w;
 
@@ -709,7 +672,7 @@ impl Flow for BlockFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            assert!(kid.starts_table_flow());
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;
@@ -723,8 +686,8 @@ impl Flow for BlockFlow {
             // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
             //
             // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-
             child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
+
             child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
         }
     }
@@ -734,29 +697,18 @@ impl Flow for BlockFlow {
             debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
             self.assign_height_float_inorder();
         } else {
-            debug!("assign_height_inorder: assigning height for block {}", self.base.id);
-            self.assign_height_block_base(ctx, true);
+            debug!("assign_height_inorder: assigning height for table_rowgroup {}", self.base.id);
+            self.assign_height_table_base(ctx, true);
         }
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        //assign height for box
-        for box_ in self.box_.iter() {
-            box_.assign_height();
-        }
-
         if self.is_float() {
             debug!("assign_height_float: assigning height for float {}", self.base.id);
             self.assign_height_float(ctx);
         } else {
-            debug!("assign_height: assigning height for block {}", self.base.id);
-            // This is the only case in which a block flow can start an inorder
-            // subtraversal.
-            if self.is_root && self.base.num_floats > 0 {
-                self.assign_height_inorder(ctx);
-                return;
-            }
-            self.assign_height_block_base(ctx, false);
+            debug!("assign_height: assigning height for table_rowgroup {}", self.base.id);
+            self.assign_height_table_base(ctx, false);
         }
     }
 
@@ -796,17 +748,11 @@ impl Flow for BlockFlow {
         *first_in_flow = false;
     }
 
-    fn mark_as_root(&mut self) {
-        self.is_root = true
-    }
-
     fn debug_str(&self) -> ~str {
         let txt = if self.is_float() {
             ~"FloatFlow: "
-        } else if self.is_root {
-            ~"RootFlow: "
         } else {
-            ~"BlockFlow: "
+            ~"TableRowGroupFlow: "
         };
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -448,22 +448,16 @@ impl Flow for TableRowGroupFlow {
 
         /* find max width from child block contexts */
         for kid in self.base.child_iter() {
-            assert!(kid.starts_table_flow());
+            assert!(kid.is_table_row());
             if self.col_widths.is_empty() {
                 self.col_widths = kid.as_table_row().col_widths.clone();
             } else {
                 let num_cols = self.col_widths.len();
                 let num_child_cols = kid.as_table_row().col_widths.len();
-                let diff = if num_child_cols > num_cols {
-                    num_child_cols - num_cols
-                } else {
-                    0
-                };
-                for _ in range(0, diff) {
-                    self.col_widths.push (Au::new(0));
+                for _ in range(num_cols, num_child_cols) {
+                    self.col_widths.push(Au::new(0));
                 }
             }
-
             let child_base = flow::mut_base(*kid);
             min_width = geometry::max(min_width, child_base.min_width);
             pref_width = geometry::max(pref_width, child_base.pref_width);
@@ -550,7 +544,7 @@ impl Flow for TableRowGroupFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_table_flow());
+            assert!(kid.is_table_row());
 
             kid.as_table_row().col_widths = self.col_widths.clone();
 

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -159,6 +159,11 @@ impl Flow for TableRowGroupFlow {
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        //assign height for box
+        for box_ in self.block_flow.box_.iter() {
+            box_.assign_height();
+        }
+
         debug!("assign_height: assigning height for table_rowgroup {}", self.block_flow.base.id);
         self.assign_height_table_rowgroup_base(ctx, false);
     }

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -48,7 +48,7 @@ impl TableRowGroupFlow {
         &self.block_flow.box_
     }
 
-    fn initialize_offset(&mut self) -> (Au, Au, Au) {
+    fn initialize_offsets(&mut self) -> (Au, Au, Au) {
         // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
         // should be updated. Currently, they are set as Au(0).
         (Au(0), Au(0), Au(0))
@@ -58,7 +58,7 @@ impl TableRowGroupFlow {
     // methods
     #[inline(always)]
     fn assign_height_table_rowgroup_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let (top_offset, bottom_offset, left_offset) = self.initialize_offset();
+        let (top_offset, bottom_offset, left_offset) = self.initialize_offsets();
 
         let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx, Point2D(-left_offset, -top_offset), inorder);
         let mut cur_y = top_offset;
@@ -142,15 +142,11 @@ impl Flow for TableRowGroupFlow {
 
             // The text alignment of a table_rowgroup flow is the text alignment of its box's style.
             self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
-            self.block_flow.initial_box_setting(box_, style, remaining_width, false, false);
+            self.block_flow.compute_padding_and_margin_if_exists(box_, style, remaining_width, false, false);
             self.block_flow.set_box_x_and_width(box_, Au(0), remaining_width);
         }
 
-        self.block_flow.propagate_assigned_width_to_children(Au(0), remaining_width);
-        for kid in self.block_flow.base.child_iter() {
-            assert!(kid.is_table_row());
-            kid.as_table_row().col_widths = self.col_widths.clone();
-        }
+        self.block_flow.propagate_assigned_width_to_children(Au(0), remaining_width, Some(self.col_widths.clone()));
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! CSS block formatting contexts.
+//! CSS table formatting contexts.
 
 use layout::box_::Box;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
-use layout::flow::{BaseFlow, BlockFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow::{BaseFlow, TableWrapperFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
 use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
 use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
@@ -19,7 +19,7 @@ use servo_util::geometry::Au;
 use servo_util::geometry;
 
 /// Information specific to floated blocks.
-pub struct FloatedBlockInfo {
+pub struct FloatedTableInfo {
     containing_width: Au,
 
     /// Offset relative to where the parent tried to position this flow
@@ -35,9 +35,9 @@ pub struct FloatedBlockInfo {
     float_type: FloatType
 }
 
-impl FloatedBlockInfo {
-    pub fn new(float_type: FloatType) -> FloatedBlockInfo {
-        FloatedBlockInfo {
+impl FloatedTableInfo {
+    pub fn new(float_type: FloatType) -> FloatedTableInfo {
+        FloatedTableInfo {
             containing_width: Au(0),
             rel_pos: Point2D(Au(0), Au(0)),
             index: None,
@@ -47,72 +47,56 @@ impl FloatedBlockInfo {
     }
 }
 
-/// A block formatting context.
-pub struct BlockFlow {
+/// A table formatting context.
+pub struct TableWrapperFlow {
     /// Data common to all flows.
     base: BaseFlow,
 
     /// The associated box.
     box_: Option<Box>,
 
-    //TODO: is_fixed and is_root should be bit fields to conserve memory.
-    /// Whether this block flow is the root flow.
-    is_root: bool,
-
+    //TODO: is_fixed should be bit fields to conserve memory.
+    /// Position property
     is_fixed: bool,
 
     /// Additional floating flow members.
-    float: Option<~FloatedBlockInfo>
+    float: Option<~FloatedTableInfo>
 }
 
-impl BlockFlow {
-    pub fn new(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+impl TableWrapperFlow {
+    pub fn new(base: BaseFlow) -> TableWrapperFlow {
+        TableWrapperFlow {
             base: base,
             box_: None,
-            is_root: false,
             is_fixed: false,
             float: None
         }
     }
 
-    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> BlockFlow {
-        BlockFlow {
+    pub fn from_box(base: BaseFlow, box_: Box, is_fixed: bool) -> TableWrapperFlow {
+        TableWrapperFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: is_fixed,
             float: None
         }
     }
 
-    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> BlockFlow {
-        BlockFlow {
+    pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableWrapperFlow {
+        TableWrapperFlow {
             base: base,
             box_: Some(box_),
-            is_root: false,
             is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
-    pub fn new_root(base: BaseFlow) -> BlockFlow {
-        BlockFlow {
+    pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableWrapperFlow {
+        TableWrapperFlow {
             base: base,
             box_: None,
-            is_root: true,
             is_fixed: false,
-            float: None
-        }
-    }
-
-    pub fn new_float(base: BaseFlow, float_type: FloatType) -> BlockFlow {
-        BlockFlow {
-            base: base,
-            box_: None,
-            is_root: false,
-            is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type))
+            float: Some(~FloatedTableInfo::new(float_type))
         }
     }
 
@@ -180,7 +164,7 @@ impl BlockFlow {
         (width_Au, left_margin_Au, right_margin_Au)
     }
 
-    fn compute_block_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
+    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
                              -> (Au, Au, Au) {
         let style = box_.style();
 
@@ -240,7 +224,7 @@ impl BlockFlow {
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
-    fn assign_height_block_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
         let mut cur_y = Au::new(0);
         let mut clearance = Au::new(0);
         let mut top_offset = Au::new(0);
@@ -288,11 +272,11 @@ impl BlockFlow {
         let mut bottom_margin_collapsible = false;
         let mut first_in_flow = true;
         for box_ in self.box_.iter() {
-            if !self.is_root && box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
+            if box_.border.get().top == Au(0) && box_.padding.get().top == Au(0) {
                 collapsible = box_.margin.get().top;
                 top_margin_collapsible = true;
             }
-            if !self.is_root && box_.border.get().bottom == Au(0) &&
+            if box_.border.get().bottom == Au(0) &&
                     box_.padding.get().bottom == Au(0) {
                 bottom_margin_collapsible = true;
             }
@@ -329,17 +313,8 @@ impl BlockFlow {
         // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
         // and it does not contain a line box, and all of its in-flow children's margins (if any) collapse.
 
-        let screen_height = ctx.screen_size.height;
 
-        let mut height = if self.is_root {
-            // FIXME(pcwalton): The max is taken here so that you can scroll the page, but this is
-            // not correct behavior according to CSS 2.1 § 10.5. Instead I think we should treat
-            // the root element as having `overflow: scroll` and use the layers-based scrolling
-            // infrastructure to make it scrollable.
-            Au::max(screen_height, cur_y)
-        } else {
-            cur_y - top_offset - collapsing
-        };
+        let mut height = cur_y - top_offset - collapsing;
 
         for box_ in self.box_.iter() {
             let style = box_.style();
@@ -354,6 +329,7 @@ impl BlockFlow {
         }
 
         let mut noncontent_height = Au::new(0);
+        let screen_height = ctx.screen_size.height;
         for box_ in self.box_.iter() {
             let mut position = box_.position.get();
             let mut margin = box_.margin.get();
@@ -366,10 +342,7 @@ impl BlockFlow {
                 box_.border.get().top + box_.border.get().bottom;
 
             let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                  height,
-                                                                  clearance + margin.top,
-                                                                  self.is_fixed);
-
+                                                                 height, clearance + margin.top, self.is_fixed);
             position.origin.y = y;
             height = h;
 
@@ -492,7 +465,7 @@ impl BlockFlow {
         box_.position.set(position);
     }
 
-    pub fn build_display_list_block<E:ExtraDisplayListData>(
+    pub fn build_display_list_table<E:ExtraDisplayListData>(
                                     &mut self,
                                     builder: &DisplayListBuilder,
                                     dirty: &Rect<Au>,
@@ -507,9 +480,9 @@ impl BlockFlow {
             return true;
         }
 
-        debug!("build_display_list_block: adding display element");
+        debug!("build_display_list_table[Wrapper]: adding display element");
 
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
         }
@@ -536,7 +509,7 @@ impl BlockFlow {
         }
 
         let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts block context
+        // add box that starts table context
         for box_ in self.box_.iter() {
             box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
         }
@@ -554,12 +527,12 @@ impl BlockFlow {
     }
 }
 
-impl Flow for BlockFlow {
+impl Flow for TableWrapperFlow {
     fn class(&self) -> FlowClass {
-        BlockFlowClass
+        TableWrapperFlowClass
     }
 
-    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+    fn as_table_wrapper<'a>(&'a mut self) -> &'a mut TableWrapperFlow {
         self
     }
 
@@ -578,7 +551,7 @@ impl Flow for BlockFlow {
 
         /* find max width from child block contexts */
         for child_ctx in self.base.child_iter() {
-            assert!(child_ctx.starts_block_flow() || child_ctx.starts_inline_flow() || child_ctx.starts_table_flow());
+            assert!(child_ctx.starts_block_flow() || child_ctx.starts_table_flow());
 
             let child_base = flow::mut_base(*child_ctx);
             min_width = geometry::max(min_width, child_base.min_width);
@@ -620,17 +593,9 @@ impl Flow for BlockFlow {
                if self.is_float() {
                    "float"
                } else {
-                   "block"
+                   "table_wrapper"
                },
                self.base.id);
-
-        if self.is_root {
-            debug!("Setting root position");
-            self.base.position.origin = Au::zero_point();
-            self.base.position.size.width = ctx.screen_size.width;
-            self.base.floats_in = FloatContext::new(self.base.num_floats);
-            self.base.flags_info.flags.set_inorder(false);
-        }
 
         // The position was set to the containing block by the flow's parent.
         let mut remaining_width = self.base.position.size.width;
@@ -646,10 +611,9 @@ impl Flow for BlockFlow {
         for box_ in self.box_.iter() {
             let style = box_.style();
 
-            // The text alignment of a block flow is the text alignment of its box's style.
+            // The text alignment of a table_wrapper flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            box_.assign_width(remaining_width);
             // Can compute padding here since we know containing block width.
             box_.compute_padding(style, remaining_width);
 
@@ -665,21 +629,20 @@ impl Flow for BlockFlow {
             let (width, margin_left, margin_right) = if self.is_float() {
                 self.compute_float_margins(box_, remaining_width)
             } else {
-                self.compute_block_margins(box_, remaining_width, available_width)
+                self.compute_table_margins(box_, remaining_width, available_width)
             };
 
             box_.margin.set(SideOffsets2D::new(margin_top,
-                                               margin_right,
-                                               margin_bottom,
-                                               margin_left));
+                                              margin_right,
+                                              margin_bottom,
+                                              margin_left));
 
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height,
-                                                                 width,
-                                                                 box_.offset(),
+                                                                 screen_size.height, 
+                                                                 width, 
+                                                                 box_.offset(), 
                                                                  self.is_fixed);
-
             x_offset = x;
             remaining_width = w;
 
@@ -709,7 +672,7 @@ impl Flow for BlockFlow {
         // FIXME(ksh8281): avoid copy
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
-            assert!(kid.starts_block_flow() || kid.starts_inline_flow() || kid.starts_table_flow());
+            assert!(kid.starts_block_flow() || kid.starts_table_flow());
 
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;
@@ -723,8 +686,8 @@ impl Flow for BlockFlow {
             // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
             //
             // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-
             child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
+
             child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
         }
     }
@@ -734,29 +697,18 @@ impl Flow for BlockFlow {
             debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
             self.assign_height_float_inorder();
         } else {
-            debug!("assign_height_inorder: assigning height for block {}", self.base.id);
-            self.assign_height_block_base(ctx, true);
+            debug!("assign_height_inorder: assigning height for table_wrapper {}", self.base.id);
+            self.assign_height_table_base(ctx, true);
         }
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
-        //assign height for box
-        for box_ in self.box_.iter() {
-            box_.assign_height();
-        }
-
         if self.is_float() {
             debug!("assign_height_float: assigning height for float {}", self.base.id);
             self.assign_height_float(ctx);
         } else {
-            debug!("assign_height: assigning height for block {}", self.base.id);
-            // This is the only case in which a block flow can start an inorder
-            // subtraversal.
-            if self.is_root && self.base.num_floats > 0 {
-                self.assign_height_inorder(ctx);
-                return;
-            }
-            self.assign_height_block_base(ctx, false);
+            debug!("assign_height: assigning height for table_wrapper {}", self.base.id);
+            self.assign_height_table_base(ctx, false);
         }
     }
 
@@ -796,17 +748,11 @@ impl Flow for BlockFlow {
         *first_in_flow = false;
     }
 
-    fn mark_as_root(&mut self) {
-        self.is_root = true
-    }
-
     fn debug_str(&self) -> ~str {
         let txt = if self.is_float() {
             ~"FloatFlow: "
-        } else if self.is_root {
-            ~"RootFlow: "
         } else {
-            ~"BlockFlow: "
+            ~"TableWrapperFlow: "
         };
         txt.append(match self.box_ {
             Some(ref rb) => rb.debug_str(),

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -614,11 +614,6 @@ impl Flow for TableWrapperFlow {
         /* if not an anonymous block context, add in block box's widths.
            these widths will not include child elements, just padding etc. */
         for box_ in self.box_.iter() {
-            {
-                // Can compute border width here since it doesn't depend on anything.
-                box_.compute_borders(box_.style())
-            }
-
             let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
             min_width = min_width + this_minimum_width;
             pref_width = pref_width + this_preferred_width;
@@ -669,9 +664,6 @@ impl Flow for TableWrapperFlow {
             // The text alignment of a table_wrapper flow is the text alignment of its box's style.
             self.base.flags_info.flags.set_text_align(style.Text.text_align);
 
-            // Can compute padding here since we know containing block width.
-            box_.compute_padding(style, remaining_width);
-
             // Margins are 0 right now so base.noncontent_width() is just borders + padding.
             let available_width = remaining_width - box_.noncontent_width();
 
@@ -705,13 +697,10 @@ impl Flow for TableWrapperFlow {
             let mut position_ref = box_.position.borrow_mut();
             if self.is_fixed {
                 position_ref.get().origin.x = x_offset + box_.margin.get().left;
-                x_offset = x_offset + box_.padding.get().left;
             } else {
                 position_ref.get().origin.x = box_.margin.get().left;
             }
-            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-            position_ref.get().size.width = remaining_width + padding_and_borders;
+            position_ref.get().size.width = remaining_width;
         }
 
         if self.is_float() {

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -363,7 +363,7 @@ impl TableWrapperFlow {
             position.origin.y = y;
             height = h;
 
-            if self.is_fixed { 
+            if self.is_fixed {
                 for kid in self.base.child_iter() {
                     let child_node = flow::mut_base(*kid);
                     child_node.position.origin.y = position.origin.y + top_offset;
@@ -654,10 +654,10 @@ impl Flow for TableWrapperFlow {
                                               margin_left));
 
             let screen_size = ctx.screen_size;
-            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width, 
-                                                                 screen_size.height, 
-                                                                 width, 
-                                                                 box_.offset(), 
+            let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
+                                                                 screen_size.height,
+                                                                 width,
+                                                                 box_.offset(),
                                                                  self.is_fixed);
             x_offset = x;
 
@@ -691,7 +691,7 @@ impl Flow for TableWrapperFlow {
         let flags_info = self.base.flags_info.clone();
         for kid in self.base.child_iter() {
             assert!(kid.is_table_caption() || kid.is_table());
-            
+
             let child_base = flow::mut_base(*kid);
             child_base.position.origin.x = x_offset;
             child_base.position.size.width = remaining_width;

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -212,7 +212,7 @@ impl Flow for TableWrapperFlow {
             x_offset = x;
 
             // Get left and right paddings, borders for table.
-            // We get these values because table_wrapper doesn't have border and padding.
+            // We get these values from the box's style since table_wrapper doesn't have it's own border or padding.
             let padding_left = specified(style.Padding.padding_left, remaining_width);
             let padding_right = specified(style.Padding.padding_right, remaining_width);
             let border_left = style.Border.border_left_width;

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -238,7 +238,7 @@ impl Flow for TableWrapperFlow {
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.block_flow.base.id);
+            debug!("assign_height_inorder_float: assigning height for floated table_wrapper {}", self.block_flow.base.id);
             self.block_flow.assign_height_float_inorder();
         } else {
             debug!("assign_height_inorder: assigning height for table_wrapper {}", self.block_flow.base.id);
@@ -247,8 +247,13 @@ impl Flow for TableWrapperFlow {
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        //assign height for box
+        for box_ in self.block_flow.box_.iter() {
+            box_.assign_height();
+        }
+
         if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.block_flow.base.id);
+            debug!("assign_height_float: assigning height for floated table_wrapper {}", self.block_flow.base.id);
             self.block_flow.assign_height_float(ctx);
         } else {
             debug!("assign_height: assigning height for table_wrapper {}", self.block_flow.base.id);

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -92,7 +92,7 @@ impl TableWrapperFlow {
     // methods
     #[inline(always)]
     fn assign_height_table_wrapper_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let (clearance, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offset(false);
+        let (clearance, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offsets(false);
 
         let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx,
                                                                               Point2D(-left_offset, -top_offset),
@@ -201,7 +201,7 @@ impl Flow for TableWrapperFlow {
 
             // The text alignment of a table_wrapper flow is the text alignment of its box's style.
             self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
-            let width = self.block_flow.initial_box_setting(box_, style, remaining_width, false, true);
+            let width = self.block_flow.compute_padding_and_margin_if_exists(box_, style, remaining_width, false, true);
 
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
@@ -211,12 +211,15 @@ impl Flow for TableWrapperFlow {
                                                                  self.block_flow.is_fixed);
             x_offset = x;
 
-            // Get left and right paddings, borders for table
+            // Get left and right paddings, borders for table.
+            // We get these values because table_wrapper doesn't have border and padding.
             let padding_left = specified(style.Padding.padding_left, remaining_width);
             let padding_right = specified(style.Padding.padding_right, remaining_width);
             let border_left = style.Border.border_left_width;
             let border_right = style.Border.border_right_width;
             let padding_and_borders = padding_left + padding_right + border_left + border_right;
+            // Get border-edge width. Because fixed_cells_width indicates content-width,
+            // padding and border values are added to fixed_cells_width.
             remaining_width = geometry::max(fixed_cells_width + padding_and_borders, w);
 
             let border_x = if self.block_flow.is_fixed {
@@ -233,7 +236,7 @@ impl Flow for TableWrapperFlow {
             _ => {}
         }
 
-        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width);
+        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width, None);
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -5,17 +5,17 @@
 //! CSS table formatting contexts.
 
 use layout::box_::Box;
-use layout::block::FloatedBlockInfo;
+use layout::block::BlockFlow;
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::flow::{BaseFlow, TableWrapperFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use layout::flow;
-use layout::model::{MaybeAuto, Specified, Auto, specified_or_none, specified};
-use layout::float_context::{FloatContext, PlacementInfo, Invalid, FloatType};
+use layout::model::{MaybeAuto, Specified, Auto, specified};
+use layout::float_context::{FloatType};
 
 use std::cell::RefCell;
 use style::computed_values::table_layout;
-use geom::{Point2D, Rect, SideOffsets2D};
+use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::geometry;
@@ -27,18 +27,7 @@ pub enum TableLayout {
 
 /// A table wrapper flow based on a block formatting context.
 pub struct TableWrapperFlow {
-    /// Data common to all flows.
-    base: BaseFlow,
-
-    /// The associated box.
-    box_: Option<Box>,
-
-    //TODO: is_fixed should be bit fields to conserve memory.
-    /// Position property
-    is_fixed: bool,
-
-    /// Additional floating flow members.
-    float: Option<~FloatedBlockInfo>,
+    block_flow: BlockFlow,
 
     /// Column widths
     col_widths: ~[Au],
@@ -50,10 +39,7 @@ pub struct TableWrapperFlow {
 impl TableWrapperFlow {
     pub fn new(base: BaseFlow) -> TableWrapperFlow {
         TableWrapperFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: None,
+            block_flow: BlockFlow::new(base),
             col_widths: ~[],
             table_layout: AutoLayout,
         }
@@ -66,204 +52,58 @@ impl TableWrapperFlow {
             AutoLayout
         };
         TableWrapperFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: is_fixed,
-            float: None,
+            block_flow: BlockFlow::from_box(base, box_, is_fixed),
             col_widths: ~[],
             table_layout: table_layout,
         }
     }
 
     pub fn float_from_box(base: BaseFlow, float_type: FloatType, box_: Box) -> TableWrapperFlow {
+        let table_layout = if (box_.style().Table.table_layout == table_layout::fixed) {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
         TableWrapperFlow {
-            base: base,
-            box_: Some(box_),
-            is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type)),
+            block_flow: BlockFlow::float_from_box(base, float_type, box_),
             col_widths: ~[],
-            table_layout: AutoLayout,
+            table_layout: table_layout,
         }
     }
 
     pub fn new_float(base: BaseFlow, float_type: FloatType) -> TableWrapperFlow {
         TableWrapperFlow {
-            base: base,
-            box_: None,
-            is_fixed: false,
-            float: Some(~FloatedBlockInfo::new(float_type)),
+            block_flow: BlockFlow::new_float(base, float_type),
             col_widths: ~[],
             table_layout: AutoLayout,
         }
     }
 
     pub fn is_float(&self) -> bool {
-        self.float.is_some()
+        self.block_flow.float.is_some()
     }
 
     pub fn teardown(&mut self) {
-        for box_ in self.box_.iter() {
-            box_.teardown();
-        }
-        self.box_ = None;
-        self.float = None;
-    }
-
-    /// Computes left and right margins and width based on CSS 2.1 section 10.3.3.
-    /// Requires borders and padding to already be computed.
-    fn compute_horiz(&self,
-                     width: MaybeAuto,
-                     left_margin: MaybeAuto,
-                     right_margin: MaybeAuto,
-                     available_width: Au)
-                     -> (Au, Au, Au) {
-        // If width is not 'auto', and width + margins > available_width, all 'auto' margins are
-        // treated as 0.
-        let (left_margin, right_margin) = match width {
-            Auto => (left_margin, right_margin),
-            Specified(width) => {
-                let left = left_margin.specified_or_zero();
-                let right = right_margin.specified_or_zero();
-
-                if((left + right + width) > available_width) {
-                    (Specified(left), Specified(right))
-                } else {
-                    (left_margin, right_margin)
-                }
-            }
-        };
-
-        //Invariant: left_margin_Au + width_Au + right_margin_Au == available_width
-        let (left_margin_Au, width_Au, right_margin_Au) = match (left_margin, width, right_margin) {
-            //If all have a computed value other than 'auto', the system is over-constrained and we need to discard a margin.
-            //if direction is ltr, ignore the specified right margin and solve for it. If it is rtl, ignore the specified
-            //left margin. FIXME(eatkinson): this assumes the direction is ltr
-            (Specified(margin_l), Specified(width), Specified(_margin_r)) => (margin_l, width, available_width - (margin_l + width )),
-
-            //If exactly one value is 'auto', solve for it
-            (Auto, Specified(width), Specified(margin_r)) => (available_width - (width + margin_r), width, margin_r),
-            (Specified(margin_l), Auto, Specified(margin_r)) => (margin_l, available_width - (margin_l + margin_r), margin_r),
-            (Specified(margin_l), Specified(width), Auto) => (margin_l, width, available_width - (margin_l + width)),
-
-            //If width is set to 'auto', any other 'auto' value becomes '0', and width is solved for
-            (Auto, Auto, Specified(margin_r)) => (Au::new(0), available_width - margin_r, margin_r),
-            (Specified(margin_l), Auto, Auto) => (margin_l, available_width - margin_l, Au::new(0)),
-            (Auto, Auto, Auto) => (Au::new(0), available_width, Au::new(0)),
-
-            //If left and right margins are auto, they become equal
-            (Auto, Specified(width), Auto) => {
-                let margin = (available_width - width).scale_by(0.5);
-                (margin, width, margin)
-            }
-
-        };
-        //return values in same order as params
-        (width_Au, left_margin_Au, right_margin_Au)
-    }
-
-    fn compute_table_margins(&self, box_: &Box, remaining_width: Au, available_width: Au)
-                             -> (Au, Au, Au) {
-        let style = box_.style();
-
-        let (width, maybe_margin_left, maybe_margin_right) =
-            (MaybeAuto::from_style(style.Box.width, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_left, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_right, remaining_width));
-
-        let (width, margin_left, margin_right) = self.compute_horiz(width,
-                                                                    maybe_margin_left,
-                                                                    maybe_margin_right,
-                                                                    available_width);
-
-        // If the tentative used width is greater than 'max-width', width should be recalculated,
-        // but this time using the computed value of 'max-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            match specified_or_none(style.Box.max_width, remaining_width) {
-                Some(value) if value < width => self.compute_horiz(Specified(value),
-                                                                   maybe_margin_left,
-                                                                   maybe_margin_right,
-                                                                   available_width),
-                _ => (width, margin_left, margin_right)
-            }
-        };
-
-        // If the resulting width is smaller than 'min-width', width should be recalculated,
-        // but this time using the value of 'min-width' as the computed value for 'width'.
-        let (width, margin_left, margin_right) = {
-            let computed_min_width = specified(style.Box.min_width, remaining_width);
-            if computed_min_width > width {
-                self.compute_horiz(Specified(computed_min_width),
-                                   maybe_margin_left,
-                                   maybe_margin_right,
-                                   available_width)
-            } else {
-                (width, margin_left, margin_right)
-            }
-        };
-
-        return (width, margin_left, margin_right);
-    }
-
-    fn compute_float_margins(&self, box_: &Box, remaining_width: Au) -> (Au, Au, Au) {
-        let style = box_.style();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
-                                                remaining_width).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
-                                                 remaining_width).specified_or_zero();
-        let shrink_to_fit = geometry::min(self.base.pref_width,
-                                          geometry::max(self.base.min_width, remaining_width));
-        let width = MaybeAuto::from_style(style.Box.width,
-                                          remaining_width).specified_or_default(shrink_to_fit);
-        debug!("assign_widths_float -- width: {}", width);
-        return (width, margin_left, margin_right);
+        self.block_flow.teardown();
+        self.col_widths = ~[];
     }
 
     // inline(always) because this is only ever called by in-order or non-in-order top-level
     // methods
     #[inline(always)]
     fn assign_height_table_wrapper_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let mut cur_y = Au::new(0);
-        let mut clearance = Au::new(0);
-        let mut top_offset = Au::new(0);
-        let mut bottom_offset = Au::new(0);
-        let mut left_offset = Au::new(0);
-        let mut float_ctx = Invalid;
-        let mut margin_top = Au::new(0);
-        let mut margin_bottom = Au::new(0);
+        let (clearance, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offset(false);
 
-        for box_ in self.box_.iter() {
-            clearance = match box_.clear() {
-                None => Au::new(0),
-                Some(clear) => {
-                    self.base.floats_in.clearance(clear)
-                }
-            };
+        let mut float_ctx = self.block_flow.handle_children_floats_if_inorder(ctx,
+                                                                              Point2D(-left_offset, -top_offset),
+                                                                              inorder);
 
-            top_offset = clearance + box_.noncontent_top();
-            cur_y = cur_y + top_offset;
-            bottom_offset = box_.noncontent_bottom();
-            left_offset = box_.noncontent_left();
-            margin_top = box_.margin.get().top;
-            margin_bottom = box_.margin.get().bottom;
-        }
+        // Table wrapper flow has margin but is not collapsed with kids(table caption and table).
+        let (margin_top, margin_bottom, _, _) = self.block_flow.precompute_margin();
 
-        if inorder {
-            // Floats for blocks work like this:
-            // self.floats_in -> child[0].floats_in
-            // visit child[0]
-            // child[i-1].floats_out -> child[i].floats_in
-            // visit child[i]
-            // repeat until all children are visited.
-            // last_child.floats_out -> self.floats_out (done at the end of this method)
-            float_ctx = self.base.floats_in.translate(Point2D(-left_offset, -top_offset));
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
+        let mut cur_y = top_offset;
 
-        for kid in self.base.child_iter() {
+        for kid in self.block_flow.base.child_iter() {
             let child_node = flow::mut_base(*kid);
             child_node.position.origin.y = cur_y;
             cur_y = cur_y + child_node.position.size.height;
@@ -271,7 +111,7 @@ impl TableWrapperFlow {
 
         let mut height = cur_y - top_offset;
 
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let style = box_.style();
 
             // At this point, `height` is the height of the containing block, so passing `height`
@@ -283,141 +123,16 @@ impl TableWrapperFlow {
             };
         }
 
-        let mut noncontent_height = Au::new(0);
-        let screen_height = ctx.screen_size.height;
-        for box_ in self.box_.iter() {
-            let mut position = box_.position.get();
-            let mut margin = box_.margin.get();
+        self.block_flow.compute_height_position(&mut height,
+                                                ctx.screen_size.height,
+                                                Au(0),
+                                                margin_top,
+                                                margin_bottom,
+                                                clearance,
+                                                top_offset);
 
-            // The associated box is the border box of this flow.
-            margin.top = margin_top;
-            margin.bottom = margin_bottom;
-
-            noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-                box_.border.get().top + box_.border.get().bottom;
-
-            let (y, h) = box_.get_y_coord_and_new_height_if_fixed(screen_height,
-                                                                 height, clearance + margin.top, self.is_fixed);
-            position.origin.y = y;
-            height = h;
-
-            if self.is_fixed {
-                for kid in self.base.child_iter() {
-                    let child_node = flow::mut_base(*kid);
-                    child_node.position.origin.y = position.origin.y + top_offset;
-                }
-            }
-
-            position.size.height = if self.is_fixed {
-                height
-            } else {
-                height + noncontent_height
-            };
-
-            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
-
-            box_.position.set(position);
-            box_.margin.set(margin);
-        }
-
-        self.base.position.size.height = if self.is_fixed {
-            height
-        } else {
-            height + noncontent_height
-        };
-
-        if inorder {
-            let extra_height = height - (cur_y - top_offset) + bottom_offset;
-            self.base.floats_out = float_ctx.translate(Point2D(left_offset, -extra_height));
-        } else {
-            self.base.floats_out = self.base.floats_in.clone();
-        }
-    }
-
-    fn assign_height_float_inorder(&mut self) {
-        // assign_height_float was already called by the traversal function
-        // so this is well-defined
-
-        let mut height = Au(0);
-        let mut clearance = Au(0);
-        let mut full_noncontent_width = Au(0);
-        let mut margin_height = Au(0);
-
-        for box_ in self.box_.iter() {
-            height = box_.position.get().size.height;
-            clearance = match box_.clear() {
-                None => Au(0),
-                Some(clear) => self.base.floats_in.clearance(clear),
-            };
-
-            let noncontent_width = box_.padding.get().left + box_.padding.get().right +
-                box_.border.get().left + box_.border.get().right;
-
-            full_noncontent_width = noncontent_width + box_.margin.get().left +
-                box_.margin.get().right;
-            margin_height = box_.margin.get().top + box_.margin.get().bottom;
-        }
-
-        let info = PlacementInfo {
-            width: self.base.position.size.width + full_noncontent_width,
-            height: height + margin_height,
-            ceiling: clearance,
-            max_width: self.float.get_ref().containing_width,
-            f_type: self.float.get_ref().float_type,
-        };
-
-        // Place the float and return the FloatContext back to the parent flow.
-        // After, grab the position and use that to set our position.
-        self.base.floats_out = self.base.floats_in.add_float(&info);
-        self.float.get_mut_ref().rel_pos = self.base.floats_out.last_float_pos();
-    }
-
-    fn assign_height_float(&mut self, ctx: &mut LayoutContext) {
-        // Now that we've determined our height, propagate that out.
-        let has_inorder_children = self.base.num_floats > 0;
-        if has_inorder_children {
-            let mut float_ctx = FloatContext::new(self.float.get_ref().floated_children);
-            for kid in self.base.child_iter() {
-                flow::mut_base(*kid).floats_in = float_ctx.clone();
-                kid.assign_height_inorder(ctx);
-                float_ctx = flow::mut_base(*kid).floats_out.clone();
-            }
-        }
-        let mut cur_y = Au(0);
-        let mut top_offset = Au(0);
-
-        for box_ in self.box_.iter() {
-            top_offset = box_.margin.get().top + box_.border.get().top + box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-        }
-
-        for kid in self.base.child_iter() {
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.y = cur_y;
-            cur_y = cur_y + child_base.position.size.height;
-        }
-
-        let mut height = cur_y - top_offset;
-
-        let mut noncontent_height;
-        let box_ = self.box_.as_ref().unwrap();
-        let mut position = box_.position.get();
-
-        // The associated box is the border box of this flow.
-        position.origin.y = box_.margin.get().top;
-
-        noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-            box_.border.get().top + box_.border.get().bottom;
-
-        //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
-                                                Au::new(0)).specified_or_zero();
-
-        height = geometry::max(height, height_prop) + noncontent_height;
-        debug!("assign_height_float -- height: {}", height);
-
-        position.size.height = height;
-        box_.position.set(position);
+        self.block_flow.set_floats_out(&mut float_ctx, height, cur_y, top_offset,
+                                       bottom_offset, left_offset, inorder);
     }
 
     pub fn build_display_list_table_wrapper<E:ExtraDisplayListData>(
@@ -426,59 +141,8 @@ impl TableWrapperFlow {
                                     dirty: &Rect<Au>,
                                     list: &RefCell<DisplayList<E>>)
                                     -> bool {
-        if self.is_float() {
-            return self.build_display_list_float(builder, dirty, list);
-        }
-
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true;
-        }
-
-        debug!("build_display_list_table[Wrapper]: adding display element");
-
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, self.base.abs_position, (&*self) as &Flow, list)
-        }
-        // TODO: handle any out-of-flow elements
-        let this_position = self.base.abs_position;
-
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = this_position + child_base.position.origin;
-        }
-
-        false
-    }
-
-    pub fn build_display_list_float<E:ExtraDisplayListData>(
-                                    &mut self,
-                                    builder: &DisplayListBuilder,
-                                    dirty: &Rect<Au>,
-                                    list: &RefCell<DisplayList<E>>)
-                                    -> bool {
-        let abs_rect = Rect(self.base.abs_position, self.base.position.size);
-        if !abs_rect.intersects(dirty) {
-            return true
-        }
-
-        let offset = self.base.abs_position + self.float.get_ref().rel_pos;
-        // add box that starts table context
-        for box_ in self.box_.iter() {
-            box_.build_display_list(builder, dirty, offset, (&*self) as &Flow, list)
-        }
-
-
-        // TODO: handle any out-of-flow elements
-
-        // go deeper into the flow tree
-        for child in self.base.child_iter() {
-            let child_base = flow::mut_base(*child);
-            child_base.abs_position = offset + child_base.position.origin;
-        }
-
-        false
+        debug!("build_display_list_table_wrapper: same process as block flow");
+        self.block_flow.build_display_list_block(builder, dirty, list)
     }
 }
 
@@ -497,42 +161,17 @@ impl Flow for TableWrapperFlow {
     min/pref widths based on child context widths and dimensions of
     any boxes it is responsible for flowing.  */
 
-    fn bubble_widths(&mut self, _: &mut LayoutContext) {
-        let mut min_width = Au::new(0);
-        let mut pref_width = Au::new(0);
-        let mut num_floats = 0;
-
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
         /* find max width from child block contexts */
-        for kid in self.base.child_iter() {
+        for kid in self.block_flow.base.child_iter() {
             assert!(kid.is_table_caption() || kid.is_table());
 
             if kid.is_table() {
                 self.col_widths.push_all(kid.as_table().col_widths);
             }
-
-            let child_base = flow::mut_base(*kid);
-            min_width = geometry::max(min_width, child_base.min_width);
-            pref_width = geometry::max(pref_width, child_base.pref_width);
-            num_floats = num_floats + child_base.num_floats;
         }
 
-        if self.is_float() {
-            self.base.num_floats = 1;
-            self.float.get_mut_ref().floated_children = num_floats;
-        } else {
-            self.base.num_floats = num_floats;
-        }
-
-        /* if not an anonymous block context, add in block box's widths.
-           these widths will not include child elements, just padding etc. */
-        for box_ in self.box_.iter() {
-            let (this_minimum_width, this_preferred_width) = box_.minimum_and_preferred_widths();
-            min_width = min_width + this_minimum_width;
-            pref_width = pref_width + this_preferred_width;
-        }
-
-        self.base.min_width = min_width;
-        self.base.pref_width = pref_width;
+        self.block_flow.bubble_widths(ctx);
     }
 
     /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
@@ -547,53 +186,29 @@ impl Flow for TableWrapperFlow {
                } else {
                    "table_wrapper"
                },
-               self.base.id);
+               self.block_flow.base.id);
 
         // The position was set to the containing block by the flow's parent.
-        let mut remaining_width = self.base.position.size.width;
+        let mut remaining_width = self.block_flow.base.position.size.width;
         let mut x_offset = Au::new(0);
 
         let fixed_cells_width = self.col_widths.iter().fold(Au(0), |sum, width| sum.add(width));
 
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = remaining_width;
+        self.block_flow.set_containing_width_if_float(remaining_width);
 
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
-
-        for box_ in self.box_.iter() {
+        for box_ in self.block_flow.box_.iter() {
             let style = box_.style();
 
             // The text alignment of a table_wrapper flow is the text alignment of its box's style.
-            self.base.flags_info.flags.set_text_align(style.Text.text_align);
-
-            // Margins are 0 right now so base.noncontent_width() is just borders + padding.
-            let available_width = remaining_width - box_.noncontent_width();
-
-            // Top and bottom margins for table are 0 if auto.
-            let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
-                                                   remaining_width).specified_or_zero();
-            let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
-                                                      remaining_width).specified_or_zero();
-
-            let (width, margin_left, margin_right) = if self.is_float() {
-                self.compute_float_margins(box_, remaining_width)
-            } else {
-                self.compute_table_margins(box_, remaining_width, available_width)
-            };
-
-            box_.margin.set(SideOffsets2D::new(margin_top,
-                                              margin_right,
-                                              margin_bottom,
-                                              margin_left));
+            self.block_flow.base.flags_info.flags.set_text_align(style.Text.text_align);
+            let width = self.block_flow.initial_box_setting(box_, style, remaining_width, false, true);
 
             let screen_size = ctx.screen_size;
             let (x, w) = box_.get_x_coord_and_new_width_if_fixed(screen_size.width,
                                                                  screen_size.height,
                                                                  width,
                                                                  box_.offset(),
-                                                                 self.is_fixed);
+                                                                 self.block_flow.is_fixed);
             x_offset = x;
 
             // Get left and right paddings, borders for table
@@ -604,67 +219,39 @@ impl Flow for TableWrapperFlow {
             let padding_and_borders = padding_left + padding_right + border_left + border_right;
             remaining_width = geometry::max(fixed_cells_width + padding_and_borders, w);
 
-            // The associated box is the border box of this flow.
-            let mut position_ref = box_.position.borrow_mut();
-            if self.is_fixed {
-                position_ref.get().origin.x = x_offset + box_.margin.get().left;
+            let border_x = if self.block_flow.is_fixed {
+                x_offset + box_.margin.get().left
             } else {
-                position_ref.get().origin.x = box_.margin.get().left;
-            }
-            position_ref.get().size.width = remaining_width;
+                box_.margin.get().left
+            };
+            self.block_flow.set_box_x_and_width(box_, border_x, remaining_width);
         }
 
         match self.table_layout {
             FixedLayout | _ if self.is_float() =>
-                self.base.position.size.width = remaining_width,
+                self.block_flow.base.position.size.width = remaining_width,
             _ => {}
         }
 
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
-
-        // FIXME(ksh8281): avoid copy
-        let flags_info = self.base.flags_info.clone();
-        for kid in self.base.child_iter() {
-            assert!(kid.is_table_caption() || kid.is_table());
-
-            let child_base = flow::mut_base(*kid);
-            child_base.position.origin.x = x_offset;
-            child_base.position.size.width = remaining_width;
-            child_base.flags_info.flags.set_inorder(has_inorder_children);
-
-            if !child_base.flags_info.flags.inorder() {
-                child_base.floats_in = FloatContext::new(0);
-            }
-
-            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
-            //
-            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
-
-            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
-        }
+        self.block_flow.propagate_assigned_width_to_children(x_offset, remaining_width);
     }
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
-            self.assign_height_float_inorder();
+            debug!("assign_height_inorder_float: assigning height for float {}", self.block_flow.base.id);
+            self.block_flow.assign_height_float_inorder();
         } else {
-            debug!("assign_height_inorder: assigning height for table_wrapper {}", self.base.id);
+            debug!("assign_height_inorder: assigning height for table_wrapper {}", self.block_flow.base.id);
             self.assign_height_table_wrapper_base(ctx, true);
         }
     }
 
     fn assign_height(&mut self, ctx: &mut LayoutContext) {
         if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
-            self.assign_height_float(ctx);
+            debug!("assign_height_float: assigning height for float {}", self.block_flow.base.id);
+            self.block_flow.assign_height_float(ctx);
         } else {
-            debug!("assign_height: assigning height for table_wrapper {}", self.base.id);
+            debug!("assign_height: assigning height for table_wrapper {}", self.block_flow.base.id);
             self.assign_height_table_wrapper_base(ctx, false);
         }
     }
@@ -676,33 +263,12 @@ impl Flow for TableWrapperFlow {
                         top_offset: &mut Au,
                         collapsing: &mut Au,
                         collapsible: &mut Au) {
-        if self.is_float() {
-            // Margins between a floated box and any other box do not collapse.
-            *collapsing = Au::new(0);
-            return;
-        }
-
-        for box_ in self.box_.iter() {
-            // The top margin collapses with its first in-flow block-level child's
-            // top margin if the parent has no top border, no top padding.
-            if *first_in_flow && top_margin_collapsible {
-                // If top-margin of parent is less than top-margin of its first child,
-                // the parent box goes down until its top is aligned with the child.
-                if *margin_top < box_.margin.get().top {
-                    // TODO: The position of child floats should be updated and this
-                    // would influence clearance as well. See #725
-                    let extra_margin = box_.margin.get().top - *margin_top;
-                    *top_offset = *top_offset + extra_margin;
-                    *margin_top = box_.margin.get().top;
-                }
-            }
-            // The bottom margin of an in-flow block-level element collapses
-            // with the top margin of its next in-flow block-level sibling.
-            *collapsing = geometry::min(box_.margin.get().top, *collapsible);
-            *collapsible = box_.margin.get().bottom;
-        }
-
-        *first_in_flow = false;
+        self.block_flow.collapse_margins(top_margin_collapsible,
+                                         first_in_flow,
+                                         margin_top,
+                                         top_offset,
+                                         collapsing,
+                                         collapsible);
     }
 
     fn debug_str(&self) -> ~str {
@@ -711,7 +277,7 @@ impl Flow for TableWrapperFlow {
         } else {
             ~"TableWrapperFlow: "
         };
-        txt.append(match self.box_ {
+        txt.append(match self.block_flow.box_ {
             Some(ref rb) => rb.debug_str(),
             None => ~"",
         })

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -96,6 +96,12 @@ pub mod layout {
     pub mod inline;
     pub mod model;
     pub mod parallel;
+    pub mod table_wrapper;
+    pub mod table;
+    pub mod table_colgroup;
+    pub mod table_rowgroup;
+    pub mod table_row;
+    pub mod table_cell;
     pub mod text;
     pub mod util;
     pub mod incremental;

--- a/src/components/main/servo.rc
+++ b/src/components/main/servo.rc
@@ -98,6 +98,7 @@ pub mod layout {
     pub mod parallel;
     pub mod table_wrapper;
     pub mod table;
+    pub mod table_caption;
     pub mod table_colgroup;
     pub mod table_rowgroup;
     pub mod table_row;

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -254,9 +254,9 @@ pub mod longhands {
                 match value {
 //                    inline_table => table,
                     inline | inline_block
-//                    | table_row_group | table_column | table_column_group
-//                    | table_header_group | table_footer_group | table_row
-//                    | table_cell | table_caption
+                    | table_row_group | table_column | table_column_group
+                    | table_header_group | table_footer_group | table_row
+                    | table_cell | table_caption
                     => block,
                     _ => value,
                 }

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -712,6 +712,9 @@ pub mod longhands {
     ${single_keyword("white-space", "normal pre", inherited=True)}
 
     // CSS 2.1, Section 17 - Tables
+    ${new_style_struct("Table")}
+
+    ${single_keyword("table-layout", "auto fixed", inherited=False)}
 
     // CSS 2.1, Section 18 - User interface
 }

--- a/src/test/html/anonymous_table.html
+++ b/src/test/html/anonymous_table.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Fixed Table</title>
+    <title>Anonymous Table objects</title>
     <style>
       .table {
         display: table;
@@ -19,8 +19,8 @@
         display: table-row;
       }
       .cell {
-        display: table-cell; 
-        border: solid red 1px; 
+        display: table-cell;
+        border: solid red 1px;
       }
     </style>
   </head>
@@ -30,12 +30,12 @@
     <p> 2. Generate missing child wrappers: `table-row`, `table-cell` </p>
     <div class="table">
         <span class="column"> inline child box of table-column. NOT Shown </span>
-        <span class="colgroup"> 
-            <span>inline child box of table-column-group</span> NOT Shown 
+        <span class="colgroup">
+            <span>inline child box of table-column-group</span> NOT Shown
         </span>
-        <span class="cell">Cell1</span>      
+        <span class="cell">Cell1</span>
         <span class="cell">Cell2</span>
-        <span class="row">              
+        <span class="row">
             2nd Row
             <span>Cell4</span>
             <span class="cell">Cell3</span>

--- a/src/test/html/anonymous_table.html
+++ b/src/test/html/anonymous_table.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      .table {
+        display: table;
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      .colgroup {
+        display: table-column-group;
+      }
+      .column {
+        display: table-column;
+      }
+      .row {
+        display: table-row;
+      }
+      .cell {
+        display: table-cell; 
+        border: solid red 1px; 
+      }
+    </style>
+  </head>
+  <body>
+    <p> This test checks Anonymous table objects(CSS 2.1, Section 17.2.1) </p>
+    <p> 1. Remove irrelevant boxes</p>
+    <p> 2. Generate missing child wrappers: `table-row`, `table-cell` </p>
+    <div class="table">
+        <span class="column"> inline child box of table-column. NOT Shown </span>
+        <span class="colgroup"> 
+            <span>inline child box of table-column-group</span> NOT Shown 
+        </span>
+        <span class="cell">Cell1</span>      
+        <span class="cell">Cell2</span>
+        <span class="row">              
+            2nd Row
+            <span>Cell4</span>
+            <span class="cell">Cell3</span>
+            Cell5
+        </span>
+    </div>
+  </body>
+<html>

--- a/src/test/html/fixed_table.html
+++ b/src/test/html/fixed_table.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }      
+      th { border: solid red 1px; }      
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table</caption>
+        <colgroup>
+          <col style="width: 200px" />
+        </colgroup>
+        <tbody>
+          <tr><th style="width: 100px">Header 1</th><td style="width: 100px">Cell 1</td><td>Cell 2</td></tr>
+          <tr><th style="width: 300px">Header 2</th><td style="width: 300px">Cell 3</th><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</th></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table.html
+++ b/src/test/html/fixed_table.html
@@ -1,3 +1,10 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as follows:
+       - 1st column: 200px (because it is defined in col element)
+       - 2nd column: 100px (because it is defined in first row)
+       - 3rd column: remaining width (becuase it is not defined so the remaining width is assigned)
+     And table, caption, td, th elements have border. -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -9,8 +16,8 @@
         border: solid black 2px;
       }
       caption { border: solid blue 1px; }
-      td { border: solid red 1px; }      
-      th { border: solid red 1px; }      
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
     </style>
   </head>
   <body>

--- a/src/test/html/fixed_table_2.html
+++ b/src/test/html/fixed_table_2.html
@@ -1,3 +1,8 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned according to their ratio of column's widths
+     which are defined in col elements.
+     And table, caption, td, th elements have border. -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -9,8 +14,8 @@
         border: solid black 2px;
       }
       caption { border: solid blue 1px; }
-      td { border: solid red 1px; }      
-      th { border: solid red 1px; }      
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
     </style>
   </head>
   <body>

--- a/src/test/html/fixed_table_2.html
+++ b/src/test/html/fixed_table_2.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }      
+      th { border: solid red 1px; }      
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table</caption>
+        <colgroup>
+          <col style="width: 10px" />
+          <col style="width: 20px" />
+          <col style="width: 30px" />
+        </colgroup>
+        <tbody>
+          <tr><th style="width: 100px">Header 1</th><td style="width: 100px">Cell 1</td><td>Cell 2</td></tr>
+          <tr><th style="width: 300px">Header 2</th><td style="width: 300px">Cell 3</th><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</th></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_additional_cols.html
+++ b/src/test/html/fixed_table_additional_cols.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }      
+      th { border: solid red 1px; }      
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x4 fixed table</caption>
+        <colgroup>
+          <col style="width: 200px" />
+          <col style="width: 200px" />
+          <col />
+          <col />
+        </colgroup>
+        <tbody>
+          <tr><th>Header 1</th><td>Cell 1</td><td>Cell 2</td></tr>
+          <tr><th>Header 2</th><td>Cell 3</th><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</th></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_additional_cols.html
+++ b/src/test/html/fixed_table_additional_cols.html
@@ -1,3 +1,10 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as follows:
+       - 1st & 2nd column: 200px (because it is defined in col element)
+       - 3rd & 4th column: remaining width / 2
+                           (becuase it is not defined so the remaining width is equally divided)
+     And table, caption, td, th elements have border. -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -9,8 +16,8 @@
         border: solid black 2px;
       }
       caption { border: solid blue 1px; }
-      td { border: solid red 1px; }      
-      th { border: solid red 1px; }      
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
     </style>
   </head>
   <body>

--- a/src/test/html/fixed_table_basic_height.html
+++ b/src/test/html/fixed_table_basic_height.html
@@ -1,0 +1,40 @@
+<!-- This test creates one table, three rows, three header cells, and six data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as 200px.
+     Each table row height is decided as max(specified row height, specified cells' heights, cells' minimum content heights).
+     As a result, each table row height will be assigned as followings:
+        - 1st row: 30px (specified cell height)
+        - 2nd row: 50px (specified row height)
+        - 3rd row: minimum content height
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table Height Test</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption {
+        border: solid blue 1px;
+      }
+      td, th {
+        border: solid red 1px;
+        padding: 0px;
+      }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This test checks table height algorithm (CSS 2.1, Section 17.5.3),
+                 excluding `vertical-align` and percentage height</caption>
+        <tbody>
+          <tr style="height:10px"><th>Header 1</th><td style="height: 30px">Cell 1</td><td>Cell 2</td></tr>
+          <tr style="height:50px"><th>Header 2</th><td>Cell 3</td><td style="height:10px">Cell 4</td></tr>
+          <tr style="height:20px"><th>Header 3</th><td style="height:10px">Cell 5</td><td><div>Cell6</div><p>Cell6</td></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_simple.html
+++ b/src/test/html/fixed_table_simple.html
@@ -1,3 +1,7 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and six data cells.
+     The table uses fixed table layout algorithm and the table's width specified to 600px.
+     Each column should have same width because the column's widths are not defined here.
+     And table, caption, td, th elements have border. -->
 <!DOCTYPE html>
 <html>
   <head>
@@ -9,8 +13,8 @@
         border: solid black 2px;
       }
       caption { border: solid blue 1px; }
-      td { border: solid red 1px; }      
-      th { border: solid red 1px; }      
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
     </style>
   </head>
   <body>

--- a/src/test/html/fixed_table_simple.html
+++ b/src/test/html/fixed_table_simple.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Simple Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }      
+      th { border: solid red 1px; }      
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table</caption>
+        <tbody>
+          <tr><th>Header 1</th><td>Cell 1</td><td>Cell 2</td></tr>
+          <tr><th>Header 2</th><td>Cell 3</td><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</td><td>Cell 6</td></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_with_marign_padding.html
+++ b/src/test/html/fixed_table_with_marign_padding.html
@@ -1,3 +1,11 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as follows:
+       - 1st column: 200px (because it is defined in col element)
+       - 2nd column: 100px (because it is defined in first row)
+       - 3rd column: remaining width (becuase it is not defined so the remaining width is assigned)
+     The table and caption elements have border, margin, and padding.
+     The td and th elements have border and padding. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/html/fixed_table_with_marign_padding.html
+++ b/src/test/html/fixed_table_with_marign_padding.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table with margin, border, and padding</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+        margin: 10px;
+        padding: 10px;
+      }
+      caption {
+        border: solid blue 1px;
+        margin: 5px;
+        padding: 5px;
+      }
+      td {
+        border: solid red 1px;
+        padding: 5px;
+      }
+      th {
+        border: solid red 1px;
+        padding: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table with margin, border, and padding</caption>
+        <colgroup>
+          <col style="width: 200px" />
+          <col />
+        </colgroup>
+        <tbody>
+          <tr><th style="width: 100px">Header 1</th><td style="width: 100px">Cell 1</td><td>Cell 2</td></tr>
+          <tr><th>Header 2</th><td>Cell 3</td><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</td></tr>
+        </tbody>
+    </table>
+  </body>
+<html>


### PR DESCRIPTION
Supporting preliminary fixed-layout table

This pr gives a preliminary implementation of fixed-layout table.
We define table-related flows, and they are organized as follows:

```
TableWrapperFlow
    BlockFlow for caption
    TableFlow
        TableColGroupFlow
        TableRowGroupFlow
            TableRowFlow
                TableCellFlow
                    BlockFlow OR InlineFlow go here
```

TableWrapperFlow corresponds display: table.
Also, TableFlow is explictly created, when TableWrapperFlow is created.

TableRowGroupFlow and TableColGroupFlow correspond display:
table-row-group, and table-column-group, respectively.

TableCellFlow and TableRowFlow correspond display: table-cell and
display: table-row, respectively.

In this fixed-layout table implementation, we
    1. Extends the current flow tree to support display: table\* properties
    2. Display fixed-layout table. In particular, it
       a) Reads specified widths from table cells bottom-up
       b) Calculates the width of the table.
       c) Calculates the margin, border, padding of table and table cells.

This pr sets up the basic structure of table, and we will extend it in
the subsequent prs.

To do:
    1. width=auto is to be done in the next pr.
    2. preliminary height calculation is to be done in the next pr.
    3. thead, tbody, tfoot are not supported yet. In particular, when
       the width of the table is calculated, the cell widths are read
       from the first row in a row group, but the row group is not
       necessarily the first row group. This is to be fixed when thead,
       tbody, tfoot are implemented.

This work is done in collaboration with @sonwow @june0cho

![table](https://f.cloud.github.com/assets/3498423/1993278/7efe944e-84d6-11e3-9114-926a526ac3d5.png)
