### PR TITLE
Change Text, Comment and ProcessingInstructions parent name from element...

### DIFF
--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -717,7 +717,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
         match self.type_id() {
             TextNodeTypeId => {
                 unsafe {
-                    if !self.with_text(|text| text.element
+                    if !self.with_text(|text| text.characterdata
                                                   .data
                                                   .chars()
                                                   .all(|c| c.is_whitespace())) {

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -112,7 +112,7 @@ pub trait TLayoutNode {
     /// FIXME(pcwalton): Don't copy text. Atomically reference count instead.
     fn text(&self) -> ~str {
         unsafe {
-            self.with_text(|text| text.element.data.to_str())
+            self.with_text(|text| text.characterdata.data.to_str())
         }
     }
 

--- a/src/components/script/dom/bindings/element.rs
+++ b/src/components/script/dom/bindings/element.rs
@@ -14,6 +14,12 @@ macro_rules! generate_cacheable_wrapper(
     )
 )
 
+macro_rules! generate_cacheable_wrapper_characterdata(
+    ($name: path, $wrap: path) => (
+        generate_cacheable_wrapper_base!($name, $wrap, characterdata)
+    )
+)
+
 macro_rules! generate_cacheable_wrapper_htmlelement(
     ($name: path, $wrap: path) => (
         generate_cacheable_wrapper_base!($name, $wrap, htmlelement)
@@ -60,6 +66,12 @@ macro_rules! generate_traceable(
     )
 )
 
+macro_rules! generate_traceable_characterdata(
+    ($name: path) => (
+        generate_traceable_base!($name, characterdata)
+    )
+)
+
 macro_rules! generate_traceable_htmlelement(
     ($name: path) => (
         generate_traceable_base!($name, htmlelement)
@@ -95,8 +107,8 @@ macro_rules! generate_traceable_base(
 )
 
 
-generate_cacheable_wrapper!(Comment, CommentBinding::Wrap)
-generate_traceable!(Comment)
+generate_cacheable_wrapper_characterdata!(Comment, CommentBinding::Wrap)
+generate_traceable_characterdata!(Comment)
 
 generate_cacheable_wrapper_node!(DocumentFragment, DocumentFragmentBinding::Wrap)
 generate_traceable_node!(DocumentFragment)
@@ -104,11 +116,11 @@ generate_traceable_node!(DocumentFragment)
 generate_cacheable_wrapper_node!(DocumentType, DocumentTypeBinding::Wrap)
 generate_traceable_node!(DocumentType)
 
-generate_cacheable_wrapper!(Text, TextBinding::Wrap)
-generate_traceable!(Text)
+generate_cacheable_wrapper_characterdata!(Text, TextBinding::Wrap)
+generate_traceable_characterdata!(Text)
 
-generate_cacheable_wrapper!(ProcessingInstruction, ProcessingInstruction::Wrap)
-generate_traceable!(ProcessingInstruction)
+generate_cacheable_wrapper_characterdata!(ProcessingInstruction, ProcessingInstruction::Wrap)
+generate_traceable_characterdata!(ProcessingInstruction)
 
 generate_cacheable_wrapper_htmlelement!(HTMLHeadElement, HTMLHeadElementBinding::Wrap)
 generate_traceable_htmlelement!(HTMLHeadElement)

--- a/src/components/script/dom/comment.rs
+++ b/src/components/script/dom/comment.rs
@@ -12,13 +12,13 @@ use servo_util::str::DOMString;
 
 /// An HTML comment.
 pub struct Comment {
-    element: CharacterData,
+    characterdata: CharacterData,
 }
 
 impl Comment {
     pub fn new_inherited(text: DOMString, document: AbstractDocument) -> Comment {
         Comment {
-            element: CharacterData::new_inherited(CommentNodeTypeId, text, document)
+            characterdata: CharacterData::new_inherited(CommentNodeTypeId, text, document)
         }
     }
 

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -342,7 +342,7 @@ impl Document {
                             for child in node.children() {
                                 if child.is_text() {
                                     child.with_imm_text(|text| {
-                                        title = title + text.element.Data();
+                                        title = title + text.characterdata.Data();
                                     });
                                 }
                             }

--- a/src/components/script/dom/htmlserializer.rs
+++ b/src/components/script/dom/htmlserializer.rs
@@ -77,7 +77,7 @@ fn serialize_text(node: AbstractNode) -> ~str {
 
 fn serialize_processing_instruction(node: AbstractNode) -> ~str {
     node.with_imm_processing_instruction(|processing_instruction| {
-        ~"<?" + processing_instruction.target + " " + processing_instruction.element.data + "?>"
+        ~"<?" + processing_instruction.target + " " + processing_instruction.characterdata.data + "?>"
     })
 }
 

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -1064,7 +1064,7 @@ impl Node {
                 for node in abstract_self.traverse_preorder() {
                     if node.is_text() {
                         node.with_imm_text(|text| {
-                            content = content + text.element.Data();
+                            content = content + text.characterdata.Data();
                         })
                     }
                 }
@@ -1591,7 +1591,7 @@ impl Node {
             node.with_imm_processing_instruction(|pi| {
                 other.with_imm_processing_instruction(|other_pi| {
                     (pi.target == other_pi.target) &&
-                    (pi.element.data == other_pi.element.data)
+                    (pi.characterdata.data == other_pi.characterdata.data)
                 })
             })
         }

--- a/src/components/script/dom/processinginstruction.rs
+++ b/src/components/script/dom/processinginstruction.rs
@@ -10,15 +10,14 @@ use servo_util::str::DOMString;
 
 /// An HTML processing instruction node.
 pub struct ProcessingInstruction {
-    // FIXME: s/element/characterdata/ https://github.com/mozilla/servo/issues/1594
-    element: CharacterData,
+    characterdata: CharacterData,
     target: DOMString,
 }
 
 impl ProcessingInstruction {
     pub fn new_inherited(target: DOMString, data: DOMString, document: AbstractDocument) -> ProcessingInstruction {
         ProcessingInstruction {
-            element: CharacterData::new_inherited(ProcessingInstructionNodeTypeId, data, document),
+            characterdata: CharacterData::new_inherited(ProcessingInstructionNodeTypeId, data, document),
             target: target
         }
     }

--- a/src/components/script/dom/text.rs
+++ b/src/components/script/dom/text.rs
@@ -12,13 +12,13 @@ use servo_util::str::DOMString;
 
 /// An HTML text node.
 pub struct Text {
-    element: CharacterData,
+    characterdata: CharacterData,
 }
 
 impl Text {
     pub fn new_inherited(text: DOMString, document: AbstractDocument) -> Text {
         Text {
-            element: CharacterData::new_inherited(TextNodeTypeId, text, document)
+            characterdata: CharacterData::new_inherited(TextNodeTypeId, text, document)
         }
     }
 

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -468,7 +468,7 @@ pub fn parse_html(cx: *JSContext,
                             for child in scriptnode.children() {
                                 debug!("child = {:?}", child);
                                 child.with_imm_text(|text| {
-                                    data.push(text.element.data.to_str());  // FIXME: Bad copy.
+                                    data.push(text.characterdata.data.to_str());  // FIXME: Bad copy.
                                 });
                             }
 
@@ -490,7 +490,7 @@ pub fn parse_html(cx: *JSContext,
                 for child in style.children() {
                     debug!("child = {:?}", child);
                     child.with_imm_text(|text| {
-                        data.push(text.element.data.to_str());  // FIXME: Bad copy.
+                        data.push(text.characterdata.data.to_str());  // FIXME: Bad copy.
                     });
                 }
 


### PR DESCRIPTION
... to characterdata

All other node's parent type names reflect the actual type of the parent. This change extends that convention to the indicated nodes.

closes #1594
