### PR TITLE
Add message to fonts.len() == 0 assert

### DIFF
--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -192,7 +192,7 @@ impl FontContext {
                 };
             }
         }
-        assert!(fonts.len() > 0);
+        assert!(fonts.len() > 0, "No matching font(s), are the appropriate fonts installed?");
         // TODO(Issue #179): Split FontStyle into specified and used styles
         let used_style = (*style).clone();
 


### PR DESCRIPTION
If msttcorefonts isn't installed, output a more informative error message.

./servo ../src/test/html/about-mozilla.html prints
           "task 'LayoutWorker' failed at 'No matching font(s), are the appropriate fonts installed?',
            ../servo/src/components/gfx/font_context.rs:195"
vs. 
            "task 'LayoutWorker' failed at 'assertion failed: fonts.len() > 0',
            ../servo/src/components/gfx/font_context.rs:195"
