### PR TITLE
Don't require root pipeline to match new pipeline

### DIFF
--- a/src/components/main/compositing/compositor.rs
+++ b/src/components/main/compositing/compositor.rs
@@ -363,7 +363,7 @@ impl IOCompositor {
             }
             _ => {
                 match self.root_pipeline {
-                    Some(ref root_pipeline) if root_pipeline.id == id => {
+                    Some(ref root_pipeline) => {
                         (root_pipeline.clone(), LayerId::null())
                     },
                     _ => fail!("Compositor: Received new layer without initialized pipeline"),


### PR DESCRIPTION
This reverts 2b0134be7bb8a4372f1a8703b5a1b114e65351f6 because it was not correct for iframes.  Oops.  (Wasn't caught by tests because we still have other crashes preventing iframe testing.)  r? @pcwalton.
