### PR TITLE
layout: Make box building thread safe by pushing down styles into

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -139,9 +139,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
         }
 
         for kid in self.children() {
-            if kid.is_element() {
-                kid.cascade_subtree(Some(*self));
-            }
+            kid.cascade_subtree(Some(*self));
         }
     }
 }

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -298,36 +298,9 @@ pub struct InlineParentInfo {
 impl Box {
     /// Constructs a new `Box` instance.
     pub fn new(node: LayoutNode, specific: SpecificBoxInfo) -> Box {
-        // Find the nearest ancestor element and take its style. (It should be either that node or
-        // its immediate parent.)
-        // CSS 2.1 § 9.2.1.1,9.2.2.1 This is for non-inherited properties on anonymous boxes
-        // example:
-        //
-        //     <div style="border: solid">
-        //         <p>Foo</p>
-        //         Bar
-        //         <p>Baz</p>
-        //     </div>
-        //
-        // An anonymous block box is generated around `Bar`, but it shouldn't inherit the border.
-
-        let node_style = if node.is_element() {
-            node.style().clone()
-        } else {
-            let mut nearest_ancestor_element = node;
-            while !nearest_ancestor_element.is_element() {
-                nearest_ancestor_element =
-                    nearest_ancestor_element.parent_node().expect("no nearest element?!");
-            }
-
-            // Anonymous box: inheriting from the ancestor with no specified declarations.
-            Arc::new(cascade(&[Arc::new(~[])],
-                             Some(nearest_ancestor_element.style().get())))
-        };
-
         Box {
             node: OpaqueNode::from_layout_node(&node),
-            style: node_style,
+            style: node.style().clone(),
             position: RefCell::new(Au::zero_rect()),
             border: RefCell::new(Zero::zero()),
             padding: RefCell::new(Zero::zero()),

--- a/src/components/main/layout/parallel.rs
+++ b/src/components/main/layout/parallel.rs
@@ -134,15 +134,15 @@ fn match_and_cascade_node(unsafe_layout_node: UnsafeLayoutNode,
             // Perform the CSS selector matching.
             let stylist: &Stylist = cast::transmute(layout_context.stylist);
             node.match_node(stylist);
-
-            // Perform the CSS cascade.
-            let parent_opt = if OpaqueNode::from_layout_node(&node) == layout_context.reflow_root {
-                None
-            } else {
-                node.parent_node()
-            };
-            node.cascade_node(parent_opt);
         }
+
+        // Perform the CSS cascade.
+        let parent_opt = if OpaqueNode::from_layout_node(&node) == layout_context.reflow_root {
+            None
+        } else {
+            node.parent_node()
+        };
+        node.cascade_node(parent_opt);
 
         // Enqueue kids.
         let mut child_count = 0;

--- a/src/test/ref/anon_block_inherit_a.html
+++ b/src/test/ref/anon_block_inherit_a.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>hi</title>
+</head>
+<body>
+<div style="border: solid">
+<p>Foo</p>
+Bar
+<p>Baz</p>
+</div>
+</body>
+</html>

--- a/src/test/ref/anon_block_inherit_b.html
+++ b/src/test/ref/anon_block_inherit_b.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>hi</title>
+</head>
+<body>
+<div style="border: solid">
+<p>Foo</p>
+<div>Bar</div>
+<p>Baz</p>
+</div>
+</body>
+</html>

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -25,3 +25,4 @@
 == img_size_a.html img_size_b.html
 == upper_id_attr.html upper_id_attr_ref.html
 # inline_border_a.html inline_border_b.html
+== anon_block_inherit_a.html anon_block_inherit_b.html


### PR DESCRIPTION
non-element children during the cascade.

Fetching them from the parent isn't thread-safe.

r? @metajack
