### PR TITLE
style: Stop copying attribute names when looking them up in the hash

### DIFF
--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -120,7 +120,7 @@ impl SelectorMap {
                                     hash: &HashMap<~str,~[Rule]>,
                                     key: &str,
                                     matching_rules: &mut ~[Rule]) {
-        match hash.find(&key.to_str()) {
+        match hash.find_equiv(&key) {
             Some(rules) => {
                 SelectorMap::get_matching_rules(node, *rules, matching_rules)
             }


### PR DESCRIPTION
table.

40% improvement in selector matching performance on the rainbow page.

r? @larsbergstrom
