### PR TITLE
Destroy LayerBuffers before dropping them

### DIFF
--- a/src/components/gfx/buffer_map.rs
+++ b/src/components/gfx/buffer_map.rs
@@ -83,6 +83,7 @@ impl<T: Tile> BufferMap<T> {
         // memory limit, no need to store this new buffer; just let it drop.
         if self.mem + new_buffer.get_mem() > self.max_mem && self.map.len() == 1 &&
             self.map.contains_key(&new_key) {
+            new_buffer.destroy(graphics_context);
             return;
         }
 


### PR DESCRIPTION
This fixes a potential pixmap leak and task failure when the LayerBuffer is dropped (#1187).

I wasn't able to reproduce the failure using the steps from #1187, but based on the stack trace I think this is the correct fix.  Alternately, would it make sense to `impl Drop for LayerBuffer`?
