### PR TITLE
Stop passing owned strings to fail!().

### DIFF
--- a/src/components/gfx/platform/android/font.rs
+++ b/src/components/gfx/platform/android/font.rs
@@ -65,7 +65,7 @@ impl Drop for FontHandle {
         assert!(self.face.is_not_null());
         unsafe {
             if !FT_Done_Face(self.face).succeeded() {
-                fail!(~"FT_Done_Face failed");
+                fail!("FT_Done_Face failed");
             }
         }
     }

--- a/src/components/gfx/platform/linux/font.rs
+++ b/src/components/gfx/platform/linux/font.rs
@@ -65,7 +65,7 @@ impl Drop for FontHandle {
         assert!(self.face.is_not_null());
         unsafe {
             if !FT_Done_Face(self.face).succeeded() {
-                fail!(~"FT_Done_Face failed");
+                fail!("FT_Done_Face failed");
             }
         }
     }

--- a/src/components/gfx/render_context.rs
+++ b/src/components/gfx/render_context.rs
@@ -99,7 +99,7 @@ impl<'a> RenderContext<'a>  {
             RGBA8 => 4,
             K8    => 1,
             KA8   => 2,
-            _     => fail!(~"color type not supported"),
+            _     => fail!("color type not supported"),
         };
         let stride = image.width * pixel_width;
 

