### PR TITLE
Fix #1652: Attribute selectors should default to the null namespace

### DIFF
--- a/src/test/ref/attr_exists_selector.html
+++ b/src/test/ref/attr_exists_selector.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Attribute exists selector: [foo]</title>
+    <style>
+      p[data-green] { color: green }
+    </style>
+  </head>
+  <body>
+    <p data-green="">This text should be green.</p>
+    <p>This text should be black.</p>
+  </body>
+</html>

--- a/src/test/ref/attr_exists_selector_ref.html
+++ b/src/test/ref/attr_exists_selector_ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Attribute exists selector: [foo] (reference)</title>
+  </head>
+  <body>
+    <p style="color: green">This text should be green.</p>
+    <p>This text should be black.</p>
+  </body>
+</html>

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -27,3 +27,4 @@
 # inline_border_a.html inline_border_b.html
 == anon_block_inherit_a.html anon_block_inherit_b.html
 == position_relative_a.html position_relative_b.html
+== attr_exists_selector.html attr_exists_selector_ref.html


### PR DESCRIPTION
… and not "any namespace" or use the default namespace declaration.
