### PR TITLE
Renamed HTMLIframeElementTypeId to HTMLIFrameElementTypeId

### DIFF
--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -36,7 +36,7 @@ use layout::wrapper::{PostorderNodeMutTraversal, TLayoutNode, ThreadSafeLayoutNo
 use gfx::font_context::FontContext;
 use script::dom::bindings::codegen::InheritTypes::TextCast;
 use script::dom::bindings::js::JS;
-use script::dom::element::{HTMLIframeElementTypeId, HTMLImageElementTypeId, HTMLObjectElementTypeId};
+use script::dom::element::{HTMLIFrameElementTypeId, HTMLImageElementTypeId, HTMLObjectElementTypeId};
 use script::dom::node::{CommentNodeTypeId, DoctypeNodeTypeId, DocumentFragmentNodeTypeId};
 use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, ProcessingInstructionNodeTypeId};
 use script::dom::node::{TextNodeTypeId};
@@ -274,7 +274,7 @@ impl<'a> FlowConstructor<'a> {
                                             -> SpecificBoxInfo {
         match node.type_id() {
             ElementNodeTypeId(HTMLImageElementTypeId) => self.build_box_info_for_image(node, node.image_url()),
-            ElementNodeTypeId(HTMLIframeElementTypeId) => IframeBox(IframeBoxInfo::new(node)),
+            ElementNodeTypeId(HTMLIFrameElementTypeId) => IframeBox(IframeBoxInfo::new(node)),
             ElementNodeTypeId(HTMLObjectElementTypeId) => {
                 let data = node.get_object_data(&self.layout_context.url);
                 self.build_box_info_for_image(node, data)

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -90,7 +90,7 @@ pub enum ElementTypeId {
     HTMLHeadElementTypeId,
     HTMLHeadingElementTypeId,
     HTMLHtmlElementTypeId,
-    HTMLIframeElementTypeId,
+    HTMLIFrameElementTypeId,
     HTMLImageElementTypeId,
     HTMLInputElementTypeId,
     HTMLLabelElementTypeId,
@@ -264,7 +264,7 @@ impl Element {
                 let mut elem: JS<HTMLImageElement> = HTMLImageElementCast::to(abstract_self);
                 elem.get_mut().AfterSetAttr(local_name.clone(), value.clone());
             }
-            ElementNodeTypeId(HTMLIframeElementTypeId) => {
+            ElementNodeTypeId(HTMLIFrameElementTypeId) => {
                 let mut elem: JS<HTMLIFrameElement> = HTMLIFrameElementCast::to(abstract_self);
                 elem.get_mut().AfterSetAttr(local_name.clone(), value.clone());
             }
@@ -333,7 +333,7 @@ impl Element {
                 let mut elem: JS<HTMLImageElement> = HTMLImageElementCast::to(abstract_self);
                 elem.get_mut().BeforeRemoveAttr(local_name.clone());
             }
-            ElementNodeTypeId(HTMLIframeElementTypeId) => {
+            ElementNodeTypeId(HTMLIFrameElementTypeId) => {
                 let mut elem: JS<HTMLIFrameElement> = HTMLIFrameElementCast::to(abstract_self);
                 elem.get_mut().BeforeRemoveAttr(local_name.clone());
             }

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLIFrameElementDerived
 use dom::bindings::js::JS;
 use dom::bindings::utils::ErrorResult;
 use dom::document::Document;
-use dom::element::HTMLIframeElementTypeId;
+use dom::element::HTMLIFrameElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId};
@@ -49,7 +49,7 @@ impl<S: Encoder> Encodable<S> for Untraceable {
 impl HTMLIFrameElementDerived for EventTarget {
     fn is_htmliframeelement(&self) -> bool {
         match self.type_id {
-            NodeTargetTypeId(ElementNodeTypeId(HTMLIframeElementTypeId)) => true,
+            NodeTargetTypeId(ElementNodeTypeId(HTMLIFrameElementTypeId)) => true,
             _ => false
         }
     }
@@ -70,7 +70,7 @@ impl HTMLIFrameElement {
 impl HTMLIFrameElement {
     pub fn new_inherited(localName: DOMString, document: JS<Document>) -> HTMLIFrameElement {
         HTMLIFrameElement {
-            htmlelement: HTMLElement::new_inherited(HTMLIframeElementTypeId, localName, document),
+            htmlelement: HTMLElement::new_inherited(HTMLIFrameElementTypeId, localName, document),
             extra: Untraceable {
                 frame: None
             },

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::js::JS;
 use dom::bindings::utils::Reflectable;
 use dom::document::Document;
-use dom::element::{HTMLLinkElementTypeId, HTMLIframeElementTypeId};
+use dom::element::{HTMLLinkElementTypeId, HTMLIFrameElementTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::htmlheadingelement::{Heading1, Heading2, Heading3, Heading4, Heading5, Heading6};
 use dom::htmliframeelement::IFrameSize;
@@ -350,7 +350,7 @@ pub fn parse_html(cx: *JSContext,
                     }
                 }
 
-                ElementNodeTypeId(HTMLIframeElementTypeId) => {
+                ElementNodeTypeId(HTMLIFrameElementTypeId) => {
                     let iframe_chan = discovery_chan.clone();
                     let mut iframe_element: JS<HTMLIFrameElement> =
                         HTMLIFrameElementCast::to(&element);


### PR DESCRIPTION
Simple change. I hope I'm using github correctly; I'm not too familiar with the PR system. Fixes #1777.
