### PR TITLE
Remove |unused| field from DOMClass.(fixes #1960)

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1657,7 +1657,6 @@ def DOMClass(descriptor):
         prototypeChainString = ', '.join(protoList)
         return """DOMClass {
   interface_chain: [ %s ],
-  unused: false,
   native_hooks: &NativeHooks as *NativePropertyHooks
 }""" % prototypeChainString
 

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -222,7 +222,6 @@ pub struct DOMClass {
     // derivedness.
     interface_chain: [PrototypeList::id::ID, ..MAX_PROTO_CHAIN_LENGTH],
 
-    unused: bool, // DOMObjectIsISupports (always false)
     native_hooks: *NativePropertyHooks
 }
 


### PR DESCRIPTION
see #1960
