### PR TITLE
script: Avoid an allocation when getting attribute data.

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -157,15 +157,16 @@ impl Element {
         }).map(|&x| x)
     }
 
+    #[inline]
     pub unsafe fn get_attr_val_for_layout(&self, namespace: Namespace, name: &str) 
                                           -> Option<&'static str> {
-        // FIXME: only case-insensitive in the HTML namespace (as opposed to SVG, etc.)
-        let name = name.to_ascii_lower();
         self.attrs.iter().find(|attr: & &@mut Attr| {
             // unsafely avoid a borrow because this is accessed by many tasks
             // during parallel layout
+            // FIXME: only case-insensitive in the HTML namespace (as opposed to SVG, etc.)
             let attr: ***Box<Attr> = cast::transmute(attr);
-            name == (***attr).data.local_name && (***attr).data.namespace == namespace
+            name.eq_ignore_ascii_case((***attr).data.local_name) &&
+                (***attr).data.namespace == namespace
        }).map(|attr| {
             let attr: **Box<Attr> = cast::transmute(attr);
             cast::transmute((**attr).data.value.as_slice())


### PR DESCRIPTION
15% improvement in selector matching performance on the rainbow page.

r? @SimonSapin
