### PR TITLE
Clear tiles before dropping CompositorLayer

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -395,6 +395,11 @@ impl IOCompositor {
 
             ContainerLayer::add_child_start(self.root_layer.clone(),
                                             ContainerLayerKind(new_layer.root_layer.clone()));
+
+            // Release all tiles from the layer before dropping it.
+            for layer in self.compositor_layer.mut_iter() {
+                layer.clear_all_tiles();
+            }
             self.compositor_layer = Some(new_layer);
         }
 

--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -879,7 +879,7 @@ impl CompositorLayer {
                 }
 
                 // Send back all tiles to renderer.
-                child.get_mut_ref().child.clear();
+                child.get_mut_ref().child.clear(); // XXX should this be clear_all_tiles?
 
                 self.build_layer_tree(graphics_context);
                 true
@@ -948,6 +948,15 @@ impl CompositorLayer {
 
                 self.pipeline.render_chan.try_send(UnusedBufferMsg(tiles));
             }
+        }
+    }
+
+    /// Destroys tiles for this layer and all descendent layers, sending the buffers back to the
+    /// renderer to be destroyed or reused.
+    pub fn clear_all_tiles(&mut self) {
+        self.clear();
+        for kid in self.children.mut_iter() {
+            kid.child.clear_all_tiles();
         }
     }
 

--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -879,7 +879,7 @@ impl CompositorLayer {
                 }
 
                 // Send back all tiles to renderer.
-                child.get_mut_ref().child.clear(); // XXX should this be clear_all_tiles?
+                child.get_mut_ref().child.clear_all_tiles();
 
                 self.build_layer_tree(graphics_context);
                 true


### PR DESCRIPTION
This fixes a pixmap leak and task failure (#2069).
