### PR TITLE
Implement style sharing and related optimizations

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -6,13 +6,16 @@
 
 use css::node_style::StyledNode;
 use layout::extra::LayoutAuxMethods;
-use layout::incremental;
 use layout::util::LayoutDataAccess;
 use layout::wrapper::LayoutNode;
 
 use extra::arc::Arc;
 use script::layout_interface::LayoutChan;
+use servo_util::cache::{Cache, LRUCache, SimpleHashCache};
+use servo_util::namespace::Null;
 use servo_util::smallvec::{SmallVec, SmallVec0, SmallVec16};
+use std::cast;
+use std::to_bytes;
 use style::{After, Before, ComputedValues, PropertyDeclaration, Stylist, TNode, cascade};
 
 pub struct ApplicableDeclarations {
@@ -37,6 +40,108 @@ impl ApplicableDeclarations {
     }
 }
 
+#[deriving(Clone)]
+struct ApplicableDeclarationsCacheEntry {
+    declarations: SmallVec16<Arc<~[PropertyDeclaration]>>,
+}
+
+impl ApplicableDeclarationsCacheEntry {
+    fn new(slice: &[Arc<~[PropertyDeclaration]>]) -> ApplicableDeclarationsCacheEntry {
+        let mut entry_declarations = SmallVec16::new();
+        for declarations in slice.iter() {
+            entry_declarations.push(declarations.clone());
+        }
+        ApplicableDeclarationsCacheEntry {
+            declarations: entry_declarations,
+        }
+    }
+}
+
+impl Eq for ApplicableDeclarationsCacheEntry {
+    fn eq(&self, other: &ApplicableDeclarationsCacheEntry) -> bool {
+        let this_as_query = ApplicableDeclarationsCacheQuery::new(self.declarations.as_slice());
+        this_as_query.equiv(other)
+    }
+}
+
+impl IterBytes for ApplicableDeclarationsCacheEntry {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        ApplicableDeclarationsCacheQuery::new(self.declarations.as_slice()).iter_bytes(lsb0, f)
+    }
+}
+
+struct ApplicableDeclarationsCacheQuery<'a> {
+    declarations: &'a [Arc<~[PropertyDeclaration]>],
+}
+
+impl<'a> ApplicableDeclarationsCacheQuery<'a> {
+    fn new(declarations: &'a [Arc<~[PropertyDeclaration]>])
+           -> ApplicableDeclarationsCacheQuery<'a> {
+        ApplicableDeclarationsCacheQuery {
+            declarations: declarations,
+        }
+    }
+}
+
+impl<'a> Equiv<ApplicableDeclarationsCacheEntry> for ApplicableDeclarationsCacheQuery<'a> {
+    fn equiv(&self, other: &ApplicableDeclarationsCacheEntry) -> bool {
+        if self.declarations.len() != other.declarations.len() {
+            return false
+        }
+        for (this, other) in self.declarations.iter().zip(other.declarations.iter()) {
+            unsafe {
+                // Workaround for lack of `ptr_eq` on Arcs...
+                let this: uint = cast::transmute_copy(this);
+                let other: uint = cast::transmute_copy(other);
+                if this != other {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+}
+
+impl<'a> IterBytes for ApplicableDeclarationsCacheQuery<'a> {
+    fn iter_bytes(&self, lsb0: bool, f: to_bytes::Cb) -> bool {
+        let mut result = true;
+        for declaration in self.declarations.iter() {
+            let ptr: uint = unsafe {
+                cast::transmute_copy(declaration)
+            };
+            result = ptr.iter_bytes(lsb0, |x| f(x));
+        }
+        result
+    }
+}
+
+static APPLICABLE_DECLARATIONS_CACHE_SIZE: uint = 32;
+
+pub struct ApplicableDeclarationsCache {
+    cache: SimpleHashCache<ApplicableDeclarationsCacheEntry,Arc<ComputedValues>>,
+}
+
+impl ApplicableDeclarationsCache {
+    pub fn new() -> ApplicableDeclarationsCache {
+        ApplicableDeclarationsCache {
+            cache: SimpleHashCache::new(APPLICABLE_DECLARATIONS_CACHE_SIZE),
+        }
+    }
+
+    fn find(&self, declarations: &[Arc<~[PropertyDeclaration]>]) -> Option<Arc<ComputedValues>> {
+        match self.cache.find_equiv(&ApplicableDeclarationsCacheQuery::new(declarations)) {
+            None => None,
+            Some(ref values) => Some((*values).clone()),
+        }
+    }
+
+    fn insert(&mut self,
+              declarations: &[Arc<~[PropertyDeclaration]>],
+              style: Arc<ComputedValues>) {
+        drop(self.cache.insert(ApplicableDeclarationsCacheEntry::new(declarations), style))
+    }
+}
+
 pub trait MatchMethods {
     /// Performs aux initialization, selector matching, and cascading sequentially.
     fn match_and_cascade_subtree(&self,
@@ -44,6 +149,7 @@ pub trait MatchMethods {
                                  layout_chan: &LayoutChan,
                                  applicable_declarations: &mut ApplicableDeclarations,
                                  initial_values: &ComputedValues,
+                                 applicable_declarations_cache: &mut ApplicableDeclarationsCache,
                                  parent: Option<LayoutNode>);
 
     fn match_node(&self, stylist: &Stylist, applicable_declarations: &mut ApplicableDeclarations);
@@ -51,11 +157,68 @@ pub trait MatchMethods {
     unsafe fn cascade_node(&self,
                            parent: Option<LayoutNode>,
                            initial_values: &ComputedValues,
-                           applicable_declarations: &ApplicableDeclarations);
+                           applicable_declarations: &ApplicableDeclarations,
+                           applicable_declarations_cache: &mut ApplicableDeclarationsCache);
+}
+
+trait PrivateMatchMethods {
+    fn cascade_node_pseudo_element(&self,
+                                   parent_style: Option<&Arc<ComputedValues>>,
+                                   applicable_declarations: &[Arc<~[PropertyDeclaration]>],
+                                   style: &mut Option<Arc<ComputedValues>>,
+                                   initial_values: &ComputedValues,
+                                   applicable_declarations_cache: &mut
+                                    ApplicableDeclarationsCache);
+}
+
+impl<'ln> PrivateMatchMethods for LayoutNode<'ln> {
+    fn cascade_node_pseudo_element(&self,
+                                   parent_style: Option<&Arc<ComputedValues>>,
+                                   applicable_declarations: &[Arc<~[PropertyDeclaration]>],
+                                   style: &mut Option<Arc<ComputedValues>>,
+                                   initial_values: &ComputedValues,
+                                   applicable_declarations_cache: &mut
+                                    ApplicableDeclarationsCache) {
+        let this_style;
+        let cacheable;
+        match parent_style {
+            Some(ref parent_style) => {
+                let cached_computed_values;
+                let cache_entry = applicable_declarations_cache.find(applicable_declarations);
+                match cache_entry {
+                    None => cached_computed_values = None,
+                    Some(ref style) => cached_computed_values = Some(style.get()),
+                }
+                let (the_style, is_cacheable) = cascade(applicable_declarations,
+                                                        Some(parent_style.get()),
+                                                        initial_values,
+                                                        cached_computed_values);
+                cacheable = is_cacheable;
+                this_style = Arc::new(the_style);
+            }
+            None => {
+                let (the_style, is_cacheable) = cascade(applicable_declarations,
+                                                        None,
+                                                        initial_values,
+                                                        None);
+                cacheable = is_cacheable;
+                this_style = Arc::new(the_style);
+            }
+        };
+
+        // Cache the resolved style if it was cacheable.
+        if cacheable {
+            applicable_declarations_cache.insert(applicable_declarations, this_style.clone());
+        }
+
+        *style = Some(this_style);
+    }
 }
 
 impl<'ln> MatchMethods for LayoutNode<'ln> {
-    fn match_node(&self, stylist: &Stylist, applicable_declarations: &mut ApplicableDeclarations) {
+    fn match_node(&self,
+                  stylist: &Stylist,
+                  applicable_declarations: &mut ApplicableDeclarations) {
         let style_attribute = self.with_element(|element| {
             match *element.style_attribute() {
                 None => None,
@@ -82,6 +245,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
                                  layout_chan: &LayoutChan,
                                  applicable_declarations: &mut ApplicableDeclarations,
                                  initial_values: &ComputedValues,
+                                 applicable_declarations_cache: &mut ApplicableDeclarationsCache,
                                  parent: Option<LayoutNode>) {
         self.initialize_layout_data((*layout_chan).clone());
 
@@ -90,7 +254,10 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
         }
 
         unsafe {
-            self.cascade_node(parent, initial_values, applicable_declarations)
+            self.cascade_node(parent,
+                              initial_values,
+                              applicable_declarations,
+                              applicable_declarations_cache)
         }
 
         applicable_declarations.clear();
@@ -100,6 +267,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
                                           layout_chan,
                                           applicable_declarations,
                                           initial_values,
+                                          applicable_declarations_cache,
                                           Some(*self))
         }
     }
@@ -107,65 +275,53 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
     unsafe fn cascade_node(&self,
                            parent: Option<LayoutNode>,
                            initial_values: &ComputedValues,
-                           applicable_declarations: &ApplicableDeclarations) {
-        macro_rules! cascade_node(
-            ($applicable_declarations: expr, $style: ident) => {{
-                // Get our parent's style. This must be unsafe so that we don't touch the parent's
-                // borrow flags.
-                //
-                // FIXME(pcwalton): Isolate this unsafety into the `wrapper` module to allow
-                // enforced safe, race-free access to the parent style.
-                let parent_style = match parent {
-                    None => None,
-                    Some(parent_node) => {
-                        let parent_layout_data = parent_node.borrow_layout_data_unchecked();
-                        match *parent_layout_data {
-                            None => fail!("no parent data?!"),
-                            Some(ref parent_layout_data) => {
-                                match parent_layout_data.data.style {
-                                    None => fail!("parent hasn't been styled yet?!"),
-                                    Some(ref style) => Some(style),
-                                }
-                            }
+                           applicable_declarations: &ApplicableDeclarations,
+                           applicable_declarations_cache: &mut ApplicableDeclarationsCache) {
+        // Get our parent's style. This must be unsafe so that we don't touch the parent's
+        // borrow flags.
+        //
+        // FIXME(pcwalton): Isolate this unsafety into the `wrapper` module to allow
+        // enforced safe, race-free access to the parent style.
+        let parent_style = match parent {
+            None => None,
+            Some(parent_node) => {
+                let parent_layout_data = parent_node.borrow_layout_data_unchecked();
+                match *parent_layout_data {
+                    None => fail!("no parent data?!"),
+                    Some(ref parent_layout_data) => {
+                        match parent_layout_data.data.style {
+                            None => fail!("parent hasn't been styled yet?!"),
+                            Some(ref style) => Some(style),
                         }
                     }
-                 };
-
-                 let computed_values = match parent_style {
-                     Some(ref style) => {
-                         Arc::new(cascade($applicable_declarations.as_slice(),
-                                          Some(style.get()),
-                                          initial_values))
-                     }
-                     None => Arc::new(cascade($applicable_declarations.as_slice(),
-                                              None,
-                                              initial_values)),
-                 };
- 
-                 let mut layout_data_ref = self.mutate_layout_data();
-                 match *layout_data_ref.get() {
-                     None => fail!("no layout data"),
-                     Some(ref mut layout_data) => {
-                         let style = &mut layout_data.data.$style;
-                         match *style {
-                             None => (),
-                             Some(ref previous_style) => {
-                                 layout_data.data.restyle_damage = Some(incremental::compute_damage(
-                                     previous_style.get(), computed_values.get()).to_int())
-                             }
-                         }
-                         *style = Some(computed_values)
-                     }
                 }
-            }}
-        );
+            }
+        };
 
-        cascade_node!(applicable_declarations.normal, style);
-        if applicable_declarations.before.len() > 0 {
-            cascade_node!(applicable_declarations.before, before_style);
-        }
-        if applicable_declarations.after.len() > 0 {
-            cascade_node!(applicable_declarations.after, after_style);
+        let mut layout_data_ref = self.mutate_layout_data();
+        match *layout_data_ref.get() {
+            None => fail!("no layout data"),
+            Some(ref mut layout_data) => {
+                self.cascade_node_pseudo_element(parent_style,
+                                                 applicable_declarations.normal.as_slice(),
+                                                 &mut layout_data.data.style,
+                                                 initial_values,
+                                                 applicable_declarations_cache);
+                if applicable_declarations.before.len() > 0 {
+                    self.cascade_node_pseudo_element(parent_style,
+                                                     applicable_declarations.before.as_slice(),
+                                                     &mut layout_data.data.before_style,
+                                                     initial_values,
+                                                     applicable_declarations_cache);
+                }
+                if applicable_declarations.after.len() > 0 {
+                    self.cascade_node_pseudo_element(parent_style,
+                                                     applicable_declarations.after.as_slice(),
+                                                     &mut layout_data.data.after_style,
+                                                     initial_values,
+                                                     applicable_declarations_cache);
+                }
+            }
         }
     }
 }

--- a/src/components/main/css/user-agent.css
+++ b/src/components/main/css/user-agent.css
@@ -88,7 +88,12 @@ u, ins              { text-decoration: underline }
 br:before           { content: "\A"; white-space: pre-line }
 
 center              { text-align: center }
-:link, :visited     { text-decoration: underline }
+a:link,
+a:visited,
+area:link,
+area:visited,
+link:link,
+link:visited        { text-decoration: underline }
 :focus              { outline: thin dotted invert }
 
 /* Begin bidirectionality settings (do not change) */
@@ -106,6 +111,8 @@ ul, ol, dl          { page-break-before: avoid }
 }
 
 /* Servo additions */
-:link               { color: blue }
+a:link,
+area:link,
+link:link           { color: blue }
 script              { display: none }
 style               { display: none }

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -193,9 +193,9 @@ impl BlockFlow {
         let style = box_.style();
 
         let (width, maybe_margin_left, maybe_margin_right) =
-            (MaybeAuto::from_style(style.Box.width, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_left, remaining_width),
-             MaybeAuto::from_style(style.Margin.margin_right, remaining_width));
+            (MaybeAuto::from_style(style.Box.get().width, remaining_width),
+             MaybeAuto::from_style(style.Margin.get().margin_left, remaining_width),
+             MaybeAuto::from_style(style.Margin.get().margin_right, remaining_width));
 
         let (width, margin_left, margin_right) = self.compute_horiz(width,
                                                                     maybe_margin_left,
@@ -206,7 +206,7 @@ impl BlockFlow {
         // If the tentative used width is greater than 'max-width', width should be recalculated,
         // but this time using the computed value of 'max-width' as the computed value for 'width'.
         let (width, margin_left, margin_right) = {
-            match specified_or_none(style.Box.max_width, remaining_width) {
+            match specified_or_none(style.Box.get().max_width, remaining_width) {
                 Some(value) if value < width => self.compute_horiz(Specified(value),
                                                                    maybe_margin_left,
                                                                    maybe_margin_right,
@@ -218,7 +218,7 @@ impl BlockFlow {
         // If the resulting width is smaller than 'min-width', width should be recalculated,
         // but this time using the value of 'min-width' as the computed value for 'width'.
         let (width, margin_left, margin_right) = {
-            let computed_min_width = specified(style.Box.min_width, remaining_width);
+            let computed_min_width = specified(style.Box.get().min_width, remaining_width);
             if computed_min_width > width {
                 self.compute_horiz(Specified(computed_min_width),
                                    maybe_margin_left,
@@ -235,13 +235,13 @@ impl BlockFlow {
     // CSS Section 10.3.5
     fn compute_float_margins(&self, box_: &Box, remaining_width: Au) -> (Au, Au, Au) {
         let style = box_.style();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
+        let margin_left = MaybeAuto::from_style(style.Margin.get().margin_left,
                                                 remaining_width).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
+        let margin_right = MaybeAuto::from_style(style.Margin.get().margin_right,
                                                  remaining_width).specified_or_zero();
         let shrink_to_fit = geometry::min(self.base.pref_width,
                                           geometry::max(self.base.min_width, remaining_width));
-        let width = MaybeAuto::from_style(style.Box.width,
+        let width = MaybeAuto::from_style(style.Box.get().width,
                                           remaining_width).specified_or_default(shrink_to_fit);
         debug!("assign_widths_float -- width: {}", width);
         return (width, margin_left, margin_right);
@@ -376,7 +376,7 @@ impl BlockFlow {
             // block per CSS 2.1 § 10.5.
             // TODO: We need to pass in the correct containing block height
             // for absolutely positioned elems
-            height = match MaybeAuto::from_style(style.Box.height, height) {
+            height = match MaybeAuto::from_style(style.Box.get().height, height) {
                 Auto => height,
                 Specified(value) => value
             };
@@ -516,7 +516,7 @@ impl BlockFlow {
             box_.border.get().top + box_.border.get().bottom;
 
         //TODO(eatkinson): compute heights properly using the 'height' property.
-        let height_prop = MaybeAuto::from_style(box_.style().Box.height,
+        let height_prop = MaybeAuto::from_style(box_.style().Box.get().height,
                                                 Au::new(0)).specified_or_zero();
 
         height = geometry::max(height, height_prop) + noncontent_height;
@@ -719,7 +719,7 @@ impl Flow for BlockFlow {
             let style = box_.style();
 
             // The text alignment of a block flow is the text alignment of its box's style.
-            self.base.flags_info.flags.set_text_align(style.InheritedText.text_align);
+            self.base.flags_info.flags.set_text_align(style.InheritedText.get().text_align);
 
             box_.assign_width(remaining_width);
             // Can compute padding here since we know containing block width.
@@ -729,9 +729,9 @@ impl Flow for BlockFlow {
             let available_width = remaining_width - box_.noncontent_width();
 
             // Top and bottom margins for blocks are 0 if auto.
-            let margin_top = MaybeAuto::from_style(style.Margin.margin_top,
+            let margin_top = MaybeAuto::from_style(style.Margin.get().margin_top,
                                                    remaining_width).specified_or_zero();
-            let margin_bottom = MaybeAuto::from_style(style.Margin.margin_bottom,
+            let margin_bottom = MaybeAuto::from_style(style.Margin.get().margin_bottom,
                                                       remaining_width).specified_or_zero();
 
             let (width, margin_left, margin_right) = if self.is_float() {

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -719,7 +719,7 @@ impl Flow for BlockFlow {
             let style = box_.style();
 
             // The text alignment of a block flow is the text alignment of its box's style.
-            self.base.flags_info.flags.set_text_align(style.Text.text_align);
+            self.base.flags_info.flags.set_text_align(style.InheritedText.text_align);
 
             box_.assign_width(remaining_width);
             // Can compute padding here since we know containing block width.

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -373,7 +373,7 @@ impl Box {
                 }
                 (_, _) => {
                     y = position_offsets.top;
-                    match MaybeAuto::from_style(self.style().Box.height, Au(0)) {
+                    match MaybeAuto::from_style(self.style().Box.get().height, Au(0)) {
                         Auto => {
                             height = screen_height - position_offsets.top - position_offsets.bottom;
                         }
@@ -408,7 +408,7 @@ impl Box {
                 }
                 (_, _) => {
                     x = position_offsets.left;
-                    match MaybeAuto::from_style(self.style().Box.width, Au(0)) {
+                    match MaybeAuto::from_style(self.style().Box.get().width, Au(0)) {
                         Auto => {
                             width = screen_width - position_offsets.left - position_offsets.right;
                         }
@@ -446,14 +446,14 @@ impl Box {
         }
 
         let style = self.style();
-        let width = MaybeAuto::from_style(style.Box.width, Au::new(0)).specified_or_zero();
-        let margin_left = MaybeAuto::from_style(style.Margin.margin_left,
+        let width = MaybeAuto::from_style(style.Box.get().width, Au::new(0)).specified_or_zero();
+        let margin_left = MaybeAuto::from_style(style.Margin.get().margin_left,
                                                 Au::new(0)).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.margin_right,
+        let margin_right = MaybeAuto::from_style(style.Margin.get().margin_right,
                                                  Au::new(0)).specified_or_zero();
 
-        let padding_left = self.compute_padding_length(style.Padding.padding_left, Au::new(0));
-        let padding_right = self.compute_padding_length(style.Padding.padding_right, Au::new(0));
+        let padding_left = self.compute_padding_length(style.Padding.get().padding_left, Au(0));
+        let padding_right = self.compute_padding_length(style.Padding.get().padding_right, Au(0));
 
         width + margin_left + margin_right + padding_left + padding_right +
             self.border.get().left + self.border.get().right
@@ -480,37 +480,45 @@ impl Box {
             }
         }
 
-        self.border.set(SideOffsets2D::new(width(style.Border.border_top_width,
-                                                 style.Border.border_top_style),
-                                           width(style.Border.border_right_width,
-                                                 style.Border.border_right_style),
-                                           width(style.Border.border_bottom_width,
-                                                 style.Border.border_bottom_style),
-                                           width(style.Border.border_left_width,
-                                                 style.Border.border_left_style)))
+        self.border.set(SideOffsets2D::new(width(style.Border.get().border_top_width,
+                                                 style.Border.get().border_top_style),
+                                           width(style.Border.get().border_right_width,
+                                                 style.Border.get().border_right_style),
+                                           width(style.Border.get().border_bottom_width,
+                                                 style.Border.get().border_bottom_style),
+                                           width(style.Border.get().border_left_width,
+                                                 style.Border.get().border_left_style)))
     }
 
     pub fn compute_positioned_offsets(&self, style: &ComputedValues, containing_width: Au, containing_height: Au) {
         self.position_offsets.set(SideOffsets2D::new(
-                MaybeAuto::from_style(style.PositionOffsets.top, containing_height)
+                MaybeAuto::from_style(style.PositionOffsets.get().top, containing_height)
                 .specified_or_zero(),
-                MaybeAuto::from_style(style.PositionOffsets.right, containing_width)
+                MaybeAuto::from_style(style.PositionOffsets.get().right, containing_width)
                 .specified_or_zero(),
-                MaybeAuto::from_style(style.PositionOffsets.bottom, containing_height)
+                MaybeAuto::from_style(style.PositionOffsets.get().bottom, containing_height)
                 .specified_or_zero(),
-                MaybeAuto::from_style(style.PositionOffsets.left, containing_width)
+                MaybeAuto::from_style(style.PositionOffsets.get().left, containing_width)
                 .specified_or_zero()));
     }
 
     /// Populates the box model padding parameters from the given computed style.
     pub fn compute_padding(&self, style: &ComputedValues, containing_block_width: Au) {
-        let padding = SideOffsets2D::new(self.compute_padding_length(style.Padding.padding_top,
+        let padding = SideOffsets2D::new(self.compute_padding_length(style.Padding
+                                                                          .get()
+                                                                          .padding_top,
                                                                      containing_block_width),
-                                         self.compute_padding_length(style.Padding.padding_right,
+                                         self.compute_padding_length(style.Padding
+                                                                          .get()
+                                                                          .padding_right,
                                                                      containing_block_width),
-                                         self.compute_padding_length(style.Padding.padding_bottom,
+                                         self.compute_padding_length(style.Padding
+                                                                          .get()
+                                                                          .padding_bottom,
                                                                      containing_block_width),
-                                         self.compute_padding_length(style.Padding.padding_left,
+                                         self.compute_padding_length(style.Padding
+                                                                          .get()
+                                                                          .padding_left,
                                                                      containing_block_width));
         self.padding.set(padding)
     }
@@ -679,28 +687,28 @@ impl Box {
         }
     }
     pub fn relative_position(&self, container_block_size: &Size2D<Au>) -> Point2D<Au> {
-        fn left_right(style: &ComputedValues,block_width: Au) -> Au {
+        fn left_right(style: &ComputedValues, block_width: Au) -> Au {
             // TODO(ksh8281) : consider RTL(right-to-left) culture
-            match (style.PositionOffsets.left, style.PositionOffsets.right) {
+            match (style.PositionOffsets.get().left, style.PositionOffsets.get().right) {
                 (LPA_Auto, _) => {
-                    -MaybeAuto::from_style(style.PositionOffsets.right, block_width)
+                    -MaybeAuto::from_style(style.PositionOffsets.get().right, block_width)
                         .specified_or_zero()
                 }
                 (_, _) => {
-                    MaybeAuto::from_style(style.PositionOffsets.left, block_width)
+                    MaybeAuto::from_style(style.PositionOffsets.get().left, block_width)
                         .specified_or_zero()
                 }
             }
         }
 
         fn top_bottom(style: &ComputedValues,block_height: Au) -> Au {
-            match (style.PositionOffsets.top, style.PositionOffsets.bottom) {
+            match (style.PositionOffsets.get().top, style.PositionOffsets.get().bottom) {
                 (LPA_Auto, _) => {
-                    -MaybeAuto::from_style(style.PositionOffsets.bottom, block_height)
+                    -MaybeAuto::from_style(style.PositionOffsets.get().bottom, block_height)
                         .specified_or_zero()
                 }
                 (_, _) => {
-                    MaybeAuto::from_style(style.PositionOffsets.top, block_height)
+                    MaybeAuto::from_style(style.PositionOffsets.get().top, block_height)
                         .specified_or_zero()
                 }
             }
@@ -711,7 +719,7 @@ impl Box {
             y: Au::new(0),
         };
 
-        if self.style().Box.position == position::relative {
+        if self.style().Box.get().position == position::relative {
             rel_pos.x = rel_pos.x + left_right(self.style(), container_block_size.width);
             rel_pos.y = rel_pos.y + top_bottom(self.style(), container_block_size.height);
         }
@@ -720,9 +728,11 @@ impl Box {
         match info.get() {
             &Some(ref info) => {
                 for info in info.parent_info.iter() {
-                    if info.style.get().Box.position == position::relative {
-                        rel_pos.x = rel_pos.x + left_right(info.style.get(), container_block_size.width);
-                        rel_pos.y = rel_pos.y + top_bottom(info.style.get(), container_block_size.height);
+                    if info.style.get().Box.get().position == position::relative {
+                        rel_pos.x = rel_pos.x + left_right(info.style.get(),
+                                                           container_block_size.width);
+                        rel_pos.y = rel_pos.y + top_bottom(info.style.get(),
+                                                           container_block_size.height);
                     }
                 }
             },
@@ -737,7 +747,7 @@ impl Box {
     #[inline(always)]
     pub fn clear(&self) -> Option<ClearType> {
         let style = self.style();
-        match style.Box.clear {
+        match style.Box.get().clear {
             clear::none => None,
             clear::left => Some(ClearLeft),
             clear::right => Some(ClearRight),
@@ -755,20 +765,20 @@ impl Box {
         debug!("(font style) start");
 
         // FIXME: Too much allocation here.
-        let font_families = my_style.Font.font_family.map(|family| {
+        let font_families = my_style.Font.get().font_family.map(|family| {
             match *family {
                 font_family::FamilyName(ref name) => (*name).clone(),
             }
         });
         debug!("(font style) font families: `{:?}`", font_families);
 
-        let font_size = my_style.Font.font_size.to_f64().unwrap() / 60.0;
+        let font_size = my_style.Font.get().font_size.to_f64().unwrap() / 60.0;
         debug!("(font style) font size: `{:f}px`", font_size);
 
         FontStyle {
             pt_size: font_size,
-            weight: my_style.Font.font_weight,
-            style: my_style.Font.font_style,
+            weight: my_style.Font.get().font_weight,
+            style: my_style.Font.get().font_style,
             families: font_families,
         }
     }
@@ -781,19 +791,19 @@ impl Box {
     /// Returns the text alignment of the computed style of the nearest ancestor-or-self `Element`
     /// node.
     pub fn text_align(&self) -> text_align::T {
-        self.style().InheritedText.text_align
+        self.style().InheritedText.get().text_align
     }
 
     pub fn line_height(&self) -> line_height::T {
-        self.style().InheritedBox.line_height
+        self.style().InheritedBox.get().line_height
     }
 
     pub fn vertical_align(&self) -> vertical_align::T {
-        self.style().Box.vertical_align
+        self.style().Box.get().vertical_align
     }
 
     pub fn white_space(&self) -> white_space::T {
-        self.style().InheritedText.white_space
+        self.style().InheritedText.get().white_space
     }
 
     /// Returns the text decoration of this box, according to the style of the nearest ancestor
@@ -804,7 +814,7 @@ impl Box {
     /// model. Therefore, this is a best lower bound approximation, but the end result may actually
     /// have the various decoration flags turned on afterward.
     pub fn text_decoration(&self) -> text_decoration::T {
-        self.style().Text.text_decoration
+        self.style().Text.get().text_decoration
     }
 
     /// Returns the sum of margin, border, and padding on the left.
@@ -862,7 +872,7 @@ impl Box {
                     bg_rect.origin.y = box_info.baseline + offset.y - info.font_ascent;
                     bg_rect.size.height = info.font_ascent + info.font_descent;
                     let background_color = info.style.get().resolve_color(
-                        info.style.get().Background.background_color);
+                        info.style.get().Background.get().background_color);
 
                     if !background_color.alpha.approx_eq(&0.0) {
                         lists.with_mut(|lists| {
@@ -886,14 +896,14 @@ impl Box {
                     bg_rect.size.height = bg_rect.size.height + border.top + border.bottom;
 
                     let style = info.style.get();
-                    let top_color = style.resolve_color(style.Border.border_top_color);
-                    let right_color = style.resolve_color(style.Border.border_right_color);
-                    let bottom_color = style.resolve_color(style.Border.border_bottom_color);
-                    let left_color = style.resolve_color(style.Border.border_left_color);
-                    let top_style = style.Border.border_top_style;
-                    let right_style = style.Border.border_right_style;
-                    let bottom_style = style.Border.border_bottom_style;
-                    let left_style = style.Border.border_left_style;
+                    let top_color = style.resolve_color(style.Border.get().border_top_color);
+                    let right_color = style.resolve_color(style.Border.get().border_right_color);
+                    let bottom_color = style.resolve_color(style.Border.get().border_bottom_color);
+                    let left_color = style.resolve_color(style.Border.get().border_left_color);
+                    let top_style = style.Border.get().border_top_style;
+                    let right_style = style.Border.get().border_right_style;
+                    let bottom_style = style.Border.get().border_bottom_style;
+                    let left_style = style.Border.get().border_left_style;
 
 
                     lists.with_mut(|lists| {
@@ -935,7 +945,7 @@ impl Box {
         // inefficient. What we really want is something like "nearest ancestor element that
         // doesn't have a box".
         let style = self.style();
-        let background_color = style.resolve_color(style.Background.background_color);
+        let background_color = style.resolve_color(style.Background.get().background_color);
         if !background_color.alpha.approx_eq(&0.0) {
             lists.with_mut(|lists| {
                 let solid_color_display_item = ~SolidColorDisplayItem {
@@ -965,14 +975,14 @@ impl Box {
         }
 
         let style = self.style();
-        let top_color = style.resolve_color(style.Border.border_top_color);
-        let right_color = style.resolve_color(style.Border.border_right_color);
-        let bottom_color = style.resolve_color(style.Border.border_bottom_color);
-        let left_color = style.resolve_color(style.Border.border_left_color);
-        let top_style = style.Border.border_top_style;
-        let right_style = style.Border.border_right_style;
-        let bottom_style = style.Border.border_bottom_style;
-        let left_style = style.Border.border_left_style;
+        let top_color = style.resolve_color(style.Border.get().border_top_color);
+        let right_color = style.resolve_color(style.Border.get().border_right_color);
+        let bottom_color = style.resolve_color(style.Border.get().border_bottom_color);
+        let left_color = style.resolve_color(style.Border.get().border_left_color);
+        let top_style = style.Border.get().border_top_style;
+        let right_style = style.Border.get().border_right_style;
+        let bottom_style = style.Border.get().border_bottom_style;
+        let left_style = style.Border.get().border_left_style;
 
         let mut abs_bounds = abs_bounds.clone();
         abs_bounds.origin.x = abs_bounds.origin.x + self.noncontent_inline_left();
@@ -1029,7 +1039,7 @@ impl Box {
                box_bounds, absolute_box_bounds, self.debug_str());
         debug!("Box::build_display_list: dirty={}, offset={}", *dirty, offset);
 
-        if self.style().InheritedBox.visibility != visibility::visible {
+        if self.style().InheritedBox.get().visibility != visibility::visible {
             return;
         }
 
@@ -1047,7 +1057,7 @@ impl Box {
         match self.specific {
             UnscannedTextBox(_) => fail!("Shouldn't see unscanned boxes here."),
             ScannedTextBox(ref text_box) => {
-                let text_color = self.style().Color.color.to_gfx_color();
+                let text_color = self.style().Color.get().color.to_gfx_color();
 
                 // Set the various text display item flags.
                 let mut flow_flags = flow::base(flow).flags_info.clone();
@@ -1472,13 +1482,13 @@ impl Box {
             }
             ImageBox(ref image_box_info) => {
                 // TODO(ksh8281): compute border,margin,padding
-                let width = ImageBoxInfo::style_length(self.style().Box.width,
+                let width = ImageBoxInfo::style_length(self.style().Box.get().width,
                                                        image_box_info.dom_width,
                                                        container_width);
 
                 // FIXME(ksh8281): we shouldn't figure height this way
                 // now, we don't know about size of parent's height
-                let height = ImageBoxInfo::style_length(self.style().Box.height,
+                let height = ImageBoxInfo::style_length(self.style().Box.get().height,
                                                        image_box_info.dom_height,
                                                        Au::new(0));
 
@@ -1520,11 +1530,11 @@ impl Box {
                 let width = image_box_info.computed_width();
                 // FIXME(ksh8281): we shouldn't assign height this way
                 // we don't know about size of parent's height
-                let height = ImageBoxInfo::style_length(self.style().Box.height,
+                let height = ImageBoxInfo::style_length(self.style().Box.get().height,
                                                         image_box_info.dom_height,
                                                         Au::new(0));
 
-                let height = match (self.style().Box.width,
+                let height = match (self.style().Box.get().width,
                                     image_box_info.dom_width,
                                     height) {
                     (LPA_Auto, None, Auto) => {
@@ -1575,7 +1585,7 @@ impl Box {
 
     /// Returns true if the contents should be clipped (i.e. if `overflow` is `hidden`).
     pub fn needs_clip(&self) -> bool {
-        self.style().Box.overflow == overflow::hidden
+        self.style().Box.get().overflow == overflow::hidden
     }
 
     /// Returns a debugging string describing this box.

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -781,11 +781,11 @@ impl Box {
     /// Returns the text alignment of the computed style of the nearest ancestor-or-self `Element`
     /// node.
     pub fn text_align(&self) -> text_align::T {
-        self.style().Text.text_align
+        self.style().InheritedText.text_align
     }
 
     pub fn line_height(&self) -> line_height::T {
-        self.style().Box.line_height
+        self.style().InheritedBox.line_height
     }
 
     pub fn vertical_align(&self) -> vertical_align::T {
@@ -793,7 +793,7 @@ impl Box {
     }
 
     pub fn white_space(&self) -> white_space::T {
-        self.style().Text.white_space
+        self.style().InheritedText.white_space
     }
 
     /// Returns the text decoration of this box, according to the style of the nearest ancestor
@@ -1029,7 +1029,7 @@ impl Box {
                box_bounds, absolute_box_bounds, self.debug_str());
         debug!("Box::build_display_list: dirty={}, offset={}", *dirty, offset);
 
-        if self.style().Box.visibility != visibility::visible {
+        if self.style().InheritedBox.visibility != visibility::visible {
             return;
         }
 

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -730,7 +730,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
                     //
                     // If you implement other values for this property, you will almost certainly
                     // want to update this check.
-                    match self.style().get().Text.white_space {
+                    match self.style().get().InheritedText.white_space {
                         white_space::normal => true,
                         _ => false,
                     }

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -628,7 +628,7 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
         let (display, float, position) = match node.type_id() {
             ElementNodeTypeId(_) => {
                 let style = node.style().get();
-                (style.Box.display, style.Box.float, style.Box.position)
+                (style.Box.get().display, style.Box.get().float, style.Box.get().position)
             }
             TextNodeTypeId => (display::inline, float::none, position::static_),
             CommentNodeTypeId |
@@ -730,7 +730,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
                     //
                     // If you implement other values for this property, you will almost certainly
                     // want to update this check.
-                    match self.style().get().InheritedText.white_space {
+                    match self.style().get().InheritedText.get().white_space {
                         white_space::normal => true,
                         _ => false,
                     }

--- a/src/components/main/layout/context.rs
+++ b/src/components/main/layout/context.rs
@@ -21,7 +21,7 @@ use script::layout_interface::LayoutChan;
 use servo_msg::constellation_msg::ConstellationChan;
 use servo_net::local_image_cache::LocalImageCache;
 use servo_util::geometry::Au;
-use style::Stylist;
+use style::{ComputedValues, Stylist};
 
 #[thread_local]
 static mut FONT_CONTEXT: *mut FontContext = 0 as *mut FontContext;
@@ -54,6 +54,9 @@ pub struct LayoutContext {
     ///
     /// FIXME(pcwalton): Make this no longer an unsafe pointer once we have fast `RWArc`s.
     stylist: *Stylist,
+
+    /// The initial set of CSS properties.
+    initial_css_values: Arc<ComputedValues>,
 
     /// The root node at which we're starting the layout.
     reflow_root: OpaqueNode,

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -309,7 +309,7 @@ static TEXT_ALIGN_SHIFT: u8 = 4;
 impl FlowFlagsInfo {
     /// Creates a new set of flow flags from the given style.
     pub fn new(style: &ComputedValues) -> FlowFlagsInfo {
-        let text_decoration = style.Text.text_decoration;
+        let text_decoration = style.Text.get().text_decoration;
         let mut flags = FlowFlags(0);
         flags.set_override_underline(text_decoration.underline);
         flags.set_override_overline(text_decoration.overline);
@@ -318,9 +318,9 @@ impl FlowFlagsInfo {
         // TODO(ksh8281) compute text-decoration-color,style,line
         let rare_flow_flags = if flags.is_text_decoration_enabled() {
             Some(~RareFlowFlags {
-                underline_color: style.Color.color.to_gfx_color(),
-                overline_color: style.Color.color.to_gfx_color(),
-                line_through_color: style.Color.color.to_gfx_color(),
+                underline_color: style.Color.get().color.to_gfx_color(),
+                overline_color: style.Color.get().color.to_gfx_color(),
+                line_through_color: style.Color.get().color.to_gfx_color(),
             })
         } else {
             None

--- a/src/components/main/layout/incremental.rs
+++ b/src/components/main/layout/incremental.rs
@@ -134,7 +134,7 @@ pub fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> RestyleDama
           Padding.padding_top, Padding.padding_right, Padding.padding_bottom, Padding.padding_left,
           Box.position, Box.width, Box.height, Box.float, Box.display,
           Font.font_family, Font.font_size, Font.font_style, Font.font_weight,
-          Text.text_align, Text.text_decoration, Box.line_height ]);
+          InheritedText.text_align, Text.text_decoration, InheritedBox.line_height ]);
 
     // FIXME: test somehow that we checked every CSS property
 

--- a/src/components/main/layout/incremental.rs
+++ b/src/components/main/layout/incremental.rs
@@ -107,7 +107,7 @@ impl RestyleDamage {
 macro_rules! add_if_not_equal(
     ($old:ident, $new:ident, $damage:ident,
      [ $($effect:ident),* ], [ $($style_struct:ident.$name:ident),* ]) => ({
-        if $( ($old.$style_struct.$name != $new.$style_struct.$name) )||* {
+        if $( ($old.$style_struct.get().$name != $new.$style_struct.get().$name) )||* {
             $damage.union_in_place( restyle_damage!( $($effect),* ) );
         }
     })

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -794,7 +794,7 @@ impl Flow for InlineFlow {
                 //
                 // The spec does not state which font to use. Previous versions of the code used
                 // the parent's font; this code uses the current font.
-                let parent_text_top = cur_box.style().Font.font_size;
+                let parent_text_top = cur_box.style().Font.get().font_size;
 
                 // We should calculate the distance from baseline to the bottom of the parent's
                 // content area. But for now we assume it's zero.

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -5,7 +5,7 @@
 //! The layout task. Performs layout on the DOM, builds display lists and sends them to be
 /// rendered.
 
-use css::matching::MatchMethods;
+use css::matching::{ApplicableDeclarations, MatchMethods};
 use css::select::new_stylist;
 use css::node_style::StyledNode;
 use layout::construct::{FlowConstructionResult, FlowConstructor, NoConstructionResult};
@@ -561,8 +561,10 @@ impl LayoutTask {
                     profile(time::LayoutSelectorMatchCategory, self.profiler_chan.clone(), || {
                         match self.parallel_traversal {
                             None => {
+                                let mut applicable_declarations = ApplicableDeclarations::new();
                                 node.match_and_cascade_subtree(self.stylist,
                                                                &layout_ctx.layout_chan,
+                                                               &mut applicable_declarations,
                                                                None)
                             }
                             Some(ref mut traversal) => {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -6,6 +6,7 @@
 /// rendered.
 
 use css::matching::{ApplicableDeclarations, ApplicableDeclarationsCache, MatchMethods};
+use css::matching::{StyleSharingCandidateCache};
 use css::select::new_stylist;
 use css::node_style::StyledNode;
 use layout::construct::{FlowConstructionResult, FlowConstructor, NoConstructionResult};
@@ -570,11 +571,14 @@ impl LayoutTask {
                                 let mut applicable_declarations = ApplicableDeclarations::new();
                                 let mut applicable_declarations_cache =
                                     ApplicableDeclarationsCache::new();
+                                let mut style_sharing_candidate_cache =
+                                    StyleSharingCandidateCache::new();
                                 node.match_and_cascade_subtree(self.stylist,
                                                                &layout_ctx.layout_chan,
                                                                &mut applicable_declarations,
                                                                layout_ctx.initial_css_values.get(),
                                                                &mut applicable_declarations_cache,
+                                                               &mut style_sharing_candidate_cache,
                                                                None)
                             }
                             Some(ref mut traversal) => {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -5,7 +5,7 @@
 //! The layout task. Performs layout on the DOM, builds display lists and sends them to be
 /// rendered.
 
-use css::matching::{ApplicableDeclarations, MatchMethods};
+use css::matching::{ApplicableDeclarations, ApplicableDeclarationsCache, MatchMethods};
 use css::select::new_stylist;
 use css::node_style::StyledNode;
 use layout::construct::{FlowConstructionResult, FlowConstructor, NoConstructionResult};
@@ -568,10 +568,13 @@ impl LayoutTask {
                         match self.parallel_traversal {
                             None => {
                                 let mut applicable_declarations = ApplicableDeclarations::new();
+                                let mut applicable_declarations_cache =
+                                    ApplicableDeclarationsCache::new();
                                 node.match_and_cascade_subtree(self.stylist,
                                                                &layout_ctx.layout_chan,
                                                                &mut applicable_declarations,
                                                                layout_ctx.initial_css_values.get(),
+                                                               &mut applicable_declarations_cache,
                                                                None)
                             }
                             Some(ref mut traversal) => {

--- a/src/components/main/layout/parallel.rs
+++ b/src/components/main/layout/parallel.rs
@@ -163,7 +163,9 @@ fn match_and_cascade_node(unsafe_layout_node: UnsafeLayoutNode,
         } else {
             node.parent_node()
         };
-        node.cascade_node(parent_opt, &applicable_declarations);
+        node.cascade_node(parent_opt,
+                          layout_context.initial_css_values.get(),
+                          &applicable_declarations);
 
         // Enqueue kids.
         let mut child_count = 0;

--- a/src/components/main/layout/parallel.rs
+++ b/src/components/main/layout/parallel.rs
@@ -6,7 +6,7 @@
 //!
 //! This code is highly unsafe. Keep this file small and easy to audit.
 
-use css::matching::MatchMethods;
+use css::matching::{ApplicableDeclarations, MatchMethods};
 use layout::context::LayoutContext;
 use layout::extra::LayoutAuxMethods;
 use layout::flow::{Flow, FlowLeafSet, PostorderFlowTraversal};
@@ -149,10 +149,12 @@ fn match_and_cascade_node(unsafe_layout_node: UnsafeLayoutNode,
         // parser.
         node.initialize_layout_data(layout_context.layout_chan.clone());
 
+        let mut applicable_declarations = ApplicableDeclarations::new();
+
         if node.is_element() {
             // Perform the CSS selector matching.
             let stylist: &Stylist = cast::transmute(layout_context.stylist);
-            node.match_node(stylist);
+            node.match_node(stylist, &mut applicable_declarations);
         }
 
         // Perform the CSS cascade.
@@ -161,7 +163,7 @@ fn match_and_cascade_node(unsafe_layout_node: UnsafeLayoutNode,
         } else {
             node.parent_node()
         };
-        node.cascade_node(parent_opt);
+        node.cascade_node(parent_opt, &applicable_declarations);
 
         // Enqueue kids.
         let mut child_count = 0;

--- a/src/components/main/layout/parallel.rs
+++ b/src/components/main/layout/parallel.rs
@@ -165,7 +165,8 @@ fn match_and_cascade_node(unsafe_layout_node: UnsafeLayoutNode,
         };
         node.cascade_node(parent_opt,
                           layout_context.initial_css_values.get(),
-                          &applicable_declarations);
+                          &applicable_declarations,
+                          layout_context.applicable_declarations_cache());
 
         // Enqueue kids.
         let mut child_count = 0;

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -12,13 +12,12 @@ use script::dom::bindings::utils::Reflectable;
 use script::dom::node::AbstractNode;
 use script::layout_interface::{LayoutChan, UntrustedNodeAddress};
 use servo_util::range::Range;
-use servo_util::smallvec::{SmallVec0, SmallVec16};
 use std::cast;
 use std::cell::{Ref, RefMut};
 use std::iter::Enumerate;
 use std::libc::uintptr_t;
 use std::vec::VecIterator;
-use style::{ComputedValues, PropertyDeclaration};
+use style::ComputedValues;
 
 /// A range of nodes.
 pub struct NodeRange {
@@ -130,13 +129,6 @@ impl ElementMapping {
 
 /// Data that layout associates with a node.
 pub struct PrivateLayoutData {
-    /// The results of CSS matching for this node.
-    applicable_declarations: SmallVec16<Arc<~[PropertyDeclaration]>>,
-
-    before_applicable_declarations: SmallVec0<Arc<~[PropertyDeclaration]>>,
-
-    after_applicable_declarations: SmallVec0<Arc<~[PropertyDeclaration]>>,
-
     /// The results of CSS styling for this node.
     before_style: Option<Arc<ComputedValues>>,
 
@@ -159,9 +151,6 @@ impl PrivateLayoutData {
     /// Creates new layout data.
     pub fn new() -> PrivateLayoutData {
         PrivateLayoutData {
-            applicable_declarations: SmallVec16::new(),
-            before_applicable_declarations: SmallVec0::new(),
-            after_applicable_declarations: SmallVec0::new(),
             before_style: None,
             style: None,
             after_style: None,
@@ -169,14 +158,6 @@ impl PrivateLayoutData {
             flow_construction_result: NoConstructionResult,
             parallel: DomParallelInfo::new(),
         }
-    }
-
-    /// Initialize the function for applicable_declarations.
-    pub fn init_applicable_declarations(&mut self) {
-        //FIXME To implement a clear() on SmallVec and use it(init_applicable_declarations).
-        self.applicable_declarations = SmallVec16::new();
-        self.before_applicable_declarations = SmallVec0::new();
-        self.after_applicable_declarations = SmallVec0::new();
     }
 }
 

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -130,10 +130,12 @@ impl ElementMapping {
 /// Data that layout associates with a node.
 pub struct PrivateLayoutData {
     /// The results of CSS styling for this node.
-    before_style: Option<Arc<ComputedValues>>,
-
     style: Option<Arc<ComputedValues>>,
 
+    /// The results of CSS styling for this node's `before` pseudo-element, if any.
+    before_style: Option<Arc<ComputedValues>>,
+
+    /// The results of CSS styling for this node's `after` pseudo-element, if any.
     after_style: Option<Arc<ComputedValues>>,
 
     /// Description of how to account for recent style changes.

--- a/src/components/style/common_types.rs
+++ b/src/components/style/common_types.rs
@@ -160,34 +160,125 @@ pub mod specified {
 }
 
 pub mod computed {
-    use cssparser;
     pub use CSSColor = cssparser::Color;
     pub use compute_CSSColor = super::super::longhands::computed_as_specified;
     use super::*;
-    use super::super::longhands;
+    use super::super::{longhands, style_structs};
+    use servo_util::cowarc::CowArc;
     pub use servo_util::geometry::Au;
 
     pub struct Context {
-        current_color: cssparser::RGBA,
-        parent_font_size: Au,
-        font_size: Au,
-        font_weight: longhands::font_weight::computed_value::T,
-        position: longhands::position::SpecifiedValue,
-        float: longhands::float::SpecifiedValue,
+        color: longhands::color::computed_value::T,
+        parent_font_weight: longhands::font_weight::computed_value::T,
+        parent_font_size: longhands::font_size::computed_value::T,
+        font_size: longhands::font_size::computed_value::T,
+        positioned: bool,
+        floated: bool,
+        border_top_present: bool,
+        border_right_present: bool,
+        border_bottom_present: bool,
+        border_left_present: bool,
         is_root_element: bool,
-        border_top_style: longhands::border_top_style::computed_value::T,
-        border_right_style: longhands::border_top_style::computed_value::T,
-        border_bottom_style: longhands::border_top_style::computed_value::T,
-        border_left_style: longhands::border_top_style::computed_value::T,
+        use_parent_font_size: bool,
         // TODO, as needed: root font size, viewport size, etc.
     }
 
+    fn border_is_present(border_style: longhands::border_top_style::computed_value::T) -> bool {
+        match border_style {
+            longhands::border_top_style::none | longhands::border_top_style::hidden => false,
+            _ => true,
+        }
+    }
+
+    impl Context {
+        #[inline]
+        pub fn new(color: &CowArc<style_structs::Color>,
+                   font: &CowArc<style_structs::Font>,
+                   css_box: &CowArc<style_structs::Box>,
+                   border: &CowArc<style_structs::Border>,
+                   is_root_element: bool)
+                   -> Context {
+            let mut context = Context {
+                color: color.get().color,
+                parent_font_weight: font.get().font_weight,
+                parent_font_size: font.get().font_size,
+                font_size: font.get().font_size,
+                positioned: false,
+                floated: false,
+                border_top_present: false,
+                border_right_present: false,
+                border_bottom_present: false,
+                border_left_present: false,
+                is_root_element: is_root_element,
+                use_parent_font_size: true,
+            };
+            context.set_position(css_box.get().position);
+            context.set_float(css_box.get().float);
+            context.set_border_top_style(border.get().border_top_style);
+            context.set_border_right_style(border.get().border_right_style);
+            context.set_border_bottom_style(border.get().border_bottom_style);
+            context.set_border_left_style(border.get().border_left_style);
+            context
+        }
+
+        pub fn set_color(&mut self, color: longhands::color::computed_value::T) {
+            self.color = color
+        }
+
+        pub fn set_position(&mut self, position: longhands::position::computed_value::T) {
+            self.positioned = match position {
+                longhands::position::absolute | longhands::position::fixed => true,
+                _ => false,
+            }
+        }
+
+        pub fn set_font_size(&mut self, font_size: longhands::font_size::computed_value::T) {
+            self.font_size = font_size
+        }
+
+        pub fn set_float(&mut self, float: longhands::float::computed_value::T) {
+            self.floated = float != longhands::float::none
+        }
+
+        pub fn set_border_top_style(&mut self,
+                                    style: longhands::border_top_style::computed_value::T) {
+            self.border_top_present = border_is_present(style)
+        }
+
+        pub fn set_border_right_style(&mut self,
+                                      style: longhands::border_top_style::computed_value::T) {
+            self.border_right_present = border_is_present(style)
+        }
+
+        pub fn set_border_bottom_style(&mut self,
+                                       style: longhands::border_top_style::computed_value::T) {
+            self.border_bottom_present = border_is_present(style)
+        }
+
+        pub fn set_border_left_style(&mut self,
+                                     style: longhands::border_top_style::computed_value::T) {
+            self.border_left_present = border_is_present(style)
+        }
+    }
+
     #[inline]
-    pub fn compute_Au(value: specified::Length, context: &Context, em_is_parent: bool) -> Au {
+    pub fn compute_Au(value: specified::Length, context: &Context) -> Au {
         match value {
             specified::Au_(value) => value,
-            specified::Em(value) if em_is_parent => context.parent_font_size.scale_by(value),
             specified::Em(value) => context.font_size.scale_by(value),
+            specified::Ex(value) => {
+                let x_height = 0.5;  // TODO: find that from the font
+                context.font_size.scale_by(value * x_height)
+            },
+        }
+    }
+
+    /// A special version of `compute_Au` used for `font-size`.
+    #[inline]
+    pub fn compute_Au_from_parent(value: specified::Length, context: &Context) -> Au {
+        match value {
+            specified::Au_(value) => value,
+            specified::Em(value) => context.parent_font_size.scale_by(value),
             specified::Ex(value) => {
                 let x_height = 0.5;  // TODO: find that from the font
                 context.font_size.scale_by(value * x_height)
@@ -203,7 +294,7 @@ pub mod computed {
     pub fn compute_LengthOrPercentage(value: specified::LengthOrPercentage, context: &Context)
                                    -> LengthOrPercentage {
         match value {
-            specified::LP_Length(value) => LP_Length(compute_Au(value, context, false)),
+            specified::LP_Length(value) => LP_Length(compute_Au(value, context)),
             specified::LP_Percentage(value) => LP_Percentage(value),
         }
     }
@@ -217,7 +308,7 @@ pub mod computed {
     pub fn compute_LengthOrPercentageOrAuto(value: specified::LengthOrPercentageOrAuto,
                                             context: &Context) -> LengthOrPercentageOrAuto {
         match value {
-            specified::LPA_Length(value) => LPA_Length(compute_Au(value, context, false)),
+            specified::LPA_Length(value) => LPA_Length(compute_Au(value, context)),
             specified::LPA_Percentage(value) => LPA_Percentage(value),
             specified::LPA_Auto => LPA_Auto,
         }
@@ -232,7 +323,7 @@ pub mod computed {
     pub fn compute_LengthOrPercentageOrNone(value: specified::LengthOrPercentageOrNone,
                                             context: &Context) -> LengthOrPercentageOrNone {
         match value {
-            specified::LPN_Length(value) => LPN_Length(compute_Au(value, context, false)),
+            specified::LPN_Length(value) => LPN_Length(compute_Au(value, context)),
             specified::LPN_Percentage(value) => LPN_Percentage(value),
             specified::LPN_None => LPN_None,
         }

--- a/src/components/style/common_types.rs
+++ b/src/components/style/common_types.rs
@@ -169,21 +169,24 @@ pub mod computed {
 
     pub struct Context {
         current_color: cssparser::RGBA,
+        parent_font_size: Au,
         font_size: Au,
         font_weight: longhands::font_weight::computed_value::T,
         position: longhands::position::SpecifiedValue,
         float: longhands::float::SpecifiedValue,
         is_root_element: bool,
-        has_border_top: bool,
-        has_border_right: bool,
-        has_border_bottom: bool,
-        has_border_left: bool,
+        border_top_style: longhands::border_top_style::computed_value::T,
+        border_right_style: longhands::border_top_style::computed_value::T,
+        border_bottom_style: longhands::border_top_style::computed_value::T,
+        border_left_style: longhands::border_top_style::computed_value::T,
         // TODO, as needed: root font size, viewport size, etc.
     }
 
-    pub fn compute_Au(value: specified::Length, context: &Context) -> Au {
+    #[inline]
+    pub fn compute_Au(value: specified::Length, context: &Context, em_is_parent: bool) -> Au {
         match value {
             specified::Au_(value) => value,
+            specified::Em(value) if em_is_parent => context.parent_font_size.scale_by(value),
             specified::Em(value) => context.font_size.scale_by(value),
             specified::Ex(value) => {
                 let x_height = 0.5;  // TODO: find that from the font
@@ -200,7 +203,7 @@ pub mod computed {
     pub fn compute_LengthOrPercentage(value: specified::LengthOrPercentage, context: &Context)
                                    -> LengthOrPercentage {
         match value {
-            specified::LP_Length(value) => LP_Length(compute_Au(value, context)),
+            specified::LP_Length(value) => LP_Length(compute_Au(value, context, false)),
             specified::LP_Percentage(value) => LP_Percentage(value),
         }
     }
@@ -214,7 +217,7 @@ pub mod computed {
     pub fn compute_LengthOrPercentageOrAuto(value: specified::LengthOrPercentageOrAuto,
                                             context: &Context) -> LengthOrPercentageOrAuto {
         match value {
-            specified::LPA_Length(value) => LPA_Length(compute_Au(value, context)),
+            specified::LPA_Length(value) => LPA_Length(compute_Au(value, context, false)),
             specified::LPA_Percentage(value) => LPA_Percentage(value),
             specified::LPA_Auto => LPA_Auto,
         }
@@ -229,7 +232,7 @@ pub mod computed {
     pub fn compute_LengthOrPercentageOrNone(value: specified::LengthOrPercentageOrNone,
                                             context: &Context) -> LengthOrPercentageOrNone {
         match value {
-            specified::LPN_Length(value) => LPN_Length(compute_Au(value, context)),
+            specified::LPN_Length(value) => LPN_Length(compute_Au(value, context, false)),
             specified::LPN_Percentage(value) => LPN_Percentage(value),
             specified::LPN_None => LPN_None,
         }

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -1122,6 +1122,7 @@ pub struct ComputedValues {
     % for style_struct in STYLE_STRUCTS:
         ${style_struct.name}: CowArc<style_structs::${style_struct.name}>,
     % endfor
+    shareable: bool,
 }
 
 impl ComputedValues {
@@ -1150,12 +1151,14 @@ pub fn initial_values() -> ComputedValues {
                 % endfor
             }),
         % endfor
+        shareable: true,
     }
 }
 
 /// Fast path for the function below. Only computes new inherited styles.
 #[allow(unused_mut)]
-fn cascade_with_cached_declarations(applicable_declarations: &[Arc<~[PropertyDeclaration]>],
+fn cascade_with_cached_declarations(applicable_declarations: &[MatchedProperty],
+                                    shareable: bool,
                                     parent_style: &ComputedValues,
                                     cached_style: &ComputedValues)
                                     -> ComputedValues {
@@ -1226,6 +1229,7 @@ fn cascade_with_cached_declarations(applicable_declarations: &[Arc<~[PropertyDec
         % for style_struct in STYLE_STRUCTS:
             ${style_struct.name}: style_${style_struct.name},
         % endfor
+        shareable: shareable,
     }
 }
 
@@ -1233,6 +1237,9 @@ fn cascade_with_cached_declarations(applicable_declarations: &[Arc<~[PropertyDec
 /// optionally a cached related style. The arguments are:
 ///
 ///   * `applicable_declarations`: The list of CSS rules that matched.
+///
+///   * `shareable`: Whether the `ComputedValues` structure to be constructed should be considered
+///     shareable.
 ///
 ///   * `parent_style`: The parent style, if applicable; if `None`, this is the root node.
 ///
@@ -1245,6 +1252,7 @@ fn cascade_with_cached_declarations(applicable_declarations: &[Arc<~[PropertyDec
 ///
 /// Returns the computed values and a boolean indicating whether the result is cacheable.
 pub fn cascade(applicable_declarations: &[MatchedProperty],
+               shareable: bool,
                parent_style: Option< &ComputedValues >,
                initial_values: &ComputedValues,
                cached_style: Option< &ComputedValues >)
@@ -1252,6 +1260,7 @@ pub fn cascade(applicable_declarations: &[MatchedProperty],
     match (cached_style, parent_style) {
         (Some(cached_style), Some(parent_style)) => {
             return (cascade_with_cached_declarations(applicable_declarations,
+                                                     shareable,
                                                      parent_style,
                                                      cached_style), false)
         }
@@ -1360,6 +1369,7 @@ pub fn cascade(applicable_declarations: &[MatchedProperty],
         % for style_struct in STYLE_STRUCTS:
             ${style_struct.name}: style_${style_struct.name},
         % endfor
+        shareable: shareable,
     }, cacheable)
 }
 

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -13,6 +13,7 @@ pub use cssparser::ast::*;
 use errors::{ErrorLoggerIterator, log_css_error};
 pub use parsing_utils::*;
 pub use self::common_types::*;
+use selector_matching::MatchedProperty;
 
 pub mod common_types;
 
@@ -1174,7 +1175,7 @@ fn cascade_with_cached_declarations(applicable_declarations: &[Arc<~[PropertyDec
 
     <%def name="apply_cached(priority)">
         for sub_list in applicable_declarations.iter() {
-            for declaration in sub_list.get().iter() {
+            for declaration in sub_list.declarations.get().iter() {
                 match declaration {
                     % for style_struct in STYLE_STRUCTS:
                         % if style_struct.inherited:
@@ -1243,7 +1244,7 @@ fn cascade_with_cached_declarations(applicable_declarations: &[Arc<~[PropertyDec
 ///     this is ignored.
 ///
 /// Returns the computed values and a boolean indicating whether the result is cacheable.
-pub fn cascade(applicable_declarations: &[Arc<~[PropertyDeclaration]>],
+pub fn cascade(applicable_declarations: &[MatchedProperty],
                parent_style: Option< &ComputedValues >,
                initial_values: &ComputedValues,
                cached_style: Option< &ComputedValues >)
@@ -1289,7 +1290,7 @@ pub fn cascade(applicable_declarations: &[Arc<~[PropertyDeclaration]>],
     let mut cacheable = true;
     <%def name="apply(needed_for_context)">
         for sub_list in applicable_declarations.iter() {
-            for declaration in sub_list.get().iter() {
+            for declaration in sub_list.declarations.get().iter() {
                 match declaration {
                     % for style_struct in STYLE_STRUCTS:
                         % for property in style_struct.longhands:

--- a/src/components/style/style.rs
+++ b/src/components/style/style.rs
@@ -19,6 +19,7 @@ extern mod servo_util = "util";
 // Public API
 pub use stylesheets::Stylesheet;
 pub use selector_matching::{Stylist, StylesheetOrigin, UserAgentOrigin, AuthorOrigin, UserOrigin};
+pub use selector_matching::{MatchedProperty};
 pub use properties::{cascade, PropertyDeclaration, ComputedValues, computed_values};
 pub use properties::{PropertyDeclarationBlock, parse_style_attribute};  // Style attributes
 pub use properties::{initial_values};

--- a/src/components/style/style.rs
+++ b/src/components/style/style.rs
@@ -21,6 +21,7 @@ pub use stylesheets::Stylesheet;
 pub use selector_matching::{Stylist, StylesheetOrigin, UserAgentOrigin, AuthorOrigin, UserOrigin};
 pub use properties::{cascade, PropertyDeclaration, ComputedValues, computed_values};
 pub use properties::{PropertyDeclarationBlock, parse_style_attribute};  // Style attributes
+pub use properties::{initial_values};
 pub use errors::with_errors_silenced;
 pub use node::{TElement, TNode};
 pub use selectors::{PseudoElement, Before, After, AttrSelector, SpecificNamespace, AnyNamespace};

--- a/src/components/util/cache.rs
+++ b/src/components/util/cache.rs
@@ -128,6 +128,7 @@ impl<K: Clone + Eq, V: Clone> LRUCache<K,V> {
         }
     }
 
+    #[inline]
     pub fn touch(&mut self, pos: uint) -> V {
         let last_index = self.entries.len() - 1;
         if pos != last_index {
@@ -135,6 +136,10 @@ impl<K: Clone + Eq, V: Clone> LRUCache<K,V> {
             self.entries.push(entry);
         }
         self.entries[last_index].second_ref().clone()
+    }
+
+    pub fn iter<'a>(&'a self) -> VecIterator<'a,(K,V)> {
+        self.entries.iter()
     }
 }
 

--- a/src/components/util/cowarc.rs
+++ b/src/components/util/cowarc.rs
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! An atomically reference counted type that copies itself on mutation.
+
+use std::cast;
+use std::ptr;
+use std::sync::atomics::{AtomicUint, SeqCst};
+
+struct CowArcAlloc<T> {
+    ref_count: AtomicUint,
+    data: T,
+}
+
+#[unsafe_no_drop_flag]
+pub struct CowArc<T> {
+    priv ptr: *mut CowArcAlloc<T>,
+}
+
+#[unsafe_destructor]
+impl<T> Drop for CowArc<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            if self.ptr != ptr::mut_null() && (*self.ptr).ref_count.fetch_sub(1, SeqCst) == 1 {
+                let _kill_it: ~CowArcAlloc<T> = cast::transmute(self.ptr);
+                self.ptr = ptr::mut_null()
+            }
+        }
+    }
+}
+
+impl<T:Eq + Freeze + Clone> Eq for CowArc<T> {
+    fn eq(&self, other: &CowArc<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<T:Freeze + Clone> Clone for CowArc<T> {
+    #[inline]
+    fn clone(&self) -> CowArc<T> {
+        unsafe {
+            drop((*self.ptr).ref_count.fetch_add(1, SeqCst));
+        }
+        CowArc {
+            ptr: self.ptr
+        }
+    }
+}
+
+impl<T:Freeze + Clone> CowArc<T> {
+    #[inline]
+    pub fn new(value: T) -> CowArc<T> {
+        let alloc = ~CowArcAlloc {
+            ref_count: AtomicUint::new(1),
+            data: value,
+        };
+        unsafe {
+            CowArc {
+                ptr: cast::transmute(alloc),
+            }
+        }
+    }
+
+    #[inline]
+    pub fn shared(&self) -> bool {
+        unsafe {
+            (*self.ptr).ref_count.load(SeqCst) != 1
+        }
+    }
+
+    #[inline]
+    pub fn get<'a>(&'a self) -> &'a T {
+        unsafe {
+            cast::transmute(&(*self.ptr).data)
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_mut<'a>(&'a mut self) -> &'a mut T {
+        unsafe {
+            if (*self.ptr).ref_count.load(SeqCst) == 1 {
+                return cast::transmute(&mut (*self.ptr).data)
+            }
+
+            let copy = ~CowArcAlloc {
+                ref_count: AtomicUint::new(1),
+                data: (*self.ptr).data.clone(),
+            };
+
+            *self = CowArc {
+                ptr: cast::transmute(copy),
+            };
+
+            cast::transmute(&mut (*self.ptr).data)
+        }
+    }
+}
+

--- a/src/components/util/smallvec.rs
+++ b/src/components/util/smallvec.rs
@@ -324,6 +324,20 @@ macro_rules! def_small_vector_drop_impl(
     )
 )
 
+macro_rules! def_small_vector_clone_impl(
+    ($name:ident) => (
+        impl<T:Clone> Clone for $name<T> {
+            fn clone(&self) -> $name<T> {
+                let mut new_vector = $name::new();
+                for element in self.iter() {
+                    new_vector.push((*element).clone())
+                }
+                new_vector
+            }
+        }
+    )
+)
+
 macro_rules! def_small_vector_impl(
     ($name:ident, $size:expr) => (
         impl<T> $name<T> {
@@ -396,47 +410,55 @@ impl<T> SmallVec0<T> {
 }
 
 def_small_vector_drop_impl!(SmallVec0, 0)
+def_small_vector_clone_impl!(SmallVec0)
 
 def_small_vector!(SmallVec1, 1)
 def_small_vector_private_trait_impl!(SmallVec1, 1)
 def_small_vector_trait_impl!(SmallVec1, 1)
 def_small_vector_drop_impl!(SmallVec1, 1)
+def_small_vector_clone_impl!(SmallVec1)
 def_small_vector_impl!(SmallVec1, 1)
 
 def_small_vector!(SmallVec2, 2)
 def_small_vector_private_trait_impl!(SmallVec2, 2)
 def_small_vector_trait_impl!(SmallVec2, 2)
 def_small_vector_drop_impl!(SmallVec2, 2)
+def_small_vector_clone_impl!(SmallVec2)
 def_small_vector_impl!(SmallVec2, 2)
 
 def_small_vector!(SmallVec4, 4)
 def_small_vector_private_trait_impl!(SmallVec4, 4)
 def_small_vector_trait_impl!(SmallVec4, 4)
 def_small_vector_drop_impl!(SmallVec4, 4)
+def_small_vector_clone_impl!(SmallVec4)
 def_small_vector_impl!(SmallVec4, 4)
 
 def_small_vector!(SmallVec8, 8)
 def_small_vector_private_trait_impl!(SmallVec8, 8)
 def_small_vector_trait_impl!(SmallVec8, 8)
 def_small_vector_drop_impl!(SmallVec8, 8)
+def_small_vector_clone_impl!(SmallVec8)
 def_small_vector_impl!(SmallVec8, 8)
 
 def_small_vector!(SmallVec16, 16)
 def_small_vector_private_trait_impl!(SmallVec16, 16)
 def_small_vector_trait_impl!(SmallVec16, 16)
 def_small_vector_drop_impl!(SmallVec16, 16)
+def_small_vector_clone_impl!(SmallVec16)
 def_small_vector_impl!(SmallVec16, 16)
 
 def_small_vector!(SmallVec24, 24)
 def_small_vector_private_trait_impl!(SmallVec24, 24)
 def_small_vector_trait_impl!(SmallVec24, 24)
 def_small_vector_drop_impl!(SmallVec24, 24)
+def_small_vector_clone_impl!(SmallVec24)
 def_small_vector_impl!(SmallVec24, 24)
 
 def_small_vector!(SmallVec32, 32)
 def_small_vector_private_trait_impl!(SmallVec32, 32)
 def_small_vector_trait_impl!(SmallVec32, 32)
 def_small_vector_drop_impl!(SmallVec32, 32)
+def_small_vector_clone_impl!(SmallVec32)
 def_small_vector_impl!(SmallVec32, 32)
 
 #[cfg(test)]

--- a/src/components/util/util.rs
+++ b/src/components/util/util.rs
@@ -13,6 +13,7 @@ extern mod native;
 
 pub mod cache;
 pub mod concurrentmap;
+pub mod cowarc;
 pub mod debug;
 pub mod geometry;
 pub mod io;


### PR DESCRIPTION
This series of patches implements style struct sharing as found in existing browser engines, as well as a bunch of related important optimizations. With them, we are faster than Blink, WebKit, and Gecko on the rainbow page for style recalc in sequential mode by at least 15%. Parallel gains are mixed—the rainbow page turns out to be a degenerate sequential case for the LRU cache used to track candidates for style sharing and so there is no improvement. For cases in which the cache is not hit, such as `perf-rainbow-hard.html`, we are around 25% slower than Blink sequentially, but have very large parallel wins so that we are around 2x faster at style recalc. (Note that parallel flow tree construction will improve this further.)

This patch series also fixes, as near as I can tell, some bugs related to ordering of properties that other properties depend on in selector matching.

r? @larsbergstrom
feedback? @SimonSapin (for selector matching changes)
feedback? @bzbarsky (for style sharing heuristics)
