### PR TITLE
When calling constructors, retrieve the global object from the callee...

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4805,13 +4805,8 @@ class CGClassConstructHook(CGAbstractExternMethod):
 
     def generate_code(self):
         preamble = """
-  //JSObject* obj = JS_GetGlobalForObject(cx, JSVAL_TO_OBJECT(JS_CALLEE(cx, vp)));
-  //XXXjdm Gecko obtains a GlobalObject from the global (maybe from the private value,
-  //       or through unwrapping a slot or something). We'll punt and get the Window
-  //       from the context for now. 
-  let page = page_from_context(cx);
-  let frame = (*page).frame();
-  let global = frame.get().get_ref().window.clone();
+  let window = global_object_for_js_object(RUST_JSVAL_TO_OBJECT(JS_CALLEE(cx, &*vp)));
+  let global = JS::from_box(window);
   let obj = global.reflector().get_jsobject();
 """
         nativeName = MakeNativeName(self._ctor.identifier.name)

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4805,8 +4805,7 @@ class CGClassConstructHook(CGAbstractExternMethod):
 
     def generate_code(self):
         preamble = """
-  let window = global_object_for_js_object(RUST_JSVAL_TO_OBJECT(JS_CALLEE(cx, &*vp)));
-  let global = JS::from_box(window);
+  let global = global_object_for_js_object(RUST_JSVAL_TO_OBJECT(JS_CALLEE(cx, &*vp)));
   let obj = global.reflector().get_jsobject();
 """
         nativeName = MakeNativeName(self._ctor.identifier.name)

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -720,32 +720,30 @@ pub fn CreateDOMGlobal(cx: *JSContext, class: *JSClass) -> *JSObject {
 }
 
 /// Returns the global object of the realm that the given JS object was created in.
-pub fn global_object_for_js_object(obj: *JSObject) -> *mut Box<window::Window> {
+pub fn global_object_for_js_object(obj: *JSObject) -> JS<window::Window> {
     unsafe {
         let global = GetGlobalForObjectCrossCompartment(obj);
         let clasp = JS_GetClass(global);
         assert!(((*clasp).flags & (JSCLASS_IS_DOMJSCLASS | JSCLASS_IS_GLOBAL)) != 0);
         // FIXME(jdm): Either don't hardcode or sanity assert prototype stuff.
         match unwrap_object::<*mut Box<window::Window>>(global, PrototypeList::id::Window, 1) {
-            Ok(win) => win,
+            Ok(win) => JS::from_box(win),
             Err(_) => fail!("found DOM global that doesn't unwrap to Window"),
         }
     }
 }
 
 fn cx_for_dom_reflector(obj: *JSObject) -> *JSContext {
-    unsafe {
-        let win = global_object_for_js_object(obj);
-        let js_info = (*win).data.page().js_info();
-        match *js_info.get() {
-            Some(ref info) => info.js_context.borrow().ptr,
-            None => fail!("no JS context for DOM global")
-        }
+    let win = global_object_for_js_object(obj);
+    let js_info = win.get().page().js_info();
+    match *js_info.get() {
+        Some(ref info) => info.js_context.borrow().ptr,
+        None => fail!("no JS context for DOM global")
     }
 }
 
 /// Returns the global object of the realm that the given DOM object was created in.
-pub fn global_object_for_dom_object<T: Reflectable>(obj: &T) -> *mut Box<window::Window> {
+pub fn global_object_for_dom_object<T: Reflectable>(obj: &T) -> JS<window::Window> {
     global_object_for_js_object(obj.reflector().get_jsobject())
 }
 

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -720,13 +720,13 @@ pub fn CreateDOMGlobal(cx: *JSContext, class: *JSClass) -> *JSObject {
 }
 
 /// Returns the global object of the realm that the given JS object was created in.
-fn global_object_for_js_object(obj: *JSObject) -> *Box<window::Window> {
+pub fn global_object_for_js_object(obj: *JSObject) -> *mut Box<window::Window> {
     unsafe {
         let global = GetGlobalForObjectCrossCompartment(obj);
         let clasp = JS_GetClass(global);
         assert!(((*clasp).flags & (JSCLASS_IS_DOMJSCLASS | JSCLASS_IS_GLOBAL)) != 0);
         // FIXME(jdm): Either don't hardcode or sanity assert prototype stuff.
-        match unwrap_object::<*Box<window::Window>>(global, PrototypeList::id::Window, 1) {
+        match unwrap_object::<*mut Box<window::Window>>(global, PrototypeList::id::Window, 1) {
             Ok(win) => win,
             Err(_) => fail!("found DOM global that doesn't unwrap to Window"),
         }
@@ -745,7 +745,7 @@ fn cx_for_dom_reflector(obj: *JSObject) -> *JSContext {
 }
 
 /// Returns the global object of the realm that the given DOM object was created in.
-pub fn global_object_for_dom_object<T: Reflectable>(obj: &T) -> *Box<window::Window> {
+pub fn global_object_for_dom_object<T: Reflectable>(obj: &T) -> *mut Box<window::Window> {
     global_object_for_js_object(obj.reflector().get_jsobject())
 }
 


### PR DESCRIPTION
...rather than the JSContext.

Requires https://github.com/mozilla-servo/rust-mozjs/pull/51.
