### PR TITLE
Split parse_url to allow for external error handling

### DIFF
--- a/src/components/util/url.rs
+++ b/src/components/util/url.rs
@@ -17,7 +17,7 @@ Create a URL object from a string. Does various helpful browsery things like
 
 */
 // TODO: about:failure->
-pub fn parse_url(str_url: &str, base_url: Option<std_url::Url>) -> std_url::Url {
+pub fn try_parse_url(str_url: &str, base_url: Option<std_url::Url>) -> Result<std_url::Url, ~str> {
     let str_url = str_url.trim_chars(& &[' ', '\t', '\n', '\r', '\x0C']).to_owned();
     let schm = std_url::get_scheme(str_url);
     let str_url = match schm {
@@ -83,9 +83,14 @@ pub fn parse_url(str_url: &str, base_url: Option<std_url::Url>) -> std_url::Url 
         }
     };
 
-    // FIXME: Need to handle errors
-    std_url::from_str(str_url).ok().expect("URL parsing failed")
+    std_url::from_str(str_url)
 }
+
+pub fn parse_url(str_url: &str, base_url: Option<std_url::Url>) -> std_url::Url {
+    // FIXME: Need to handle errors
+    try_parse_url(str_url, base_url).ok().expect("URL parsing failed")
+}
+
 
 #[cfg(test)]
 mod parse_url_tests {


### PR DESCRIPTION
Sometimes it's useful to bubble out the error from the URL parsing so the caller can deal with the result as per its needs.

[The XHR `open()`](http://xhr.spec.whatwg.org/#the-open%28%29-method), for example, is one place where the bubbling out of an error is required.

Blocks #2282
