### PR TITLE
Convert window size to px before passing to script or layout

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -235,12 +235,12 @@ DONE_net = $(B)src/components/net/libnet.dummy
 
 DEPS_net = $(CRATE_net) $(SRC_net) $(DONE_SUBMODULES) $(DONE_util)
 
-RFLAGS_msg = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES))
+RFLAGS_msg = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util
 SRC_msg = $(call rwildcard,$(S)src/components/msg/,*.rs)
 CRATE_msg = $(S)src/components/msg/msg.rs
 DONE_msg = $(B)src/components/msg/libmsg.dummy
 
-DEPS_msg = $(CRATE_msg) $(SRC_msg) $(DONE_SUBMODULES)
+DEPS_msg = $(CRATE_msg) $(SRC_msg) $(DONE_SUBMODULES) $(DONE_util)
 
 RFLAGS_gfx = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/util -L $(B)src/components/style -L $(B)src/components/net -L $(B)src/components/msg -L$(B)src/components/macros
 SRC_gfx = $(call rwildcard,$(S)src/components/gfx/,*.rs)

--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -4,7 +4,7 @@
 
 use compositing::*;
 
-use geom::size::Size2D;
+use geom::size::TypedSize2D;
 use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, ResizedWindowMsg};
 use servo_util::time::ProfilerChan;
 use servo_util::time;
