### PR TITLE
Remove pub use globs in script.rs

### DIFF
--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::AttrBinding;
+use dom::bindings::codegen::BindingDeclarations::AttrBinding;
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};

--- a/src/components/script/dom/attrlist.rs
+++ b/src/components/script/dom/attrlist.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::attr::Attr;
-use dom::bindings::codegen::AttrListBinding;
+use dom::bindings::codegen::BindingDeclarations::AttrListBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::element::Element;

--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4155,7 +4155,7 @@ class CGRegisterProtos(CGAbstractMethod):
         self.config = config
 
     def _registerProtos(self):
-        lines = ["  codegen::%sBinding::DefineDOMInterface(window, js_info);" % desc.name
+        lines = ["  codegen::BindingDeclarations::%sBinding::DefineDOMInterface(window, js_info);" % desc.name
                  for desc in self.config.getDescriptors(hasInterfaceObject=True,
                                                         register=True)]
         return '\n'.join(lines) + '\n'
@@ -4279,6 +4279,7 @@ class CGBindingRoot(CGThing):
             'dom::bindings::conversions::IDLInterface',
             'dom::bindings::conversions::{Default, Empty}',
             'dom::bindings::codegen::*',
+            'dom::bindings::codegen::BindingDeclarations::*',
             'dom::bindings::codegen::UnionTypes::*',
             'dom::bindings::error::{FailureUnknown, Fallible, Error, ErrorResult}',
             'dom::bindings::error::{throw_method_failed_with_details}',
@@ -5206,7 +5207,7 @@ class GlobalGenRoots():
 
         def pathToType(descriptor):
             if descriptor.interface.isCallback():
-                return "dom::bindings::codegen::%sBinding" % descriptor.name
+                return "dom::bindings::codegen::BindingDeclarations::%sBinding" % descriptor.name
             return "dom::%s" % descriptor.name.lower()
 
         descriptors = [d.name for d in config.getDescriptors(register=True, hasInterfaceObject=True)]

--- a/src/components/script/dom/blob.rs
+++ b/src/components/script/dom/blob.rs
@@ -5,7 +5,7 @@
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::error::Fallible;
-use dom::bindings::codegen::BlobBinding;
+use dom::bindings::codegen::BindingDeclarations::BlobBinding;
 use dom::window::Window;
 use servo_util::str::DOMString;
 

--- a/src/components/script/dom/clientrect.rs
+++ b/src/components/script/dom/clientrect.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::ClientRectBinding;
+use dom::bindings::codegen::BindingDeclarations::ClientRectBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;

--- a/src/components/script/dom/clientrectlist.rs
+++ b/src/components/script/dom/clientrectlist.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::ClientRectListBinding;
+use dom::bindings::codegen::BindingDeclarations::ClientRectListBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::clientrect::ClientRect;

--- a/src/components/script/dom/comment.rs
+++ b/src/components/script/dom/comment.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::InheritTypes::CommentDerived;
-use dom::bindings::codegen::CommentBinding;
+use dom::bindings::codegen::BindingDeclarations::CommentBinding;
 use dom::bindings::js::JS;
 use dom::bindings::error::Fallible;
 use dom::characterdata::CharacterData;

--- a/src/components/script/dom/console.rs
+++ b/src/components/script/dom/console.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::ConsoleBinding;
+use dom::bindings::codegen::BindingDeclarations::ConsoleBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::InheritTypes::{DocumentDerived, EventCast, HTMLEleme
 use dom::bindings::codegen::InheritTypes::{DocumentBase, NodeCast, DocumentCast};
 use dom::bindings::codegen::InheritTypes::{HTMLHeadElementCast, TextCast, ElementCast};
 use dom::bindings::codegen::InheritTypes::{DocumentTypeCast, HTMLHtmlElementCast};
-use dom::bindings::codegen::DocumentBinding;
+use dom::bindings::codegen::BindingDeclarations::DocumentBinding;
 use dom::bindings::js::JS;
 use dom::bindings::trace::Untraceable;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};

--- a/src/components/script/dom/documentfragment.rs
+++ b/src/components/script/dom/documentfragment.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::InheritTypes::{DocumentFragmentDerived, NodeCast};
-use dom::bindings::codegen::DocumentFragmentBinding;
+use dom::bindings::codegen::BindingDeclarations::DocumentFragmentBinding;
 use dom::bindings::js::JS;
 use dom::bindings::error::Fallible;
 use dom::document::Document;

--- a/src/components/script/dom/documenttype.rs
+++ b/src/components/script/dom/documenttype.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::InheritTypes::DocumentTypeDerived;
-use dom::bindings::codegen::DocumentTypeBinding;
+use dom::bindings::codegen::BindingDeclarations::DocumentTypeBinding;
 use dom::bindings::js::JS;
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};

