### PR TITLE
Add ProgressEvent interface

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -43,6 +43,7 @@ DOMInterfaces = {
 'NodeList': {},
 'Performance': {},
 'PerformanceTiming': {},
+'ProgressEvent': {},
 'UIEvent': {},
 'ValidityState': {},
 'Window': {

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -37,7 +37,8 @@ pub enum EventTypeId {
     HTMLEventTypeId,
     UIEventTypeId,
     MouseEventTypeId,
-    KeyEventTypeId
+    KeyEventTypeId,
+    ProgressEventTypeId
 }
 
 #[deriving(Encodable)]

--- a/src/components/script/dom/progressevent.rs
+++ b/src/components/script/dom/progressevent.rs
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::BindingDeclarations::ProgressEventBinding;
+use dom::bindings::codegen::InheritTypes::ProgressEventDerived;
+use dom::bindings::error::Fallible;
+use dom::bindings::js::{JSRef, Temporary};
+use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::event::{Event, ProgressEventTypeId};
+use dom::window::Window;
+use servo_util::str::DOMString;
+
+#[deriving(Encodable)]
+pub struct ProgressEvent {
+    event: Event,
+    length_computable: bool,
+    loaded: u64,
+    total: u64
+}
+
+impl ProgressEventDerived for Event {
+    fn is_progressevent(&self) -> bool {
+        self.type_id == ProgressEventTypeId
+    }
+}
+
+impl ProgressEvent {
+    pub fn new_inherited(length_computable: bool, loaded: u64, total: u64) -> ProgressEvent {
+        ProgressEvent {
+            event: Event::new_inherited(ProgressEventTypeId),
+            length_computable: length_computable,
+            loaded: loaded,
+            total: total
+        }
+    }
+    pub fn new(window: &JSRef<Window>, length_computable: bool,
+                loaded: u64, total: u64) -> Temporary<ProgressEvent> {
+        reflect_dom_object(~ProgressEvent::new_inherited(length_computable, loaded, total),
+                           window,
+                           ProgressEventBinding::Wrap)
+    }
+    pub fn Constructor(owner: &JSRef<Window>,
+                       type_: DOMString,
+                       init: &ProgressEventBinding::ProgressEventInit)
+                       -> Fallible<Temporary<ProgressEvent>> {
+        let ev = ProgressEvent::new(owner, init.lengthComputable, init.loaded, init.total);
+        Ok(ev)
+    }
+}
+
+pub trait ProgressEventMethods {
+    fn LengthComputable(&self) -> bool;
+    fn Loaded(&self) -> u64;
+    fn Total(&self) -> u64;
+}
+
+impl<'a> ProgressEventMethods for JSRef<'a, ProgressEvent> {
+    fn LengthComputable(&self) -> bool {
+        self.length_computable
+    }
+    fn Loaded(&self) -> u64{
+        self.loaded
+    }
+    fn Total(&self) -> u64 {
+        self.total
+    }
+}
+
+impl Reflectable for ProgressEvent {
+    fn reflector<'a>(&'a self) -> &'a Reflector {
+        self.event.reflector()
+    }
+
+    fn mut_reflector<'a>(&'a mut self) -> &'a mut Reflector {
+        self.event.mut_reflector()
+    }
+}

--- a/src/components/script/dom/webidls/ProgressEvent.webidl
+++ b/src/components/script/dom/webidls/ProgressEvent.webidl
@@ -1,0 +1,28 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * http://xhr.spec.whatwg.org/#interface-progressevent
+ *
+ * To the extent possible under law, the editor has waived all copyright
+ * and related or neighboring rights to this work. In addition, as of 1 May 2014,
+ * the editor has made this specification available under the Open Web Foundation
+ * Agreement Version 1.0, which is available at
+ * http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
+ */
+
+[Constructor(DOMString type, optional ProgressEventInit eventInitDict),
+ Exposed=Window,Worker]
+interface ProgressEvent : Event {
+  readonly attribute boolean lengthComputable;
+  readonly attribute unsigned long long loaded;
+  readonly attribute unsigned long long total;
+};
+
+dictionary ProgressEventInit : EventInit {
+  boolean lengthComputable = false;
+  unsigned long long loaded = 0;
+  unsigned long long total = 0;
+};

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -156,6 +156,7 @@ pub mod dom {
     pub mod processinginstruction;
     pub mod performance;
     pub mod performancetiming;
+    pub mod progressevent;
     pub mod uievent;
     pub mod text;
     pub mod validitystate;


### PR DESCRIPTION
Adds the ProgressEvent webidl and implementation according to the XHR spec.

Blocks #2282
