### PR TITLE
Move debug functions to Window IDL.

### DIFF
--- a/src/components/script/dom/webidls/Window.webidl
+++ b/src/components/script/dom/webidls/Window.webidl
@@ -84,3 +84,9 @@ interface WindowTimers {
   void clearInterval(optional long handle = 0);*/
 };
 Window implements WindowTimers;
+
+// Proprietary extensions.
+partial interface Window {
+  void debug(DOMString arg);
+  void gc();
+};

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -23,6 +23,7 @@ use servo_util::str::DOMString;
 use servo_util::task::{spawn_named};
 
 use js::jsapi::JSContext;
+use js::jsapi::{JS_GC, JS_GetRuntime};
 use js::jsval::{NullValue, JSVal};
 
 use collections::hashmap::HashMap;
@@ -138,6 +139,8 @@ pub trait WindowMethods {
     fn Window(&self) -> Temporary<Window>;
     fn Self(&self) -> Temporary<Window>;
     fn Performance(&mut self) -> Temporary<Performance>;
+    fn Debug(&self, message: DOMString);
+    fn Gc(&self);
 }
 
 impl<'a> WindowMethods for JSRef<'a, Window> {
@@ -262,6 +265,16 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
             self.performance.assign(Some(performance));
         }
         Temporary::new(self.performance.get_ref().clone())
+    }
+
+    fn Debug(&self, message: DOMString) {
+        debug!("{:s}", message);
+    }
+
+    fn Gc(&self) {
+        unsafe {
+            JS_GC(JS_GetRuntime(self.get_cx()));
+        }
     }
 }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -34,8 +34,7 @@ use layout_interface;
 
 use geom::point::Point2D;
 use geom::size::Size2D;
-use js::global::DEBUG_FNS;
-use js::jsapi::{JS_CallFunctionValue, JS_DefineFunctions};
+use js::jsapi::JS_CallFunctionValue;
 use js::jsapi::{JS_SetWrapObjectCallbacks, JS_SetGCZeal, JS_DEFAULT_ZEAL_FREQ, JS_GC};
 use js::jsapi::{JSContext, JSRuntime};
 use js::jsval::NullValue;
@@ -1004,13 +1003,6 @@ impl ScriptTask {
         debug!("js_scripts: {:?}", js_scripts);
 
         with_compartment((**cx).ptr, window.reflector().get_jsobject(), || {
-            // Define debug functions.
-            unsafe {
-                assert!(JS_DefineFunctions((**cx).ptr,
-                                           window.reflector().get_jsobject(),
-                                           DEBUG_FNS.as_ptr()) != 0);
-            }
-
             // Evaluate every script in the document.
             for file in js_scripts.iter() {
                 let global_obj = window.reflector().get_jsobject();


### PR DESCRIPTION
This is a cleaner way to expose those functions, and makes it possible to
remove a significant amount code in rust-mozjs.

The assert() function is no longer exposed, as it was unused and not very
useful.