--- a/src/components/script/dom/domexception.rs
+++ b/src/components/script/dom/domexception.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::DOMExceptionBinding;
-use dom::bindings::codegen::DOMExceptionBinding::DOMExceptionConstants;
+use dom::bindings::codegen::BindingDeclarations::DOMExceptionBinding;
+use dom::bindings::codegen::BindingDeclarations::DOMExceptionBinding::DOMExceptionConstants;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;

--- a/src/components/script/dom/domimplementation.rs
+++ b/src/components/script/dom/domimplementation.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::DOMImplementationBinding;
+use dom::bindings::codegen::BindingDeclarations::DOMImplementationBinding;
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};

--- a/src/components/script/dom/domparser.rs
+++ b/src/components/script/dom/domparser.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::DOMParserBinding;
-use dom::bindings::codegen::DOMParserBinding::SupportedTypeValues::{Text_html, Text_xml};
+use dom::bindings::codegen::BindingDeclarations::DOMParserBinding;
+use dom::bindings::codegen::BindingDeclarations::DOMParserBinding::SupportedTypeValues::{Text_html, Text_xml};
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};
 use dom::bindings::error::{Fallible, FailureUnknown};

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -6,7 +6,7 @@
 
 use dom::attr::{Attr, AttrSettingType, ReplacedAttr, FirstSetAttr};
 use dom::attrlist::AttrList;
-use dom::bindings::codegen::ElementBinding;
+use dom::bindings::codegen::BindingDeclarations::ElementBinding;
 use dom::bindings::codegen::InheritTypes::{ElementDerived, NodeCast};
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector};

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::EventBinding;
-use dom::bindings::codegen::EventBinding::EventConstants;
+use dom::bindings::codegen::BindingDeclarations::EventBinding;
+use dom::bindings::codegen::BindingDeclarations::EventBinding::EventConstants;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::error::Fallible;

--- a/src/components/script/dom/eventtarget.rs
+++ b/src/components/script/dom/eventtarget.rs
@@ -5,7 +5,7 @@
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::bindings::error::{Fallible, InvalidState};
-use dom::bindings::codegen::EventListenerBinding;
+use dom::bindings::codegen::BindingDeclarations::EventListenerBinding;
 use self::EventListenerBinding::EventListener;
 use dom::event::Event;
 use dom::eventdispatcher::dispatch_event;

--- a/src/components/script/dom/formdata.rs
+++ b/src/components/script/dom/formdata.rs
@@ -4,7 +4,7 @@
 
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::error::{Fallible};
-use dom::bindings::codegen::FormDataBinding;
+use dom::bindings::codegen::BindingDeclarations::FormDataBinding;
 use dom::bindings::js::JS;
 use dom::blob::Blob;
 use dom::htmlformelement::HTMLFormElement;

--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLAnchorElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLAnchorElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlappletelement.rs
+++ b/src/components/script/dom/htmlappletelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLAppletElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLAppletElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAppletElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLAreaElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLAreaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlaudioelement.rs
+++ b/src/components/script/dom/htmlaudioelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLAudioElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLAudioElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAudioElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmlbaseelement.rs
+++ b/src/components/script/dom/htmlbaseelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLBaseElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLBaseElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLBaseElementDerived;
 use dom::bindings::error::ErrorResult;
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlbodyelement.rs
+++ b/src/components/script/dom/htmlbodyelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLBodyElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLBodyElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementDerived;
 use dom::bindings::error::ErrorResult;
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlbrelement.rs
+++ b/src/components/script/dom/htmlbrelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLBRElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLBRElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLBRElementDerived;
 use dom::bindings::error::ErrorResult;
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLButtonElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLButtonElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlcanvaselement.rs
+++ b/src/components/script/dom/htmlcanvaselement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLCanvasElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLCanvasElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::{ErrorResult};

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::InheritTypes::{ElementCast, NodeCast};
-use dom::bindings::codegen::HTMLCollectionBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLCollectionBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::element::{Element, AttributeHandlers};

