### PR TITLE
Remove all old layers before adding a new root layer (fixes #2259)

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -381,13 +381,7 @@ impl IOCompositor {
                                                           self.opts.cpu_painting);
             new_layer.unrendered_color = unrendered_color;
 
-            let first_child = self.root_layer.first_child.borrow().clone();
-            match first_child {
-                None => {}
-                Some(old_layer) => {
-                    ContainerLayer::remove_child(self.root_layer.clone(), old_layer)
-                }
-            }
+            self.root_layer.remove_all_children();
 
             assert!(new_layer.add_child_if_necessary(self.root_layer.clone(),
                                                      root_pipeline_id,

--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -367,8 +367,10 @@ impl IOCompositor {
             }
             _ => {
                 match self.root_pipeline {
-                    Some(ref root_pipeline) => (root_pipeline.clone(), LayerId::null()),
-                    None => fail!("Compositor: Received new layer without initialized pipeline"),
+                    Some(ref root_pipeline) if root_pipeline.id == id => {
+                        (root_pipeline.clone(), LayerId::null())
+                    },
+                    _ => fail!("Compositor: Received new layer without initialized pipeline"),
                 }
             }
         };

--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -298,10 +298,6 @@ impl IOCompositor {
                     self.set_layer_clip_rect(pipeline_id, layer_id, new_rect);
                 }
 
-                (Ok(DeleteLayerGroup(id)), _) => {
-                    self.delete_layer(id);
-                }
-
                 (Ok(Paint(pipeline_id, layer_id, new_layer_buffer_set, epoch)), false) => {
                     self.paint(pipeline_id, layer_id, new_layer_buffer_set, epoch);
                 }
@@ -462,22 +458,6 @@ impl IOCompositor {
         let ask: bool = match self.compositor_layer {
             Some(ref mut layer) => {
                 assert!(layer.set_clipping_rect(pipeline_id, layer_id, new_rect));
-                true
-            }
-            None => {
-                false
-            }
-        };
-
-        if ask {
-            self.ask_for_tiles();
-        }
-    }
-
-    fn delete_layer(&mut self, id: PipelineId) {
-        let ask: bool = match self.compositor_layer {
-            Some(ref mut layer) => {
-                assert!(layer.delete(&self.graphics_context, id));
                 true
             }
             None => {

--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -126,10 +126,6 @@ impl RenderListener for CompositorChan {
         self.chan.send(SetLayerClipRect(pipeline_id, layer_id, new_rect))
     }
 
-    fn delete_layer_group(&self, id: PipelineId) {
-        self.chan.send(DeleteLayerGroup(id))
-    }
-
     fn set_render_state(&self, render_state: RenderState) {
         self.chan.send(ChangeRenderState(render_state))
     }
@@ -175,8 +171,6 @@ pub enum Msg {
     SetLayerPageSize(PipelineId, LayerId, Size2D<f32>, Epoch),
     /// Alerts the compositor that the specified layer's clipping rect has changed.
     SetLayerClipRect(PipelineId, LayerId, Rect<f32>),
-    /// Alerts the compositor that the specified pipeline has been deleted.
-    DeleteLayerGroup(PipelineId),
     /// Scroll a page in a window
     ScrollFragmentPoint(PipelineId, LayerId, Point2D<f32>),
     /// Requests that the compositor paint the given layer buffer set for the given page size.

--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -78,7 +78,7 @@ impl NullCompositor {
 
                 CreateRootCompositorLayerIfNecessary(..) |
                 CreateDescendantCompositorLayerIfNecessary(..) | SetLayerPageSize(..) |
-                SetLayerClipRect(..) | DeleteLayerGroup(..) | Paint(..) |
+                SetLayerClipRect(..) | Paint(..) |
                 ChangeReadyState(..) | ChangeRenderState(..) | ScrollFragmentPoint(..) |
                 SetUnRenderedColor(..) | LoadComplete(..) => ()
             }

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -134,8 +134,6 @@ pub trait RenderListener {
                            layer_id: LayerId,
                            new_rect: Rect<uint>);
 
-    fn delete_layer_group(&self, PipelineId);
-
     /// Sends new tiles for the given layer to the compositor.
     fn paint(&self,
              pipeline_id: PipelineId,


### PR DESCRIPTION
This fixes #2259 which was caused by some of the previous layers sticking around incorrectly.  Depends on mozilla-servo/rust-layers#69.

Also includes some related cleanup as separate commits.

No reftest because our test harness doesn't yet support navigating to a new page (#2574).
