### PR TITLE
Fix issues with margin collapse

### DIFF
--- a/src/components/layout/block.rs
+++ b/src/components/layout/block.rs
@@ -760,7 +760,7 @@ impl BlockFlow {
     }
 
     /// If this is the root flow, shifts all kids down and adjusts our size to account for
-    /// collapsed margins.
+    /// root flow margins, which should never be collapsed according to CSS § 8.3.1.
     ///
     /// TODO(#2017, pcwalton): This is somewhat inefficient (traverses kids twice); can we do
     /// better?
@@ -770,7 +770,7 @@ impl BlockFlow {
         }
 
         let (block_start_margin_value, block_end_margin_value) = match self.base.collapsible_margins {
-            MarginsCollapseThrough(margin) => (Au(0), margin.collapse()),
+            MarginsCollapseThrough(_) => fail!("Margins unexpectedly collapsed through root flow."),
             MarginsCollapse(block_start_margin, block_end_margin) => {
                 (block_start_margin.collapse(), block_end_margin.collapse())
             }
@@ -1580,6 +1580,10 @@ impl Flow for BlockFlow {
         if self.is_float() {
             debug!("assign_block_size_float: assigning block_size for float");
             self.assign_block_size_float(ctx);
+        } else if self.is_root() {
+            // Root element margins should never be collapsed according to CSS § 8.3.1.
+            debug!("assign_block_size: assigning block_size for root flow");
+            self.assign_block_size_block_base(ctx, MarginsMayNotCollapse);
         } else {
             debug!("assign_block_size: assigning block_size for block");
             self.assign_block_size_block_base(ctx, MarginsMayCollapse);

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -91,3 +91,4 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == inline_whitespace_b.html inline_whitespace_ref.html
 == inline_whitespace_a.html inline_whitespace_ref.html
 == line_height_a.html line_height_ref.html
+== root_margin_collapse_a.html root_margin_collapse_b.html

--- a/src/test/ref/root_margin_collapse_a.html
+++ b/src/test/ref/root_margin_collapse_a.html
@@ -1,0 +1,5 @@
+<html style="margin-top: 10px;">
+    <body style="margin-top: 10px;">
+        <div style="width: 100px; height: 100px; background: black;"></div>
+    </body>
+</html>

--- a/src/test/ref/root_margin_collapse_b.html
+++ b/src/test/ref/root_margin_collapse_b.html
@@ -1,0 +1,5 @@
+<html>
+    <body style="margin-top: 20px;">
+        <div style="width: 100px; height: 100px; background: black;"></div>
+    </body>
+</html>


### PR DESCRIPTION
According to the CSS specification, section 8.3.1, margins of the root
element's box do not collapse. Ensure that root flow margins do not
collapse during the assign heights phase.
