### PR TITLE
Implement vtables for DOM nodes.

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -36,7 +36,6 @@ use hubbub::hubbub::{QuirksMode, NoQuirks, LimitedQuirks, FullQuirks};
 use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage};
 use servo_util::namespace::Null;
 use servo_util::str::DOMString;
-use servo_util::url::parse_url;
 
 use extra::url::{Url, from_str};
 use js::jsapi::{JSObject, JSContext};
@@ -481,7 +480,6 @@ impl Document {
         self.window.get().wait_until_safe_to_modify_dom();
     }
 
-
     /// Remove any existing association between the provided id and any elements in this document.
     pub fn unregister_named_element(&mut self,
                                     id: DOMString) {
@@ -508,12 +506,8 @@ impl Document {
                           });
     }
 
+    /// Commence a new URL load which could replace this document.
     pub fn load_anchor_href(&self, href: DOMString) {
-        let page = self.window.get().page;
-        let base_url = page.url.as_ref().map(|&(ref url, _)| url.clone());
-        debug!("current page url is {:?}", base_url);
-        let url = parse_url(href, base_url);
-        let click_frag = href.starts_with("#");
-        self.window.get().load_url(url, click_frag);
+        self.window.get().load_url(href);
     }
 }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -36,6 +36,7 @@ use hubbub::hubbub::{QuirksMode, NoQuirks, LimitedQuirks, FullQuirks};
 use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage};
 use servo_util::namespace::Null;
 use servo_util::str::DOMString;
+use servo_util::url::parse_url;
 
 use extra::url::{Url, from_str};
 use js::jsapi::{JSObject, JSContext};
@@ -505,5 +506,14 @@ impl Document {
                           |_, old_element: &mut JS<Element>, new_element: &JS<Element>| {
                               *old_element = new_element.clone();
                           });
+    }
+
+    pub fn load_anchor_href(&self, href: DOMString) {
+        let page = self.window.get().page;
+        let base_url = page.url.as_ref().map(|&(ref url, _)| url.clone());
+        debug!("current page url is {:?}", base_url);
+        let url = parse_url(href, base_url);
+        let click_frag = href.starts_with("#");
+        self.window.get().load_url(url, click_frag);
     }
 }

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -6,7 +6,7 @@
 
 use dom::attr::Attr;
 use dom::attrlist::AttrList;
-use dom::bindings::codegen::InheritTypes::{ElementDerived, NodeCast};
+use dom::bindings::codegen::InheritTypes::{ElementDerived, NodeCast, ElementCast};
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::bindings::utils::{ErrorResult, Fallible, NamespaceError, InvalidCharacter};
@@ -672,5 +672,17 @@ impl VirtualMethods for Element {
     fn before_remove_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
         self.super_type().map(|s| s.before_remove_attr(abstract_self, name.clone(), value.clone()));
         self.before_remove_attribute(abstract_self, name, value);
+    }
+
+    fn bind_to_tree(&mut self, abstract_self: &JS<Node>) {
+        self.super_type().map(|s| s.bind_to_tree(abstract_self));
+        let element: JS<Element> = ElementCast::to(abstract_self);
+        element.bind_to_tree_impl();
+    }
+
+    fn unbind_from_tree(&mut self, abstract_self: &JS<Node>) {
+        self.super_type().map(|s| s.unbind_from_tree(abstract_self));
+        let element: JS<Element> = ElementCast::to(abstract_self);
+        element.unbind_from_tree_impl();
     }
 }

--- a/src/components/script/dom/eventtarget.rs
+++ b/src/components/script/dom/eventtarget.rs
@@ -9,6 +9,7 @@ use dom::bindings::codegen::EventListenerBinding::EventListener;
 use dom::event::Event;
 use dom::eventdispatcher::dispatch_event;
 use dom::node::NodeTypeId;
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 use std::hashmap::HashMap;
@@ -121,5 +122,11 @@ impl Reflectable for EventTarget {
 
     fn mut_reflector<'a>(&'a mut self) -> &'a mut Reflector {
         &mut self.reflector_
+    }
+}
+
+impl VirtualMethods for EventTarget {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods> {
+        None
     }
 }

