### PR TITLE
Add APIs to abstract Page::query_layout()

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -20,7 +20,7 @@ use dom::htmlcollection::HTMLCollection;
 use dom::htmlserializer::serialize;
 use dom::node::{ElementNodeTypeId, Node, NodeHelpers, NodeIterator, document_from_node};
 use dom::virtualmethods::{VirtualMethods, vtable_for};
-use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery};
+use layout_interface::{ContentBoxesQuery};
 use layout_interface::{ContentBoxesResponse, ContentChangedDocumentDamage};
 use layout_interface::MatchSelectorsDocumentDamage;
 use style;
@@ -625,9 +625,7 @@ impl Element {
         let doc = self.node.owner_doc();
         let win = &doc.get().window;
         let node: JS<Node> = NodeCast::from(abstract_self);
-        let (chan, port) = channel();
-        let addr = node.to_trusted_node_address();
-        let ContentBoxResponse(rect) = win.get().page().query_layout(ContentBoxQuery(addr, chan), port);
+        let rect = node.get_bounding_content_box();
         ClientRect::new(
             win,
             rect.origin.y,

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -20,8 +20,7 @@ use dom::htmlcollection::HTMLCollection;
 use dom::htmlserializer::serialize;
 use dom::node::{ElementNodeTypeId, Node, NodeHelpers, NodeIterator, document_from_node};
 use dom::virtualmethods::{VirtualMethods, vtable_for};
-use layout_interface::{ContentBoxesQuery};
-use layout_interface::{ContentBoxesResponse, ContentChangedDocumentDamage};
+use layout_interface::ContentChangedDocumentDamage;
 use layout_interface::MatchSelectorsDocumentDamage;
 use style;
 use servo_util::namespace;
@@ -605,9 +604,7 @@ impl Element {
         let doc = self.node.owner_doc();
         let win = &doc.get().window;
         let node: JS<Node> = NodeCast::from(abstract_self);
-        let (chan, port) = channel();
-        let addr = node.to_trusted_node_address();
-        let ContentBoxesResponse(rects) = win.get().page().query_layout(ContentBoxesQuery(addr, chan), port);
+        let rects = node.get_content_boxes();
         let rects = rects.map(|r| {
             ClientRect::new(
                 win,

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -16,7 +16,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId, NodeHelpers, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 use servo_util::geometry::to_px;
-use layout_interface::{ContentBoxQuery, ContentBoxResponse};
 use servo_net::image_cache_task;
 use servo_util::url::parse_url;
 use servo_util::str::DOMString;
@@ -131,11 +130,7 @@ impl HTMLImageElement {
 
     pub fn Width(&self, abstract_self: &JS<HTMLImageElement>) -> u32 {
         let node: JS<Node> = NodeCast::from(abstract_self);
-        let window = window_from_node(&node);
-        let page = window.get().page();
-        let (chan, port) = channel();
-        let addr = node.to_trusted_node_address();
-        let ContentBoxResponse(rect) = page.query_layout(ContentBoxQuery(addr, chan), port);
+        let rect = node.get_bounding_content_box();
         to_px(rect.size.width) as u32
     }
 
@@ -145,13 +140,8 @@ impl HTMLImageElement {
     }
 
     pub fn Height(&self, abstract_self: &JS<HTMLImageElement>) -> u32 {
-        let node = &self.htmlelement.element.node;
-        let doc = node.owner_doc();
-        let page = doc.get().window.get().page();
-        let (chan, port) = channel();
-        let this_node: JS<Node> = NodeCast::from(abstract_self);
-        let addr = this_node.to_trusted_node_address();
-        let ContentBoxResponse(rect) = page.query_layout(ContentBoxQuery(addr, chan), port);
+        let node: JS<Node> = NodeCast::from(abstract_self);
+        let rect = node.get_bounding_content_box();
         to_px(rect.size.height) as u32
     }
 

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -28,7 +28,8 @@ use dom::virtualmethods::{VirtualMethods, vtable_for};
 use dom::window::Window;
 use geom::rect::Rect;
 use html::hubbub_html_parser::build_element_from_tag;
-use layout_interface::{ContentBoxQuery, ContentBoxResponse, LayoutChan, ReapLayoutDataMsg, TrustedNodeAddress, UntrustedNodeAddress};
+use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery, ContentBoxesResponse,
+                       LayoutChan, ReapLayoutDataMsg, TrustedNodeAddress, UntrustedNodeAddress};
 use servo_util::geometry::Au;
 use servo_util::str::{DOMString, null_str_as_empty};
 
@@ -286,6 +287,7 @@ pub trait NodeHelpers {
     fn to_trusted_node_address(&self) -> TrustedNodeAddress;
 
     fn get_bounding_content_box(&self) -> Rect<Au>;
+    fn get_content_boxes(&self) -> ~[Rect<Au>];
 }
 
 impl NodeHelpers for JS<Node> {
@@ -576,6 +578,15 @@ impl NodeHelpers for JS<Node> {
         let addr = self.to_trusted_node_address();
         let ContentBoxResponse(rect) = page.query_layout(ContentBoxQuery(addr, chan), port);
         rect
+    }
+
+    fn get_content_boxes(&self) -> ~[Rect<Au>] {
+        let window = window_from_node(self);
+        let page = window.get().page();
+        let (chan, port) = channel();
+        let addr = self.to_trusted_node_address();
+        let ContentBoxesResponse(rects) = page.query_layout(ContentBoxesQuery(addr, chan), port);
+        rects
     }
 }
 

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -26,9 +26,10 @@ use dom::processinginstruction::ProcessingInstruction;
 use dom::text::Text;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
 use dom::window::Window;
+use geom::rect::Rect;
 use html::hubbub_html_parser::build_element_from_tag;
-use layout_interface::{LayoutChan, ReapLayoutDataMsg, UntrustedNodeAddress};
-use layout_interface::TrustedNodeAddress;
+use layout_interface::{ContentBoxQuery, ContentBoxResponse, LayoutChan, ReapLayoutDataMsg, TrustedNodeAddress, UntrustedNodeAddress};
+use servo_util::geometry::Au;
 use servo_util::str::{DOMString, null_str_as_empty};
 
 use js::jsapi::{JSContext, JSObject, JSRuntime};
@@ -283,6 +284,8 @@ pub trait NodeHelpers {
 
     fn from_untrusted_node_address(runtime: *JSRuntime, candidate: UntrustedNodeAddress) -> Self;
     fn to_trusted_node_address(&self) -> TrustedNodeAddress;
+
+    fn get_bounding_content_box(&self) -> Rect<Au>;
 }
 
 impl NodeHelpers for JS<Node> {
@@ -564,6 +567,15 @@ impl NodeHelpers for JS<Node> {
 
     fn to_trusted_node_address(&self) -> TrustedNodeAddress {
         TrustedNodeAddress(self.get() as *Node as *libc::c_void)
+    }
+
+    fn get_bounding_content_box(&self) -> Rect<Au> {
+        let window = window_from_node(self);
+        let page = window.get().page();
+        let (chan, port) = channel();
+        let addr = self.to_trusted_node_address();
+        let ContentBoxResponse(rect) = page.query_layout(ContentBoxQuery(addr, chan), port);
+        rect
     }
 }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -22,7 +22,6 @@ use html::hubbub_html_parser::HtmlParserResult;
 use html::hubbub_html_parser::{HtmlDiscoveredStyle, HtmlDiscoveredIFrame, HtmlDiscoveredScript};
 use html::hubbub_html_parser;
 use layout_interface::{AddStylesheetMsg, DocumentDamage};
-use layout_interface::{ContentBoxQuery, ContentBoxResponse};
 use layout_interface::{DocumentDamageLevel, HitTestQuery, HitTestResponse, LayoutQuery, MouseOverQuery, MouseOverResponse};
 use layout_interface::{LayoutChan, MatchSelectorsDocumentDamage, QueryMsg};
 use layout_interface::{Reflow, ReflowDocumentDamage, ReflowForDisplay, ReflowGoal, ReflowMsg};
@@ -958,11 +957,9 @@ impl ScriptTask {
         chan.send(LoadCompleteMsg(page.id, url));
     }
 
-    fn scroll_fragment_point(&self, pipeline_id: PipelineId, page: &Page, node: JS<Element>) {
-        let (chan, port) = channel();
+    fn scroll_fragment_point(&self, pipeline_id: PipelineId, node: JS<Element>) {
         let node: JS<Node> = NodeCast::from(&node);
-        let ContentBoxResponse(rect) =
-            page.query_layout(ContentBoxQuery(node.to_trusted_node_address(), chan), port);
+        let rect = node.get_bounding_content_box();
         let point = Point2D(to_frac_px(rect.origin.x).to_f32().unwrap(),
                             to_frac_px(rect.origin.y).to_f32().unwrap());
         // FIXME(#2003, pcwalton): This is pretty bogus when multiple layers are involved.
@@ -1000,7 +997,7 @@ impl ScriptTask {
 
                 let mut fragment_node = page.fragment_node.deref().borrow_mut();
                 match fragment_node.take() {
-                    Some(node) => self.scroll_fragment_point(pipeline_id, page, node),
+                    Some(node) => self.scroll_fragment_point(pipeline_id, node),
                     None => {}
                 }
 
@@ -1159,7 +1156,7 @@ impl ScriptTask {
 
             if click_frag {
                 match page.find_fragment_node(url.fragment.unwrap()) {
-                    Some(node) => self.scroll_fragment_point(page.id, page, node),
+                    Some(node) => self.scroll_fragment_point(page.id, node),
                     None => {}
                 }
             } else {

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -457,6 +457,26 @@ impl Page {
         };
         address
     }
+
+    pub fn get_nodes_under_mouse(&self, point: &Point2D<f32>) -> Option<~[UntrustedNodeAddress]> {
+        let frame = self.frame();
+        let document = frame.get_ref().document.clone();
+        let root = document.get().GetDocumentElement();
+        if root.is_none() {
+            return None;
+        }
+        let root: JS<Node> = NodeCast::from(&root.unwrap());
+        let (chan, port) = channel();
+        let address = match self.query_layout(MouseOverQuery(root.to_trusted_node_address(), *point, chan), port) {
+            Ok(MouseOverResponse(node_address)) => {
+                Some(node_address)
+            }
+            Err(()) => {
+                None
+            }
+        };
+        address
+    }
 }
 
 /// Information for one frame in the browsing context.
@@ -1077,22 +1097,15 @@ impl ScriptTask {
                             }
                         }
                     }
+
                     None => {}
                 }
             }
             MouseDownEvent(..) => {}
             MouseUpEvent(..) => {}
             MouseMoveEvent(point) => {
-                let frame = page.frame();
-                let document = frame.get_ref().document.clone();
-                let root = document.get().GetDocumentElement();
-                if root.is_none() {
-                    return;
-                }
-                let root: JS<Node> = NodeCast::from(&root.unwrap());
-                let (chan, port) = channel();
-                match page.query_layout(MouseOverQuery(root.to_trusted_node_address(), point, chan), port) {
-                    Ok(MouseOverResponse(node_address)) => {
+                match page.get_nodes_under_mouse(&point) {
+                    Some(node_address) => {
 
                         let mut target_list: ~[JS<Node>] = ~[];
                         let mut target_compare = false;
@@ -1150,8 +1163,9 @@ impl ScriptTask {
                             }
                             *mouse_over_targets = Some(target_list);
                         }
-                    },
-                    Err(()) => {},
+                    }
+
+                    None => {}
               }
             }
         }


### PR DESCRIPTION
- see #356
- To decrease the conversion code, `JS<Node>` -> `Node`, I added API methods to `NodeHelpers`.
- I added APIs to `Page` not `Document` because I had thought that their APIs returns the hitted nodes address in the "page".
