### PR TITLE
Update web-platform-tests expectations.

### DIFF
--- a/src/test/wpt/metadata/dom/events/Event-constructors.html.ini
+++ b/src/test/wpt/metadata/dom/events/Event-constructors.html.ini
@@ -1,5 +1,5 @@
 [Event-constructors.html]
   type: testharness
-  [Event constructors]
-    expected: TIMEOUT
+  [Event constructors 12]
+    expected: FAIL
 

--- a/src/test/wpt/metadata/dom/nodes/Node-normalize.html.ini
+++ b/src/test/wpt/metadata/dom/nodes/Node-normalize.html.ini
@@ -1,5 +1,0 @@
-[Node-normalize.html]
-  type: testharness
-  [Node.normalize()]
-    expected: FAIL
-


### PR DESCRIPTION
The first 11 tests in Event-constructors.html were fixed in #2194; the
remaining failure is #2173. Node-normalize.html was fixed in #2221.
