### PR TITLE
Use ContravariantLifetime in LayoutNode.

### DIFF
--- a/src/components/main/layout/parallel.rs
+++ b/src/components/main/layout/parallel.rs
@@ -37,7 +37,7 @@ fn static_assertion(node: UnsafeLayoutNode) {
 /// Memory representation that is at least as large as UnsafeLayoutNode, as it must be
 /// safely transmutable to and from that type to accommodate the type-unsafe parallel work
 /// queue usage that stores both flows and nodes.
-pub type PaddedUnsafeFlow = (uint, uint, uint);
+pub type PaddedUnsafeFlow = (uint, uint);
 
 trait UnsafeFlowConversions {
     fn to_flow(&self) -> UnsafeFlow;
@@ -46,13 +46,13 @@ trait UnsafeFlowConversions {
 
 impl UnsafeFlowConversions for PaddedUnsafeFlow {
     fn to_flow(&self) -> UnsafeFlow {
-        let (vtable, ptr, _padding) = *self;
+        let (vtable, ptr) = *self;
         (vtable, ptr)
     }
 
     fn from_flow(flow: &UnsafeFlow) -> PaddedUnsafeFlow {
         let &(vtable, ptr) = flow;
-        (vtable, ptr, 0)
+        (vtable, ptr)
     }
 }
 

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -149,8 +149,7 @@ impl<'ln> Clone for LayoutNode<'ln> {
 impl<'a> Eq for LayoutNode<'a> {
     #[inline]
     fn eq(&self, other: &LayoutNode) -> bool {
-        self.node == other.node &&
-        self.chain == other.chain
+        self.node == other.node
     }
 }
 

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -48,6 +48,7 @@ use servo_util::namespace;
 use servo_util::namespace::Namespace;
 use std::cast;
 use std::cell::{Ref, RefMut};
+use std::kinds::marker::ContravariantLifetime;
 use style::{PropertyDeclarationBlock, TElement, TNode, AttrSelector, SpecificNamespace};
 use style::{AnyNamespace};
 use style::computed_values::{content, display};
@@ -133,8 +134,8 @@ pub struct LayoutNode<'a> {
     /// The wrapped node.
     node: JS<Node>,
 
-    /// Being chained to a value prevents `LayoutNode`s from escaping.
-    pub chain: &'a (),
+    /// Being chained to a ContravariantLifetime prevents `LayoutNode`s from escaping.
+    pub chain: ContravariantLifetime<'a>,
 }
 
 impl<'ln> Clone for LayoutNode<'ln> {
@@ -192,10 +193,9 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
 impl<'ln> LayoutNode<'ln> {
     /// Creates a new layout node, scoped to the given closure.
     pub unsafe fn with_layout_node<R>(node: JS<Node>, f: <'a> |LayoutNode<'a>| -> R) -> R {
-        let heavy_iron_ball = ();
         f(LayoutNode {
             node: node,
-            chain: &heavy_iron_ball,
+            chain: ContravariantLifetime,
         })
     }
 
@@ -708,7 +708,7 @@ pub trait PostorderNodeMutTraversal {
 
 /// Opaque type stored in type-unsafe work queues for parallel layout.
 /// Must be transmutable to and from LayoutNode/ThreadsafeLayoutNode/PaddedUnsafeFlow.
-pub type UnsafeLayoutNode = (uint, uint, uint);
+pub type UnsafeLayoutNode = (uint, uint);
 
 pub fn layout_node_to_unsafe_layout_node(node: &LayoutNode) -> UnsafeLayoutNode {
     unsafe {


### PR DESCRIPTION
Since ContravariantLifetime uses no storage, this will reduce the size of a LayoutNode from 3 words to 2.