--- a/src/components/script/dom/htmldataelement.rs
+++ b/src/components/script/dom/htmldataelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLDataElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLDataElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDataElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmldatalistelement.rs
+++ b/src/components/script/dom/htmldatalistelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLDataListElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLDataListElementBinding;
 use dom::bindings::codegen::InheritTypes::{HTMLDataListElementDerived, NodeCast};
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmldirectoryelement.rs
+++ b/src/components/script/dom/htmldirectoryelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLDirectoryElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLDirectoryElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDirectoryElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmldivelement.rs
+++ b/src/components/script/dom/htmldivelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLDivElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLDivElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDivElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmldlistelement.rs
+++ b/src/components/script/dom/htmldlistelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLDListElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLDListElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDListElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlelement.rs
+++ b/src/components/script/dom/htmlelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLElementBinding;
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementDerived;
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlembedelement.rs
+++ b/src/components/script/dom/htmlembedelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLEmbedElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLEmbedElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLEmbedElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlfieldsetelement.rs
+++ b/src/components/script/dom/htmlfieldsetelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLFieldSetElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLFieldSetElementBinding;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLFieldSetElementDerived, NodeCast};
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlfontelement.rs
+++ b/src/components/script/dom/htmlfontelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLFontElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLFontElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFontElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlformelement.rs
+++ b/src/components/script/dom/htmlformelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLFormElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLFormElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFormElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlframeelement.rs
+++ b/src/components/script/dom/htmlframeelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLFrameElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLFrameElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFrameElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlframesetelement.rs
+++ b/src/components/script/dom/htmlframesetelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLFrameSetElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLFrameSetElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFrameSetElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlheadelement.rs
+++ b/src/components/script/dom/htmlheadelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLHeadElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLHeadElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHeadElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmlheadingelement.rs
+++ b/src/components/script/dom/htmlheadingelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLHeadingElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLHeadingElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHeadingElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmlhrelement.rs
+++ b/src/components/script/dom/htmlhrelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLHRElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLHRElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHRElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlhtmlelement.rs
+++ b/src/components/script/dom/htmlhtmlelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLHtmlElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLHtmlElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHtmlElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLIFrameElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLIFrameElementBinding;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLIFrameElementDerived, HTMLElementCast};
 use dom::bindings::error::ErrorResult;
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLImageElementBinding;
-use dom::bindings::codegen::InheritTypes::{NodeCast, HTMLImageElementDerived};
-use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
+use dom::bindings::codegen::BindingDeclarations::HTMLImageElementBinding;
+use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLElementCast, HTMLImageElementDerived};
 use dom::bindings::error::ErrorResult;
 use dom::bindings::js::JS;
 use dom::bindings::trace::Untraceable;

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLInputElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLInputElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::{ErrorResult, Fallible};

--- a/src/components/script/dom/htmllabelelement.rs
+++ b/src/components/script/dom/htmllabelelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLLabelElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLLabelElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLabelElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmllegendelement.rs
+++ b/src/components/script/dom/htmllegendelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLLegendElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLLegendElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLegendElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmllielement.rs
+++ b/src/components/script/dom/htmllielement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLLIElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLLIElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLIElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLLinkElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLLinkElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlmainelement.rs
+++ b/src/components/script/dom/htmlmainelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLMainElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLMainElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMainElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmlmapelement.rs
+++ b/src/components/script/dom/htmlmapelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLMapElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLMapElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMapElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlmetaelement.rs
+++ b/src/components/script/dom/htmlmetaelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLMetaElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLMetaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMetaElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlmeterelement.rs
+++ b/src/components/script/dom/htmlmeterelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLMeterElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLMeterElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMeterElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlmodelement.rs
+++ b/src/components/script/dom/htmlmodelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLModElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLModElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLModElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLObjectElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLObjectElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlolistelement.rs
+++ b/src/components/script/dom/htmlolistelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLOListElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLOListElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLOListElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmloptgroupelement.rs
+++ b/src/components/script/dom/htmloptgroupelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLOptGroupElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLOptGroupElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLOptionElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLOptionElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmloutputelement.rs
+++ b/src/components/script/dom/htmloutputelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLOutputElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLOutputElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLOutputElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlparagraphelement.rs
+++ b/src/components/script/dom/htmlparagraphelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLParagraphElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLParagraphElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLParagraphElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlparamelement.rs
+++ b/src/components/script/dom/htmlparamelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLParamElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLParamElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLParamElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlpreelement.rs
+++ b/src/components/script/dom/htmlpreelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLPreElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLPreElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLPreElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlprogresselement.rs
+++ b/src/components/script/dom/htmlprogresselement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLProgressElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLProgressElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLProgressElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::{ErrorResult, Fallible};

