### PR TITLE
Ensure that optional primitive arguments aren't treated as nullable.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -855,19 +855,21 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
     if failureCode is None:
         failureCode = 'return 0'
 
-    #XXXjdm support conversionBehavior here
-    template = (
-        "match FromJSValConvertible::from_jsval(cx, ${val}, ()) {\n"
-        "  Ok(v) => ${declName} = v,\n"
-        "  Err(_) => { %s }\n"
-        "}" % exceptionCode)
-
+    value = "v"
     declType = CGGeneric(builtinNames[type.tag()])
     if type.nullable():
         declType = CGWrapper(declType, pre="Option<", post=">")
 
     if isOptional:
+        value = "Some(%s)" % value
         declType = CGWrapper(declType, pre="Option<", post=">")
+
+    #XXXjdm support conversionBehavior here
+    template = (
+        "match FromJSValConvertible::from_jsval(cx, ${val}, ()) {\n"
+        "  Ok(v) => ${declName} = %s,\n"
+        "  Err(_) => { %s }\n"
+        "}" % (value, exceptionCode))
 
     if defaultValue is not None:
         if isinstance(defaultValue, IDLNullValue):


### PR DESCRIPTION
By forgetting the Some(), we caused type inference to convert to Option<T>
for optional non-nullable primitive arguments, and to Option<Option<T>> for
optional nullable primitive arguments (essentially the same thing). This
change brings the primitive codegen in line with the DOMString codegen.

Using distinct types for optionality and nullability would have prevented
this issue.
