### PR TITLE
Make ContainerLayer::first_child borrow temporary

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -379,8 +379,8 @@ impl IOCompositor {
             let first_child = self.root_layer.first_child.borrow().clone();
             match first_child {
                 None => {}
-                Some(ref old_layer) => {
-                    ContainerLayer::remove_child(self.root_layer.clone(), old_layer.clone())
+                Some(old_layer) => {
+                    ContainerLayer::remove_child(self.root_layer.clone(), old_layer)
                 }
             }
 

--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -376,7 +376,8 @@ impl IOCompositor {
                                                           self.opts.tile_size,
                                                           self.opts.cpu_painting);
 
-            match *self.root_layer.first_child.borrow() {
+            let first_child = self.root_layer.first_child.borrow().clone();
+            match first_child {
                 None => {}
                 Some(ref old_layer) => {
                     ContainerLayer::remove_child(self.root_layer.clone(), old_layer.clone())


### PR DESCRIPTION
Fixes a crash in ContainerLayer::remove_child (#1778). r? @larsbergstrom