--- a/src/components/script/dom/htmlquoteelement.rs
+++ b/src/components/script/dom/htmlquoteelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLQuoteElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLQuoteElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLQuoteElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlscriptelement.rs
+++ b/src/components/script/dom/htmlscriptelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLScriptElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLScriptElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLScriptElementDerived;
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLSelectElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLSelectElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLSelectElementDerived;
 use dom::bindings::codegen::UnionTypes::{HTMLElementOrLong, HTMLOptionElementOrHTMLOptGroupElement};
 use dom::bindings::js::JS;

--- a/src/components/script/dom/htmlsourceelement.rs
+++ b/src/components/script/dom/htmlsourceelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLSourceElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLSourceElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLSourceElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlspanelement.rs
+++ b/src/components/script/dom/htmlspanelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLSpanElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLSpanElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLSpanElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLStyleElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLStyleElementBinding;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLStyleElementDerived, NodeCast};
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltablecaptionelement.rs
+++ b/src/components/script/dom/htmltablecaptionelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableCaptionElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableCaptionElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableCaptionElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltablecolelement.rs
+++ b/src/components/script/dom/htmltablecolelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableColElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableColElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableColElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltabledatacellelement.rs
+++ b/src/components/script/dom/htmltabledatacellelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableDataCellElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableDataCellElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableDataCellElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmltableelement.rs
+++ b/src/components/script/dom/htmltableelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltableheadercellelement.rs
+++ b/src/components/script/dom/htmltableheadercellelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableHeaderCellElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableHeaderCellElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableHeaderCellElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmltablerowelement.rs
+++ b/src/components/script/dom/htmltablerowelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableRowElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableRowElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableRowElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltablesectionelement.rs
+++ b/src/components/script/dom/htmltablesectionelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTableSectionElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTableSectionElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableSectionElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltemplateelement.rs
+++ b/src/components/script/dom/htmltemplateelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTemplateElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTemplateElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTemplateElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTextAreaElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTextAreaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTextAreaElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::{ErrorResult, Fallible};

--- a/src/components/script/dom/htmltimeelement.rs
+++ b/src/components/script/dom/htmltimeelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTimeElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTimeElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTimeElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltitleelement.rs
+++ b/src/components/script/dom/htmltitleelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTitleElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTitleElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTitleElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmltrackelement.rs
+++ b/src/components/script/dom/htmltrackelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLTrackElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLTrackElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTrackElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlulistelement.rs
+++ b/src/components/script/dom/htmlulistelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLUListElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLUListElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLUListElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/htmlunknownelement.rs
+++ b/src/components/script/dom/htmlunknownelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLUnknownElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLUnknownElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLUnknownElementDerived;
 use dom::bindings::js::JS;
 use dom::document::Document;

--- a/src/components/script/dom/htmlvideoelement.rs
+++ b/src/components/script/dom/htmlvideoelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::HTMLVideoElementBinding;
+use dom::bindings::codegen::BindingDeclarations::HTMLVideoElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLVideoElementDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::ErrorResult;

