### PR TITLE
Adding most commonly used parts of window.console. 

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -136,6 +136,9 @@ DOMInterfaces = {
     'nativeType': 'ClientRectList',
 }],
 
+'Console': {
+},
+
 'CSS2Properties': {
   'nativeType': 'nsDOMCSSDeclaration',
   'prefable': True,

--- a/src/components/script/dom/console.rs
+++ b/src/components/script/dom/console.rs
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{DOMString};
+use dom::bindings::codegen::ConsoleBinding;
+use dom::window::Window;
+
+pub struct Console {
+    reflector_: Reflector
+}
+
+impl Console {
+    pub fn new_inherited() -> Console {
+        Console {
+            reflector_: Reflector::new()
+        }
+    }
+
+    pub fn new(window: &Window) -> @mut Console {
+        reflect_dom_object(@mut Console::new_inherited(), window, ConsoleBinding::Wrap)
+    }
+
+    pub fn Log(&self, message: DOMString) {
+        println!("{:s}", message);
+    }
+
+    pub fn Debug(&self, message: DOMString) {
+        println!("{:s}", message);
+    }
+
+    pub fn Info(&self, message: DOMString) {
+        println!("{:s}", message);
+    }
+
+    pub fn Warn(&self, message: DOMString) {
+        println!("{:s}", message);
+    }
+
+    pub fn Error(&self, message: DOMString) {
+        println!("{:s}", message);
+    }
+}
+
+impl Reflectable for Console {
+    fn reflector<'a>(&'a self) -> &'a Reflector {
+        &self.reflector_
+    }
+
+    fn mut_reflector<'a>(&'a mut self) -> &'a mut Reflector {
+        &mut self.reflector_
+    }
+}

--- a/src/components/script/dom/webidls/Console.webidl
+++ b/src/components/script/dom/webidls/Console.webidl
@@ -1,0 +1,20 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * References:
+ *   MDN Docs - https://developer.mozilla.org/en-US/docs/Web/API/console
+ *   Draft Spec - http://sideshowbarker.github.io/console-spec/
+ *
+ * © Copyright 2014 Mozilla Foundation.
+ */
+
+interface Console {
+  // These should be DOMString message, DOMString message2, ...
+  void log(DOMString message);
+  void debug(DOMString message);
+  void info(DOMString message);
+  void warn(DOMString message);
+  void error(DOMString message);
+};

--- a/src/components/script/dom/webidls/Window.webidl
+++ b/src/components/script/dom/webidls/Window.webidl
@@ -55,6 +55,13 @@
 
 
 };
+
+// Not part of any spec
+partial interface Window {
+  // web developer niceties
+  readonly attribute Console console;
+};
+
 /*Window implements GlobalEventHandlers;
   Window implements WindowEventHandlers;*/
 

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -9,6 +9,7 @@ use dom::bindings::utils::DOMString;
 use dom::document::AbstractDocument;
 use dom::eventtarget::{EventTarget, WindowTypeId};
 use dom::node::AbstractNode;
+use dom::console::Console;
 use dom::location::Location;
 use dom::navigator::Navigator;
 
@@ -65,6 +66,7 @@ pub struct Window {
     page: @mut Page,
     script_chan: ScriptChan,
     compositor: @ScriptListener,
+    console: Option<@mut Console>,
     timer_chan: SharedChan<TimerControlMsg>,
     location: Option<@mut Location>,
     navigator: Option<@mut Navigator>,
@@ -148,6 +150,13 @@ impl Window {
             self.location = Some(Location::new(self, self.page));
         }
         self.location.unwrap()
+    }
+
+    pub fn Console(&mut self) -> @mut Console {
+        if self.console.is_none() {
+            self.console = Some(Console::new(self));
+        }
+        self.console.unwrap()
     }
 
     pub fn Navigator(&mut self) -> @mut Navigator {
@@ -246,6 +255,7 @@ impl Window {
             page: page,
             script_chan: script_chan.clone(),
             compositor: compositor,
+            console: None,
             timer_chan: {
                 let (timer_port, timer_chan): (Port<TimerControlMsg>, SharedChan<TimerControlMsg>) = SharedChan::new();
                 let id = page.id.clone();

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -52,6 +52,7 @@ pub mod dom {
     pub mod clientrect;
     pub mod clientrectlist;
     pub mod comment;
+    pub mod console;
     pub mod document;
     pub mod documentfragment;
     pub mod documenttype;

--- a/src/test/html/test-js-console.html
+++ b/src/test/html/test-js-console.html
@@ -1,0 +1,7 @@
+<script>
+console.log('many webdevs');
+console.info('put informative');
+console.warn('or worrysome', 'or many');
+console.error('or even errors');
+console.debug('into the debug statements into their JS');
+</script>


### PR DESCRIPTION
Here is an attempt to fix Issue#506.

I couldn't figure out how to do variadic arguments to `console.log`, but I did test calling `console.log('foo', 'bar', 'baz')` and it prints the first argument and doesn't error out, which is nice.

window.console is not a web standards. I did the popular functions, but not some of the newer ones documented [on MDN](https://developer.mozilla.org/en-US/docs/Web/API/console).

This PR will allow more pages to load properly, where developers have left in window.console calls.
