### PR TITLE
Move box splitting logic out of box_.rs and into inline.rs

### DIFF
--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -243,6 +243,8 @@ impl ScannedTextBoxInfo {
 
 #[deriving(Show)]
 pub struct SplitInfo {
+    // TODO(bjz): this should only need to be a single character index, but both values are
+    // currently needed for splitting in the `inline::try_append_*` functions.
     pub range: Range<CharIndex>,
     pub width: Au,
 }
@@ -1107,8 +1109,11 @@ impl Box {
     /// A return value of `None` indicates that the box is not splittable.
     /// Otherwise the split information is returned. The right information is
     /// optional due to the possibility of it being whitespace.
+    //
+    // TODO(bjz): The text run should be removed in the future, but it is currently needed for
+    // the current method of box splitting in the `inline::try_append_*` functions.
     pub fn find_split_info_by_new_line(&self)
-            -> Option<(SplitInfo, Option<SplitInfo>, Arc<owned::Box<TextRun>> /* TODO: remove */)> {
+            -> Option<(SplitInfo, Option<SplitInfo>, Arc<owned::Box<TextRun>> /* TODO(bjz): remove */)> {
         match self.specific {
             GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
             TableRowBox | TableWrapperBox => None,
@@ -1144,8 +1149,11 @@ impl Box {
     /// Otherwise the information pertaining to the split is returned. The left
     /// and right split information are both optional due to the possibility of
     /// them being whitespace.
+    //
+    // TODO(bjz): The text run should be removed in the future, but it is currently needed for
+    // the current method of box splitting in the `inline::try_append_*` functions.
     pub fn find_split_info_for_width(&self, start: CharIndex, max_width: Au, starts_line: bool)
-            -> Option<(Option<SplitInfo>, Option<SplitInfo>, Arc<owned::Box<TextRun>> /* TODO: remove */)> {
+            -> Option<(Option<SplitInfo>, Option<SplitInfo>, Arc<owned::Box<TextRun>> /* TODO(bjz): remove */)> {
         match self.specific {
             GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
             TableRowBox | TableWrapperBox => None,

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -1099,7 +1099,7 @@ impl Box {
     /// Otherwise the split information is returned. The right information is
     /// optional due to the possibility of it being whitespace.
     pub fn find_split_info_by_new_line(&self)
-            -> Option<(SplitInfo, Option<SplitInfo>, Arc<~TextRun> /* TODO: remove */)> {
+            -> Option<(SplitInfo, Option<SplitInfo>, Arc<owned::Box<TextRun>> /* TODO: remove */)> {
         match self.specific {
             GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
             TableRowBox | TableWrapperBox => None,
@@ -1142,7 +1142,7 @@ impl Box {
     /// and right split information are both optional due to the possibility of
     /// them being whitespace.
     pub fn find_split_info_for_width(&self, start: CharIndex, max_width: Au, starts_line: bool)
-            -> Option<(Option<SplitInfo>, Option<SplitInfo>, Arc<~TextRun> /* TODO: remove */)> {
+            -> Option<(Option<SplitInfo>, Option<SplitInfo>, Arc<owned::Box<TextRun>> /* TODO: remove */)> {
         match self.specific {
             GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
             TableRowBox | TableWrapperBox => None,

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -247,6 +247,15 @@ pub struct SplitInfo {
     pub width: Au,
 }
 
+impl SplitInfo {
+    fn new(range: Range<CharIndex>, info: &ScannedTextBoxInfo) -> SplitInfo {
+        SplitInfo {
+            range: range,
+            width: info.run.advance_for_range(&range),
+        }
+    }
+}
+
 /// Data for an unscanned text box. Unscanned text boxes are the results of flow construction that
 /// have not yet had their width determined.
 #[deriving(Clone)]
@@ -1114,17 +1123,11 @@ impl Box {
                                              text_box_info.range.length() - (cur_new_line_pos + CharIndex(1)));
 
                 // Left box is for left text of first founded new-line character.
-                let left_box = SplitInfo {
-                    range: left_range,
-                    width: text_box_info.run.advance_for_range(&left_range),
-                };
+                let left_box = SplitInfo::new(left_range, text_box_info);
 
                 // Right box is for right text of first founded new-line character.
                 let right_box = if right_range.length() > CharIndex(0) {
-                    Some(SplitInfo {
-                        range: right_range,
-                        width: text_box_info.run.advance_for_range(&right_range),
-                    })
+                    Some(SplitInfo::new(right_range, text_box_info))
                 } else {
                     None
                 };
@@ -1224,20 +1227,11 @@ impl Box {
                     None
                 } else {
                     let left = if left_is_some {
-                        Some(SplitInfo {
-                            range: left_range,
-                            width: text_box_info.run.advance_for_range(&left_range),
-                        })
+                        Some(SplitInfo::new(left_range, text_box_info))
                     } else {
-                        None
+                         None
                     };
-
-                    let right = right_range.map(|right_range| {
-                        SplitInfo {
-                            range: right_range,
-                            width: text_box_info.run.advance_for_range(&right_range),
-                        }
-                    });
+                    let right = right_range.map(|right_range| SplitInfo::new(right_range, text_box_info));
 
                     Some((left, right, text_box_info.run.clone()))
                 }

--- a/src/components/main/layout/box_.rs
+++ b/src/components/main/layout/box_.rs
@@ -1098,7 +1098,7 @@ impl Box {
     /// A return value of `None` indicates that the box is not splittable.
     /// Otherwise the split information is returned. The right information is
     /// optional due to the possibility of it being whitespace.
-    pub fn find_split_positions_by_new_line(&self)
+    pub fn find_split_info_by_new_line(&self)
             -> Option<(SplitInfo, Option<SplitInfo>, Arc<~TextRun> /* TODO: remove */)> {
         match self.specific {
             GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |
@@ -1141,7 +1141,7 @@ impl Box {
     /// Otherwise the information pertaining to the split is returned. The left
     /// and right split information are both optional due to the possibility of
     /// them being whitespace.
-    pub fn find_split_positions(&self, start: CharIndex, max_width: Au, starts_line: bool)
+    pub fn find_split_info_for_width(&self, start: CharIndex, max_width: Au, starts_line: bool)
             -> Option<(Option<SplitInfo>, Option<SplitInfo>, Arc<~TextRun> /* TODO: remove */)> {
         match self.specific {
             GenericBox | IframeBox(_) | ImageBox(_) | TableBox | TableCellBox |

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use css::node_style::StyledNode;
-use layout::box_::{Box, ScannedTextBox, ScannedTextBoxInfo};
+use layout::box_::{Box, ScannedTextBox, ScannedTextBoxInfo, SplitInfo};
 use layout::context::LayoutContext;
 use layout::floats::{FloatLeft, Floats, PlacementInfo};
 use layout::flow::{BaseFlow, FlowClass, Flow, InlineFlowClass};
@@ -494,16 +494,16 @@ impl LineboxScanner {
         let available_width = green_zone.width - self.pending_line.bounds.size.width;
         match in_box.find_split_positions(CharIndex(0), available_width, line_is_empty).map(
             |(left, right, run)| {
-                let make_box = |(range, width): (Range<CharIndex>, Au)| {
-                    let info = ScannedTextBoxInfo::new(run.clone(), range);
+                // TODO: Remove box splitting
+                let split_box = |split: SplitInfo| {
+                    let info = ScannedTextBoxInfo::new(run.clone(), split.range);
                     let specific = ScannedTextBox(info);
-                    let size = Size2D(width, in_box.border_box.size.height);
-                    // TODO: Remove box splitting
+                    let size = Size2D(split.width, in_box.border_box.size.height);
                     in_box.transform(size, specific)
                 };
 
-                (left.map(|x|  { debug!("LineboxScanner: Left split {}",  x); make_box(x) }),
-                 right.map(|x| { debug!("LineboxScanner: Right split {}", x); make_box(x) }))
+                (left.map(|x| { debug!("LineboxScanner: Left split {}", x); split_box(x) }),
+                 right.map(|x| { debug!("LineboxScanner: Right split {}", x); split_box(x) }))
             }
         ) {
             None => {

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -427,7 +427,7 @@ impl LineboxScanner {
             debug!("LineboxScanner: Found a new-line character, so splitting theline.");
             match in_box.find_split_info_by_new_line() {
                 Some((left, right, run)) => {
-                    // TODO: Remove box splitting
+                    // TODO(bjz): Remove box splitting
                     let split_box = |split: SplitInfo| {
                         let info = ScannedTextBoxInfo::new(run.clone(), split.range);
                         let specific = ScannedTextBox(info);
@@ -511,7 +511,7 @@ impl LineboxScanner {
         let available_width = green_zone.width - self.pending_line.bounds.size.width;
         match in_box.find_split_info_for_width(CharIndex(0), available_width, line_is_empty).map(
             |(left, right, run)| {
-                // TODO: Remove box splitting
+                // TODO(bjz): Remove box splitting
                 let split_box = |split: SplitInfo| {
                     let info = ScannedTextBoxInfo::new(run.clone(), split.range);
                     let specific = ScannedTextBox(info);

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -425,7 +425,7 @@ impl LineboxScanner {
             true
         } else {
             debug!("LineboxScanner: Found a new-line character, so splitting theline.");
-            match in_box.split_by_new_line() {
+            match in_box.find_split_info_by_new_line() {
                 Some((left, right, run)) => {
                     // TODO: Remove box splitting
                     let split_box = |split: SplitInfo| {
@@ -509,7 +509,7 @@ impl LineboxScanner {
         }
 
         let available_width = green_zone.width - self.pending_line.bounds.size.width;
-        match in_box.find_split_positions(CharIndex(0), available_width, line_is_empty).map(
+        match in_box.find_split_info_for_width(CharIndex(0), available_width, line_is_empty).map(
             |(left, right, run)| {
                 // TODO: Remove box splitting
                 let split_box = |split: SplitInfo| {

--- a/src/components/main/layout/inline.rs
+++ b/src/components/main/layout/inline.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use css::node_style::StyledNode;
-use layout::box_::Box;
+use layout::box_::{Box, ScannedTextBox, ScannedTextBoxInfo};
 use layout::context::LayoutContext;
 use layout::floats::{FloatLeft, Floats, PlacementInfo};
 use layout::flow::{BaseFlow, FlowClass, Flow, InlineFlowClass};
@@ -492,7 +492,20 @@ impl LineboxScanner {
         }
 
         let available_width = green_zone.width - self.pending_line.bounds.size.width;
-        match in_box.split_to_width(available_width, line_is_empty) {
+        match in_box.find_split_positions(CharIndex(0), available_width, line_is_empty).map(
+            |(left, right, run)| {
+                let make_box = |(range, width): (Range<CharIndex>, Au)| {
+                    let info = ScannedTextBoxInfo::new(run.clone(), range);
+                    let specific = ScannedTextBox(info);
+                    let size = Size2D(width, in_box.border_box.size.height);
+                    // TODO: Remove box splitting
+                    in_box.transform(size, specific)
+                };
+
+                (left.map(|x|  { debug!("LineboxScanner: Left split {}",  x); make_box(x) }),
+                 right.map(|x| { debug!("LineboxScanner: Right split {}", x); make_box(x) }))
+            }
+        ) {
             None => {
                 debug!("LineboxScanner: Tried to split unsplittable render box! Deferring to next \
                        line. {}", in_box);


### PR DESCRIPTION
This will make removing the box splitting logic easier to implement. I am also using a `SplitInfo` struct for returning the split results, which should make the code more self-documenting. In the future the `TextRun` should not be returned, and `SplitInfo` should only require a single `CharIndex`, but one thing at a time...

@pcwalton r?
