### PR TITLE
Use std::io::timer instead of servo_util::time::Timer.

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -32,9 +32,10 @@ use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, LoadUrlMsg, Navig
 use servo_msg::constellation_msg::{PipelineId, ResizedWindowMsg};
 use servo_msg::constellation_msg;
 use servo_util::opts::Opts;
-use servo_util::time::{profile, ProfilerChan, Timer};
+use servo_util::time::{profile, ProfilerChan};
 use servo_util::{time, url};
 use std::comm::{Empty, Disconnected, Data, Sender, Receiver};
+use std::io::timer::sleep;
 use std::path::Path;
 use std::rc::Rc;
 use time::precise_time_s;
@@ -195,7 +196,7 @@ impl IOCompositor {
                 self.composite();
             }
 
-            Timer::sleep(10);
+            sleep(10);
 
             // If a pinch-zoom happened recently, ask for tiles at the new resolution
             if self.zoom_action && precise_time_s() - self.zoom_time > 0.3 {

--- a/src/components/util/time.rs
+++ b/src/components/util/time.rs
@@ -9,23 +9,8 @@ use collections::treemap::TreeMap;
 use std::comm::{Sender, channel, Receiver};
 use std::f64;
 use std::iter::AdditiveIterator;
+use std::io::timer::sleep;
 use task::{spawn_named};
-
-// TODO: This code should be changed to use the commented code that uses timers
-// directly, once native timers land in Rust.
-extern {
-    pub fn usleep(secs: u64) -> u32;
-}
-
-pub struct Timer;
-impl Timer {
-    pub fn sleep(ms: u64) {
-        //
-        //  let mut timer = Timer::new().unwrap();
-        //  timer.sleep(period);
-       unsafe { usleep((ms * 1000)); }
-    }
-}
 
 // front-end representation of the profiler used to communicate with the profiler
 #[deriving(Clone)]
@@ -133,7 +118,7 @@ impl Profiler {
                 let chan = chan.clone();
                 spawn_named("Profiler timer", proc() {
                     loop {
-                        Timer::sleep(period);
+                        sleep(period);
                         if !chan.try_send(PrintMsg) {
                             break;
                         }


### PR DESCRIPTION
Now, our rust compiler has `std::io::timer`!
