### PR TITLE
Rust upgrade: Use new attributes syntax

### DIFF
--- a/src/components/gfx/gfx.rs
+++ b/src/components/gfx/gfx.rs
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#gfx:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla/servo#gfx:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[feature(globs, managed_boxes, macro_rules, phase)];
+#![feature(globs, managed_boxes, macro_rules, phase)]
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/components/macros/macros.rs
+++ b/src/components/macros/macros.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#macros:0.1"];
-#[crate_type = "lib"];
+#![crate_id = "github.com/mozilla/servo#macros:0.1"]
+#![crate_type = "lib"]
 
-#[feature(macro_rules)];
+#![feature(macro_rules)]
 
 #[macro_export]
 macro_rules! bitfield(

--- a/src/components/main/servo.rs
+++ b/src/components/main/servo.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo"];
-#[comment = "The Servo Parallel Browser Project"];
-#[license = "MPL"];
+#![crate_id = "github.com/mozilla/servo"]
+#![comment = "The Servo Parallel Browser Project"]
+#![license = "MPL"]
 
-#[feature(globs, macro_rules, managed_boxes, phase, thread_local)];
+#![feature(globs, macro_rules, managed_boxes, phase, thread_local)]
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/components/msg/msg.rs
+++ b/src/components/msg/msg.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#msg:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla/servo#msg:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[feature(managed_boxes)];
+#![feature(managed_boxes)]
 
 extern crate azure;
 extern crate geom;

--- a/src/components/net/net.rs
+++ b/src/components/net/net.rs
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#net:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla/servo#net:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[feature(globs, managed_boxes)];
+#![feature(globs, managed_boxes)]
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#script:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla/servo#script:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[comment = "The Servo Parallel Browser Project"];
-#[license = "MPL"];
+#![comment = "The Servo Parallel Browser Project"]
+#![license = "MPL"]
 
-#[feature(globs, macro_rules, struct_variant, managed_boxes, phase)];
+#![feature(globs, macro_rules, struct_variant, managed_boxes, phase)]
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/components/style/common_types.rs
+++ b/src/components/style/common_types.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[allow(non_camel_case_types)];
+#![allow(non_camel_case_types)]
 
 pub use servo_util::geometry::Au;
 

--- a/src/components/style/style.rs
+++ b/src/components/style/style.rs
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#style:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla/servo#style:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[comment = "The Servo Parallel Browser Project"];
-#[license = "MPL"];
+#![comment = "The Servo Parallel Browser Project"]
+#![license = "MPL"]
 
-#[feature(globs, macro_rules, managed_boxes)];
+#![feature(globs, macro_rules, managed_boxes)]
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)] extern crate log;
 
 extern crate cssparser;

--- a/src/components/util/debug.rs
+++ b/src/components/util/debug.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/components/util/util.rs
+++ b/src/components/util/util.rs
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[crate_id = "github.com/mozilla/servo#util:0.1"];
-#[crate_type = "lib"];
-#[crate_type = "dylib"];
-#[crate_type = "rlib"];
+#![crate_id = "github.com/mozilla/servo#util:0.1"]
+#![crate_type = "lib"]
+#![crate_type = "dylib"]
+#![crate_type = "rlib"]
 
-#[feature(macro_rules, managed_boxes)];
+#![feature(macro_rules, managed_boxes)]
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 


### PR DESCRIPTION
I've fixed it for components/

I'm not sure if it needs to be fixed anywhere else, the rest of the instances seem to be submodules.
