### PR TITLE
Default to CPU rendering on Android

### DIFF
--- a/src/components/main/servo.rs
+++ b/src/components/main/servo.rs
@@ -143,7 +143,16 @@ pub extern "C" fn android_start(argc: int, argv: **u8) -> int {
                 args.push(str::raw::from_c_str(*argv.offset(i as int) as *i8));
             }
         }
-        opts::from_cmdline_args(args).map(run);
+
+        let mut opts = opts::from_cmdline_args(args);
+        match opts {
+            Some(mut o) => {
+                // Always use CPU rendering on android.
+                o.cpu_painting = true;
+                run(o);
+            },
+            None => {}
+        }
     })
 }
 


### PR DESCRIPTION
On Android, our feeble GPU graphics stack is even less reliable than it is on Linux. To make it easier to bring Android devices online, this patch defaults to CPU rendering, which is much more stable and, frankly, faster.

r? @metajack
