### PR TITLE
Create a Line DisplayItem

### DIFF
--- a/src/components/gfx/display_list.rs
+++ b/src/components/gfx/display_list.rs
@@ -127,6 +127,7 @@ pub enum DisplayItem<E> {
     TextDisplayItemClass(~TextDisplayItem<E>),
     ImageDisplayItemClass(~ImageDisplayItem<E>),
     BorderDisplayItemClass(~BorderDisplayItem<E>),
+    LineDisplayItemClass(~LineDisplayItem<E>),
     ClipDisplayItemClass(~ClipDisplayItem<E>)
 }
 
@@ -204,6 +205,17 @@ pub struct BorderDisplayItem<E> {
 
     /// The border styles.
     style: SideOffsets2D<border_style::T>
+}
+
+/// Renders a line segment
+pub struct LineDisplayItem<E> {
+    base: BaseDisplayItem<E>,
+
+    /// The line segment color.
+    color: Color,
+
+    /// The line segemnt style.
+    style: border_style::T
 }
 
 pub struct ClipDisplayItem<E> {
@@ -303,6 +315,12 @@ impl<E> DisplayItem<E> {
                                            border.color,
                                            border.style)
             }
+
+            LineDisplayItemClass(ref line) => {
+                render_context.draw_line(&line.base.bounds,
+                                          line.color,
+                                          line.style)
+            }
         }
     }
 
@@ -314,6 +332,7 @@ impl<E> DisplayItem<E> {
                 TextDisplayItemClass(ref text) => transmute_region(&text.base),
                 ImageDisplayItemClass(ref image_item) => transmute_region(&image_item.base),
                 BorderDisplayItemClass(ref border) => transmute_region(&border.base),
+                LineDisplayItemClass(ref line) => transmute_region(&line.base),
                 ClipDisplayItemClass(ref clip) => transmute_region(&clip.base),
             }
         }
@@ -329,7 +348,8 @@ impl<E> DisplayItem<E> {
             SolidColorDisplayItemClass(..) |
             TextDisplayItemClass(..) |
             ImageDisplayItemClass(..) |
-            BorderDisplayItemClass(..) => EmptyDisplayItemIterator,
+            BorderDisplayItemClass(..) |
+            LineDisplayItemClass(..) => EmptyDisplayItemIterator,
         }
     }
 
@@ -350,6 +370,7 @@ impl<E> DisplayItem<E> {
             TextDisplayItemClass(_) => "Text",
             ImageDisplayItemClass(_) => "Image",
             BorderDisplayItemClass(_) => "Border",
+            LineDisplayItemClass(_) => "Line",
             ClipDisplayItemClass(_) => "Clip",
         };
         format!("{} @ {:?}", class, self.base().bounds)

--- a/src/components/gfx/render_context.rs
+++ b/src/components/gfx/render_context.rs
@@ -62,6 +62,15 @@ impl<'a> RenderContext<'a>  {
         self.draw_border_segment(Left, bounds, border, color, style);
     }
 
+    pub fn draw_line(&self,
+                     bounds: &Rect<Au>,
+                     color: Color,
+                     style: border_style::T) {
+        self.draw_target.make_current();
+
+        self.draw_line_segment(bounds, color, style);
+    }
+
     pub fn draw_push_clip(&self, bounds: &Rect<Au>) {
         let rect = bounds.to_azure_rect();
         let path_builder = self.draw_target.create_path_builder();
@@ -144,6 +153,25 @@ impl<'a> RenderContext<'a>  {
                 self.draw_solid_border_segment(direction,bounds,border,color_select);
             }
             //FIXME(sammykim): Five more styles should be implemented.
+            //double, groove, ridge, inset, outset
+        }
+    }
+
+    fn draw_line_segment(&self, bounds: &Rect<Au>, color: Color, style: border_style::T) {
+        let border = SideOffsets2D::new_all_same(bounds.size.width).to_float_px();
+
+        match style{
+            border_style::none | border_style::hidden => {}
+            border_style::dotted => {
+                //FIXME(sankha93): Dotted style should be implemented.
+            }
+            border_style::dashed => {
+                self.draw_dashed_border_segment(Right,bounds,border,color);
+            }
+            border_style::solid => {
+                self.draw_solid_border_segment(Right,bounds,border,color);
+            }
+            //FIXME(sankha93): Five more styles should be implemented.
             //double, groove, ridge, inset, outset
         }
     }

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -9,6 +9,7 @@ use extra::arc::{MutexArc, Arc};
 use geom::{Point2D, Rect, Size2D, SideOffsets2D};
 use gfx::color::rgb;
 use gfx::display_list::{BaseDisplayItem, BorderDisplayItem, BorderDisplayItemClass};
+use gfx::display_list::{LineDisplayItem, LineDisplayItemClass};
 use gfx::display_list::{ImageDisplayItem, ImageDisplayItemClass};
 use gfx::display_list::{SolidColorDisplayItem, SolidColorDisplayItemClass, TextDisplayItem};
 use gfx::display_list::{TextDisplayItemClass, TextDisplayItemFlags, ClipDisplayItem};
@@ -1126,25 +1127,22 @@ impl Box {
                     });
 
                     // Draw a rectangle representing the baselines.
-                    //
-                    // TODO(Issue #221): Create and use a Line display item for the baseline.
                     let ascent = text_box.run.get().metrics_for_range(
                         &text_box.range).ascent;
                     let baseline = Rect(absolute_box_bounds.origin + Point2D(Au(0), ascent),
                                         Size2D(absolute_box_bounds.size.width, Au(0)));
 
                     lists.with_mut(|lists| {
-                        let border_display_item = ~BorderDisplayItem {
+                        let line_display_item = ~LineDisplayItem {
                             base: BaseDisplayItem {
                                 bounds: baseline,
                                 extra: ExtraDisplayListData::new(self),
                             },
-                            border: debug_border,
-                            color: SideOffsets2D::new_all_same(rgb(0, 200, 0)),
-                            style: SideOffsets2D::new_all_same(border_style::dashed)
+                            color: rgb(0, 200, 0),
+                            style: border_style::dashed
 
                         };
-                        lists.lists[index].append_item(BorderDisplayItemClass(border_display_item));
+                        lists.lists[index].append_item(LineDisplayItemClass(line_display_item));
                     });
                 });
             },


### PR DESCRIPTION
This fixes #221.

I used the `BaseDisplayItem` class to define rectangle in which the line will be drawn. The width of the rectangle will be used as the thickness of the line segment.
