### PR TITLE
Ensure Node.Normalize() acts on all descendants

### DIFF
--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -1590,6 +1590,8 @@ impl Node {
                     }
                 }
             } else {
+                let c = &mut child.clone();
+                child.get_mut().Normalize(c);
                 prev_text = None;
             }
 


### PR DESCRIPTION
Fixes #2170 by recursively calling `normalize()` on all children that aren't text nodes.
