### PR TITLE
Support fixed-layout table and a part of anonymous table object

### DIFF
--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -625,47 +625,38 @@ impl BlockFlow {
         self.base.fixed_descendants.static_y_offsets = fixed_descendant_y_offsets;
     }
 
-    /// Assign height for current flow.
-    ///
-    /// + Collapse margins for flow's children and set in-flow child flows'
-    /// y-coordinates now that we know their heights.
-    /// + Calculate and set the height of the current flow.
-    /// + Calculate height, vertical margins, and y-coordinate for the flow's
-    /// box. Ideally, this should be calculated using CSS Section 10.6.7
-    ///
-    /// For absolute flows, store the calculated content height for the flow.
-    /// Defer the calculation of the other values till a later traversal.
-    ///
-    /// inline(always) because this is only ever called by in-order or non-in-order top-level
-    /// methods
-    #[inline(always)]
-    fn assign_height_block_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
-        let mut cur_y = Au::new(0);
-        let mut clearance = Au::new(0);
-        // Offset to content edge of box_
-        let mut top_offset = Au::new(0);
-        let mut bottom_offset = Au::new(0);
-        let mut left_offset = Au::new(0);
-
-        for box_ in self.box_.iter() {
-            // Note: Ignoring clearance for absolute flows as of now.
-            if !self.is_absolutely_positioned() {
-                clearance = match box_.clear() {
-                    None => Au::new(0),
-                    Some(clear) => {
-                        self.base.floats.clearance(clear)
-                    }
+    /// Calculate clearance, top_offset, bottom_offset, and left_offset for the box.
+    /// If `ignore_clear` is true, clearance does not need to be calculated.
+    pub fn initialize_offsets(&mut self, ignore_clear: bool) -> (Au, Au, Au, Au) {
+        match self.box_ {
+            None => (Au(0), Au(0), Au(0), Au(0)),
+            Some(ref box_) => {
+                let clearance = match box_.clear() {
+                    Some(clear) if !ignore_clear => self.base.floats.clearance(clear),
+                    _ => Au::new(0)
                 };
+
+                // Offset to content edge of box_
+                let top_offset = clearance + box_.margin.get().top + box_.border.get().top +
+                    box_.padding.get().top;
+                let bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
+                    box_.padding.get().bottom;
+                let left_offset = box_.offset();
+
+                (clearance, top_offset, bottom_offset, left_offset)
             }
-
-            top_offset = clearance + box_.margin.get().top + box_.border.get().top +
-                box_.padding.get().top;
-            cur_y = cur_y + top_offset;
-            bottom_offset = box_.margin.get().bottom + box_.border.get().bottom +
-                box_.padding.get().bottom;
-            left_offset = box_.offset();
         }
+    }
 
+    /// In case of inorder assign_height traversal and not absolute flow,
+    /// 'assign_height's of all children are visited
+    /// and Float info is shared between adjacent children.
+    /// Float info of the last child is saved in parent flow.
+    pub fn handle_children_floats_if_necessary(&mut self,
+                                               ctx: &mut LayoutContext,
+                                               inorder: bool,
+                                               left_offset: Au,
+                                               top_offset: Au) {
         // Note: Ignoring floats for absolute flow as of now.
         if inorder && !self.is_absolutely_positioned() {
             // Floats for blocks work like this:
@@ -684,9 +675,41 @@ impl BlockFlow {
             }
             self.base.floats = floats;
         }
+    }
 
-        // The amount of margin that we can potentially collapse with
-        let mut collapsible = Au::new(0);
+    /// Compute margin_top and margin_bottom. Also, it is decided whether top margin and
+    /// bottom margin are collapsible according to CSS 2.1 § 8.3.1.
+    pub fn precompute_margin(&mut self) -> (Au, Au, bool, bool) {
+        match self.box_ {
+            // Margins for an absolutely positioned element do not collapse with
+            // its children.
+            Some(ref box_) if !self.is_absolutely_positioned() => {
+                let top_margin_collapsible = !self.is_root &&
+                                             box_.border.get().top == Au(0) &&
+                                             box_.padding.get().top == Au(0);
+
+                let bottom_margin_collapsible = !self.is_root &&
+                                                box_.border.get().bottom == Au(0) &&
+                                                box_.padding.get().bottom == Au(0);
+
+                let margin_top = box_.margin.get().top;
+                let margin_bottom = box_.margin.get().bottom;
+
+                (margin_top, margin_bottom, top_margin_collapsible, bottom_margin_collapsible)
+            },
+            _ => (Au(0), Au(0), false, false)
+        }
+    }
+
+    /// Compute collapsed margins between adjacent children or between the first/last child and parent
+    /// according to CSS 2.1 § 8.3.1. Current y position(cur_y) is continually updated for collapsing result.
+    pub fn compute_margin_collapse(&mut self,
+                                   cur_y: &mut Au,
+                                   top_offset: &mut Au,
+                                   margin_top: &mut Au,
+                                   margin_bottom: &mut Au,
+                                   top_margin_collapsible: bool,
+                                   bottom_margin_collapsible: bool) -> Au {
         // How much to move up by to get to the beginning of
         // current kid flow.
         // Example: if previous sibling's margin-bottom is 20px and your
@@ -694,55 +717,38 @@ impl BlockFlow {
         // will be at the bottom margin edge of the previous sibling, we have
         // to move up by 12px to get to our top margin edge. So, `collapsing`
         // will be set to 12px
-        let mut collapsing = Au::new(0);
-        let mut margin_top = Au::new(0);
-        let mut margin_bottom = Au::new(0);
-        let mut top_margin_collapsible = false;
-        let mut bottom_margin_collapsible = false;
         let mut first_in_flow = true;
-        // Margins for an absolutely positioned element do not collapse with
-        // its children.
-        if !self.is_absolutely_positioned() {
-            for box_ in self.box_.iter() {
-                if !self.is_root() && box_.border.get().top == Au(0)
-                    && box_.padding.get().top == Au(0) {
-
-                    collapsible = box_.margin.get().top;
-                    top_margin_collapsible = true;
-                }
-                if !self.is_root() && box_.border.get().bottom == Au(0) &&
-                    box_.padding.get().bottom == Au(0) {
-                    bottom_margin_collapsible = true;
-                }
-                margin_top = box_.margin.get().top;
-                margin_bottom = box_.margin.get().bottom;
-            }
-        }
+        let mut collapsing = Au::new(0);
+        // The amount of margin that we can potentially collapse with
+        let mut collapsible = if top_margin_collapsible {
+            *margin_top
+        } else {
+            Au(0)
+        };
 
         // At this point, cur_y is at the content edge of the flow's box_
         for kid in self.base.child_iter() {
             // At this point, cur_y is at bottom margin edge of previous kid
-
             if kid.is_absolutely_positioned() {
                 // Assume that the `hypothetical box` for an absolute flow
                 // starts immediately after the bottom margin edge of the
                 // previous flow.
-                kid.as_block().base.position.origin.y = cur_y;
+                kid.as_block().base.position.origin.y = *cur_y;
                 // Skip the collapsing for absolute flow kids and continue
                 // with the next flow.
             } else {
                 kid.collapse_margins(top_margin_collapsible,
                                      &mut first_in_flow,
-                                     &mut margin_top,
-                                     &mut top_offset,
+                                     margin_top,
+                                     top_offset,
                                      &mut collapsing,
                                      &mut collapsible);
                 let child_node = flow::mut_base(kid);
-                cur_y = cur_y - collapsing;
+                *cur_y = *cur_y - collapsing;
                 // At this point, after moving up by `collapsing`, cur_y is at the
                 // top margin edge of kid
-                child_node.position.origin.y = cur_y;
-                cur_y = cur_y + child_node.position.size.height;
+                child_node.position.origin.y = *cur_y;
+                *cur_y = *cur_y + child_node.position.size.height;
                 // At this point, cur_y is at the bottom margin edge of kid
             }
         }
@@ -754,13 +760,127 @@ impl BlockFlow {
         // The bottom margin for an absolutely positioned element does not
         // collapse even with its children.
         collapsing = if bottom_margin_collapsible && !self.is_absolutely_positioned() {
-            if margin_bottom < collapsible {
-                margin_bottom = collapsible;
+            if *margin_bottom < collapsible {
+                *margin_bottom = collapsible;
             }
             collapsible
         } else {
             Au::new(0)
         };
+
+        collapsing
+    }
+
+    /// For an absolutely positioned element, store the content height for use in calculating
+    /// the absolute flow's dimensions later.
+    pub fn store_content_height_if_absolutely_positioned(&mut self,
+                                                         height: Au) -> bool {
+        if self.is_absolutely_positioned() {
+            for box_ in self.box_.iter() {
+                let mut temp_position = box_.border_box.get();
+                temp_position.size.height = height;
+                box_.border_box.set(temp_position);
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Compute the box height and set border_box and margin of the box.
+    pub fn compute_height_position(&mut self,
+                                   height: &mut Au,
+                                   border_and_padding: Au,
+                                   margin_top: Au,
+                                   margin_bottom: Au,
+                                   clearance: Au) {
+        // Here, height is content height of box_
+        let mut noncontent_height = border_and_padding;
+        for box_ in self.box_.iter() {
+            let mut position = box_.border_box.get();
+            let mut margin = box_.margin.get();
+
+            // The associated box is the border box of this flow.
+            // Margin after collapse
+            margin.top = margin_top;
+            margin.bottom = margin_bottom;
+
+            position.origin.y = clearance + margin.top;
+            // Border box height
+            position.size.height = *height + noncontent_height;
+
+            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
+
+            box_.border_box.set(position);
+            box_.margin.set(margin);
+        }
+
+        // Height of margin box + clearance
+        self.base.position.size.height = *height + noncontent_height;
+    }
+
+    /// Set floats_out at the last step of the assign height calculation.
+    pub fn set_floats_out_if_inorder(&mut self,
+                                     inorder: bool,
+                                     height: Au,
+                                     cur_y: Au,
+                                     top_offset: Au,
+                                     bottom_offset: Au,
+                                     left_offset: Au) {
+        if inorder {
+            let extra_height = height - (cur_y - top_offset) + bottom_offset;
+            self.base.floats.translate(Point2D(left_offset, -extra_height));
+        }
+    }
+
+    /// Assign heights for all flows in absolute flow tree and store overflow for all
+    /// absolute descendants.
+    pub fn assign_height_absolute_flows(&mut self, ctx: &mut LayoutContext) {
+        if self.is_root_of_absolute_flow_tree() {
+            // Assign heights for all flows in this Absolute flow tree.
+            // This is preorder because the height of an absolute flow may depend on
+            // the height of its CB, which may also be an absolute flow.
+            self.traverse_preorder_absolute_flows(&mut AbsoluteAssignHeightsTraversal(ctx));
+            // Store overflow for all absolute descendants.
+            self.traverse_postorder_absolute_flows(&mut AbsoluteStoreOverflowTraversal {
+                layout_context: ctx,
+            });
+        }
+    }
+
+    /// Assign height for current flow.
+    ///
+    /// + Collapse margins for flow's children and set in-flow child flows'
+    /// y-coordinates now that we know their heights.
+    /// + Calculate and set the height of the current flow.
+    /// + Calculate height, vertical margins, and y-coordinate for the flow's
+    /// box. Ideally, this should be calculated using CSS Section 10.6.7
+    ///
+    /// For absolute flows, store the calculated content height for the flow.
+    /// Defer the calculation of the other values till a later traversal.
+    ///
+    /// inline(always) because this is only ever called by in-order or non-in-order top-level
+    /// methods
+    #[inline(always)]
+    fn assign_height_block_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+
+        // Note: Ignoring clearance for absolute flows as of now.
+        let ignore_clear = self.is_absolutely_positioned();
+        let (clearance, mut top_offset, bottom_offset, left_offset) =
+                            self.initialize_offsets(ignore_clear);
+
+        self.handle_children_floats_if_necessary(ctx, inorder,
+                                                 left_offset, top_offset);
+
+        let (mut margin_top, mut margin_bottom,
+             top_margin_collapsible, bottom_margin_collapsible) = self.precompute_margin();
+
+        let mut cur_y = top_offset;
+        let collapsing = self.compute_margin_collapse(&mut cur_y,
+                                                      &mut top_offset,
+                                                      &mut margin_top,
+                                                      &mut margin_bottom,
+                                                      top_margin_collapsible,
+                                                      bottom_margin_collapsible);
 
         // TODO: A box's own margins collapse if the 'min-height' property is zero, and it has neither
         // top or bottom borders nor top or bottom padding, and it has a 'height' of either 0 or 'auto',
@@ -782,17 +902,12 @@ impl BlockFlow {
             cur_y - top_offset - collapsing
         };
 
-        if self.is_absolutely_positioned() {
-            // Store the content height for use in calculating the absolute
-            // flow's dimensions later.
-            for box_ in self.box_.iter() {
-                let mut temp_position = box_.border_box.get();
-                temp_position.size.height = height;
-                box_.border_box.set(temp_position);
-            }
+        // For an absolutely positioned element, store the content height and stop the function.
+        if self.store_content_height_if_absolutely_positioned(height) {
             return;
         }
 
+        let mut border_and_padding = Au::new(0);
         for box_ in self.box_.iter() {
             let style = box_.style();
 
@@ -803,51 +918,19 @@ impl BlockFlow {
                 Auto => height,
                 Specified(value) => value
             };
+
+            border_and_padding = box_.padding.get().top + box_.padding.get().bottom +
+                                 box_.border.get().top + box_.border.get().bottom;
         }
 
-        // Here, height is content height of box_
+        self.compute_height_position(&mut height,
+                                     border_and_padding,
+                                     margin_top,
+                                     margin_bottom,
+                                     clearance);
 
-        let mut noncontent_height = Au::new(0);
-        for box_ in self.box_.iter() {
-            let mut position = box_.border_box.get();
-            let mut margin = box_.margin.get();
-
-            // The associated box is the border box of this flow.
-            // Margin after collapse
-            margin.top = margin_top;
-            margin.bottom = margin_bottom;
-
-            noncontent_height = box_.padding.get().top + box_.padding.get().bottom +
-                box_.border.get().top + box_.border.get().bottom;
-
-            position.origin.y = clearance + margin.top;
-            // Border box height
-            position.size.height = height + noncontent_height;
-
-            noncontent_height = noncontent_height + clearance + margin.top + margin.bottom;
-
-            box_.border_box.set(position);
-            box_.margin.set(margin);
-        }
-
-        // Height of margin box + clearance
-        self.base.position.size.height = height + noncontent_height;
-
-        if inorder {
-            let extra_height = height - (cur_y - top_offset) + bottom_offset;
-            self.base.floats.translate(Point2D(left_offset, -extra_height));
-        }
-
-        if self.is_root_of_absolute_flow_tree() {
-            // Assign heights for all flows in this Absolute flow tree.
-            // This is preorder because the height of an absolute flow may depend on
-            // the height of its CB, which may also be an absolute flow.
-            self.traverse_preorder_absolute_flows(&mut AbsoluteAssignHeightsTraversal(ctx));
-            // Store overflow for all absolute descendants.
-            self.traverse_postorder_absolute_flows(&mut AbsoluteStoreOverflowTraversal {
-                layout_context: ctx,
-            });
-        }
+        self.set_floats_out_if_inorder(inorder, height, cur_y, top_offset, bottom_offset, left_offset);
+        self.assign_height_absolute_flows(ctx);
         if self.is_root() {
             self.assign_height_store_overflow_fixed_flows(ctx);
         }
@@ -988,6 +1071,74 @@ impl BlockFlow {
 
         position.size.height = height;
         box_.border_box.set(position);
+    }
+
+    /// In case of float, initialize containing_width at the beginning step of assign_width.
+    pub fn set_containing_width_if_float(&mut self, containing_block_width: Au) {
+        if self.is_float() {
+            self.float.get_mut_ref().containing_width = containing_block_width;
+
+            // Parent usually sets this, but floats are never inorder
+            self.base.flags_info.flags.set_inorder(false);
+        }
+    }
+
+    /// Assign the computed left_content_edge and content_width to children.
+    pub fn propagate_assigned_width_to_children(&mut self, left_content_edge: Au,
+                                                content_width: Au) {
+        let has_inorder_children = if self.is_float() {
+            self.base.num_floats > 0
+        } else {
+            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
+        };
+
+        let kid_abs_cb_x_offset;
+        if self.is_positioned() {
+            match self.box_ {
+                Some(ref box_) => {
+                    // Pass yourself as a new Containing Block
+                    // The static x offset for any immediate kid flows will be the
+                    // left padding
+                    kid_abs_cb_x_offset = box_.padding.get().left;
+                }
+                None => fail!("BlockFlow: no principal box found"),
+            }
+        } else {
+            // For kids, the left margin edge will be at our left content edge.
+            // The current static offset is at our left margin
+            // edge. So move in to the left content edge.
+            kid_abs_cb_x_offset = self.base.absolute_static_x_offset + left_content_edge;
+        }
+        let kid_fixed_cb_x_offset = self.base.fixed_static_x_offset + left_content_edge;
+
+        // FIXME(ksh8281): avoid copy
+        let flags_info = self.base.flags_info.clone();
+        for kid in self.base.child_iter() {
+            assert!(kid.is_block_flow() || kid.is_inline_flow());
+
+            if kid.is_block_flow() {
+                let kid_block = kid.as_block();
+                kid_block.base.absolute_static_x_offset = kid_abs_cb_x_offset;
+                kid_block.base.fixed_static_x_offset = kid_fixed_cb_x_offset;
+            }
+            let child_base = flow::mut_base(kid);
+            // Left margin edge of kid flow is at our left content edge
+            child_base.position.origin.x = left_content_edge;
+            // Width of kid flow is our content width
+            child_base.position.size.width = content_width;
+            child_base.flags_info.flags.set_inorder(has_inorder_children);
+
+            if !child_base.flags_info.flags.inorder() {
+                child_base.floats = Floats::new();
+            }
+
+            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
+            //
+            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
+
+            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
+            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
+        }
     }
 
     /// Add display items for current block.
@@ -1323,12 +1474,7 @@ impl Flow for BlockFlow {
         let mut left_content_edge = Au::new(0);
         let mut content_width = containing_block_width;
 
-        if self.is_float() {
-            self.float.get_mut_ref().containing_width = containing_block_width;
-
-            // Parent usually sets this, but floats are never inorder
-            self.base.flags_info.flags.set_inorder(false);
-        }
+        self.set_containing_width_if_float(containing_block_width);
 
         self.compute_used_width(ctx, containing_block_width);
 
@@ -1345,59 +1491,7 @@ impl Flow for BlockFlow {
             self.base.position.size.width = content_width;
         }
 
-        let has_inorder_children = if self.is_float() {
-            self.base.num_floats > 0
-        } else {
-            self.base.flags_info.flags.inorder() || self.base.num_floats > 0
-        };
-
-        let kid_abs_cb_x_offset;
-        if self.is_positioned() {
-            match self.box_ {
-                Some(ref box_) => {
-                    // Pass yourself as a new Containing Block
-                    // The static x offset for any immediate kid flows will be the
-                    // left padding
-                    kid_abs_cb_x_offset = box_.padding.get().left;
-                }
-                None => fail!("BlockFlow: no principal box found"),
-            }
-        } else {
-            // For kids, the left margin edge will be at our left content edge.
-            // The current static offset is at our left margin
-            // edge. So move in to the left content edge.
-            kid_abs_cb_x_offset = self.base.absolute_static_x_offset + left_content_edge;
-        }
-        let kid_fixed_cb_x_offset = self.base.fixed_static_x_offset + left_content_edge;
-
-        // FIXME(ksh8281): avoid copy
-        let flags_info = self.base.flags_info.clone();
-        for kid in self.base.child_iter() {
-            assert!(kid.is_block_flow() || kid.is_inline_flow());
-
-            if kid.is_block_flow() {
-                let kid_block = kid.as_block();
-                kid_block.base.absolute_static_x_offset = kid_abs_cb_x_offset;
-                kid_block.base.fixed_static_x_offset = kid_fixed_cb_x_offset;
-            }
-            let child_base = flow::mut_base(kid);
-            // Left margin edge of kid flow is at our left content edge
-            child_base.position.origin.x = left_content_edge;
-            // Width of kid flow is our content width
-            child_base.position.size.width = content_width;
-            child_base.flags_info.flags.set_inorder(has_inorder_children);
-
-            if !child_base.flags_info.flags.inorder() {
-                child_base.floats = Floats::new();
-            }
-
-            // Per CSS 2.1 § 16.3.1, text decoration propagates to all children in flow.
-            //
-            // TODO(pcwalton): When we have out-of-flow children, don't unconditionally propagate.
-
-            child_base.flags_info.propagate_text_decoration_from_parent(&flags_info);
-            child_base.flags_info.propagate_text_alignment_from_parent(&flags_info)
-        }
+        self.propagate_assigned_width_to_children(left_content_edge, content_width);
     }
 
     /// This is called on kid flows by a parent.

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -108,6 +108,11 @@ pub enum SpecificBoxInfo {
     ImageBox(ImageBoxInfo),
     IframeBox(IframeBoxInfo),
     ScannedTextBox(ScannedTextBoxInfo),
+    TableBox,
+    TableCellBox,
+    TableColumnBox(TableColumnBoxInfo),
+    TableRowBox,
+    TableWrapperBox,
     UnscannedTextBox(UnscannedTextBoxInfo),
 }
 
@@ -310,6 +315,29 @@ pub struct InlineParentInfo {
     node: OpaqueNode,
 }
 
+/// A box that represents a table column.
+#[deriving(Clone)]
+pub struct TableColumnBoxInfo {
+    /// the number of columns a <col> element should span
+    span: Option<int>,
+}
+
+impl TableColumnBoxInfo {
+    /// Create the information specific to an table column box.
+    pub fn new(node: &ThreadSafeLayoutNode) -> TableColumnBoxInfo {
+        let span = {
+            let element = node.as_element();
+            element.get_attr(&namespace::Null, "span").and_then(|string| {
+                let n: Option<int> = FromStr::from_str(string);
+                n
+            })
+        };
+        TableColumnBoxInfo {
+            span: span,
+        }
+    }
+}
+
 // FIXME: Take just one parameter and use concat_ident! (mozilla/rust#12249)
 macro_rules! def_noncontent( ($side:ident, $get:ident, $inline_get:ident) => (
     impl Box {
@@ -396,6 +424,22 @@ impl Box {
             padding: RefCell::new(Zero::zero()),
             margin: RefCell::new(Zero::zero()),
             specific: constructor.build_specific_box_info_for_node(node),
+            position_offsets: RefCell::new(Zero::zero()),
+            inline_info: RefCell::new(None),
+            new_line_pos: ~[],
+        }
+    }
+
+    /// Constructs a new `Box` instance from a specific info.
+    pub fn new_from_specific_info(node: &ThreadSafeLayoutNode, specific: SpecificBoxInfo) -> Box {
+        Box {
+            node: OpaqueNode::from_thread_safe_layout_node(node),
+            style: node.style().clone(),
+            border_box: RefCell::new(Au::zero_rect()),
+            border: RefCell::new(Zero::zero()),
+            padding: RefCell::new(Zero::zero()),
+            margin: RefCell::new(Zero::zero()),
+            specific: specific,
             position_offsets: RefCell::new(Zero::zero()),
             inline_info: RefCell::new(None),
             new_line_pos: ~[],
@@ -521,20 +565,40 @@ impl Box {
     /// Returns the shared part of the width for computation of minimum and preferred width per
     /// CSS 2.1.
     fn guess_width(&self) -> Au {
+        let style = self.style();
+        let mut margin_left = Au::new(0);
+        let mut margin_right = Au::new(0);
+        let mut padding_left = Au::new(0);
+        let mut padding_right = Au::new(0);
+
         match self.specific {
-            GenericBox | IframeBox(_) | ImageBox(_) => {}
-            ScannedTextBox(_) | UnscannedTextBox(_) => return Au(0),
+            GenericBox | IframeBox(_) | ImageBox(_) => {
+                margin_left = MaybeAuto::from_style(style.Margin.get().margin_left,
+                                                    Au::new(0)).specified_or_zero();
+                margin_right = MaybeAuto::from_style(style.Margin.get().margin_right,
+                                                     Au::new(0)).specified_or_zero();
+                padding_left = self.compute_padding_length(style.Padding.get().padding_left,
+                                                           Au::new(0));
+                padding_right = self.compute_padding_length(style.Padding.get().padding_right,
+                                                            Au::new(0));
+            }
+            TableBox | TableCellBox => {
+                padding_left = self.compute_padding_length(style.Padding.get().padding_left,
+                                                           Au::new(0));
+                padding_right = self.compute_padding_length(style.Padding.get().padding_right,
+                                                            Au::new(0));
+            }
+            TableWrapperBox => {
+                margin_left = MaybeAuto::from_style(style.Margin.get().margin_left,
+                                                    Au::new(0)).specified_or_zero();
+                margin_right = MaybeAuto::from_style(style.Margin.get().margin_right,
+                                                     Au::new(0)).specified_or_zero();
+            }
+            TableRowBox => {}
+            ScannedTextBox(_) | TableColumnBox(_) | UnscannedTextBox(_) => return Au(0),
         }
 
-        let style = self.style();
         let width = MaybeAuto::from_style(style.Box.get().width, Au::new(0)).specified_or_zero();
-        let margin_left = MaybeAuto::from_style(style.Margin.get().margin_left,
-                                                Au::new(0)).specified_or_zero();
-        let margin_right = MaybeAuto::from_style(style.Margin.get().margin_right,
-                                                 Au::new(0)).specified_or_zero();
-
-        let padding_left = self.compute_padding_length(style.Padding.get().padding_left, Au(0));
-        let padding_right = self.compute_padding_length(style.Padding.get().padding_right, Au(0));
 
         width + margin_left + margin_right + padding_left + padding_right +
             self.border.get().left + self.border.get().right
@@ -552,23 +616,31 @@ impl Box {
     ///
     /// FIXME(pcwalton): This should not be necessary. Just go to the style.
     pub fn compute_borders(&self, style: &ComputedValues) {
-        #[inline]
-        fn width(width: Au, style: border_style::T) -> Au {
-            if style == border_style::none {
-                Au(0)
-            } else {
-                width
-            }
-        }
+        let border = match self.specific {
+            TableWrapperBox => {
+                SideOffsets2D::new(Au(0), Au(0), Au(0), Au(0))
+            },
+            _ => {
+                #[inline]
+                fn width(width: Au, style: border_style::T) -> Au {
+                    if style == border_style::none {
+                        Au(0)
+                    } else {
+                        width
+                    }
+                }
 
-        self.border.set(SideOffsets2D::new(width(style.Border.get().border_top_width,
-                                                 style.Border.get().border_top_style),
-                                           width(style.Border.get().border_right_width,
-                                                 style.Border.get().border_right_style),
-                                           width(style.Border.get().border_bottom_width,
-                                                 style.Border.get().border_bottom_style),
-                                           width(style.Border.get().border_left_width,
-                                                 style.Border.get().border_left_style)))
+                SideOffsets2D::new(width(style.Border.get().border_top_width,
+                                         style.Border.get().border_top_style),
+                                   width(style.Border.get().border_right_width,
+                                         style.Border.get().border_right_style),
+                                   width(style.Border.get().border_bottom_width,
+                                         style.Border.get().border_bottom_style),
+                                   width(style.Border.get().border_left_width,
+                                         style.Border.get().border_left_style))
+            }
+        };
+        self.border.set(border)
     }
 
     pub fn compute_positioned_offsets(&self, style: &ComputedValues, containing_width: Au, containing_height: Au) {
@@ -589,36 +661,51 @@ impl Box {
     /// If it is auto, it is up to assign-height to ignore this value and
     /// calculate the correct margin values.
     pub fn compute_margin_top_bottom(&self, containing_block_width: Au) {
-        let style = self.style();
-        // Note: CSS 2.1 defines margin % values wrt CB *width* (not height).
-        let margin_top = MaybeAuto::from_style(style.Margin.get().margin_top,
-                                               containing_block_width).specified_or_zero();
-        let margin_bottom = MaybeAuto::from_style(style.Margin.get().margin_bottom,
-                                                  containing_block_width).specified_or_zero();
-        let mut margin = self.margin.get();
-        margin.top = margin_top;
-        margin.bottom = margin_bottom;
-        self.margin.set(margin);
+        match self.specific {
+            TableBox | TableCellBox | TableRowBox | TableColumnBox(_) => {
+                self.margin.set(SideOffsets2D::new(Au(0), Au(0), Au(0), Au(0)))
+            },
+            _ => {
+                let style = self.style();
+                // Note: CSS 2.1 defines margin % values wrt CB *width* (not height).
+                let margin_top = MaybeAuto::from_style(style.Margin.get().margin_top,
+                                                       containing_block_width).specified_or_zero();
+                let margin_bottom = MaybeAuto::from_style(style.Margin.get().margin_bottom,
+                                                          containing_block_width).specified_or_zero();
+                let mut margin = self.margin.get();
+                margin.top = margin_top;
+                margin.bottom = margin_bottom;
+                self.margin.set(margin);
+            }
+        }
     }
 
     /// Populates the box model padding parameters from the given computed style.
     pub fn compute_padding(&self, style: &ComputedValues, containing_block_width: Au) {
-        let padding = SideOffsets2D::new(self.compute_padding_length(style.Padding
-                                                                          .get()
-                                                                          .padding_top,
-                                                                     containing_block_width),
-                                         self.compute_padding_length(style.Padding
-                                                                          .get()
-                                                                          .padding_right,
-                                                                     containing_block_width),
-                                         self.compute_padding_length(style.Padding
-                                                                          .get()
-                                                                          .padding_bottom,
-                                                                     containing_block_width),
-                                         self.compute_padding_length(style.Padding
-                                                                          .get()
-                                                                          .padding_left,
-                                                                     containing_block_width));
+        let padding = match self.specific {
+            TableColumnBox(_) | TableRowBox | TableWrapperBox => {
+                SideOffsets2D::new(Au(0), Au(0), Au(0), Au(0))
+            },
+            GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
+            ScannedTextBox(_) | UnscannedTextBox(_) => {
+                SideOffsets2D::new(self.compute_padding_length(style.Padding
+                                                                    .get()
+                                                                    .padding_top,
+                                                               containing_block_width),
+                                   self.compute_padding_length(style.Padding
+                                                                    .get()
+                                                                    .padding_right,
+                                                               containing_block_width),
+                                   self.compute_padding_length(style.Padding
+                                                                    .get()
+                                                                    .padding_bottom,
+                                                               containing_block_width),
+                                   self.compute_padding_length(style.Padding
+                                                                    .get()
+                                                                    .padding_left,
+                                                               containing_block_width))
+            }
+        };
         self.padding.set(padding)
     }
 
@@ -773,9 +860,37 @@ impl Box {
         self.style().Text.get().text_decoration
     }
 
-    /// Returns the sum of margin, border, and padding on the left.
-    pub fn offset(&self) -> Au {
-        self.margin.get().left + self.border.get().left + self.padding.get().left
+    /// Returns the left offset from margin edge to content edge.
+    pub fn left_offset(&self) -> Au {
+        match self.specific {
+            TableWrapperBox => self.margin.get().left,
+            TableBox | TableCellBox => self.border.get().left + self.padding.get().left,
+            TableRowBox => self.border.get().left,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().left + self.border.get().left + self.padding.get().left
+        }
+    }
+
+    /// Returns the top offset from margin edge to content edge.
+    pub fn top_offset(&self) -> Au {
+        match self.specific {
+            TableWrapperBox => self.margin.get().top,
+            TableBox | TableCellBox => self.border.get().top + self.padding.get().top,
+            TableRowBox => self.border.get().top,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().top + self.border.get().top + self.padding.get().top
+        }
+    }
+
+    /// Returns the bottom offset from margin edge to content edge.
+    pub fn bottom_offset(&self) -> Au {
+        match self.specific {
+            TableWrapperBox => self.margin.get().bottom,
+            TableBox | TableCellBox => self.border.get().bottom + self.padding.get().bottom,
+            TableRowBox => self.border.get().bottom,
+            TableColumnBox(_) => Au(0),
+            _ => self.margin.get().bottom + self.border.get().bottom + self.padding.get().bottom
+        }
     }
 
     /// Returns true if this element is replaced content. This is true for images, form elements,
@@ -1052,6 +1167,7 @@ impl Box {
 
         match self.specific {
             UnscannedTextBox(_) => fail!("Shouldn't see unscanned boxes here."),
+            TableColumnBox(_) => fail!("Shouldn't see table column boxes here."),
             ScannedTextBox(ref text_box) => {
                 let text_color = self.style().Color.get().color.to_gfx_color();
 
@@ -1141,7 +1257,8 @@ impl Box {
                     });
                 });
             },
-            GenericBox | IframeBox(..) => {
+            GenericBox | IframeBox(..) | TableBox | TableCellBox | TableRowBox |
+            TableWrapperBox => {
                 lists.with_mut(|lists| {
                     let item = ~ClipDisplayItem {
                         base: BaseDisplayItem {
@@ -1246,7 +1363,7 @@ impl Box {
             IframeBox(ref iframe_box) => {
                 self.finalize_position_and_size_of_iframe(iframe_box, flow_origin, builder.ctx)
             }
-            GenericBox | ImageBox(_) | ScannedTextBox(_) | UnscannedTextBox(_) => {}
+            _ => {}
         }
 
     }
@@ -1255,7 +1372,8 @@ impl Box {
     pub fn minimum_and_preferred_widths(&self) -> (Au, Au) {
         let guessed_width = self.guess_width();
         let (additional_minimum, additional_preferred) = match self.specific {
-            GenericBox | IframeBox(_) => (Au(0), Au(0)),
+            GenericBox | IframeBox(_) | TableBox | TableCellBox | TableColumnBox(_) |
+            TableRowBox | TableWrapperBox => (Au(0), Au(0)),
             ImageBox(ref image_box_info) => {
                 let image_width = image_box_info.image_width();
                 (image_width, image_width)
@@ -1281,7 +1399,8 @@ impl Box {
     /// TODO: What exactly does this function return? Why is it Au(0) for GenericBox?
     pub fn content_width(&self) -> Au {
         match self.specific {
-            GenericBox | IframeBox(_) => Au(0),
+            GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
+            TableWrapperBox => Au(0),
             ImageBox(ref image_box_info) => {
                 image_box_info.computed_width()
             }
@@ -1290,6 +1409,7 @@ impl Box {
                 let text_bounds = run.get().metrics_for_range(range).bounding_box;
                 text_bounds.size.width
             }
+            TableColumnBox(_) => fail!("Table column boxes do not have width"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }
     }
@@ -1297,7 +1417,8 @@ impl Box {
     ///
     pub fn content_height(&self) -> Au {
         match self.specific {
-            GenericBox | IframeBox(_) => Au(0),
+            GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
+            TableWrapperBox => Au(0),
             ImageBox(ref image_box_info) => {
                 image_box_info.computed_height()
             }
@@ -1308,6 +1429,7 @@ impl Box {
                 let em_size = text_bounds.size.height;
                 self.calculate_line_height(em_size)
             }
+            TableColumnBox(_) => fail!("Table column boxes do not have height"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }
     }
@@ -1322,7 +1444,9 @@ impl Box {
     /// Split box which includes new-line character
     pub fn split_by_new_line(&self) -> SplitBoxResult {
         match self.specific {
-            GenericBox | IframeBox(_) | ImageBox(_) => CannotSplit,
+            GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
+            TableRowBox | TableWrapperBox => CannotSplit,
+            TableColumnBox(_) => fail!("Table column boxes do not need to split"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
             ScannedTextBox(ref text_box_info) => {
                 let mut new_line_pos = self.new_line_pos.clone();
@@ -1359,7 +1483,9 @@ impl Box {
     /// Attempts to split this box so that its width is no more than `max_width`.
     pub fn split_to_width(&self, max_width: Au, starts_line: bool) -> SplitBoxResult {
         match self.specific {
-            GenericBox | IframeBox(_) | ImageBox(_) => CannotSplit,
+            GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
+            TableRowBox | TableWrapperBox => CannotSplit,
+            TableColumnBox(_) => fail!("Table column boxes do not have width"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
             ScannedTextBox(ref text_box_info) => {
                 let mut pieces_processed_count: uint = 0;
@@ -1478,8 +1604,8 @@ impl Box {
     /// CSS 2.1 § 10.3.2.
     pub fn assign_replaced_width_if_necessary(&self,container_width: Au) {
         match self.specific {
-            GenericBox | IframeBox(_) => {
-            }
+            GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
+            TableWrapperBox => {}
             ImageBox(ref image_box_info) => {
                 // TODO(ksh8281): compute border,margin,padding
                 let width = ImageBoxInfo::style_length(self.style().Box.get().width,
@@ -1518,6 +1644,7 @@ impl Box {
                 position.get().size.width = position.get().size.width + self.noncontent_width() +
                     self.noncontent_inline_left() + self.noncontent_inline_right();
             }
+            TableColumnBox(_) => fail!("Table column boxes do not have width"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }
     }
@@ -1527,8 +1654,8 @@ impl Box {
     /// Ideally, this should follow CSS 2.1 § 10.6.2
     pub fn assign_replaced_height_if_necessary(&self) {
         match self.specific {
-            GenericBox | IframeBox(_) => {
-            }
+            GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
+            TableWrapperBox => {}
             ImageBox(ref image_box_info) => {
                 // TODO(ksh8281): compute border,margin,padding
                 let width = image_box_info.computed_width();
@@ -1566,6 +1693,7 @@ impl Box {
                 position.get().size.height
                     = position.get().size.height + self.noncontent_height()
             }
+            TableColumnBox(_) => fail!("Table column boxes do not have height"),
             UnscannedTextBox(_) => fail!("Unscanned text boxes should have been scanned by now!"),
         }
     }
@@ -1601,6 +1729,11 @@ impl Box {
             IframeBox(_) => "IframeBox",
             ImageBox(_) => "ImageBox",
             ScannedTextBox(_) => "ScannedTextBox",
+            TableBox => "TableBox",
+            TableCellBox => "TableCellBox",
+            TableColumnBox(_) => "TableColumnBox",
+            TableRowBox => "TableRowBox",
+            TableWrapperBox => "TableWrapperBox",
             UnscannedTextBox(_) => "UnscannedTextBox",
         };
 

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -5,6 +5,7 @@
 use css::node_style::StyledNode;
 use layout::box_::{Box, CannotSplit, GenericBox, IframeBox, ImageBox, ScannedTextBox, SplitDidFit};
 use layout::box_::{SplitDidNotFit, UnscannedTextBox, InlineInfo};
+use layout::box_::{TableColumnBox, TableRowBox, TableWrapperBox, TableCellBox, TableBox};
 use layout::context::LayoutContext;
 use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
 use layout::floats::{FloatLeft, Floats, PlacementInfo};
@@ -761,10 +762,12 @@ impl Flow for InlineFlow {
 
                         (text_offset, line_height - text_offset, text_ascent)
                     },
-                    GenericBox | IframeBox(_) => {
+                    GenericBox | IframeBox(_) | TableBox | TableCellBox | TableRowBox |
+                    TableWrapperBox => {
                         let height = cur_box.border_box.get().size.height;
                         (height, Au::new(0), height)
                     },
+                    TableColumnBox(_) => fail!("Table column boxes do not have height"),
                     UnscannedTextBox(_) => {
                         fail!("Unscanned text boxes should have been scanned by now.")
                     }

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -1,0 +1,327 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::Box;
+use layout::block::BlockFlow;
+use layout::block::{WidthAndMarginsComputer, WidthConstraintInput, WidthConstraintSolution};
+use layout::construct::FlowConstructor;
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::floats::{FloatKind};
+use layout::flow::{TableFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow;
+use layout::table_wrapper::{TableLayout, FixedLayout, AutoLayout};
+use layout::wrapper::ThreadSafeLayoutNode;
+
+use std::cell::RefCell;
+use style::computed_values::table_layout;
+use geom::{Point2D, Rect, Size2D};
+use gfx::display_list::DisplayListCollection;
+use servo_util::geometry::Au;
+
+/// A table flow corresponded to the table's internal table box under a table wrapper flow.
+/// The properties `position`, `float`, and `margin-*` are used on the table wrapper box,
+/// not table box per CSS 2.1 § 10.5.
+pub struct TableFlow {
+    block_flow: BlockFlow,
+
+    /// Column widths
+    col_widths: ~[Au],
+
+    /// Table-layout property
+    table_layout: TableLayout,
+}
+
+impl TableFlow {
+    pub fn from_node_and_box(node: &ThreadSafeLayoutNode,
+                             box_: Box)
+                             -> TableFlow {
+        let mut block_flow = BlockFlow::from_node_and_box(node, box_);
+        let table_layout = if block_flow.box_().style().Table.get().table_layout ==
+                              table_layout::fixed {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
+        TableFlow {
+            block_flow: block_flow,
+            col_widths: ~[],
+            table_layout: table_layout
+        }
+    }
+
+    pub fn from_node(constructor: &mut FlowConstructor,
+                     node: &ThreadSafeLayoutNode)
+                     -> TableFlow {
+        let mut block_flow = BlockFlow::from_node(constructor, node);
+        let table_layout = if block_flow.box_().style().Table.get().table_layout ==
+                              table_layout::fixed {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
+        TableFlow {
+            block_flow: block_flow,
+            col_widths: ~[],
+            table_layout: table_layout
+        }
+    }
+
+    pub fn float_from_node(constructor: &mut FlowConstructor,
+                           node: &ThreadSafeLayoutNode,
+                           float_kind: FloatKind)
+                           -> TableFlow {
+        let mut block_flow = BlockFlow::float_from_node(constructor, node, float_kind);
+        let table_layout = if block_flow.box_().style().Table.get().table_layout ==
+                              table_layout::fixed {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
+        TableFlow {
+            block_flow: block_flow,
+            col_widths: ~[],
+            table_layout: table_layout
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        self.block_flow.teardown();
+        self.col_widths = ~[];
+    }
+
+    /// Assign height for table flow.
+    ///
+    /// inline(always) because this is only ever called by in-order or non-in-order top-level
+    /// methods
+    #[inline(always)]
+    fn assign_height_table_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+
+        let (_, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offsets(true);
+
+        self.block_flow.handle_children_floats_if_necessary(ctx, inorder,
+                                                            left_offset, top_offset);
+
+        let mut cur_y = top_offset;
+        for kid in self.block_flow.base.child_iter() {
+            let child_node = flow::mut_base(kid);
+            child_node.position.origin.y = cur_y;
+            cur_y = cur_y + child_node.position.size.height;
+        }
+
+        let height = cur_y - top_offset;
+
+        let mut noncontent_height = Au::new(0);
+        for box_ in self.block_flow.box_.iter() {
+            let mut position = box_.border_box.get();
+
+            // noncontent_height = border_top/bottom + padding_top/bottom of box
+            noncontent_height = box_.noncontent_height();
+
+            position.origin.y = Au(0);
+            position.size.height = height + noncontent_height;
+
+            box_.border_box.set(position);
+        }
+
+        self.block_flow.base.position.size.height = height + noncontent_height;
+
+        self.block_flow.set_floats_out_if_inorder(inorder, height, cur_y,
+                                                  top_offset, bottom_offset, left_offset);
+    }
+
+    pub fn build_display_list_table<E:ExtraDisplayListData>(
+                                    &mut self,
+                                    builder: &DisplayListBuilder,
+                                    container_block_size: &Size2D<Au>,
+                                    absolute_cb_abs_position: Point2D<Au>,
+                                    dirty: &Rect<Au>,
+                                    index: uint,
+                                    lists: &RefCell<DisplayListCollection<E>>)
+                                    -> uint {
+        debug!("build_display_list_table: same process as block flow");
+        self.block_flow.build_display_list_block(builder, container_block_size,
+                                                 absolute_cb_abs_position,
+                                                 dirty, index, lists)
+    }
+}
+
+impl Flow for TableFlow {
+    fn class(&self) -> FlowClass {
+        TableFlowClass
+    }
+
+    fn as_table<'a>(&'a mut self) -> &'a mut TableFlow {
+        self
+    }
+
+    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+        &mut self.block_flow
+    }
+
+    /// This function finds the specified column widths from column group and the first row.
+    /// Those are used in fixed table layout calculation.
+    /* FIXME: automatic table layout calculation */
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        let mut did_first_row = false;
+
+        /* find max width from child block contexts */
+        for kid in self.block_flow.base.child_iter() {
+            assert!(kid.is_proper_table_child());
+
+            if kid.is_table_colgroup() {
+                self.col_widths.push_all(kid.as_table_colgroup().widths);
+            } else if kid.is_table_rowgroup() || kid.is_table_row() {
+                // read column widths from table-row-group/table-row, and assign
+                // width=0 for the columns not defined in column-group
+                // FIXME: need to read widths from either table-header-group OR
+                // first table-row
+                let kid_col_widths = if kid.is_table_rowgroup() {
+                    &kid.as_table_rowgroup().col_widths
+                } else {
+                    &kid.as_table_row().col_widths
+                };
+                match self.table_layout {
+                    FixedLayout if !did_first_row => {
+                        did_first_row = true;
+                        let mut child_widths = kid_col_widths.iter();
+                        for col_width in self.col_widths.mut_iter() {
+                            match child_widths.next() {
+                                Some(child_width) => {
+                                    if *col_width == Au::new(0) {
+                                        *col_width = *child_width;
+                                    }
+                                },
+                                None => break
+                            }
+                        }
+                    },
+                    _ => {}
+                }
+                let num_child_cols = kid_col_widths.len();
+                let num_cols = self.col_widths.len();
+                debug!("colgroup has {} column(s) and child has {} column(s)", num_cols, num_child_cols);
+                for i in range(num_cols, num_child_cols) {
+                    self.col_widths.push( kid_col_widths[i] );
+                }
+            }
+        }
+        self.block_flow.bubble_widths(ctx);
+    }
+
+    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
+    /// on this context, the context has had its width set by the parent context.
+    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow", "table");
+
+        // The position was set to the containing block by the flow's parent.
+        let containing_block_width = self.block_flow.base.position.size.width;
+        let mut left_content_edge = Au::new(0);
+        let mut content_width = containing_block_width;
+
+        let mut num_unspecified_widths = 0;
+        let mut total_column_width = Au::new(0);
+        for col_width in self.col_widths.iter() {
+            if *col_width == Au::new(0) {
+                num_unspecified_widths += 1;
+            } else {
+                total_column_width = total_column_width.add(col_width);
+            }
+        }
+
+        let width_computer = InternalTable;
+        width_computer.compute_used_width(&mut self.block_flow, ctx, containing_block_width);
+
+        for box_ in self.block_flow.box_.iter() {
+            left_content_edge = box_.padding.get().left + box_.border.get().left;
+            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
+                                      box_.border.get().left + box_.border.get().right;
+            content_width = box_.border_box.get().size.width - padding_and_borders;
+        }
+
+        // In fixed table layout, we distribute extra space among the unspecified columns if there are
+        // any, or among all the columns if all are specified.
+        if (total_column_width < content_width) && (num_unspecified_widths == 0) {
+            let ratio = content_width.to_f64().unwrap() / total_column_width.to_f64().unwrap();
+            for col_width in self.col_widths.mut_iter() {
+                *col_width = (*col_width).scale_by(ratio);
+            }
+        } else if num_unspecified_widths != 0 {
+            let extra_column_width = (content_width - total_column_width) / Au::new(num_unspecified_widths);
+            for col_width in self.col_widths.mut_iter() {
+                if *col_width == Au(0) {
+                    *col_width = extra_column_width;
+                }
+            }
+        }
+
+        self.block_flow.propagate_assigned_width_to_children(left_content_edge, content_width, Some(self.col_widths.clone()));
+    }
+
+    /// This is called on kid flows by a parent.
+    ///
+    /// Hence, we can assume that assign_height has already been called on the
+    /// kid (because of the bottom-up traversal).
+    fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height_inorder: assigning height for table");
+        self.assign_height_table_base(ctx, true);
+    }
+
+    fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height: assigning height for table");
+        self.assign_height_table_base(ctx, false);
+    }
+
+    // CSS Section 8.3.1 - Collapsing Margins
+    // Since `margin` is not used on table box, `collapsing` and `collapsible` are set to 0
+    fn collapse_margins(&mut self,
+                        _: bool,
+                        _: &mut bool,
+                        _: &mut Au,
+                        _: &mut Au,
+                        collapsing: &mut Au,
+                        collapsible: &mut Au) {
+        // `margin` is not used on table box.
+        *collapsing = Au::new(0);
+        *collapsible = Au::new(0);
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableFlow: ";
+        txt.append(match self.block_flow.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}
+
+/// Table, TableRowGroup, TableRow, TableCell types.
+/// Their widths are calculated in the same way and do not have margins.
+pub struct InternalTable;
+impl WidthAndMarginsComputer for InternalTable {
+
+    /// Compute the used value of width, taking care of min-width and max-width.
+    ///
+    /// CSS Section 10.4: Minimum and Maximum widths
+    fn compute_used_width(&self,
+                          block: &mut BlockFlow,
+                          ctx: &mut LayoutContext,
+                          parent_flow_width: Au) {
+        let input = self.compute_width_constraint_inputs(block, parent_flow_width, ctx);
+
+        let solution = self.solve_width_constraints(block, input);
+
+        self.set_width_constraint_solutions(block, solution);
+    }
+
+    /// Solve the width and margins constraints for this block flow.
+    fn solve_width_constraints(&self,
+                               _: &mut BlockFlow,
+                               input: WidthConstraintInput)
+                               -> WidthConstraintSolution {
+        WidthConstraintSolution::new(input.available_width, Au::new(0), Au::new(0))
+    }
+}

--- a/src/components/main/layout/table_caption.rs
+++ b/src/components/main/layout/table_caption.rs
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::block::BlockFlow;
+use layout::construct::FlowConstructor;
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::flow::{TableCaptionFlowClass, FlowClass, Flow};
+use layout::wrapper::ThreadSafeLayoutNode;
+
+use std::cell::RefCell;
+use geom::{Point2D, Rect, Size2D};
+use gfx::display_list::DisplayListCollection;
+use servo_util::geometry::Au;
+
+/// A table formatting context.
+pub struct TableCaptionFlow {
+    block_flow: BlockFlow,
+}
+
+impl TableCaptionFlow {
+    pub fn from_node(constructor: &mut FlowConstructor,
+                     node: &ThreadSafeLayoutNode)
+                     -> TableCaptionFlow {
+        TableCaptionFlow {
+            block_flow: BlockFlow::from_node(constructor, node)
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        self.block_flow.teardown();
+    }
+
+    pub fn build_display_list_table_caption<E:ExtraDisplayListData>(
+                                           &mut self,
+                                           builder: &DisplayListBuilder,
+                                           container_block_size: &Size2D<Au>,
+                                           absolute_cb_abs_position: Point2D<Au>,
+                                           dirty: &Rect<Au>,
+                                           index: uint,
+                                           lists: &RefCell<DisplayListCollection<E>>)
+                                           -> uint {
+        debug!("build_display_list_table_caption: same process as block flow");
+        self.block_flow.build_display_list_block(builder, container_block_size,
+                                                 absolute_cb_abs_position,
+                                                 dirty, index, lists)
+    }
+}
+
+impl Flow for TableCaptionFlow {
+    fn class(&self) -> FlowClass {
+        TableCaptionFlowClass
+    }
+
+    fn as_table_caption<'a>(&'a mut self) -> &'a mut TableCaptionFlow {
+        self
+    }
+
+    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+        &mut self.block_flow
+    }
+
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        self.block_flow.bubble_widths(ctx);
+    }
+
+    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow", "table_caption");
+        self.block_flow.assign_widths(ctx);
+    }
+
+    /// This is called on kid flows by a parent.
+    ///
+    /// Hence, we can assume that assign_height has already been called on the
+    /// kid (because of the bottom-up traversal).
+    fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height_inorder: assigning height for table_caption");
+        self.block_flow.assign_height_inorder(ctx);
+    }
+
+    fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height: assigning height for table_caption");
+        self.block_flow.assign_height(ctx);
+    }
+
+    /// table-caption has margins but is not collapsed with a sibling(table)
+    /// or its parents(table-wrapper).
+    /// Therefore, margins to be collapsed do not exist.
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableCaptionFlow: ";
+        txt.append(match self.block_flow.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::Box;
+use layout::block::{BlockFlow, WidthAndMarginsComputer};
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::flow::{TableCellFlowClass, FlowClass, Flow};
+use layout::table::InternalTable;
+use layout::wrapper::ThreadSafeLayoutNode;
+
+use std::cell::RefCell;
+use geom::{Point2D, Rect, Size2D};
+use gfx::display_list::{DisplayListCollection};
+use servo_util::geometry::Au;
+
+/// A table formatting context.
+pub struct TableCellFlow {
+    /// Data common to all flows.
+    block_flow: BlockFlow,
+}
+
+impl TableCellFlow {
+    pub fn from_node_and_box(node: &ThreadSafeLayoutNode,
+                             box_: Box)
+                             -> TableCellFlow {
+        TableCellFlow {
+            block_flow: BlockFlow::from_node_and_box(node, box_)
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        self.block_flow.teardown()
+    }
+
+    pub fn box_<'a>(&'a mut self) -> &'a Option<Box>{
+        &self.block_flow.box_
+    }
+
+    /// Assign height for table-cell flow.
+    ///
+    /// inline(always) because this is only ever called by in-order or non-in-order top-level
+    /// methods
+    #[inline(always)]
+    fn assign_height_table_cell_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+        let (_, mut top_offset, bottom_offset, left_offset) = self.block_flow
+                                                                  .initialize_offsets(true);
+
+        self.block_flow.handle_children_floats_if_necessary(ctx, inorder,
+                                                            left_offset, top_offset);
+        let mut cur_y = top_offset;
+        // Since table cell does not have `margin`, the first child's top margin and
+        // the last child's bottom margin do not collapse.
+        self.block_flow.compute_margin_collapse(&mut cur_y,
+                                                &mut top_offset,
+                                                &mut Au(0),
+                                                &mut Au(0),
+                                                false,
+                                                false);
+
+        // CSS 2.1 § 17.5.3. Table cell box height is the minimum height required by the content.
+        let height = cur_y - top_offset;
+
+        // TODO(june0cho): vertical-align of table-cell should be calculated.
+        let mut noncontent_height = Au::new(0);
+        for box_ in self.block_flow.box_.iter() {
+            let mut position = box_.border_box.get();
+
+            // noncontent_height = border_top/bottom + padding_top/bottom of box
+            noncontent_height = box_.noncontent_height();
+
+            position.origin.y = Au(0);
+            position.size.height = height + noncontent_height;
+
+            box_.border_box.set(position);
+        }
+
+        self.block_flow.base.position.size.height = height + noncontent_height;
+
+        self.block_flow.set_floats_out_if_inorder(inorder, height, cur_y, top_offset,
+                                                  bottom_offset, left_offset);
+        self.block_flow.assign_height_absolute_flows(ctx);
+    }
+
+    pub fn build_display_list_table_cell<E:ExtraDisplayListData>(
+                                           &mut self,
+                                           builder: &DisplayListBuilder,
+                                           container_block_size: &Size2D<Au>,
+                                           absolute_cb_abs_position: Point2D<Au>,
+                                           dirty: &Rect<Au>,
+                                           index: uint,
+                                           lists: &RefCell<DisplayListCollection<E>>)
+                                           -> uint {
+        debug!("build_display_list_table_cell: same process as block flow");
+        self.block_flow.build_display_list_block(builder, container_block_size,
+                                                 absolute_cb_abs_position,
+                                                 dirty, index, lists)
+    }
+}
+
+impl Flow for TableCellFlow {
+    fn class(&self) -> FlowClass {
+        TableCellFlowClass
+    }
+
+    fn as_table_cell<'a>(&'a mut self) -> &'a mut TableCellFlow {
+        self
+    }
+
+    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+        &mut self.block_flow
+    }
+
+    /// Minimum/preferred widths set by this function are used in automatic table layout calculation.
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        self.block_flow.bubble_widths(ctx);
+    }
+
+    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
+    /// on this context, the context has had its width set by the parent table row.
+    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow", "table_cell");
+
+        // The position was set to the column width by the parent flow, table row flow.
+        let containing_block_width = self.block_flow.base.position.size.width;
+        let mut left_content_edge = Au::new(0);
+        let mut content_width = containing_block_width;
+
+        let width_computer = InternalTable;
+        width_computer.compute_used_width(&mut self.block_flow, ctx, containing_block_width);
+
+        for box_ in self.block_flow.box_.iter() {
+            left_content_edge = box_.border_box.get().origin.x + box_.padding.get().left + box_.border.get().left;
+            let padding_and_borders = box_.padding.get().left + box_.padding.get().right +
+                                      box_.border.get().left + box_.border.get().right;
+            content_width = box_.border_box.get().size.width - padding_and_borders;
+        }
+
+        self.block_flow.propagate_assigned_width_to_children(left_content_edge, content_width, None);
+    }
+
+    /// This is called on kid flows by a parent.
+    ///
+    /// Hence, we can assume that assign_height has already been called on the
+    /// kid (because of the bottom-up traversal).
+    fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height_inorder: assigning height for table_cell");
+        self.assign_height_table_cell_base(ctx, true);
+    }
+
+    fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height: assigning height for table_cell");
+        self.assign_height_table_cell_base(ctx, false);
+    }
+
+    /// TableCellBox and their parents(TableRowBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableCellFlow: ";
+        txt.append(match self.block_flow.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}
+

--- a/src/components/main/layout/table_colgroup.rs
+++ b/src/components/main/layout/table_colgroup.rs
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::{Box, TableColumnBox};
+use layout::context::LayoutContext;
+use layout::flow::{BaseFlow, TableColGroupFlowClass, FlowClass, Flow};
+use layout::model::{MaybeAuto};
+use layout::wrapper::ThreadSafeLayoutNode;
+use servo_util::geometry::Au;
+
+/// A table formatting context.
+pub struct TableColGroupFlow {
+    /// Data common to all flows.
+    base: BaseFlow,
+
+    /// The associated box.
+    box_: Option<Box>,
+
+    /// The table column boxes
+    cols: ~[Box],
+
+    /// The specified widths of table columns
+    widths: ~[Au],
+}
+
+impl TableColGroupFlow {
+    pub fn from_node_and_boxes(node: &ThreadSafeLayoutNode,
+                               box_: Box,
+                               boxes: ~[Box]) -> TableColGroupFlow {
+        TableColGroupFlow {
+            base: BaseFlow::new((*node).clone()),
+            box_: Some(box_),
+            cols: boxes,
+            widths: ~[],
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        for box_ in self.box_.iter() {
+            box_.teardown();
+        }
+        self.box_ = None;
+        self.cols = ~[];
+        self.widths = ~[];
+    }
+}
+
+impl Flow for TableColGroupFlow {
+    fn class(&self) -> FlowClass {
+        TableColGroupFlowClass
+    }
+
+    fn as_table_colgroup<'a>(&'a mut self) -> &'a mut TableColGroupFlow {
+        self
+    }
+
+    fn bubble_widths(&mut self, _: &mut LayoutContext) {
+        for box_ in self.cols.iter() {
+            // get the specified value from width property
+            let width = MaybeAuto::from_style(box_.style().Box.get().width,
+                                              Au::new(0)).specified_or_zero();
+
+            let span: int = match box_.specific {
+                TableColumnBox(col_box) => col_box.span.unwrap_or(1),
+                _ => fail!("Other box come out in TableColGroupFlow. {:?}", box_.specific)
+            };
+            for _ in range(0, span) {
+                self.widths.push(width);
+            }
+        }
+    }
+
+    /// Table column widths are assigned in table flow and propagated to table row or rowgroup flow.
+    /// Therefore, table colgroup flow does not need to assign its width.
+    fn assign_widths(&mut self, _ctx: &mut LayoutContext) {
+    }
+
+    /// Table column do not have height.
+    fn assign_height(&mut self, _ctx: &mut LayoutContext) {
+    }
+
+    /// TableColumnBox and their parents(TableBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableColGroupFlow: ";
+        txt.append(match self.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::Box;
+use layout::block::BlockFlow;
+use layout::block::WidthAndMarginsComputer;
+use layout::construct::FlowConstructor;
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::flow::{TableRowFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow;
+use layout::table::InternalTable;
+use layout::model::{MaybeAuto, Specified, Auto};
+use layout::wrapper::ThreadSafeLayoutNode;
+
+use std::cell::RefCell;
+use geom::{Point2D, Rect, Size2D};
+use gfx::display_list::DisplayListCollection;
+use servo_util::geometry::Au;
+use servo_util::geometry;
+
+/// A table formatting context.
+pub struct TableRowFlow {
+    block_flow: BlockFlow,
+
+    /// Column widths.
+    col_widths: ~[Au],
+}
+
+impl TableRowFlow {
+    pub fn from_node_and_box(node: &ThreadSafeLayoutNode,
+                             box_: Box)
+                             -> TableRowFlow {
+        TableRowFlow {
+            block_flow: BlockFlow::from_node_and_box(node, box_),
+            col_widths: ~[],
+        }
+    }
+
+    pub fn from_node(constructor: &mut FlowConstructor,
+                     node: &ThreadSafeLayoutNode)
+                     -> TableRowFlow {
+        TableRowFlow {
+            block_flow: BlockFlow::from_node(constructor, node),
+            col_widths: ~[],
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        self.block_flow.teardown();
+        self.col_widths = ~[];
+    }
+
+    pub fn box_<'a>(&'a mut self) -> &'a Option<Box>{
+        &self.block_flow.box_
+    }
+
+    fn initialize_offsets(&mut self) -> (Au, Au, Au) {
+        // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
+        // should be updated. Currently, they are set as Au(0).
+        (Au(0), Au(0), Au(0))
+    }
+
+    /// Assign height for table-row flow.
+    ///
+    /// inline(always) because this is only ever called by in-order or non-in-order top-level
+    /// methods
+    #[inline(always)]
+    fn assign_height_table_row_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+        let (top_offset, bottom_offset, left_offset) = self.initialize_offsets();
+
+        self.block_flow.handle_children_floats_if_necessary(ctx, inorder,
+                                                            left_offset, top_offset);
+        let mut cur_y = top_offset;
+
+        // Per CSS 2.1 § 17.5.3, find max_y = max( computed `height`, minimum height of all cells )
+        let mut max_y = Au::new(0);
+        for kid in self.block_flow.base.child_iter() {
+            for child_box in kid.as_table_cell().box_().iter() {
+                // TODO: Percentage height
+                let child_specified_height = MaybeAuto::from_style(child_box.style().Box.get().height,
+                                                                   Au::new(0)).specified_or_zero();
+                max_y = geometry::max(max_y, child_specified_height + child_box.noncontent_height());
+            }
+            let child_node = flow::mut_base(kid);
+            child_node.position.origin.y = cur_y;
+            max_y = geometry::max(max_y, child_node.position.size.height);
+        }
+
+        let mut height = max_y;
+        for box_ in self.block_flow.box_.iter() {
+            // TODO: Percentage height
+            height = match MaybeAuto::from_style(box_.style().Box.get().height, Au(0)) {
+                Auto => height,
+                Specified(value) => geometry::max(value, height)
+            };
+        }
+        cur_y = cur_y + height;
+
+        // Assign the height of own box
+        for box_ in self.block_flow.box_.iter() {
+            let mut position = box_.border_box.get();
+            position.size.height = height;
+            box_.border_box.set(position);
+        }
+        self.block_flow.base.position.size.height = height;
+
+        // Assign the height of kid boxes, which is the same value as own height.
+        for kid in self.block_flow.base.child_iter() {
+            for kid_box_ in kid.as_table_cell().box_().iter() {
+                let mut position = kid_box_.border_box.get();
+                position.size.height = height;
+                kid_box_.border_box.set(position);
+            }
+            let child_node = flow::mut_base(kid);
+            child_node.position.size.height = height;
+        }
+
+        self.block_flow.set_floats_out_if_inorder(inorder, height, cur_y,
+                                                  top_offset, bottom_offset, left_offset);
+    }
+
+    pub fn build_display_list_table_row<E:ExtraDisplayListData>(
+                                        &mut self,
+                                        builder: &DisplayListBuilder,
+                                        container_block_size: &Size2D<Au>,
+                                        absolute_cb_abs_position: Point2D<Au>,
+                                        dirty: &Rect<Au>,
+                                        index: uint,
+                                        lists: &RefCell<DisplayListCollection<E>>)
+                                        -> uint {
+        debug!("build_display_list_table_row: same process as block flow");
+        self.block_flow.build_display_list_block(builder, container_block_size,
+                                                 absolute_cb_abs_position,
+                                                 dirty, index, lists)
+    }
+}
+
+impl Flow for TableRowFlow {
+    fn class(&self) -> FlowClass {
+        TableRowFlowClass
+    }
+
+    fn as_table_row<'a>(&'a mut self) -> &'a mut TableRowFlow {
+        self
+    }
+
+    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+        &mut self.block_flow
+    }
+
+    /// Recursively (bottom-up) determines the context's preferred and minimum widths. When called
+    /// on this context, all child contexts have had their min/pref widths set. This function must
+    /// decide min/pref widths based on child context widths and dimensions of any boxes it is
+    /// responsible for flowing.
+    /// Min/pref widths set by this function are used in automatic table layout calculation.
+    /// Also, this function collects the specified column widths of children cells. Those are used
+    /// in fixed table layout calculation
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        /* find the specified widths from child table-cell contexts */
+        for kid in self.block_flow.base.child_iter() {
+            assert!(kid.is_table_cell());
+
+            for child_box in kid.as_table_cell().box_().iter() {
+                let child_specified_width = MaybeAuto::from_style(child_box.style().Box.get().width,
+                                                                  Au::new(0)).specified_or_zero();
+                self.col_widths.push(child_specified_width);
+            }
+        }
+
+        // TODO: calculate min_width & pref_width for automatic table layout calculation
+        self.block_flow.bubble_widths(ctx);
+    }
+
+    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
+    /// on this context, the context has had its width set by the parent context.
+    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow", "table_row");
+
+        // The position was set to the containing block by the flow's parent.
+        let containing_block_width = self.block_flow.base.position.size.width;
+        // FIXME: In case of border-collapse: collapse, left_content_edge should be border-left
+        let left_content_edge = Au::new(0);
+
+        let width_computer = InternalTable;
+        width_computer.compute_used_width(&mut self.block_flow, ctx, containing_block_width);
+
+        self.block_flow.propagate_assigned_width_to_children(left_content_edge, Au(0), Some(self.col_widths.clone()));
+    }
+
+    /// This is called on kid flows by a parent.
+    ///
+    /// Hence, we can assume that assign_height has already been called on the
+    /// kid (because of the bottom-up traversal).
+    fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height_inorder: assigning height for table_row");
+        self.assign_height_table_row_base(ctx, true);
+    }
+
+    fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height: assigning height for table_row");
+        self.assign_height_table_row_base(ctx, false);
+    }
+
+    /// TableRowBox and their parents(TableBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableRowFlow: ";
+        txt.append(match self.block_flow.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}
+

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::Box;
+use layout::block::BlockFlow;
+use layout::block::WidthAndMarginsComputer;
+use layout::construct::FlowConstructor;
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::flow::{TableRowGroupFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow;
+use layout::table::InternalTable;
+use layout::wrapper::ThreadSafeLayoutNode;
+
+use std::cell::RefCell;
+use geom::{Point2D, Rect, Size2D};
+use gfx::display_list::DisplayListCollection;
+use servo_util::geometry::Au;
+
+/// A table formatting context.
+pub struct TableRowGroupFlow {
+    block_flow: BlockFlow,
+
+    /// Column widths
+    col_widths: ~[Au],
+}
+
+impl TableRowGroupFlow {
+    pub fn from_node_and_box(node: &ThreadSafeLayoutNode,
+                             box_: Box)
+                             -> TableRowGroupFlow {
+        TableRowGroupFlow {
+            block_flow: BlockFlow::from_node_and_box(node, box_),
+            col_widths: ~[],
+        }
+    }
+
+    pub fn from_node(constructor: &mut FlowConstructor,
+                     node: &ThreadSafeLayoutNode)
+                     -> TableRowGroupFlow {
+        TableRowGroupFlow {
+            block_flow: BlockFlow::from_node(constructor, node),
+            col_widths: ~[],
+        }
+    }
+
+    pub fn teardown(&mut self) {
+        self.block_flow.teardown();
+        self.col_widths = ~[];
+    }
+
+    pub fn box_<'a>(&'a mut self) -> &'a Option<Box>{
+        &self.block_flow.box_
+    }
+
+    fn initialize_offsets(&mut self) -> (Au, Au, Au) {
+        // TODO: If border-collapse: collapse, top_offset, bottom_offset, and left_offset
+        // should be updated. Currently, they are set as Au(0).
+        (Au(0), Au(0), Au(0))
+    }
+
+    /// Assign height for table-rowgroup flow.
+    ///
+    /// inline(always) because this is only ever called by in-order or non-in-order top-level
+    /// methods
+    #[inline(always)]
+    fn assign_height_table_rowgroup_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+        let (top_offset, bottom_offset, left_offset) = self.initialize_offsets();
+
+        self.block_flow.handle_children_floats_if_necessary(ctx, inorder,
+                                                            left_offset, top_offset);
+        let mut cur_y = top_offset;
+
+        for kid in self.block_flow.base.child_iter() {
+            let child_node = flow::mut_base(kid);
+            child_node.position.origin.y = cur_y;
+            cur_y = cur_y + child_node.position.size.height;
+        }
+
+        let height = cur_y - top_offset;
+
+        for box_ in self.block_flow.box_.iter() {
+            let mut position = box_.border_box.get();
+            position.size.height = height;
+            box_.border_box.set(position);
+        }
+        self.block_flow.base.position.size.height = height;
+
+        self.block_flow.set_floats_out_if_inorder(inorder, height, cur_y,
+                                                  top_offset, bottom_offset, left_offset);
+    }
+
+    pub fn build_display_list_table_rowgroup<E:ExtraDisplayListData>(
+                                            &mut self,
+                                            builder: &DisplayListBuilder,
+                                            container_block_size: &Size2D<Au>,
+                                            absolute_cb_abs_position: Point2D<Au>,
+                                            dirty: &Rect<Au>,
+                                            index: uint,
+                                            lists: &RefCell<DisplayListCollection<E>>)
+                                            -> uint {
+        debug!("build_display_list_table_rowgroup: same process as block flow");
+        self.block_flow.build_display_list_block(builder, container_block_size,
+                                                 absolute_cb_abs_position,
+                                                 dirty, index, lists)
+    }
+}
+
+impl Flow for TableRowGroupFlow {
+    fn class(&self) -> FlowClass {
+        TableRowGroupFlowClass
+    }
+
+    fn as_table_rowgroup<'a>(&'a mut self) -> &'a mut TableRowGroupFlow {
+        self
+    }
+
+    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+        &mut self.block_flow
+    }
+
+    /// Recursively (bottom-up) determines the context's preferred and minimum widths. When called
+    /// on this context, all child contexts have had their min/pref widths set. This function must
+    /// decide min/pref widths based on child context widths and dimensions of any boxes it is
+    /// responsible for flowing.
+    /// Min/pref widths set by this function are used in automatic table layout calculation.
+    /// Also, this function finds the specified column widths from the first row.
+    /// Those are used in fixed table layout calculation
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        /* find the specified column widths from the first table-row.
+           update the number of column widths from other table-rows. */
+        for kid in self.block_flow.base.child_iter() {
+            assert!(kid.is_table_row());
+            if self.col_widths.is_empty() {
+                self.col_widths = kid.as_table_row().col_widths.clone();
+            } else {
+                let num_cols = self.col_widths.len();
+                let num_child_cols = kid.as_table_row().col_widths.len();
+                for _ in range(num_cols, num_child_cols) {
+                    self.col_widths.push(Au::new(0));
+                }
+            }
+        }
+
+        // TODO: calculate min_width & pref_width for automatic table layout calculation
+        self.block_flow.bubble_widths(ctx);
+    }
+
+    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
+    /// on this context, the context has had its width set by the parent context.
+    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow", "table_rowgroup");
+
+        // The position was set to the containing block by the flow's parent.
+        let containing_block_width = self.block_flow.base.position.size.width;
+        // FIXME: In case of border-collapse: collapse, left_content_edge should be border-left
+        let left_content_edge = Au::new(0);
+        let content_width = containing_block_width;
+
+        let width_computer = InternalTable;
+        width_computer.compute_used_width(&mut self.block_flow, ctx, containing_block_width);
+
+        self.block_flow.propagate_assigned_width_to_children(left_content_edge, content_width, Some(self.col_widths.clone()));
+    }
+
+    /// This is called on kid flows by a parent.
+    ///
+    /// Hence, we can assume that assign_height has already been called on the
+    /// kid (because of the bottom-up traversal).
+    fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height_inorder: assigning height for table_rowgroup");
+        self.assign_height_table_rowgroup_base(ctx, true);
+    }
+
+    fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_height: assigning height for table_rowgroup");
+        self.assign_height_table_rowgroup_base(ctx, false);
+    }
+
+    /// TableRowBox and their parents(TableBox) do not have margins.
+    /// Therefore, margins to be collapsed do not exist.
+    fn collapse_margins(&mut self, _: bool, _: &mut bool, _: &mut Au,
+                        _: &mut Au, _: &mut Au, _: &mut Au) {
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = ~"TableRowGroupFlow: ";
+        txt.append(match self.block_flow.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}
+

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -1,0 +1,368 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS table formatting contexts.
+
+use layout::box_::Box;
+use layout::block::BlockFlow;
+use layout::block::{WidthAndMarginsComputer, WidthConstraintInput, WidthConstraintSolution};
+use layout::construct::FlowConstructor;
+use layout::context::LayoutContext;
+use layout::display_list_builder::{DisplayListBuilder, ExtraDisplayListData};
+use layout::floats::{FloatKind};
+use layout::flow::{TableWrapperFlowClass, FlowClass, Flow, ImmutableFlowUtils};
+use layout::flow;
+use layout::model::{MaybeAuto, Specified, Auto, specified};
+use layout::wrapper::ThreadSafeLayoutNode;
+
+use std::cell::RefCell;
+use style::computed_values::table_layout;
+use geom::{Point2D, Rect, Size2D};
+use gfx::display_list::DisplayListCollection;
+use servo_util::geometry::Au;
+use servo_util::geometry;
+
+pub enum TableLayout {
+    FixedLayout,
+    AutoLayout
+}
+
+/// A table wrapper flow based on a block formatting context.
+pub struct TableWrapperFlow {
+    block_flow: BlockFlow,
+
+    /// Column widths
+    col_widths: ~[Au],
+
+    /// Table-layout property
+    table_layout: TableLayout,
+}
+
+impl TableWrapperFlow {
+    pub fn from_node_and_box(node: &ThreadSafeLayoutNode,
+                             box_: Box)
+                             -> TableWrapperFlow {
+        let mut block_flow = BlockFlow::from_node_and_box(node, box_);
+        let table_layout = if block_flow.box_().style().Table.get().table_layout ==
+                              table_layout::fixed {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
+        TableWrapperFlow {
+            block_flow: block_flow,
+            col_widths: ~[],
+            table_layout: table_layout
+        }
+    }
+
+    pub fn from_node(constructor: &mut FlowConstructor,
+                     node: &ThreadSafeLayoutNode)
+                     -> TableWrapperFlow {
+        let mut block_flow = BlockFlow::from_node(constructor, node);
+        let table_layout = if block_flow.box_().style().Table.get().table_layout ==
+                              table_layout::fixed {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
+        TableWrapperFlow {
+            block_flow: block_flow,
+            col_widths: ~[],
+            table_layout: table_layout
+        }
+    }
+
+    pub fn float_from_node(constructor: &mut FlowConstructor,
+                           node: &ThreadSafeLayoutNode,
+                           float_kind: FloatKind)
+                           -> TableWrapperFlow {
+        let mut block_flow = BlockFlow::float_from_node(constructor, node, float_kind);
+        let table_layout = if block_flow.box_().style().Table.get().table_layout ==
+                              table_layout::fixed {
+            FixedLayout
+        } else {
+            AutoLayout
+        };
+        TableWrapperFlow {
+            block_flow: block_flow,
+            col_widths: ~[],
+            table_layout: table_layout
+        }
+    }
+
+    pub fn is_float(&self) -> bool {
+        self.block_flow.float.is_some()
+    }
+
+    pub fn teardown(&mut self) {
+        self.block_flow.teardown();
+        self.col_widths = ~[];
+    }
+
+    /// Assign height for table-wrapper flow.
+    /// `Assign height` of table-wrapper flow follows a similar process to that of block flow.
+    /// However, table-wrapper flow doesn't consider collapsing margins for flow's children
+    /// and calculating padding/border.
+    ///
+    /// inline(always) because this is only ever called by in-order or non-in-order top-level
+    /// methods
+    #[inline(always)]
+    fn assign_height_table_wrapper_base(&mut self, ctx: &mut LayoutContext, inorder: bool) {
+
+        // Note: Ignoring clearance for absolute flows as of now.
+        let ignore_clear = self.is_absolutely_positioned();
+        let (clearance, top_offset, bottom_offset, left_offset) = self.block_flow.initialize_offsets(ignore_clear);
+
+        self.block_flow.handle_children_floats_if_necessary(ctx, inorder,
+                                                            left_offset, top_offset);
+
+        // Table wrapper flow has margin but is not collapsed with kids(table caption and table).
+        let (margin_top, margin_bottom, _, _) = self.block_flow.precompute_margin();
+
+        let mut cur_y = top_offset;
+
+        for kid in self.block_flow.base.child_iter() {
+            let child_node = flow::mut_base(kid);
+            child_node.position.origin.y = cur_y;
+            cur_y = cur_y + child_node.position.size.height;
+        }
+
+        // top_offset: top margin-edge of the topmost child.
+        // hence, height = content height
+        let mut height = cur_y - top_offset;
+
+        // For an absolutely positioned element, store the content height and stop the function.
+        if self.block_flow.store_content_height_if_absolutely_positioned(height) {
+            return;
+        }
+
+        for box_ in self.block_flow.box_.iter() {
+            let style = box_.style();
+
+            // At this point, `height` is the height of the containing block, so passing `height`
+            // as the second argument here effectively makes percentages relative to the containing
+            // block per CSS 2.1 § 10.5.
+            height = match MaybeAuto::from_style(style.Box.get().height, height) {
+                Auto => height,
+                Specified(value) => geometry::max(value, height)
+            };
+        }
+
+        self.block_flow.compute_height_position(&mut height,
+                                                Au(0),
+                                                margin_top,
+                                                margin_bottom,
+                                                clearance);
+
+        self.block_flow.set_floats_out_if_inorder(inorder, height, cur_y,
+                                                  top_offset, bottom_offset, left_offset);
+        self.block_flow.assign_height_absolute_flows(ctx);
+    }
+
+    pub fn build_display_list_table_wrapper<E:ExtraDisplayListData>(
+                                            &mut self,
+                                            builder: &DisplayListBuilder,
+                                            container_block_size: &Size2D<Au>,
+                                            absolute_cb_abs_position: Point2D<Au>,
+                                            dirty: &Rect<Au>,
+                                            index: uint,
+                                            lists: &RefCell<DisplayListCollection<E>>)
+                                            -> uint {
+        debug!("build_display_list_table_wrapper: same process as block flow");
+        self.block_flow.build_display_list_block(builder, container_block_size,
+                                                 absolute_cb_abs_position,
+                                                 dirty, index, lists)
+    }
+}
+
+impl Flow for TableWrapperFlow {
+    fn class(&self) -> FlowClass {
+        TableWrapperFlowClass
+    }
+
+    fn as_table_wrapper<'a>(&'a mut self) -> &'a mut TableWrapperFlow {
+        self
+    }
+
+    fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
+        &mut self.block_flow
+    }
+
+    /* Recursively (bottom-up) determine the context's preferred and
+    minimum widths.  When called on this context, all child contexts
+    have had their min/pref widths set. This function must decide
+    min/pref widths based on child context widths and dimensions of
+    any boxes it is responsible for flowing.  */
+
+    fn bubble_widths(&mut self, ctx: &mut LayoutContext) {
+        /* find max width from child block contexts */
+        for kid in self.block_flow.base.child_iter() {
+            assert!(kid.is_table_caption() || kid.is_table());
+
+            if kid.is_table() {
+                self.col_widths.push_all(kid.as_table().col_widths);
+            }
+        }
+
+        self.block_flow.bubble_widths(ctx);
+    }
+
+    /// Recursively (top-down) determines the actual width of child contexts and boxes. When called
+    /// on this context, the context has had its width set by the parent context.
+    ///
+    /// Dual boxes consume some width first, and the remainder is assigned to all child (block)
+    /// contexts.
+    fn assign_widths(&mut self, ctx: &mut LayoutContext) {
+        debug!("assign_widths({}): assigning width for flow",
+               if self.is_float() {
+                   "floated table_wrapper"
+               } else {
+                   "table_wrapper"
+               });
+
+        // The position was set to the containing block by the flow's parent.
+        let containing_block_width = self.block_flow.base.position.size.width;
+        let mut left_content_edge = Au::new(0);
+        let mut content_width = containing_block_width;
+
+        self.block_flow.set_containing_width_if_float(containing_block_width);
+
+        let width_computer = TableWrapper;
+        width_computer.compute_used_width_table_wrapper(self, ctx, containing_block_width);
+
+        for box_ in self.block_flow.box_.iter() {
+            left_content_edge = box_.border_box.get().origin.x;
+            content_width = box_.border_box.get().size.width;
+        }
+
+        match self.table_layout {
+            FixedLayout | _ if self.is_float() =>
+                self.block_flow.base.position.size.width = content_width,
+            _ => {}
+        }
+
+        self.block_flow.propagate_assigned_width_to_children(left_content_edge, content_width, None);
+    }
+
+    /// This is called on kid flows by a parent.
+    ///
+    /// Hence, we can assume that assign_height has already been called on the
+    /// kid (because of the bottom-up traversal).
+    fn assign_height_inorder(&mut self, ctx: &mut LayoutContext) {
+        if self.is_float() {
+            debug!("assign_height_inorder_float: assigning height for floated table_wrapper");
+            self.block_flow.assign_height_float_inorder();
+        } else {
+            debug!("assign_height_inorder: assigning height for table_wrapper");
+            self.assign_height_table_wrapper_base(ctx, true);
+        }
+    }
+
+    fn assign_height(&mut self, ctx: &mut LayoutContext) {
+        if self.is_float() {
+            debug!("assign_height_float: assigning height for floated table_wrapper");
+            self.block_flow.assign_height_float(ctx);
+        } else {
+            debug!("assign_height: assigning height for table_wrapper");
+            self.assign_height_table_wrapper_base(ctx, false);
+        }
+    }
+
+    // CSS Section 8.3.1 - Collapsing Margins
+    // `self`: the Flow whose margins we want to collapse.
+    // `collapsing`: value to be set by this function. This tells us how much
+    // of the top margin has collapsed with a previous margin.
+    // `collapsible`: Potential collapsible margin at the bottom of this flow's box.
+    fn collapse_margins(&mut self,
+                        top_margin_collapsible: bool,
+                        first_in_flow: &mut bool,
+                        margin_top: &mut Au,
+                        top_offset: &mut Au,
+                        collapsing: &mut Au,
+                        collapsible: &mut Au) {
+        self.block_flow.collapse_margins(top_margin_collapsible,
+                                         first_in_flow,
+                                         margin_top,
+                                         top_offset,
+                                         collapsing,
+                                         collapsible);
+    }
+
+    fn debug_str(&self) -> ~str {
+        let txt = if self.is_float() {
+            ~"TableWrapperFlow(Float): "
+        } else {
+            ~"TableWrapperFlow: "
+        };
+        txt.append(match self.block_flow.box_ {
+            Some(ref rb) => rb.debug_str(),
+            None => ~"",
+        })
+    }
+}
+
+struct TableWrapper;
+impl TableWrapper {
+    fn compute_used_width_table_wrapper(&self,
+                                        table_wrapper: &mut TableWrapperFlow,
+                                        ctx: &mut LayoutContext,
+                                        parent_flow_width: Au) {
+        let input = self.compute_width_constraint_inputs_table_wrapper(table_wrapper,
+                                                                           parent_flow_width,
+                                                                           ctx);
+
+        let solution = self.solve_width_constraints(&mut table_wrapper.block_flow, input);
+
+        self.set_width_constraint_solutions(&mut table_wrapper.block_flow, solution);
+        self.set_flow_x_coord_if_necessary(&mut table_wrapper.block_flow, solution);
+    }
+
+    fn compute_width_constraint_inputs_table_wrapper(&self,
+                                                     table_wrapper: &mut TableWrapperFlow,
+                                                     parent_flow_width: Au,
+                                                     ctx: &mut LayoutContext)
+                                                     -> WidthConstraintInput {
+        let mut input = self.compute_width_constraint_inputs(&mut table_wrapper.block_flow,
+                                                             parent_flow_width,
+                                                             ctx);
+        match table_wrapper.table_layout {
+            FixedLayout => {
+                let fixed_cells_width = table_wrapper.col_widths.iter().fold(Au(0),
+                                                                             |sum, width| sum.add(width));
+                for box_ in table_wrapper.block_flow.box_.iter() {
+                    let style = box_.style();
+
+                    // Get left and right paddings, borders for table.
+                    // We get these values from the box's style since table_wrapper doesn't have it's own border or padding.
+                    // input.available_width is same as containing_block_width in table_wrapper.
+                    let padding_left = specified(style.Padding.get().padding_left,
+                                                 input.available_width);
+                    let padding_right = specified(style.Padding.get().padding_right,
+                                                  input.available_width);
+                    let border_left = style.Border.get().border_left_width;
+                    let border_right = style.Border.get().border_right_width;
+                    let padding_and_borders = padding_left + padding_right + border_left + border_right;
+                    let mut computed_width = input.computed_width.specified_or_zero();
+                    // Compare border-edge widths. Because fixed_cells_width indicates content-width,
+                    // padding and border values are added to fixed_cells_width.
+                    computed_width = geometry::max(fixed_cells_width + padding_and_borders, computed_width);
+                    input.computed_width = Specified(computed_width);
+                }
+            },
+            _ => {}
+        }
+        input
+    }
+}
+
+impl WidthAndMarginsComputer for TableWrapper {
+    /// Solve the width and margins constraints for this block flow.
+    fn solve_width_constraints(&self,
+                               block: &mut BlockFlow,
+                               input: WidthConstraintInput)
+                               -> WidthConstraintSolution {
+        self.solve_block_width_constraints(block, input)
+    }
+}

--- a/src/components/main/servo.rs
+++ b/src/components/main/servo.rs
@@ -101,6 +101,13 @@ pub mod layout {
     pub mod inline;
     pub mod model;
     pub mod parallel;
+    pub mod table_wrapper;
+    pub mod table;
+    pub mod table_caption;
+    pub mod table_colgroup;
+    pub mod table_rowgroup;
+    pub mod table_row;
+    pub mod table_cell;
     pub mod text;
     pub mod util;
     pub mod incremental;

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -284,11 +284,11 @@ pub mod longhands {
 //            }
             if context.positioned || context.floated || context.is_root_element {
                 match value {
-//                    inline_table => table,
+                    inline_table => table,
                     inline | inline_block
-//                    | table_row_group | table_column | table_column_group
-//                    | table_header_group | table_footer_group | table_row
-//                    | table_cell | table_caption
+                    | table_row_group | table_column | table_column_group
+                    | table_header_group | table_footer_group | table_row
+                    | table_cell | table_caption
                     => block,
                     _ => value,
                 }
@@ -808,6 +808,9 @@ pub mod longhands {
     ${single_keyword("white-space", "normal pre")}
 
     // CSS 2.1, Section 17 - Tables
+    ${new_style_struct("Table", is_inherited=False)}
+
+    ${single_keyword("table-layout", "auto fixed")}
 
     // CSS 2.1, Section 18 - User interface
 }

--- a/src/test/html/anonymous_table.html
+++ b/src/test/html/anonymous_table.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      .table {
+        display: table;
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      .colgroup {
+        display: table-column-group;
+      }
+      .column {
+        display: table-column;
+      }
+      .row {
+        display: table-row;
+      }
+      .cell {
+        display: table-cell;
+        border: solid red 1px;
+      }
+    </style>
+  </head>
+  <body>
+    <p> This test checks Anonymous table objects(CSS 2.1, Section 17.2.1) </p>
+    <p> 1. Remove irrelevant boxes</p>
+    <p> 2. Generate missing child wrappers: `table-row`, `table-cell` </p>
+    <div class="table">
+        <span class="column"> inline child box of table-column. NOT Shown </span>
+        <span class="colgroup">
+            <span>inline child box of table-column-group</span> NOT Shown
+        </span>
+        <span class="cell">Cell1</span>
+        <span class="cell">Cell2</span>
+        <span class="row">
+            2nd Row
+            <span>Cell4</span>
+            <span class="cell">Cell3</span>
+            Cell5
+        </span>
+    </div>
+  </body>
+<html>

--- a/src/test/html/fixed_table.html
+++ b/src/test/html/fixed_table.html
@@ -1,0 +1,36 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as follows:
+       - 1st column: 200px (because it is defined in col element)
+       - 2nd column: 100px (because it is defined in first row)
+       - 3rd column: remaining width (becuase it is not defined so the remaining width is assigned)
+     And table, caption, td, th elements have border. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table</caption>
+        <colgroup>
+          <col style="width: 200px" />
+        </colgroup>
+        <tbody>
+          <tr><th style="width: 100px">Header 1</th><td style="width: 100px">Cell 1</td><td>Cell 2</td></tr>
+          <tr><th style="width: 300px">Header 2</th><td style="width: 300px">Cell 3</th><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</th></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_2.html
+++ b/src/test/html/fixed_table_2.html
@@ -1,0 +1,36 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned according to their ratio of column's widths
+     which are defined in col elements.
+     And table, caption, td, th elements have border. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table</caption>
+        <colgroup>
+          <col style="width: 10px" />
+          <col style="width: 20px" />
+          <col style="width: 30px" />
+        </colgroup>
+        <tbody>
+          <tr><th style="width: 100px">Header 1</th><td style="width: 100px">Cell 1</td><td>Cell 2</td></tr>
+          <tr><th style="width: 300px">Header 2</th><td style="width: 300px">Cell 3</th><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</th></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_additional_cols.html
+++ b/src/test/html/fixed_table_additional_cols.html
@@ -1,0 +1,39 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as follows:
+       - 1st & 2nd column: 200px (because it is defined in col element)
+       - 3rd & 4th column: remaining width / 2
+                           (becuase it is not defined so the remaining width is equally divided)
+     And table, caption, td, th elements have border. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x4 fixed table</caption>
+        <colgroup>
+          <col style="width: 200px" />
+          <col style="width: 200px" />
+          <col />
+          <col />
+        </colgroup>
+        <tbody>
+          <tr><th>Header 1</th><td>Cell 1</td><td>Cell 2</td></tr>
+          <tr><th>Header 2</th><td>Cell 3</th><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</th></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_basic_height.html
+++ b/src/test/html/fixed_table_basic_height.html
@@ -1,0 +1,40 @@
+<!-- This test creates one table, three rows, three header cells, and six data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as 200px.
+     Each table row height is decided as max(specified row height, specified cells' heights, cells' minimum content heights).
+     As a result, each table row height will be assigned as followings:
+        - 1st row: 30px (specified cell height)
+        - 2nd row: 50px (specified row height)
+        - 3rd row: minimum content height
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Table Height Test</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption {
+        border: solid blue 1px;
+      }
+      td, th {
+        border: solid red 1px;
+        padding: 0px;
+      }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This test checks table height algorithm (CSS 2.1, Section 17.5.3),
+                 excluding `vertical-align` and percentage height</caption>
+        <tbody>
+          <tr style="height:10px"><th>Header 1</th><td style="height: 30px">Cell 1</td><td>Cell 2</td></tr>
+          <tr style="height:50px"><th>Header 2</th><td>Cell 3</td><td style="height:10px">Cell 4</td></tr>
+          <tr style="height:20px"><th>Header 3</th><td style="height:10px">Cell 5</td><td><div>Cell6</div><p>Cell6</td></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_simple.html
+++ b/src/test/html/fixed_table_simple.html
@@ -1,0 +1,30 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and six data cells.
+     The table uses fixed table layout algorithm and the table's width specified to 600px.
+     Each column should have same width because the column's widths are not defined here.
+     And table, caption, td, th elements have border. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Simple Fixed Table</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+      }
+      caption { border: solid blue 1px; }
+      td { border: solid red 1px; }
+      th { border: solid red 1px; }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table</caption>
+        <tbody>
+          <tr><th>Header 1</th><td>Cell 1</td><td>Cell 2</td></tr>
+          <tr><th>Header 2</th><td>Cell 3</td><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</td><td>Cell 6</td></tr>
+        </tbody>
+    </table>
+  </body>
+<html>

--- a/src/test/html/fixed_table_with_margin_padding.html
+++ b/src/test/html/fixed_table_with_margin_padding.html
@@ -1,0 +1,50 @@
+<!-- This test creates one table, one caption, three rows, three header cells, and five data cells.
+     The table uses the fixed table layout algorithm and the table's width specified to 600px.
+     Each column's width will be assigned as follows:
+       - 1st column: 200px (because it is defined in col element)
+       - 2nd column: 100px (because it is defined in first row)
+       - 3rd column: remaining width (becuase it is not defined so the remaining width is assigned)
+     The table and caption elements have border, margin, and padding.
+     The td and th elements have border and padding. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixed Table with margin, border, and padding</title>
+    <style>
+      table {
+        table-layout: fixed;
+        width: 600px;
+        border: solid black 2px;
+        margin: 10px;
+        padding: 10px;
+      }
+      caption {
+        border: solid blue 1px;
+        margin: 5px;
+        padding: 5px;
+      }
+      td {
+        border: solid red 1px;
+        padding: 5px;
+      }
+      th {
+        border: solid red 1px;
+        padding: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <table>
+        <caption>This is a 3x3 fixed table with margin, border, and padding</caption>
+        <colgroup>
+          <col style="width: 200px" />
+          <col />
+        </colgroup>
+        <tbody>
+          <tr><th style="width: 100px">Header 1</th><td style="width: 100px">Cell 1</td><td>Cell 2</td></tr>
+          <tr><th>Header 2</th><td>Cell 3</td><td>Cell 4</td></tr>
+          <tr><th>Header 3</th><td>Cell 5</td></tr>
+        </tbody>
+    </table>
+  </body>
+<html>


### PR DESCRIPTION
This is a rebase of #1548 on recent master.

There have been many changes since #1548 is first uploaded, so I'm creating new PR.
This PR includes:
- construction of table-\* flows (table-wrapper, table-caption, table, table-rowgroup, table-row, table-cell)
- fixed-layout table calculation
- a part of anonymous table object implementation 
  [CSS 2.1, 17.2.1](http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes) (Step 1-1, 1-2, Step 2)
