### PR TITLE
Fix hidpi parameter of android

### DIFF
--- a/src/components/main/platform/common/glut_windowing.rs
+++ b/src/components/main/platform/common/glut_windowing.rs
@@ -182,7 +182,7 @@ impl WindowMethods<Application> for Window {
 
     fn hidpi_factor(&self) -> f32 {
         //FIXME: Do nothing in GLUT now.
-    0f32
+    1f32
     }
 }
 


### PR DESCRIPTION
Fix for android rendering.
Need to consider about getting accurate size framebuffer & window parameter respectively from android stack and follow up the stuffs on another platform. 
