### PR TITLE
 	layout: Implement the correct behavior for block formatting contexts adjacent to floats per CSS 2.1 § 9.5.

### DIFF
--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -745,7 +745,7 @@ impl Box {
     }
 
     /// Returns the sum of margin, border, and padding on the left.
-    pub fn offset(&self) -> Au {
+    pub fn content_left(&self) -> Au {
         self.margin.get().left + self.border.get().left + self.padding.get().left
     }
 
@@ -1514,8 +1514,7 @@ impl Box {
             ScannedTextBox(_) => {
                 // Scanned text boxes will have already had their widths assigned by this point
                 let mut position = self.border_box.borrow_mut();
-                position.get().size.height
-                    = position.get().size.height + self.noncontent_height()
+                position.get().size.height = position.get().size.height + self.noncontent_height()
             }
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }

--- a/src/components/main/layout/floats.rs
+++ b/src/components/main/layout/floats.rs
@@ -379,5 +379,12 @@ impl Floats {
         }
         clearance
     }
+
+    pub fn len(&self) -> uint {
+        match self.list.get() {
+            None => 0,
+            Some(list) => list.floats.len(),
+        }
+    }
 }
 

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -217,7 +217,7 @@ impl<'a> PostorderFlowTraversal for AssignHeightsAndStoreOverflowTraversal<'a> {
 
     #[inline]
     fn should_process(&mut self, flow: &mut Flow) -> bool {
-        !flow::base(flow).flags_info.flags.inorder()
+        !flow::base(flow).flags_info.flags.impacted_by_floats()
     }
 }
 

--- a/src/test/html/perf-acid1.html
+++ b/src/test/html/perf-acid1.html
@@ -1,0 +1,1561 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=windows-1252">
+		<title>
+			 display/box/float/clear test 
+		</title>
+ 	<style type="text/css">
+/* last modified: 1 Dec 98 */ 	
+
+html {
+font: 10px/1 Verdana, sans-serif;
+background-color: blue;
+color: white;
+}
+
+body {
+margin: 1.5em;
+border: .5em solid black;
+padding: 0;
+width: 48em;
+background-color: white;
+}
+
+dl {
+margin: 0;
+border: 0;
+padding: .5em;
+}
+
+dt { 
+background-color: rgb(204,0,0);
+margin: 0; 
+padding: 1em;
+width: 10.638%; /* refers to parent element's width of 47em. = 5em or 50px */
+height: 28em;
+border: .5em solid black;
+float: left;
+}
+
+dd {
+float: right;
+margin: 0 0 0 1em;
+border: 1em solid black;
+padding: 1em;
+width: 34em;
+height: 27em;
+}
+
+ul {
+margin: 0;
+border: 0;
+padding: 0;
+}
+
+li {
+display: block; /* i.e., suppress marker */
+color: black;
+height: 9em;
+width: 5em;
+margin: 0;
+border: .5em solid black;
+padding: 1em;
+float: left;
+background-color: #FC0;
+}
+
+#bar {
+background-color: black;
+color: white;
+width: 41.17%; /* = 14em */
+border: 0;
+margin: 0 1em;
+}
+
+#baz {
+margin: 1em 0;
+border: 0;
+padding: 1em;
+width: 10em;
+height: 10em;
+background-color: black;
+color: white;
+}
+
+form { 
+margin: 0;
+display: inline;
+}
+
+p { 
+margin: 0;
+}
+
+form p {
+line-height: 1.9;
+}
+
+blockquote {
+margin: 1em 1em 1em 2em;
+border-width: 1em 1.5em 2em .5em;
+border-style: solid;
+border-color: black;
+padding: 1em 0;
+width: 5em;
+height: 9em;
+float: left;
+background-color: #FC0;
+color: black;
+}
+
+address {
+font-style: normal;
+}
+
+h1 {
+background-color: black;
+color: white;
+float: left;
+margin: 1em 0;
+border: 0;
+padding: 1em;
+width: 10em;
+height: 10em;
+font-weight: normal;
+font-size: 1em;
+}
+  </style>
+	</head>
+	<body>
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+		<dl>
+			<dt>
+			 toggle 
+			</dt>
+			<dd>
+			<ul>
+				<li>
+				 the way 
+				</li>
+				<li id="bar">
+				<p>
+				 the world ends 
+				</p>
+				<form action="./" method="get">
+					<p>
+					 bang 
+					<input name="foo" value="off" type="radio">
+					</p>
+					<p>
+					 whimper 
+					<input name="foo2" value="on" type="radio">
+					</p>
+				</form>
+				</li>
+				<li>
+				 i grow old 
+				</li>
+				<li id="baz">
+				 pluot? 
+				</li>
+			</ul>
+			<blockquote>
+				<address>
+					 bar maids, 
+				</address>
+			</blockquote>
+			<h1>
+				 sing to me, erbarme dich 
+			</h1>
+			</dd>
+		</dl>
+		<p style="color: black; font-size: 1em; line-height: 1.3em; clear: both">
+		 This is a nonsensical document, but syntactically valid HTML 4.0. All
+ 100%-conformant CSS1 agents should be able to render the document 
+elements above this paragraph indistinguishably (to the pixel) from this
+ 
+			<a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.gif">reference rendering,</a>
+		 (except font rasterization and form widgets). All discrepancies 
+should be traceable to CSS1 implementation shortcomings. Once you have 
+finished evaluating this test, you can return to the <a href="http://www.w3.org/Style/CSS/Test/CSS1/current/sec5526c.htm">parent page</a>. 
+		</p>
+	
+
+</body></html>

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -36,3 +36,4 @@
 # == simple_iframe.html simple_iframe_ref.html -- disabled due to iframe crashiness
 == object_element_a.html object_element_b.html
 == height_compute_reset.html height_compute.html
