### PR TITLE
Fix some unused_mut/unused_result warnings

### DIFF
--- a/src/components/script/dom/bindings/trace.rs
+++ b/src/components/script/dom/bindings/trace.rs
@@ -138,8 +138,7 @@ impl<T> DerefMut<T> for Traceable<T> {
 
 impl<S: Encoder<E>, E, T: Encodable<S, E>> Encodable<S, E> for Traceable<RefCell<T>> {
     fn encode(&self, s: &mut S) -> Result<(), E> {
-        self.borrow().encode(s);
-        Ok(())
+        self.borrow().encode(s)
     }
 }
 

--- a/src/components/script/dom/domimplementation.rs
+++ b/src/components/script/dom/domimplementation.rs
@@ -82,7 +82,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
         // Step 1.
         let mut doc = Document::new(&win.root_ref(), None, NonHTMLDocument, None).root();
         // Step 2-3.
-        let mut maybe_elem = if qname.is_empty() {
+        let maybe_elem = if qname.is_empty() {
             None
         } else {
             match doc.CreateElementNS(namespace, qname) {

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -73,8 +73,7 @@ impl<S: Encoder<E>, E> Encodable<S, E> for TrustedNodeAddress {
         let node = addr as *Node as *mut Node;
         unsafe {
             JS::from_raw(node).encode(s)
-        };
-        Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
The `.encode()`s from where the unused_result warnings come from seem to wrap an `encode()` and return `Ok(())`.

They should probably bubble the result out.
