### PR TITLE
Remove the needless comment for document.getElementById.

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -675,8 +675,6 @@ impl Document {
             node.is_in_doc()
         });
 
-        // TODO: support the case if multiple elements
-        // which haves same id are in the same document.
         // FIXME https://github.com/mozilla/rust/issues/13195
         //       Use mangle() when it exists again.
         match self.idmap.find_mut(&id) {

--- a/src/test/content/test_document_getElementById.html
+++ b/src/test/content/test_document_getElementById.html
@@ -76,9 +76,9 @@
       is(document.getElementById("should-not-exist"), e, "test 4-1");
     }
 
-    // TODO:
     // test5: "in tree order, within the context object's tree"
     // http://dom.spec.whatwg.org/#dom-document-getelementbyid.
+    // we test this in test_document_getElementById_tree_order.html
 
     // TODO:
     // test6: innerHTML


### PR DESCRIPTION
Follow up #1917
(Derived from #2066)
