### PR TITLE
Stop using deprecated RefCell<T>::get

### DIFF
--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -123,7 +123,7 @@ impl FrameTree {
             let mut child = children.mut_iter()
                 .find(|child| child.frame_tree.pipeline.id == id);
             for child in child.mut_iter() {
-                new_child.parent.set(child.frame_tree.parent.get());
+                new_child.parent.set(child.frame_tree.parent.borrow().clone());
                 return ReplacedNode(replace(&mut child.frame_tree, new_child));
             }
         }
@@ -556,7 +556,7 @@ impl Constellation {
             source Id of LoadIframeUrlMsg does have an associated pipeline in
             constellation. This should be impossible.").clone();
 
-        let source_url = source_pipeline.url.get().clone().expect("Constellation: LoadUrlIframeMsg's
+        let source_url = source_pipeline.url.borrow().clone().expect("Constellation: LoadUrlIframeMsg's
         source's Url is None. There should never be a LoadUrlIframeMsg from a pipeline
         that was never given a url to load.");
 
@@ -727,12 +727,9 @@ impl Constellation {
             let to_add = frame_change.after.clone();
 
             // Create the next frame tree that will be given to the compositor
-            // NOTE: work around borrowchk issues
-            let tmp = to_add.parent.clone();
-            let next_frame_tree = if tmp.get().is_some() {
+            let next_frame_tree = if to_add.parent.borrow().is_some() {
                 // NOTE: work around borrowchk issues
-                let tmp = self.current_frame().get_ref();
-                tmp.clone()
+                self.current_frame().get_ref().clone()
             } else {
                 to_add.clone()
             };

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -202,7 +202,7 @@ impl Pipeline {
     }
 
     pub fn reload(&self) {
-        self.url.get().clone().map(|url| {
+        self.url.borrow().clone().map(|url| {
             self.load(url);
         });
     }

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -252,7 +252,7 @@ pub fn parse_html(page: &Page,
                   resource_task: ResourceTask)
                   -> HtmlParserResult {
     debug!("Hubbub: parsing {:?}", url);
-    let next_subpage_id: SubpageId = page.next_subpage_id.get();
+    let next_subpage_id: SubpageId = *page.next_subpage_id.borrow();
     // Spawn a CSS parser to receive links to CSS style sheets.
     let resource_task2 = resource_task.clone();
 
@@ -375,7 +375,7 @@ pub fn parse_html(page: &Page,
                         iframe_element.get_mut().set_frame(iframe_url.clone());
 
                         // Subpage Id
-                        let subpage_id = next_subpage_id.get();
+                        let subpage_id = *next_subpage_id.borrow();
                         let SubpageId(id_num) = subpage_id;
                         next_subpage_id.set(SubpageId(id_num + 1));
 


### PR DESCRIPTION
It's going away in the next Rust upgrade (mozilla/rust#13301). r? @larsbergstrom

We'll need to do the same in rust-layers.
