### PR TITLE
Prevent '&nbsp' from stripping as whitespace

### DIFF
--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -22,7 +22,7 @@ use servo_util::geometry::Au;
 use servo_util::geometry;
 use servo_util::range::*;
 use servo_util::namespace;
-use servo_util::str::is_whitespace_not_nbsp;
+use servo_util::str::is_whitespace;
 
 use std::cast;
 use std::cell::RefCell;
@@ -1429,7 +1429,7 @@ impl Box {
     /// Returns true if this box is an unscanned text box that consists entirely of whitespace.
     pub fn is_whitespace_only(&self) -> bool {
         match self.specific {
-            UnscannedTextBox(ref text_box_info) => is_whitespace_not_nbsp(text_box_info.text),
+            UnscannedTextBox(ref text_box_info) => is_whitespace(text_box_info.text),
             _ => false,
         }
     }

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -22,6 +22,7 @@ use servo_util::geometry::Au;
 use servo_util::geometry;
 use servo_util::range::*;
 use servo_util::namespace;
+use servo_util::str::is_whitespace_not_nbsp;
 
 use std::cast;
 use std::cell::RefCell;
@@ -1428,7 +1429,7 @@ impl Box {
     /// Returns true if this box is an unscanned text box that consists entirely of whitespace.
     pub fn is_whitespace_only(&self) -> bool {
         match self.specific {
-            UnscannedTextBox(ref text_box_info) => text_box_info.text.is_whitespace(),
+            UnscannedTextBox(ref text_box_info) => is_whitespace_not_nbsp(text_box_info.text),
             _ => false,
         }
     }

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -43,7 +43,7 @@ use style::ComputedValues;
 use servo_util::namespace;
 use servo_util::url::parse_url;
 use servo_util::url::is_image_data;
-use servo_util::str::is_whitespace_not_nbsp;
+use servo_util::str::is_whitespace;
 
 use extra::url::Url;
 use extra::arc::Arc;
@@ -725,7 +725,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
         match self.type_id() {
             TextNodeTypeId => {
                 unsafe {
-                    if !self.with_text(|text| is_whitespace_not_nbsp(text.characterdata.data)) {
+                    if !self.with_text(|text| is_whitespace(text.characterdata.data)) {
                         return false
                     }
 

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -43,6 +43,7 @@ use style::ComputedValues;
 use servo_util::namespace;
 use servo_util::url::parse_url;
 use servo_util::url::is_image_data;
+use servo_util::str::is_whitespace_not_nbsp;
 
 use extra::url::Url;
 use extra::arc::Arc;
@@ -724,10 +725,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
         match self.type_id() {
             TextNodeTypeId => {
                 unsafe {
-                    if !self.with_text(|text| text.characterdata
-                                                  .data
-                                                  .chars()
-                                                  .all(|c| c.is_whitespace())) {
+                    if !self.with_text(|text| is_whitespace_not_nbsp(text.characterdata.data)) {
                         return false
                     }
 

--- a/src/components/util/str.rs
+++ b/src/components/util/str.rs
@@ -19,3 +19,6 @@ pub fn null_str_as_empty_ref<'a>(s: &'a Option<DOMString>) -> &'a str {
     }
 }
 
+pub fn is_whitespace_not_nbsp(s: &str) -> bool {
+    s.chars().all(|c| c.is_whitespace() && c != '\xa0')
+}

--- a/src/components/util/str.rs
+++ b/src/components/util/str.rs
@@ -19,6 +19,9 @@ pub fn null_str_as_empty_ref<'a>(s: &'a Option<DOMString>) -> &'a str {
     }
 }
 
-pub fn is_whitespace_not_nbsp(s: &str) -> bool {
-    s.chars().all(|c| c.is_whitespace() && c != '\xa0')
+pub fn is_whitespace(s: &str) -> bool {
+    s.chars().all(|c| match c {
+        '\u0020' | '\u0009' | '\u000D' | '\u000A' => true,
+        _ => false
+    })
 }


### PR DESCRIPTION
Fix #1727.
