### PR TITLE
Remove addHTMLElement from Bindings.conf.

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -23,8 +23,11 @@ DOMInterfaces = {
 'CharacterData': {},
 'ClientRect': {},
 'ClientRectList': {},
+'Comment': {},
 'Console': {},
 'Document': {},
+'DocumentFragment': {},
+'DocumentType': {},
 'DOMException': {},
 'DOMImplementation': {},
 'DOMParser': {},
@@ -35,7 +38,76 @@ DOMInterfaces = {
 },
 'EventTarget': {},
 'FormData': {},
+'HTMLAnchorElement': {},
+'HTMLAppletElement': {},
+'HTMLAreaElement': {},
+'HTMLAudioElement': {},
+'HTMLButtonElement': {},
+'HTMLBaseElement': {},
+'HTMLBodyElement': {},
+'HTMLBRElement': {},
+'HTMLCanvasElement': {},
 'HTMLCollection': {},
+'HTMLDataElement': {},
+'HTMLDivElement': {},
+'HTMLDataListElement': {},
+'HTMLDirectoryElement': {},
+'HTMLDListElement': {},
+'HTMLElement': {},
+'HTMLEmbedElement': {},
+'HTMLFieldSetElement': {},
+'HTMLFontElement': {},
+'HTMLFormElement': {},
+'HTMLFrameElement': {},
+'HTMLFrameSetElement': {},
+'HTMLHeadElement': {},
+'HTMLHeadingElement': {},
+'HTMLHtmlElement': {},
+'HTMLHRElement': {},
+'HTMLIFrameElement': {},
+'HTMLImageElement': {},
+'HTMLInputElement': {},
+'HTMLLabelElement': {},
+'HTMLLegendElement': {},
+'HTMLLIElement': {},
+'HTMLLinkElement': {},
+'HTMLMapElement': {},
+'HTMLMainElement': {},
+'HTMLMediaElement': {},
+'HTMLMetaElement': {},
+'HTMLMeterElement': {},
+'HTMLModElement': {},
+'HTMLObjectElement': {},
+'HTMLOListElement': {},
+'HTMLOptGroupElement': {},
+'HTMLOptionElement': {},
+'HTMLOutputElement': {},
+'HTMLParagraphElement': {},
+'HTMLParamElement': {},
+'HTMLPreElement': {},
+'HTMLProgressElement': {},
+'HTMLQuoteElement': {},
+'HTMLScriptElement': {},
+'HTMLSelectElement': {},
+'HTMLSourceElement': {},
+'HTMLSpanElement': {},
+'HTMLStyleElement': {},
+'HTMLTableCaptionElement': {},
+'HTMLTableElement': {},
+'HTMLTableCellElement': {},
+'HTMLTableDataCellElement': {},
+'HTMLTableHeaderCellElement': {},
+'HTMLTableColElement': {},
+'HTMLTableRowElement': {},
+'HTMLTableSectionElement': {},
+'HTMLTemplateElement': {},
+'HTMLTextAreaElement': {},
+'HTMLTimeElement': {},
+'HTMLTitleElement': {},
+'HTMLTrackElement': {},
+'HTMLUListElement': {},
+'HTMLVideoElement': {},
+'HTMLUnknownElement': {},
 'Location': {},
 'MouseEvent': {},
 'Navigator': {},
@@ -43,7 +115,9 @@ DOMInterfaces = {
 'NodeList': {},
 'Performance': {},
 'PerformanceTiming': {},
+'ProcessingInstruction': {},
 'ProgressEvent': {},
+'Text': {},
 'UIEvent': {},
 'ValidityState': {},
 'Window': {
@@ -59,82 +133,3 @@ DOMInterfaces = {
 
 }
 
-# FIXME: This should be renamed: https://github.com/mozilla/servo/issues/1625
-def addHTMLElement(element):
-  DOMInterfaces[element] = {}
-
-addHTMLElement('Comment')
-addHTMLElement('DocumentFragment')
-addHTMLElement('DocumentType')
-addHTMLElement('Text')
-addHTMLElement('ProcessingInstruction')
-
-addHTMLElement('HTMLAnchorElement')
-addHTMLElement('HTMLAppletElement')
-addHTMLElement('HTMLAreaElement')
-addHTMLElement('HTMLAudioElement')
-addHTMLElement('HTMLButtonElement')
-addHTMLElement('HTMLBaseElement')
-addHTMLElement('HTMLBodyElement')
-addHTMLElement('HTMLBRElement')
-addHTMLElement('HTMLCanvasElement')
-addHTMLElement('HTMLDataElement')
-addHTMLElement('HTMLDivElement')
-addHTMLElement('HTMLDataListElement')
-addHTMLElement('HTMLDirectoryElement')
-addHTMLElement('HTMLDListElement')
-addHTMLElement('HTMLElement')
-addHTMLElement('HTMLEmbedElement')
-addHTMLElement('HTMLFieldSetElement')
-addHTMLElement('HTMLFontElement')
-addHTMLElement('HTMLFormElement')
-addHTMLElement('HTMLFrameElement')
-addHTMLElement('HTMLFrameSetElement')
-addHTMLElement('HTMLHeadElement')
-addHTMLElement('HTMLHeadingElement')
-addHTMLElement('HTMLHtmlElement')
-addHTMLElement('HTMLHRElement')
-addHTMLElement('HTMLIFrameElement')
-addHTMLElement('HTMLImageElement')
-addHTMLElement('HTMLInputElement')
-addHTMLElement('HTMLLabelElement')
-addHTMLElement('HTMLLegendElement')
-addHTMLElement('HTMLLIElement')
-addHTMLElement('HTMLLinkElement')
-addHTMLElement('HTMLMapElement')
-addHTMLElement('HTMLMainElement')
-addHTMLElement('HTMLMediaElement')
-addHTMLElement('HTMLMetaElement')
-addHTMLElement('HTMLMeterElement')
-addHTMLElement('HTMLModElement')
-addHTMLElement('HTMLObjectElement')
-addHTMLElement('HTMLOListElement')
-addHTMLElement('HTMLOptGroupElement')
-addHTMLElement('HTMLOptionElement')
-addHTMLElement('HTMLOutputElement')
-addHTMLElement('HTMLParagraphElement')
-addHTMLElement('HTMLParamElement')
-addHTMLElement('HTMLPreElement')
-addHTMLElement('HTMLProgressElement')
-addHTMLElement('HTMLQuoteElement')
-addHTMLElement('HTMLScriptElement')
-addHTMLElement('HTMLSelectElement')
-addHTMLElement('HTMLSourceElement')
-addHTMLElement('HTMLSpanElement')
-addHTMLElement('HTMLStyleElement')
-addHTMLElement('HTMLTableCaptionElement')
-addHTMLElement('HTMLTableElement')
-addHTMLElement('HTMLTableCellElement')
-addHTMLElement('HTMLTableDataCellElement')
-addHTMLElement('HTMLTableHeaderCellElement')
-addHTMLElement('HTMLTableColElement')
-addHTMLElement('HTMLTableRowElement')
-addHTMLElement('HTMLTableSectionElement')
-addHTMLElement('HTMLTemplateElement')
-addHTMLElement('HTMLTextAreaElement')
-addHTMLElement('HTMLTimeElement')
-addHTMLElement('HTMLTitleElement')
-addHTMLElement('HTMLTrackElement')
-addHTMLElement('HTMLUListElement')
-addHTMLElement('HTMLVideoElement')
-addHTMLElement('HTMLUnknownElement')


### PR DESCRIPTION
We can just use the defaults for all of the HTML elements for now and
deal with the nonstandard behavior later. This fixes #2207.
