### PR TITLE
Fix #922: Bindings generator generates .pyc files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -298,7 +298,7 @@ bindinggen_dependencies := $(addprefix $(BINDINGS_SRC)/, BindingGen.py Bindings.
 $(AUTOGEN_SRC_script): $(BINDINGS_SRC)/%Binding.rs: $(bindinggen_dependencies) \
                                                     $(addprefix $(WEBIDLS_SRC)/, %.webidl)
 	@$(call E, "Maybe generating $(shell basename $@)...")
-	$(Q)PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
+	$(Q) $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(BINDINGS_SRC) \
 	  $(BINDINGS_SRC)/BindingGen.py rs \
@@ -317,7 +317,7 @@ $(CACHE_DIR)/.done:
 
 $(BINDINGS_SRC)/ParserResults.pkl: $(globalgen_dependencies) \
                                    $(WEBIDLS_script)
-	$(Q)PYTHONDONTWRITEBYTECODE=1 $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
+	$(Q) $(CFG_PYTHON2) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(BINDINGS_SRC) \
 	  $(BINDINGS_SRC)/GlobalGen.py $(BINDINGS_SRC)/Bindings.conf . \

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -43,7 +43,7 @@ clean-gfx:
 
 clean-script:
 	@$(call E, "cleaning script")
-	$(Q)cd $(B)/src/components/script/ && rm -rf libscript*.dylib libscript*.dSYM libscript*.so $(DONE_script)
+	$(Q)cd $(B)/src/components/script/ && rm -rf libscript*.dylib libscript*.dSYM libscript*.so $(DONE_script) && find $(S)/src/components/script/ -name \*.pyc -delete
 
 clean-style:
 	@$(call E, "cleaning style")

--- a/src/components/script/dom/bindings/codegen/Makefile.in
+++ b/src/components/script/dom/bindings/codegen/Makefile.in
@@ -95,7 +95,7 @@ CSS2Properties.webidl: $(topsrcdir)/layout/style/nsCSSPropList.h \
                        $(srcdir)/GenerateCSS2PropertiesWebIDL.py \
                        $(GLOBAL_DEPS)
 	$(CPP) $(DEFINES) $(ACDEFINES) -I$(topsrcdir)/layout/style $(webidl_base)/CSS2PropertiesProps.h | \
-	  PYTHONDONTWRITEBYTECODE=1 $(PYTHON) \
+	  $(PYTHON) \
 	  $(srcdir)/GenerateCSS2PropertiesWebIDL.py $(webidl_base)/CSS2Properties.webidl.in > CSS2Properties.webidl
 
 $(webidl_files): %: $(webidl_base)/%
@@ -107,7 +107,7 @@ $(test_webidl_files): %: $(srcdir)/test/%
 $(binding_header_files): %Binding.h: $(bindinggen_dependencies) \
                                      %.webidl \
                                      $(NULL)
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(topsrcdir)/config/pythonpath.py \
+	$(PYTHON) $(topsrcdir)/config/pythonpath.py \
 	  $(PLY_INCLUDE) -I$(srcdir)/parser \
 	  $(srcdir)/BindingGen.py header \
 	  $(srcdir)/Bindings.conf $*Binding \
@@ -116,7 +116,7 @@ $(binding_header_files): %Binding.h: $(bindinggen_dependencies) \
 $(binding_cpp_files): %Binding.cpp: $(bindinggen_dependencies) \
                                     %.webidl \
                                     $(NULL)
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(topsrcdir)/config/pythonpath.py \
+	$(PYTHON) $(topsrcdir)/config/pythonpath.py \
 	  $(PLY_INCLUDE) -I$(srcdir)/parser \
 	  $(srcdir)/BindingGen.py cpp \
 	  $(srcdir)/Bindings.conf $*Binding \
@@ -142,7 +142,7 @@ $(CACHE_DIR)/.done:
 
 ParserResults.pkl: $(globalgen_dependencies) \
                    $(all_webidl_files)
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(topsrcdir)/config/pythonpath.py \
+	$(PYTHON) $(topsrcdir)/config/pythonpath.py \
     $(PLY_INCLUDE) -I$(srcdir)/parser \
     $(srcdir)/GlobalGen.py $(srcdir)/Bindings.conf . \
     --cachedir=$(CACHE_DIR) \

--- a/src/components/script/dom/bindings/codegen/test/Makefile.in
+++ b/src/components/script/dom/bindings/codegen/test/Makefile.in
@@ -79,9 +79,9 @@ $(CPPSRCS): ../%Binding.cpp: $(bindinggen_dependencies) \
 	$(MAKE) -C .. $*Binding.cpp
 
 check::
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(topsrcdir)/config/pythonpath.py \
+	$(PYTHON) $(topsrcdir)/config/pythonpath.py \
 	  $(PLY_INCLUDE) $(srcdir)/../parser/runtests.py
 
 check-interactive:
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(topsrcdir)/config/pythonpath.py \
+	$(PYTHON) $(topsrcdir)/config/pythonpath.py \
 	  $(PLY_INCLUDE) $(srcdir)/../parser/runtests.py -q


### PR DESCRIPTION
Forgot to actually claim #922. I hope no one is working on it.

I removed `PYTHONDONTWRITEBYTECODE=1` from every relevant file and I added code for removing `*.pyc` files in `clean-script` in `mk/clean.mk`. You might want to move the main logic into a function like `REMOVE_PYC_FILES`, since the files will exist eventually in other trees under `/src`. I used `find` in order to find all `*.pyc` files, since they might be in other subdirectories.

This is my first PR, so feel free to give me any feedback you might think is necessary.