--- a/src/components/script/dom/htmlelement.rs
+++ b/src/components/script/dom/htmlelement.rs
@@ -10,6 +10,7 @@ use dom::document::Document;
 use dom::element::{Element, ElementTypeId, HTMLElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::node::{Node, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use js::jsapi::{JSContext, JSVal};
 use js::JSVAL_NULL;
 use servo_util::namespace;
@@ -165,5 +166,11 @@ impl HTMLElement {
 
     pub fn OffsetHeight(&self) -> i32 {
         0
+    }
+}
+
+impl VirtualMethods for HTMLElement {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods> {
+        Some(&mut self.element as &mut VirtualMethods)
     }
 }

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLIFrameElementDerived
 use dom::bindings::js::JS;
 use dom::bindings::utils::ErrorResult;
 use dom::document::Document;
-use dom::element::HTMLIframeElementTypeId;
+use dom::element::{Element, HTMLIframeElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId};
@@ -237,13 +237,13 @@ impl VirtualMethods for HTMLIFrameElement {
         Some(&mut self.htmlelement as &mut VirtualMethods)
     }
 
-    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
-        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+    fn after_set_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(abstract_self, name.clone(), value.clone()));
         self.AfterSetAttr(name, value);
     }
 
-    fn before_remove_attr(&mut self, name: DOMString) {
-        self.super_type().map(|s| s.before_remove_attr(name.clone()));
+    fn before_remove_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.before_remove_attr(abstract_self, name.clone(), value.clone()));
         self.BeforeRemoveAttr(name);
     }
 }

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -11,6 +11,7 @@ use dom::element::HTMLIframeElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use dom::windowproxy::WindowProxy;
 use servo_util::str::DOMString;
 
@@ -228,5 +229,21 @@ impl HTMLIFrameElement {
 
     pub fn GetSVGDocument(&self) -> Option<JS<Document>> {
         None
+    }
+}
+
+impl VirtualMethods for HTMLIFrameElement {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods> {
+        Some(&mut self.htmlelement as &mut VirtualMethods)
+    }
+
+    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+        self.AfterSetAttr(name, value);
+    }
+
+    fn before_remove_attr(&mut self, name: DOMString) {
+        self.super_type().map(|s| s.before_remove_attr(name.clone()));
+        self.BeforeRemoveAttr(name);
     }
 }

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -251,13 +251,13 @@ impl VirtualMethods for HTMLImageElement {
         Some(&mut self.htmlelement as &mut VirtualMethods)
     }
 
-    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
-        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+    fn after_set_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(abstract_self, name.clone(), value.clone()));
         self.AfterSetAttr(name, value);
     }
 
-    fn before_remove_attr(&mut self, name: DOMString) {
-        self.super_type().map(|s| s.before_remove_attr(name.clone()));
+    fn before_remove_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.before_remove_attr(abstract_self, name.clone(), value.clone()));
         self.BeforeRemoveAttr(name);
     }
 }

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -12,6 +12,7 @@ use dom::element::{Element, HTMLImageElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId, NodeHelpers};
+use dom::virtualmethods::VirtualMethods;
 use extra::url::Url;
 use servo_util::geometry::to_px;
 use layout_interface::{ContentBoxQuery, ContentBoxResponse};
@@ -242,5 +243,21 @@ impl HTMLImageElement {
 
     pub fn SetBorder(&mut self, _border: DOMString) -> ErrorResult {
         Ok(())
+    }
+}
+
+impl VirtualMethods for HTMLImageElement {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods> {
+        Some(&mut self.htmlelement as &mut VirtualMethods)
+    }
+
+    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+        self.AfterSetAttr(name, value);
+    }
+
+    fn before_remove_attr(&mut self, name: DOMString) {
+        self.super_type().map(|s| s.before_remove_attr(name.clone()));
+        self.BeforeRemoveAttr(name);
     }
 }

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::InheritTypes::HTMLObjectElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::utils::ErrorResult;
 use dom::document::Document;
-use dom::element::HTMLObjectElementTypeId;
+use dom::element::{Element, HTMLObjectElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::htmlformelement::HTMLFormElement;
@@ -252,8 +252,8 @@ impl VirtualMethods for HTMLObjectElement {
         Some(&mut self.htmlelement as &mut VirtualMethods)
     }
 
-    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
-        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+    fn after_set_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(abstract_self, name.clone(), value.clone()));
         self.AfterSetAttr(name, value);
     }
 }

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -13,6 +13,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlformelement::HTMLFormElement;
 use dom::node::{Node, ElementNodeTypeId};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
 use dom::windowproxy::WindowProxy;
 use servo_util::str::DOMString;
 
