### PR TITLE
Remove an unused field from CodegenRust.py.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3250,7 +3250,6 @@ class CGClass(CGThing):
         self.isStruct = isStruct
         self.disallowCopyConstruction = disallowCopyConstruction
         self.indent = indent
-        self.defaultVisibility ='pub' if isStruct else 'priv'
         self.decorators = decorators
         self.extradeclarations = extradeclarations
         self.extradefinitions = extradefinitions


### PR DESCRIPTION
The defaultVisibility field was cloned from the C++ implementation,
where it tracks the difference between struct and class visibility.
Since no similar concept exists in Rust, it should be removed.
