### PR TITLE
Move the computed style to a new SharedLayoutData struct.

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -195,7 +195,7 @@ impl StyleSharingCandidate {
             match *node.borrow_layout_data_unchecked() {
                 None => return None,
                 Some(ref layout_data_ref) => {
-                    match layout_data_ref.data.style {
+                    match layout_data_ref.shared_data.style {
                         None => return None,
                         Some(ref data) => (*data).clone(),
                     }
@@ -206,7 +206,7 @@ impl StyleSharingCandidate {
             match *parent_node.borrow_layout_data_unchecked() {
                 None => return None,
                 Some(ref parent_layout_data_ref) => {
-                    match parent_layout_data_ref.data.style {
+                    match parent_layout_data_ref.shared_data.style {
                         None => return None,
                         Some(ref data) => (*data).clone(),
                     }
@@ -394,7 +394,7 @@ impl<'ln> PrivateMatchMethods for LayoutNode<'ln> {
         match parent_layout_data {
             &Some(ref parent_layout_data_ref) => {
                 // Check parent style.
-                let parent_style = parent_layout_data_ref.data.style.as_ref().unwrap();
+                let parent_style = parent_layout_data_ref.shared_data.style.as_ref().unwrap();
                 if !arc_ptr_eq(parent_style, &candidate.parent_style) {
                     return None
                 }
@@ -458,7 +458,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
                 Some(shared_style) => {
                     // Yay, cache hit. Share the style.
                     let mut layout_data_ref = self.mutate_layout_data();
-                    layout_data_ref.get_mut_ref().data.style = Some(shared_style);
+                    layout_data_ref.get_mut_ref().shared_data.style = Some(shared_style);
                     return StyleWasShared(i)
                 }
                 None => {}
@@ -543,7 +543,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
                 match *parent_layout_data {
                     None => fail!("no parent data?!"),
                     Some(ref parent_layout_data) => {
-                        match parent_layout_data.data.style {
+                        match parent_layout_data.shared_data.style {
                             None => fail!("parent hasn't been styled yet?!"),
                             Some(ref style) => Some(style),
                         }
@@ -558,7 +558,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
             &Some(ref mut layout_data) => {
                 self.cascade_node_pseudo_element(parent_style,
                                                  applicable_declarations.normal.as_slice(),
-                                                 &mut layout_data.data.style,
+                                                 &mut layout_data.shared_data.style,
                                                  initial_values,
                                                  applicable_declarations_cache,
                                                  applicable_declarations.normal_shareable);

--- a/src/components/main/css/node_util.rs
+++ b/src/components/main/css/node_util.rs
@@ -45,7 +45,7 @@ impl<'ln> NodeUtil for ThreadSafeLayoutNode<'ln> {
                 Normal => {
                     cast::transmute_region(layout_data_ref.as_ref()
                                                           .unwrap()
-                                                          .data
+                                                          .shared_data
                                                           .style
                                                           .as_ref()
                                                           .unwrap())
@@ -57,7 +57,7 @@ impl<'ln> NodeUtil for ThreadSafeLayoutNode<'ln> {
     /// Does this node have a computed style yet?
     fn have_css_select_results(&self) -> bool {
         let layout_data_ref = self.borrow_layout_data();
-        layout_data_ref.get_ref().data.style.is_some()
+        layout_data_ref.get_ref().shared_data.style.is_some()
     }
 
     /// Get the description of how to account for recent style changes.

--- a/src/components/main/layout/extra.rs
+++ b/src/components/main/layout/extra.rs
@@ -6,6 +6,7 @@
 
 use layout::util::{PrivateLayoutData, LayoutDataAccess, LayoutDataWrapper};
 use layout::wrapper::LayoutNode;
+use script::dom::node::SharedLayoutData;
 use script::layout_interface::LayoutChan;
 
 /// Functionality useful for querying the layout-specific data on DOM nodes.
@@ -24,6 +25,7 @@ impl<'ln> LayoutAuxMethods for LayoutNode<'ln> {
             None => {
                 *layout_data_ref = Some(LayoutDataWrapper {
                     chan: Some(chan),
+                    shared_data: SharedLayoutData { style: None },
                     data: ~PrivateLayoutData::new(),
                 });
             }

--- a/src/components/main/layout/util.rs
+++ b/src/components/main/layout/util.rs
@@ -11,7 +11,7 @@ use gfx;
 use libc::uintptr_t;
 use script::dom::bindings::js::JS;
 use script::dom::bindings::utils::Reflectable;
-use script::dom::node::Node;
+use script::dom::node::{Node, SharedLayoutData};
 use script::layout_interface::{LayoutChan, UntrustedNodeAddress, TrustedNodeAddress};
 use std::cast;
 use std::cell::{Ref, RefMut};
@@ -21,9 +21,6 @@ use sync::Arc;
 
 /// Data that layout associates with a node.
 pub struct PrivateLayoutData {
-    /// The results of CSS styling for this node.
-    pub style: Option<Arc<ComputedValues>>,
-
     /// The results of CSS styling for this node's `before` pseudo-element, if any.
     pub before_style: Option<Arc<ComputedValues>>,
 
@@ -50,7 +47,6 @@ impl PrivateLayoutData {
     pub fn new() -> PrivateLayoutData {
         PrivateLayoutData {
             before_style: None,
-            style: None,
             after_style: None,
             restyle_damage: None,
             flow_construction_result: NoConstructionResult,
@@ -63,6 +59,7 @@ impl PrivateLayoutData {
 
 pub struct LayoutDataWrapper {
     pub chan: Option<LayoutChan>,
+    pub shared_data: SharedLayoutData,
     pub data: ~PrivateLayoutData,
 }
 

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -561,7 +561,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
                 after_style.Box.get().display
             }
             Normal => {
-                let after_style = node_layout_data_wrapper.data.style.get_ref();
+                let after_style = node_layout_data_wrapper.shared_data.style.get_ref();
                 after_style.Box.get().display
             }
         };

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -44,6 +44,8 @@ use std::cast;
 use std::cell::{RefCell, Ref, RefMut};
 use std::iter::{Map, Filter};
 use std::mem;
+use style::ComputedValues;
+use sync::Arc;
 
 use serialize::{Encoder, Encodable};
 
@@ -143,9 +145,16 @@ enum SuppressObserver {
     Unsuppressed
 }
 
+/// Layout data that is shared between the script and layout tasks.
+pub struct SharedLayoutData {
+    /// The results of CSS styling for this node.
+    pub style: Option<Arc<ComputedValues>>,
+}
+
 /// Encapsulates the abstract layout data.
 pub struct LayoutData {
     chan: Option<LayoutChan>,
+    shared_data: SharedLayoutData,
     data: *(),
 }
 

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -30,6 +30,7 @@ extern crate servo_macros = "macros";
 extern crate servo_net = "net";
 extern crate servo_util = "util";
 extern crate style;
+extern crate sync;
 extern crate servo_msg = "msg";
 extern crate url;
 


### PR DESCRIPTION
Implementing the CSSOM requires giving the script task access to the
computed style for a node. Moving it into a new SharedLayoutData struct
member of LayoutDataRef seems to be the best way to achieve this.

This is the first step towards #1721.
