### PR TITLE
xml_name_type() should report namespace error if name ends with colon

### DIFF
--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -728,6 +728,10 @@ pub fn xml_name_type(name: &str) -> XMLName {
         }
     }
 
+    if name.as_slice().ends_with(":") {
+        return Name;
+    }
+
     match non_qname_colons {
         false => QName,
         true => Name


### PR DESCRIPTION
This means that either there is a non-qualified name colon, or no local name. The WPT tests expect
a NAMESPACE_ERR to be thrown, so this blocks #2185 to some degree

I've re-opened this because I disagree with the decision to close the other one over a fear of withdrawing consent for the code to be used.

Show me a CLA, I'll sign it and hand over rights to whatever N lines of code there are here. I am not the kind of person to back out of a legally binding agreement.
