### PR TITLE
Remove an obsolete comment

### DIFF
--- a/src/components/macros/macros.rs
+++ b/src/components/macros/macros.rs
@@ -7,10 +7,6 @@
 
 #[feature(macro_rules)];
 
-// Spawn a task, capturing the listed variables in a way that avoids the
-// move-from-closure error.  This is sugar around the function spawn_with,
-// taking care of building a tuple and a lambda.
-
 #[macro_export]
 macro_rules! bitfield(
     ($bitfieldname:ident, $getter:ident, $setter:ident, $value:expr) => (


### PR DESCRIPTION
Remove a comment that was about a macro that was removed in a7ef1cd35e9347a285f245041db4eb94047f4ab0
