### PR TITLE
Prevent child layers from overriding root background color

### DIFF
--- a/src/components/main/compositing/compositor_layer.rs
+++ b/src/components/main/compositing/compositor_layer.rs
@@ -965,5 +965,19 @@ impl CompositorLayer {
     pub fn id_of_first_child(&self) -> LayerId {
         self.children.iter().next().expect("no first child!").child.id
     }
+
+    pub fn set_unrendered_color(&mut self, pipeline_id: PipelineId, layer_id: LayerId, color: Color) -> bool {
+        if self.pipeline.id != pipeline_id || self.id != layer_id {
+            for child_layer in self.children.mut_iter() {
+                if child_layer.child.set_unrendered_color(pipeline_id, layer_id, color) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        self.unrendered_color = color;
+        return true;
+    }
 }
 

--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -96,7 +96,8 @@ impl RenderListener for CompositorChan {
             if first {
                 self.chan.send(CreateRootCompositorLayerIfNecessary(pipeline_id,
                                                                     metadata.id,
-                                                                    size));
+                                                                    size,
+                                                                    metadata.background_color));
                 first = false
             } else {
                 self.chan
@@ -166,7 +167,7 @@ pub enum Msg {
 
     /// Tells the compositor to create the root layer for a pipeline if necessary (i.e. if no layer
     /// with that ID exists).
-    CreateRootCompositorLayerIfNecessary(PipelineId, LayerId, Size2D<f32>),
+    CreateRootCompositorLayerIfNecessary(PipelineId, LayerId, Size2D<f32>, Color),
     /// Tells the compositor to create a descendant layer for a pipeline if necessary (i.e. if no
     /// layer with that ID exists).
     CreateDescendantCompositorLayerIfNecessary(PipelineId, LayerId, Rect<f32>, ScrollPolicy),

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -75,3 +75,4 @@
 == linebreak_simple_a.html linebreak_simple_b.html
 == linebreak_inline_span_a.html linebreak_inline_span_b.html
 == overconstrained_block.html overconstrained_block_ref.html
+== position_fixed_background_color_a.html position_fixed_background_color_b.html

--- a/src/test/ref/position_fixed_background_color_a.html
+++ b/src/test/ref/position_fixed_background_color_a.html
@@ -1,0 +1,6 @@
+<html>
+<body style="background:pink">
+    <div style="position: fixed;">
+    </div>
+</body>
+</html>

--- a/src/test/ref/position_fixed_background_color_b.html
+++ b/src/test/ref/position_fixed_background_color_b.html
@@ -1,0 +1,4 @@
+<html>
+<body style="background:pink">
+</body>
+</html>


### PR DESCRIPTION
The first layer implicitly provides the size of the page, but child
layer background colors can still improperly override the body
background color. This commit ensures that layer background colors only
apply to layers with the same id and pipeline id. Additionally the root
layer's unrendered color is defined by the first layer's background
color, just like for size.
