### PR TITLE
Remove some unnecessary transmutes.

### DIFF
--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -27,7 +27,7 @@
 //! * You must also not use `.get()`; instead, use `.unsafe_get()`.
 //!
 //! * Do not call any methods on DOM nodes without checking to see whether they use borrow flags.
-//!   
+//!
 //!   o Instead of `get_attr()`, use `.get_attr_val_for_layout()`.
 //!
 //!   o Instead of `html_element_in_html_document()`, use
@@ -68,7 +68,7 @@ pub trait TLayoutNode {
     /// Returns the interior of this node as a `Node`. This is highly unsafe for layout to call
     /// and as such is marked `unsafe`.
     unsafe fn get<'a>(&'a self) -> &'a Node {
-        cast::transmute::<*mut Node,&'a Node>(self.get_jsmanaged().unsafe_get())
+        &*self.get_jsmanaged().unsafe_get()
     }
 
     fn node_is_element(&self) -> bool {
@@ -436,7 +436,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
             // FIXME(pcwalton): Workaround until Rust gets multiple lifetime parameters on
             // implementations.
             ThreadSafeLayoutElement {
-                element: cast::transmute::<*mut Element,&mut Element>(element),
+                element: &mut *element,
             }
         }
     }
@@ -536,4 +536,3 @@ pub fn layout_node_to_unsafe_layout_node(node: &LayoutNode) -> UnsafeLayoutNode 
         cast::transmute_copy(node)
     }
 }
-

--- a/src/components/script/dom/bindings/proxyhandler.rs
+++ b/src/components/script/dom/bindings/proxyhandler.rs
@@ -74,7 +74,7 @@ pub fn _obj_toString(cx: *JSContext, className: *libc::c_char) -> *JSString {
   unsafe {
     let name = str::raw::from_c_str(className);
     let nchars = "[object ]".len() + name.len();
-    let chars: *mut jschar = cast::transmute(JS_malloc(cx, (nchars + 1) as libc::size_t * (size_of::<jschar>() as libc::size_t)));
+    let chars: *mut jschar = JS_malloc(cx, (nchars + 1) as libc::size_t * (size_of::<jschar>() as libc::size_t)) as *mut jschar;
     if chars.is_null() {
         return ptr::null();
     }
@@ -84,9 +84,9 @@ pub fn _obj_toString(cx: *JSContext, className: *libc::c_char) -> *JSString {
       *chars.offset(i as int) = c as jschar;
     }
     *chars.offset(nchars as int) = 0;
-    let jsstr = JS_NewUCString(cx, cast::transmute(chars), nchars as libc::size_t);
+    let jsstr = JS_NewUCString(cx, chars as *jschar, nchars as libc::size_t);
     if jsstr.is_null() {
-        JS_free(cx, cast::transmute(chars));
+        JS_free(cx, chars as *libc::c_void);
     }
     jsstr
   }

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -91,12 +91,12 @@ pub unsafe fn get_dom_class(obj: *JSObject) -> Result<DOMClass, ()> {
     let clasp = JS_GetClass(obj);
     if is_dom_class(clasp) {
         debug!("plain old dom object");
-        let domjsclass: *DOMJSClass = cast::transmute(clasp);
+        let domjsclass: *DOMJSClass = clasp as *DOMJSClass;
         return Ok((*domjsclass).dom_class);
     }
     if is_dom_proxy(obj) {
         debug!("proxy dom object");
-        let dom_class: *DOMClass = cast::transmute(GetProxyHandlerExtra(obj));
+        let dom_class: *DOMClass = GetProxyHandlerExtra(obj) as *DOMClass;
         return Ok(*dom_class);
     }
     debug!("not a dom object");
@@ -233,7 +233,7 @@ pub struct DOMJSClass {
 pub fn GetProtoOrIfaceArray(global: *JSObject) -> **JSObject {
     unsafe {
         /*assert ((*JS_GetClass(global)).flags & JSCLASS_DOM_GLOBAL) != 0;*/
-        cast::transmute(JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT).to_private())
+        JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT).to_private() as **JSObject
     }
 }
 

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -163,9 +163,7 @@ impl Element {
             return false
         }
         let owner_doc: *JS<Document> = self.node.owner_doc();
-        let owner_doc: **Document = cast::transmute::<*JS<Document>,
-                                                      **Document>(
-                                                      owner_doc);
+        let owner_doc: **Document = owner_doc as **Document;
         (**owner_doc).is_html_document
     }
 

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -123,8 +123,7 @@ bitfield!(NodeFlags, get_in_hover_state, set_is_in_hover_state, 0x02)
 impl Drop for Node {
     fn drop(&mut self) {
         unsafe {
-            let this: &mut Node = cast::transmute(self);
-            this.reap_layout_data()
+            self.reap_layout_data()
         }
     }
 }
@@ -203,7 +202,7 @@ impl LayoutDataRef {
 }
 
 /// A trait that represents abstract layout data.
-/// 
+///
 /// FIXME(pcwalton): Very very unsafe!!! We need to send these back to the layout task to be
 /// destroyed when this node is finalized.
 pub trait TLayoutData {}
@@ -338,7 +337,7 @@ impl NodeHelpers for JS<Node> {
     fn parent_node(&self) -> Option<JS<Node>> {
         self.get().parent_node.clone()
     }
-    
+
     fn first_child(&self) -> Option<JS<Node>> {
         self.get().first_child.clone()
     }
@@ -1826,8 +1825,7 @@ impl Node {
     }
 
     pub unsafe fn get_hover_state_for_layout(&self) -> bool {
-        let unsafe_this: *Node = cast::transmute::<&Node,*Node>(self);
-        (*unsafe_this).flags.get_in_hover_state()
+        self.flags.get_in_hover_state()
     }
 }
 


### PR DESCRIPTION
These can either be done by implicit `&` -> `*` coercions, explicit `*`
-> `*` casts, or an explicit `&*x` `*` -> `&` re-borrow (which is still
unsafe, but significantly more controlled compared to a `transmute`).
