### PR TITLE
Force infallible binding methods to return void.(fixes #1933)

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2461,6 +2461,8 @@ class CGCallGenerator(CGThing):
             call = CGWrapper(call, pre="result_fallible = ")
         elif result is not None:
             call = CGWrapper(call, pre="result = ")
+        else:
+            call = CGWrapper(call, pre="let _: () = ")
 
         call = CGWrapper(call)
         self.cgRoot.append(call)


### PR DESCRIPTION
see #1933
