### PR TITLE
Fix text decoration bug in applicable declarations cache

### DIFF
--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -131,7 +131,7 @@ impl<'a> Hash for ApplicableDeclarationsCacheQuery<'a> {
 static APPLICABLE_DECLARATIONS_CACHE_SIZE: uint = 32;
 
 pub struct ApplicableDeclarationsCache {
-    pub cache: SimpleHashCache<ApplicableDeclarationsCacheEntry,Arc<ComputedValues>>,
+    cache: SimpleHashCache<ApplicableDeclarationsCacheEntry,Arc<ComputedValues>>,
 }
 
 impl ApplicableDeclarationsCache {
@@ -149,7 +149,7 @@ impl ApplicableDeclarationsCache {
     }
 
     fn insert(&mut self, declarations: &[MatchedProperty], style: Arc<ComputedValues>) {
-        drop(self.cache.insert(ApplicableDeclarationsCacheEntry::new(declarations), style))
+        self.cache.insert(ApplicableDeclarationsCacheEntry::new(declarations), style)
     }
 }
 

--- a/src/components/main/css/matching.rs
+++ b/src/components/main/css/matching.rs
@@ -340,12 +340,11 @@ impl<'ln> PrivateMatchMethods for LayoutNode<'ln> {
         let cacheable;
         match parent_style {
             Some(ref parent_style) => {
-                let cached_computed_values;
                 let cache_entry = applicable_declarations_cache.find(applicable_declarations);
-                match cache_entry {
-                    None => cached_computed_values = None,
-                    Some(ref style) => cached_computed_values = Some(&**style),
-                }
+                let cached_computed_values = match cache_entry {
+                    None => None,
+                    Some(ref style) => Some(&**style),
+                };
                 let (the_style, is_cacheable) = cascade(applicable_declarations,
                                                         shareable,
                                                         Some(&***parent_style),

--- a/src/components/util/cache.rs
+++ b/src/components/util/cache.rs
@@ -216,7 +216,7 @@ impl<K:Clone+Eq+Hash,V:Clone> SimpleHashCache<K,V> {
 impl<K:Clone+Eq+Hash,V:Clone> Cache<K,V> for SimpleHashCache<K,V> {
     fn insert(&mut self, key: K, value: V) {
         let bucket_index = self.bucket_for_key(&key);
-        *self.entries.get_mut(bucket_index) = Some((key, value))
+        *self.entries.get_mut(bucket_index) = Some((key, value));
     }
 
     fn find(&mut self, key: &K) -> Option<V> {

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -18,6 +18,7 @@
 == border_style_none_a.html border_style_none_b.html
 == borders_a.html borders_b.html
 == acid1_a.html acid1_b.html
+== text_decoration_cached.html text_decoration_cached_ref.html
 # text_decoration_propagation_a.html text_decoration_propagation_b.html
 # inline_text_align_a.html inline_text_align_b.html
 == font_size_em.html font_size_em_ref.html

--- a/src/test/ref/text_decoration_cached.html
+++ b/src/test/ref/text_decoration_cached.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>text-decoration cache test</title>
+    <style>
+      span { text-decoration: underline; }
+    </style>
+  </head>
+<body>
+  <u>test</u>
+  <u>test</u>
+<body>
+</html>

--- a/src/test/ref/text_decoration_cached_ref.html
+++ b/src/test/ref/text_decoration_cached_ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>text-decoration cache reference</title>
+    <style>
+      span { text-decoration: underline; }
+    </style>
+  </head>
+<body>
+  <u>test</u>
+  <span>test</span>
+<body>
+</html>


### PR DESCRIPTION
Fixes #2498.  Also includes a reftest, and some related code cleanup (in separate commits).

Note: The fix in `properties.rs.mako` is much more readable with `git diff -w`.