@@ -33,7 +33,7 @@ impl NullCompositor {
         // Tell the constellation about the initial fake size.
         {
             let ConstellationChan(ref chan) = constellation_chan;
-            chan.send(ResizedWindowMsg(Size2D(640u, 480u)));
+            chan.send(ResizedWindowMsg(TypedSize2D(640_f32, 480_f32)));
         }
         compositor.handle_message(constellation_chan);
 

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -581,8 +581,8 @@ impl LayoutTask {
             _ => false
         };
 
-        let current_screen_size = Size2D(Au::from_px(data.window_size.width as int),
-                                         Au::from_px(data.window_size.height as int));
+        let current_screen_size = Size2D(Au::from_page_px(data.window_size.width),
+                                         Au::from_page_px(data.window_size.height));
         if self.screen_size != current_screen_size {
             all_style_damage = true
         }

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -5,7 +5,7 @@
 use compositing::CompositorChan;
 use layout::layout_task::LayoutTask;
 
-use geom::size::Size2D;
+use geom::size::TypedSize2D;
 use gfx::render_task::{PaintPermissionGranted, PaintPermissionRevoked};
 use gfx::render_task::{RenderChan, RenderTask};
 use script::layout_interface::LayoutChan;
@@ -15,6 +15,7 @@ use script::script_task;
 use servo_msg::constellation_msg::{ConstellationChan, Failure, PipelineId, SubpageId};
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
+use servo_util::geometry::PagePx;
 use servo_util::opts::Opts;
 use servo_util::time::ProfilerChan;
 use std::rc::Rc;
@@ -112,7 +113,7 @@ impl Pipeline {
                   image_cache_task: ImageCacheTask,
                   resource_task: ResourceTask,
                   profiler_chan: ProfilerChan,
-                  window_size: Size2D<uint>,
+                  window_size: TypedSize2D<PagePx, f32>,
                   opts: Opts,
                   url: Url)
                   -> Pipeline {

--- a/src/components/main/platform/common/glfw_windowing.rs
+++ b/src/components/main/platform/common/glfw_windowing.rs
@@ -145,9 +145,15 @@ impl WindowMethods<Application> for Window {
         wrapped_window
     }
 
-    /// Returns the size of the window.
-    fn size(&self) -> TypedSize2D<DevicePixel, f32> {
+    /// Returns the size of the window in hardware pixels.
+    fn framebuffer_size(&self) -> TypedSize2D<DevicePixel, uint> {
         let (width, height) = self.glfw_window.get_framebuffer_size();
+        TypedSize2D(width as uint, height as uint)
+    }
+
+    /// Returns the size of the window in density-independent "px" units.
+    fn size(&self) -> TypedSize2D<ScreenPx, f32> {
+        let (width, height) = self.glfw_window.get_size();
         TypedSize2D(width as f32, height as f32)
     }
 
@@ -196,9 +202,9 @@ impl WindowMethods<Application> for Window {
     }
 
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32> {
-        let (backing_size, _) = self.glfw_window.get_framebuffer_size();
-        let (window_size, _) = self.glfw_window.get_size();
-        ScaleFactor((backing_size as f32) / (window_size as f32))
+        let backing_size = self.framebuffer_size().width.get();
+        let window_size = self.size().width.get();
+        ScaleFactor((backing_size as f32) / window_size)
     }
 }
 
@@ -211,7 +217,8 @@ impl Window {
                 }
             },
             glfw::FramebufferSizeEvent(width, height) => {
-                self.event_queue.borrow_mut().push(ResizeWindowEvent(width as uint, height as uint));
+                self.event_queue.borrow_mut().push(
+                    ResizeWindowEvent(TypedSize2D(width as uint, height as uint)));
             },
             glfw::RefreshEvent => {
                 self.event_queue.borrow_mut().push(RefreshWindowEvent);

--- a/src/components/main/platform/common/glut_windowing.rs
+++ b/src/components/main/platform/common/glut_windowing.rs
@@ -144,9 +144,14 @@ impl WindowMethods<Application> for Window {
         wrapped_window
     }
 
-    /// Returns the size of the window.
-    fn size(&self) -> TypedSize2D<DevicePixel, f32> {
-        TypedSize2D(glut::get(WindowWidth) as f32, glut::get(WindowHeight) as f32)
+    /// Returns the size of the window in hardware pixels.
+    fn framebuffer_size(&self) -> TypedSize2D<DevicePixel, uint> {
+        TypedSize2D(glut::get(WindowWidth) as uint, glut::get(WindowHeight) as uint)
+    }
+
+    /// Returns the size of the window in density-independent "px" units.
+    fn size(&self) -> TypedSize2D<ScreenPx, f32> {
+        self.framebuffer_size().as_f32() / self.hidpi_factor()
     }
 
     /// Presents the window to the screen (perhaps by page flipping).

--- a/src/components/main/windowing.rs
+++ b/src/components/main/windowing.rs
@@ -32,7 +32,7 @@ pub enum WindowEvent {
     /// Sent when part of the window is marked dirty and needs to be redrawn.
     RefreshWindowEvent,
     /// Sent when the window is resized.
-    ResizeWindowEvent(uint, uint),
+    ResizeWindowEvent(TypedSize2D<DevicePixel, uint>),
     /// Sent when a new URL is to be loaded.
     LoadUrlWindowEvent(String),
     /// Sent when a mouse hit test is to be performed.
@@ -59,8 +59,10 @@ pub trait ApplicationMethods {
 pub trait WindowMethods<A> {
     /// Creates a new window.
     fn new(app: &A, is_foreground: bool) -> Rc<Self>;
-    /// Returns the size of the window.
-    fn size(&self) -> TypedSize2D<DevicePixel, f32>;
+    /// Returns the size of the window in hardware pixels.
+    fn framebuffer_size(&self) -> TypedSize2D<DevicePixel, uint>;
+    /// Returns the size of the window in density-independent "px" units.
+    fn size(&self) -> TypedSize2D<ScreenPx, f32>;
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self);
 

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -6,7 +6,8 @@
 /// coupling between these two components
 
 use geom::rect::Rect;
-use geom::size::Size2D;
+use geom::size::TypedSize2D;
+use servo_util::geometry::PagePx;
 use std::comm::{channel, Sender, Receiver};
 use url::Url;
 
@@ -44,7 +45,7 @@ pub enum Msg {
     LoadIframeUrlMsg(Url, PipelineId, SubpageId, IFrameSandboxState),
     NavigateMsg(NavigationDirection),
     RendererReadyMsg(PipelineId),
-    ResizedWindowMsg(Size2D<uint>),
+    ResizedWindowMsg(TypedSize2D<PagePx, f32>),
 }
 
 /// Represents the two different ways to which a page can be navigated

--- a/src/components/msg/msg.rs
+++ b/src/components/msg/msg.rs
@@ -11,6 +11,7 @@ extern crate azure;
 extern crate geom;
 extern crate layers;
 extern crate serialize;
+extern crate servo_util = "util";
 extern crate std;
 extern crate url;
 

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -10,14 +10,16 @@ use dom::bindings::error::Fallible;
 use dom::eventtarget::EventTarget;
 use dom::window::Window;
 use servo_util::str::DOMString;
+use servo_util::geometry::PagePx;
 use std::cell::Cell;
 
 use geom::point::Point2D;
+use geom::size::TypedSize2D;
 
 use time;
 
 pub enum Event_ {
-    ResizeEvent(uint, uint),
+    ResizeEvent(TypedSize2D<PagePx, f32>),
     ReflowEvent,
     ClickEvent(uint, Point2D<f32>),
     MouseDownEvent(uint, Point2D<f32>),

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -11,10 +11,10 @@ use dom::node::{Node, LayoutDataRef};
 
 use geom::point::Point2D;
 use geom::rect::Rect;
-use geom::size::Size2D;
+use geom::size::TypedSize2D;
 use libc::c_void;
 use script_task::{ScriptChan};
-use servo_util::geometry::Au;
+use servo_util::geometry::{Au, PagePx};
 use std::cmp;
 use std::comm::{channel, Receiver, Sender};
 use style::Stylesheet;
@@ -137,7 +137,7 @@ pub struct Reflow {
     /// The channel through which messages can be sent back to the script task.
     pub script_chan: ScriptChan,
     /// The current window size.
-    pub window_size: Size2D<uint>,
+    pub window_size: TypedSize2D<PagePx, f32>,
     /// The channel that we send a notification to.
     pub script_join_chan: Sender<()>,
     /// Unique identifier

--- a/src/components/util/geometry.rs
+++ b/src/components/util/geometry.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use geom::length::Length;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
@@ -176,6 +177,11 @@ impl Au {
     #[inline]
     pub fn from_px(px: int) -> Au {
         NumCast::from(px * 60).unwrap()
+    }
+
+    #[inline]
+    pub fn from_page_px(px: Length<PagePx, f32>) -> Au {
+        NumCast::from(px.get() * 60f32).unwrap()
     }
 
     #[inline]


### PR DESCRIPTION
This fixes an issue where the CSS viewport was too large on high-DPI displays
because it was set to the window size in device pixels, instead of px.  This
patch ensures that the window size is converted from device pixels to px
before being passed to script/layout code.

The Window trait now exposes the window size in both device pixels and
density-independent screen coordinates, with clearer method names.
