### PR TITLE
Support for ASCII whitespace check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.pyc
 *.swp
 *.swo
+.DS_Store
 servo-test
 Makefile
 Servo.app

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -29,7 +29,7 @@ use layout_interface::{MatchSelectorsDocumentDamage};
 use style;
 use servo_util::namespace;
 use servo_util::namespace::{Namespace, Null};
-use servo_util::str::{DOMString, null_str_as_empty_ref};
+use servo_util::str::{DOMString, null_str_as_empty_ref, split_html_space_chars};
 
 use std::ascii::StrAsciiExt;
 use std::cast;
@@ -376,9 +376,8 @@ impl AttributeHandlers for JS<Element> {
     }
 
     fn has_class(&self, name: &str) -> bool {
-        // FIXME: https://github.com/mozilla/servo/issues/1840
         let class_names = self.get_string_attribute("class");
-        let mut classes = class_names.split(' ');
+        let mut classes = split_html_space_chars(class_names);
         classes.any(|class| name == class)
     }
 

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -10,7 +10,7 @@ use dom::element::{Element, AttributeHandlers};
 use dom::node::{Node, NodeHelpers};
 use dom::window::Window;
 use servo_util::namespace::Namespace;
-use servo_util::str::DOMString;
+use servo_util::str::{DOMString, split_html_space_chars};
 
 use serialize::{Encoder, Encodable};
 
@@ -100,7 +100,7 @@ impl HTMLCollection {
             }
         }
         let filter = ClassNameFilter {
-            classes: classes.split(' ').map(|class| class.into_owned()).to_owned_vec()
+            classes: split_html_space_chars(classes).map(|class| class.into_owned()).to_owned_vec()
         };
         HTMLCollection::create(window, root, ~filter)
     }

--- a/src/components/util/str.rs
+++ b/src/components/util/str.rs
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::iter::Filter;
+use std::str::CharSplits;
+
 pub type DOMString = ~str;
+pub type StaticCharVec = &'static [char];
 pub type StaticStringVec = &'static [&'static str];
 
 pub fn null_str_as_empty(s: &Option<DOMString>) -> DOMString {
@@ -31,7 +35,7 @@ pub fn is_whitespace(s: &str) -> bool {
 ///
 ///     http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#
 ///     space-character
-pub static HTML_SPACE_CHARACTERS: [char, ..5] = [
+pub static HTML_SPACE_CHARACTERS: StaticCharVec = &[
     '\u0020',
     '\u0009',
     '\u000a',
@@ -39,3 +43,6 @@ pub static HTML_SPACE_CHARACTERS: [char, ..5] = [
     '\u000d',
 ];
 
+pub fn split_html_space_chars<'a>(s: &'a str) -> Filter<'a, &'a str, CharSplits<'a, StaticCharVec>> {
+    s.split(HTML_SPACE_CHARACTERS).filter(|&split| !split.is_empty())
+}

--- a/src/test/content/test_htmlspacechars.html
+++ b/src/test/content/test_htmlspacechars.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="harness.js"></script>
+        <script>
+            is(document.getElementsByClassName("foo").length, 6);
+            is_not(document.getElementById("bar").className, "ggg foo");
+            finish();
+        </script>
+    </head>
+    <body>
+        <!-- \u0020 Space -->
+        <div id="foo-1" class="aaa&#32;foo"></div>
+        <!-- \u0009 Character tabulation -->
+        <div id="foo-2" class="bbb&#9;foo"></div>
+        <!-- \u000a Line feed -->
+        <div id="foo-3" class="ccc&#10;foo"></div>
+        <!-- \u000c Form feed -->
+        <div id="foo-4" class="ddd&#12;foo"></div>
+        <!-- \u000d Carriage return -->
+        <div id="foo-5" class="eee&#13;foo"></div>
+        <!-- Space -->
+        <div id="foo-6" class="fff foo"></div>
+        <!-- Non-HTML space character -->
+        <div id="bar" class="ggg&#11;foo"></div>
+    </body>
+</html>


### PR DESCRIPTION
Specs:
http://dom.spec.whatwg.org/#concept-ordered-set-parser
http://encoding.spec.whatwg.org/#ascii-whitespace

This PR implements the HTMLSpaceCharSplits iterator, used to split a string in a subset of strings separated by valid HTML space characters. Its first usage is upon splitting `class` attribute values.

Closes #1840.
