### PR TITLE
Provide AbstractDocument::from_node(node: AbstractNode)

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -75,6 +75,15 @@ impl AbstractDocument {
             document: ptr as *mut Box<Document>
         }
     }
+
+    pub fn from_node(node: AbstractNode) -> AbstractDocument {
+        if !node.is_document() {
+            fail!("node is not a document");
+        }
+        unsafe {
+            cast::transmute(node)
+        }
+    }
 }
 
 #[deriving(Eq)]


### PR DESCRIPTION
TSIA.

@jdm mentioned to use `AbstractDocument::from_box` internally, though.
