### PR TITLE
Basic framework for running web platform tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ src/components/script/dom/bindings/codegen/RegisterBindings.cpp
 src/components/script/dom/bindings/codegen/PrototypeList.h
 src/components/script/dom/bindings/codegen/UnionTypes.h
 src/components/script/dom/bindings/codegen/UnionConversions.h
+src/test/wpt/metadata/

--- a/.gitmodules
+++ b/.gitmodules
@@ -119,3 +119,6 @@
 [submodule "src/platform/android/servo-android-glue"]
 	path = src/platform/android/servo-android-glue
 	url = https://github.com/mozilla-servo/servo-android-glue.git
+[submodule "src/test/wpt/web-platform-tests"]
+	path = src/test/wpt/web-platform-tests
+	url = https://github.com/mozilla-servo/web-platform-tests.git

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -91,6 +91,10 @@ check-content: contenttest
 	@$(call E, check: contenttests)
 	$(Q)./contenttest --source-dir=$(S)src/test/content $(TESTNAME)
 
+.PHONY: check-wpt
+check-wpt:
+	bash $(S)src/test/wpt/run.sh $(S)
+
 .PHONY: tidy
 tidy:
 	@$(call E, check: tidy)

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -49,6 +49,10 @@ clean-style:
 	@$(call E, "cleaning style")
 	$(Q)cd $(B)/src/components/style/ && rm -rf libstyle*.dylib libstyle*.rlib libstyle*.dSYM libstyle*.so $(DONE_style)
 
+clean-wpt:
+	$(Q)rm -r _virtualenv
+	$(Q)rm $(S)/src/test/wpt/metadata/MANIFEST.json
+
 clean-servo: clean-gfx clean-util clean-net clean-script clean-msg clean-style
 	@$(call E, "cleaning servo")
 	$(Q)rm -f servo servo-test $(foreach lib_crate,$(SERVO_LIB_CRATES),servo-test-$(lib_crate)) libservo*.so libservo*.a

--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -37,6 +37,7 @@ exceptions = [
     "src/compiler", # Upstream
     "src/components/main/dom/bindings/codegen", # Generated and upstream code combined with our own. Could use cleanup
     "src/components/script/dom/bindings/codegen", # Generated and upstream code combined with our own. Could use cleanup
+    "src/test/wpt/web-platform-tests", # Upstream
 ]
 
 def should_check(name):

--- a/src/test/wpt/run.py
+++ b/src/test/wpt/run.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import sys, os, argparse
+
+here = os.path.split(__file__)[0]
+servo_root = os.path.abspath(os.path.join(here, "..", "..", ".."))
+
+def wptsubdir(*args):
+    return os.path.join(here, *args)
+
+# Imports
+sys.path.append(wptsubdir("web-platform-tests"))
+sys.path.append(wptsubdir("web-platform-tests", "tools", "scripts"))
+from wptrunner import wptrunner, wptcommandline
+import manifest
+
+def ensure_manifest():
+    if not os.path.isfile(wptsubdir("metadata", "MANIFEST.json")):
+        opts = argparse.Namespace(rebuild=False, experimental_include_local_changes=True,
+                                  path=wptsubdir("metadata", "MANIFEST.json"))
+        manifest.update_manifest(wptsubdir("web-platform-tests"), opts)
+
+def run_tests(**kwargs):
+    logger = wptrunner.setup_logging(kwargs, {"raw": sys.stdout})
+    result = wptrunner.run_tests(**kwargs)
+
+def set_defaults(args):
+    args.metadata_root = args.metadata_root if args.metadata_root else wptsubdir("metadata")
+    args.tests_root = args.tests_root if args.tests_root else wptsubdir("web-platform-tests")
+    args.include = args.include if args.include else ["/dom"]
+    args.binary = args.binary if args.binary else os.path.join(servo_root, "build", "servo")
+    args.product = "servo"
+    return vars(args)
+
+def main():
+    ensure_manifest()
+    parser = wptcommandline.create_parser(False)
+    args = parser.parse_args()
+    kwargs = set_defaults(args)
+    return run_tests(**kwargs)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/test/wpt/run.sh
+++ b/src/test/wpt/run.sh
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+cd $1/build
+
+test -d _virtualenv || virtualenv _virtualenv
+test -d $1/src/test/wpt/metadata || mkdir -p $1/src/test/wpt/metadata
+test -d $1/src/test/wpt/prefs || mkdir -p $1/src/test/wpt/prefs
+source _virtualenv/bin/activate
+(python -c "import html5lib" &>/dev/null) || pip install html5lib
+(python -c "import wptrunner"  &>/dev/null) || pip install wptrunner
+python $1/src/test/wpt/run.py


### PR DESCRIPTION
See #1479

This sets up a basic environment for running wpt. It instantiates a virtualenv, generates the manifest if it doesn't exist*, and runs the tests.

Currently @Ms2ger's [`run-in-servo` fork of wpt](https://github.com/Ms2ger/web-platform-tests/tree/run-in-servo/)  is used.

Note: I did everything in a shell script instead of make since one cannot run `source` from a makefile (the environment is immutable, apparently)

*It does not, however, update the manifest. We'll have to add an extra script for that.
