### PR TITLE
Set a name for WorkQueue tasks (fixes #1830)

### DIFF
--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -290,7 +290,7 @@ impl LayoutTask {
         let local_image_cache = MutexArc::new(LocalImageCache(image_cache_task.clone()));
         let screen_size = Size2D(Au(0), Au(0));
         let parallel_traversal = if opts.layout_threads != 1 {
-            Some(WorkQueue::new(opts.layout_threads, ptr::mut_null()))
+            Some(WorkQueue::new("LayoutWorker", opts.layout_threads, ptr::mut_null()))
         } else {
             None
         };

--- a/src/components/util/workqueue.rs
+++ b/src/components/util/workqueue.rs
@@ -7,7 +7,7 @@
 //! Data associated with queues is simply a pair of unsigned integers. It is expected that a
 //! higher-level API on top of this could allow safe fork-join parallelism.
 
-use native;
+use task;
 use std::cast;
 use std::comm;
 use std::mem;
@@ -200,7 +200,7 @@ pub struct WorkQueue<QUD,WUD> {
 impl<QUD:Send,WUD:Send> WorkQueue<QUD,WUD> {
     /// Creates a new work queue and spawns all the threads associated with
     /// it.
-    pub fn new(thread_count: uint, user_data: QUD) -> WorkQueue<QUD,WUD> {
+    pub fn new(task_name: &str, thread_count: uint, user_data: QUD) -> WorkQueue<QUD,WUD> {
         // Set up data structures.
         let (supervisor_port, supervisor_chan) = Chan::new();
         let (mut infos, mut threads) = (~[], ~[]);
@@ -235,7 +235,7 @@ impl<QUD:Send,WUD:Send> WorkQueue<QUD,WUD> {
 
         // Spawn threads.
         for thread in threads.move_iter() {
-            native::task::spawn(proc() {
+            task::spawn_named(task_name.to_owned(), proc() {
                 let mut thread = thread;
                 thread.start()
             })


### PR DESCRIPTION
This is my first Servo patch.  Please don't hesitate to offer basic Rust tips.

Note: This assigns the same name to all of the worker tasks for a given WorkQueue.  Would it be useful to generate a unique name for each tasks (LayoutWorker1, LayoutWorker2...)?