@@ -243,5 +244,16 @@ impl HTMLObjectElement {
 
     pub fn GetSVGDocument(&self) -> Option<JS<Document>> {
         None
+    }
+}
+
+impl VirtualMethods for HTMLObjectElement {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods> {
+        Some(&mut self.htmlelement as &mut VirtualMethods)
+    }
+
+    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+        self.AfterSetAttr(name, value);
     }
 }

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -17,8 +17,9 @@ use dom::documenttype::DocumentType;
 use dom::element::{Element, ElementTypeId, HTMLAnchorElementTypeId, IElement};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::nodelist::{NodeList};
-use dom::text::Text;
 use dom::processinginstruction::ProcessingInstruction;
+use dom::text::Text;
+use dom::virtualmethods::VirtualMethods;
 use layout_interface::{LayoutChan, ReapLayoutDataMsg, UntrustedNodeAddress};
 use layout_interface::TrustedNodeAddress;
 use servo_util::str::{DOMString, null_str_as_empty};
@@ -1602,3 +1603,8 @@ impl Reflectable for Node {
     }
 }
 
+impl VirtualMethods for Node {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods> {
+        Some(&mut self.eventtarget as &mut VirtualMethods)
+    }
+}

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -14,12 +14,12 @@ use dom::bindings::utils;
 use dom::characterdata::CharacterData;
 use dom::document::Document;
 use dom::documenttype::DocumentType;
-use dom::element::{Element, ElementTypeId, HTMLAnchorElementTypeId, IElement};
+use dom::element::{Element, ElementTypeId, HTMLAnchorElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::nodelist::{NodeList};
 use dom::processinginstruction::ProcessingInstruction;
 use dom::text::Text;
-use dom::virtualmethods::VirtualMethods;
+use dom::virtualmethods::{VirtualMethods, vtable_for};
 use layout_interface::{LayoutChan, ReapLayoutDataMsg, UntrustedNodeAddress};
 use layout_interface::TrustedNodeAddress;
 use servo_util::str::{DOMString, null_str_as_empty};
@@ -400,10 +400,9 @@ impl NodeHelpers for JS<Node> {
         let document = self.get().owner_doc();
 
         for node in self.traverse_preorder() {
-            if node.is_element() {
-                let element: JS<Element> = ElementCast::to(&node);
-                element.bind_to_tree_impl();
-            }
+            let mut mut_node = node.clone();
+            let vtable = vtable_for(&mut mut_node);
+            vtable.bind_to_tree(&node.clone());
         }
 
         document.get().content_changed();
@@ -415,10 +414,9 @@ impl NodeHelpers for JS<Node> {
         let document = self.get().owner_doc();
 
         for node in self.traverse_preorder() {
-            if node.is_element() {
-                let element: JS<Element> = ElementCast::to(&node);
-                element.unbind_from_tree_impl();
-            }
+            let mut mut_node = node.clone();
+            let vtable = vtable_for(&mut mut_node);
+            vtable.unbind_from_tree(&node);
         }
 
         document.get().content_changed();

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::InheritTypes::HTMLElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
+use dom::bindings::js::JS;
+use dom::element::{HTMLImageElementTypeId, HTMLIframeElementTypeId, HTMLObjectElementTypeId};
+use dom::htmlelement::HTMLElement;
+use dom::htmliframeelement::HTMLIFrameElement;
+use dom::htmlimageelement::HTMLImageElement;
+use dom::htmlobjectelement::HTMLObjectElement;
+use dom::node::{Node, ElementNodeTypeId};
+use servo_util::str::DOMString;
+
+use std::cast;
+
+pub trait VirtualMethods {
+    fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods>;
+
+    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
+        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+    }
+
+    fn before_remove_attr(&mut self, name: DOMString) {
+        self.super_type().map(|s| s.before_remove_attr(name.clone()));
+    }
+}
+
+pub fn vtable_for<'a>(node: &'a mut JS<Node>) -> &'a mut VirtualMethods {
+    unsafe {
+        match node.get().type_id {
+            ElementNodeTypeId(HTMLImageElementTypeId) => {
+                let mut elem: JS<HTMLImageElement> = HTMLImageElementCast::to(node);
+                cast::transmute_mut_region(elem.get_mut()) as &mut VirtualMethods
+            }
+            ElementNodeTypeId(HTMLIframeElementTypeId) => {
+                let mut elem: JS<HTMLIFrameElement> = HTMLIFrameElementCast::to(node);
+                cast::transmute_mut_region(elem.get_mut()) as &mut VirtualMethods
+            }
+            ElementNodeTypeId(HTMLObjectElementTypeId) => {
+                let mut elem: JS<HTMLObjectElement> = HTMLObjectElementCast::to(node);
+                cast::transmute_mut_region(elem.get_mut()) as &mut VirtualMethods
+            }
+            ElementNodeTypeId(_) => {
+                let mut elem: JS<HTMLElement> = HTMLElementCast::to(node);
+                cast::transmute_mut_region(elem.get_mut()) as &mut VirtualMethods
+            }
+            _ => {
+                cast::transmute_mut_region(node.get_mut()) as &mut VirtualMethods
+            }
+        }
+    }
+}

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -22,9 +22,12 @@ use servo_util::str::DOMString;
 
 use std::cast;
 
