### PR TITLE
Use downloaded snapshots instead of in-tree rust. Also a working linux travis conf, and rust upgrade.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+
+install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -q
+  - sudo apt-get install -qq --force-yes -y autoconf2.13 gperf libxxf86vm-dev libglfw-dev libstdc++6-4.7-dev
+  - echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+  - sudo apt-get install ttf-mscorefonts-installer > /dev/null
+before_script:
+  - mkdir -p build
+
+script: |
+  cd build
+  ../configure
+  make -j2
+  make check
+
+git:
+  submodules: true
+
+notifications:
+  email: false
+
+branches:
+  only:
+    - travis
+    - master
+after_success:

--- a/bld/linux.py
+++ b/bld/linux.py
@@ -1,7 +1,7 @@
 config = {
     'mock_target': 'mozilla-centos6-x86_64',
     'mock_packages': ['freetype-devel', 'fontconfig-devel', 'glib2-devel', 'autoconf213', 'git', 'make', 'libX11-devel', 'mesa-libGL-devel', 'freeglut-devel',
-                      'xorg-x11-server-devel', 'libXrandr-devel', 'libXi-devel', 'libpng-devel', 'expat-devel', 'gperf', 'gcc473_0moz1', 'libffi-dev'],
+                      'xorg-x11-server-devel', 'libXrandr-devel', 'libXi-devel', 'libpng-devel', 'expat-devel', 'gperf', 'gcc473_0moz1', 'libffi-dev', 'libffi6'],
     'mock_files': [('/home/servobld/.ssh', '/home/mock_mozilla/.ssh')],
     'concurrency': 6,
     'add_actions': ['setup-mock'],

--- a/bld/linux.py
+++ b/bld/linux.py
@@ -1,7 +1,7 @@
 config = {
     'mock_target': 'mozilla-centos6-x86_64',
     'mock_packages': ['freetype-devel', 'fontconfig-devel', 'glib2-devel', 'autoconf213', 'git', 'make', 'libX11-devel', 'mesa-libGL-devel', 'freeglut-devel',
-                      'xorg-x11-server-devel', 'libXrandr-devel', 'libXi-devel', 'libpng-devel', 'expat-devel', 'gperf', 'gcc473_0moz1'],
+                      'xorg-x11-server-devel', 'libXrandr-devel', 'libXi-devel', 'libpng-devel', 'expat-devel', 'gperf', 'gcc473_0moz1', 'libffi-dev'],
     'mock_files': [('/home/servobld/.ssh', '/home/mock_mozilla/.ssh')],
     'concurrency': 6,
     'add_actions': ['setup-mock'],

--- a/configure
+++ b/configure
@@ -401,6 +401,26 @@ probe CFG_CLANG            clang++
 
 CFG_BUILD_DIR="${CFG_BUILD_HOME}${CFG_TARGET}/"
 make_dir "${CFG_BUILD_DIR}"
+SNAPSHOT_VERSION=$(cat ${CFG_SRC_DIR}/src/compiler/rust-snapshot-hash | rev | cut -d/ -f1 | rev)
+if [ $CFG_OSTYPE = "linux-androideabi" ]
+then
+CFG_TREE_RUST=1 # We don't yet have Android snapshots
+fi
+if [ -z "$CFG_TREE_RUST" ]
+then
+    if ! [ -f ${CFG_BUILD_DIR}/rust_snapshot/${SNAPSHOT_VERSION}-${DEFAULT_TARGET}/bin/rustc -a -f ${CFG_BUILD_DIR}/src/compiler/rust-snapshot-hash-stamp -a -z "$(diff ${CFG_BUILD_DIR}/src/compiler/rust-snapshot-hash-stamp ${CFG_SRC_DIR}/src/compiler/rust-snapshot-hash)" ]
+    then
+    rm -rf ${CFG_BUILD_DIR}/rust_snapshot
+    make_dir ${CFG_BUILD_DIR}/rust_snapshot
+    make_dir ${CFG_BUILD_DIR}/src/compiler/rust
+    SNAPSHOT_URL="http://servo-rust.s3.amazonaws.com/$(cat ${CFG_SRC_DIR}/src/compiler/rust-snapshot-hash)-${DEFAULT_TARGET}.tar.gz"
+    step_msg "Fetching snapshot from ${SNAPSHOT_URL}"
+    curl -o ${CFG_BUILD_DIR}/rust_snapshot/snapshot.tgz ${SNAPSHOT_URL}
+    tar -zxf ${CFG_BUILD_DIR}/rust_snapshot/snapshot.tgz -C ${CFG_BUILD_DIR}/rust_snapshot/
+    cp -f ${CFG_SRC_DIR}/src/compiler/rust-snapshot-hash ${CFG_BUILD_DIR}/src/compiler/rust-snapshot-hash-stamp
+    fi
+    CFG_LOCAL_RUST_ROOT=${CFG_BUILD_DIR}/rust_snapshot/${SNAPSHOT_VERSION}-${DEFAULT_TARGET}
+fi
 
 if [ ! -z "$CFG_LOCAL_RUST_ROOT" ]
 then
@@ -560,6 +580,7 @@ putvar CFG_RUST_HOME
 putvar CFG_PATH
 putvar CFG_LOCAL_RUSTC
 putvar CFG_LOCAL_RUST_ROOT
+putvar CFG_TREE_RUST
 putvar CFG_ENABLE_DEBUG
 putvar CFG_ENABLE_DEBUG_SKIA
 

--- a/src/compiler/rust-snapshot-hash
+++ b/src/compiler/rust-snapshot-hash
@@ -1,0 +1,1 @@
+0935beba717bf6d3b54ad1b2eace359dea5dfca0/rust-0.11.0-pre


### PR DESCRIPTION
`$CFG_TREE_RUST` brings back the old behavior

This also upgrades Rust (The new Rust works without any changes).
