### PR TITLE
style: Switch text decoration computation over to a derived property

### DIFF
--- a/src/components/gfx/display_list.rs
+++ b/src/components/gfx/display_list.rs
@@ -228,6 +228,16 @@ pub struct SolidColorDisplayItem {
     color: Color,
 }
 
+/// Text decoration information.
+pub struct TextDecorations {
+    /// The color to use for underlining, if any.
+    underline: Option<Color>,
+    /// The color to use for overlining, if any.
+    overline: Option<Color>,
+    /// The color to use for line-through, if any.
+    line_through: Option<Color>,
+}
+
 /// Renders text.
 pub struct TextDisplayItem {
     /// Fields common to all display items.
@@ -242,30 +252,9 @@ pub struct TextDisplayItem {
     /// The color of the text.
     text_color: Color,
 
-    /// A bitfield of flags for text display items.
-    flags: TextDisplayItemFlags,
-
-    /// The color of text-decorations
-    underline_color: Color,
-    overline_color: Color,
-    line_through_color: Color,
+    /// Text decorations in effect.
+    text_decorations: TextDecorations,
 }
-
-/// Flags for text display items.
-pub struct TextDisplayItemFlags(u8);
-
-impl TextDisplayItemFlags {
-    pub fn new() -> TextDisplayItemFlags {
-        TextDisplayItemFlags(0)
-    }
-}
-
-// Whether underlining is forced on.
-bitfield!(TextDisplayItemFlags, override_underline, set_override_underline, 0x01)
-// Whether overlining is forced on.
-bitfield!(TextDisplayItemFlags, override_overline, set_override_overline, 0x02)
-// Whether line-through is forced on.
-bitfield!(TextDisplayItemFlags, override_line_through, set_override_line_through, 0x04)
 
 /// Renders an image.
 pub struct ImageDisplayItem {
@@ -369,22 +358,24 @@ impl DisplayItem {
                 let strikeout_size = font_metrics.strikeout_size;
                 let strikeout_offset = font_metrics.strikeout_offset;
 
-                if text_run.decoration.underline || text.flags.override_underline() {
+                for underline_color in text.text_decorations.underline.iter() {
                     let underline_y = baseline_origin.y - underline_offset;
                     let underline_bounds = Rect(Point2D(baseline_origin.x, underline_y),
                                                 Size2D(width, underline_size));
-                    render_context.draw_solid_color(&underline_bounds, text.underline_color);
+                    render_context.draw_solid_color(&underline_bounds, *underline_color);
                 }
-                if text_run.decoration.overline || text.flags.override_overline() {
+
+                for overline_color in text.text_decorations.overline.iter() {
                     let overline_bounds = Rect(Point2D(baseline_origin.x, origin.y),
                                                Size2D(width, underline_size));
-                    render_context.draw_solid_color(&overline_bounds, text.overline_color);
+                    render_context.draw_solid_color(&overline_bounds, *overline_color);
                 }
-                if text_run.decoration.line_through || text.flags.override_line_through() {
+
+                for line_through_color in text.text_decorations.line_through.iter() {
                     let strikeout_y = baseline_origin.y - strikeout_offset;
                     let strikeout_bounds = Rect(Point2D(baseline_origin.x, strikeout_y),
                                                 Size2D(width, strikeout_size));
-                    render_context.draw_solid_color(&strikeout_bounds, text.line_through_color);
+                    render_context.draw_solid_color(&strikeout_bounds, *line_through_color);
                 }
             }
 

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -500,7 +500,6 @@ impl InlineFlow {
                                     builder,
                                     info,
                                     self.base.abs_position + rel_offset,
-                                    (&*self) as &Flow,
                                     ContentLevel);
         }
 
@@ -709,7 +708,7 @@ impl Flow for InlineFlow {
         let mut line_height_offset = Au::new(0);
 
         // All lines use text alignment of the flow.
-        let text_align = self.base.flags_info.flags.text_align();
+        let text_align = self.base.flags.text_align();
 
         // Now, go through each line and lay out the boxes inside.
         for line in self.lines.mut_iter() {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -159,7 +159,7 @@ impl PreorderFlowTraversal for FlowTreeVerificationTraversal {
     #[inline]
     fn process(&mut self, flow: &mut Flow) -> bool {
         let base = flow::base(flow);
-        if !base.flags_info.flags.is_leaf() && !base.flags_info.flags.is_nonleaf() {
+        if !base.flags.is_leaf() && !base.flags.is_nonleaf() {
             println("flow tree verification failed: flow wasn't a leaf or a nonleaf!");
             flow.dump();
             fail!("flow tree verification failed")
@@ -224,7 +224,7 @@ impl<'a> PostorderFlowTraversal for AssignHeightsAndStoreOverflowTraversal<'a> {
 
     #[inline]
     fn should_process(&mut self, flow: &mut Flow) -> bool {
-        !flow::base(flow).flags_info.flags.inorder()
+        !flow::base(flow).flags.inorder()
     }
 }
 

--- a/src/components/style/common_types.rs
+++ b/src/components/style/common_types.rs
@@ -170,11 +170,13 @@ pub mod computed {
     pub use servo_util::geometry::Au;
 
     pub struct Context {
-        color: longhands::color::computed_value::T,
         inherited_font_weight: longhands::font_weight::computed_value::T,
         inherited_font_size: longhands::font_size::computed_value::T,
         inherited_minimum_line_height: longhands::_servo_minimum_line_height::T,
+        inherited_text_decorations_in_effect: longhands::_servo_text_decorations_in_effect::T,
         inherited_height: longhands::height::T,
+        color: longhands::color::computed_value::T,
+        text_decoration: longhands::text_decoration::computed_value::T,
         font_size: longhands::font_size::computed_value::T,
         display: longhands::display::computed_value::T,
         positioned: bool,

--- a/src/components/style/properties.rs.mako
+++ b/src/components/style/properties.rs.mako
@@ -36,7 +36,10 @@ class Longhand(object):
         self.name = name
         self.ident = to_rust_ident(name)
         self.style_struct = THIS_STYLE_STRUCT
-        self.derived_from = None if derived_from is None else to_rust_ident(derived_from)
+        if derived_from is None:
+            self.derived_from = None
+        else:
+            self.derived_from = [ to_rust_ident(name) for name in derived_from ]
 
 class Shorthand(object):
     def __init__(self, name, sub_properties):
@@ -85,11 +88,17 @@ pub mod longhands {
 
     <%def name="raw_longhand(name, no_super=False, derived_from=None)">
     <%
+        if derived_from is not None:
+            derived_from = derived_from.split()
+
         property = Longhand(name, derived_from=derived_from)
         THIS_STYLE_STRUCT.longhands.append(property)
         LONGHANDS.append(property)
         LONGHANDS_BY_NAME[name] = property
-        DERIVED_LONGHANDS.setdefault(derived_from, []).append(property)
+
+        if derived_from is not None:
+            for name in derived_from:
+                DERIVED_LONGHANDS.setdefault(name, []).append(property)
     %>
         pub mod ${property.ident} {
             % if not no_super:
@@ -420,8 +429,9 @@ pub mod longhands {
         }
 
         #[inline]
-        pub fn derive(value: line_height::computed_value::T, context: &computed::Context)
-                      -> Au {
+        pub fn derive_from_line_height(value: line_height::computed_value::T,
+                                       context: &computed::Context)
+                                       -> Au {
             if context.display != display::computed_value::inline {
                 match value {
                     line_height::Normal => context.font_size.scale_by(DEFAULT_LINE_HEIGHT),
@@ -947,6 +957,82 @@ pub mod longhands {
     </%self:longhand>
 
     ${switch_to_style_struct("InheritedText")}
+
+    <%self:longhand name="-servo-text-decorations-in-effect"
+                    derived_from="display text-decoration">
+        use super::RGBA;
+        use super::super::longhands::display;
+
+        pub use to_computed_value = super::computed_as_specified;
+
+        #[deriving(Clone, Eq)]
+        pub struct SpecifiedValue {
+            underline: Option<RGBA>,
+            overline: Option<RGBA>,
+            line_through: Option<RGBA>,
+        }
+
+        pub mod computed_value {
+            pub type T = super::SpecifiedValue;
+        }
+
+        #[inline]
+        pub fn get_initial_value() -> computed_value::T {
+            SpecifiedValue {
+                underline: None,
+                overline: None,
+                line_through: None,
+            }
+        }
+
+        fn maybe(flag: bool, context: &computed::Context) -> Option<RGBA> {
+            if flag {
+                Some(context.color)
+            } else {
+                None
+            }
+        }
+
+        fn derive(context: &computed::Context) -> computed_value::T {
+            // Start with no declarations if this is a block; otherwise, start with the
+            // declarations in effect and add in the text decorations that this inline specifies.
+            let mut result = match context.display {
+                display::computed_value::inline => context.inherited_text_decorations_in_effect,
+                _ => {
+                    SpecifiedValue {
+                        underline: None,
+                        overline: None,
+                        line_through: None,
+                    }
+                }
+            };
+
+            if result.underline.is_none() {
+                result.underline = maybe(context.text_decoration.underline, context)
+            }
+            if result.overline.is_none() {
+                result.overline = maybe(context.text_decoration.overline, context)
+            }
+            if result.line_through.is_none() {
+                result.line_through = maybe(context.text_decoration.line_through, context)
+            }
+
+            result
+        }
+
+        #[inline]
+        pub fn derive_from_text_decoration(_: text_decoration::computed_value::T,
+                                           context: &computed::Context)
+                                           -> computed_value::T {
+            derive(context)
+        }
+
+        #[inline]
+        pub fn derive_from_display(_: display::computed_value::T, context: &computed::Context)
+                                   -> computed_value::T {
+            derive(context)
+        }
+    </%self:longhand>
 
     ${single_keyword("white-space", "normal pre")}
 
@@ -1496,9 +1582,11 @@ fn cascade_with_cached_declarations(applicable_declarations: &[MatchedProperty],
                                     % if property.name in DERIVED_LONGHANDS:
                                         % for derived in DERIVED_LONGHANDS[property.name]:
                                             style_${derived.style_struct.name}.get_mut()
-                                                .${derived.ident} =
-                                                longhands::${derived.ident}::derive(computed_value,
-                                                                                    context);
+                                                                              .${derived.ident} =
+                                                longhands::${derived.ident}
+                                                         ::derive_from_${property.ident}(
+                                                             computed_value,
+                                                             context);
                                         % endfor
                                     % endif
                                 }
@@ -1562,10 +1650,13 @@ pub fn cascade(applicable_declarations: &[MatchedProperty],
             inherited_minimum_line_height: inherited_style.InheritedBox
                                                           .get()
                                                           ._servo_minimum_line_height,
+            inherited_text_decorations_in_effect:
+                inherited_style.InheritedText.get()._servo_text_decorations_in_effect,
             // To be overridden by applicable declarations:
             font_size: inherited_font_style.font_size,
             display: longhands::display::get_initial_value(),
             color: inherited_style.Color.get().color,
+            text_decoration: longhands::text_decoration::get_initial_value(),
             positioned: false,
             floated: false,
             border_top_present: false,
@@ -1612,6 +1703,9 @@ pub fn cascade(applicable_declarations: &[MatchedProperty],
                 }
                 float_declaration(ref value) => {
                     context.floated = get_specified!(Box, float, value) != longhands::float::none;
+                }
+                text_decoration_declaration(ref value) => {
+                    context.text_decoration = get_specified!(Text, text_decoration, value);
                 }
                 % for side in ["top", "right", "bottom", "left"]:
                     border_${side}_style_declaration(ref value) => {
@@ -1683,9 +1777,11 @@ pub fn cascade(applicable_declarations: &[MatchedProperty],
                                 % if property.name in DERIVED_LONGHANDS:
                                     % for derived in DERIVED_LONGHANDS[property.name]:
                                         style_${derived.style_struct.name}.get_mut()
-                                            .${derived.ident} =
-                                            longhands::${derived.ident}::derive(computed_value,
-                                                                                &context);
+                                                                          .${derived.ident} =
+                                            longhands::${derived.ident}
+                                                     ::derive_from_${property.ident}(
+                                                         computed_value,
+                                                         &context);
                                     % endfor
                                 % endif
                             }


### PR DESCRIPTION
`-servo-text-decorations-in-effect`.

This mirrors what WebKit does; WebKit's property is called
`-webkit-text-decorations-in-effect`. It allows us to simplify a lot of
layout code--most notably, the `FlowFlagsInfo` is gone. This commit is a
necessary predecessor to removal of `InlineParentInfo`, which itself is
a necessary predecessor to reenabling parallel layout.

r? @SimonSapin
