### PR TITLE
Remove JSPageInfo::js_compartment.

### DIFF
--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -20,7 +20,7 @@ use servo_net::image_cache_task::ImageCacheTask;
 use servo_util::str::DOMString;
 use servo_util::task::{spawn_named};
 
-use js::jsapi::{JSObject, JSContext, JS_DefineProperty, JS_PropertyStub, JS_StrictPropertyStub};
+use js::jsapi::{JSContext, JS_DefineProperty, JS_PropertyStub, JS_StrictPropertyStub};
 use js::jsval::{NullValue, ObjectValue, JSVal};
 use js::JSPROP_ENUMERATE;
 
@@ -91,9 +91,9 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn get_cx(&self) -> *JSObject {
+    pub fn get_cx(&self) -> *JSContext {
         let js_info = self.page().js_info();
-        js_info.get_ref().js_compartment.deref().cx.deref().ptr
+        (**js_info.get_ref().js_context).ptr
     }
 
     pub fn page<'a>(&'a self) -> &'a Page {


### PR DESCRIPTION
A js::rust::Compartment is little more than a glorified pointer to the
reflector of a window, so there's no good reason to use it. Instead, this
commit passes a JS<Window> directly when it's necessary.

This also means that we now have to use JS_DefineFunctions rather than
Compartment::define_functions; I believe the former is clearer to the reader
than the extra indirection involved in the latter calling through three
reopsitories.

This commit also simplifies ScriptTask::load to reuse the 'cx' local that is
in scope already, rather than refetching it through js_info.