+== block_formatting_context_a.html block_formatting_context_b.html

--- a/src/test/ref/block_formatting_context_a.html
+++ b/src/test/ref/block_formatting_context_a.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Can't read my poker face</title>
+<style>
+#a {
+    float: right;
+}
+
+#b {
+    overflow: hidden;
+    padding: 6px 0 6px 6px;
+}
+</style>
+</head>
+<body>
+<div id=a>floatyfloatyfloaty</div>
+<div id=b>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi tempor nisl id mauris scelerisque, et suscipit elit fringilla. Integer lacinia est ac erat euismod, ac venenatis orci bibendum. Proin quis lectus eu mauris hendrerit sagittis. Cras dolor felis, vehicula vel nisi vel, dictum volutpat mi. Aenean fermentum pharetra imperdiet. Suspendisse feugiat dui velit, at tempus erat tincidunt sit amet. Duis lacinia vulputate lacus, sed sollicitudin dolor consectetur vitae. Curabitur lacus enim, mattis quis est vitae, semper aliquet orci. Phasellus enim nisl, euismod et magna vel, porttitor luctus nunc. Nulla interdum iaculis est, et luctus mauris laoreet vel. Pellentesque sit amet odio imperdiet, convallis orci non, interdum magna. Ut aliquam quam sodales pharetra ultrices. Aenean tempor orci vitae vestibulum vestibulum. Donec turpis turpis, elementum vel purus ac, ultrices molestie nulla. Nunc vulputate tortor a erat commodo laoreet.
+
+Nulla eu mi convallis, blandit nunc vitae, posuere urna. Pellentesque lectus nisl, lobortis eget mi id, dapibus tincidunt elit. Ut gravida mauris nec venenatis lobortis. Ut laoreet blandit ligula eget egestas. Aenean sit amet commodo sapien, in ullamcorper mi. Aenean malesuada eros lorem, id rhoncus massa eleifend vitae. Donec viverra luctus orci, ut lobortis nisl vestibulum ut. Donec porta magna ante, non lobortis justo consectetur ut. Vestibulum consequat, justo quis gravida pharetra, nunc dolor mattis purus, eget molestie massa eros ac tellus. Duis odio dui, rhoncus et odio id, imperdiet egestas massa. Integer ultrices scelerisque lectus, nec placerat est porta in. Praesent et interdum nulla. Aliquam sagittis neque et vestibulum consequat. Integer laoreet justo sit amet diam lacinia, in suscipit erat ultricies. Cras suscipit eleifend pulvinar. Aliquam augue justo, venenatis id orci id, accumsan facilisis mauris.
+
+Nam ac neque lorem. Curabitur id gravida orci, a laoreet lorem. Vestibulum pharetra felis ac vestibulum tristique. Vestibulum in lorem et leo adipiscing pulvinar sagittis ut massa. Integer egestas malesuada nisi quis pretium. Maecenas pellentesque, turpis ut ultricies facilisis, nulla ligula cursus lectus, imperdiet blandit sapien risus sit amet eros. Curabitur rutrum sollicitudin enim quis ultricies. Duis dictum metus eu justo tincidunt venenatis. Integer tempus mattis mauris, in blandit nisl sollicitudin non. Etiam dignissim magna non volutpat blandit. 
+</div>
+</body>
+</html>
+

