### PR TITLE
Disable parallel layout

### DIFF
--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -8,8 +8,6 @@
 use azure::azure_hl::{BackendType, CairoBackend, CoreGraphicsBackend};
 use azure::azure_hl::{CoreGraphicsAcceleratedBackend, Direct2DBackend, SkiaBackend};
 use getopts;
-use std::cmp;
-use std::rt;
 use std::io;
 use std::os;
 
@@ -144,7 +142,9 @@ pub fn from_cmdline_args(args: &[~str]) -> Option<Opts> {
 
     let layout_threads: uint = match opt_match.opt_str("y") {
         Some(layout_threads_str) => from_str(layout_threads_str).unwrap(),
-        None => cmp::max(rt::default_sched_threads() * 3 / 4, 1),
+        // FIXME: Re-enable the below computation, once a fix for #1926 lands.
+        // cmp::max(rt::default_sched_threads() * 3 / 4, 1),
+        None => 1,
     };
 
     Some(Opts {


### PR DESCRIPTION
Until we land a fix for #1926, set the default number of threads for parallel layout to 1 to avoid races, a double-borrow, and task failure resulting in all cores spinning indefinitely.

r? @metajack
