### PR TITLE
Make 'JS<T>' smart pointers a POD type

### DIFF
--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -181,7 +181,7 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
 
     fn first_child(&self) -> Option<LayoutNode<'ln>> {
         unsafe {
-            self.get_jsmanaged().first_child_ref().map(|node| self.new_with_this_lifetime(node))
+            self.get_jsmanaged().first_child_ref().map(|node| self.new_with_this_lifetime(&node))
         }
     }
 
@@ -230,19 +230,19 @@ impl<'ln> LayoutNode<'ln> {
 impl<'ln> TNode<LayoutElement<'ln>> for LayoutNode<'ln> {
     fn parent_node(&self) -> Option<LayoutNode<'ln>> {
         unsafe {
-            self.node.parent_node_ref().map(|node| self.new_with_this_lifetime(node))
+            self.node.parent_node_ref().map(|node| self.new_with_this_lifetime(&node))
         }
     }
 
     fn prev_sibling(&self) -> Option<LayoutNode<'ln>> {
         unsafe {
-            self.node.prev_sibling_ref().map(|node| self.new_with_this_lifetime(node))
+            self.node.prev_sibling_ref().map(|node| self.new_with_this_lifetime(&node))
         }
     }
 
     fn next_sibling(&self) -> Option<LayoutNode<'ln>> {
         unsafe {
-            self.node.next_sibling_ref().map(|node| self.new_with_this_lifetime(node))
+            self.node.next_sibling_ref().map(|node| self.new_with_this_lifetime(&node))
         }
     }
 
@@ -471,7 +471,7 @@ impl<'ln> TLayoutNode for ThreadSafeLayoutNode<'ln> {
         }
 
         unsafe {
-            self.get_jsmanaged().first_child_ref().map(|node| self.new_with_this_lifetime(node))
+            self.get_jsmanaged().first_child_ref().map(|node| self.new_with_this_lifetime(&node))
         }
     }
 
@@ -521,10 +521,10 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
     /// Returns the next sibling of this node. Unsafe and private because this can lead to races.
     unsafe fn next_sibling(&self) -> Option<ThreadSafeLayoutNode<'ln>> {
         if self.pseudo == Before || self.pseudo == BeforeBlock {
-            return self.get_jsmanaged().first_child_ref().map(|node| self.new_with_this_lifetime(node))
+            return self.get_jsmanaged().first_child_ref().map(|node| self.new_with_this_lifetime(&node))
         }
 
-        self.get_jsmanaged().next_sibling_ref().map(|node| self.new_with_this_lifetime(node))
+        self.get_jsmanaged().next_sibling_ref().map(|node| self.new_with_this_lifetime(&node))
     }
 
     /// Returns an iterator over this node's children.

--- a/src/components/main/layout/wrapper.rs
+++ b/src/components/main/layout/wrapper.rs
@@ -136,6 +136,10 @@ pub struct LayoutNode<'a> {
 
     /// Being chained to a ContravariantLifetime prevents `LayoutNode`s from escaping.
     pub chain: ContravariantLifetime<'a>,
+
+    /// Padding to ensure the transmute `JS<T>` -> `LayoutNode`, `LayoutNode` -> `UnsafeLayoutNode`,
+    /// and `UnsafeLayoutNode` -> others.
+    pad: uint
 }
 
 impl<'ln> Clone for LayoutNode<'ln> {
@@ -143,6 +147,7 @@ impl<'ln> Clone for LayoutNode<'ln> {
         LayoutNode {
             node: self.node.clone(),
             chain: self.chain,
+            pad: 0,
         }
     }
 }
@@ -160,6 +165,7 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
         LayoutNode {
             node: node.transmute_copy(),
             chain: self.chain,
+            pad: 0,
         }
     }
 
@@ -196,6 +202,7 @@ impl<'ln> LayoutNode<'ln> {
         f(LayoutNode {
             node: node,
             chain: ContravariantLifetime,
+            pad: 0,
         })
     }
 
