### PR TITLE
Prevent unused result warning in codegen. Always expect success for now.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5341,7 +5341,7 @@ class GlobalGenRoots():
             trace = [CGGeneric(string.Template('''impl JSTraceable for ${name} {
     fn trace(&self, tracer: *mut JSTracer) {
         unsafe {
-            self.encode(&mut *tracer);
+            self.encode(&mut *tracer).ok().expect("failed to encode");
         }
     }
 }


### PR DESCRIPTION
Is it reasonable to always expect success here for now?

Fixes #2246.
