### PR TITLE
Associate ResourceTask with UrlProvenance

### DIFF
--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -111,7 +111,7 @@ fn css_link_listener(to_parent: Sender<HtmlDiscoveryMessage>,
     loop {
         match from_parent.recv_opt() {
             Some(CSSTaskNewFile(provenance)) => {
-                result_vec.push(spawn_css_parser(provenance, resource_task.clone()));
+                result_vec.push(spawn_css_parser(provenance));
             }
             Some(CSSTaskExit) | None => {
                 break;
@@ -357,7 +357,7 @@ pub fn parse_html(page: &Page,
                                 }) => {
                             debug!("found CSS stylesheet: {:s}", href.get().value_ref());
                             let url = parse_url(href.get().value_ref(), Some(url2.clone()));
-                            css_chan2.send(CSSTaskNewFile(UrlProvenance(url)));
+                            css_chan2.send(CSSTaskNewFile(UrlProvenance(url, resource_task.clone())));
                         }
                         _ => {}
                     }


### PR DESCRIPTION
Fixes #2121

I thought this would be better than passing an `Option<ResourceTask>` to `parse_css` because it avoids having to handle the potential failure at runtime when unwrapping.

No test included, but the error was reproducible by running content/test_getBoundingClientRect.html, and this fixes it. Glad to find a way to add an explicit test if need be.