@@ -425,6 +432,7 @@ impl<'ln> TLayoutNode for ThreadSafeLayoutNode<'ln> {
             node: LayoutNode {
                 node: node.transmute_copy(),
                 chain: self.node.chain,
+                pad: 0,
             },
             pseudo: Normal,
         }

--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -13,6 +13,7 @@ use dom::virtualmethods::vtable_for;
 use servo_util::namespace;
 use servo_util::namespace::Namespace;
 use servo_util::str::DOMString;
+use std::cell::Cell;
 
 pub enum AttrSettingType {
     FirstSetAttr,
@@ -29,7 +30,7 @@ pub struct Attr {
     pub prefix: Option<DOMString>,
 
     /// the element that owns this attribute.
-    pub owner: JS<Element>,
+    pub owner: Cell<JS<Element>>,
 }
 
 impl Reflectable for Attr {
@@ -53,7 +54,7 @@ impl Attr {
             name: name, //TODO: Intern attribute names
             namespace: namespace,
             prefix: prefix,
-            owner: owner.unrooted(),
+            owner: Cell::new(owner.unrooted()),
         }
     }
 
@@ -65,7 +66,7 @@ impl Attr {
     }
 
     pub fn set_value(&mut self, set_type: AttrSettingType, value: DOMString) {
-        let mut owner = self.owner.root();
+        let mut owner = self.owner.get().root();
         let node: &mut JSRef<Node> = NodeCast::from_mut_ref(&mut *owner);
         let namespace_is_null = self.namespace == namespace::Null;
 

--- a/src/components/script/dom/attrlist.rs
+++ b/src/components/script/dom/attrlist.rs
@@ -39,11 +39,11 @@ pub trait AttrListMethods {
 
 impl<'a> AttrListMethods for JSRef<'a, AttrList> {
     fn Length(&self) -> u32 {
-        self.owner.root().attrs.len() as u32
+        self.owner.root().attrs.borrow().len() as u32
     }
 
     fn Item(&self, index: u32) -> Option<Temporary<Attr>> {
-        self.owner.root().attrs.as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
+        self.owner.root().attrs.borrow().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
     }
 
     fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {

--- a/src/components/script/dom/bindings/js.rs
+++ b/src/components/script/dom/bindings/js.rs
@@ -47,7 +47,7 @@ use layout_interface::TrustedNodeAddress;
 use script_task::StackRoots;
 
 use std::cast;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::kinds::marker::ContravariantLifetime;
 
 /// A type that represents a JS-owned value that is rooted for the lifetime of this value.
@@ -268,6 +268,15 @@ impl<T: Assignable<U>, U: Reflectable> OptionalSettable<T> for Option<JS<U>> {
         *self = val.map(|val| unsafe { val.get_js() });
     }
 }
+
+impl<T: Assignable<U>, U: Reflectable> OptionalSettable<T> for Cell<Option<JS<U>>> {
+    fn assign(&mut self, val: Option<T>) {
+        let mut item = self.get();
+        item.assign(val);
+        self.set(item);
+    }
+}
+
 
 /// Root a rootable Option type (used for Option<Temporary<T>>)
 pub trait OptionalRootable<T> {

--- a/src/components/script/dom/bindings/trace.rs
+++ b/src/components/script/dom/bindings/trace.rs
@@ -168,6 +168,12 @@ impl<T: Reflectable+Encodable<S, E>, S: Encoder<E>, E> Encodable<S, E> for Cell<
     }
 }
 
+impl<T: Reflectable+Encodable<S, E>, S: Encoder<E>, E> Encodable<S, E> for Cell<Option<JS<T>>> {
+    fn encode(&self, s: &mut S) -> Result<(), E> {
+        self.get().encode(s)
+    }
+}
+
 /// for a field which contains non-POD type contains DOMType
 impl<T: Reflectable+Encodable<S, E>, S: Encoder<E>, E> Encodable<S, E> for RefCell<Vec<JS<T>>> {
     fn encode(&self, s: &mut S) -> Result<(), E> {

--- a/src/components/script/dom/bindings/trace.rs
+++ b/src/components/script/dom/bindings/trace.rs
@@ -160,3 +160,10 @@ impl<S: Encoder<E>, E> Encodable<S, E> for Traceable<JSVal> {
         Ok(())
     }
 }
+
+/// for a field which contains DOMType
+impl<T: Reflectable+Encodable<S, E>, S: Encoder<E>, E> Encodable<S, E> for Cell<JS<T>> {
+    fn encode(&self, s: &mut S) -> Result<(), E> {
+        self.get().encode(s)
+    }
+}

--- a/src/components/script/dom/bindings/trace.rs
+++ b/src/components/script/dom/bindings/trace.rs
@@ -167,3 +167,10 @@ impl<T: Reflectable+Encodable<S, E>, S: Encoder<E>, E> Encodable<S, E> for Cell<
         self.get().encode(s)
     }
 }
+
+/// for a field which contains non-POD type contains DOMType
+impl<T: Reflectable+Encodable<S, E>, S: Encoder<E>, E> Encodable<S, E> for RefCell<Vec<JS<T>>> {
+    fn encode(&self, s: &mut S) -> Result<(), E> {
+        self.borrow().encode(s)
+    }
+}

--- a/src/components/script/dom/clientrectlist.rs
+++ b/src/components/script/dom/clientrectlist.rs
@@ -18,9 +18,10 @@ pub struct ClientRectList {
 impl ClientRectList {
     pub fn new_inherited(window: &JSRef<Window>,
                          rects: Vec<JSRef<ClientRect>>) -> ClientRectList {
+        let rects = rects.iter().map(|rect| rect.unrooted()).collect();
         ClientRectList {
             reflector_: Reflector::new(),
-            rects: rects.iter().map(|rect| rect.unrooted()).collect(),
+            rects: rects,
             window: window.unrooted(),
         }
     }
@@ -44,8 +45,9 @@ impl<'a> ClientRectListMethods for JSRef<'a, ClientRectList> {
     }
 
     fn Item(&self, index: u32) -> Option<Temporary<ClientRect>> {
-        if index < self.rects.len() as u32 {
-            Some(Temporary::new(self.rects.get(index as uint).clone()))
+        let rects = &self.rects;
+        if index < rects.len() as u32 {
+            Some(Temporary::new(rects.get(index as uint).clone()))
         } else {
             None
         }

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -10,6 +10,7 @@ use dom::bindings::error::Fallible;
 use dom::eventtarget::EventTarget;
 use dom::window::Window;
 use servo_util::str::DOMString;
+use std::cell::Cell;
 
 use geom::point::Point2D;
 
@@ -46,8 +47,8 @@ pub enum EventTypeId {
 pub struct Event {
     pub type_id: EventTypeId,
     pub reflector_: Reflector,
-    pub current_target: Option<JS<EventTarget>>,
-    pub target: Option<JS<EventTarget>>,
+    pub current_target: Cell<Option<JS<EventTarget>>>,
+    pub target: Cell<Option<JS<EventTarget>>>,
     pub type_: DOMString,
     pub phase: EventPhase,
     pub canceled: bool,
@@ -66,8 +67,8 @@ impl Event {
         Event {
             type_id: type_id,
             reflector_: Reflector::new(),
-            current_target: None,
-            target: None,
+            current_target: Cell::new(None),
+            target: Cell::new(None),
             phase: PhaseNone,
             type_: "".to_owned(),
             canceled: false,
@@ -123,11 +124,11 @@ impl<'a> EventMethods for JSRef<'a, Event> {
     }
 
     fn GetTarget(&self) -> Option<Temporary<EventTarget>> {
-        self.target.as_ref().map(|target| Temporary::new(target.clone()))
+        self.target.get().as_ref().map(|target| Temporary::new(target.clone()))
     }
 
     fn GetCurrentTarget(&self) -> Option<Temporary<EventTarget>> {
-        self.current_target.as_ref().map(|target| Temporary::new(target.clone()))
+        self.current_target.get().as_ref().map(|target| Temporary::new(target.clone()))
     }
 
     fn DefaultPrevented(&self) -> bool {
@@ -173,7 +174,7 @@ impl<'a> EventMethods for JSRef<'a, Event> {
         self.stop_immediate = false;
         self.canceled = false;
         self.trusted = false;
-        self.target = None;
+        self.target.set(None);
         self.type_ = type_;
         self.bubbles = bubbles;
         self.cancelable = cancelable;

--- a/src/components/script/dom/eventdispatcher.rs
+++ b/src/components/script/dom/eventdispatcher.rs
@@ -140,7 +140,7 @@ pub fn dispatch_event<'a, 'b>(target: &JSRef<'a, EventTarget>,
 
     event.dispatching = false;
     event.phase = PhaseNone;
-    event.current_target = None;
+    event.current_target.set(None);
 
     !event.DefaultPrevented()
 }

--- a/src/components/script/dom/formdata.rs
+++ b/src/components/script/dom/formdata.rs
@@ -10,7 +10,6 @@ use dom::blob::Blob;
 use dom::htmlformelement::HTMLFormElement;
 use dom::window::Window;
 use servo_util::str::DOMString;
-
 use collections::hashmap::HashMap;
 
 #[deriving(Encodable)]

--- a/src/components/script/dom/htmlserializer.rs
+++ b/src/components/script/dom/htmlserializer.rs
@@ -106,7 +106,7 @@ fn serialize_doctype(doctype: &JSRef<DocumentType>, html: &mut StrBuf) {
 fn serialize_elem(elem: &JSRef<Element>, open_elements: &mut Vec<~str>, html: &mut StrBuf) {
     html.push_char('<');
     html.push_str(elem.deref().local_name);
-    for attr in elem.deref().attrs.iter() {
+    for attr in elem.deref().attrs.borrow().iter() {
         let attr = attr.root();
         serialize_attr(&*attr, html);
     };

--- a/src/components/script/dom/mouseevent.rs
+++ b/src/components/script/dom/mouseevent.rs
@@ -12,6 +12,7 @@ use dom::eventtarget::EventTarget;
 use dom::uievent::{UIEvent, UIEventMethods};
 use dom::window::Window;
 use servo_util::str::DOMString;
+use std::cell::Cell;
 
 #[deriving(Encodable)]
 pub struct MouseEvent {
@@ -25,7 +26,7 @@ pub struct MouseEvent {
     pub alt_key: bool,
     pub meta_key: bool,
     pub button: u16,
-    pub related_target: Option<JS<EventTarget>>
+    pub related_target: Cell<Option<JS<EventTarget>>>
 }
 
 impl MouseEventDerived for Event {
@@ -47,7 +48,7 @@ impl MouseEvent {
             alt_key: false,
             meta_key: false,
             button: 0,
-            related_target: None
+            related_target: Cell::new(None)
         }
     }
 
@@ -168,7 +169,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
     }
 
     fn GetRelatedTarget(&self) -> Option<Temporary<EventTarget>> {
-        self.related_target.clone().map(|target| Temporary::new(target))
+        self.related_target.get().clone().map(|target| Temporary::new(target))
     }
 
     fn GetModifierState(&self, _keyArg: DOMString) -> bool {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -41,7 +41,7 @@ use libc;
 use libc::uintptr_t;
 use std::cast::transmute;
 use std::cast;
-use std::cell::{RefCell, Ref, RefMut};
+use std::cell::{Cell, RefCell, Ref, RefMut};
 use std::iter::{Map, Filter};
 use std::mem;
 use style::ComputedValues;
@@ -63,25 +63,25 @@ pub struct Node {
     pub type_id: NodeTypeId,
 
     /// The parent of this node.
-    pub parent_node: Option<JS<Node>>,
+    pub parent_node: Cell<Option<JS<Node>>>,
 
     /// The first child of this node.
-    pub first_child: Option<JS<Node>>,
+    pub first_child: Cell<Option<JS<Node>>>,
 
     /// The last child of this node.
-    pub last_child: Option<JS<Node>>,
+    pub last_child: Cell<Option<JS<Node>>>,
 
     /// The next sibling of this node.
-    pub next_sibling: Option<JS<Node>>,
+    pub next_sibling: Cell<Option<JS<Node>>>,
 
     /// The previous sibling of this node.
-    pub prev_sibling: Option<JS<Node>>,
+    pub prev_sibling: Cell<Option<JS<Node>>>,
 
     /// The document that this node belongs to.
-    owner_doc: Option<JS<Document>>,
+    owner_doc: Cell<Option<JS<Document>>>,
 
     /// The live list of children return by .childNodes.
-    pub child_list: Option<JS<NodeList>>,
+    pub child_list: Cell<Option<JS<NodeList>>>,
 
     /// A bitfield of flags for node items.
     flags: NodeFlags,
@@ -327,26 +327,26 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
     ///
     /// Fails unless `child` is a child of this node. (FIXME: This is not yet checked.)
     fn remove_child(&mut self, child: &mut JSRef<Node>) {
-        assert!(child.parent_node.is_some());
+        assert!(child.parent_node.get().is_some());
 
-        match child.prev_sibling.root() {
+        match child.prev_sibling.get().root() {
             None => {
-                let next_sibling = child.next_sibling.root();
+                let next_sibling = child.next_sibling.get().root();
                 self.set_first_child(next_sibling.root_ref());
             }
             Some(ref mut prev_sibling) => {
-                let next_sibling = child.next_sibling.root();
+                let next_sibling = child.next_sibling.get().root();
                 prev_sibling.set_next_sibling(next_sibling.root_ref());
             }
         }
 
-        match child.next_sibling.root() {
+        match child.next_sibling.get().root() {
             None => {
-                let prev_sibling = child.prev_sibling.root();
+                let prev_sibling = child.prev_sibling.get().root();
                 self.set_last_child(prev_sibling.root_ref());
             }
             Some(ref mut next_sibling) => {
-                let prev_sibling = child.prev_sibling.root();
+                let prev_sibling = child.prev_sibling.get().root();
                 next_sibling.set_prev_sibling(prev_sibling.root_ref());
             }
         }
@@ -475,25 +475,25 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
     }
 
     fn parent_node(&self) -> Option<Temporary<Node>> {
-        self.deref().parent_node.clone().map(|node| Temporary::new(node))
+        self.deref().parent_node.get().map(|node| Temporary::new(node))
     }
 
     fn first_child(&self) -> Option<Temporary<Node>> {
-        self.deref().first_child.clone().map(|node| Temporary::new(node))
+        self.deref().first_child.get().map(|node| Temporary::new(node))
     }
 
     fn last_child(&self) -> Option<Temporary<Node>> {
-        self.deref().last_child.clone().map(|node| Temporary::new(node))
+        self.deref().last_child.get().map(|node| Temporary::new(node))
     }
 
     /// Returns the previous sibling of this node. Fails if this node is borrowed mutably.
     fn prev_sibling(&self) -> Option<Temporary<Node>> {
-        self.deref().prev_sibling.clone().map(|node| Temporary::new(node))
+        self.deref().prev_sibling.get().map(|node| Temporary::new(node))
     }
 
     /// Returns the next sibling of this node. Fails if this node is borrowed mutably.
     fn next_sibling(&self) -> Option<Temporary<Node>> {
-        self.deref().next_sibling.clone().map(|node| Temporary::new(node))
+        self.deref().next_sibling.get().map(|node| Temporary::new(node))
     }
 
     #[inline]
@@ -593,12 +593,12 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
 
     fn ancestors(&self) -> AncestorIterator {
         AncestorIterator {
-            current: self.parent_node.clone().map(|node| (*node.root()).clone()),
+            current: self.parent_node.get().map(|node| (*node.root()).clone()),
         }
     }
 
     fn owner_doc(&self) -> Temporary<Document> {
-        Temporary::new(self.owner_doc.get_ref().clone())
+        Temporary::new(self.owner_doc.get().get_ref().clone())
     }
 
     fn set_owner_doc(&mut self, document: &JSRef<Document>) {
@@ -607,7 +607,7 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
 
     fn children(&self) -> AbstractNodeChildrenIterator {
         AbstractNodeChildrenIterator {
-            current_node: self.first_child.clone().map(|node| (*node.root()).clone()),
+            current_node: self.first_child.get().map(|node| (*node.root()).clone()),
         }
     }
 
@@ -654,13 +654,13 @@ pub fn from_untrusted_node_address(runtime: *mut JSRuntime, candidate: Untrusted
 pub trait LayoutNodeHelpers {
     unsafe fn type_id_for_layout(&self) -> NodeTypeId;
 
-    unsafe fn parent_node_ref<'a>(&'a self) -> Option<&'a JS<Node>>;
-    unsafe fn first_child_ref<'a>(&'a self) -> Option<&'a JS<Node>>;
-    unsafe fn last_child_ref<'a>(&'a self) -> Option<&'a JS<Node>>;
-    unsafe fn prev_sibling_ref<'a>(&'a self) -> Option<&'a JS<Node>>;
-    unsafe fn next_sibling_ref<'a>(&'a self) -> Option<&'a JS<Node>>;
+    unsafe fn parent_node_ref<'a>(&'a self) -> Option<JS<Node>>;
+    unsafe fn first_child_ref<'a>(&'a self) -> Option<JS<Node>>;
+    unsafe fn last_child_ref<'a>(&'a self) -> Option<JS<Node>>;
+    unsafe fn prev_sibling_ref<'a>(&'a self) -> Option<JS<Node>>;
+    unsafe fn next_sibling_ref<'a>(&'a self) -> Option<JS<Node>>;
 
-    unsafe fn owner_doc_for_layout<'a>(&'a self) -> &'a JS<Document>;
+    unsafe fn owner_doc_for_layout<'a>(&'a self) -> JS<Document>;
 
     unsafe fn is_element_for_layout(&self) -> bool;
 }
@@ -675,32 +675,32 @@ impl LayoutNodeHelpers for JS<Node> {
     }
 
     #[inline]
-    unsafe fn parent_node_ref<'a>(&'a self) -> Option<&'a JS<Node>> {
-        (*self.unsafe_get()).parent_node.as_ref()
+    unsafe fn parent_node_ref<'a>(&'a self) -> Option<JS<Node>> {
+        (*self.unsafe_get()).parent_node.get()
     }
 
     #[inline]
-    unsafe fn first_child_ref<'a>(&'a self) -> Option<&'a JS<Node>> {
-        (*self.unsafe_get()).first_child.as_ref()
+    unsafe fn first_child_ref<'a>(&'a self) -> Option<JS<Node>> {
+        (*self.unsafe_get()).first_child.get()
     }
 
     #[inline]
-    unsafe fn last_child_ref<'a>(&'a self) -> Option<&'a JS<Node>> {
-        (*self.unsafe_get()).last_child.as_ref()
+    unsafe fn last_child_ref<'a>(&'a self) -> Option<JS<Node>> {
+        (*self.unsafe_get()).last_child.get()
     }
 
     #[inline]
-    unsafe fn prev_sibling_ref<'a>(&'a self) -> Option<&'a JS<Node>> {
-        (*self.unsafe_get()).prev_sibling.as_ref()
+    unsafe fn prev_sibling_ref<'a>(&'a self) -> Option<JS<Node>> {
+        (*self.unsafe_get()).prev_sibling.get()
     }
 
     #[inline]
-    unsafe fn next_sibling_ref<'a>(&'a self) -> Option<&'a JS<Node>> {
-        (*self.unsafe_get()).next_sibling.as_ref()
+    unsafe fn next_sibling_ref<'a>(&'a self) -> Option<JS<Node>> {
+        (*self.unsafe_get()).next_sibling.get()
     }
 