+/// Trait to allow DOM nodes to opt-in to overriding (or adding to) common behaviours.
+/// Replicates the effect of C++ virtual methods.
 pub trait VirtualMethods {
     fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods>;
 
+    /// Called when changing or adding attributes, after the attribute's value has been updated.
     fn after_set_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
         let s = self.super_type();
         if s.is_some() {
@@ -32,6 +35,7 @@ pub trait VirtualMethods {
         }
     }
 
+    /// Called when changing or removing attributes, before any modification has taken place.
     fn before_remove_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
         let s = self.super_type();
         if s.is_some() {
@@ -39,6 +43,7 @@ pub trait VirtualMethods {
         }
     }
 
+    /// Called when a Node is appended to a tree that is part of a Document.
     fn bind_to_tree(&mut self, abstract_self: &JS<Node>) {
         let s = self.super_type();
         if s.is_some() {
@@ -46,6 +51,7 @@ pub trait VirtualMethods {
         }
     }
 
+    /// Called when a Node is removed from a tree that is part of a Document.
     fn unbind_from_tree(&mut self, abstract_self: &JS<Node>) {
         let s = self.super_type();
         if s.is_some() {
@@ -53,6 +59,7 @@ pub trait VirtualMethods {
         }
    }
 
+    /// Called during event dispatch after the bubbling phase completes.
     fn handle_event(&mut self, abstract_self: &JS<Node>, event: &JS<Event>) {
         let s = self.super_type();
         if s.is_some() {
@@ -61,6 +68,9 @@ pub trait VirtualMethods {
     }
 }
 
+/// Obtain a VirtualMethods instance for a given Node-derived object. Any method call
+/// on the trait object will invoke the corresponding method on the concrete type,
+/// propagating up the parent hierarchy unless otherwise interrupted.
 pub fn vtable_for<'a>(node: &'a mut JS<Node>) -> &'a mut VirtualMethods {
     unsafe {
         match node.get().type_id {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -7,6 +7,7 @@ use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::js::JS;
+use dom::element::Element;
 use dom::element::{HTMLImageElementTypeId, HTMLIframeElementTypeId, HTMLObjectElementTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::htmliframeelement::HTMLIFrameElement;
@@ -20,12 +21,18 @@ use std::cast;
 pub trait VirtualMethods {
     fn super_type<'a>(&'a mut self) -> Option<&'a mut VirtualMethods>;
 
-    fn after_set_attr(&mut self, name: DOMString, value: DOMString) {
-        self.super_type().map(|s| s.after_set_attr(name.clone(), value.clone()));
+    fn after_set_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        let s = self.super_type();
+        if s.is_some() {
+            s.unwrap().after_set_attr(abstract_self, name, value);
+        }
     }
 
-    fn before_remove_attr(&mut self, name: DOMString) {
-        self.super_type().map(|s| s.before_remove_attr(name.clone()));
+    fn before_remove_attr(&mut self, abstract_self: &JS<Element>, name: DOMString, value: DOMString) {
+        let s = self.super_type();
+        if s.is_some() {
+            s.unwrap().before_remove_attr(abstract_self, name, value);
+        }
     }
 }
 

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::js::JS;
 use dom::element::Element;
-use dom::element::{HTMLImageElementTypeId, HTMLIframeElementTypeId, HTMLObjectElementTypeId};
+use dom::element::{HTMLAnchorElementTypeId, HTMLImageElementTypeId};
+use dom::element::{HTMLIframeElementTypeId, HTMLObjectElementTypeId};
+use dom::event::Event;
+use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlelement::HTMLElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
@@ -47,12 +51,23 @@ pub trait VirtualMethods {
         if s.is_some() {
             s.unwrap().unbind_from_tree(abstract_self);
         }
+   }
+
+    fn handle_event(&mut self, abstract_self: &JS<Node>, event: &JS<Event>) {
+        let s = self.super_type();
+        if s.is_some() {
+            s.unwrap().handle_event(abstract_self, event);
+        }
     }
 }
 
 pub fn vtable_for<'a>(node: &'a mut JS<Node>) -> &'a mut VirtualMethods {
     unsafe {
         match node.get().type_id {
+            ElementNodeTypeId(HTMLAnchorElementTypeId) => {
+                let mut elem: JS<HTMLAnchorElement> = HTMLAnchorElementCast::to(node);
+                cast::transmute_mut_region(elem.get_mut()) as &mut VirtualMethods
+            }
             ElementNodeTypeId(HTMLImageElementTypeId) => {
                 let mut elem: JS<HTMLImageElement> = HTMLImageElementCast::to(node);
                 cast::transmute_mut_region(elem.get_mut()) as &mut VirtualMethods

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -34,6 +34,20 @@ pub trait VirtualMethods {
             s.unwrap().before_remove_attr(abstract_self, name, value);
         }
     }
+
+    fn bind_to_tree(&mut self, abstract_self: &JS<Node>) {
+        let s = self.super_type();
+        if s.is_some() {
+            s.unwrap().bind_to_tree(abstract_self);
+        }
+    }
+
+    fn unbind_from_tree(&mut self, abstract_self: &JS<Node>) {
+        let s = self.super_type();
+        if s.is_some() {
+            s.unwrap().unbind_from_tree(abstract_self);
+        }
+    }
 }
 
 pub fn vtable_for<'a>(node: &'a mut JS<Node>) -> &'a mut VirtualMethods {

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -13,7 +13,8 @@ use dom::location::Location;
 use dom::navigator::Navigator;
 
 use layout_interface::{ReflowForDisplay, DocumentDamageLevel};
-use script_task::{ExitWindowMsg, FireTimerMsg, Page, ScriptChan};
+use script_task::{ExitWindowMsg, FireTimerMsg, Page, ScriptChan, TriggerLoadMsg};
+use script_task::TriggerFragmentMsg;
 use servo_msg::compositor_msg::ScriptListener;
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_util::str::DOMString;
@@ -33,6 +34,7 @@ use std::ptr;
 use std::to_bytes::Cb;
 
 use extra::serialize::{Encoder, Encodable};
+use extra::url::Url;
 
 pub enum TimerControlMsg {
     TimerMessage_Fire(~TimerData),
@@ -259,6 +261,14 @@ impl Window {
         // FIXME: This disables concurrent layout while we are modifying the DOM, since
         //        our current architecture is entirely unsafe in the presence of races.
         self.page.join_layout();
+    }
+
+    pub fn load_url(&self, url: Url, fragment: bool) {
+        if fragment {
+            self.script_chan.send(TriggerFragmentMsg(self.page.id, url));
+        } else {
+            self.script_chan.send(TriggerLoadMsg(self.page.id, url));
+        }
     }
 
     pub fn new(cx: *JSContext,

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -148,6 +148,7 @@ pub mod dom {
     pub mod uievent;
     pub mod text;
     pub mod validitystate;
+    pub mod virtualmethods;
     pub mod window;
     pub mod windowproxy;
 }

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -351,6 +351,7 @@ impl Page {
         }
     }
 
+    /// Attempt to find a named element in this page's document.
     fn find_fragment_node(&self, fragid: ~str) -> Option<JS<Element>> {
         let document = self.frame.get_ref().document.clone();
         match document.get().GetElementById(fragid.to_owned()) {

--- a/src/test/html/content/test_click_prevent.html
+++ b/src/test/html/content/test_click_prevent.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+<script src="harness.js"></script>
+<a id="foo" href="/nonexistent">test link</a>
+<script>
+var link = document.getElementById('foo');
+link.addEventListener('click', function(ev) {
+  ev.preventDefault();
+});
+var ev = new Event('click', {bubbles: true, cancelable: true});
+link.dispatchEvent(ev);
+setTimeout(function() {
+  is(true, true, "load probably would have occurred by now");
+  finish();
+}, 500);
+</script>
+</head>
+</html>


### PR DESCRIPTION
In addition, this adds extremely basic click event default action support, cleans up the named element registration code, and creates the basis for allowing elements to perform actions when attaching to or detaching from a document tree. Fixes #1527. Works towards #1528, but that shouldn't be closed until we actually fulfil the rules of the spec for implementing default actions.
