### PR TITLE
Set a name for WorkQueue tasks (fixes #1830)

### DIFF
--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -290,7 +290,7 @@ impl LayoutTask {
         let local_image_cache = MutexArc::new(LocalImageCache(image_cache_task.clone()));
         let screen_size = Size2D(Au(0), Au(0));
         let parallel_traversal = if opts.layout_threads != 1 {
-            Some(WorkQueue::new(opts.layout_threads, ptr::mut_null()))
+            Some(WorkQueue::new("LayoutWorker", opts.layout_threads, ptr::mut_null()))
         } else {
             None
         };


### PR DESCRIPTION
Now with 100% less breaking everything.  (An earlier version of this patch in #1948 switched WorkQueue from native tasks to green tasks, which I missed in testing because we don't spawn new layout threads by default on 1- or 2-core machines.)
