### PR TITLE
Add UIEvent::new_uninitialized() and MouseEvent::new_uninitialized()

### DIFF
--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -532,8 +532,8 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
         match interface.to_ascii_lower().as_slice() {
             // FIXME: Implement CustomEvent (http://dom.spec.whatwg.org/#customevent)
-            "uievents" | "uievent" => Ok(EventCast::from_temporary(UIEvent::new(&*window))),
             "mouseevents" | "mouseevent" => Ok(EventCast::from_temporary(MouseEvent::new(&*window))),
+            "uievents" | "uievent" => Ok(EventCast::from_temporary(UIEvent::new_uninitialized(&*window))),
             "htmlevents" | "events" | "event" => Ok(Event::new(&*window)),
             _ => Err(NotSupported)
         }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -532,8 +532,8 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
         match interface.to_ascii_lower().as_slice() {
             // FIXME: Implement CustomEvent (http://dom.spec.whatwg.org/#customevent)
-            "mouseevents" | "mouseevent" => Ok(EventCast::from_temporary(MouseEvent::new(&*window))),
             "uievents" | "uievent" => Ok(EventCast::from_temporary(UIEvent::new_uninitialized(&*window))),
+            "mouseevents" | "mouseevent" => Ok(EventCast::from_temporary(MouseEvent::new_uninitialized(&*window))),
             "htmlevents" | "events" | "event" => Ok(Event::new(&*window)),
             _ => Err(NotSupported)
         }

--- a/src/components/script/dom/mouseevent.rs
+++ b/src/components/script/dom/mouseevent.rs
@@ -51,22 +51,46 @@ impl MouseEvent {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<MouseEvent> {
+    pub fn new_uninitialized(window: &JSRef<Window>) -> Temporary<MouseEvent> {
         reflect_dom_object(~MouseEvent::new_inherited(),
                            window,
                            MouseEventBinding::Wrap)
     }
 
+    pub fn new(window: &JSRef<Window>,
+               type_: DOMString,
+               canBubble: bool,
+               cancelable: bool,
+               view: Option<JSRef<Window>>,
+               detail: i32,
+               screenX: i32,
+               screenY: i32,
+               clientX: i32,
+               clientY: i32,
+               ctrlKey: bool,
+               altKey: bool,
+               shiftKey: bool,
+               metaKey: bool,
+               button: u16,
+               relatedTarget: Option<JSRef<EventTarget>>) -> Temporary<MouseEvent> {
+        let mut ev = MouseEvent::new_uninitialized(window).root();
+        ev.InitMouseEvent(type_, canBubble, cancelable, view, detail,
+                          screenX, screenY, clientX, clientY,
+                          ctrlKey, altKey, shiftKey, metaKey,
+                          button, relatedTarget);
+        Temporary::from_rooted(&*ev)
+    }
+
     pub fn Constructor(owner: &JSRef<Window>,
                        type_: DOMString,
                        init: &MouseEventBinding::MouseEventInit) -> Fallible<Temporary<MouseEvent>> {
-        let mut ev = MouseEvent::new(owner).root();
-        ev.InitMouseEvent(type_, init.bubbles, init.cancelable, init.view.root_ref(),
-                          init.detail, init.screenX, init.screenY,
-                          init.clientX, init.clientY, init.ctrlKey,
-                          init.altKey, init.shiftKey, init.metaKey,
-                          init.button, init.relatedTarget.root_ref());
-        Ok(Temporary::from_rooted(&*ev))
+        let event = MouseEvent::new(owner, type_, init.bubbles, init.cancelable,
+                                    init.view.root_ref(),
+                                    init.detail, init.screenX, init.screenY,
+                                    init.clientX, init.clientY, init.ctrlKey,
+                                    init.altKey, init.shiftKey, init.metaKey,
+                                    init.button, init.relatedTarget.root_ref());
+        Ok(event)
     }
 }
 

--- a/src/components/script/dom/uievent.rs
+++ b/src/components/script/dom/uievent.rs
@@ -36,19 +36,30 @@ impl UIEvent {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<UIEvent> {
+    pub fn new_uninitialized(window: &JSRef<Window>) -> Temporary<UIEvent> {
         reflect_dom_object(~UIEvent::new_inherited(UIEventTypeId),
                            window,
                            UIEventBinding::Wrap)
     }
 
+    pub fn new(window: &JSRef<Window>,
+               type_: DOMString,
+               can_bubble: bool,
+               cancelable: bool,
+               view: Option<JSRef<Window>>,
+               detail: i32) -> Temporary<UIEvent> {
+        let mut ev = UIEvent::new_uninitialized(window).root();
+        ev.InitUIEvent(type_, can_bubble, cancelable, view, detail);
+        Temporary::from_rooted(&*ev)
+    }
+
     pub fn Constructor(owner: &JSRef<Window>,
                        type_: DOMString,
                        init: &UIEventBinding::UIEventInit) -> Fallible<Temporary<UIEvent>> {
-        let mut ev = UIEvent::new(owner).root();
-        ev.InitUIEvent(type_, init.parent.bubbles, init.parent.cancelable,
-                       init.view.root_ref(), init.detail);
-        Ok(Temporary::from_rooted(&*ev))
+        let event = UIEvent::new(owner, type_,
+                                 init.parent.bubbles, init.parent.cancelable,
+                                 init.view.root_ref(), init.detail);
+        Ok(event)
     }
 }
 

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -16,7 +16,7 @@ use dom::document::{Document, HTMLDocument, DocumentMethods, DocumentHelpers};
 use dom::element::{Element, AttributeHandlers};
 use dom::event::{Event_, ResizeEvent, ReflowEvent, ClickEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent};
 use dom::event::{Event, EventMethods};
-use dom::uievent::{UIEvent, UIEventMethods};
+use dom::uievent::UIEvent;
 use dom::eventtarget::{EventTarget, EventTargetHelpers};
 use dom::node;
 use dom::node::{Node, NodeHelpers};
@@ -1093,9 +1093,8 @@ impl ScriptTask {
                     Some(mut window) => {
                         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
                         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#event-type-resize
-                        let mut uievent = UIEvent::new(&*window).root();
-                        uievent.InitUIEvent("resize".to_owned(), false, false,
-                                            Some((*window).clone()), 0i32);
+                        let mut uievent = UIEvent::new(&window.clone(), "resize".to_owned(), false, false,
+                                                       Some((*window).clone()), 0i32).root();
                         let event: &mut JSRef<Event> = EventCast::from_mut_ref(&mut *uievent);
 
                         let wintarget: &mut JSRef<EventTarget> = EventTargetCast::from_mut_ref(&mut *window);


### PR DESCRIPTION
Fix #2383

These changes introduce `FooEvent::new_uninitialized()` constructor. This constructor use to create `FooEvent` without calling `FooEvent::InitFooEvent`.
#2383 says integrating `FooEvent::new()` and `InitFooEvent`, but we need to preserve simple `FooEvent::new_uninitialized()` for `document.createEvent()`.

@jdm r?
