### PR TITLE
Implement Window.set/clearInterval.(fixes #2116)

### DIFF
--- a/src/components/script/dom/webidls/Window.webidl
+++ b/src/components/script/dom/webidls/Window.webidl
@@ -71,6 +71,8 @@ interface WindowTimers {
   //XXXjdm No support for Function or variadic arguments yet
   long setTimeout(any handler, optional long timeout = 0/*, any... arguments*/);
   void clearTimeout(optional long handle = 0);
+  long setInterval(any handler, optional long timeout = 0/*, any... arguments*/);
+  void clearInterval(optional long handler = 0);
   /*long setTimeout(DOMString handler, optional long timeout = 0, any... arguments);
   long setInterval(Function handler, optional long timeout = 0, any... arguments);
   long setInterval(DOMString handler, optional long timeout = 0, any... arguments);

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -660,9 +660,15 @@ impl ScriptTask {
         let frame = page.frame();
         let mut window = frame.get_ref().window.clone();
 
-        let timer_handle = window.get_mut().active_timers.pop(&timer_data.handle);
-        if timer_handle.is_none() {
-            return;
+        {
+            let timer_handle = window.get().active_timers.find(&timer_data.handle);
+            if timer_handle.is_none() {
+                return;
+            }
+        }
+
+        if !timer_data.is_interval {
+            window.get_mut().active_timers.remove(&timer_data.handle);
         }
 
         let js_info = page.js_info();

--- a/src/test/content/test_window_setInterval.html
+++ b/src/test/content/test_window_setInterval.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <script src="harness.js"></script>
+  </head>
+  <body>
+    <script>
+      var x = 0;
+      var intervalID = setInterval(function() {
+        x += 1;
+        if (x == 2) {
+          clearInterval(intervalID);
+          setTimeout(function() {
+            is(x, 2);
+            finish();
+          }, 300);
+        }
+      }, 10);
+    </script>
+  </body>
+</html>

--- a/src/test/html/test_interval.html
+++ b/src/test/html/test_interval.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <script>
+      var x = 0;
+      alert("Interval begin");
+      var intervalID = setInterval(function() {
+        if (x < 10) {
+          alert("interval " + x);
+          x += 1;
+        } else {
+          clearInterval(intervalID);
+          alert("Interval deleted");
+        }
+      }, 300);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
see #2116
I add an `is_interval` field, so that when the `TimerData` is passed by `SetInterval`, we will not delete it from `active_timers`.
Also I think maybe we can extract the code in `ClearTimeout` and `ClearInterval` into another method to avoid duplicate.
