### PR TITLE
Remove unnecessary ClipDisplayItems in box_.rs

### DIFF
--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -321,14 +321,20 @@ impl Box {
         }
     }
 
+    // CSS Section 10.6.4
+    // We have to solve the constraint equation:
+    // top + bottom + height + (vertical border + padding) = height of
+    // containing block (`screen_height`)
+    //
+    // `y`: static position of the element
     //TODO(ibnc) take into account padding.
-    pub fn get_y_coord_and_new_height_if_fixed(&self, 
+    pub fn get_y_coord_and_new_height_if_fixed(&self,
                                                screen_height: Au,
                                                mut height: Au,
                                                mut y: Au,
                                                is_fixed: bool)
                                                -> (Au, Au) {
-        if is_fixed { 
+        if is_fixed {
             let position_offsets = self.position_offsets.get();
             match (position_offsets.top, position_offsets.bottom) {
                 (Au(0), Au(0)) => {}
@@ -352,6 +358,7 @@ impl Box {
         return (y, height);
     }
 
+    // CSS Section 10.3.7
     //TODO(ibnc) removing padding when width needs to be stretched.
     pub fn get_x_coord_and_new_width_if_fixed(&self,
                                               screen_width: Au,
@@ -1461,7 +1468,7 @@ impl Box {
                                                         image_box_info.dom_height,
                                                         Au::new(0));
 
-                let height = match (self.style().Box.width, 
+                let height = match (self.style().Box.width,
                                     image_box_info.dom_width,
                                     height) {
                     (LPA_Auto, None, Auto) => {
@@ -1545,7 +1552,7 @@ impl Box {
                 *value.right,
                 *value.bottom,
                 *value.left)
-    } 
+    }
 
     /// Sends the size and position of this iframe box to the constellation. This is out of line to
     /// guide inlining.
@@ -1571,4 +1578,3 @@ impl Box {
         layout_context.constellation_chan.send(msg)
     }
 }
-

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -967,18 +967,6 @@ impl Box {
         match self.specific {
             UnscannedTextBox(_) => fail!("Shouldn't see unscanned boxes here."),
             ScannedTextBox(ref text_box) => {
-                lists.with_mut(|lists| {
-                    let item = ~ClipDisplayItem {
-                        base: BaseDisplayItem {
-                            bounds: absolute_box_bounds,
-                            extra: ExtraDisplayListData::new(self),
-                        },
-                        child_list: ~[],
-                        need_clip: false
-                    };
-                    lists.lists[index].append_item(ClipDisplayItemClass(item));
-                });
-
                 let text_color = self.style().Color.color.to_gfx_color();
 
                 // Set the various text display item flags.
@@ -998,7 +986,7 @@ impl Box {
                 text_flags.set_override_underline(flow_flags.flags.override_underline());
                 text_flags.set_override_overline(flow_flags.flags.override_overline());
                 text_flags.set_override_line_through(flow_flags.flags.override_line_through());
-                
+
                 let mut bounds = absolute_box_bounds.clone();
                 bounds.origin.x = bounds.origin.x + self.noncontent_left()
                                   + self.noncontent_inline_left();
@@ -1104,18 +1092,6 @@ impl Box {
                 });
             },
             ImageBox(ref image_box) => {
-                lists.with_mut(|lists| {
-                    let item = ~ClipDisplayItem {
-                        base: BaseDisplayItem {
-                            bounds: absolute_box_bounds,
-                            extra: ExtraDisplayListData::new(self),
-                        },
-                        child_list: ~[],
-                        need_clip: false
-                    };
-                    lists.lists[index].append_item(ClipDisplayItemClass(item));
-                });
-
                 let mut image_ref = image_box.image.borrow_mut();
                 let mut bounds = absolute_box_bounds.clone();
                 bounds.origin.x = bounds.origin.x + self.noncontent_left()


### PR DESCRIPTION
For ScannedTextBox and ImageBox, the ClipDisplayItem's child_list is
currently always empty.

ClipDisplayItem is used to implement overflow hidden and should only be
created for block containers, as per
http://www.w3.org/TR/CSS2/visufx.html#propdef-overflow
