### PR TITLE
xml_name_type() should report namespace error if name ends with colon

### DIFF
--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -728,6 +728,10 @@ pub fn xml_name_type(name: &str) -> XMLName {
         }
     }
 
+    if name.as_slice().ends_with(":") {
+        return Name;
+    }
+
     match non_qname_colons {
         false => QName,
         true => Name


### PR DESCRIPTION
This means that either there is a non-qualified name colon, or no local name. The WPT tests expect
a NAMESPACE_ERR to be thrown, so this blocks #2185 to some degree

Show me a license agreement to turn these lines over, and I'll sign it, any misguided legal worries can be forgotten about.

And, before it even gets to that, you can even take a look at the code and see if you won't accept it for any reason other than misguided worries about legal issues.

If you're going to work for an open organization, act like it.
