### PR TITLE
Shut down the profiler in headless compositing mode

### DIFF
--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -209,7 +209,8 @@ impl CompositorTask {
             }
             Headless => {
                 headless::NullCompositor::create(port,
-                                                 constellation_chan.clone())
+                                                 constellation_chan.clone(),
+                                                 profiler_chan)
             }
         };
     }

--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -7,7 +7,8 @@ use compositing::*;
 use geom::size::Size2D;
 use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, ResizedWindowMsg};
 use std::comm::Port;
-
+use servo_util::time::ProfilerChan;
+use servo_util::time;
 
 /// Starts the compositor, which listens for messages on the specified port.
 ///
@@ -19,20 +20,26 @@ pub struct NullCompositor {
 }
 
 impl NullCompositor {
-
     fn new(port: Port<Msg>) -> NullCompositor {
-
         NullCompositor {
-            port: port
+            port: port,
         }
     }
 
-    pub fn create(port: Port<Msg>, constellation_chan: ConstellationChan) {
+    pub fn create(port: Port<Msg>,
+                  constellation_chan: ConstellationChan,
+                  profiler_chan: ProfilerChan) {
         let compositor = NullCompositor::new(port);
 
         // Tell the constellation about the initial fake size.
         constellation_chan.send(ResizedWindowMsg(Size2D(640u, 480u)));
         compositor.handle_message(constellation_chan);
+
+        // Drain compositor port, sometimes messages contain channels that are blocking
+        // another task from finishing (i.e. SetIds)
+        while compositor.port.try_recv().is_some() {}
+
+        profiler_chan.send(time::ExitMsg);
     }
 
     fn handle_message(&self, constellation_chan: ConstellationChan) {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -235,7 +235,7 @@ impl ImageResponder for LayoutImageResponder {
         let id = self.id.clone();
         let script_chan = self.script_chan.clone();
         let f: proc(ImageResponseMsg) = proc(_) {
-            script_chan.send(SendEventMsg(id.clone(), ReflowEvent))
+            drop(script_chan.try_send(SendEventMsg(id.clone(), ReflowEvent)))
         };
         f
     }
@@ -392,6 +392,7 @@ impl LayoutTask {
                     }
                 }
                 ExitNowMsg => {
+                    debug!("layout task is exiting...");
                     self.exit_now();
                     break
                 }


### PR DESCRIPTION
This fixes a hang in content tests in my deleafset branch. No idea why it worked before though…

This just replicates the code in non-headless mode over to the headless mode.

r? @kmcallister
