### PR TITLE
Ensure ref tests wait to write their PNG until the page has fully loaded and reflowed

### DIFF
--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -21,6 +21,8 @@ use servo_util::time::ProfilerChan;
 use std::comm::{Chan, SharedChan, Port};
 use std::num::Orderable;
 
+use extra::url::Url;
+
 #[cfg(target_os="linux")]
 use azure::azure_hl;
 
@@ -151,6 +153,9 @@ pub enum Msg {
     SetIds(SendableFrameTree, Chan<()>, ConstellationChan),
 
     SetUnRenderedColor(PipelineId, Color),
+
+    /// The load of a page for a given URL has completed.
+    LoadComplete(PipelineId, Url),
 }
 
 pub enum CompositorMode {

--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -63,7 +63,7 @@ impl NullCompositor {
 
                 NewLayer(..) | SetLayerPageSize(..) | SetLayerClipRect(..) | DeleteLayer(..) |
                 Paint(..) | InvalidateRect(..) | ChangeReadyState(..) | ChangeRenderState(..)|
-                ScrollFragmentPoint(..) | SetUnRenderedColor(..)
+                ScrollFragmentPoint(..) | SetUnRenderedColor(..) | LoadComplete(..)
                     => ()
             }
         }

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -26,11 +26,12 @@ pub enum IFrameSandboxState {
     IFrameUnsandboxed
 }
 
-/// Messages from the compositor to the constellation.
+/// Messages from the compositor and script to the constellation.
 pub enum Msg {
     ExitMsg,
     FailureMsg(PipelineId, Option<SubpageId>),
     InitLoadUrlMsg(Url),
+    LoadCompleteMsg(PipelineId, Url),
     FrameRectMsg(PipelineId, SubpageId, Rect<f32>),
     LoadUrlMsg(PipelineId, Url),
     LoadIframeUrlMsg(Url, PipelineId, SubpageId, IFrameSandboxState),


### PR DESCRIPTION
Add a LoadComplete message so that script informs the constellation, which can then inform the compositor (and anyone else, later) about the completion of loading a page. This is important for ref tests, which should not emit a PNG until load has completed, even if we perform a composite before then.

Note that we must _also_ wait for the `ready_state` to indicate that additionally layout has completed any associated reflow with the page, otherwise we could get the `LoadComplete` while the final reflow is still in progress and thus would write out the `n-1`'th reflow result.

r? @pcwalton
