### PR TITLE
Open a background non-focus-stealing window for tests on OS X.

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -117,7 +117,7 @@ impl IOCompositor {
                port: Receiver<Msg>,
                constellation_chan: ConstellationChan,
                profiler_chan: ProfilerChan) -> IOCompositor {
-        let window: Rc<Window> = WindowMethods::new(app);
+        let window: Rc<Window> = WindowMethods::new(app, opts.output_file.is_none());
 
         // Create an initial layer tree.
         //

--- a/src/components/main/platform/common/glfw_windowing.rs
+++ b/src/components/main/platform/common/glfw_windowing.rs
@@ -103,8 +103,9 @@ pub struct Window {
 
 impl WindowMethods<Application> for Window {
     /// Creates a new window.
-    fn new(app: &Application) -> Rc<Window> {
+    fn new(app: &Application, is_foreground: bool) -> Rc<Window> {
         // Create the GLFW window.
+        app.glfw.window_hint(glfw::Visible(is_foreground));
         let (glfw_window, events) = app.glfw.create_window(800, 600, "Servo", glfw::Windowed)
             .expect("Failed to create GLFW window");
         glfw_window.make_current();

--- a/src/components/main/platform/common/glut_windowing.rs
+++ b/src/components/main/platform/common/glut_windowing.rs
@@ -61,7 +61,7 @@ pub struct Window {
 
 impl WindowMethods<Application> for Window {
     /// Creates a new window.
-    fn new(_: &Application) -> Rc<Window> {
+    fn new(_: &Application, _: bool) -> Rc<Window> {
         // Create the GLUT window.
         glut::init_window_size(800, 600);
         let glut_window = glut::create_window("Servo".to_owned());

--- a/src/components/main/windowing.rs
+++ b/src/components/main/windowing.rs
@@ -56,7 +56,7 @@ pub trait ApplicationMethods {
 
 pub trait WindowMethods<A> {
     /// Creates a new window.
-    fn new(app: &A) -> Rc<Self>;
+    fn new(app: &A, is_foreground: bool) -> Rc<Self>;
     /// Returns the size of the window.
     fn size(&self) -> Size2D<f32>;
     /// Presents the window to the screen (perhaps by page flipping).


### PR DESCRIPTION
Use false for the glfw::Visible window hint to open a background window
on OS X. This requires an upgrade to glfw 3.0.4 in order for this to
also not steal focus.

This requires adding a new parameter to WindowMethods<A>::new.

Fixes https://github.com/mozilla/servo/issues/2363. r? @larsbergstrom
