### PR TITLE
Replace uses of JS<T>.unrooted() with JS::from_rooted #2580

### DIFF
--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -88,7 +88,7 @@ impl Attr {
             name: name, //TODO: Intern attribute names
             namespace: namespace,
             prefix: prefix,
-            owner: Cell::new(owner.unrooted()),
+            owner: Cell::new(JS::from_rooted(owner)),
         }
     }
 

--- a/src/components/script/dom/attrlist.rs
+++ b/src/components/script/dom/attrlist.rs
@@ -20,8 +20,8 @@ impl AttrList {
     pub fn new_inherited(window: &JSRef<Window>, elem: &JSRef<Element>) -> AttrList {
         AttrList {
             reflector_: Reflector::new(),
-            window: window.unrooted(),
-            owner: elem.unrooted(),
+            window: JS::from_rooted(window),
+            owner: JS::from_rooted(elem),
         }
     }
 

--- a/src/components/script/dom/bindings/js.rs
+++ b/src/components/script/dom/bindings/js.rs
@@ -88,7 +88,7 @@ impl<T: Reflectable> Temporary<T> {
 
     /// Create a new Temporary value from a rooted value.
     pub fn from_rooted<'a>(root: &JSRef<'a, T>) -> Temporary<T> {
-        Temporary::new(root.unrooted())
+        Temporary::new(JS::from_rooted(root))
     }
 
     /// Create a stack-bounded root for this value.
@@ -167,7 +167,7 @@ impl<T: Reflectable> JS<T> {
 }
 
 impl<T: Assignable<U>, U: Reflectable> JS<U> {
-    pub fn from_rooted(root: T) -> JS<U> {
+    pub fn from_rooted(root: &T) -> JS<U> {
         unsafe {
             root.get_js()
         }
@@ -296,7 +296,7 @@ pub trait OptionalUnrootable<T> {
 
 impl<'a, T: Reflectable> OptionalUnrootable<T> for Option<JSRef<'a, T>> {
     fn unrooted(&self) -> Option<JS<T>> {
-        self.as_ref().map(|inner| inner.unrooted())
+        self.as_ref().map(|inner| JS::from_rooted(inner))
     }
 }
 

--- a/src/components/script/dom/blob.rs
+++ b/src/components/script/dom/blob.rs
@@ -18,7 +18,7 @@ impl Blob {
     pub fn new_inherited(window: &JSRef<Window>) -> Blob {
         Blob {
             reflector_: Reflector::new(),
-            window: window.unrooted()
+            window: JS::from_rooted(window)
         }
     }
 

--- a/src/components/script/dom/browsercontext.rs
+++ b/src/components/script/dom/browsercontext.rs
@@ -75,7 +75,7 @@ pub struct SessionHistoryEntry {
 impl SessionHistoryEntry {
     fn new(document: &JSRef<Document>) -> SessionHistoryEntry {
         SessionHistoryEntry {
-            document: document.unrooted(),
+            document: JS::from_rooted(document),
             children: vec!()
         }
     }

--- a/src/components/script/dom/clientrect.rs
+++ b/src/components/script/dom/clientrect.rs
@@ -28,7 +28,7 @@ impl ClientRect {
             left: left.to_nearest_px() as f32,
             right: right.to_nearest_px() as f32,
             reflector_: Reflector::new(),
-            window: window.unrooted(),
+            window: JS::from_rooted(window),
         }
     }
 

--- a/src/components/script/dom/clientrectlist.rs
+++ b/src/components/script/dom/clientrectlist.rs
@@ -18,11 +18,11 @@ pub struct ClientRectList {
 impl ClientRectList {
     pub fn new_inherited(window: &JSRef<Window>,
                          rects: Vec<JSRef<ClientRect>>) -> ClientRectList {
-        let rects = rects.iter().map(|rect| rect.unrooted()).collect();
+        let rects = rects.iter().map(|rect| JS::from_rooted(rect)).collect();
         ClientRectList {
             reflector_: Reflector::new(),
             rects: rects,
-            window: window.unrooted(),
+            window: JS::from_rooted(window),
         }
     }
 

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -215,7 +215,7 @@ impl Document {
         Document {
             node: Node::new_without_doc(DocumentNodeTypeId),
             reflector_: Reflector::new(),
-            window: window.unrooted(),
+            window: JS::from_rooted(window),
             idmap: Traceable::new(RefCell::new(HashMap::new())),
             implementation: Cell::new(None),
             content_type: match content_type {

--- a/src/components/script/dom/domimplementation.rs
+++ b/src/components/script/dom/domimplementation.rs
@@ -28,7 +28,7 @@ pub struct DOMImplementation {
 impl DOMImplementation {
     pub fn new_inherited(owner: &JSRef<Window>) -> DOMImplementation {
         DOMImplementation {
-            owner: owner.unrooted(),
+            owner: JS::from_rooted(owner),
             reflector_: Reflector::new(),
         }
     }

--- a/src/components/script/dom/domparser.rs
+++ b/src/components/script/dom/domparser.rs
@@ -20,7 +20,7 @@ pub struct DOMParser {
 impl DOMParser {
     pub fn new_inherited(owner: &JSRef<Window>) -> DOMParser {
         DOMParser {
-            owner: owner.unrooted(),
+            owner: JS::from_rooted(owner),
             reflector_: Reflector::new()
         }
     }

--- a/src/components/script/dom/domtokenlist.rs
+++ b/src/components/script/dom/domtokenlist.rs
@@ -24,7 +24,7 @@ impl DOMTokenList {
                          local_name: &'static str) -> DOMTokenList {
         DOMTokenList {
             reflector_: Reflector::new(),
-            element: JS::from_rooted(element.clone()),
+            element: JS::from_rooted(element),
             local_name: local_name,
         }
     }

--- a/src/components/script/dom/eventdispatcher.rs
+++ b/src/components/script/dom/eventdispatcher.rs
@@ -4,7 +4,7 @@
 
 use dom::bindings::callback::ReportExceptions;
 use dom::bindings::codegen::InheritTypes::{EventTargetCast, NodeCast, NodeDerived};
-use dom::bindings::js::{JSRef, OptionalSettable, OptionalRootable, Root};
+use dom::bindings::js::{JS, JSRef, OptionalSettable, OptionalRootable, Root};
 use dom::eventtarget::{Capturing, Bubbling, EventTarget};
 use dom::event::{Event, PhaseAtTarget, PhaseNone, PhaseBubbling, PhaseCapturing, EventMethods};
 use dom::node::{Node, NodeHelpers};
@@ -29,7 +29,7 @@ pub fn dispatch_event<'a, 'b>(target: &JSRef<'a, EventTarget>,
         let target_node: &JSRef<Node> = NodeCast::to_ref(target).unwrap();
         target_node.ancestors().map(|ancestor| {
             let ancestor_target: &JSRef<EventTarget> = EventTargetCast::from_ref(&ancestor);
-            ancestor_target.unrooted().root()
+            JS::from_rooted(ancestor_target).root()
         }).collect()
     } else {
         vec!()

--- a/src/components/script/dom/formdata.rs
+++ b/src/components/script/dom/formdata.rs
@@ -33,7 +33,7 @@ impl FormData {
         FormData {
             data: Traceable::new(RefCell::new(HashMap::new())),
             reflector_: Reflector::new(),
-            window: window.unrooted(),
+            window: JS::from_rooted(window),
             form: form.unrooted(),
         }
     }
@@ -55,7 +55,7 @@ pub trait FormDataMethods {
 impl<'a> FormDataMethods for JSRef<'a, FormData> {
     fn Append(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
         let blob = BlobData {
-            blob: value.unrooted(),
+            blob: JS::from_rooted(value),
             name: filename.unwrap_or("default".to_string())
         };
         self.data.deref().borrow_mut().insert(name.clone(), blob);

--- a/src/components/script/dom/htmlcollection.rs
+++ b/src/components/script/dom/htmlcollection.rs
@@ -42,7 +42,7 @@ impl HTMLCollection {
         HTMLCollection {
             collection: collection,
             reflector_: Reflector::new(),
-            window: window.unrooted(),
+            window: JS::from_rooted(window),
         }
     }
 
@@ -55,7 +55,7 @@ impl HTMLCollection {
 impl HTMLCollection {
     pub fn create(window: &JSRef<Window>, root: &JSRef<Node>,
                   filter: Box<CollectionFilter>) -> Temporary<HTMLCollection> {
-        HTMLCollection::new(window, Live(root.unrooted(), filter))
+        HTMLCollection::new(window, Live(JS::from_rooted(root), filter))
     }
 
     pub fn by_tag_name(window: &JSRef<Window>, root: &JSRef<Node>, tag: DOMString)

--- a/src/components/script/dom/nodelist.rs
+++ b/src/components/script/dom/nodelist.rs
@@ -27,7 +27,7 @@ impl NodeList {
         NodeList {
             list_type: list_type,
             reflector_: Reflector::new(),
-            window: window.unrooted()
+            window: JS::from_rooted(window)
         }
     }
 
@@ -38,11 +38,11 @@ impl NodeList {
     }
 
     pub fn new_simple_list(window: &JSRef<Window>, elements: Vec<JSRef<Node>>) -> Temporary<NodeList> {
-        NodeList::new(window, Simple(elements.iter().map(|element| element.unrooted()).collect()))
+        NodeList::new(window, Simple(elements.iter().map(|element| JS::from_rooted(element)).collect()))
     }
 
     pub fn new_child_list(window: &JSRef<Window>, node: &JSRef<Node>) -> Temporary<NodeList> {
-        NodeList::new(window, Children(node.unrooted()))
+        NodeList::new(window, Children(JS::from_rooted(node)))
     }
 }
 

--- a/src/components/script/dom/performance.rs
+++ b/src/components/script/dom/performance.rs
@@ -19,7 +19,7 @@ pub struct Performance {
 
 impl Performance {
     fn new_inherited(window: &JSRef<Window>) -> Performance {
-        let timing = PerformanceTiming::new(window).root().root_ref().unrooted();
+        let timing = JS::from_rooted(&PerformanceTiming::new(window).root().root_ref());
         Performance {
             reflector_: Reflector::new(),
             timing: timing,

--- a/src/components/script/dom/validitystate.rs
+++ b/src/components/script/dom/validitystate.rs
@@ -19,7 +19,7 @@ impl ValidityState {
     pub fn new_inherited(window: &JSRef<Window>) -> ValidityState {
         ValidityState {
             reflector_: Reflector::new(),
-            window: Cell::new(window.unrooted()),
+            window: Cell::new(JS::from_rooted(window)),
             state: 0,
         }
     }

--- a/src/components/script/dom/xmlhttprequest.rs
+++ b/src/components/script/dom/xmlhttprequest.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::Bindings::XMLHttpRequestBinding::XMLHttpRequestRespo
 use dom::bindings::codegen::InheritTypes::{EventCast, EventTargetCast, XMLHttpRequestDerived};
 use dom::bindings::conversions::ToJSValConvertible;
 use dom::bindings::error::{ErrorResult, Fallible, InvalidState, InvalidAccess, Network, Syntax, Security};
-use dom::bindings::js::{JS, JSRef, Temporary, OptionalSettable, OptionalRootedRootable};
+use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootedRootable};
 use dom::bindings::str::ByteString;
 use dom::bindings::trace::Untraceable;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
@@ -106,7 +106,7 @@ pub struct XMLHttpRequest {
     ready_state: XMLHttpRequestState,
     timeout: u32,
     with_credentials: bool,
-    upload: Cell<Option<JS<XMLHttpRequestUpload>>>,
+    upload: Cell<JS<XMLHttpRequestUpload>>,
     response_url: DOMString,
     status: u16,
     status_text: ByteString,
@@ -136,7 +136,7 @@ impl XMLHttpRequest {
             ready_state: Unsent,
             timeout: 0u32,
             with_credentials: false,
-            upload: Cell::new(None),
+            upload: Cell::new(JS::from_rooted(&XMLHttpRequestUpload::new(owner))),
             response_url: "".to_string(),
             status: 0,
             status_text: ByteString::new(vec!()),
@@ -155,10 +155,9 @@ impl XMLHttpRequest {
             upload_complete: false,
             upload_events: false,
 
-            global: owner.unrooted(),
+            global: JS::from_rooted(owner),
             pinned: false,
         };
-        xhr.upload.assign(Some(XMLHttpRequestUpload::new(owner)));
         xhr
     }
     pub fn new(window: &JSRef<Window>) -> Temporary<XMLHttpRequest> {
@@ -407,7 +406,7 @@ impl<'a> XMLHttpRequestMethods<'a> for JSRef<'a, XMLHttpRequest> {
         self.with_credentials = with_credentials
     }
     fn Upload(&self) -> Temporary<XMLHttpRequestUpload> {
-        Temporary::new(self.upload.get().get_ref().clone())
+        Temporary::new(self.upload.get())
     }
     fn Send(&mut self, data: Option<DOMString>) -> ErrorResult {
         if self.ready_state != Opened || self.send_flag {
@@ -429,7 +428,7 @@ impl<'a> XMLHttpRequestMethods<'a> for JSRef<'a, XMLHttpRequest> {
         };
         if !self.sync {
             // Step 8
-            let upload_target = &*self.upload.get().root().unwrap();
+            let upload_target = &*self.upload.get().root();
             let event_target: &JSRef<EventTarget> = EventTargetCast::from_ref(upload_target);
             if event_target.has_handlers() {
                 self.upload_events = true;
@@ -738,10 +737,10 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
 
     fn dispatch_progress_event(&self, upload: bool, type_: DOMString, loaded: u64, total: Option<u64>) {
         let win = &*self.global.root();
-        let upload_target = &*self.upload.get().root().unwrap();
-        let progressevent = ProgressEvent::new(win, type_, false, false,
-                                               total.is_some(), loaded,
-                                               total.unwrap_or(0)).root();
+        let upload_target = &*self.upload.get().root();
+        let mut progressevent = ProgressEvent::new(win, type_, false, false,
+                                                   total.is_some(), loaded,
+                                                   total.unwrap_or(0)).root();
         let target: &JSRef<EventTarget> = if upload {
             EventTargetCast::from_ref(upload_target)
         } else {

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -972,8 +972,8 @@ impl ScriptTask {
             // Create the root frame.
             let mut frame = page.mut_frame();
             *frame = Some(Frame {
-                document: document.deref().unrooted(),
-                window: window.deref().unrooted(),
+                document: JS::from_rooted(document.deref()),
+                window: JS::from_rooted(window.deref()),
             });
         }
 
@@ -1178,12 +1178,12 @@ impl ScriptTask {
                                     match *mouse_over_targets {
                                         Some(ref mouse_over_targets) => {
                                             if !target_compare {
-                                                target_compare = !mouse_over_targets.contains(&node.unrooted());
+                                                target_compare = !mouse_over_targets.contains(&JS::from_rooted(&node));
                                             }
                                         }
                                         None => {}
                                     }
-                                    target_list.push(node.unrooted());
+                                    target_list.push(JS::from_rooted(&node));
                                 }
                                 None => {}
                             }


### PR DESCRIPTION
removed .clone() calls
modified from_rooted method parameter: T to &T