--- a/src/components/script/dom/location.rs
+++ b/src/components/script/dom/location.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::LocationBinding;
+use dom::bindings::codegen::BindingDeclarations::LocationBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::error::Fallible;

--- a/src/components/script/dom/mouseevent.rs
+++ b/src/components/script/dom/mouseevent.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::MouseEventBinding;
+use dom::bindings::codegen::BindingDeclarations::MouseEventBinding;
 use dom::bindings::codegen::InheritTypes::MouseEventDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::Fallible;

--- a/src/components/script/dom/navigator.rs
+++ b/src/components/script/dom/navigator.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::NavigatorBinding;
+use dom::bindings::codegen::BindingDeclarations::NavigatorBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::error::Fallible;

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::InheritTypes::{CommentCast, DocumentCast, DocumentTy
 use dom::bindings::codegen::InheritTypes::{ElementCast, TextCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{CharacterDataCast, NodeBase, NodeDerived};
 use dom::bindings::codegen::InheritTypes::{ProcessingInstructionCast, EventTargetCast};
-use dom::bindings::codegen::NodeBinding::NodeConstants;
+use dom::bindings::codegen::BindingDeclarations::NodeBinding::NodeConstants;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::error::{ErrorResult, Fallible, NotFound, HierarchyRequest};

--- a/src/components/script/dom/nodelist.rs
+++ b/src/components/script/dom/nodelist.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::NodeListBinding;
+use dom::bindings::codegen::BindingDeclarations::NodeListBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::node::{Node, NodeHelpers};

--- a/src/components/script/dom/processinginstruction.rs
+++ b/src/components/script/dom/processinginstruction.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::ProcessingInstructionBinding;
+use dom::bindings::codegen::BindingDeclarations::ProcessingInstructionBinding;
 use dom::bindings::codegen::InheritTypes::ProcessingInstructionDerived;
 use dom::bindings::js::JS;
 use dom::characterdata::CharacterData;

--- a/src/components/script/dom/testbinding.rs
+++ b/src/components/script/dom/testbinding.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::js::JS;
-use dom::bindings::codegen::TestBindingBinding;
+use dom::bindings::codegen::BindingDeclarations::TestBindingBinding;
 use dom::bindings::codegen::UnionTypes::HTMLElementOrLong;
 use self::TestBindingBinding::TestEnum;
 use self::TestBindingBinding::TestEnumValues::_empty;

--- a/src/components/script/dom/text.rs
+++ b/src/components/script/dom/text.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::TextBinding;
+use dom::bindings::codegen::BindingDeclarations::TextBinding;
 use dom::bindings::codegen::InheritTypes::TextDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::Fallible;

--- a/src/components/script/dom/uievent.rs
+++ b/src/components/script/dom/uievent.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::UIEventBinding;
+use dom::bindings::codegen::BindingDeclarations::UIEventBinding;
 use dom::bindings::codegen::InheritTypes::UIEventDerived;
 use dom::bindings::js::JS;
 use dom::bindings::error::Fallible;

--- a/src/components/script/dom/validitystate.rs
+++ b/src/components/script/dom/validitystate.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::ValidityStateBinding;
+use dom::bindings::codegen::BindingDeclarations::ValidityStateBinding;
 use dom::bindings::js::JS;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::WindowBinding;
+use dom::bindings::codegen::BindingDeclarations::WindowBinding;
 use dom::bindings::js::JS;
 use dom::bindings::trace::Untraceable;
 use dom::bindings::utils::{Reflectable, Reflector};

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -53,9 +53,8 @@ pub mod dom {
         }
     }
 
-    pub mod types {
-        pub use super::bindings::codegen::InterfaceTypes::*;
-    }
+    #[path="bindings/codegen/InterfaceTypes.rs"]
+    pub mod types;
 
     pub mod attr;
     pub mod attrlist;

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -44,7 +44,6 @@ pub mod dom {
         pub mod proxyhandler;
         pub mod trace;
         pub mod codegen {
-            pub use self::BindingDeclarations::*;
             pub mod InterfaceTypes;
             pub mod InheritTypes;
             pub mod PrototypeList;


### PR DESCRIPTION
- Fix #2128
- Take over from #2220

I didn't change `InterfaceTypes.rs` to `type.rs` because `type` is very common name which might be troublesome.
