### PR TITLE
Remove unused teardown methods

### DIFF
--- a/src/components/gfx/font.rs
+++ b/src/components/gfx/font.rs
@@ -159,10 +159,6 @@ impl FontGroup {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.fonts = vec!();
-    }
-
     pub fn create_textrun(&self, text: ~str, decoration: text_decoration::T) -> TextRun {
         assert!(self.fonts.len() > 0);
 
@@ -295,11 +291,6 @@ impl<'a> Font {
                self.handle.family_name(), self.handle.face_name());
 
         return result;
-    }
-
-    pub fn teardown(&mut self) {
-        self.shaper = None;
-        self.azure_font = None;
     }
 
     // TODO: this should return a borrowed pointer, but I can't figure

--- a/src/components/gfx/text/text_run.rs
+++ b/src/components/gfx/text/text_run.rs
@@ -110,9 +110,6 @@ impl<'a> TextRun {
         return run;
     }
 
-    pub fn teardown(&self) {
-    }
-
     pub fn break_and_shape(font: &mut Font, text: &str) -> Vec<Arc<GlyphStore>> {
         // TODO(Issue #230): do a better job. See Gecko's LineBreaker.
 

--- a/src/components/main/layout/block.rs
+++ b/src/components/main/layout/block.rs
@@ -709,11 +709,6 @@ impl BlockFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.box_.teardown();
-        self.float = None;
-    }
-
     /// Return shrink-to-fit width.
     ///
     /// This is where we use the preferred widths and minimum widths

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -1391,14 +1391,6 @@ impl Box {
         }
     }
 
-    /// Cleans up all the memory associated with this box.
-    pub fn teardown(&self) {
-        match self.specific {
-            ScannedTextBox(ref text_box_info) => text_box_info.run.teardown(),
-            _ => {}
-        }
-    }
-
     /// Returns true if the contents should be clipped (i.e. if `overflow` is `hidden`).
     pub fn needs_clip(&self) -> bool {
         self.style().Box.get().overflow == overflow::hidden

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -594,13 +594,6 @@ impl InlineFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        for (fragment, _) in self.boxes.iter() {
-            fragment.teardown();
-        }
-        self.boxes = InlineBoxes::new();
-    }
-
     pub fn build_display_list_inline(&mut self, layout_context: &LayoutContext) {
         let abs_rect = Rect(self.base.abs_position, self.base.position.size);
         if !abs_rect.intersects(&layout_context.dirty) {

--- a/src/components/main/layout/table.rs
+++ b/src/components/main/layout/table.rs
@@ -96,13 +96,6 @@ impl TableFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.block_flow.teardown();
-        self.col_widths = vec!();
-        self.col_min_widths = vec!();
-        self.col_pref_widths = vec!();
-    }
-
     /// Update the corresponding value of self_widths if a value of kid_widths has larger value
     /// than one of self_widths.
     pub fn update_col_widths(self_widths: &mut Vec<Au>, kid_widths: &Vec<Au>) -> Au {

--- a/src/components/main/layout/table_caption.rs
+++ b/src/components/main/layout/table_caption.rs
@@ -24,10 +24,6 @@ impl TableCaptionFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.block_flow.teardown();
-    }
-
     pub fn build_display_list_table_caption(&mut self, layout_context: &LayoutContext) {
         debug!("build_display_list_table_caption: same process as block flow");
         self.block_flow.build_display_list_block(layout_context)

--- a/src/components/main/layout/table_cell.rs
+++ b/src/components/main/layout/table_cell.rs
@@ -27,10 +27,6 @@ impl TableCellFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.block_flow.teardown()
-    }
-
     pub fn box_<'a>(&'a mut self) -> &'a Box {
         &self.block_flow.box_
     }

--- a/src/components/main/layout/table_colgroup.rs
+++ b/src/components/main/layout/table_colgroup.rs
@@ -37,15 +37,6 @@ impl TableColGroupFlow {
             widths: vec!(),
         }
     }
-
-    pub fn teardown(&mut self) {
-        for box_ in self.box_.iter() {
-            box_.teardown();
-        }
-        self.box_ = None;
-        self.cols = vec!();
-        self.widths = vec!();
-    }
 }
 
 impl Flow for TableColGroupFlow {

--- a/src/components/main/layout/table_row.rs
+++ b/src/components/main/layout/table_row.rs
@@ -55,13 +55,6 @@ impl TableRowFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.block_flow.teardown();
-        self.col_widths = vec!();
-        self.col_min_widths = vec!();
-        self.col_pref_widths = vec!();
-    }
-
     pub fn box_<'a>(&'a mut self) -> &'a Box {
         &self.block_flow.box_
     }

--- a/src/components/main/layout/table_rowgroup.rs
+++ b/src/components/main/layout/table_rowgroup.rs
@@ -54,13 +54,6 @@ impl TableRowGroupFlow {
         }
     }
 
-    pub fn teardown(&mut self) {
-        self.block_flow.teardown();
-        self.col_widths = vec!();
-        self.col_min_widths = vec!();
-        self.col_pref_widths = vec!();
-    }
-
     pub fn box_<'a>(&'a mut self) -> &'a Box {
         &self.block_flow.box_
     }

--- a/src/components/main/layout/table_wrapper.rs
+++ b/src/components/main/layout/table_wrapper.rs
@@ -91,11 +91,6 @@ impl TableWrapperFlow {
         self.block_flow.float.is_some()
     }
 
-    pub fn teardown(&mut self) {
-        self.block_flow.teardown();
-        self.col_widths = vec!();
-    }
-
     /// Assign height for table-wrapper flow.
     /// `Assign height` of table-wrapper flow follows a similar process to that of block flow.
     ///


### PR DESCRIPTION
According to @pcwalton these used to be important for memory safety but are no longer needed now.
