### PR TITLE
Request termination for XHR

### DIFF
--- a/src/components/net/resource_task.rs
+++ b/src/components/net/resource_task.rs
@@ -118,12 +118,20 @@ pub enum ProgressMsg {
 
 /// For use by loaders in responding to a Load message.
 pub fn start_sending(start_chan: Sender<LoadResponse>, metadata: Metadata) -> Sender<ProgressMsg> {
+    start_sending_opt(start_chan, metadata).ok().unwrap()
+}
+
+/// For use by loaders in responding to a Load message.
+pub fn start_sending_opt(start_chan: Sender<LoadResponse>, metadata: Metadata) -> Result<Sender<ProgressMsg>, ()> {
     let (progress_chan, progress_port) = channel();
-    start_chan.send(LoadResponse {
+    let result = start_chan.send_opt(LoadResponse {
         metadata:      metadata,
         progress_port: progress_port,
     });
-    progress_chan
+    match result {
+        Ok(_) => Ok(progress_chan),
+        Err(_) => Err(())
+    }
 }
 
 /// Convenience function for synchronously loading a whole resource.

--- a/src/components/script/dom/bindings/error.rs
+++ b/src/components/script/dom/bindings/error.rs
@@ -28,7 +28,9 @@ pub enum Error {
     NamespaceError,
     InvalidAccess,
     Security,
-    Network
+    Network,
+    Abort,
+    Timeout
 }
 
 pub type Fallible<T> = Result<T, Error>;

--- a/src/components/script/dom/domexception.rs
+++ b/src/components/script/dom/domexception.rs
@@ -51,6 +51,8 @@ impl DOMErrorName {
             error::InvalidAccess => InvalidAccessError,
             error::Security => SecurityError,
             error::Network => NetworkError,
+            error::Abort => AbortError,
+            error::Timeout => TimeoutError,
             error::FailureUnknown => fail!(),
         }
     }

--- a/src/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/src/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -45,12 +45,13 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
 
   [Throws]
   void setRequestHeader(ByteString name, ByteString value);
+  [SetterThrows]
            attribute unsigned long timeout;
            attribute boolean withCredentials;
   readonly attribute XMLHttpRequestUpload upload;
   [Throws]
   void send(optional /*(ArrayBufferView or Blob or Document or [EnsureUTF16] */ DOMString/* or FormData or URLSearchParams)*/? data = null);
-  // void abort();
+  void abort();
 
   // response
   readonly attribute DOMString responseURL;


### PR DESCRIPTION
This implements abort and timeout for XHR.

[Here's the wpt run result](http://manishearth.anapnea.net/xhr/logtm3.html). Ignore the timeouts, they're due to a bug in wpt (Need to [upgrade wpt](https://github.com/mozilla-servo/web-platform-tests/pull/1) to fix it). The two failures for abort tests have been fixed.

Blocks #2282
