### PR TITLE
Replace ~[T] by Vec<T>

### DIFF
--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -754,7 +754,7 @@ impl LayoutTask {
             ContentBoxesQuery(node, reply_chan) => {
                 let node: OpaqueNode = OpaqueNodeMethods::from_script_node(node);
 
-                fn add_boxes_for_node(accumulator: &mut ~[Rect<Au>],
+                fn add_boxes_for_node(accumulator: &mut Vec<Rect<Au>>,
                                       mut iter: DisplayItemIterator,
                                       node: OpaqueNode) {
                     for item in iter {
@@ -765,7 +765,7 @@ impl LayoutTask {
                     }
                 }
 
-                let mut boxes = ~[];
+                let mut boxes = vec!();
                 match self.display_list {
                     None => fail!("no display list!"),
                     Some(ref display_list) => {

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -830,7 +830,7 @@ impl LayoutTask {
                 fn mouse_over_test(x: Au,
                                    y: Au,
                                    list: &[DisplayItem],
-                                   result: &mut ~[UntrustedNodeAddress]) {
+                                   result: &mut Vec<UntrustedNodeAddress>) {
                     for item in list.rev_iter() {
                         match *item {
                             ClipDisplayItemClass(ref cc) => {
@@ -856,7 +856,7 @@ impl LayoutTask {
                     }
                 }
 
-                let mut mouse_over_list:~[UntrustedNodeAddress] = ~[];
+                let mut mouse_over_list: Vec<UntrustedNodeAddress> = vec!();
                 let (x, y) = (Au::from_frac_px(point.x as f64),
                               Au::from_frac_px(point.y as f64));
                 match self.display_list {

--- a/src/components/net/file_loader.rs
+++ b/src/components/net/file_loader.rs
@@ -16,7 +16,7 @@ fn read_all(reader: &mut io::Stream, progress_chan: &Sender<ProgressMsg>)
     loop {
         let mut buf = Vec::new();
         match reader.push_exact(&mut buf, READ_SIZE) {
-            Ok(_) => progress_chan.send(Payload(buf.iter().map(|&x| x).collect())),
+            Ok(_) => progress_chan.send(Payload(buf)),
             Err(e) => match e.kind {
                 io::EndOfFile => return Ok(()),
                 _ => return Err(()),

--- a/src/components/net/http_loader.rs
+++ b/src/components/net/http_loader.rs
@@ -104,7 +104,8 @@ fn load(mut url: Url, start_chan: Sender<LoadResponse>) {
             match response.read(buf) {
                 Ok(len) => {
                     unsafe { buf.set_len(len); }
-                    progress_chan.send(Payload(buf));
+                    let buf: ~[u8] = buf;
+                    progress_chan.send(Payload(buf.move_iter().collect()));
                 }
                 Err(_) => {
                     progress_chan.send(Done(Ok(())));

--- a/src/components/net/image/base.rs
+++ b/src/components/net/image/base.rs
@@ -21,8 +21,8 @@ pub fn Image(width: u32, height: u32, color_type: png::ColorType, data: ~[u8]) -
 
 static TEST_IMAGE: &'static [u8] = include_bin!("test.jpeg");
 
-pub fn test_image_bin() -> ~[u8] {
-    TEST_IMAGE.into_owned()
+pub fn test_image_bin() -> Vec<u8> {
+    TEST_IMAGE.iter().map(|&x| x).collect()
 }
 
 // TODO(pcwalton): Speed up with SIMD, or better yet, find some way to not do this.

--- a/src/components/net/image_cache_task.rs
+++ b/src/components/net/image_cache_task.rs
@@ -491,7 +491,7 @@ fn load_image_data(url: Url, resource_task: ResourceTask) -> Result<~[u8], ()> {
     loop {
         match progress_port.recv() {
             resource_task::Payload(data) => {
-                image_data.push_all(data);
+                image_data.push_all(data.as_slice());
             }
             resource_task::Done(result::Ok(..)) => {
                 return Ok(image_data);
@@ -554,7 +554,7 @@ mod tests {
     struct SendBogusImage;
     impl Closure for SendBogusImage {
         fn invoke(&self, response: Sender<resource_task::ProgressMsg>) {
-            response.send(resource_task::Payload(~[]));
+            response.send(resource_task::Payload(vec!()));
             response.send(resource_task::Done(Ok(())));
         }
     }

--- a/src/components/script/dom/attrlist.rs
+++ b/src/components/script/dom/attrlist.rs
@@ -35,7 +35,7 @@ impl AttrList {
     }
 
     pub fn Item(&self, index: u32) -> Option<JS<Attr>> {
-        self.owner.get().attrs.get(index as uint).map(|x| x.clone())
+        self.owner.get().attrs.as_slice().get(index as uint).map(|x| x.clone())
     }
 
     pub fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<JS<Attr>> {

--- a/src/components/script/dom/clientrectlist.rs
+++ b/src/components/script/dom/clientrectlist.rs
@@ -11,13 +11,13 @@ use dom::window::Window;
 #[deriving(Encodable)]
 pub struct ClientRectList {
     pub reflector_: Reflector,
-    pub rects: ~[JS<ClientRect>],
+    pub rects: Vec<JS<ClientRect>>,
     pub window: JS<Window>,
 }
 
 impl ClientRectList {
     pub fn new_inherited(window: JS<Window>,
-                         rects: ~[JS<ClientRect>]) -> ClientRectList {
+                         rects: Vec<JS<ClientRect>>) -> ClientRectList {
         ClientRectList {
             reflector_: Reflector::new(),
             rects: rects,
@@ -26,7 +26,7 @@ impl ClientRectList {
     }
 
     pub fn new(window: &JS<Window>,
-               rects: ~[JS<ClientRect>]) -> JS<ClientRectList> {
+               rects: Vec<JS<ClientRect>>) -> JS<ClientRectList> {
         reflect_dom_object(~ClientRectList::new_inherited(window.clone(), rects),
                            window, ClientRectListBinding::Wrap)
     }
@@ -37,7 +37,7 @@ impl ClientRectList {
 
     pub fn Item(&self, index: u32) -> Option<JS<ClientRect>> {
         if index < self.rects.len() as u32 {
-            Some(self.rects[index as uint].clone())
+            Some(self.rects.get(index as uint).clone())
         } else {
             None
         }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -58,7 +58,7 @@ pub struct Document {
     pub node: Node,
     pub reflector_: Reflector,
     pub window: JS<Window>,
-    pub idmap: HashMap<DOMString, ~[JS<Element>]>,
+    pub idmap: HashMap<DOMString, Vec<JS<Element>>>,
     pub implementation: Option<JS<DOMImplementation>>,
     pub content_type: DOMString,
     pub encoding_name: DOMString,
@@ -232,11 +232,9 @@ impl Document {
 
     // http://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid
     pub fn GetElementById(&self, id: DOMString) -> Option<JS<Element>> {
-        // TODO: "in tree order, within the context object's tree"
-        // http://dom.spec.whatwg.org/#dom-document-getelementbyid.
         match self.idmap.find_equiv(&id) {
             None => None,
-            Some(ref elements) => Some(elements[0].clone()),
+            Some(ref elements) => Some(elements.get(0).clone()),
         }
     }
 
@@ -679,7 +677,7 @@ impl Document {
                 for node in root.traverse_preorder() {
                     match ElementCast::to(&node) {
                         Some(elem) => {
-                            if elements[head] == elem {
+                            if elements.get(head) == &elem {
                                 head = head + 1;
                             }
                             if new_node == node || head == elements.len() {
@@ -694,6 +692,6 @@ impl Document {
             },
             None => (),
         }
-        self.idmap.insert(id, ~[element.clone()]);
+        self.idmap.insert(id, vec!(element.clone()));
     }
 }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -386,10 +386,9 @@ impl Document {
                     }
                 });
         });
-        let v: ~[&str] = title.words().collect();
-        title = v.connect(" ");
-        title = title.trim().to_owned();
-        title
+        let v: Vec<&str> = title.words().collect();
+        let title = v.connect(" ");
+        title.trim().to_owned()
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#document.title

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -608,7 +608,7 @@ impl Document {
     }
 
     pub fn createNodeList(&self, callback: |node: &JS<Node>| -> bool) -> JS<NodeList> {
-        let mut nodes: ~[JS<Node>] = ~[];
+        let mut nodes = vec!();
         match self.GetDocumentElement() {
             None => {},
             Some(root) => {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -36,7 +36,7 @@ pub struct Element {
     pub local_name: DOMString,     // TODO: This should be an atom, not a DOMString.
     pub namespace: Namespace,
     pub prefix: Option<DOMString>,
-    pub attrs: ~[JS<Attr>],
+    pub attrs: Vec<JS<Attr>>,
     pub style_attribute: Option<style::PropertyDeclarationBlock>,
     pub attr_list: Option<JS<AttrList>>
 }
@@ -145,7 +145,7 @@ impl Element {
             local_name: local_name,
             namespace: namespace,
             prefix: prefix,
-            attrs: ~[],
+            attrs: vec!(),
             attr_list: None,
             style_attribute: None,
         }
@@ -264,7 +264,7 @@ impl AttributeHandlers for JS<Element> {
         let idx = self.get().attrs.iter().position(cb);
         let (mut attr, set_type): (JS<Attr>, AttrSettingType) = match idx {
             Some(idx) => {
-                let attr = self.get_mut().attrs[idx].clone();
+                let attr = self.get_mut().attrs.get(idx).clone();
                 (attr, ReplacedAttr)
             }
 
@@ -376,7 +376,7 @@ impl AttributeHandlers for JS<Element> {
             None => (),
             Some(idx) => {
                 if namespace == namespace::Null {
-                    let removed_raw_value = self.get().attrs[idx].get().Value();
+                    let removed_raw_value = self.get().attrs.get(idx).get().Value();
                     vtable_for(&node).before_remove_attr(local_name.clone(), removed_raw_value);
                 }
 

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -651,8 +651,8 @@ pub fn get_attribute_parts(name: DOMString) -> (Option<~str>, ~str) {
     //FIXME: Throw for XML-invalid names
     //FIXME: Throw for XMLNS-invalid names
     let (prefix, local_name) = if name.contains(":")  {
-        let parts: ~[&str] = name.splitn(':', 1).collect();
-        (Some(parts[0].to_owned()), parts[1].to_owned())
+        let mut parts = name.splitn(':', 1);
+        (Some(parts.next().unwrap().to_owned()), parts.next().unwrap().to_owned())
     } else {
         (None, name)
     };

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -26,7 +26,7 @@ impl<S: Encoder<E>, E> Encodable<S, E> for ~CollectionFilter {
 
 #[deriving(Encodable)]
 pub enum CollectionTypeId {
-    Static(~[JS<Element>]),
+    Static(Vec<JS<Element>>),
     Live(JS<Node>, ~CollectionFilter)
 }
 
@@ -135,6 +135,7 @@ impl HTMLCollection {
     pub fn Item(&self, index: u32) -> Option<JS<Element>> {
         match self.collection {
             Static(ref elems) => elems
+                .as_slice()
                 .get(index as uint)
                 .map(|elem| elem.clone()),
             Live(ref root, ref filter) => root.traverse_preorder()

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -94,7 +94,7 @@ impl HTMLCollection {
     pub fn by_class_name(window: &JS<Window>, root: &JS<Node>, classes: DOMString)
                          -> JS<HTMLCollection> {
         struct ClassNameFilter {
-            classes: ~[DOMString]
+            classes: Vec<DOMString>
         }
         impl CollectionFilter for ClassNameFilter {
             fn filter(&self, elem: &JS<Element>, _root: &JS<Node>) -> bool {

--- a/src/components/script/dom/htmlformelement.rs
+++ b/src/components/script/dom/htmlformelement.rs
@@ -118,7 +118,7 @@ impl HTMLFormElement {
         // FIXME: https://github.com/mozilla/servo/issues/1844
         let doc = self.htmlelement.element.node.owner_doc();
         let doc = doc.get();
-        HTMLCollection::new(&doc.window, Static(~[]))
+        HTMLCollection::new(&doc.window, Static(vec!()))
     }
 
     pub fn Length(&self) -> i32 {

--- a/src/components/script/dom/htmlmapelement.rs
+++ b/src/components/script/dom/htmlmapelement.rs
@@ -54,6 +54,6 @@ impl HTMLMapElement {
         // FIXME: https://github.com/mozilla/servo/issues/1845
         let doc = self.htmlelement.element.node.owner_doc();
         let doc = doc.get();
-        HTMLCollection::new(&doc.window, Static(~[]))
+        HTMLCollection::new(&doc.window, Static(vec!()))
     }
 }

--- a/src/components/script/dom/htmlserializer.rs
+++ b/src/components/script/dom/htmlserializer.rs
@@ -21,7 +21,7 @@ use dom::text::Text;
 
 pub fn serialize(iterator: &mut NodeIterator) -> ~str {
     let mut html = ~"";
-    let mut open_elements: ~[~str] = ~[];
+    let mut open_elements: Vec<~str> = vec!();
 
     for node in *iterator {
         while open_elements.len() > iterator.depth {
@@ -93,7 +93,7 @@ fn serialize_doctype(doctype: &JS<DocumentType>) -> ~str {
     ~"<!DOCTYPE" + doctype.get().name + ">"
 }
 
-fn serialize_elem(elem: &JS<Element>, open_elements: &mut ~[~str]) -> ~str {
+fn serialize_elem(elem: &JS<Element>, open_elements: &mut Vec<~str>) -> ~str {
     let mut rv = ~"<" + elem.get().local_name;
     for attr in elem.get().attrs.iter() {
         rv.push_str(serialize_attr(attr));

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -517,14 +517,14 @@ impl NodeHelpers for JS<Node> {
 
     /// Iterates over this node and all its descendants, in preorder.
     fn traverse_preorder(&self) -> TreeIterator {
-        let mut nodes = ~[];
+        let mut nodes = vec!();
         gather_abstract_nodes(self, &mut nodes, false);
         TreeIterator::new(nodes)
     }
 
     /// Iterates over this node and all its descendants, in postorder.
     fn sequential_traverse_postorder(&self) -> TreeIterator {
-        let mut nodes = ~[];
+        let mut nodes = vec!();
         gather_abstract_nodes(self, &mut nodes, true);
         TreeIterator::new(nodes)
     }
@@ -633,12 +633,12 @@ impl Iterator<JS<Node>> for AncestorIterator {
 // FIXME: Do this without precomputing a vector of refs.
 // Easy for preorder; harder for postorder.
 pub struct TreeIterator {
-    nodes: ~[JS<Node>],
+    nodes: Vec<JS<Node>>,
     index: uint,
 }
 
 impl TreeIterator {
-    fn new(nodes: ~[JS<Node>]) -> TreeIterator {
+    fn new(nodes: Vec<JS<Node>>) -> TreeIterator {
         TreeIterator {
             nodes: nodes,
             index: 0,
@@ -651,7 +651,7 @@ impl Iterator<JS<Node>> for TreeIterator {
         if self.index >= self.nodes.len() {
             None
         } else {
-            let v = self.nodes[self.index].clone();
+            let v = self.nodes.get(self.index).clone();
             self.index += 1;
             Some(v)
         }
@@ -735,7 +735,7 @@ impl Iterator<JS<Node>> for NodeIterator {
     }
 }
 
-fn gather_abstract_nodes(cur: &JS<Node>, refs: &mut ~[JS<Node>], postorder: bool) {
+fn gather_abstract_nodes(cur: &JS<Node>, refs: &mut Vec<JS<Node>>, postorder: bool) {
     if !postorder {
         refs.push(cur.clone());
     }

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -288,7 +288,7 @@ pub trait NodeHelpers {
     fn to_trusted_node_address(&self) -> TrustedNodeAddress;
 
     fn get_bounding_content_box(&self) -> Rect<Au>;
-    fn get_content_boxes(&self) -> ~[Rect<Au>];
+    fn get_content_boxes(&self) -> Vec<Rect<Au>>;
 }
 
 impl NodeHelpers for JS<Node> {
@@ -581,7 +581,7 @@ impl NodeHelpers for JS<Node> {
         rect
     }
 
-    fn get_content_boxes(&self) -> ~[Rect<Au>] {
+    fn get_content_boxes(&self) -> Vec<Rect<Au>> {
         let window = window_from_node(self);
         let page = window.get().page();
         let (chan, port) = channel();

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -1201,7 +1201,7 @@ impl Node {
         // Step 4.
         let mut nodes = match node.type_id() {
             DocumentFragmentNodeTypeId => node.children().collect(),
-            _ => ~[node.clone()],
+            _ => vec!(node.clone()),
         };
 
         // Step 5: DocumentFragment, mutation records.
@@ -1242,14 +1242,14 @@ impl Node {
         }
 
         // Step 2.
-        let removedNodes: ~[JS<Node>] = parent.children().collect();
+        let removedNodes: Vec<JS<Node>> = parent.children().collect();
 
         // Step 3.
         let addedNodes = match node {
-            None => ~[],
+            None => vec!(),
             Some(ref node) => match node.type_id() {
                 DocumentFragmentNodeTypeId => node.children().collect(),
-                _ => ~[node.clone()],
+                _ => vec!(node.clone()),
             },
         };
 

--- a/src/components/script/dom/nodelist.rs
+++ b/src/components/script/dom/nodelist.rs
@@ -10,7 +10,7 @@ use dom::window::Window;
 
 #[deriving(Encodable)]
 pub enum NodeListType {
-    Simple(~[JS<Node>]),
+    Simple(Vec<JS<Node>>),
     Children(JS<Node>)
 }
 
@@ -37,7 +37,7 @@ impl NodeList {
                            window, NodeListBinding::Wrap)
     }
 
-    pub fn new_simple_list(window: &JS<Window>, elements: ~[JS<Node>]) -> JS<NodeList> {
+    pub fn new_simple_list(window: &JS<Window>, elements: Vec<JS<Node>>) -> JS<NodeList> {
         NodeList::new(window, Simple(elements))
     }
 
@@ -55,7 +55,7 @@ impl NodeList {
     pub fn Item(&self, index: u32) -> Option<JS<Node>> {
         match self.list_type {
             _ if index >= self.Length() => None,
-            Simple(ref elems) => Some(elems[index as uint].clone()),
+            Simple(ref elems) => Some(elems.get(index as uint).clone()),
             Children(ref node) => node.children().nth(index as uint)
         }
     }

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -111,7 +111,6 @@ pub struct TimerData {
     pub handle: i32,
     pub is_interval: bool,
     pub funval: JSVal,
-    pub args: ~[JSVal],
 }
 
 impl Window {
@@ -248,7 +247,6 @@ impl Window {
                         handle: handle,
                         is_interval: is_interval,
                         funval: callback,
-                        args: ~[],
                     };
                     let ScriptChan(ref chan) = chan;
                     chan.send(FireTimerMsg(page_id, data));

--- a/src/components/script/html/cssparse.rs
+++ b/src/components/script/html/cssparse.rs
@@ -62,8 +62,8 @@ struct ProgressMsgPortIterator {
     progress_port: Receiver<ProgressMsg>
 }
 
-impl Iterator<~[u8]> for ProgressMsgPortIterator {
-    fn next(&mut self) -> Option<~[u8]> {
+impl Iterator<Vec<u8>> for ProgressMsgPortIterator {
+    fn next(&mut self) -> Option<Vec<u8>> {
         match self.progress_port.recv() {
             Payload(data) => Some(data),
             Done(..) => None

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -50,7 +50,7 @@ pub struct JSFile {
     pub url: Url
 }
 
-pub type JSResult = ~[JSFile];
+pub type JSResult = Vec<JSFile>;
 
 enum CSSMessage {
     CSSTaskNewFile(StylesheetProvenance),
@@ -105,7 +105,7 @@ spawned, collates them, and sends them to the given result channel.
 */
 fn css_link_listener(to_parent: Sender<HtmlDiscoveryMessage>,
                      from_parent: Receiver<CSSMessage>) {
-    let mut result_vec = ~[];
+    let mut result_vec = vec!();
 
     loop {
         match from_parent.recv_opt() {
@@ -128,7 +128,7 @@ fn css_link_listener(to_parent: Sender<HtmlDiscoveryMessage>,
 fn js_script_listener(to_parent: Sender<HtmlDiscoveryMessage>,
                       from_parent: Receiver<JSMessage>,
                       resource_task: ResourceTask) {
-    let mut result_vec = ~[];
+    let mut result_vec = vec!();
 
     loop {
         match from_parent.recv_opt() {
@@ -465,7 +465,7 @@ pub fn parse_html(page: &Page,
                         js_chan2.send(JSTaskNewFile(new_url));
                     }
                     None => {
-                        let mut data = ~[];
+                        let mut data = vec!();
                         let scriptnode: JS<Node> = NodeCast::from(&script);
                         debug!("iterating over children {:?}", scriptnode.first_child());
                         for child in scriptnode.children() {

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -493,7 +493,7 @@ pub fn parse_html(page: &Page,
         match load_response.progress_port.recv() {
             Payload(data) => {
                 debug!("received data");
-                parser.parse_chunk(data);
+                parser.parse_chunk(data.as_slice());
             }
             Done(Err(..)) => {
                 fail!("Failed to load page URL {:s}", url.to_str());

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -83,7 +83,7 @@ impl<S: Encoder<E>, E> Encodable<S, E> for TrustedNodeAddress {
 pub type UntrustedNodeAddress = *c_void;
 
 pub struct ContentBoxResponse(pub Rect<Au>);
-pub struct ContentBoxesResponse(pub ~[Rect<Au>]);
+pub struct ContentBoxesResponse(pub Vec<Rect<Au>>);
 pub struct HitTestResponse(pub UntrustedNodeAddress);
 pub struct MouseOverResponse(pub Vec<UntrustedNodeAddress>);
 

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -85,7 +85,7 @@ pub type UntrustedNodeAddress = *c_void;
 pub struct ContentBoxResponse(pub Rect<Au>);
 pub struct ContentBoxesResponse(pub ~[Rect<Au>]);
 pub struct HitTestResponse(pub UntrustedNodeAddress);
-pub struct MouseOverResponse(pub ~[UntrustedNodeAddress]);
+pub struct MouseOverResponse(pub Vec<UntrustedNodeAddress>);
 
 /// Determines which part of the
 #[deriving(Eq, Ord, TotalEq, TotalOrd, Encodable)]

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -459,7 +459,7 @@ impl Page {
         address
     }
 
-    pub fn get_nodes_under_mouse(&self, point: &Point2D<f32>) -> Option<~[UntrustedNodeAddress]> {
+    pub fn get_nodes_under_mouse(&self, point: &Point2D<f32>) -> Option<Vec<UntrustedNodeAddress>> {
         let frame = self.frame();
         let document = frame.get_ref().document.clone();
         let root = document.get().GetDocumentElement();

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -647,7 +647,7 @@ impl ScriptTask {
     fn handle_msgs(&self) -> bool {
         // Handle pending resize events.
         // Gather them first to avoid a double mut borrow on self.
-        let mut resizes = ~[];
+        let mut resizes = vec!();
 
         {
             let mut page_tree = self.page_tree.borrow_mut();
@@ -669,7 +669,7 @@ impl ScriptTask {
         }
 
         // Store new resizes, and gather all other events.
-        let mut sequential = ~[];
+        let mut sequential = vec!();
 
         // Receive at least one message so we don't spinloop.
         let mut event = self.port.recv();

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -524,7 +524,7 @@ pub struct ScriptTask {
     /// The JavaScript runtime.
     pub js_runtime: js::rust::rt,
 
-    pub mouse_over_targets: RefCell<Option<~[JS<Node>]>>
+    pub mouse_over_targets: RefCell<Option<Vec<JS<Node>>>>
 }
 
 /// In the event of task failure, all data on the stack runs its destructor. However, there
@@ -1101,7 +1101,7 @@ impl ScriptTask {
                 match page.get_nodes_under_mouse(&point) {
                     Some(node_address) => {
 
-                        let mut target_list: ~[JS<Node>] = ~[];
+                        let mut target_list = vec!();
                         let mut target_compare = false;
 
                         let mouse_over_targets = &mut *self.mouse_over_targets.borrow_mut();

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -751,11 +751,7 @@ impl ScriptTask {
             window.get_mut().active_timers.remove(&timer_data.handle);
         }
 
-        let this_value = if timer_data.args.len() > 0 {
-            fail!("NYI")
-        } else {
-            window.reflector().get_jsobject()
-        };
+        let this_value = window.reflector().get_jsobject();
 
         // TODO: Support extra arguments. This requires passing a `*JSVal` array as `argv`.
         let rval = NullValue();

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -151,11 +151,11 @@ pub struct Page {
 
 pub struct PageTree {
     pub page: Rc<Page>,
-    pub inner: ~[PageTree],
+    pub inner: Vec<PageTree>,
 }
 
 pub struct PageTreeIterator<'a> {
-    stack: ~[&'a mut PageTree],
+    stack: Vec<&'a mut PageTree>,
 }
 
 impl PageTree {
@@ -175,7 +175,7 @@ impl PageTree {
                 fragment_node: Traceable::new(RefCell::new(None)),
                 last_reflow_id: Traceable::new(RefCell::new(0)),
             }),
-            inner: ~[],
+            inner: vec!(),
         }
     }
 
@@ -198,7 +198,7 @@ impl PageTree {
 
     pub fn iter<'a>(&'a mut self) -> PageTreeIterator<'a> {
         PageTreeIterator {
-            stack: ~[self],
+            stack: vec!(self),
         }
     }
 

--- a/src/components/style/stylesheets.rs
+++ b/src/components/style/stylesheets.rs
@@ -41,13 +41,13 @@ pub struct StyleRule {
 
 
 impl Stylesheet {
-    pub fn from_bytes_iter<I: Iterator<~[u8]>>(
+    pub fn from_bytes_iter<I: Iterator<Vec<u8>>>(
             mut input: I, base_url: Url, protocol_encoding_label: Option<&str>,
             environment_encoding: Option<EncodingRef>) -> Stylesheet {
         let mut bytes = ~[];
         // TODO: incremental decoding and tokinization/parsing
         for chunk in input {
-            bytes.push_all(chunk)
+            bytes.push_all(chunk.as_slice())
         }
         Stylesheet::from_bytes(bytes, base_url, protocol_encoding_label, environment_encoding)
     }


### PR DESCRIPTION
I'd rather do this before it turns out that a rust upgrade removed `~[T]` behind our back.