--- a/src/test/ref/block_formatting_context_b.html
+++ b/src/test/ref/block_formatting_context_b.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Can't read my poker face</title>
+<style>
+#a {
+    float: right;
+    padding-bottom: 200em;
+}
+
+#b {
+    padding: 6px 0 6px 6px;
+}
+</style>
+</head>
+<body>
+<div id=a>floatyfloatyfloaty</div>
+<div id=b>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi tempor nisl id mauris scelerisque, et suscipit elit fringilla. Integer lacinia est ac erat euismod, ac venenatis orci bibendum. Proin quis lectus eu mauris hendrerit sagittis. Cras dolor felis, vehicula vel nisi vel, dictum volutpat mi. Aenean fermentum pharetra imperdiet. Suspendisse feugiat dui velit, at tempus erat tincidunt sit amet. Duis lacinia vulputate lacus, sed sollicitudin dolor consectetur vitae. Curabitur lacus enim, mattis quis est vitae, semper aliquet orci. Phasellus enim nisl, euismod et magna vel, porttitor luctus nunc. Nulla interdum iaculis est, et luctus mauris laoreet vel. Pellentesque sit amet odio imperdiet, convallis orci non, interdum magna. Ut aliquam quam sodales pharetra ultrices. Aenean tempor orci vitae vestibulum vestibulum. Donec turpis turpis, elementum vel purus ac, ultrices molestie nulla. Nunc vulputate tortor a erat commodo laoreet.
+
+Nulla eu mi convallis, blandit nunc vitae, posuere urna. Pellentesque lectus nisl, lobortis eget mi id, dapibus tincidunt elit. Ut gravida mauris nec venenatis lobortis. Ut laoreet blandit ligula eget egestas. Aenean sit amet commodo sapien, in ullamcorper mi. Aenean malesuada eros lorem, id rhoncus massa eleifend vitae. Donec viverra luctus orci, ut lobortis nisl vestibulum ut. Donec porta magna ante, non lobortis justo consectetur ut. Vestibulum consequat, justo quis gravida pharetra, nunc dolor mattis purus, eget molestie massa eros ac tellus. Duis odio dui, rhoncus et odio id, imperdiet egestas massa. Integer ultrices scelerisque lectus, nec placerat est porta in. Praesent et interdum nulla. Aliquam sagittis neque et vestibulum consequat. Integer laoreet justo sit amet diam lacinia, in suscipit erat ultricies. Cras suscipit eleifend pulvinar. Aliquam augue justo, venenatis id orci id, accumsan facilisis mauris.
+
+Nam ac neque lorem. Curabitur id gravida orci, a laoreet lorem. Vestibulum pharetra felis ac vestibulum tristique. Vestibulum in lorem et leo adipiscing pulvinar sagittis ut massa. Integer egestas malesuada nisi quis pretium. Maecenas pellentesque, turpis ut ultricies facilisis, nulla ligula cursus lectus, imperdiet blandit sapien risus sit amet eros. Curabitur rutrum sollicitudin enim quis ultricies. Duis dictum metus eu justo tincidunt venenatis. Integer tempus mattis mauris, in blandit nisl sollicitudin non. Etiam dignissim magna non volutpat blandit. 
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
Results in an 80% parallel improvement over sequential on youtube.com.

This is quite tricky—it involves a sea change to layout in order to make block layout interruptible and resumable, and intertwines assign-widths and assign-heights even more—and I'd be happy to go over this via video or IRC.

r? @larsbergstrom
