### PR TITLE
Remove needless '&mut self' from DOM type methods

### DIFF
--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -44,7 +44,7 @@ impl HTMLAnchorElement {
 
 pub trait HTMLAnchorElementMethods {
     fn Href(&self) -> DOMString;
-    fn SetHref(&mut self, _href: DOMString) -> ErrorResult;
+    fn SetHref(&self, _href: DOMString) -> ErrorResult;
     fn Target(&self) -> DOMString;
     fn SetTarget(&self, _target: DOMString) -> ErrorResult;
     fn Download(&self) -> DOMString;
@@ -56,19 +56,19 @@ pub trait HTMLAnchorElementMethods {
     fn Hreflang(&self) -> DOMString;
     fn SetHreflang(&self, _href_lang: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Text(&self) -> DOMString;
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult;
+    fn SetText(&self, _text: DOMString) -> ErrorResult;
     fn Coords(&self) -> DOMString;
-    fn SetCoords(&mut self, _coords: DOMString) -> ErrorResult;
+    fn SetCoords(&self, _coords: DOMString) -> ErrorResult;
     fn Charset(&self) -> DOMString;
-    fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult;
+    fn SetCharset(&self, _charset: DOMString) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Rev(&self) -> DOMString;
-    fn SetRev(&mut self, _rev: DOMString) -> ErrorResult;
+    fn SetRev(&self, _rev: DOMString) -> ErrorResult;
     fn Shape(&self) -> DOMString;
-    fn SetShape(&mut self, _shape: DOMString) -> ErrorResult;
+    fn SetShape(&self, _shape: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
@@ -76,7 +76,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetHref(&mut self, _href: DOMString) -> ErrorResult {
+    fn SetHref(&self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -124,7 +124,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -132,7 +132,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult {
+    fn SetText(&self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -140,7 +140,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetCoords(&mut self, _coords: DOMString) -> ErrorResult {
+    fn SetCoords(&self, _coords: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -148,7 +148,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult {
+    fn SetCharset(&self, _charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -156,7 +156,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -164,7 +164,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetRev(&mut self, _rev: DOMString) -> ErrorResult {
+    fn SetRev(&self, _rev: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -172,7 +172,7 @@ impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
         "".to_owned()
     }
 
-    fn SetShape(&mut self, _shape: DOMString) -> ErrorResult {
+    fn SetShape(&self, _shape: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlappletelement.rs
+++ b/src/components/script/dom/htmlappletelement.rs
@@ -39,7 +39,7 @@ impl HTMLAppletElement {
 
 pub trait HTMLAppletElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn Alt(&self) -> DOMString;
     fn SetAlt(&self, _alt: DOMString) -> ErrorResult;
     fn Archive(&self) -> DOMString;
@@ -51,15 +51,15 @@ pub trait HTMLAppletElementMethods {
     fn Height(&self) -> DOMString;
     fn SetHeight(&self, _height: DOMString) -> ErrorResult;
     fn Hspace(&self) -> u32;
-    fn SetHspace(&mut self, _hspace: u32) -> ErrorResult;
+    fn SetHspace(&self, _hspace: u32) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Object(&self) -> DOMString;
-    fn SetObject(&mut self, _object: DOMString) -> ErrorResult;
+    fn SetObject(&self, _object: DOMString) -> ErrorResult;
     fn Vspace(&self) -> u32;
-    fn SetVspace(&mut self, _vspace: u32) -> ErrorResult;
+    fn SetVspace(&self, _vspace: u32) -> ErrorResult;
     fn Width(&self) -> DOMString;
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult;
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
@@ -67,7 +67,7 @@ impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -115,7 +115,7 @@ impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
         0
     }
 
-    fn SetHspace(&mut self, _hspace: u32) -> ErrorResult {
+    fn SetHspace(&self, _hspace: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -123,7 +123,7 @@ impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -131,7 +131,7 @@ impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
         "".to_owned()
     }
 
-    fn SetObject(&mut self, _object: DOMString) -> ErrorResult {
+    fn SetObject(&self, _object: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -139,7 +139,7 @@ impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
         0
     }
 
-    fn SetVspace(&mut self, _vspace: u32) -> ErrorResult {
+    fn SetVspace(&self, _vspace: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -147,7 +147,7 @@ impl<'a> HTMLAppletElementMethods for JSRef<'a, HTMLAppletElement> {
         "".to_owned()
     }
 
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -53,7 +53,7 @@ pub trait HTMLAreaElementMethods {
     fn Ping(&self) -> DOMString;
     fn SetPing(&self, _ping: DOMString) -> ErrorResult;
     fn NoHref(&self) -> bool;
-    fn SetNoHref(&mut self, _no_href: bool) -> ErrorResult;
+    fn SetNoHref(&self, _no_href: bool) -> ErrorResult;
 }
 
 impl<'a> HTMLAreaElementMethods for JSRef<'a, HTMLAreaElement> {
@@ -117,7 +117,7 @@ impl<'a> HTMLAreaElementMethods for JSRef<'a, HTMLAreaElement> {
         false
     }
 
-    fn SetNoHref(&mut self, _no_href: bool) -> ErrorResult {
+    fn SetNoHref(&self, _no_href: bool) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlbrelement.rs
+++ b/src/components/script/dom/htmlbrelement.rs
@@ -39,7 +39,7 @@ impl HTMLBRElement {
 
 pub trait HTMLBRElementMethods {
     fn Clear(&self) -> DOMString;
-    fn SetClear(&mut self, _text: DOMString) -> ErrorResult;
+    fn SetClear(&self, _text: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLBRElementMethods for JSRef<'a, HTMLBRElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLBRElementMethods for JSRef<'a, HTMLBRElement> {
         "".to_owned()
     }
 
-    fn SetClear(&mut self, _text: DOMString) -> ErrorResult {
+    fn SetClear(&self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -41,33 +41,33 @@ impl HTMLButtonElement {
 
 pub trait HTMLButtonElementMethods {
     fn Autofocus(&self) -> bool;
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult;
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult;
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn GetForm(&self) -> Option<Temporary<HTMLFormElement>>;
     fn FormAction(&self) -> DOMString;
-    fn SetFormAction(&mut self, _formaction: DOMString) -> ErrorResult;
+    fn SetFormAction(&self, _formaction: DOMString) -> ErrorResult;
     fn FormEnctype(&self) -> DOMString;
-    fn SetFormEnctype(&mut self, _formenctype: DOMString) -> ErrorResult;
+    fn SetFormEnctype(&self, _formenctype: DOMString) -> ErrorResult;
     fn FormMethod(&self) -> DOMString;
-    fn SetFormMethod(&mut self, _formmethod: DOMString) -> ErrorResult;
+    fn SetFormMethod(&self, _formmethod: DOMString) -> ErrorResult;
     fn FormNoValidate(&self) -> bool;
-    fn SetFormNoValidate(&mut self, _novalidate: bool) -> ErrorResult;
+    fn SetFormNoValidate(&self, _novalidate: bool) -> ErrorResult;
     fn FormTarget(&self) -> DOMString;
-    fn SetFormTarget(&mut self, _formtarget: DOMString) -> ErrorResult;
+    fn SetFormTarget(&self, _formtarget: DOMString) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetValue(&self, _value: DOMString) -> ErrorResult;
     fn WillValidate(&self) -> bool;
-    fn SetWillValidate(&mut self, _will_validate: bool);
+    fn SetWillValidate(&self, _will_validate: bool);
     fn Validity(&self) -> Temporary<ValidityState>;
     fn ValidationMessage(&self) -> DOMString;
-    fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult;
+    fn SetValidationMessage(&self, _message: DOMString) -> ErrorResult;
     fn CheckValidity(&self) -> bool;
-    fn SetCustomValidity(&mut self, _error: DOMString);
+    fn SetCustomValidity(&self, _error: DOMString);
 }
 
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
@@ -75,7 +75,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         false
     }
 
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult {
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -83,7 +83,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -95,7 +95,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetFormAction(&mut self, _formaction: DOMString) -> ErrorResult {
+    fn SetFormAction(&self, _formaction: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -103,7 +103,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetFormEnctype(&mut self, _formenctype: DOMString) -> ErrorResult {
+    fn SetFormEnctype(&self, _formenctype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -111,7 +111,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetFormMethod(&mut self, _formmethod: DOMString) -> ErrorResult {
+    fn SetFormMethod(&self, _formmethod: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -119,7 +119,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         false
     }
 
-    fn SetFormNoValidate(&mut self, _novalidate: bool) -> ErrorResult {
+    fn SetFormNoValidate(&self, _novalidate: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -127,7 +127,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetFormTarget(&mut self, _formtarget: DOMString) -> ErrorResult {
+    fn SetFormTarget(&self, _formtarget: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -135,7 +135,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -143,7 +143,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -151,7 +151,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -159,7 +159,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         false
     }
 
-    fn SetWillValidate(&mut self, _will_validate: bool) {
+    fn SetWillValidate(&self, _will_validate: bool) {
     }
 
     fn Validity(&self) -> Temporary<ValidityState> {
@@ -171,7 +171,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         "".to_owned()
     }
 
-    fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult {
+    fn SetValidationMessage(&self, _message: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -179,6 +179,6 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         true
     }
 
-    fn SetCustomValidity(&mut self, _error: DOMString) {
+    fn SetCustomValidity(&self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlcanvaselement.rs
+++ b/src/components/script/dom/htmlcanvaselement.rs
@@ -39,9 +39,9 @@ impl HTMLCanvasElement {
 
 pub trait HTMLCanvasElementMethods {
     fn Width(&self) -> u32;
-    fn SetWidth(&mut self, _width: u32) -> ErrorResult;
+    fn SetWidth(&self, _width: u32) -> ErrorResult;
     fn Height(&self) -> u32;
-    fn SetHeight(&mut self, _height: u32) -> ErrorResult;
+    fn SetHeight(&self, _height: u32) -> ErrorResult;
 }
 
 impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
         0
     }
 
-    fn SetWidth(&mut self, _width: u32) -> ErrorResult {
+    fn SetWidth(&self, _width: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
         0
     }
 
-    fn SetHeight(&mut self, _height: u32) -> ErrorResult {
+    fn SetHeight(&self, _height: u32) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmldataelement.rs
+++ b/src/components/script/dom/htmldataelement.rs
@@ -39,7 +39,7 @@ impl HTMLDataElement {
 
 pub trait HTMLDataElementMethods {
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetValue(&self, _value: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLDataElementMethods for JSRef<'a, HTMLDataElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLDataElementMethods for JSRef<'a, HTMLDataElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmldirectoryelement.rs
+++ b/src/components/script/dom/htmldirectoryelement.rs
@@ -39,7 +39,7 @@ impl HTMLDirectoryElement {
 
 pub trait HTMLDirectoryElementMethods {
     fn Compact(&self) -> bool;
-    fn SetCompact(&mut self, _compact: bool) -> ErrorResult;
+    fn SetCompact(&self, _compact: bool) -> ErrorResult;
 }
 
 impl<'a> HTMLDirectoryElementMethods for JSRef<'a, HTMLDirectoryElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLDirectoryElementMethods for JSRef<'a, HTMLDirectoryElement> {
         false
     }
 
-    fn SetCompact(&mut self, _compact: bool) -> ErrorResult {
+    fn SetCompact(&self, _compact: bool) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmldivelement.rs
+++ b/src/components/script/dom/htmldivelement.rs
@@ -39,7 +39,7 @@ impl HTMLDivElement {
 
 pub trait HTMLDivElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLDivElementMethods for JSRef<'a, HTMLDivElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLDivElementMethods for JSRef<'a, HTMLDivElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmldlistelement.rs
+++ b/src/components/script/dom/htmldlistelement.rs
@@ -39,9 +39,9 @@ impl HTMLDListElement {
 
 pub trait HTMLDListElementMethods {
     fn Compact(&self) -> bool;
-    fn SetCompact(&mut self, _compact: bool) -> ErrorResult;
+    fn SetCompact(&self, _compact: bool) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLDListElementMethods for JSRef<'a, HTMLDListElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLDListElementMethods for JSRef<'a, HTMLDListElement> {
         false
     }
 
-    fn SetCompact(&mut self, _compact: bool) -> ErrorResult {
+    fn SetCompact(&self, _compact: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLDListElementMethods for JSRef<'a, HTMLDListElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlembedelement.rs
+++ b/src/components/script/dom/htmlembedelement.rs
@@ -39,17 +39,17 @@ impl HTMLEmbedElement {
 
 pub trait HTMLEmbedElementMethods {
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Width(&self) -> DOMString;
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult;
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult;
     fn Height(&self) -> DOMString;
-    fn SetHeight(&mut self, _height: DOMString) -> ErrorResult;
+    fn SetHeight(&self, _height: DOMString) -> ErrorResult;
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _type: DOMString) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetName(&self, _type: DOMString) -> ErrorResult;
     fn GetSVGDocument(&self) -> Option<Temporary<Document>>;
 }
 
@@ -58,7 +58,7 @@ impl<'a> HTMLEmbedElementMethods for JSRef<'a, HTMLEmbedElement> {
         "".to_owned()
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -66,7 +66,7 @@ impl<'a> HTMLEmbedElementMethods for JSRef<'a, HTMLEmbedElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -74,7 +74,7 @@ impl<'a> HTMLEmbedElementMethods for JSRef<'a, HTMLEmbedElement> {
         "".to_owned()
     }
 
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl<'a> HTMLEmbedElementMethods for JSRef<'a, HTMLEmbedElement> {
         "".to_owned()
     }
 
-    fn SetHeight(&mut self, _height: DOMString) -> ErrorResult {
+    fn SetHeight(&self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -90,7 +90,7 @@ impl<'a> HTMLEmbedElementMethods for JSRef<'a, HTMLEmbedElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -98,7 +98,7 @@ impl<'a> HTMLEmbedElementMethods for JSRef<'a, HTMLEmbedElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetName(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlfieldsetelement.rs
+++ b/src/components/script/dom/htmlfieldsetelement.rs
@@ -42,17 +42,17 @@ impl HTMLFieldSetElement {
 
 pub trait HTMLFieldSetElementMethods {
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn GetForm(&self) -> Option<Temporary<HTMLFormElement>>;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
     fn Elements(&self) -> Temporary<HTMLCollection>;
     fn WillValidate(&self) -> bool;
     fn Validity(&self) -> Temporary<ValidityState>;
     fn ValidationMessage(&self) -> DOMString;
     fn CheckValidity(&self) -> bool;
-    fn SetCustomValidity(&mut self, _error: DOMString);
+    fn SetCustomValidity(&self, _error: DOMString);
 }
 
 impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
@@ -60,7 +60,7 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -72,7 +72,7 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -114,6 +114,6 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
         false
     }
 
-    fn SetCustomValidity(&mut self, _error: DOMString) {
+    fn SetCustomValidity(&self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlfontelement.rs
+++ b/src/components/script/dom/htmlfontelement.rs
@@ -39,11 +39,11 @@ impl HTMLFontElement {
 
 pub trait HTMLFontElementMethods {
     fn Color(&self) -> DOMString;
-    fn SetColor(&mut self, _color: DOMString) -> ErrorResult;
+    fn SetColor(&self, _color: DOMString) -> ErrorResult;
     fn Face(&self) -> DOMString;
-    fn SetFace(&mut self, _face: DOMString) -> ErrorResult;
+    fn SetFace(&self, _face: DOMString) -> ErrorResult;
     fn Size(&self) -> DOMString;
-    fn SetSize(&mut self, _size: DOMString) -> ErrorResult;
+    fn SetSize(&self, _size: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLFontElementMethods for JSRef<'a, HTMLFontElement> {
@@ -51,7 +51,7 @@ impl<'a> HTMLFontElementMethods for JSRef<'a, HTMLFontElement> {
         "".to_owned()
     }
 
-    fn SetColor(&mut self, _color: DOMString) -> ErrorResult {
+    fn SetColor(&self, _color: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -59,7 +59,7 @@ impl<'a> HTMLFontElementMethods for JSRef<'a, HTMLFontElement> {
         "".to_owned()
     }
 
-    fn SetFace(&mut self, _face: DOMString) -> ErrorResult {
+    fn SetFace(&self, _face: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -67,7 +67,7 @@ impl<'a> HTMLFontElementMethods for JSRef<'a, HTMLFontElement> {
         "".to_owned()
     }
 
-    fn SetSize(&mut self, _size: DOMString) -> ErrorResult {
+    fn SetSize(&self, _size: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlformelement.rs
+++ b/src/components/script/dom/htmlformelement.rs
@@ -40,23 +40,23 @@ impl HTMLFormElement {
 
 pub trait HTMLFormElementMethods {
     fn AcceptCharset(&self) -> DOMString;
-    fn SetAcceptCharset(&mut self, _accept_charset: DOMString) -> ErrorResult;
+    fn SetAcceptCharset(&self, _accept_charset: DOMString) -> ErrorResult;
     fn Action(&self) -> DOMString;
-    fn SetAction(&mut self, _action: DOMString) -> ErrorResult;
+    fn SetAction(&self, _action: DOMString) -> ErrorResult;
     fn Autocomplete(&self) -> DOMString;
-    fn SetAutocomplete(&mut self, _autocomplete: DOMString) -> ErrorResult;
+    fn SetAutocomplete(&self, _autocomplete: DOMString) -> ErrorResult;
     fn Enctype(&self) -> DOMString;
-    fn SetEnctype(&mut self, _enctype: DOMString) -> ErrorResult;
+    fn SetEnctype(&self, _enctype: DOMString) -> ErrorResult;
     fn Encoding(&self) -> DOMString;
-    fn SetEncoding(&mut self, _encoding: DOMString) -> ErrorResult;
+    fn SetEncoding(&self, _encoding: DOMString) -> ErrorResult;
     fn Method(&self) -> DOMString;
-    fn SetMethod(&mut self, _method: DOMString) -> ErrorResult;
+    fn SetMethod(&self, _method: DOMString) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn NoValidate(&self) -> bool;
-    fn SetNoValidate(&mut self, _no_validate: bool) -> ErrorResult;
+    fn SetNoValidate(&self, _no_validate: bool) -> ErrorResult;
     fn Target(&self) -> DOMString;
-    fn SetTarget(&mut self, _target: DOMString) -> ErrorResult;
+    fn SetTarget(&self, _target: DOMString) -> ErrorResult;
     fn Elements(&self) -> Temporary<HTMLCollection>;
     fn Length(&self) -> i32;
     fn Submit(&self) -> ErrorResult;
@@ -70,7 +70,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetAcceptCharset(&mut self, _accept_charset: DOMString) -> ErrorResult {
+    fn SetAcceptCharset(&self, _accept_charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -78,7 +78,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetAction(&mut self, _action: DOMString) -> ErrorResult {
+    fn SetAction(&self, _action: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -86,7 +86,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetAutocomplete(&mut self, _autocomplete: DOMString) -> ErrorResult {
+    fn SetAutocomplete(&self, _autocomplete: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetEnctype(&mut self, _enctype: DOMString) -> ErrorResult {
+    fn SetEnctype(&self, _enctype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -102,7 +102,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetEncoding(&mut self, _encoding: DOMString) -> ErrorResult {
+    fn SetEncoding(&self, _encoding: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -110,7 +110,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetMethod(&mut self, _method: DOMString) -> ErrorResult {
+    fn SetMethod(&self, _method: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -118,7 +118,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -126,7 +126,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         false
     }
 
-    fn SetNoValidate(&mut self, _no_validate: bool) -> ErrorResult {
+    fn SetNoValidate(&self, _no_validate: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -134,7 +134,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
         "".to_owned()
     }
 
-    fn SetTarget(&mut self, _target: DOMString) -> ErrorResult {
+    fn SetTarget(&self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlframeelement.rs
+++ b/src/components/script/dom/htmlframeelement.rs
@@ -40,23 +40,23 @@ impl HTMLFrameElement {
 
 pub trait HTMLFrameElementMethods {
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Scrolling(&self) -> DOMString;
-    fn SetScrolling(&mut self, _scrolling: DOMString) -> ErrorResult;
+    fn SetScrolling(&self, _scrolling: DOMString) -> ErrorResult;
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn FrameBorder(&self) -> DOMString;
-    fn SetFrameBorder(&mut self, _frameborder: DOMString) -> ErrorResult;
+    fn SetFrameBorder(&self, _frameborder: DOMString) -> ErrorResult;
     fn LongDesc(&self) -> DOMString;
-    fn SetLongDesc(&mut self, _longdesc: DOMString) -> ErrorResult;
+    fn SetLongDesc(&self, _longdesc: DOMString) -> ErrorResult;
     fn NoResize(&self) -> bool;
-    fn SetNoResize(&mut self, _no_resize: bool) -> ErrorResult;
+    fn SetNoResize(&self, _no_resize: bool) -> ErrorResult;
     fn GetContentDocument(&self) -> Option<Temporary<Document>>;
     fn GetContentWindow(&self) -> Option<Temporary<Window>>;
     fn MarginHeight(&self) -> DOMString;
-    fn SetMarginHeight(&mut self, _height: DOMString) -> ErrorResult;
+    fn SetMarginHeight(&self, _height: DOMString) -> ErrorResult;
     fn MarginWidth(&self) -> DOMString;
-    fn SetMarginWidth(&mut self, _height: DOMString) -> ErrorResult;
+    fn SetMarginWidth(&self, _height: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
@@ -64,7 +64,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -72,7 +72,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetScrolling(&mut self, _scrolling: DOMString) -> ErrorResult {
+    fn SetScrolling(&self, _scrolling: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetFrameBorder(&mut self, _frameborder: DOMString) -> ErrorResult {
+    fn SetFrameBorder(&self, _frameborder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetLongDesc(&mut self, _longdesc: DOMString) -> ErrorResult {
+    fn SetLongDesc(&self, _longdesc: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -104,7 +104,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         false
     }
 
-    fn SetNoResize(&mut self, _no_resize: bool) -> ErrorResult {
+    fn SetNoResize(&self, _no_resize: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -120,7 +120,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetMarginHeight(&mut self, _height: DOMString) -> ErrorResult {
+    fn SetMarginHeight(&self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -128,7 +128,7 @@ impl<'a> HTMLFrameElementMethods for JSRef<'a, HTMLFrameElement> {
         "".to_owned()
     }
 
-    fn SetMarginWidth(&mut self, _height: DOMString) -> ErrorResult {
+    fn SetMarginWidth(&self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlframesetelement.rs
+++ b/src/components/script/dom/htmlframesetelement.rs
@@ -39,9 +39,9 @@ impl HTMLFrameSetElement {
 
 pub trait HTMLFrameSetElementMethods {
     fn Cols(&self) -> DOMString;
-    fn SetCols(&mut self, _cols: DOMString) -> ErrorResult;
+    fn SetCols(&self, _cols: DOMString) -> ErrorResult;
     fn Rows(&self) -> DOMString;
-    fn SetRows(&mut self, _rows: DOMString) -> ErrorResult;
+    fn SetRows(&self, _rows: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLFrameSetElementMethods for JSRef<'a, HTMLFrameSetElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLFrameSetElementMethods for JSRef<'a, HTMLFrameSetElement> {
         "".to_owned()
     }
 
-    fn SetCols(&mut self, _cols: DOMString) -> ErrorResult {
+    fn SetCols(&self, _cols: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLFrameSetElementMethods for JSRef<'a, HTMLFrameSetElement> {
         "".to_owned()
     }
 
-    fn SetRows(&mut self, _rows: DOMString) -> ErrorResult {
+    fn SetRows(&self, _rows: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlheadingelement.rs
+++ b/src/components/script/dom/htmlheadingelement.rs
@@ -50,7 +50,7 @@ impl HTMLHeadingElement {
 
 pub trait HTMLHeadingElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString);
+    fn SetAlign(&self, _align: DOMString);
 }
 
 impl<'a> HTMLHeadingElementMethods for JSRef<'a, HTMLHeadingElement> {
@@ -58,6 +58,6 @@ impl<'a> HTMLHeadingElementMethods for JSRef<'a, HTMLHeadingElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) {
+    fn SetAlign(&self, _align: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlhrelement.rs
+++ b/src/components/script/dom/htmlhrelement.rs
@@ -39,15 +39,15 @@ impl HTMLHRElement {
 
 pub trait HTMLHRElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn Color(&self) -> DOMString;
-    fn SetColor(&mut self, _color: DOMString) -> ErrorResult;
+    fn SetColor(&self, _color: DOMString) -> ErrorResult;
     fn NoShade(&self) -> bool;
     fn SetNoShade(&self, _no_shade: bool) -> ErrorResult;
     fn Size(&self) -> DOMString;
-    fn SetSize(&mut self, _size: DOMString) -> ErrorResult;
+    fn SetSize(&self, _size: DOMString) -> ErrorResult;
     fn Width(&self) -> DOMString;
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult;
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLHRElementMethods for JSRef<'a, HTMLHRElement> {
@@ -55,7 +55,7 @@ impl<'a> HTMLHRElementMethods for JSRef<'a, HTMLHRElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -63,7 +63,7 @@ impl<'a> HTMLHRElementMethods for JSRef<'a, HTMLHRElement> {
         "".to_owned()
     }
 
-    fn SetColor(&mut self, _color: DOMString) -> ErrorResult {
+    fn SetColor(&self, _color: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -79,7 +79,7 @@ impl<'a> HTMLHRElementMethods for JSRef<'a, HTMLHRElement> {
         "".to_owned()
     }
 
-    fn SetSize(&mut self, _size: DOMString) -> ErrorResult {
+    fn SetSize(&self, _size: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -87,7 +87,7 @@ impl<'a> HTMLHRElementMethods for JSRef<'a, HTMLHRElement> {
         "".to_owned()
     }
 
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlhtmlelement.rs
+++ b/src/components/script/dom/htmlhtmlelement.rs
@@ -39,7 +39,7 @@ impl HTMLHtmlElement {
 
 pub trait HTMLHtmlElementMethods {
     fn Version(&self) -> DOMString;
-    fn SetVersion(&mut self, _version: DOMString) -> ErrorResult;
+    fn SetVersion(&self, _version: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLHtmlElementMethods for JSRef<'a, HTMLHtmlElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLHtmlElementMethods for JSRef<'a, HTMLHtmlElement> {
         "".to_owned()
     }
 
-    fn SetVersion(&mut self, _version: DOMString) -> ErrorResult {
+    fn SetVersion(&self, _version: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -39,67 +39,67 @@ impl HTMLInputElement {
 
 pub trait HTMLInputElementMethods {
     fn Accept(&self) -> DOMString;
-    fn SetAccept(&mut self, _accept: DOMString) -> ErrorResult;
+    fn SetAccept(&self, _accept: DOMString) -> ErrorResult;
     fn Alt(&self) -> DOMString;
-    fn SetAlt(&mut self, _alt: DOMString) -> ErrorResult;
+    fn SetAlt(&self, _alt: DOMString) -> ErrorResult;
     fn Autocomplete(&self) -> DOMString;
-    fn SetAutocomplete(&mut self, _autocomple: DOMString) -> ErrorResult;
+    fn SetAutocomplete(&self, _autocomple: DOMString) -> ErrorResult;
     fn Autofocus(&self) -> bool;
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult;
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult;
     fn DefaultChecked(&self) -> bool;
-    fn SetDefaultChecked(&mut self, _default_checked: bool) -> ErrorResult;
+    fn SetDefaultChecked(&self, _default_checked: bool) -> ErrorResult;
     fn Checked(&self) -> bool;
-    fn SetChecked(&mut self, _checked: bool);
+    fn SetChecked(&self, _checked: bool);
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn FormAction(&self) -> DOMString;
-    fn SetFormAction(&mut self, _form_action: DOMString) -> ErrorResult;
+    fn SetFormAction(&self, _form_action: DOMString) -> ErrorResult;
     fn FormEnctype(&self) -> DOMString;
-    fn SetFormEnctype(&mut self, _form_enctype: DOMString) -> ErrorResult;
+    fn SetFormEnctype(&self, _form_enctype: DOMString) -> ErrorResult;
     fn FormMethod(&self) -> DOMString;
-    fn SetFormMethod(&mut self, _form_method: DOMString) -> ErrorResult;
+    fn SetFormMethod(&self, _form_method: DOMString) -> ErrorResult;
     fn FormNoValidate(&self) -> bool;
-    fn SetFormNoValidate(&mut self, _form_no_validate: bool) -> ErrorResult;
+    fn SetFormNoValidate(&self, _form_no_validate: bool) -> ErrorResult;
     fn FormTarget(&self) -> DOMString;
-    fn SetFormTarget(&mut self, _form_target: DOMString) -> ErrorResult;
+    fn SetFormTarget(&self, _form_target: DOMString) -> ErrorResult;
     fn Height(&self) -> u32;
-    fn SetHeight(&mut self, _height: u32) -> ErrorResult;
+    fn SetHeight(&self, _height: u32) -> ErrorResult;
     fn Indeterminate(&self) -> bool;
-    fn SetIndeterminate(&mut self, _indeterminate: bool);
+    fn SetIndeterminate(&self, _indeterminate: bool);
     fn InputMode(&self) -> DOMString;
-    fn SetInputMode(&mut self, _input_mode: DOMString) -> ErrorResult;
+    fn SetInputMode(&self, _input_mode: DOMString) -> ErrorResult;
     fn Max(&self) -> DOMString;
-    fn SetMax(&mut self, _max: DOMString) -> ErrorResult;
+    fn SetMax(&self, _max: DOMString) -> ErrorResult;
     fn MaxLength(&self) -> i32;
-    fn SetMaxLength(&mut self, _max_length: i32) -> ErrorResult;
+    fn SetMaxLength(&self, _max_length: i32) -> ErrorResult;
     fn Min(&self) -> DOMString;
-    fn SetMin(&mut self, _min: DOMString) -> ErrorResult;
+    fn SetMin(&self, _min: DOMString) -> ErrorResult;
     fn Multiple(&self) -> bool;
-    fn SetMultiple(&mut self, _multiple: bool) -> ErrorResult;
+    fn SetMultiple(&self, _multiple: bool) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Pattern(&self) -> DOMString;
-    fn SetPattern(&mut self, _pattern: DOMString) -> ErrorResult;
+    fn SetPattern(&self, _pattern: DOMString) -> ErrorResult;
     fn Placeholder(&self) -> DOMString;
-    fn SetPlaceholder(&mut self, _placeholder: DOMString) -> ErrorResult;
+    fn SetPlaceholder(&self, _placeholder: DOMString) -> ErrorResult;
     fn ReadOnly(&self) -> bool;
-    fn SetReadOnly(&mut self, _read_only: bool) -> ErrorResult;
+    fn SetReadOnly(&self, _read_only: bool) -> ErrorResult;
     fn Required(&self) -> bool;
-    fn SetRequired(&mut self, _required: bool) -> ErrorResult;
+    fn SetRequired(&self, _required: bool) -> ErrorResult;
     fn Size(&self) -> u32;
-    fn SetSize(&mut self, _size: u32) -> ErrorResult;
+    fn SetSize(&self, _size: u32) -> ErrorResult;
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn Step(&self) -> DOMString;
-    fn SetStep(&mut self, _step: DOMString) -> ErrorResult;
+    fn SetStep(&self, _step: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn DefaultValue(&self) -> DOMString;
-    fn SetDefaultValue(&mut self, _default_value: DOMString) -> ErrorResult;
+    fn SetDefaultValue(&self, _default_value: DOMString) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetValue(&self, _value: DOMString) -> ErrorResult;
     fn Width(&self) -> u32;
-    fn SetWidth(&mut self, _width: u32);
+    fn SetWidth(&self, _width: u32);
     fn WillValidate(&self) -> bool;
     fn SetWillValidate(&self, _will_validate: bool);
     fn GetValidationMessage(&self) -> Fallible<DOMString>;
@@ -107,15 +107,15 @@ pub trait HTMLInputElementMethods {
     fn SetCustomValidity(&self, _error: DOMString);
     fn Select(&self);
     fn GetSelectionStart(&self) -> Fallible<i32>;
-    fn SetSelectionStart(&mut self, _selection_start: i32) -> ErrorResult;
+    fn SetSelectionStart(&self, _selection_start: i32) -> ErrorResult;
     fn GetSelectionEnd(&self) -> Fallible<i32>;
-    fn SetSelectionEnd(&mut self, _selection_end: i32) -> ErrorResult;
+    fn SetSelectionEnd(&self, _selection_end: i32) -> ErrorResult;
     fn GetSelectionDirection(&self) -> Fallible<DOMString>;
-    fn SetSelectionDirection(&mut self, _selection_direction: DOMString) -> ErrorResult;
+    fn SetSelectionDirection(&self, _selection_direction: DOMString) -> ErrorResult;
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn UseMap(&self) -> DOMString;
-    fn SetUseMap(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetUseMap(&self, _align: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
@@ -123,7 +123,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetAccept(&mut self, _accept: DOMString) -> ErrorResult {
+    fn SetAccept(&self, _accept: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -131,7 +131,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetAlt(&mut self, _alt: DOMString) -> ErrorResult {
+    fn SetAlt(&self, _alt: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -139,7 +139,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetAutocomplete(&mut self, _autocomple: DOMString) -> ErrorResult {
+    fn SetAutocomplete(&self, _autocomple: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -147,7 +147,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult {
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -155,7 +155,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetDefaultChecked(&mut self, _default_checked: bool) -> ErrorResult {
+    fn SetDefaultChecked(&self, _default_checked: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -163,14 +163,14 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetChecked(&mut self, _checked: bool) {
+    fn SetChecked(&self, _checked: bool) {
     }
 
     fn Disabled(&self) -> bool {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -178,7 +178,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetFormAction(&mut self, _form_action: DOMString) -> ErrorResult {
+    fn SetFormAction(&self, _form_action: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -186,7 +186,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetFormEnctype(&mut self, _form_enctype: DOMString) -> ErrorResult {
+    fn SetFormEnctype(&self, _form_enctype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -194,7 +194,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetFormMethod(&mut self, _form_method: DOMString) -> ErrorResult {
+    fn SetFormMethod(&self, _form_method: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -202,7 +202,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetFormNoValidate(&mut self, _form_no_validate: bool) -> ErrorResult {
+    fn SetFormNoValidate(&self, _form_no_validate: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -210,7 +210,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetFormTarget(&mut self, _form_target: DOMString) -> ErrorResult {
+    fn SetFormTarget(&self, _form_target: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -218,7 +218,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         0
     }
 
-    fn SetHeight(&mut self, _height: u32) -> ErrorResult {
+    fn SetHeight(&self, _height: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -226,14 +226,14 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetIndeterminate(&mut self, _indeterminate: bool) {
+    fn SetIndeterminate(&self, _indeterminate: bool) {
     }
 
     fn InputMode(&self) -> DOMString {
         "".to_owned()
     }
 
-    fn SetInputMode(&mut self, _input_mode: DOMString) -> ErrorResult {
+    fn SetInputMode(&self, _input_mode: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -241,7 +241,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetMax(&mut self, _max: DOMString) -> ErrorResult {
+    fn SetMax(&self, _max: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -249,7 +249,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         0
     }
 
-    fn SetMaxLength(&mut self, _max_length: i32) -> ErrorResult {
+    fn SetMaxLength(&self, _max_length: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -257,7 +257,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetMin(&mut self, _min: DOMString) -> ErrorResult {
+    fn SetMin(&self, _min: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -265,7 +265,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetMultiple(&mut self, _multiple: bool) -> ErrorResult {
+    fn SetMultiple(&self, _multiple: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -273,7 +273,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -281,7 +281,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetPattern(&mut self, _pattern: DOMString) -> ErrorResult {
+    fn SetPattern(&self, _pattern: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -289,7 +289,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetPlaceholder(&mut self, _placeholder: DOMString) -> ErrorResult {
+    fn SetPlaceholder(&self, _placeholder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -297,7 +297,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetReadOnly(&mut self, _read_only: bool) -> ErrorResult {
+    fn SetReadOnly(&self, _read_only: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -305,7 +305,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         false
     }
 
-    fn SetRequired(&mut self, _required: bool) -> ErrorResult {
+    fn SetRequired(&self, _required: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -313,7 +313,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         0
     }
 
-    fn SetSize(&mut self, _size: u32) -> ErrorResult {
+    fn SetSize(&self, _size: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -321,7 +321,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -329,7 +329,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetStep(&mut self, _step: DOMString) -> ErrorResult {
+    fn SetStep(&self, _step: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -337,7 +337,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -345,7 +345,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetDefaultValue(&mut self, _default_value: DOMString) -> ErrorResult {
+    fn SetDefaultValue(&self, _default_value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -353,7 +353,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -361,7 +361,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         0
     }
 
-    fn SetWidth(&mut self, _width: u32) {
+    fn SetWidth(&self, _width: u32) {
     }
 
     fn WillValidate(&self) -> bool {
@@ -389,7 +389,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         Ok(0)
     }
 
-    fn SetSelectionStart(&mut self, _selection_start: i32) -> ErrorResult {
+    fn SetSelectionStart(&self, _selection_start: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -397,7 +397,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         Ok(0)
     }
 
-    fn SetSelectionEnd(&mut self, _selection_end: i32) -> ErrorResult {
+    fn SetSelectionEnd(&self, _selection_end: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -405,7 +405,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         Ok("".to_owned())
     }
 
-    fn SetSelectionDirection(&mut self, _selection_direction: DOMString) -> ErrorResult {
+    fn SetSelectionDirection(&self, _selection_direction: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -413,7 +413,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -421,7 +421,7 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
         "".to_owned()
     }
 
-    fn SetUseMap(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetUseMap(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmllabelelement.rs
+++ b/src/components/script/dom/htmllabelelement.rs
@@ -38,7 +38,7 @@ impl HTMLLabelElement {
 
 pub trait HTMLLabelElementMethods {
     fn HtmlFor(&self) -> DOMString;
-    fn SetHtmlFor(&mut self, _html_for: DOMString);
+    fn SetHtmlFor(&self, _html_for: DOMString);
 }
 
 impl<'a> HTMLLabelElementMethods for JSRef<'a, HTMLLabelElement> {
@@ -46,6 +46,6 @@ impl<'a> HTMLLabelElementMethods for JSRef<'a, HTMLLabelElement> {
         "".to_owned()
     }
 
-    fn SetHtmlFor(&mut self, _html_for: DOMString) {
+    fn SetHtmlFor(&self, _html_for: DOMString) {
     }
 }

--- a/src/components/script/dom/htmllegendelement.rs
+++ b/src/components/script/dom/htmllegendelement.rs
@@ -39,7 +39,7 @@ impl HTMLLegendElement {
 
 pub trait HTMLLegendElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLLegendElementMethods for JSRef<'a, HTMLLegendElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLLegendElementMethods for JSRef<'a, HTMLLegendElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmllielement.rs
+++ b/src/components/script/dom/htmllielement.rs
@@ -39,9 +39,9 @@ impl HTMLLIElement {
 
 pub trait HTMLLIElementMethods {
     fn Value(&self) -> i32;
-    fn SetValue(&mut self, _value: i32) -> ErrorResult;
+    fn SetValue(&self, _value: i32) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLLIElementMethods for JSRef<'a, HTMLLIElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLLIElementMethods for JSRef<'a, HTMLLIElement> {
         0
     }
 
-    fn SetValue(&mut self, _value: i32) -> ErrorResult {
+    fn SetValue(&self, _value: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLLIElementMethods for JSRef<'a, HTMLLIElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -39,25 +39,25 @@ impl HTMLLinkElement {
 
 pub trait HTMLLinkElementMethods {
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disable: bool);
+    fn SetDisabled(&self, _disable: bool);
     fn Href(&self) -> DOMString;
-    fn SetHref(&mut self, _href: DOMString) -> ErrorResult;
+    fn SetHref(&self, _href: DOMString) -> ErrorResult;
     fn CrossOrigin(&self) -> DOMString;
-    fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult;
+    fn SetCrossOrigin(&self, _cross_origin: DOMString) -> ErrorResult;
     fn Rel(&self) -> DOMString;
-    fn SetRel(&mut self, _rel: DOMString) -> ErrorResult;
+    fn SetRel(&self, _rel: DOMString) -> ErrorResult;
     fn Media(&self) -> DOMString;
-    fn SetMedia(&mut self, _media: DOMString) -> ErrorResult;
+    fn SetMedia(&self, _media: DOMString) -> ErrorResult;
     fn Hreflang(&self) -> DOMString;
-    fn SetHreflang(&mut self, _href: DOMString) -> ErrorResult;
+    fn SetHreflang(&self, _href: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Charset(&self) -> DOMString;
-    fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult;
+    fn SetCharset(&self, _charset: DOMString) -> ErrorResult;
     fn Rev(&self) -> DOMString;
-    fn SetRev(&mut self, _rev: DOMString) -> ErrorResult;
+    fn SetRev(&self, _rev: DOMString) -> ErrorResult;
     fn Target(&self) -> DOMString;
-    fn SetTarget(&mut self, _target: DOMString) -> ErrorResult;
+    fn SetTarget(&self, _target: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
@@ -65,14 +65,14 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disable: bool) {
+    fn SetDisabled(&self, _disable: bool) {
     }
 
     fn Href(&self) -> DOMString {
         "".to_owned()
     }
 
-    fn SetHref(&mut self, _href: DOMString) -> ErrorResult {
+    fn SetHref(&self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
+    fn SetCrossOrigin(&self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetRel(&mut self, _rel: DOMString) -> ErrorResult {
+    fn SetRel(&self, _rel: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetMedia(&mut self, _media: DOMString) -> ErrorResult {
+    fn SetMedia(&self, _media: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -104,7 +104,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetHreflang(&mut self, _href: DOMString) -> ErrorResult {
+    fn SetHreflang(&self, _href: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -112,7 +112,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -120,7 +120,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult {
+    fn SetCharset(&self, _charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -128,7 +128,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetRev(&mut self, _rev: DOMString) -> ErrorResult {
+    fn SetRev(&self, _rev: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -136,7 +136,7 @@ impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
         "".to_owned()
     }
 
-    fn SetTarget(&mut self, _target: DOMString) -> ErrorResult {
+    fn SetTarget(&self, _target: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlmapelement.rs
+++ b/src/components/script/dom/htmlmapelement.rs
@@ -40,7 +40,7 @@ impl HTMLMapElement {
 
 pub trait HTMLMapElementMethods {
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Areas(&self) -> Temporary<HTMLCollection>;
 }
 
@@ -49,7 +49,7 @@ impl<'a> HTMLMapElementMethods for JSRef<'a, HTMLMapElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlmediaelement.rs
+++ b/src/components/script/dom/htmlmediaelement.rs
@@ -37,39 +37,39 @@ impl HTMLMediaElement {
 
 pub trait HTMLMediaElementMethods {
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn CurrentSrc(&self) -> DOMString;
     fn CrossOrigin(&self) -> DOMString;
-    fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult;
+    fn SetCrossOrigin(&self, _cross_origin: DOMString) -> ErrorResult;
     fn Preload(&self) -> DOMString;
-    fn SetPreload(&mut self, _preload: DOMString) -> ErrorResult;
+    fn SetPreload(&self, _preload: DOMString) -> ErrorResult;
     fn Load(&self);
     fn CanPlayType(&self, _type: DOMString) -> DOMString;
     fn ReadyState(&self) -> u16;
     fn Seeking(&self) -> bool;
     fn CurrentTime(&self) -> f64;
-    fn SetCurrentTime(&mut self, _current_time: f64) -> ErrorResult;
+    fn SetCurrentTime(&self, _current_time: f64) -> ErrorResult;
     fn GetDuration(&self) -> f64;
     fn Paused(&self) -> bool;
     fn DefaultPlaybackRate(&self) -> f64;
-    fn SetDefaultPlaybackRate(&mut self, _default_playback_rate: f64) -> ErrorResult;
+    fn SetDefaultPlaybackRate(&self, _default_playback_rate: f64) -> ErrorResult;
     fn PlaybackRate(&self) -> f64;
-    fn SetPlaybackRate(&mut self, _playback_rate: f64) -> ErrorResult;
+    fn SetPlaybackRate(&self, _playback_rate: f64) -> ErrorResult;
     fn Ended(&self) -> bool;
     fn Autoplay(&self) -> bool;
-    fn SetAutoplay(&mut self, _autoplay: bool) -> ErrorResult;
+    fn SetAutoplay(&self, _autoplay: bool) -> ErrorResult;
     fn Loop(&self) -> bool;
-    fn SetLoop(&mut self, _loop: bool) -> ErrorResult;
+    fn SetLoop(&self, _loop: bool) -> ErrorResult;
     fn Play(&self) -> ErrorResult;
     fn Pause(&self) -> ErrorResult;
     fn Controls(&self) -> bool;
-    fn SetControls(&mut self, _controls: bool) -> ErrorResult;
+    fn SetControls(&self, _controls: bool) -> ErrorResult;
     fn Volume(&self) -> f64;
-    fn SetVolume(&mut self, _volume: f64) -> ErrorResult;
+    fn SetVolume(&self, _volume: f64) -> ErrorResult;
     fn Muted(&self) -> bool;
-    fn SetMuted(&mut self, _muted: bool);
+    fn SetMuted(&self, _muted: bool);
     fn DefaultMuted(&self) -> bool;
-    fn SetDefaultMuted(&mut self, _default_muted: bool) -> ErrorResult;
+    fn SetDefaultMuted(&self, _default_muted: bool) -> ErrorResult;
 }
 
 impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
@@ -77,7 +77,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         "".to_owned()
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         "".to_owned()
     }
 
-    fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
+    fn SetCrossOrigin(&self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -97,7 +97,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         "".to_owned()
     }
 
-    fn SetPreload(&mut self, _preload: DOMString) -> ErrorResult {
+    fn SetPreload(&self, _preload: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -120,7 +120,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         0f64
     }
 
-    fn SetCurrentTime(&mut self, _current_time: f64) -> ErrorResult {
+    fn SetCurrentTime(&self, _current_time: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -136,7 +136,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         0f64
     }
 
-    fn SetDefaultPlaybackRate(&mut self, _default_playback_rate: f64) -> ErrorResult {
+    fn SetDefaultPlaybackRate(&self, _default_playback_rate: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -144,7 +144,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         0f64
     }
 
-    fn SetPlaybackRate(&mut self, _playback_rate: f64) -> ErrorResult {
+    fn SetPlaybackRate(&self, _playback_rate: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -156,7 +156,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         false
     }
 
-    fn SetAutoplay(&mut self, _autoplay: bool) -> ErrorResult {
+    fn SetAutoplay(&self, _autoplay: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -164,7 +164,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         false
     }
 
-    fn SetLoop(&mut self, _loop: bool) -> ErrorResult {
+    fn SetLoop(&self, _loop: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -180,7 +180,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         false
     }
 
-    fn SetControls(&mut self, _controls: bool) -> ErrorResult {
+    fn SetControls(&self, _controls: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -188,7 +188,7 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         0f64
     }
 
-    fn SetVolume(&mut self, _volume: f64) -> ErrorResult {
+    fn SetVolume(&self, _volume: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -196,14 +196,14 @@ impl<'a> HTMLMediaElementMethods for JSRef<'a, HTMLMediaElement> {
         false
     }
 
-    fn SetMuted(&mut self, _muted: bool) {
+    fn SetMuted(&self, _muted: bool) {
     }
 
     fn DefaultMuted(&self) -> bool {
         false
     }
 
-    fn SetDefaultMuted(&mut self, _default_muted: bool) -> ErrorResult {
+    fn SetDefaultMuted(&self, _default_muted: bool) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlmetaelement.rs
+++ b/src/components/script/dom/htmlmetaelement.rs
@@ -39,13 +39,13 @@ impl HTMLMetaElement {
 
 pub trait HTMLMetaElementMethods {
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn HttpEquiv(&self) -> DOMString;
-    fn SetHttpEquiv(&mut self, _http_equiv: DOMString) -> ErrorResult;
+    fn SetHttpEquiv(&self, _http_equiv: DOMString) -> ErrorResult;
     fn Content(&self) -> DOMString;
-    fn SetContent(&mut self, _content: DOMString) -> ErrorResult;
+    fn SetContent(&self, _content: DOMString) -> ErrorResult;
     fn Scheme(&self) -> DOMString;
-    fn SetScheme(&mut self, _scheme: DOMString) -> ErrorResult;
+    fn SetScheme(&self, _scheme: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLMetaElementMethods for JSRef<'a, HTMLMetaElement> {
@@ -53,7 +53,7 @@ impl<'a> HTMLMetaElementMethods for JSRef<'a, HTMLMetaElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl<'a> HTMLMetaElementMethods for JSRef<'a, HTMLMetaElement> {
         "".to_owned()
     }
 
-    fn SetHttpEquiv(&mut self, _http_equiv: DOMString) -> ErrorResult {
+    fn SetHttpEquiv(&self, _http_equiv: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -69,7 +69,7 @@ impl<'a> HTMLMetaElementMethods for JSRef<'a, HTMLMetaElement> {
         "".to_owned()
     }
 
-    fn SetContent(&mut self, _content: DOMString) -> ErrorResult {
+    fn SetContent(&self, _content: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -77,7 +77,7 @@ impl<'a> HTMLMetaElementMethods for JSRef<'a, HTMLMetaElement> {
         "".to_owned()
     }
 
-    fn SetScheme(&mut self, _scheme: DOMString) -> ErrorResult {
+    fn SetScheme(&self, _scheme: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlmeterelement.rs
+++ b/src/components/script/dom/htmlmeterelement.rs
@@ -39,17 +39,17 @@ impl HTMLMeterElement {
 
 pub trait HTMLMeterElementMethods {
     fn Value(&self) -> f64;
-    fn SetValue(&mut self, _value: f64) -> ErrorResult;
+    fn SetValue(&self, _value: f64) -> ErrorResult;
     fn Min(&self) -> f64;
-    fn SetMin(&mut self, _min: f64) -> ErrorResult;
+    fn SetMin(&self, _min: f64) -> ErrorResult;
     fn Max(&self) -> f64;
-    fn SetMax(&mut self, _max: f64) -> ErrorResult;
+    fn SetMax(&self, _max: f64) -> ErrorResult;
     fn Low(&self) -> f64;
-    fn SetLow(&mut self, _low: f64) -> ErrorResult;
+    fn SetLow(&self, _low: f64) -> ErrorResult;
     fn High(&self) -> f64;
-    fn SetHigh(&mut self, _high: f64) -> ErrorResult;
+    fn SetHigh(&self, _high: f64) -> ErrorResult;
     fn Optimum(&self) -> f64;
-    fn SetOptimum(&mut self, _optimum: f64) -> ErrorResult;
+    fn SetOptimum(&self, _optimum: f64) -> ErrorResult;
 }
 
 impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
@@ -57,7 +57,7 @@ impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
         0.0
     }
 
-    fn SetValue(&mut self, _value: f64) -> ErrorResult {
+    fn SetValue(&self, _value: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -65,7 +65,7 @@ impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
         0.0
     }
 
-    fn SetMin(&mut self, _min: f64) -> ErrorResult {
+    fn SetMin(&self, _min: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -73,7 +73,7 @@ impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
         0.0
     }
 
-    fn SetMax(&mut self, _max: f64) -> ErrorResult {
+    fn SetMax(&self, _max: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -81,7 +81,7 @@ impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
         0.0
     }
 
-    fn SetLow(&mut self, _low: f64) -> ErrorResult {
+    fn SetLow(&self, _low: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
         0.0
     }
 
-    fn SetHigh(&mut self, _high: f64) -> ErrorResult {
+    fn SetHigh(&self, _high: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -97,7 +97,7 @@ impl<'a> HTMLMeterElementMethods for JSRef<'a, HTMLMeterElement> {
         0.0
     }
 
-    fn SetOptimum(&mut self, _optimum: f64) -> ErrorResult {
+    fn SetOptimum(&self, _optimum: f64) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlmodelement.rs
+++ b/src/components/script/dom/htmlmodelement.rs
@@ -39,9 +39,9 @@ impl HTMLModElement {
 
 pub trait HTMLModElementMethods {
     fn Cite(&self) -> DOMString;
-    fn SetCite(&mut self, _cite: DOMString) -> ErrorResult;
+    fn SetCite(&self, _cite: DOMString) -> ErrorResult;
     fn DateTime(&self) -> DOMString;
-    fn SetDateTime(&mut self, _datetime: DOMString) -> ErrorResult;
+    fn SetDateTime(&self, _datetime: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLModElementMethods for JSRef<'a, HTMLModElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLModElementMethods for JSRef<'a, HTMLModElement> {
         "".to_owned()
     }
 
-    fn SetCite(&mut self, _cite: DOMString) -> ErrorResult {
+    fn SetCite(&self, _cite: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLModElementMethods for JSRef<'a, HTMLModElement> {
         "".to_owned()
     }
 
-    fn SetDateTime(&mut self, _datetime: DOMString) -> ErrorResult {
+    fn SetDateTime(&self, _datetime: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -52,13 +52,13 @@ impl HTMLObjectElement {
 }
 
 trait ProcessDataURL {
-    fn process_data_url(&mut self, image_cache: ImageCacheTask, url: Option<Url>);
+    fn process_data_url(&self, image_cache: ImageCacheTask, url: Option<Url>);
 }
 
 impl<'a> ProcessDataURL for JSRef<'a, HTMLObjectElement> {
     // Makes the local `data` member match the status of the `data` attribute and starts
     /// prefetching the image. This method must be called after `data` is changed.
-    fn process_data_url(&mut self, image_cache: ImageCacheTask, url: Option<Url>) {
+    fn process_data_url(&self, image_cache: ImageCacheTask, url: Option<Url>) {
         let elem: &JSRef<Element> = ElementCast::from_ref(self);
 
         // TODO: support other values
@@ -78,45 +78,45 @@ impl<'a> ProcessDataURL for JSRef<'a, HTMLObjectElement> {
 
 pub trait HTMLObjectElementMethods {
     fn Data(&self) -> DOMString;
-    fn SetData(&mut self, _data: DOMString) -> ErrorResult;
+    fn SetData(&self, _data: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn UseMap(&self) -> DOMString;
-    fn SetUseMap(&mut self, _use_map: DOMString) -> ErrorResult;
+    fn SetUseMap(&self, _use_map: DOMString) -> ErrorResult;
     fn GetForm(&self) -> Option<Temporary<HTMLFormElement>>;
     fn Width(&self) -> DOMString;
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult;
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult;
     fn Height(&self) -> DOMString;
-    fn SetHeight(&mut self, _height: DOMString) -> ErrorResult;
+    fn SetHeight(&self, _height: DOMString) -> ErrorResult;
     fn GetContentDocument(&self) -> Option<Temporary<Document>>;
     fn GetContentWindow(&self) -> Option<Temporary<Window>>;
     fn WillValidate(&self) -> bool;
     fn Validity(&self) -> Temporary<ValidityState>;
     fn ValidationMessage(&self) -> DOMString;
     fn CheckValidity(&self) -> bool;
-    fn SetCustomValidity(&mut self, _error: DOMString);
+    fn SetCustomValidity(&self, _error: DOMString);
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn Archive(&self) -> DOMString;
-    fn SetArchive(&mut self, _archive: DOMString) -> ErrorResult;
+    fn SetArchive(&self, _archive: DOMString) -> ErrorResult;
     fn Code(&self) -> DOMString;
-    fn SetCode(&mut self, _code: DOMString) -> ErrorResult;
+    fn SetCode(&self, _code: DOMString) -> ErrorResult;
     fn Declare(&self) -> bool;
-    fn SetDeclare(&mut self, _declare: bool) -> ErrorResult;
+    fn SetDeclare(&self, _declare: bool) -> ErrorResult;
     fn Hspace(&self) -> u32;
-    fn SetHspace(&mut self, _hspace: u32) -> ErrorResult;
+    fn SetHspace(&self, _hspace: u32) -> ErrorResult;
     fn Standby(&self) -> DOMString;
-    fn SetStandby(&mut self, _standby: DOMString) -> ErrorResult;
+    fn SetStandby(&self, _standby: DOMString) -> ErrorResult;
     fn Vspace(&self) -> u32;
-    fn SetVspace(&mut self, _vspace: u32) -> ErrorResult;
+    fn SetVspace(&self, _vspace: u32) -> ErrorResult;
     fn CodeBase(&self) -> DOMString;
-    fn SetCodeBase(&mut self, _codebase: DOMString) -> ErrorResult;
+    fn SetCodeBase(&self, _codebase: DOMString) -> ErrorResult;
     fn CodeType(&self) -> DOMString;
-    fn SetCodeType(&mut self, _codetype: DOMString) -> ErrorResult;
+    fn SetCodeType(&self, _codetype: DOMString) -> ErrorResult;
     fn Border(&self) -> DOMString;
-    fn SetBorder(&mut self, _border: DOMString) -> ErrorResult;
+    fn SetBorder(&self, _border: DOMString) -> ErrorResult;
     fn GetSVGDocument(&self) -> Option<Temporary<Document>>;
 }
 
@@ -125,7 +125,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetData(&mut self, _data: DOMString) -> ErrorResult {
+    fn SetData(&self, _data: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -133,7 +133,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -141,7 +141,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -149,7 +149,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetUseMap(&mut self, _use_map: DOMString) -> ErrorResult {
+    fn SetUseMap(&self, _use_map: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -161,7 +161,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -169,7 +169,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetHeight(&mut self, _height: DOMString) -> ErrorResult {
+    fn SetHeight(&self, _height: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -198,14 +198,14 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         false
     }
 
-    fn SetCustomValidity(&mut self, _error: DOMString) {
+    fn SetCustomValidity(&self, _error: DOMString) {
     }
 
     fn Align(&self) -> DOMString {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -213,7 +213,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetArchive(&mut self, _archive: DOMString) -> ErrorResult {
+    fn SetArchive(&self, _archive: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -221,7 +221,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetCode(&mut self, _code: DOMString) -> ErrorResult {
+    fn SetCode(&self, _code: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -229,7 +229,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         false
     }
 
-    fn SetDeclare(&mut self, _declare: bool) -> ErrorResult {
+    fn SetDeclare(&self, _declare: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -237,7 +237,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         0
     }
 
-    fn SetHspace(&mut self, _hspace: u32) -> ErrorResult {
+    fn SetHspace(&self, _hspace: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -245,7 +245,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetStandby(&mut self, _standby: DOMString) -> ErrorResult {
+    fn SetStandby(&self, _standby: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -253,7 +253,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         0
     }
 
-    fn SetVspace(&mut self, _vspace: u32) -> ErrorResult {
+    fn SetVspace(&self, _vspace: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -261,7 +261,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetCodeBase(&mut self, _codebase: DOMString) -> ErrorResult {
+    fn SetCodeBase(&self, _codebase: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -269,7 +269,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetCodeType(&mut self, _codetype: DOMString) -> ErrorResult {
+    fn SetCodeType(&self, _codetype: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -277,7 +277,7 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         "".to_owned()
     }
 
-    fn SetBorder(&mut self, _border: DOMString) -> ErrorResult {
+    fn SetBorder(&self, _border: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlolistelement.rs
+++ b/src/components/script/dom/htmlolistelement.rs
@@ -41,9 +41,9 @@ pub trait HTMLOListElementMethods {
     fn Reversed(&self) -> bool;
     fn SetReversed(&self, _reversed: bool) -> ErrorResult;
     fn Start(&self) -> i32;
-    fn SetStart(&mut self, _start: i32) -> ErrorResult;
+    fn SetStart(&self, _start: i32) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Compact(&self) -> bool;
     fn SetCompact(&self, _compact: bool) -> ErrorResult;
 }
@@ -61,7 +61,7 @@ impl<'a> HTMLOListElementMethods for JSRef<'a, HTMLOListElement> {
         0
     }
 
-    fn SetStart(&mut self, _start: i32) -> ErrorResult {
+    fn SetStart(&self, _start: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -69,7 +69,7 @@ impl<'a> HTMLOListElementMethods for JSRef<'a, HTMLOListElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmloptgroupelement.rs
+++ b/src/components/script/dom/htmloptgroupelement.rs
@@ -39,9 +39,9 @@ impl HTMLOptGroupElement {
 
 pub trait HTMLOptGroupElementMethods {
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn Label(&self) -> DOMString;
-    fn SetLabel(&mut self, _label: DOMString) -> ErrorResult;
+    fn SetLabel(&self, _label: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
         "".to_owned()
     }
 
-    fn SetLabel(&mut self, _label: DOMString) -> ErrorResult {
+    fn SetLabel(&self, _label: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -40,18 +40,18 @@ impl HTMLOptionElement {
 
 pub trait HTMLOptionElementMethods {
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn GetForm(&self) -> Option<Temporary<HTMLFormElement>>;
     fn Label(&self) -> DOMString;
-    fn SetLabel(&mut self, _label: DOMString) -> ErrorResult;
+    fn SetLabel(&self, _label: DOMString) -> ErrorResult;
     fn DefaultSelected(&self) -> bool;
-    fn SetDefaultSelected(&mut self, _default_selected: bool) -> ErrorResult;
+    fn SetDefaultSelected(&self, _default_selected: bool) -> ErrorResult;
     fn Selected(&self) -> bool;
-    fn SetSelected(&mut self, _selected: bool) -> ErrorResult;
+    fn SetSelected(&self, _selected: bool) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetValue(&self, _value: DOMString) -> ErrorResult;
     fn Text(&self) -> DOMString;
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult;
+    fn SetText(&self, _text: DOMString) -> ErrorResult;
     fn Index(&self) -> i32;
 }
 
@@ -60,7 +60,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -72,7 +72,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         "".to_owned()
     }
 
-    fn SetLabel(&mut self, _label: DOMString) -> ErrorResult {
+    fn SetLabel(&self, _label: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         false
     }
 
-    fn SetDefaultSelected(&mut self, _default_selected: bool) -> ErrorResult {
+    fn SetDefaultSelected(&self, _default_selected: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         false
     }
 
-    fn SetSelected(&mut self, _selected: bool) -> ErrorResult {
+    fn SetSelected(&self, _selected: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -104,7 +104,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         "".to_owned()
     }
 
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult {
+    fn SetText(&self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmloutputelement.rs
+++ b/src/components/script/dom/htmloutputelement.rs
@@ -42,19 +42,19 @@ impl HTMLOutputElement {
 pub trait HTMLOutputElementMethods {
     fn GetForm(&self) -> Option<Temporary<HTMLFormElement>>;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
     fn DefaultValue(&self) -> DOMString;
-    fn SetDefaultValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetDefaultValue(&self, _value: DOMString) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetValue(&self, _value: DOMString) -> ErrorResult;
     fn WillValidate(&self) -> bool;
-    fn SetWillValidate(&mut self, _will_validate: bool);
+    fn SetWillValidate(&self, _will_validate: bool);
     fn Validity(&self) -> Temporary<ValidityState>;
     fn ValidationMessage(&self) -> DOMString;
-    fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult;
+    fn SetValidationMessage(&self, _message: DOMString) -> ErrorResult;
     fn CheckValidity(&self) -> bool;
-    fn SetCustomValidity(&mut self, _error: DOMString);
+    fn SetCustomValidity(&self, _error: DOMString);
 }
 
 impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
@@ -66,7 +66,7 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -78,7 +78,7 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
         "".to_owned()
     }
 
-    fn SetDefaultValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetDefaultValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -86,7 +86,7 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
         false
     }
 
-    fn SetWillValidate(&mut self, _will_validate: bool) {
+    fn SetWillValidate(&self, _will_validate: bool) {
     }
 
     fn Validity(&self) -> Temporary<ValidityState> {
@@ -106,7 +106,7 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
         "".to_owned()
     }
 
-    fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult {
+    fn SetValidationMessage(&self, _message: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -114,6 +114,6 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
         true
     }
 
-    fn SetCustomValidity(&mut self, _error: DOMString) {
+    fn SetCustomValidity(&self, _error: DOMString) {
     }
 }

--- a/src/components/script/dom/htmlparagraphelement.rs
+++ b/src/components/script/dom/htmlparagraphelement.rs
@@ -39,7 +39,7 @@ impl HTMLParagraphElement {
 
 pub trait HTMLParagraphElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLParagraphElementMethods for JSRef<'a, HTMLParagraphElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLParagraphElementMethods for JSRef<'a, HTMLParagraphElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlparamelement.rs
+++ b/src/components/script/dom/htmlparamelement.rs
@@ -39,13 +39,13 @@ impl HTMLParamElement {
 
 pub trait HTMLParamElementMethods {
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult;
+    fn SetValue(&self, _value: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn ValueType(&self) -> DOMString;
-    fn SetValueType(&mut self, _value_type: DOMString) -> ErrorResult;
+    fn SetValueType(&self, _value_type: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLParamElementMethods for JSRef<'a, HTMLParamElement> {
@@ -53,7 +53,7 @@ impl<'a> HTMLParamElementMethods for JSRef<'a, HTMLParamElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl<'a> HTMLParamElementMethods for JSRef<'a, HTMLParamElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) -> ErrorResult {
+    fn SetValue(&self, _value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -69,7 +69,7 @@ impl<'a> HTMLParamElementMethods for JSRef<'a, HTMLParamElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -77,7 +77,7 @@ impl<'a> HTMLParamElementMethods for JSRef<'a, HTMLParamElement> {
         "".to_owned()
     }
 
-    fn SetValueType(&mut self, _value_type: DOMString) -> ErrorResult {
+    fn SetValueType(&self, _value_type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlpreelement.rs
+++ b/src/components/script/dom/htmlpreelement.rs
@@ -39,7 +39,7 @@ impl HTMLPreElement {
 
 pub trait HTMLPreElementMethods {
     fn Width(&self) -> i32;
-    fn SetWidth(&mut self, _width: i32) -> ErrorResult;
+    fn SetWidth(&self, _width: i32) -> ErrorResult;
 }
 
 impl<'a> HTMLPreElementMethods for JSRef<'a, HTMLPreElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLPreElementMethods for JSRef<'a, HTMLPreElement> {
         0
     }
 
-    fn SetWidth(&mut self, _width: i32) -> ErrorResult {
+    fn SetWidth(&self, _width: i32) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlprogresselement.rs
+++ b/src/components/script/dom/htmlprogresselement.rs
@@ -39,9 +39,9 @@ impl HTMLProgressElement {
 
 pub trait HTMLProgressElementMethods {
     fn Value(&self) -> f64;
-    fn SetValue(&mut self, _value: f64) -> ErrorResult;
+    fn SetValue(&self, _value: f64) -> ErrorResult;
     fn Max(&self) -> f64;
-    fn SetMax(&mut self, _max: f64) -> ErrorResult;
+    fn SetMax(&self, _max: f64) -> ErrorResult;
     fn Position(&self) -> f64;
     fn GetPositiom(&self) -> Fallible<f64>;
 }
@@ -51,7 +51,7 @@ impl<'a> HTMLProgressElementMethods for JSRef<'a, HTMLProgressElement> {
         0f64
     }
 
-    fn SetValue(&mut self, _value: f64) -> ErrorResult {
+    fn SetValue(&self, _value: f64) -> ErrorResult {
         Ok(())
     }
 
@@ -59,7 +59,7 @@ impl<'a> HTMLProgressElementMethods for JSRef<'a, HTMLProgressElement> {
         0f64
     }
 
-    fn SetMax(&mut self, _max: f64) -> ErrorResult {
+    fn SetMax(&self, _max: f64) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlscriptelement.rs
+++ b/src/components/script/dom/htmlscriptelement.rs
@@ -40,23 +40,23 @@ impl HTMLScriptElement {
 
 pub trait HTMLScriptElementMethods {
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Charset(&self) -> DOMString;
-    fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult;
+    fn SetCharset(&self, _charset: DOMString) -> ErrorResult;
     fn Async(&self) -> bool;
     fn SetAsync(&self, _async: bool) -> ErrorResult;
     fn Defer(&self) -> bool;
     fn SetDefer(&self, _defer: bool) -> ErrorResult;
     fn CrossOrigin(&self) -> DOMString;
-    fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult;
+    fn SetCrossOrigin(&self, _cross_origin: DOMString) -> ErrorResult;
     fn Text(&self) -> DOMString;
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult;
+    fn SetText(&self, _text: DOMString) -> ErrorResult;
     fn Event(&self) -> DOMString;
-    fn SetEvent(&mut self, _event: DOMString) -> ErrorResult;
+    fn SetEvent(&self, _event: DOMString) -> ErrorResult;
     fn HtmlFor(&self) -> DOMString;
-    fn SetHtmlFor(&mut self, _html_for: DOMString) -> ErrorResult;
+    fn SetHtmlFor(&self, _html_for: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
@@ -65,7 +65,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         element.get_url_attribute("src")
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -73,7 +73,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -81,7 +81,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         "".to_owned()
     }
 
-    fn SetCharset(&mut self, _charset: DOMString) -> ErrorResult {
+    fn SetCharset(&self, _charset: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -105,7 +105,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         "".to_owned()
     }
 
-    fn SetCrossOrigin(&mut self, _cross_origin: DOMString) -> ErrorResult {
+    fn SetCrossOrigin(&self, _cross_origin: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -113,7 +113,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         "".to_owned()
     }
 
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult {
+    fn SetText(&self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -121,7 +121,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         "".to_owned()
     }
 
-    fn SetEvent(&mut self, _event: DOMString) -> ErrorResult {
+    fn SetEvent(&self, _event: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -129,7 +129,7 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
         "".to_owned()
     }
 
-    fn SetHtmlFor(&mut self, _html_for: DOMString) -> ErrorResult {
+    fn SetHtmlFor(&self, _html_for: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -43,38 +43,38 @@ impl HTMLSelectElement {
 
 pub trait HTMLSelectElementMethods {
     fn Autofocus(&self) -> bool;
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult;
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult;
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn GetForm(&self) -> Option<Temporary<HTMLFormElement>>;
     fn Multiple(&self) -> bool;
-    fn SetMultiple(&mut self, _multiple: bool) -> ErrorResult;
+    fn SetMultiple(&self, _multiple: bool) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Required(&self) -> bool;
-    fn SetRequired(&mut self, _multiple: bool) -> ErrorResult;
+    fn SetRequired(&self, _multiple: bool) -> ErrorResult;
     fn Size(&self) -> u32;
-    fn SetSize(&mut self, _size: u32) -> ErrorResult;
+    fn SetSize(&self, _size: u32) -> ErrorResult;
     fn Type(&self) -> DOMString;
     fn Length(&self) -> u32;
-    fn SetLength(&mut self, _length: u32) -> ErrorResult;
+    fn SetLength(&self, _length: u32) -> ErrorResult;
     fn Item(&self, _index: u32) -> Option<Temporary<Element>>;
     fn NamedItem(&self, _name: DOMString) -> Option<Temporary<HTMLOptionElement>>;
     fn IndexedGetter(&self, _index: u32, _found: &mut bool) -> Option<Temporary<Element>>;
-    fn IndexedSetter(&mut self, _index: u32, _option: Option<JSRef<HTMLOptionElement>>) -> ErrorResult;
+    fn IndexedSetter(&self, _index: u32, _option: Option<JSRef<HTMLOptionElement>>) -> ErrorResult;
     fn Remove_(&self);
     fn Remove(&self, _index: i32);
     fn SelectedIndex(&self) -> i32;
-    fn SetSelectedIndex(&mut self, _index: i32) -> ErrorResult;
+    fn SetSelectedIndex(&self, _index: i32) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString);
+    fn SetValue(&self, _value: DOMString);
     fn WillValidate(&self) -> bool;
-    fn SetWillValidate(&mut self, _will_validate: bool);
+    fn SetWillValidate(&self, _will_validate: bool);
     fn Validity(&self) -> Temporary<ValidityState>;
     fn ValidationMessage(&self) -> DOMString;
-    fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult;
+    fn SetValidationMessage(&self, _message: DOMString) -> ErrorResult;
     fn CheckValidity(&self) -> bool;
-    fn SetCustomValidity(&mut self, _error: DOMString);
+    fn SetCustomValidity(&self, _error: DOMString);
     fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) -> ErrorResult;
 }
 
@@ -83,7 +83,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         false
     }
 
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult {
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -91,7 +91,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -103,7 +103,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         false
     }
 
-    fn SetMultiple(&mut self, _multiple: bool) -> ErrorResult {
+    fn SetMultiple(&self, _multiple: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -111,7 +111,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -119,7 +119,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         false
     }
 
-    fn SetRequired(&mut self, _multiple: bool) -> ErrorResult {
+    fn SetRequired(&self, _multiple: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -127,7 +127,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         0
     }
 
-    fn SetSize(&mut self, _size: u32) -> ErrorResult {
+    fn SetSize(&self, _size: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -139,7 +139,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         0
     }
 
-    fn SetLength(&mut self, _length: u32) -> ErrorResult {
+    fn SetLength(&self, _length: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -155,7 +155,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         None
     }
 
-    fn IndexedSetter(&mut self, _index: u32, _option: Option<JSRef<HTMLOptionElement>>) -> ErrorResult {
+    fn IndexedSetter(&self, _index: u32, _option: Option<JSRef<HTMLOptionElement>>) -> ErrorResult {
         Ok(())
     }
 
@@ -169,7 +169,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         0
     }
 
-    fn SetSelectedIndex(&mut self, _index: i32) -> ErrorResult {
+    fn SetSelectedIndex(&self, _index: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -177,14 +177,14 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) {
+    fn SetValue(&self, _value: DOMString) {
     }
 
     fn WillValidate(&self) -> bool {
         false
     }
 
-    fn SetWillValidate(&mut self, _will_validate: bool) {
+    fn SetWillValidate(&self, _will_validate: bool) {
     }
 
     fn Validity(&self) -> Temporary<ValidityState> {
@@ -196,7 +196,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         "".to_owned()
     }
 
-    fn SetValidationMessage(&mut self, _message: DOMString) -> ErrorResult {
+    fn SetValidationMessage(&self, _message: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -204,7 +204,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
         true
     }
 
-    fn SetCustomValidity(&mut self, _error: DOMString) {
+    fn SetCustomValidity(&self, _error: DOMString) {
     }
 
     fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) -> ErrorResult {

--- a/src/components/script/dom/htmlsourceelement.rs
+++ b/src/components/script/dom/htmlsourceelement.rs
@@ -39,11 +39,11 @@ impl HTMLSourceElement {
 
 pub trait HTMLSourceElementMethods {
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Media(&self) -> DOMString;
-    fn SetMedia(&mut self, _media: DOMString) -> ErrorResult;
+    fn SetMedia(&self, _media: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLSourceElementMethods for JSRef<'a, HTMLSourceElement> {
@@ -51,7 +51,7 @@ impl<'a> HTMLSourceElementMethods for JSRef<'a, HTMLSourceElement> {
         "".to_owned()
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -59,7 +59,7 @@ impl<'a> HTMLSourceElementMethods for JSRef<'a, HTMLSourceElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -67,7 +67,7 @@ impl<'a> HTMLSourceElementMethods for JSRef<'a, HTMLSourceElement> {
         "".to_owned()
     }
 
-    fn SetMedia(&mut self, _media: DOMString) -> ErrorResult {
+    fn SetMedia(&self, _media: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -44,9 +44,9 @@ pub trait HTMLStyleElementMethods {
     fn Disabled(&self) -> bool;
     fn SetDisabled(&self, _disabled: bool);
     fn Media(&self) -> DOMString;
-    fn SetMedia(&mut self, _media: DOMString) -> ErrorResult;
+    fn SetMedia(&self, _media: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
     fn Scoped(&self) -> bool;
     fn SetScoped(&self, _scoped: bool) -> ErrorResult;
 }
@@ -63,7 +63,7 @@ impl<'a> HTMLStyleElementMethods for JSRef<'a, HTMLStyleElement> {
         "".to_owned()
     }
 
-    fn SetMedia(&mut self, _media: DOMString) -> ErrorResult {
+    fn SetMedia(&self, _media: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl<'a> HTMLStyleElementMethods for JSRef<'a, HTMLStyleElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmltablecaptionelement.rs
+++ b/src/components/script/dom/htmltablecaptionelement.rs
@@ -39,7 +39,7 @@ impl HTMLTableCaptionElement {
 
 pub trait HTMLTableCaptionElementMethods {
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLTableCaptionElementMethods for JSRef<'a, HTMLTableCaptionElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLTableCaptionElementMethods for JSRef<'a, HTMLTableCaptionElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltablecolelement.rs
+++ b/src/components/script/dom/htmltablecolelement.rs
@@ -39,17 +39,17 @@ impl HTMLTableColElement {
 
 pub trait HTMLTableColElementMethods {
     fn Span(&self) -> u32;
-    fn SetSpan(&mut self, _span: u32) -> ErrorResult;
+    fn SetSpan(&self, _span: u32) -> ErrorResult;
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn Ch(&self) -> DOMString;
-    fn SetCh(&mut self, _ch: DOMString) -> ErrorResult;
+    fn SetCh(&self, _ch: DOMString) -> ErrorResult;
     fn ChOff(&self) -> DOMString;
-    fn SetChOff(&mut self, _ch_off: DOMString) -> ErrorResult;
+    fn SetChOff(&self, _ch_off: DOMString) -> ErrorResult;
     fn VAlign(&self) -> DOMString;
-    fn SetVAlign(&mut self, _v_align: DOMString) -> ErrorResult;
+    fn SetVAlign(&self, _v_align: DOMString) -> ErrorResult;
     fn Width(&self) -> DOMString;
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult;
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
@@ -57,7 +57,7 @@ impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
         0
     }
 
-    fn SetSpan(&mut self, _span: u32) -> ErrorResult {
+    fn SetSpan(&self, _span: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -65,7 +65,7 @@ impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -73,7 +73,7 @@ impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
         "".to_owned()
     }
 
-    fn SetCh(&mut self, _ch: DOMString) -> ErrorResult {
+    fn SetCh(&self, _ch: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -81,7 +81,7 @@ impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
         "".to_owned()
     }
 
-    fn SetChOff(&mut self, _ch_off: DOMString) -> ErrorResult {
+    fn SetChOff(&self, _ch_off: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -89,7 +89,7 @@ impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
         "".to_owned()
     }
 
-    fn SetVAlign(&mut self, _v_align: DOMString) -> ErrorResult {
+    fn SetVAlign(&self, _v_align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -97,7 +97,7 @@ impl<'a> HTMLTableColElementMethods for JSRef<'a, HTMLTableColElement> {
         "".to_owned()
     }
 
-    fn SetWidth(&mut self, _width: DOMString) -> ErrorResult {
+    fn SetWidth(&self, _width: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltableelement.rs
+++ b/src/components/script/dom/htmltableelement.rs
@@ -41,7 +41,7 @@ pub trait HTMLTableElementMethods {
     fn DeleteCaption(&self);
     fn DeleteTHead(&self);
     fn DeleteTFoot(&self);
-    fn DeleteRow(&mut self, _index: i32) -> ErrorResult;
+    fn DeleteRow(&self, _index: i32) -> ErrorResult;
     fn Sortable(&self) -> bool;
     fn SetSortable(&self, _sortable: bool);
     fn StopSorting(&self);
@@ -75,7 +75,7 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
     fn DeleteTFoot(&self) {
     }
 
-    fn DeleteRow(&mut self, _index: i32) -> ErrorResult {
+    fn DeleteRow(&self, _index: i32) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmltablerowelement.rs
+++ b/src/components/script/dom/htmltablerowelement.rs
@@ -42,7 +42,7 @@ pub trait HTMLTableRowElementMethods {
     fn GetRowIndex(&self) -> i32;
     fn SectionRowIndex(&self) -> i32;
     fn GetSectionRowIndex(&self) -> i32;
-    fn DeleteCell(&mut self, _index: i32) -> ErrorResult;
+    fn DeleteCell(&self, _index: i32) -> ErrorResult;
     fn Align(&self) -> DOMString;
     fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn Ch(&self) -> DOMString;
@@ -72,7 +72,7 @@ impl<'a> HTMLTableRowElementMethods for JSRef<'a, HTMLTableRowElement> {
         0
     }
 
-    fn DeleteCell(&mut self, _index: i32) -> ErrorResult {
+    fn DeleteCell(&self, _index: i32) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmltablesectionelement.rs
+++ b/src/components/script/dom/htmltablesectionelement.rs
@@ -38,19 +38,19 @@ impl HTMLTableSectionElement {
 }
 
 pub trait HTMLTableSectionElementMethods {
-    fn DeleteRow(&mut self, _index: i32) -> ErrorResult;
+    fn DeleteRow(&self, _index: i32) -> ErrorResult;
     fn Align(&self) -> DOMString;
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult;
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult;
     fn Ch(&self) -> DOMString;
-    fn SetCh(&mut self, _ch: DOMString) -> ErrorResult;
+    fn SetCh(&self, _ch: DOMString) -> ErrorResult;
     fn ChOff(&self) -> DOMString;
-    fn SetChOff(&mut self, _ch_off: DOMString) -> ErrorResult;
+    fn SetChOff(&self, _ch_off: DOMString) -> ErrorResult;
     fn VAlign(&self) -> DOMString;
-    fn SetVAlign(&mut self, _v_align: DOMString) -> ErrorResult;
+    fn SetVAlign(&self, _v_align: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLTableSectionElementMethods for JSRef<'a, HTMLTableSectionElement> {
-    fn DeleteRow(&mut self, _index: i32) -> ErrorResult {
+    fn DeleteRow(&self, _index: i32) -> ErrorResult {
         Ok(())
     }
 
@@ -58,7 +58,7 @@ impl<'a> HTMLTableSectionElementMethods for JSRef<'a, HTMLTableSectionElement> {
         "".to_owned()
     }
 
-    fn SetAlign(&mut self, _align: DOMString) -> ErrorResult {
+    fn SetAlign(&self, _align: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -66,7 +66,7 @@ impl<'a> HTMLTableSectionElementMethods for JSRef<'a, HTMLTableSectionElement> {
         "".to_owned()
     }
 
-    fn SetCh(&mut self, _ch: DOMString) -> ErrorResult {
+    fn SetCh(&self, _ch: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -74,7 +74,7 @@ impl<'a> HTMLTableSectionElementMethods for JSRef<'a, HTMLTableSectionElement> {
         "".to_owned()
     }
 
-    fn SetChOff(&mut self, _ch_off: DOMString) -> ErrorResult {
+    fn SetChOff(&self, _ch_off: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl<'a> HTMLTableSectionElementMethods for JSRef<'a, HTMLTableSectionElement> {
         "".to_owned()
     }
 
-    fn SetVAlign(&mut self, _v_align: DOMString) -> ErrorResult {
+    fn SetVAlign(&self, _v_align: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -39,35 +39,35 @@ impl HTMLTextAreaElement {
 
 pub trait HTMLTextAreaElementMethods {
     fn Autofocus(&self) -> bool;
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult;
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult;
     fn Cols(&self) -> u32;
     fn SetCols(&self, _cols: u32) -> ErrorResult;
     fn Disabled(&self) -> bool;
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult;
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult;
     fn MaxLength(&self) -> i32;
     fn SetMaxLength(&self, _max_length: i32) -> ErrorResult;
     fn Name(&self) -> DOMString;
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult;
+    fn SetName(&self, _name: DOMString) -> ErrorResult;
     fn Placeholder(&self) -> DOMString;
-    fn SetPlaceholder(&mut self, _placeholder: DOMString) -> ErrorResult;
+    fn SetPlaceholder(&self, _placeholder: DOMString) -> ErrorResult;
     fn ReadOnly(&self) -> bool;
-    fn SetReadOnly(&mut self, _read_only: bool) -> ErrorResult;
+    fn SetReadOnly(&self, _read_only: bool) -> ErrorResult;
     fn Required(&self) -> bool;
-    fn SetRequired(&mut self, _required: bool) -> ErrorResult;
+    fn SetRequired(&self, _required: bool) -> ErrorResult;
     fn Rows(&self) -> u32;
     fn SetRows(&self, _rows: u32) -> ErrorResult;
     fn Wrap(&self) -> DOMString;
-    fn SetWrap(&mut self, _wrap: DOMString) -> ErrorResult;
+    fn SetWrap(&self, _wrap: DOMString) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString);
+    fn SetType(&self, _type: DOMString);
     fn DefaultValue(&self) -> DOMString;
-    fn SetDefaultValue(&mut self, _default_value: DOMString) -> ErrorResult;
+    fn SetDefaultValue(&self, _default_value: DOMString) -> ErrorResult;
     fn Value(&self) -> DOMString;
-    fn SetValue(&mut self, _value: DOMString);
+    fn SetValue(&self, _value: DOMString);
     fn TextLength(&self) -> u32;
     fn SetTextLength(&self, _text_length: u32) -> ErrorResult;
     fn WillValidate(&self) -> bool;
-    fn SetWillValidate(&mut self, _will_validate: bool) -> ErrorResult;
+    fn SetWillValidate(&self, _will_validate: bool) -> ErrorResult;
     fn ValidationMessage(&self) -> DOMString;
     fn CheckValidity(&self) -> bool;
     fn SetCustomValidity(&self, _error: DOMString);
@@ -86,7 +86,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         false
     }
 
-    fn SetAutofocus(&mut self, _autofocus: bool) -> ErrorResult {
+    fn SetAutofocus(&self, _autofocus: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -102,7 +102,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         false
     }
 
-    fn SetDisabled(&mut self, _disabled: bool) -> ErrorResult {
+    fn SetDisabled(&self, _disabled: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -118,7 +118,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         "".to_owned()
     }
 
-    fn SetName(&mut self, _name: DOMString) -> ErrorResult {
+    fn SetName(&self, _name: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -126,7 +126,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         "".to_owned()
     }
 
-    fn SetPlaceholder(&mut self, _placeholder: DOMString) -> ErrorResult {
+    fn SetPlaceholder(&self, _placeholder: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -134,7 +134,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         false
     }
 
-    fn SetReadOnly(&mut self, _read_only: bool) -> ErrorResult {
+    fn SetReadOnly(&self, _read_only: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -142,7 +142,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         false
     }
 
-    fn SetRequired(&mut self, _required: bool) -> ErrorResult {
+    fn SetRequired(&self, _required: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -158,7 +158,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         "".to_owned()
     }
 
-    fn SetWrap(&mut self, _wrap: DOMString) -> ErrorResult {
+    fn SetWrap(&self, _wrap: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -166,14 +166,14 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) {
+    fn SetType(&self, _type: DOMString) {
     }
 
     fn DefaultValue(&self) -> DOMString {
         "".to_owned()
     }
 
-    fn SetDefaultValue(&mut self, _default_value: DOMString) -> ErrorResult {
+    fn SetDefaultValue(&self, _default_value: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -181,7 +181,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         "".to_owned()
     }
 
-    fn SetValue(&mut self, _value: DOMString) {
+    fn SetValue(&self, _value: DOMString) {
     }
 
     fn TextLength(&self) -> u32 {
@@ -196,7 +196,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         false
     }
 
-    fn SetWillValidate(&mut self, _will_validate: bool) -> ErrorResult {
+    fn SetWillValidate(&self, _will_validate: bool) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmltimeelement.rs
+++ b/src/components/script/dom/htmltimeelement.rs
@@ -39,7 +39,7 @@ impl HTMLTimeElement {
 
 pub trait HTMLTimeElementMethods {
     fn DateTime(&self) -> DOMString;
-    fn SetDateTime(&mut self, _dateTime: DOMString) -> ErrorResult;
+    fn SetDateTime(&self, _dateTime: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLTimeElementMethods for JSRef<'a, HTMLTimeElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLTimeElementMethods for JSRef<'a, HTMLTimeElement> {
         "".to_owned()
     }
 
-    fn SetDateTime(&mut self, _dateTime: DOMString) -> ErrorResult {
+    fn SetDateTime(&self, _dateTime: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltitleelement.rs
+++ b/src/components/script/dom/htmltitleelement.rs
@@ -39,7 +39,7 @@ impl HTMLTitleElement {
 
 pub trait HTMLTitleElementMethods {
     fn Text(&self) -> DOMString;
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult;
+    fn SetText(&self, _text: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
@@ -47,7 +47,7 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
         "".to_owned()
     }
 
-    fn SetText(&mut self, _text: DOMString) -> ErrorResult {
+    fn SetText(&self, _text: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmltrackelement.rs
+++ b/src/components/script/dom/htmltrackelement.rs
@@ -39,15 +39,15 @@ impl HTMLTrackElement {
 
 pub trait HTMLTrackElementMethods {
     fn Kind(&self) -> DOMString;
-    fn SetKind(&mut self, _kind: DOMString) -> ErrorResult;
+    fn SetKind(&self, _kind: DOMString) -> ErrorResult;
     fn Src(&self) -> DOMString;
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult;
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult;
     fn Srclang(&self) -> DOMString;
-    fn SetSrclang(&mut self, _srclang: DOMString) -> ErrorResult;
+    fn SetSrclang(&self, _srclang: DOMString) -> ErrorResult;
     fn Label(&self) -> DOMString;
-    fn SetLabel(&mut self, _label: DOMString) -> ErrorResult;
+    fn SetLabel(&self, _label: DOMString) -> ErrorResult;
     fn Default(&self) -> bool;
-    fn SetDefault(&mut self, _default: bool) -> ErrorResult;
+    fn SetDefault(&self, _default: bool) -> ErrorResult;
     fn ReadyState(&self) -> u16;
 }
 
@@ -56,7 +56,7 @@ impl<'a> HTMLTrackElementMethods for JSRef<'a, HTMLTrackElement> {
         "".to_owned()
     }
 
-    fn SetKind(&mut self, _kind: DOMString) -> ErrorResult {
+    fn SetKind(&self, _kind: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -64,7 +64,7 @@ impl<'a> HTMLTrackElementMethods for JSRef<'a, HTMLTrackElement> {
         "".to_owned()
     }
 
-    fn SetSrc(&mut self, _src: DOMString) -> ErrorResult {
+    fn SetSrc(&self, _src: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -72,7 +72,7 @@ impl<'a> HTMLTrackElementMethods for JSRef<'a, HTMLTrackElement> {
         "".to_owned()
     }
 
-    fn SetSrclang(&mut self, _srclang: DOMString) -> ErrorResult {
+    fn SetSrclang(&self, _srclang: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl<'a> HTMLTrackElementMethods for JSRef<'a, HTMLTrackElement> {
         "".to_owned()
     }
 
-    fn SetLabel(&mut self, _label: DOMString) -> ErrorResult {
+    fn SetLabel(&self, _label: DOMString) -> ErrorResult {
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl<'a> HTMLTrackElementMethods for JSRef<'a, HTMLTrackElement> {
         false
     }
 
-    fn SetDefault(&mut self, _default: bool) -> ErrorResult {
+    fn SetDefault(&self, _default: bool) -> ErrorResult {
         Ok(())
     }
 

--- a/src/components/script/dom/htmlulistelement.rs
+++ b/src/components/script/dom/htmlulistelement.rs
@@ -39,9 +39,9 @@ impl HTMLUListElement {
 
 pub trait HTMLUListElementMethods {
     fn Compact(&self) -> bool;
-    fn SetCompact(&mut self, _compact: bool) -> ErrorResult;
+    fn SetCompact(&self, _compact: bool) -> ErrorResult;
     fn Type(&self) -> DOMString;
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult;
+    fn SetType(&self, _type: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLUListElementMethods for JSRef<'a, HTMLUListElement> {
@@ -49,7 +49,7 @@ impl<'a> HTMLUListElementMethods for JSRef<'a, HTMLUListElement> {
         false
     }
 
-    fn SetCompact(&mut self, _compact: bool) -> ErrorResult {
+    fn SetCompact(&self, _compact: bool) -> ErrorResult {
         Ok(())
     }
 
@@ -57,7 +57,7 @@ impl<'a> HTMLUListElementMethods for JSRef<'a, HTMLUListElement> {
         "".to_owned()
     }
 
-    fn SetType(&mut self, _type: DOMString) -> ErrorResult {
+    fn SetType(&self, _type: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/htmlvideoelement.rs
+++ b/src/components/script/dom/htmlvideoelement.rs
@@ -39,13 +39,13 @@ impl HTMLVideoElement {
 
 pub trait HTMLVideoElementMethods {
     fn Width(&self) -> u32;
-    fn SetWidth(&mut self, _width: u32) -> ErrorResult;
+    fn SetWidth(&self, _width: u32) -> ErrorResult;
     fn Height(&self) -> u32;
-    fn SetHeight(&mut self, _height: u32) -> ErrorResult;
+    fn SetHeight(&self, _height: u32) -> ErrorResult;
     fn VideoWidth(&self) -> u32;
     fn VideoHeight(&self) -> u32;
     fn Poster(&self) -> DOMString;
-    fn SetPoster(&mut self, _poster: DOMString) -> ErrorResult;
+    fn SetPoster(&self, _poster: DOMString) -> ErrorResult;
 }
 
 impl<'a> HTMLVideoElementMethods for JSRef<'a, HTMLVideoElement> {
@@ -53,7 +53,7 @@ impl<'a> HTMLVideoElementMethods for JSRef<'a, HTMLVideoElement> {
         0
     }
 
-    fn SetWidth(&mut self, _width: u32) -> ErrorResult {
+    fn SetWidth(&self, _width: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl<'a> HTMLVideoElementMethods for JSRef<'a, HTMLVideoElement> {
         0
     }
 
-    fn SetHeight(&mut self, _height: u32) -> ErrorResult {
+    fn SetHeight(&self, _height: u32) -> ErrorResult {
         Ok(())
     }
 
@@ -77,7 +77,7 @@ impl<'a> HTMLVideoElementMethods for JSRef<'a, HTMLVideoElement> {
         "".to_owned()
     }
 
-    fn SetPoster(&mut self, _poster: DOMString) -> ErrorResult {
+    fn SetPoster(&self, _poster: DOMString) -> ErrorResult {
         Ok(())
     }
 }

--- a/src/components/script/dom/uievent.rs
+++ b/src/components/script/dom/uievent.rs
@@ -74,7 +74,7 @@ pub trait UIEventMethods {
     fn GetRangeParent(&self) -> Option<Temporary<Node>>;
     fn RangeOffset(&self) -> i32;
     fn CancelBubble(&self) -> bool;
-    fn SetCancelBubble(&mut self, _val: bool);
+    fn SetCancelBubble(&self, _val: bool);
     fn IsChar(&self) -> bool;
     fn InitUIEvent(&mut self,
                    type_: DOMString,
@@ -147,7 +147,7 @@ impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
         false
     }
 
-    fn SetCancelBubble(&mut self, _val: bool) {
+    fn SetCancelBubble(&self, _val: bool) {
         //TODO
     }
 


### PR DESCRIPTION
Related #2514
- This removes needless `&mut self`s from some DOM type method simply.
- This doesn't include some DOM Types which have basis method called from other types (e.g. `Element`). We still have to need to open their changes.
- This does not include to remove an implicit `deref_mut()`.
