### PR TITLE
Rewrite the handling of optional arguments in getJSToNativeConversionTemplate.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -628,14 +628,14 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
                     "(${val}).to_object()"))
 
         declType = CGGeneric(descriptor.nativeType)
-        if type.nullable() or isOptional:
+        if type.nullable():
             templateBody = "Some(%s)" % templateBody
             declType = CGWrapper(declType, pre="Option<", post=">")
 
         templateBody = wrapObjectTemplate(templateBody, isDefinitelyObject,
                                           type, failureCode)
 
-        return (templateBody, declType, isOptional, "None" if isOptional else None)
+        return handleOptional(templateBody, declType, isOptional)
 
     if type.isSpiderMonkeyInterface():
         raise TypeError("Can't handle SpiderMonkey interface arguments yet")

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -757,13 +757,8 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
         assert not isEnforceRange and not isClamp
 
         declType = CGGeneric("JSVal")
-        value = CGGeneric("${val}")
-        if isOptional:
-            declType = CGWrapper(declType, pre="Option<", post=">")
-            value = CGWrapper(value, pre="Some(", post=")")
-
-        templateBody = handleDefaultNull(value.define(), "NullValue()")
-        return (templateBody, declType, isOptional, "None" if isOptional else None)
+        templateBody = handleDefaultNull("${val}", "NullValue()")
+        return handleOptional(templateBody, declType, isOptional)
 
     if type.isObject():
         raise TypeError("Can't handle object arguments yet")

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -722,7 +722,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
                                       (enum,
                                        getEnumValueName(defaultValue.value))))
 
-        return (template, CGGeneric(enum), isOptional, None)
+        return handleOptional(template, CGGeneric(enum), isOptional)
 
     if type.isCallback():
         assert not isEnforceRange and not isClamp

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -776,7 +776,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
                     "  Err(_) => return 0,\n"
                     "}" % (typeName, val))
 
-        return (template, declType, False, None)
+        return handleOptional(template, declType, isOptional)
 
     if type.isVoid():
         assert not isOptional

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -610,7 +610,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
 
             template = wrapObjectTemplate(conversion, isDefinitelyObject, type,
                                           failureCode)
-            return (template, declType, isOptional, None)
+            return handleOptional(template, declType, isOptional)
 
         templateBody = ""
         if descriptor.interface.isConsequential():

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -658,16 +658,12 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
         else:
             nullBehavior = treatAs[treatNullAs]
 
-        def getConversionCode(isOptional=False):
-            strval = "strval"
-            if isOptional:
-                strval = "Some(%s)" % strval
-
+        def getConversionCode():
             conversionCode = (
                 "match FromJSValConvertible::from_jsval(cx, ${val}, %s) {\n"
-                "  Ok(strval) => %s,\n"
+                "  Ok(strval) => strval,\n"
                 "  Err(_) => { %s },\n"
-                "}" % (nullBehavior, strval, exceptionCode))
+                "}" % (nullBehavior, exceptionCode))
 
             if defaultValue is None:
                 return conversionCode
@@ -690,15 +686,10 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
             return handleDefault(conversionCode, default)
 
         declType = "DOMString"
-        initialValue = None
         if type.nullable():
             declType = "Option<%s>" % declType
 
-        if isOptional:
-            declType = "Option<%s>" % declType
-            initialValue = "None"
-
-        return (getConversionCode(isOptional), CGGeneric(declType), False, initialValue)
+        return handleOptional(getConversionCode(), CGGeneric(declType), isOptional)
 
     if type.isEnum():
         assert not isEnforceRange and not isClamp

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -597,7 +597,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
         templateBody = handleDefaultNull(templateBody.define(),
                                          "None")
 
-        return (templateBody, declType, isOptional, "None" if isOptional else None)
+        return handleOptional(templateBody, declType, isOptional)
 
     if type.isGeckoInterface():
         assert not isEnforceRange and not isClamp

