### PR TITLE
Make manifest updates/html5lib non mandatory

### DIFF
--- a/src/test/wpt/run.py
+++ b/src/test/wpt/run.py
@@ -16,13 +16,15 @@ sys.path.append(wptsubdir("web-platform-tests", "tools", "scripts"))
 from wptrunner import wptrunner, wptcommandline
 import manifest
 
-def ensure_manifest():
-    if not os.path.isfile(wptsubdir("metadata", "MANIFEST.json")):
-        opts = argparse.Namespace(rebuild=False, experimental_include_local_changes=True,
-                                  path=wptsubdir("metadata", "MANIFEST.json"))
-        manifest.update_manifest(wptsubdir("web-platform-tests"), opts)
+def update_manifest():
+    opts = argparse.Namespace(rebuild=False, experimental_include_local_changes=True,
+                              path=wptsubdir("metadata", "MANIFEST.json"))
+    manifest.update_manifest(wptsubdir("web-platform-tests"), opts)
+    return True
 
 def run_tests(**kwargs):
+    if not os.path.isfile(wptsubdir("metadata", "MANIFEST.json")):
+        raise Exception("Manifest not found. Please use --update-manifest in WPTARGS to create one")
     wptrunner.setup_logging(kwargs, {"raw": sys.stdout})
     return wptrunner.run_tests(**kwargs)
 
@@ -35,9 +37,12 @@ def set_defaults(args):
     return vars(args)
 
 def main():
-    ensure_manifest()
     parser = wptcommandline.create_parser(False)
+    parser.add_argument('--update-manifest', dest='update_manifest', action='store_true')
     args = parser.parse_args()
+    if args.update_manifest:
+        update_manifest()
+        return True
     kwargs = set_defaults(args)
     return run_tests(**kwargs)
 

--- a/src/test/wpt/run.sh
+++ b/src/test/wpt/run.sh
@@ -11,7 +11,9 @@ test -d _virtualenv || virtualenv _virtualenv
 test -d $servo_root/src/test/wpt/metadata || mkdir -p $servo_root/src/test/wpt/metadata
 test -d $servo_root/src/test/wpt/prefs || mkdir -p $servo_root/src/test/wpt/prefs
 source _virtualenv/bin/activate
-(python -c "import html5lib" &>/dev/null) || pip install html5lib
+if [[ $* == *--update-manifest* ]]; then
+    (python -c "import html5lib" &>/dev/null) || pip install html5lib
+fi
 (python -c "import wptrunner"  &>/dev/null) || pip install wptrunner
 
 python $servo_root/src/test/wpt/run.py --binary $objdir/../servo "$@"


### PR DESCRIPTION
Since the manifest is now checked in to the tree, we don't need html5lib unless we want to explicitly update the manifest.

I've added the `--update-manifest` argument to the make target (`export WPTARGS=--update-manifest;make check-wpt`) which triggers the update, installing dependencies if necessary.
