### PR TITLE
"JS<T>::from_raw" should accept "*T" instead of "*mut T"

### DIFF
--- a/src/components/script/dom/bindings/js.rs
+++ b/src/components/script/dom/bindings/js.rs
@@ -150,9 +150,9 @@ impl JS<XMLHttpRequest> {
 
 impl<T: Reflectable> JS<T> {
     /// Create a new JS-owned value wrapped from a raw Rust pointer.
-    pub unsafe fn from_raw(raw: *mut T) -> JS<T> {
+    pub unsafe fn from_raw(raw: *T) -> JS<T> {
         JS {
-            ptr: raw as *T
+            ptr: raw
         }
     }
 

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -84,10 +84,10 @@ pub unsafe fn dom_object_slot(obj: *mut JSObject) -> u32 {
     }
 }
 
-pub unsafe fn unwrap<T>(obj: *mut JSObject) -> *mut T {
+pub unsafe fn unwrap<T>(obj: *mut JSObject) -> *T {
     let slot = dom_object_slot(obj);
     let val = JS_GetReservedSlot(obj, slot);
-    val.to_private() as *mut T
+    val.to_private() as *T
 }
 
 pub unsafe fn get_dom_class(obj: *mut JSObject) -> Result<DOMClass, ()> {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -646,7 +646,7 @@ pub fn from_untrusted_node_address(runtime: *mut JSRuntime, candidate: Untrusted
         if object.is_null() {
             fail!("Attempted to create a `JS<Node>` from an invalid pointer!")
         }
-        let boxed_node: *mut Node = utils::unwrap(object);
+        let boxed_node: *Node = utils::unwrap(object);
         Temporary::new(JS::from_raw(boxed_node))
     }
 }

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -70,7 +70,7 @@ pub struct TrustedNodeAddress(pub *c_void);
 impl<S: Encoder<E>, E> Encodable<S, E> for TrustedNodeAddress {
     fn encode(&self, s: &mut S) -> Result<(), E> {
         let TrustedNodeAddress(addr) = *self;
-        let node = addr as *Node as *mut Node;
+        let node = addr as *Node;
         unsafe {
             JS::from_raw(node).encode(s)
         }


### PR DESCRIPTION
Fix #2511

@jdm r?