--- a/src/components/script/dom/testbinding.rs
+++ b/src/components/script/dom/testbinding.rs
@@ -127,7 +127,7 @@ impl TestBinding {
     pub fn PassOptionalFloat(&self, _: Option<f32>) {}
     pub fn PassOptionalDouble(&self, _: Option<f64>) {}
     pub fn PassOptionalString(&self, _: Option<DOMString>) {}
-    // pub fn PassOptionalEnum(&self, _: Option<TestEnum>) {}
+    pub fn PassOptionalEnum(&self, _: Option<TestEnum>) {}
     pub fn PassOptionalInterface(&self, _: Option<JS<Blob>>) {}
     pub fn PassOptionalUnion(&self, _: Option<HTMLElementOrLong>) {}
     pub fn PassOptionalAny(&self, _: *JSContext, _: Option<JSVal>) {}

--- a/src/components/script/dom/testbinding.rs
+++ b/src/components/script/dom/testbinding.rs
@@ -145,7 +145,7 @@ impl TestBinding {
     pub fn PassOptionalNullableDouble(&self, _: Option<Option<f64>>) {}
     pub fn PassOptionalNullableString(&self, _: Option<Option<DOMString>>) {}
     // pub fn PassOptionalNullableEnum(&self, _: Option<Option<TestEnum>>) {}
-    // pub fn PassOptionalNullableInterface(&self, _: Option<Option<JS<Blob>>>) {}
+    pub fn PassOptionalNullableInterface(&self, _: Option<Option<JS<Blob>>>) {}
     pub fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
 
     pub fn PassOptionalBooleanWithDefault(&self, _: bool) {}

--- a/src/components/script/dom/testbinding.rs
+++ b/src/components/script/dom/testbinding.rs
@@ -129,7 +129,7 @@ impl TestBinding {
     pub fn PassOptionalString(&self, _: Option<DOMString>) {}
     // pub fn PassOptionalEnum(&self, _: Option<TestEnum>) {}
     pub fn PassOptionalInterface(&self, _: Option<JS<Blob>>) {}
-    // pub fn PassOptionalUnion(&self, _: Option<HTMLElementOrLong>) {}
+    pub fn PassOptionalUnion(&self, _: Option<HTMLElementOrLong>) {}
     pub fn PassOptionalAny(&self, _: *JSContext, _: Option<JSVal>) {}
 
     pub fn PassOptionalNullableBoolean(&self, _: Option<Option<bool>>) {}
@@ -146,7 +146,7 @@ impl TestBinding {
     pub fn PassOptionalNullableString(&self, _: Option<Option<DOMString>>) {}
     // pub fn PassOptionalNullableEnum(&self, _: Option<Option<TestEnum>>) {}
     // pub fn PassOptionalNullableInterface(&self, _: Option<Option<JS<Blob>>>) {}
-    // pub fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
+    pub fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
 
     pub fn PassOptionalBooleanWithDefault(&self, _: bool) {}
     pub fn PassOptionalByteWithDefault(&self, _: i8) {}

--- a/src/components/script/dom/webidls/TestBinding.webidl
+++ b/src/components/script/dom/webidls/TestBinding.webidl
@@ -150,7 +150,7 @@ interface TestBinding {
   void passOptionalNullableDouble(optional double? arg);
   void passOptionalNullableString(optional DOMString? arg);
   // void passOptionalNullableEnum(optional TestEnum? arg);
-  // void passOptionalNullableInterface(optional Blob? arg);
+  void passOptionalNullableInterface(optional Blob? arg);
   void passOptionalNullableUnion(optional (HTMLElement or long)? arg);
 
   void passOptionalBooleanWithDefault(optional boolean arg = false);

--- a/src/components/script/dom/webidls/TestBinding.webidl
+++ b/src/components/script/dom/webidls/TestBinding.webidl
@@ -134,7 +134,7 @@ interface TestBinding {
   void passOptionalString(optional DOMString arg);
   // void passOptionalEnum(optional TestEnum arg);
   void passOptionalInterface(optional Blob arg);
-  // void passOptionalUnion(optional (HTMLElement or long) arg);
+  void passOptionalUnion(optional (HTMLElement or long) arg);
   void passOptionalAny(optional any arg);
 
   void passOptionalNullableBoolean(optional boolean? arg);
@@ -151,7 +151,7 @@ interface TestBinding {
   void passOptionalNullableString(optional DOMString? arg);
   // void passOptionalNullableEnum(optional TestEnum? arg);
   // void passOptionalNullableInterface(optional Blob? arg);
-  // void passOptionalNullableUnion(optional (HTMLElement or long)? arg);
+  void passOptionalNullableUnion(optional (HTMLElement or long)? arg);
 
   void passOptionalBooleanWithDefault(optional boolean arg = false);
   void passOptionalByteWithDefault(optional byte arg = 0);

--- a/src/components/script/dom/webidls/TestBinding.webidl
+++ b/src/components/script/dom/webidls/TestBinding.webidl
@@ -132,7 +132,7 @@ interface TestBinding {
   void passOptionalFloat(optional float arg);
   void passOptionalDouble(optional double arg);
   void passOptionalString(optional DOMString arg);
-  // void passOptionalEnum(optional TestEnum arg);
+  void passOptionalEnum(optional TestEnum arg);
   void passOptionalInterface(optional Blob arg);
   void passOptionalUnion(optional (HTMLElement or long) arg);
   void passOptionalAny(optional any arg);


### PR DESCRIPTION
This moves all handling of `isOptional` (except `type.isCallback()`, which I believe @jdm is rewriting in #2204) into one place.
