### PR TITLE
script: Fix background color of Acid2.

### DIFF
--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -499,6 +499,7 @@ pub mod longhands {
                         let image_url = parse_url(url.as_slice(), Some(base_url.clone()));
                         Some(Some(image_url))
                     },
+                    &ast::Ident(ref value) if "none" == value.to_ascii_lower() => Some(None),
                     _ => None,
                 }
             }

--- a/src/components/util/str.rs
+++ b/src/components/util/str.rs
@@ -25,3 +25,16 @@ pub fn is_whitespace(s: &str) -> bool {
         _ => false
     })
 }
+
+/// A "space character" according to:
+///
+///     http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#
+///     space-character
+pub static HTML_SPACE_CHARACTERS: [char, ..5] = [
+    '\u0020',
+    '\u0009',
+    '\u000a',
+    '\u000c',
+    '\u000d',
+];
+

--- a/src/test/ref/background_none_a.html
+++ b/src/test/ref/background_none_a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>background: none test</title>
+<style>
+#a {
+    background: red;
+    width: 32px;
+    height: 32px;
+}
+
+#a {
+    background: none;
+}
+</style>
+</head>
+<body>
+<div id=a></div>
+</body>
+</html>
+

--- a/src/test/ref/background_none_b.html
+++ b/src/test/ref/background_none_b.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>background: none test</title>
+<style>
+#a {
+    width: 32px;
+    height: 32px;
+}
+</style>
+</head>
+<body>
+<div id=a></div>
+</body>
+</html>
+

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -53,3 +53,4 @@
 == position_fixed_static_y_a.html position_fixed_static_y_b.html
 == position_relative_a.html position_relative_b.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
+== background_none_a.html background_none_b.html


### PR DESCRIPTION
There were two problems here: (1) we did not process style sheets with an
unexpected `rel` attribute but a correct MIME type; (2) we did not
consider `none` a valid value for the `background` property.

r? @SimonSapin
