### PR TITLE
Don't use the Untraceable fields outside the module they're defined in.

### DIFF
--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -82,7 +82,7 @@ pub trait TLayoutNode {
                 fail!("not an image!")
             }
             let image_element: JS<HTMLImageElement> = self.get_jsmanaged().transmute_copy();
-            (*image_element.unsafe_get()).extra.image.as_ref().map(|url| (*url).clone())
+            (*image_element.unsafe_get()).image().as_ref().map(|url| (*url).clone())
         }
     }
 

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -61,7 +61,7 @@ pub struct Document {
     content_type: DOMString,
     encoding_name: DOMString,
     is_html_document: bool,
-    extra: Untraceable,
+    priv extra: Untraceable,
 }
 
 struct Untraceable {
@@ -139,6 +139,12 @@ impl Document {
 }
 
 impl Document {
+    pub fn url<'a>(&'a self) -> &'a Url {
+        &self.extra.url
+    }
+}
+
+impl Document {
     // http://dom.spec.whatwg.org/#dom-document
     pub fn Constructor(owner: &JS<Window>) -> Fallible<JS<Document>> {
         Ok(Document::new(owner, None, NonHTMLDocument, None))
@@ -166,7 +172,7 @@ impl Document {
 
     // http://dom.spec.whatwg.org/#dom-document-url
     pub fn URL(&self) -> DOMString {
-        self.extra.url.to_str()
+        self.url().to_str()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-documenturi

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -241,7 +241,7 @@ impl Element {
         match local_name.as_slice() {
             "style" => {
                 let doc = self.node.owner_doc();
-                let base_url = doc.get().extra.url.clone();
+                let base_url = doc.get().url().clone();
                 self.style_attribute = Some(style::parse_style_attribute(value, &base_url))
             }
             "id" => {

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -32,7 +32,7 @@ enum SandboxAllowance {
 #[deriving(Encodable)]
 pub struct HTMLIFrameElement {
     htmlelement: HTMLElement,
-    extra: Untraceable,
+    priv extra: Untraceable,
     size: Option<IFrameSize>,
     sandbox: Option<u8>
 }
@@ -64,6 +64,10 @@ pub struct IFrameSize {
 impl HTMLIFrameElement {
     pub fn is_sandboxed(&self) -> bool {
         self.sandbox.is_some()
+    }
+
+    pub fn set_frame(&mut self, frame: Url) {
+        self.extra.frame = Some(frame);
     }
 }
 

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -24,7 +24,7 @@ use extra::serialize::{Encoder, Encodable};
 #[deriving(Encodable)]
 pub struct HTMLImageElement {
     htmlelement: HTMLElement,
-    extra: Untraceable,
+    priv extra: Untraceable,
 }
 
 struct Untraceable {
@@ -62,6 +62,10 @@ impl HTMLImageElement {
 }
 
 impl HTMLImageElement {
+    pub fn image<'a>(&'a self) -> &'a Option<Url> {
+        &self.extra.image
+    }
+
     /// Makes the local `image` member match the status of the `src` attribute and starts
     /// prefetching the image. This method must be called after `src` is changed.
     fn update_image(&mut self, value: Option<DOMString>, url: Option<Url>) {

--- a/src/components/script/dom/location.rs
+++ b/src/components/script/dom/location.rs
@@ -18,7 +18,7 @@ use extra::serialize::{Encoder, Encodable};
 #[deriving(Encodable)]
 pub struct Location {
     reflector_: Reflector, //XXXjdm cycle: window->Location->window
-    extra: Untraceable,
+    priv extra: Untraceable,
 }
 
 struct Untraceable {

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -81,7 +81,7 @@ pub struct Window {
     image_cache_task: ImageCacheTask,
     active_timers: ~HashSet<TimerHandle>,
     next_timer_handle: i32,
-    extra: Untraceable
+    priv extra: Untraceable
 }
 
 struct Untraceable {

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -357,7 +357,7 @@ pub fn parse_html(page: &Page,
                     let src_opt = elem.get().get_attribute(Null, "src").map(|x| x.get().Value());
                     for src in src_opt.iter() {
                         let iframe_url = parse_url(*src, Some(url2.clone()));
-                        iframe_element.get_mut().extra.frame = Some(iframe_url.clone());
+                        iframe_element.get_mut().set_frame(iframe_url.clone());
 
                         // Subpage Id
                         let subpage_id = next_subpage_id.get();


### PR DESCRIPTION
This pattern will become illegal with the next Rust upgrade.
