### PR TITLE
Remove leaf sets

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -71,7 +71,7 @@ impl BlockFlow {
     pub fn from_node(constructor: &mut FlowConstructor, node: &ThreadSafeLayoutNode, is_fixed: bool)
                      -> BlockFlow {
         BlockFlow {
-            base: BaseFlow::new(constructor.next_flow_id(), node),
+            base: BaseFlow::new((*node).clone()),
             box_: Some(Box::new(constructor, node)),
             is_root: false,
             is_fixed: is_fixed,
@@ -84,7 +84,7 @@ impl BlockFlow {
                            float_type: FloatType)
                            -> BlockFlow {
         BlockFlow {
-            base: BaseFlow::new(constructor.next_flow_id(), node),
+            base: BaseFlow::new((*node).clone()),
             box_: Some(Box::new(constructor, node)),
             is_root: false,
             is_fixed: false,
@@ -688,13 +688,12 @@ impl Flow for BlockFlow {
     /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
     /// contexts.
     fn assign_widths(&mut self, ctx: &mut LayoutContext) {
-        debug!("assign_widths({}): assigning width for flow {}",
+        debug!("assign_widths({}): assigning width for flow",
                if self.is_float() {
                    "float"
                } else {
                    "block"
-               },
-               self.base.id);
+               });
 
         if self.is_root {
             debug!("Setting root position");
@@ -803,10 +802,10 @@ impl Flow for BlockFlow {
 
     fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
         if self.is_float() {
-            debug!("assign_height_inorder_float: assigning height for float {}", self.base.id);
+            debug!("assign_height_inorder_float: assigning height for float");
             self.assign_height_float_inorder();
         } else {
-            debug!("assign_height_inorder: assigning height for block {}", self.base.id);
+            debug!("assign_height_inorder: assigning height for block");
             self.assign_height_block_base(ctx, true);
         }
     }
@@ -818,10 +817,10 @@ impl Flow for BlockFlow {
         }
 
         if self.is_float() {
-            debug!("assign_height_float: assigning height for float {}", self.base.id);
+            debug!("assign_height_float: assigning height for float");
             self.assign_height_float(ctx);
         } else {
-            debug!("assign_height: assigning height for block {}", self.base.id);
+            debug!("assign_height: assigning height for block");
             // This is the only case in which a block flow can start an inorder
             // subtraversal.
             if self.is_root && self.base.num_floats > 0 {

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -84,8 +84,8 @@ impl LineboxScanner {
         self.floats.clone()
     }
 
-    fn reset_scanner(&mut self, flow: &mut InlineFlow) {
-        debug!("Resetting line box scanner's state for flow f{:d}.", flow.base.id);
+    fn reset_scanner(&mut self) {
+        debug!("Resetting line box scanner's state for flow.");
         self.lines = ~[];
         self.new_boxes = ~[];
         self.cur_y = Au::new(0);
@@ -99,7 +99,7 @@ impl LineboxScanner {
     }
 
     pub fn scan_for_lines(&mut self, flow: &mut InlineFlow) {
-        self.reset_scanner(flow);
+        self.reset_scanner();
 
         loop {
             // acquire the next box to lay out from work list or box list
@@ -142,9 +142,8 @@ impl LineboxScanner {
     }
 
     fn swap_out_results(&mut self, flow: &mut InlineFlow) {
-        debug!("LineboxScanner: Propagating scanned lines[n={:u}] to inline flow f{:d}",
-               self.lines.len(),
-               flow.base.id);
+        debug!("LineboxScanner: Propagating scanned lines[n={:u}] to inline flow",
+               self.lines.len());
 
         util::swap(&mut flow.boxes, &mut self.new_boxes);
         util::swap(&mut flow.lines, &mut self.lines);
@@ -466,9 +465,9 @@ pub struct InlineFlow {
 }
 
 impl InlineFlow {
-    pub fn from_boxes(id: int, node: &ThreadSafeLayoutNode, boxes: ~[Box]) -> InlineFlow {
+    pub fn from_boxes(node: ThreadSafeLayoutNode, boxes: ~[Box]) -> InlineFlow {
         InlineFlow {
-            base: BaseFlow::new(id, node),
+            base: BaseFlow::new(node),
             boxes: boxes,
             lines: ~[],
             elems: ElementMapping::new(),
@@ -497,9 +496,7 @@ impl InlineFlow {
 
         // TODO(#228): Once we form line boxes and have their cached bounds, we can be smarter and
         // not recurse on a line if nothing in it can intersect the dirty region.
-        debug!("Flow[{:d}]: building display list for {:u} inline boxes",
-               self.base.id,
-               self.boxes.len());
+        debug!("Flow: building display list for {:u} inline boxes", self.boxes.len());
 
         for box_ in self.boxes.iter() {
             let rel_offset: Point2D<Au> = box_.relative_position(container_block_size);
@@ -636,7 +633,7 @@ impl Flow for InlineFlow {
         let mut pref_width = Au::new(0);
 
         for box_ in self.boxes.iter() {
-            debug!("Flow[{:d}]: measuring {:s}", self.base.id, box_.debug_str());
+            debug!("Flow: measuring {:s}", box_.debug_str());
             box_.compute_borders(box_.style());
             let (this_minimum_width, this_preferred_width) =
                 box_.minimum_and_preferred_widths();
@@ -690,7 +687,7 @@ impl Flow for InlineFlow {
     }
 
     fn assign_height(&mut self, _: &mut LayoutContext) {
-        debug!("assign_height_inline: assigning height for flow {}", self.base.id);
+        debug!("assign_height_inline: assigning height for flow");
 
         // Divide the boxes into lines.
         //

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -9,17 +9,17 @@ use css::matching::{ApplicableDeclarations, ApplicableDeclarationsCache, MatchMe
 use css::matching::{StyleSharingCandidateCache};
 use css::select::new_stylist;
 use css::node_style::StyledNode;
-use layout::construct::{FlowConstructionResult, FlowConstructor, NoConstructionResult};
+use layout::construct::{FlowConstructionResult, NoConstructionResult};
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ToGfxColor};
-use layout::flow::{Flow, FlowLeafSet, ImmutableFlowUtils, MutableFlowUtils, MutableOwnedFlowUtils};
+use layout::flow::{Flow, ImmutableFlowUtils, MutableFlowUtils, MutableOwnedFlowUtils};
 use layout::flow::{PreorderFlowTraversal, PostorderFlowTraversal};
 use layout::flow;
 use layout::incremental::RestyleDamage;
 use layout::parallel::PaddedUnsafeFlow;
 use layout::parallel;
 use layout::util::{LayoutDataAccess, OpaqueNode, LayoutDataWrapper};
-use layout::wrapper::{DomLeafSet, LayoutNode, TLayoutNode, ThreadSafeLayoutNode};
+use layout::wrapper::{LayoutNode, TLayoutNode, ThreadSafeLayoutNode};
 
 use extra::url::Url;
 use extra::arc::{Arc, MutexArc};
@@ -27,7 +27,7 @@ use geom::rect::Rect;
 use geom::size::Size2D;
 use gfx::display_list::{ClipDisplayItemClass, DisplayItem, DisplayItemIterator};
 use gfx::display_list::{DisplayList, DisplayListCollection};
-use gfx::font_context::FontContextInfo;
+use gfx::font_context::{FontContext, FontContextInfo};
 use gfx::render_task::{RenderMsg, RenderChan, RenderLayer};
 use gfx::{render_task, color};
 use script::dom::bindings::js::JS;
@@ -38,7 +38,7 @@ use script::layout_interface::{AddStylesheetMsg, ContentBoxQuery};
 use script::layout_interface::{ContentBoxesQuery, ContentBoxesResponse, ExitNowMsg, LayoutQuery};
 use script::layout_interface::{HitTestQuery, ContentBoxResponse, HitTestResponse, MouseOverQuery, MouseOverResponse};
 use script::layout_interface::{ContentChangedDocumentDamage, LayoutChan, Msg, PrepareToExitMsg};
-use script::layout_interface::{QueryMsg, ReapLayoutDataMsg, Reflow, ReflowDocumentDamage, UntrustedNodeAddress};
+use script::layout_interface::{QueryMsg, ReapLayoutDataMsg, Reflow, UntrustedNodeAddress};
 use script::layout_interface::{ReflowForDisplay, ReflowMsg};
 use script::script_task::{ReflowCompleteMsg, ScriptChan, SendEventMsg};
 use servo_msg::constellation_msg::{ConstellationChan, PipelineId, Failure, FailureMsg};
@@ -85,12 +85,6 @@ pub struct LayoutTask {
 
     /// The local image cache.
     local_image_cache: MutexArc<LocalImageCache>,
-
-    /// The set of leaves in the DOM tree.
-    dom_leaf_set: Arc<DomLeafSet>,
-
-    /// The set of leaves in the flow tree.
-    flow_leaf_set: Arc<FlowLeafSet>,
 
     /// The size of the viewport.
     screen_size: Size2D<Au>,
@@ -305,8 +299,6 @@ impl LayoutTask {
             image_cache_task: image_cache_task.clone(),
             local_image_cache: local_image_cache,
             screen_size: screen_size,
-            dom_leaf_set: Arc::new(DomLeafSet::new()),
-            flow_leaf_set: Arc::new(FlowLeafSet::new()),
 
             display_list_collection: None,
             stylist: ~new_stylist(),
@@ -325,7 +317,7 @@ impl LayoutTask {
     }
 
     // Create a layout context for use in building display lists, hit testing, &c.
-    fn build_layout_context(&self, reflow_root: &LayoutNode) -> LayoutContext {
+    fn build_layout_context(&self, reflow_root: &LayoutNode, url: &Url) -> LayoutContext {
         let font_context_info = FontContextInfo {
             backend: self.opts.render_backend,
             needs_font_list: true,
@@ -336,13 +328,13 @@ impl LayoutTask {
             image_cache: self.local_image_cache.clone(),
             screen_size: self.screen_size.clone(),
             constellation_chan: self.constellation_chan.clone(),
-            dom_leaf_set: self.dom_leaf_set.clone(),
-            flow_leaf_set: self.flow_leaf_set.clone(),
             layout_chan: self.chan.clone(),
             font_context_info: font_context_info,
             stylist: &*self.stylist,
             initial_css_values: self.initial_css_values.clone(),
+            url: (*url).clone(),
             reflow_root: OpaqueNode::from_layout_node(reflow_root),
+            opts: self.opts.clone(),
         }
     }
 
@@ -424,17 +416,8 @@ impl LayoutTask {
         self.stylist.add_stylesheet(sheet, AuthorOrigin)
     }
 
-    /// Builds the flow tree.
-    ///
-    /// This corresponds to the various `nsCSSFrameConstructor` methods in Gecko or
-    /// `createRendererIfNeeded` in WebKit. Note, however that in WebKit `createRendererIfNeeded`
-    /// is intertwined with selector matching, making it difficult to compare directly. It is
-    /// marked `#[inline(never)]` to aid benchmarking in sampling profilers.
-    #[inline(never)]
-    fn construct_flow_tree(&self, layout_context: &mut LayoutContext, node: &mut LayoutNode, url: &Url) -> ~Flow {
-        let mut node = ThreadSafeLayoutNode::new(node);
-        node.traverse_postorder_mut(&mut FlowConstructor::init(layout_context, url));
-
+    /// Retrieves the flow tree root from the root node.
+    fn get_layout_root(&self, node: LayoutNode) -> ~Flow {
         let mut layout_data_ref = node.mutate_layout_data();
         let result = match *layout_data_ref.get() {
             Some(ref mut layout_data) => {
@@ -458,7 +441,7 @@ impl LayoutTask {
     fn solve_constraints(&mut self,
                          layout_root: &mut Flow,
                          layout_context: &mut LayoutContext) {
-        {
+        if layout_context.opts.bubble_widths_separately {
             let mut traversal = BubbleWidthsTraversal {
                 layout_context: layout_context,
             };
@@ -494,14 +477,16 @@ impl LayoutTask {
     fn solve_constraints_parallel(&mut self,
                                   layout_root: &mut ~Flow,
                                   layout_context: &mut LayoutContext) {
+        if layout_context.opts.bubble_widths_separately {
+            let mut traversal = BubbleWidthsTraversal {
+                layout_context: layout_context,
+            };
+            layout_root.traverse_postorder(&mut traversal);
+        }
+
         match self.parallel_traversal {
             None => fail!("solve_contraints_parallel() called with no parallel traversal ready"),
             Some(ref mut traversal) => {
-                parallel::traverse_flow_tree_postorder(&self.flow_leaf_set,
-                                                       self.profiler_chan.clone(),
-                                                       layout_context,
-                                                       traversal);
-
                 // NOTE: this currently computes borders, so any pruning should separate that
                 // operation out.
                 parallel::traverse_flow_tree_preorder(layout_root,
@@ -560,45 +545,41 @@ impl LayoutTask {
         self.screen_size = current_screen_size;
 
         // Create a layout context for use throughout the following passes.
-        let mut layout_ctx = self.build_layout_context(node);
+        let mut layout_ctx = self.build_layout_context(node, &data.url);
+
+        // Create a font context, if this is sequential.
+        //
+        // FIXME(pcwalton): This is a pretty bogus thing to do. Essentially this is a workaround
+        // for libgreen having slow TLS.
+        let mut font_context_opt = if self.parallel_traversal.is_none() {
+            Some(~FontContext::new(layout_ctx.font_context_info.clone()))
+        } else {
+            None
+        };
 
         let mut layout_root = profile(time::LayoutStyleRecalcCategory,
                                       self.profiler_chan.clone(),
                                       || {
-            // Perform CSS selector matching if necessary.
-            match data.damage.level {
-                ReflowDocumentDamage => {}
-                _ => {
-                    profile(time::LayoutSelectorMatchCategory, self.profiler_chan.clone(), || {
-                        match self.parallel_traversal {
-                            None => {
-                                let mut applicable_declarations = ApplicableDeclarations::new();
-                                let mut applicable_declarations_cache =
-                                    ApplicableDeclarationsCache::new();
-                                let mut style_sharing_candidate_cache =
-                                    StyleSharingCandidateCache::new();
-                                node.match_and_cascade_subtree(self.stylist,
-                                                               &layout_ctx.layout_chan,
-                                                               &mut applicable_declarations,
-                                                               layout_ctx.initial_css_values.get(),
-                                                               &mut applicable_declarations_cache,
-                                                               &mut style_sharing_candidate_cache,
-                                                               None)
-                            }
-                            Some(ref mut traversal) => {
-                                parallel::match_and_cascade_subtree(node,
-                                                                    &mut layout_ctx,
-                                                                    traversal)
-                            }
-                        }
-                    })
+            // Perform CSS selector matching and flow construction.
+            match self.parallel_traversal {
+                None => {
+                    let mut applicable_declarations = ApplicableDeclarations::new();
+                    let mut applicable_declarations_cache = ApplicableDeclarationsCache::new();
+                    let mut style_sharing_candidate_cache = StyleSharingCandidateCache::new();
+                    drop(node.recalc_style_for_subtree(self.stylist,
+                                                       &mut layout_ctx,
+                                                       font_context_opt.take_unwrap(),
+                                                       &mut applicable_declarations,
+                                                       &mut applicable_declarations_cache,
+                                                       &mut style_sharing_candidate_cache,
+                                                       None))
+                }
+                Some(ref mut traversal) => {
+                    parallel::recalc_style_for_subtree(node, &mut layout_ctx, traversal)
                 }
             }
 
-            // Construct the flow tree.
-            profile(time::LayoutTreeBuilderCategory,
-                    self.profiler_chan.clone(),
-                    || self.construct_flow_tree(&mut layout_ctx, node, &data.url))
+            self.get_layout_root((*node).clone())
         });
 
         // Verification of the flow tree, which ensures that all nodes were either marked as leaves
@@ -685,7 +666,7 @@ impl LayoutTask {
             });
         }
 
-        layout_root.destroy(self.flow_leaf_set.get());
+        layout_root.destroy();
 
         // Tell script that we're done.
         //

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -557,6 +557,16 @@ impl LayoutTask {
             None
         };
 
+        // Create a font context, if this is sequential.
+        //
+        // FIXME(pcwalton): This is a pretty bogus thing to do. Essentially this is a workaround
+        // for libgreen having slow TLS.
+        let mut font_context_opt = if self.parallel_traversal.is_none() {
+            Some(~FontContext::new(layout_ctx.font_context_info.clone()))
+        } else {
+            None
+        };
+
         let mut layout_root = profile(time::LayoutStyleRecalcCategory,
                                       self.profiler_chan.clone(),
                                       || {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -16,8 +16,7 @@ use layout::flow::{Flow, FlowLeafSet, ImmutableFlowUtils, MutableFlowUtils, Muta
 use layout::flow::{PreorderFlowTraversal, PostorderFlowTraversal};
 use layout::flow;
 use layout::incremental::RestyleDamage;
-use layout::parallel::{AssignHeightsAndStoreOverflowTraversalKind, BubbleWidthsTraversalKind};
-use layout::parallel::{PaddedUnsafeFlow};
+use layout::parallel::PaddedUnsafeFlow;
 use layout::parallel;
 use layout::util::{LayoutDataAccess, OpaqueNode, LayoutDataWrapper};
 use layout::wrapper::{DomLeafSet, LayoutNode, TLayoutNode, ThreadSafeLayoutNode};
@@ -498,8 +497,7 @@ impl LayoutTask {
         match self.parallel_traversal {
             None => fail!("solve_contraints_parallel() called with no parallel traversal ready"),
             Some(ref mut traversal) => {
-                parallel::traverse_flow_tree_postorder(BubbleWidthsTraversalKind,
-                                                       &self.flow_leaf_set,
+                parallel::traverse_flow_tree_postorder(&self.flow_leaf_set,
                                                        self.profiler_chan.clone(),
                                                        layout_context,
                                                        traversal);
@@ -510,12 +508,6 @@ impl LayoutTask {
                                                       self.profiler_chan.clone(),
                                                       layout_context,
                                                       traversal);
-
-                parallel::traverse_flow_tree_postorder(AssignHeightsAndStoreOverflowTraversalKind,
-                                                       &self.flow_leaf_set,
-                                                       self.profiler_chan.clone(),
-                                                       layout_context,
-                                                       traversal);
             }
         }
     }

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -25,7 +25,6 @@ use script::dom::htmlimageelement::HTMLImageElement;
 use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, Node, NodeTypeId, NodeHelpers};
 use script::dom::text::Text;
 use servo_msg::constellation_msg::{PipelineId, SubpageId};
-use servo_util::concurrentmap::{ConcurrentHashMap, ConcurrentHashMapIterator};
 use servo_util::namespace;
 use servo_util::namespace::Namespace;
 use std::cast;
@@ -492,35 +491,6 @@ pub type UnsafeLayoutNode = (uint, uint, uint);
 pub fn layout_node_to_unsafe_layout_node(node: &LayoutNode) -> UnsafeLayoutNode {
     unsafe {
         cast::transmute_copy(node)
-    }
-}
-
-/// Keeps track of the leaves of the DOM. This is used to efficiently start bottom-up traversals.
-pub struct DomLeafSet {
-    priv set: ConcurrentHashMap<UnsafeLayoutNode,()>,
-}
-
-impl DomLeafSet {
-    /// Creates a new DOM leaf set.
-    pub fn new() -> DomLeafSet {
-        DomLeafSet {
-            set: ConcurrentHashMap::with_locks_and_buckets(64, 256),
-        }
-    }
-
-    /// Inserts a DOM node into the leaf set.
-    pub fn insert(&self, node: &LayoutNode) {
-        self.set.insert(layout_node_to_unsafe_layout_node(node), ());
-    }
-
-    /// Removes all DOM nodes from the set.
-    pub fn clear(&self) {
-        self.set.clear()
-    }
-
-    /// Iterates over the DOM nodes in the leaf set.
-    pub fn iter<'a>(&'a self) -> ConcurrentHashMapIterator<'a,UnsafeLayoutNode,()> {
-        self.set.iter()
     }
 }
 

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -46,6 +46,12 @@ pub struct Opts {
     output_file: Option<~str>,
     headless: bool,
     hard_fail: bool,
+
+    /// True if we should bubble intrinsic widths sequentially (`-b`). If this is true, then
+    /// intrinsic widths are computed as a separate pass instead of during flow construction. You
+    /// may wish to turn this flag on in order to benchmark style recalculation against other
+    /// browser engines.
+    bubble_widths_separately: bool,
 }
 
 fn print_usage(app: &str, opts: &[groups::OptGroup]) {
@@ -68,6 +74,7 @@ pub fn from_cmdline_args(args: &[~str]) -> Opts {
         groups::optopt("y", "layout-threads", "Number of threads to use for layout", "1"),
         groups::optflag("z", "headless", "Headless mode"),
         groups::optflag("f", "hard-fail", "Exit on task failure instead of displaying about:failure"),
+        groups::optflag("b", "bubble-widths", "Bubble intrinsic widths separately like other engines"),
         groups::optflag("h", "help", "Print this message")
     ];
 
@@ -143,5 +150,6 @@ pub fn from_cmdline_args(args: &[~str]) -> Opts {
         output_file: opt_match.opt_str("o"),
         headless: opt_match.opt_present("z"),
         hard_fail: opt_match.opt_present("f"),
+        bubble_widths_separately: opt_match.opt_present("b"),
     }
 }


### PR DESCRIPTION
cc @pradeep90 — This removes leaf sets and should be enough to get you started.

This series of patches combines various layout passes to eliminate the overhead involved with bottom-up passes. It also makes assign-widths and flow construction run in parallel. No raw layout code was touched (except in trivial ways); rather this just changes the way methods are invoked. So the overall level of code cleanliness should remain the same. In fact, this is a (slight) net loss in LOC, and should be an improvement in safety due to not having to ensure that the nodes in the leaf sets stay alive!

This was quite a nice speedup; we're now 38% faster than Blink sequentially for style recalc on the rainbow page and 2.56x faster with 4 cores. (The relatively low speedup is because the LRU cache hits perfectly on that page sequentially.)

There is a data race somewhere in the unsafe code I added, so _do not merge yet_.