-    unsafe fn owner_doc_for_layout<'a>(&'a self) -> &'a JS<Document> {
-        (*self.unsafe_get()).owner_doc.get_ref()
+    unsafe fn owner_doc_for_layout<'a>(&'a self) -> JS<Document> {
+        (*self.unsafe_get()).owner_doc.get().unwrap()
     }
 }
 
@@ -822,7 +822,7 @@ impl<'a> Iterator<JSRef<'a, Node>> for NodeIterator {
         self.current_node = match self.current_node.as_ref().map(|node| node.root()) {
             None => {
                 if self.include_start {
-                    Some(self.start_node.clone())
+                    Some(self.start_node)
                 } else {
                     self.next_child(&*self.start_node.root())
                         .map(|child| child.unrooted())
@@ -860,7 +860,7 @@ impl<'a> Iterator<JSRef<'a, Node>> for NodeIterator {
                 }
             }
         };
-        self.current_node.clone().map(|node| (*node.root()).clone())
+        self.current_node.map(|node| (*node.root()).clone())
     }
 }
 
@@ -911,14 +911,14 @@ impl Node {
             eventtarget: EventTarget::new_inherited(NodeTargetTypeId(type_id)),
             type_id: type_id,
 
-            parent_node: None,
-            first_child: None,
-            last_child: None,
-            next_sibling: None,
-            prev_sibling: None,
+            parent_node: Cell::new(None),
+            first_child: Cell::new(None),
+            last_child: Cell::new(None),
+            next_sibling: Cell::new(None),
+            prev_sibling: Cell::new(None),
 
-            owner_doc: doc.unrooted(),
-            child_list: None,
+            owner_doc: Cell::new(doc.unrooted()),
+            child_list: Cell::new(None),
 
             flags: NodeFlags::new(type_id),
 
@@ -1427,12 +1427,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
     // http://dom.spec.whatwg.org/#dom-node-parentnode
     fn GetParentNode(&self) -> Option<Temporary<Node>> {
-        self.parent_node.clone().map(|node| Temporary::new(node))
+        self.parent_node.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-parentelement
     fn GetParentElement(&self) -> Option<Temporary<Element>> {
-        self.parent_node.clone()
+        self.parent_node.get()
                         .and_then(|parent| {
                             let parent = parent.root();
                             ElementCast::to_ref(&*parent).map(|elem| {
@@ -1443,12 +1443,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
     // http://dom.spec.whatwg.org/#dom-node-haschildnodes
     fn HasChildNodes(&self) -> bool {
-        self.first_child.is_some()
+        self.first_child.get().is_some()
     }
 
     // http://dom.spec.whatwg.org/#dom-node-childnodes
     fn ChildNodes(&mut self) -> Temporary<NodeList> {
-        match self.child_list {
+        match self.child_list.get() {
             None => (),
             Some(ref list) => return Temporary::new(list.clone()),
         }
@@ -1457,27 +1457,27 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         let window = doc.deref().window.root();
         let child_list = NodeList::new_child_list(&*window, self);
         self.child_list.assign(Some(child_list));
-        Temporary::new(self.child_list.get_ref().clone())
+        Temporary::new(self.child_list.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-node-firstchild
     fn GetFirstChild(&self) -> Option<Temporary<Node>> {
-        self.first_child.clone().map(|node| Temporary::new(node))
+        self.first_child.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lastchild
     fn GetLastChild(&self) -> Option<Temporary<Node>> {
-        self.last_child.clone().map(|node| Temporary::new(node))
+        self.last_child.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-previoussibling
     fn GetPreviousSibling(&self) -> Option<Temporary<Node>> {
-        self.prev_sibling.clone().map(|node| Temporary::new(node))
+        self.prev_sibling.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nextsibling
     fn GetNextSibling(&self) -> Option<Temporary<Node>> {
-        self.next_sibling.clone().map(|node| Temporary::new(node))
+        self.next_sibling.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodevalue

--- a/src/components/script/dom/performance.rs
+++ b/src/components/script/dom/performance.rs
@@ -7,7 +7,6 @@ use dom::bindings::js::{JS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::performancetiming::{PerformanceTiming, PerformanceTimingMethods};
 use dom::window::Window;
-
 use time;
 
 pub type DOMHighResTimeStamp = f64;
@@ -20,9 +19,10 @@ pub struct Performance {
 
 impl Performance {
     fn new_inherited(window: &JSRef<Window>) -> Performance {
+        let timing = PerformanceTiming::new(window).root().root_ref().unrooted();
         Performance {
             reflector_: Reflector::new(),
-            timing: PerformanceTiming::new(window).root().root_ref().unrooted(),
+            timing: timing,
         }
     }
 

--- a/src/components/script/dom/testbinding.rs
+++ b/src/components/script/dom/testbinding.rs
@@ -15,10 +15,12 @@ use servo_util::str::DOMString;
 use js::jsapi::JSContext;
 use js::jsval::{JSVal, NullValue};
 
+use std::cell::Cell;
+
 #[deriving(Encodable)]
 pub struct TestBinding {
     pub reflector: Reflector,
-    pub window: JS<Window>,
+    pub window: Cell<JS<Window>>,
 }
 
 pub trait TestBindingMethods {
@@ -243,19 +245,19 @@ pub trait TestBindingMethods {
 
 impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn InterfaceAttribute(&self) -> Temporary<Blob> {
-        let window = self.window.root();
+        let window = self.window.get().root();
         Blob::new(&*window)
     }
     fn GetInterfaceAttributeNullable(&self) -> Option<Temporary<Blob>> {
-        let window = self.window.root();
+        let window = self.window.get().root();
         Some(Blob::new(&*window))
     }
     fn ReceiveInterface(&self) -> Temporary<Blob> {
-        let window = self.window.root();
+        let window = self.window.get().root();
         Blob::new(&*window)
     }
     fn ReceiveNullableInterface(&self) -> Option<Temporary<Blob>> {
-        let window = self.window.root();
+        let window = self.window.get().root();
         Some(Blob::new(&*window))
     }
 }

--- a/src/components/script/dom/uievent.rs
+++ b/src/components/script/dom/uievent.rs
@@ -86,7 +86,7 @@ pub trait UIEventMethods {
 
 impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
     fn GetView(&self) -> Option<Temporary<Window>> {
-        self.view.clone().map(|view| Temporary::new(view))
+        self.view.map(|view| Temporary::new(view))
     }
 
     fn Detail(&self) -> i32 {

--- a/src/components/script/dom/validitystate.rs
+++ b/src/components/script/dom/validitystate.rs
@@ -6,11 +6,12 @@ use dom::bindings::codegen::BindingDeclarations::ValidityStateBinding;
 use dom::bindings::js::{JS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;
+use std::cell::Cell;
 
 #[deriving(Encodable)]
 pub struct ValidityState {
     pub reflector_: Reflector,
-    pub window: JS<Window>,
+    pub window: Cell<JS<Window>>,
     pub state: u8,
 }
 
@@ -18,7 +19,7 @@ impl ValidityState {
     pub fn new_inherited(window: &JSRef<Window>) -> ValidityState {
         ValidityState {
             reflector_: Reflector::new(),
-            window: window.unrooted(),
+            window: Cell::new(window.unrooted()),
             state: 0,
         }
     }


### PR DESCRIPTION
This change to make `JS<T>` to a POD type about #1854.

Fix #1854

@jdm r?
