### PR TITLE
Treat HTTPS requests as a network error (not a catastrophe)

### DIFF
--- a/src/components/net/http_loader.rs
+++ b/src/components/net/http_loader.rs
@@ -52,7 +52,11 @@ fn load(mut url: Url, start_chan: Sender<LoadResponse>) {
 
         redirected_to.insert(url.clone());
 
-        assert!("http" == url.scheme);
+        if "http" != url.scheme {
+            info!("{:s} request, but we don't support that scheme", url.scheme);
+            send_error(url, start_chan);
+            return;
+        }
 
         info!("requesting {:s}", url.to_str());
 

--- a/src/test/html/https.html
+++ b/src/test/html/https.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+</head>
+<body>
+<img src="https://some-site.org/some-image.png"/>
+</body>
+</html>


### PR DESCRIPTION
This is a stab at #2401 - I think this was what @jdm had in mind for a fix.

I've also included a test. There's no "i tried" star, I'm too much of a newb for that, but hopefully the test at least confirms that servo doesn't crash on HTTPS requests.
