### PR TITLE
Remove not-yet-implemented methods from CharacterData.

### DIFF
--- a/src/components/script/dom/characterdata.rs
+++ b/src/components/script/dom/characterdata.rs
@@ -59,18 +59,6 @@ impl CharacterData {
         self.data.push_str(arg);
         Ok(())
     }
-
-    pub fn InsertData(&mut self, _offset: u32, _arg: DOMString) -> ErrorResult {
-        fail!("CharacterData::InsertData() is unimplemented")
-    }
-
-    pub fn DeleteData(&mut self, _offset: u32, _count: u32) -> ErrorResult {
-        fail!("CharacterData::DeleteData() is unimplemented")
-    }
-
-    pub fn ReplaceData(&mut self, _offset: u32, _count: u32, _arg: DOMString) -> ErrorResult {
-        fail!("CharacterData::ReplaceData() is unimplemented")
-    }
 }
 
 impl Reflectable for CharacterData {

--- a/src/components/script/dom/webidls/CharacterData.webidl
+++ b/src/components/script/dom/webidls/CharacterData.webidl
@@ -17,12 +17,6 @@ interface CharacterData : Node {
   DOMString substringData(unsigned long offset, unsigned long count);
   [Throws]
   void appendData(DOMString data);
-  [Throws]
-  void insertData(unsigned long offset, DOMString data);
-  [Throws]
-  void deleteData(unsigned long offset, unsigned long count);
-  [Throws]
-  void replaceData(unsigned long offset, unsigned long count, DOMString data);
 };
 
 //CharacterData implements ChildNode;


### PR DESCRIPTION
This speeds up a web-platform-tests run by about 45 seconds (of 11-12 minutes)
by avoiding three timeouts.
