### PR TITLE
Crash when navigating back with "RefCell is already borrowed"

### DIFF
--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -202,7 +202,8 @@ impl Pipeline {
     }
 
     pub fn reload(&self) {
-        self.url.borrow().clone().map(|url| {
+        let url = self.url.borrow().clone();
+        url.map(|url| {
             self.load(url);
         });
     }

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -810,19 +810,16 @@ impl ScriptTask {
             is a bug.");
         let page = page_tree.page();
 
-        {
-            let mut page_url = page.mut_url();
-            let last_loaded_url = replace(&mut *page_url, None);
-            for loaded in last_loaded_url.iter() {
-                let (ref loaded, needs_reflow) = *loaded;
-                if *loaded == url {
-                    *page_url = Some((loaded.clone(), false));
-                    if needs_reflow {
-                        page.damage(ContentChangedDocumentDamage);
-                        page.reflow(ReflowForDisplay, self.chan.clone(), self.compositor);
-                    }
-                    return;
+        let last_loaded_url = replace(&mut *page.mut_url(), None);
+        for loaded in last_loaded_url.iter() {
+            let (ref loaded, needs_reflow) = *loaded;
+            if *loaded == url {
+                *page.mut_url() = Some((loaded.clone(), false));
+                if needs_reflow {
+                    page.damage(ContentChangedDocumentDamage);
+                    page.reflow(ReflowForDisplay, self.chan.clone(), self.compositor);
                 }
+                return;
             }
         }
 


### PR DESCRIPTION
This fixes two `RefCell<T> is already borrowed` failures when reloading an
existing pipeline, both caused by functions trying to modify `Pipeline::url`
or `ScriptTask::url` while a reference to a previous borrow is still in scope.

Note: After applying this patch, there are some painting issues after navigating back.
