### PR TITLE
Restore perf improvement from #1554

### DIFF
--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -19,6 +19,7 @@ pub trait TNode<E:TElement> : Clone {
 
 pub trait TElement {
     fn get_attr(&self, namespace: Option<~str>, attr: &str) -> Option<&'static str>;
+    fn match_attr(&self, ns_url: Option<~str>, name: &str, test: &|&str| -> bool) -> bool;
     fn get_link(&self) -> Option<~str>;
     fn get_local_name<'a>(&'a self) -> &'a str;
     fn get_namespace_url<'a>(&'a self) -> &'a str;

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -5,6 +5,9 @@
 //! Traits that nodes must implement. Breaks the otherwise-cyclic dependency between layout and
 //! style.
 
+use selectors::AttrSelector;
+
+
 pub trait TNode<E:TElement> : Clone {
     fn parent_node(&self) -> Option<Self>;
     fn prev_sibling(&self) -> Option<Self>;
@@ -15,11 +18,12 @@ pub trait TNode<E:TElement> : Clone {
 
     /// FIXME(pcwalton): This should not use the `with` pattern.
     fn with_element<'a, R>(&self, f: |&E| -> R) -> R;
+
+    fn match_attr(&self, attr: &AttrSelector, test: |&str| -> bool) -> bool;
 }
 
 pub trait TElement {
     fn get_attr(&self, namespace: Option<~str>, attr: &str) -> Option<&'static str>;
-    fn match_attr(&self, ns_url: Option<~str>, name: &str, test: &|&str| -> bool) -> bool;
     fn get_link(&self) -> Option<~str>;
     fn get_local_name<'a>(&'a self) -> &'a str;
     fn get_namespace_url<'a>(&'a self) -> &'a str;

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -513,22 +513,22 @@ fn matches_simple_selector<E:TElement,N:TNode<E>>(selector: &SimpleSelector, ele
             })
         }
 
-        AttrExists(ref attr) => match_attribute(attr, element, |_| true),
-        AttrEqual(ref attr, ref value) => match_attribute(attr, element, |v| v == value.as_slice()),
-        AttrIncludes(ref attr, ref value) => match_attribute(attr, element, |attr_value| {
+        AttrExists(ref attr) => element.match_attr(attr, |_| true),
+        AttrEqual(ref attr, ref value) => element.match_attr(attr, |v| v == value.as_slice()),
+        AttrIncludes(ref attr, ref value) => element.match_attr(attr, |attr_value| {
             attr_value.split(SELECTOR_WHITESPACE).any(|v| v == value.as_slice())
         }),
         AttrDashMatch(ref attr, ref value, ref dashing_value)
-        => match_attribute(attr, element, |attr_value| {
+        => element.match_attr(attr, |attr_value| {
             attr_value == value.as_slice() || attr_value.starts_with(dashing_value.as_slice())
         }),
-        AttrPrefixMatch(ref attr, ref value) => match_attribute(attr, element, |attr_value| {
+        AttrPrefixMatch(ref attr, ref value) => element.match_attr(attr, |attr_value| {
             attr_value.starts_with(value.as_slice())
         }),
-        AttrSubstringMatch(ref attr, ref value) => match_attribute(attr, element, |attr_value| {
+        AttrSubstringMatch(ref attr, ref value) => element.match_attr(attr, |attr_value| {
             attr_value.contains(value.as_slice())
         }),
-        AttrSuffixMatch(ref attr, ref value) => match_attribute(attr, element, |attr_value| {
+        AttrSuffixMatch(ref attr, ref value) => element.match_attr(attr, |attr_value| {
             attr_value.ends_with(value.as_slice())
         }),
 
@@ -696,18 +696,6 @@ fn matches_last_child<E:TElement,N:TNode<E>>(element: &N) -> bool {
     }
 }
 
-#[inline]
-fn match_attribute<E:TElement,
-                   N:TNode<E>>(
-                   attr: &AttrSelector,
-                   element: &N,
-                   test: |&str| -> bool)
-                   -> bool {
-    element.with_element(|element: &E| {
-        // FIXME: avoid .clone() here? See #1367
-        element.match_attr(attr.namespace.clone(), attr.name, &test)
-    })
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -701,14 +701,11 @@ fn match_attribute<E:TElement,
                    N:TNode<E>>(
                    attr: &AttrSelector,
                    element: &N,
-                   f: |&str| -> bool)
+                   test: |&str| -> bool)
                    -> bool {
     element.with_element(|element: &E| {
         // FIXME: avoid .clone() here? See #1367
-        match element.get_attr(attr.namespace.clone(), attr.name) {
-            None => false,
-            Some(value) => f(value)
-        }
+        element.match_attr(attr.namespace.clone(), attr.name, &test)
     })
 }
 

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -88,6 +88,7 @@ pub enum SimpleSelector {
 #[deriving(Eq, Clone)]
 pub struct AttrSelector {
     name: ~str,
+    lower_name: ~str,
     namespace: Option<~str>,
 }
 
@@ -423,6 +424,7 @@ fn parse_attribute_selector(content: ~[ComponentValue], namespaces: &NamespaceMa
         QualifiedName(_, None) => fail!("Implementation error, this should not happen."),
         QualifiedName(namespace, Some(local_name)) => AttrSelector {
             namespace: namespace,
+            lower_name: local_name.to_ascii_lower(),
             name: local_name,
         },
     };

--- a/src/components/style/style.rc
+++ b/src/components/style/style.rc
@@ -23,7 +23,7 @@ pub use properties::{cascade, PropertyDeclaration, ComputedValues, computed_valu
 pub use properties::{PropertyDeclarationBlock, parse_style_attribute};  // Style attributes
 pub use errors::with_errors_silenced;
 pub use node::{TElement, TNode};
-pub use selectors::{PseudoElement, Before, After};
+pub use selectors::{PseudoElement, Before, After, AttrSelector};
 
 mod stylesheets;
 mod errors;


### PR DESCRIPTION
Lower-case attribute names when parsing selectors rather than when matching. This avoid one allocation in matching code.

Also do not lowercase names for *AttributeNS APIs. (Move lower-casing to callers.)
