### PR TITLE
Fix rendering of new pages after navigating

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -354,16 +354,15 @@ impl IOCompositor {
         self.constellation_chan = new_constellation_chan;
     }
 
-    // FIXME(pcwalton): Take the pipeline ID into account.
     fn create_root_compositor_layer_if_necessary(&mut self,
-                                                 _: PipelineId,
+                                                 id: PipelineId,
                                                  layer_id: LayerId,
                                                  size: Size2D<f32>) {
         let (root_pipeline, root_layer_id) = match self.compositor_layer {
-            Some(ref compositor_layer) => {
+            Some(ref compositor_layer) if compositor_layer.pipeline.id == id => {
                 (compositor_layer.pipeline.clone(), compositor_layer.id_of_first_child())
             }
-            None => {
+            _ => {
                 match self.root_pipeline {
                     Some(ref root_pipeline) => (root_pipeline.clone(), LayerId::null()),
                     None => fail!("Compositor: Received new layer without initialized pipeline"),

--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -83,13 +83,6 @@ impl RenderListener for CompositorChan {
         self.chan.send(Paint(pipeline_id, layer_id, layer_buffer_set, epoch))
     }
 
-    fn create_layer_group_for_pipeline(&self, id: PipelineId, page_size: Size2D<uint>) {
-        let Size2D { width, height } = page_size;
-        self.chan.send(CreateRootCompositorLayerIfNecessary(id,
-                                                            LayerId::null(),
-                                                            Size2D(width as f32, height as f32)))
-    }
-
     fn initialize_layers_for_pipeline(&self,
                                       pipeline_id: PipelineId,
                                       metadata: ~[LayerMetadata],

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -121,7 +121,6 @@ pub struct LayerMetadata {
 /// submit them to be drawn to the display.
 pub trait RenderListener {
     fn get_graphics_metadata(&self) -> Option<NativeGraphicsMetadata>;
-    fn create_layer_group_for_pipeline(&self, PipelineId, Size2D<uint>);
 
     /// Informs the compositor of the layers for the given pipeline. The compositor responds by
     /// creating and/or destroying render layers as necessary.


### PR DESCRIPTION
After clicking a link to load a new page, the new page content is never painted.  This is because the compositor is still sending render messages to old frame tree's pipeline, not the new one.

This patch fixes this by ensuring that the compositor's new root layer is attached to the correct pipeline. (Note: You will also need to apply #2080 if you want to test this without crashing.)
