### PR TITLE
Ubuntu doesn't have g++ installed by default, adding it to pre-requisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install autoconf2.13 curl freeglut3-dev libtool \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    msttcorefonts gperf
+    msttcorefonts gperf g++
 ```
 
 On Debian-based Linuxes (cross-compilation for Android):


### PR DESCRIPTION
..per title
