### PR TITLE
Split JSValConvertible into two traits.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1232,7 +1232,7 @@ for (uint32_t i = 0; i < length; ++i) {
         successVal = preSuccess + successVal + postSuccess
     #XXXjdm support conversionBehavior here
     template = (
-        "match JSValConvertible::from_jsval(cx, ${val}) {\n"
+        "match FromJSValConvertible::from_jsval(cx, ${val}) {\n"
         "  Ok(v) => ${declName} = %s,\n"
         "  Err(_) => %s\n"
         "}" % (successVal, failureCode))
@@ -5276,7 +5276,7 @@ class CGBindingRoot(CGThing):
                           'dom::bindings::callback::{CallbackContainer,CallbackInterface}',
                           'dom::bindings::callback::{CallSetup,ExceptionHandling}',
                           'dom::bindings::callback::{WrapCallThisObject}',
-                          'dom::bindings::conversions::JSValConvertible',
+                          'dom::bindings::conversions::{FromJSValConvertible, ToJSValConvertible}',
                           'dom::bindings::codegen::*',
                           'dom::bindings::codegen::UnionTypes::*',
                           'dom::bindings::codegen::UnionConversions::*',
@@ -6426,7 +6426,7 @@ class GlobalGenRoots():
                           'dom::bindings::utils::unwrap_jsmanaged',
                           'dom::bindings::codegen::UnionTypes::*',
                           'dom::bindings::codegen::PrototypeList',
-                          'dom::bindings::conversions::JSValConvertible',
+                          'dom::bindings::conversions::{FromJSValConvertible, ToJSValConvertible}',
                           'js::{crust, JS_ARGV, JS_CALLEE, JS_THIS_OBJECT}',
                           'js::{JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_IS_DOMJSCLASS}',
                           'js::{JSCLASS_IS_GLOBAL, JSCLASS_RESERVED_SLOTS_SHIFT}',

--- a/src/components/script/dom/bindings/conversions.rs
+++ b/src/components/script/dom/bindings/conversions.rs
@@ -10,8 +10,11 @@ use js::{JSVAL_FALSE, JSVAL_TRUE, JSVAL_NULL};
 use js::glue::{RUST_INT_TO_JSVAL, RUST_UINT_TO_JSVAL, RUST_JS_NumberValue};
 use js::glue::{RUST_JSVAL_IS_NULL, RUST_JSVAL_IS_VOID};
 
-pub trait JSValConvertible {
+pub trait ToJSValConvertible {
     fn to_jsval(&self) -> JSVal;
+}
+
+pub trait FromJSValConvertible {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<Self, ()>;
 }
 
@@ -28,7 +31,7 @@ unsafe fn convert_from_jsval<T: Default>(
 }
 
 
-impl JSValConvertible for bool {
+impl ToJSValConvertible for bool {
     fn to_jsval(&self) -> JSVal {
         if *self {
             JSVAL_TRUE
@@ -36,150 +39,174 @@ impl JSValConvertible for bool {
             JSVAL_FALSE
         }
     }
+}
 
+impl FromJSValConvertible for bool {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<bool, ()> {
         let result = unsafe { convert_from_jsval(cx, val, JS_ValueToBoolean) };
         result.map(|b| b != 0)
     }
 }
 
-impl JSValConvertible for i8 {
+impl ToJSValConvertible for i8 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_INT_TO_JSVAL(*self as i32)
         }
     }
+}
 
+impl FromJSValConvertible for i8 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<i8, ()> {
         let result = unsafe { convert_from_jsval(cx, val, JS_ValueToECMAInt32) };
         result.map(|v| v as i8)
     }
 }
 
-impl JSValConvertible for u8 {
+impl ToJSValConvertible for u8 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_INT_TO_JSVAL(*self as i32)
         }
     }
+}
 
+impl FromJSValConvertible for u8 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<u8, ()> {
         let result = unsafe { convert_from_jsval(cx, val, JS_ValueToECMAInt32) };
         result.map(|v| v as u8)
     }
 }
 
