### PR TITLE
Make the I Tried star appear when a top-level page load fails for networ...

### DIFF
--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -208,6 +208,8 @@ impl Pipeline {
     }
 
     pub fn exit(&self) {
+        debug!("pipeline {:?} exiting", self.id);
+
         // Script task handles shutting down layout, and layout handles shutting down the renderer.
         // For now, if the script task has failed, we give up on clean shutdown.
         let ScriptChan(ref chan) = self.script_chan;

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -172,7 +172,7 @@ impl PageTree {
                 next_subpage_id: Untraceable::new(RefCell::new(SubpageId(0))),
                 resize_event: Untraceable::new(RefCell::new(None)),
                 fragment_node: Traceable::new(RefCell::new(None)),
-                last_reflow_id: Traceable::new(RefCell::new(0))
+                last_reflow_id: Traceable::new(RefCell::new(0)),
             }),
             inner: ~[],
         }


### PR DESCRIPTION
...k-related reasons.

Under the hood, this requires treating the I Tried pipeline as a new load instead of a replacement, since the failure-handling code interacts poorly with the rest of the replacement code when we get a series of staggered failures over time from the various pipeline components.
