### PR TITLE
Pass a JSRef to RegisterBindings::Register.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2078,7 +2078,7 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
     """
     def __init__(self, descriptor):
         args = [
-            Argument('&JS<Window>', 'window'),
+            Argument('&JSRef<Window>', 'window'),
             Argument('&mut JSPageInfo', 'js_info'),
         ]
         CGAbstractMethod.__init__(self, descriptor, 'DefineDOMInterface', 'void', args, pub=True)
@@ -4192,7 +4192,7 @@ class CGDictionary(CGThing):
 class CGRegisterProtos(CGAbstractMethod):
     def __init__(self, config):
         arguments = [
-            Argument('&JS<Window>', 'window'),
+            Argument('&JSRef<Window>', 'window'),
             Argument('&mut JSPageInfo', 'js_info'),
         ]
         CGAbstractMethod.__init__(self, None, 'Register', 'void', arguments,

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -956,7 +956,7 @@ impl ScriptTask {
 
         with_compartment((**cx).ptr, window.reflector().get_jsobject(), || {
             let mut js_info = page.mut_js_info();
-            RegisterBindings::Register(&window.unrooted(), js_info.get_mut_ref());
+            RegisterBindings::Register(&*window, js_info.get_mut_ref());
         });
 
         self.compositor.set_ready_state(Loading);


### PR DESCRIPTION
JS<T> should only be used for members of traced structures; the correct type
for arguments is JSRef.
