### PR TITLE
Pass Option<JSVal> for optional JSVals.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1162,10 +1162,18 @@ for (uint32_t i = 0; i < length; ++i) {
         if isMember:
             raise TypeError("Can't handle member 'any'; need to sort out "
                             "rooting issues")
-        templateBody = "${declName} = ${val};"
+
+        declType = CGGeneric("JSVal")
+        value = CGGeneric("${val}")
+        if isOptional:
+            declType = CGWrapper(declType, pre="Option<", post=">")
+            value = CGWrapper(value, pre="Some(", post=")")
+
+        templateBody = "${declName} = %s;" % value.define()
         templateBody = handleDefaultNull(templateBody,
                                          "${declName} = JSVAL_NULL")
-        return (templateBody, CGGeneric("JSVal"), None, isOptional, "JSVAL_NULL")
+
+        return (templateBody, declType, None, isOptional, "None" if isOptional else None)
 
     if type.isObject():
         assert not isEnforceRange and not isClamp

--- a/src/components/script/dom/testbinding.rs
+++ b/src/components/script/dom/testbinding.rs
@@ -8,6 +8,9 @@ use dom::blob::Blob;
 use dom::window::Window;
 use servo_util::str::DOMString;
 
+use js::JSVAL_NULL;
+use js::jsapi::{JSVal, JSContext};
+
 #[deriving(Encodable)]
 pub struct TestBinding {
     reflector: Reflector,
@@ -41,6 +44,8 @@ impl TestBinding {
     pub fn SetStringAttribute(&self, _: DOMString) {}
     pub fn InterfaceAttribute(&self) -> JS<Blob> { Blob::new(&self.window) }
     pub fn SetInterfaceAttribute(&self, _: &JS<Blob>) {}
+    pub fn AnyAttribute(&self, _: *JSContext) -> JSVal { JSVAL_NULL }
+    pub fn SetAnyAttribute(&self, _: *JSContext, _: JSVal) {}
 
     pub fn GetBooleanAttributeNullable(&self) -> Option<bool> { Some(false) }
     pub fn SetBooleanAttributeNullable(&self, _: Option<bool>) {}
@@ -83,6 +88,7 @@ impl TestBinding {
     // pub fn PassOptionalDouble(&self, _: Option<f64>) {}
     pub fn PassOptionalString(&self, _: Option<DOMString>) {}
     pub fn PassOptionalInterface(&self, _: Option<JS<Blob>>) {}
+    pub fn PassOptionalAny(&self, _: *JSContext, _: Option<JSVal>) {}
 
     // pub fn PassOptionalNullableBoolean(&self, _: Option<Option<bool>>) {}
     // pub fn PassOptionalNullableByte(&self, _: Option<Option<i8>>) {}
@@ -122,6 +128,7 @@ impl TestBinding {
     pub fn PassOptionalNullableDoubleWithDefault(&self, _: Option<f64>) {}
     // pub fn PassOptionalNullableStringWithDefault(&self, _: Option<DOMString>) {}
     pub fn PassOptionalNullableInterfaceWithDefault(&self, _: Option<JS<Blob>>) {}
+    pub fn PassOptionalAnyWithDefault(&self, _: *JSContext, _: JSVal) {}
 
     pub fn PassOptionalNullableBooleanWithNonNullDefault(&self, _: Option<bool>) {}
     pub fn PassOptionalNullableByteWithNonNullDefault(&self, _: Option<i8>) {}

--- a/src/components/script/dom/webidls/TestBinding.webidl
+++ b/src/components/script/dom/webidls/TestBinding.webidl
@@ -16,6 +16,7 @@ interface TestBinding {
            attribute double doubleAttribute;
            attribute DOMString stringAttribute;
            attribute Blob interfaceAttribute;
+           attribute any anyAttribute;
 
            attribute boolean? booleanAttributeNullable;
            attribute byte? byteAttributeNullable;
@@ -45,6 +46,7 @@ interface TestBinding {
   // void passOptionalDouble(optional double arg);
   void passOptionalString(optional DOMString arg);
   void passOptionalInterface(optional Blob arg);
+  void passOptionalAny(optional any arg);
 
   // void passOptionalNullableBoolean(optional boolean? arg);
   // void passOptionalNullableByte(optional byte? arg);
@@ -82,6 +84,7 @@ interface TestBinding {
   void passOptionalNullableUnsignedLongLongWithDefault(optional unsigned long long? arg = null);
   // void passOptionalNullableStringWithDefault(optional DOMString? arg = null);
   void passOptionalNullableInterfaceWithDefault(optional Blob? arg = null);
+  void passOptionalAnyWithDefault(optional any arg = null);
 
   void passOptionalNullableBooleanWithNonNullDefault(optional boolean? arg = false);
   void passOptionalNullableByteWithNonNullDefault(optional byte? arg = 7);

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -207,7 +207,7 @@ impl Window {
     pub fn Print(&self) {
     }
 
-    pub fn ShowModalDialog(&self, _cx: *JSContext, _url: DOMString, _argument: JSVal) -> JSVal {
+    pub fn ShowModalDialog(&self, _cx: *JSContext, _url: DOMString, _argument: Option<JSVal>) -> JSVal {
         JSVAL_NULL
     }
 }


### PR DESCRIPTION
Right now, we silently default to null, which is somewhat fishy.
