### PR TITLE
Replace most of the SmallVec0 usages with std::vec::Vec

### DIFF
--- a/src/components/gfx/display_list.rs
+++ b/src/components/gfx/display_list.rs
@@ -26,7 +26,6 @@ use libc::uintptr_t;
 use servo_net::image::base::Image;
 use servo_util::geometry::Au;
 use servo_util::range::Range;
-use servo_util::smallvec::{SmallVec, SmallVec0};
 use std::mem;
 use std::slice::Items;
 use style::computed_values::border_style;
@@ -90,7 +89,7 @@ struct StackingContext {
     ///
     /// TODO(pcwalton): `z-index` should be the actual CSS property value in order to handle
     /// `auto`, not just an integer.
-    pub positioned_descendants: SmallVec0<(i32, DisplayList)>,
+    pub positioned_descendants: Vec<(i32, DisplayList)>,
 }
 
 impl StackingContext {
@@ -105,7 +104,7 @@ impl StackingContext {
             block_backgrounds_and_borders: DisplayList::new(),
             floats: DisplayList::new(),
             content: DisplayList::new(),
-            positioned_descendants: SmallVec0::new(),
+            positioned_descendants: Vec::new(),
         };
 
         for item in list.move_iter() {

--- a/src/components/main/layout/construct.rs
+++ b/src/components/main/layout/construct.rs
@@ -57,7 +57,6 @@ use script::dom::node::{TextNodeTypeId};
 use script::dom::text::Text;
 use servo_util::namespace;
 use servo_util::range::Range;
-use servo_util::smallvec::{SmallVec, SmallVec0};
 use servo_util::str::is_whitespace;
 use servo_util::url::{is_image_data, parse_url};
 use std::mem;
@@ -1226,7 +1225,7 @@ fn strip_ignorable_whitespace_from_start(boxes: &mut InlineBoxes) {
 
     // FIXME(#2264, pcwalton): This is slow because vector shift is broken. :(
     let mut found_nonwhitespace = false;
-    let mut new_boxes = SmallVec0::new();
+    let mut new_boxes = Vec::new();
     for fragment in old_boxes.iter() {
         if !found_nonwhitespace && fragment.is_whitespace_only() {
             debug!("stripping ignorable whitespace from start");

--- a/src/components/main/layout/flow.rs
+++ b/src/components/main/layout/flow.rs
@@ -54,7 +54,6 @@ use gfx::display_list::DisplayList;
 use gfx::render_task::RenderLayer;
 use servo_msg::compositor_msg::LayerId;
 use servo_util::geometry::Au;
-use servo_util::smallvec::{SmallVec, SmallVec0};
 use std::cast;
 use std::iter::Zip;
 use std::num::Zero;
@@ -558,16 +557,16 @@ impl FlowFlags {
 /// FIXME: This should use @pcwalton's reference counting scheme (Coming Soon).
 pub struct Descendants {
     /// Links to every Descendant.
-    pub descendant_links: SmallVec0<Rawlink>,
+    pub descendant_links: Vec<Rawlink>,
     /// Static y offsets of all descendants from the start of this flow box.
-    pub static_y_offsets: SmallVec0<Au>,
+    pub static_y_offsets: Vec<Au>,
 }
 
 impl Descendants {
     pub fn new() -> Descendants {
         Descendants {
-            descendant_links: SmallVec0::new(),
-            static_y_offsets: SmallVec0::new(),
+            descendant_links: Vec::new(),
+            static_y_offsets: Vec::new(),
         }
     }
 

--- a/src/components/main/layout/text.rs
+++ b/src/components/main/layout/text.rs
@@ -14,7 +14,6 @@ use gfx::text::text_run::TextRun;
 use gfx::text::util::{CompressWhitespaceNewline, transform_text, CompressNone};
 use servo_util::geometry::Au;
 use servo_util::range::Range;
-use servo_util::smallvec::{SmallVec, SmallVec0};
 use std::mem;
 use style::ComputedValues;
 use style::computed_values::{font_family, line_height, white_space};
@@ -54,7 +53,7 @@ impl TextRunScanner {
         } = mem::replace(&mut flow.as_inline().boxes, InlineBoxes::new());
 
         let mut last_whitespace = true;
-        let mut new_boxes = SmallVec0::new();
+        let mut new_boxes = Vec::new();
         for box_i in range(0, old_boxes.len()) {
             debug!("TextRunScanner: considering box: {:u}", box_i);
             if box_i > 0 && !can_coalesce_text_nodes(old_boxes.as_slice(), box_i - 1, box_i) {
@@ -97,7 +96,7 @@ impl TextRunScanner {
     pub fn flush_clump_to_list(&mut self,
                                font_context: &mut FontContext,
                                in_boxes: &[Box],
-                               out_boxes: &mut SmallVec0<Box>,
+                               out_boxes: &mut Vec<Box>,
                                last_whitespace: bool)
                                -> bool {
         assert!(self.clump.length() > 0);

--- a/src/components/util/smallvec.rs
+++ b/src/components/util/smallvec.rs
@@ -312,11 +312,7 @@ macro_rules! def_small_vector(
             ptr: *T,
             data: [T, ..$size],
         }
-    )
-)
 
-macro_rules! def_small_vector_private_trait_impl(
-    ($name:ident, $size:expr) => (
         impl<T> SmallVecPrivate<T> for $name<T> {
             unsafe fn set_len(&mut self, new_len: uint) {
                 self.len = new_len
@@ -342,11 +338,7 @@ macro_rules! def_small_vector_private_trait_impl(
                 self.ptr = cast::transmute(new_ptr)
             }
         }
-    )
-)
 
-macro_rules! def_small_vector_trait_impl(
-    ($name:ident, $size:expr) => (
         impl<T> SmallVec<T> for $name<T> {
             fn inline_size(&self) -> uint {
                 $size
@@ -358,51 +350,7 @@ macro_rules! def_small_vector_trait_impl(
                 self.cap
             }
         }
-    )
-)
 
-macro_rules! def_small_vector_drop_impl(
-    ($name:ident, $size:expr) => (
-        #[unsafe_destructor]
-        impl<T> Drop for $name<T> {
-            fn drop(&mut self) {
-                if !self.spilled() {
-                    return
-                }
-
-                unsafe {
-                    let ptr = self.mut_ptr();
-                    for i in range(0, self.len()) {
-                        *ptr.offset(i as int) = mem::uninit();
-                    }
-
-                    if intrinsics::owns_managed::<T>() {
-                        local_heap::local_free(self.ptr() as *u8)
-                    } else {
-                        global_heap::exchange_free(self.ptr() as *u8)
-                    }
-                }
-            }
-        }
-    )
-)
-
-macro_rules! def_small_vector_clone_impl(
-    ($name:ident) => (
-        impl<T:Clone> Clone for $name<T> {
-            fn clone(&self) -> $name<T> {
-                let mut new_vector = $name::new();
-                for element in self.iter() {
-                    new_vector.push((*element).clone())
-                }
-                new_vector
-            }
-        }
-    )
-)
-
-macro_rules! def_small_vector_impl(
-    ($name:ident, $size:expr) => (
         impl<T> $name<T> {
             #[inline]
             pub fn new() -> $name<T> {
@@ -418,6 +366,14 @@ macro_rules! def_small_vector_impl(
         }
     )
 )
+
+def_small_vector!(SmallVec1, 1)
+def_small_vector!(SmallVec2, 2)
+def_small_vector!(SmallVec4, 4)
+def_small_vector!(SmallVec8, 8)
+def_small_vector!(SmallVec16, 16)
+def_small_vector!(SmallVec24, 24)
+def_small_vector!(SmallVec32, 32)
 
 /// TODO(pcwalton): Remove in favor of `vec_ng` after a Rust upgrade.
 pub struct SmallVec0<T> {
@@ -472,57 +428,63 @@ impl<T> SmallVec0<T> {
     }
 }
 
+macro_rules! def_small_vector_drop_impl(
+    ($name:ident, $size:expr) => (
+        #[unsafe_destructor]
+        impl<T> Drop for $name<T> {
+            fn drop(&mut self) {
+                if !self.spilled() {
+                    return
+                }
+
+                unsafe {
+                    let ptr = self.mut_ptr();
+                    for i in range(0, self.len()) {
+                        *ptr.offset(i as int) = mem::uninit();
+                    }
+
+                    if intrinsics::owns_managed::<T>() {
+                        local_heap::local_free(self.ptr() as *u8)
+                    } else {
+                        global_heap::exchange_free(self.ptr() as *u8)
+                    }
+                }
+            }
+        }
+    )
+)
+
 def_small_vector_drop_impl!(SmallVec0, 0)
-def_small_vector_clone_impl!(SmallVec0)
-
-def_small_vector!(SmallVec1, 1)
-def_small_vector_private_trait_impl!(SmallVec1, 1)
-def_small_vector_trait_impl!(SmallVec1, 1)
 def_small_vector_drop_impl!(SmallVec1, 1)
-def_small_vector_clone_impl!(SmallVec1)
-def_small_vector_impl!(SmallVec1, 1)
-
-def_small_vector!(SmallVec2, 2)
-def_small_vector_private_trait_impl!(SmallVec2, 2)
-def_small_vector_trait_impl!(SmallVec2, 2)
 def_small_vector_drop_impl!(SmallVec2, 2)
-def_small_vector_clone_impl!(SmallVec2)
-def_small_vector_impl!(SmallVec2, 2)
-
-def_small_vector!(SmallVec4, 4)
-def_small_vector_private_trait_impl!(SmallVec4, 4)
-def_small_vector_trait_impl!(SmallVec4, 4)
 def_small_vector_drop_impl!(SmallVec4, 4)
-def_small_vector_clone_impl!(SmallVec4)
-def_small_vector_impl!(SmallVec4, 4)
-
-def_small_vector!(SmallVec8, 8)
-def_small_vector_private_trait_impl!(SmallVec8, 8)
-def_small_vector_trait_impl!(SmallVec8, 8)
 def_small_vector_drop_impl!(SmallVec8, 8)
-def_small_vector_clone_impl!(SmallVec8)
-def_small_vector_impl!(SmallVec8, 8)
-
-def_small_vector!(SmallVec16, 16)
-def_small_vector_private_trait_impl!(SmallVec16, 16)
-def_small_vector_trait_impl!(SmallVec16, 16)
 def_small_vector_drop_impl!(SmallVec16, 16)
-def_small_vector_clone_impl!(SmallVec16)
-def_small_vector_impl!(SmallVec16, 16)
-
-def_small_vector!(SmallVec24, 24)
-def_small_vector_private_trait_impl!(SmallVec24, 24)
-def_small_vector_trait_impl!(SmallVec24, 24)
 def_small_vector_drop_impl!(SmallVec24, 24)
-def_small_vector_clone_impl!(SmallVec24)
-def_small_vector_impl!(SmallVec24, 24)
-
-def_small_vector!(SmallVec32, 32)
-def_small_vector_private_trait_impl!(SmallVec32, 32)
-def_small_vector_trait_impl!(SmallVec32, 32)
 def_small_vector_drop_impl!(SmallVec32, 32)
+
+macro_rules! def_small_vector_clone_impl(
+    ($name:ident) => (
+        impl<T:Clone> Clone for $name<T> {
+            fn clone(&self) -> $name<T> {
+                let mut new_vector = $name::new();
+                for element in self.iter() {
+                    new_vector.push((*element).clone())
+                }
+                new_vector
+            }
+        }
+    )
+)
+
+def_small_vector_clone_impl!(SmallVec0)
+def_small_vector_clone_impl!(SmallVec1)
+def_small_vector_clone_impl!(SmallVec2)
+def_small_vector_clone_impl!(SmallVec4)
+def_small_vector_clone_impl!(SmallVec8)
+def_small_vector_clone_impl!(SmallVec16)
+def_small_vector_clone_impl!(SmallVec24)
 def_small_vector_clone_impl!(SmallVec32)
-def_small_vector_impl!(SmallVec32, 32)
 
 #[cfg(test)]
 pub mod tests {


### PR DESCRIPTION
We can't replace the ones in the `style` crate because some functions expect generic `SmallVec`s.

I also did some reorganisation of the `smallvec` macros.

cc @pcwalton