-impl JSValConvertible for i16 {
+impl ToJSValConvertible for i16 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_INT_TO_JSVAL(*self as i32)
         }
     }
+}
 
+impl FromJSValConvertible for i16 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<i16, ()> {
         let result = unsafe { convert_from_jsval(cx, val, JS_ValueToECMAInt32) };
         result.map(|v| v as i16)
     }
 }
 
-impl JSValConvertible for u16 {
+impl ToJSValConvertible for u16 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_UINT_TO_JSVAL(*self as u32)
         }
     }
+}
 
+impl FromJSValConvertible for u16 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<u16, ()> {
         unsafe { convert_from_jsval(cx, val, JS_ValueToUint16) }
     }
 }
 
-impl JSValConvertible for i32 {
+impl ToJSValConvertible for i32 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_INT_TO_JSVAL(*self)
         }
     }
+}
 
+impl FromJSValConvertible for i32 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<i32, ()> {
         unsafe { convert_from_jsval(cx, val, JS_ValueToECMAInt32) }
     }
 }
 
-impl JSValConvertible for u32 {
+impl ToJSValConvertible for u32 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_UINT_TO_JSVAL(*self)
         }
     }
+}
 
+impl FromJSValConvertible for u32 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<u32, ()> {
         unsafe { convert_from_jsval(cx, val, JS_ValueToECMAUint32) }
     }
 }
 
-impl JSValConvertible for i64 {
+impl ToJSValConvertible for i64 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_JS_NumberValue(*self as f64)
         }
     }
+}
 
+impl FromJSValConvertible for i64 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<i64, ()> {
         unsafe { convert_from_jsval(cx, val, JS_ValueToInt64) }
     }
 }
 
-impl JSValConvertible for u64 {
+impl ToJSValConvertible for u64 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_JS_NumberValue(*self as f64)
         }
     }
+}
 
+impl FromJSValConvertible for u64 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<u64, ()> {
         unsafe { convert_from_jsval(cx, val, JS_ValueToUint64) }
     }
 }
 
-impl JSValConvertible for f32 {
+impl ToJSValConvertible for f32 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_JS_NumberValue(*self as f64)
         }
     }
+}
 
+impl FromJSValConvertible for f32 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<f32, ()> {
         let result = unsafe { convert_from_jsval(cx, val, JS_ValueToNumber) };
         result.map(|f| f as f32)
     }
 }
 
-impl JSValConvertible for f64 {
+impl ToJSValConvertible for f64 {
     fn to_jsval(&self) -> JSVal {
         unsafe {
             RUST_JS_NumberValue(*self)
         }
     }
+}
 
+impl FromJSValConvertible for f64 {
     fn from_jsval(cx: *JSContext, val: JSVal) -> Result<f64, ()> {
         unsafe { convert_from_jsval(cx, val, JS_ValueToNumber) }
     }
 }
 
-impl<T: JSValConvertible> JSValConvertible for Option<T> {
+impl<T: ToJSValConvertible> ToJSValConvertible for Option<T> {
     fn to_jsval(&self) -> JSVal {
         match self {
             &Some(ref value) => value.to_jsval(),
             &None => JSVAL_NULL,
         }
     }
+}
 
+impl<T: FromJSValConvertible> FromJSValConvertible for Option<T> {
     fn from_jsval(cx: *JSContext, value: JSVal) -> Result<Option<T>, ()> {
         if unsafe { RUST_JSVAL_IS_NULL(value) != 0 || RUST_JSVAL_IS_VOID(value) != 0 } {
             Ok(None)
         } else {
-            let result: Result<T, ()> = JSValConvertible::from_jsval(cx, value);
+            let result: Result<T, ()> = FromJSValConvertible::from_jsval(cx, value);
             result.map(|v| Some(v))
         }
     }


### PR DESCRIPTION
Later, we'll want to implement variations of the conversion _from_ JS, but
not the conversion _to_ JS.
