### PR TITLE
Enable ref tests

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -58,11 +58,11 @@ check-test:
 
 ifeq ($(CFG_OSTYPE),apple-darwin)
 .PHONY: check
-check: $(DEPS_CHECK_TARGETS_FAST) check-servo check-content tidy
+check: $(DEPS_CHECK_TARGETS_FAST) check-servo check-content check-ref tidy
 	@$(call E, check: all)
 
 .PHONY: check-all
-check-all: $(DEPS_CHECK_TARGETS_ALL) check-servo check-content tidy
+check-all: $(DEPS_CHECK_TARGETS_ALL) check-servo check-content check-ref tidy
 	@$(call E, check: all)
 else
 .PHONY: check

--- a/src/test/harness/reftest/reftest.rs
+++ b/src/test/harness/reftest/reftest.rs
@@ -81,6 +81,7 @@ fn parse_lists(filenames: &[~str]) -> ~[TestDescAndFn] {
             let kind = match parts[0] {
                 "==" => Same,
                 "!=" => Different,
+                "#" => continue,
                 _ => fail!("reftest line: '{:s}' has invalid kind '{:s}'",
                            line, parts[0])
             };

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -12,13 +12,13 @@
 == first_of_type_pseudo_a.html first_of_type_pseudo_b.html
 == last_of_type_pseudo_a.html last_of_type_pseudo_b.html
 == only_of_type_pseudo_a.html only_of_type_pseudo_b.html
-== visibility_hidden.html visibility_hidden_ref.html
+# visibility_hidden.html visibility_hidden_ref.html
 == root_height_a.html root_height_b.html
 == png_rgba_colorspace_a.html png_rgba_colorspace_b.html
 == border_style_none_a.html border_style_none_b.html
 == acid1_a.html acid1_b.html
-== text_decoration_propagation_a.html text_decoration_propagation_b.html
-== inline_text_align_a.html inline_text_align_b.html
+# text_decoration_propagation_a.html text_decoration_propagation_b.html
+# inline_text_align_a.html inline_text_align_b.html
 == font_size_em.html font_size_em_ref.html
 == font_size_percentage.html font_size_em_ref.html
 == position_fixed_a.html position_fixed_b.html


### PR DESCRIPTION
Ref tests should now be stable enough to put them back in the list of checked tests that we run at checkin. This will at least ensure ACID1 no longer breaks.

I had to disable three tests that have regressed since ref tests first became unstable. I will open separate issues for each of them if we agree to land this PR.
