### PR TITLE
Make TimeStamp in event.rs return the actual timestamp

### DIFF
--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate time;
+
 use dom::bindings::codegen::EventBinding;
 use dom::bindings::codegen::EventBinding::EventConstants;
 use dom::bindings::js::JS;
@@ -54,6 +56,7 @@ pub struct Event {
     pub trusted: bool,
     pub dispatching: bool,
     pub initialized: bool,
+    pub timestamp: u64,
 }
 
 impl Event {
@@ -73,6 +76,7 @@ impl Event {
             stop_propagation: false,
             stop_immediate: false,
             initialized: false,
+            timestamp: time::get_time().sec as u64,
         }
     }
 
@@ -126,7 +130,7 @@ impl Event {
     }
 
     pub fn TimeStamp(&self) -> u64 {
-        0
+        return self.timestamp;
     }
 
     pub fn InitEvent(&mut self,

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate time;
-
 use dom::bindings::codegen::EventBinding;
 use dom::bindings::codegen::EventBinding::EventConstants;
 use dom::bindings::js::JS;
@@ -14,6 +12,8 @@ use dom::window::Window;
 use servo_util::str::DOMString;
 
 use geom::point::Point2D;
+
+use time;
 
 pub enum Event_ {
     ResizeEvent(uint, uint),
@@ -130,7 +130,7 @@ impl Event {
     }
 
     pub fn TimeStamp(&self) -> u64 {
-        return self.timestamp;
+        self.timestamp
     }
 
     pub fn InitEvent(&mut self,

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -24,6 +24,7 @@ extern crate js;
 extern crate libc;
 extern crate native;
 extern crate serialize;
+extern crate time;
 #[phase(syntax)]
 extern crate servo_macros = "macros";
 extern crate servo_net = "net";


### PR DESCRIPTION
Timestamp should return the time the event was created, not 0. This fixes three test cases in dom/events/Event-constructors.html. This is my first pull request, let me know if there are any issues.