--- a/src/components/gfx/text/glyph.rs
+++ b/src/components/gfx/text/glyph.rs
@@ -361,7 +361,7 @@ impl<'a> DetailedGlyphStore {
         // FIXME: This is a workaround for borrow of self.detail_lookup not getting inferred.
         let records : &[DetailedGlyphRecord] = self.detail_lookup;
         match records.binary_search_index(&key) {
-            None => fail!(~"Invalid index not found in detailed glyph lookup table!"),
+            None => fail!("Invalid index not found in detailed glyph lookup table!"),
             Some(i) => {
                 assert!(i + (count as uint) <= self.detail_buffer.len());
                 // return a slice into the buffer
@@ -385,7 +385,7 @@ impl<'a> DetailedGlyphStore {
         // FIXME: This is a workaround for borrow of self.detail_lookup not getting inferred.
         let records: &[DetailedGlyphRecord] = self.detail_lookup;
         match records.binary_search_index(&key) {
-            None => fail!(~"Invalid index not found in detailed glyph lookup table!"),
+            None => fail!("Invalid index not found in detailed glyph lookup table!"),
             Some(i) => {
                 assert!(i + (detail_offset as uint)  < self.detail_buffer.len());
                 &self.detail_buffer[i+(detail_offset as uint)]

--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -760,7 +760,7 @@ impl CompositorLayer {
                         common.next_sibling.clone()
                     })
                 }
-                Some(_) => fail!(~"found unexpected layer kind"),
+                Some(_) => fail!("found unexpected layer kind"),
             };
 
             // Set the layer's transform.

--- a/src/components/main/layout/text.rs
+++ b/src/components/main/layout/text.rs
@@ -114,7 +114,7 @@ impl TextRunScanner {
         let mut new_whitespace = last_whitespace;
         match (is_singleton, is_text_clump) {
             (false, false) => {
-                fail!(~"WAT: can't coalesce non-text nodes in flush_clump_to_list()!")
+                fail!("WAT: can't coalesce non-text nodes in flush_clump_to_list()!")
             }
             (true, false) => {
                 // FIXME(pcwalton): Stop cloning boxes, as above.

--- a/src/components/net/image/base.rs
+++ b/src/components/net/image/base.rs
@@ -60,7 +60,7 @@ pub fn load_from_memory(buffer: &[u8]) -> Option<Image> {
                 byte_swap(png::RGBA8, image.data);
                 Some(Image(image.width as u32, image.height as u32, png::RGBA8, image.data))
             }
-            stb_image::ImageF32(_image) => fail!(~"HDR images not implemented"),
+            stb_image::ImageF32(_image) => fail!("HDR images not implemented"),
             stb_image::Error(_) => None
         }
     }

--- a/src/components/net/image_cache_task.rs
+++ b/src/components/net/image_cache_task.rs
@@ -64,7 +64,7 @@ impl Eq for ImageResponseMsg {
     fn eq(&self, other: &ImageResponseMsg) -> bool {
         // FIXME: Bad copies
         match (self.clone(), other.clone()) {
-            (ImageReady(..), ImageReady(..)) => fail!(~"unimplemented comparison"),
+            (ImageReady(..), ImageReady(..)) => fail!("unimplemented comparison"),
             (ImageNotReady, ImageNotReady) => true,
             (ImageFailed, ImageFailed) => true,
 
@@ -304,14 +304,14 @@ impl ImageCache {
           | Decoding
           | Decoded(..)
           | Failed => {
-            fail!(~"wrong state for storing prefetched image")
+            fail!("wrong state for storing prefetched image")
           }
         }
     }
 
     fn decode(&mut self, url: Url) {
         match self.get_state(url.clone()) {
-            Init => fail!(~"decoding image before prefetch"),
+            Init => fail!("decoding image before prefetch"),
 
             Prefetching(DoNotDecode) => {
                 // We don't have the data yet, queue up the decode
@@ -369,7 +369,7 @@ impl ImageCache {
           | Prefetched(..)
           | Decoded(..)
           | Failed => {
-            fail!(~"incorrect state in store_image")
+            fail!("incorrect state in store_image")
           }
         }
 
@@ -396,9 +396,9 @@ impl ImageCache {
 
     fn get_image(&self, url: Url, response: Sender<ImageResponseMsg>) {
         match self.get_state(url.clone()) {
-            Init => fail!(~"request for image before prefetch"),
+            Init => fail!("request for image before prefetch"),
             Prefetching(DoDecode) => response.send(ImageNotReady),
-            Prefetching(DoNotDecode) | Prefetched(..) => fail!(~"request for image before decode"),
+            Prefetching(DoNotDecode) | Prefetched(..) => fail!("request for image before decode"),
             Decoding => response.send(ImageNotReady),
             Decoded(image) => response.send(ImageReady(image.clone())),
             Failed => response.send(ImageFailed),
@@ -407,9 +407,9 @@ impl ImageCache {
 
     fn wait_for_image(&mut self, url: Url, response: Sender<ImageResponseMsg>) {
         match self.get_state(url.clone()) {
-            Init => fail!(~"request for image before prefetch"),
+            Init => fail!("request for image before prefetch"),
 
-            Prefetching(DoNotDecode) | Prefetched(..) => fail!(~"request for image before decode"),
+            Prefetching(DoNotDecode) | Prefetched(..) => fail!("request for image before decode"),
 
             Prefetching(DoDecode) | Decoding => {
                 // We don't have this image yet

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -421,7 +421,7 @@ pub fn parse_html(page: &Page,
         clone_node: |_node, deep| {
             debug!("clone node");
             if deep { error!("-- deep clone unimplemented"); }
-            fail!(~"clone node unimplemented")
+            fail!("clone node unimplemented")
         },
         reparent_children: |_node, _new_parent| {
             debug!("reparent children");

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -324,7 +324,7 @@ impl Page {
 
                     debug!("script: layout joined")
                 }
-                None => fail!(~"reader forked but no join port?"),
+                None => fail!("reader forked but no join port?"),
             }
         }
     }

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -119,7 +119,7 @@ pub fn from_cmdline_args(args: &[~str]) -> Option<Opts> {
             } else if backend_str == ~"skia" {
                 SkiaBackend
             } else {
-                fail!(~"unknown backend type")
+                fail!("unknown backend type")
             }
         }
         None => SkiaBackend


### PR DESCRIPTION
The ~"string" expression is being removed in upstream rust.
