### PR TITLE
Separate "desktop" and "mobile" zoom calculations.

### DIFF
--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -4,8 +4,9 @@
 
 use compositing::*;
 
+use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
-use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, ResizedWindowMsg};
+use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, ResizedWindowMsg, WindowSizeData};
 use servo_util::time::ProfilerChan;
 use servo_util::time;
 
@@ -33,7 +34,11 @@ impl NullCompositor {
         // Tell the constellation about the initial fake size.
         {
             let ConstellationChan(ref chan) = constellation_chan;
-            chan.send(ResizedWindowMsg(TypedSize2D(640_f32, 480_f32)));
+            chan.send(ResizedWindowMsg(WindowSizeData {
+                initial_viewport: TypedSize2D(640_f32, 480_f32),
+                visible_viewport: TypedSize2D(640_f32, 480_f32),
+                device_pixel_ratio: ScaleFactor(1.0),
+            }));
         }
         compositor.handle_message(constellation_chan);
 

--- a/src/components/main/layout/layout_task.rs
+++ b/src/components/main/layout/layout_task.rs
@@ -581,8 +581,12 @@ impl LayoutTask {
             _ => false
         };
 
-        let current_screen_size = Size2D(Au::from_page_px(data.window_size.width),
-                                         Au::from_page_px(data.window_size.height));
+        // TODO: Calculate the "actual viewport":
+        // http://www.w3.org/TR/css-device-adapt/#actual-viewport
+        let viewport_size = data.window_size.initial_viewport;
+
+        let current_screen_size = Size2D(Au::from_frac32_px(viewport_size.width.get()),
+                                         Au::from_frac32_px(viewport_size.height.get()));
         if self.screen_size != current_screen_size {
             all_style_damage = true
         }

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -5,7 +5,6 @@
 use compositing::CompositorChan;
 use layout::layout_task::LayoutTask;
 
-use geom::size::TypedSize2D;
 use gfx::render_task::{PaintPermissionGranted, PaintPermissionRevoked};
 use gfx::render_task::{RenderChan, RenderTask};
 use script::layout_interface::LayoutChan;
@@ -13,9 +12,9 @@ use script::script_task::LoadMsg;
 use script::script_task::{AttachLayoutMsg, NewLayoutInfo, ScriptTask, ScriptChan};
 use script::script_task;
 use servo_msg::constellation_msg::{ConstellationChan, Failure, PipelineId, SubpageId};
+use servo_msg::constellation_msg::WindowSizeData;
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
-use servo_util::geometry::PagePx;
 use servo_util::opts::Opts;
 use servo_util::time::ProfilerChan;
 use std::rc::Rc;
@@ -113,7 +112,7 @@ impl Pipeline {
                   image_cache_task: ImageCacheTask,
                   resource_task: ResourceTask,
                   profiler_chan: ProfilerChan,
-                  window_size: TypedSize2D<PagePx, f32>,
+                  window_size: WindowSizeData,
                   opts: Opts,
                   url: Url)
                   -> Pipeline {

--- a/src/components/main/windowing.rs
+++ b/src/components/main/windowing.rs
@@ -43,6 +43,8 @@ pub enum WindowEvent {
     ScrollWindowEvent(TypedPoint2D<DevicePixel, f32>, TypedPoint2D<DevicePixel, i32>),
     /// Sent when the user zooms.
     ZoomWindowEvent(f32),
+    /// Simulated "pinch zoom" gesture for non-touch platforms (e.g. ctrl-scrollwheel).
+    PinchZoomWindowEvent(f32),
     /// Sent when the user uses chrome navigation (i.e. backspace or shift-backspace).
     NavigationWindowEvent(WindowNavigateMsg),
     /// Sent when rendering is finished.

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -7,7 +7,8 @@
 
 use geom::rect::Rect;
 use geom::size::TypedSize2D;
-use servo_util::geometry::PagePx;
+use geom::scale_factor::ScaleFactor;
+use servo_util::geometry::{DevicePixel, PagePx, ViewportPx};
 use std::comm::{channel, Sender, Receiver};
 use url::Url;
 
@@ -34,6 +35,18 @@ pub struct Failure {
     pub subpage_id: Option<SubpageId>,
 }
 
+pub struct WindowSizeData {
+    /// The size of the initial layout viewport, before parsing an
+    /// http://www.w3.org/TR/css-device-adapt/#initial-viewport
+    pub initial_viewport: TypedSize2D<ViewportPx, f32>,
+
+    /// The "viewing area" in page px. See `PagePx` documentation for details.
+    pub visible_viewport: TypedSize2D<PagePx, f32>,
+
+    /// The resolution of the window in dppx, not including any "pinch zoom" factor.
+    pub device_pixel_ratio: ScaleFactor<ViewportPx, DevicePixel, f32>,
+}
+
 /// Messages from the compositor and script to the constellation.
 pub enum Msg {
     ExitMsg,
@@ -45,7 +58,7 @@ pub enum Msg {
     LoadIframeUrlMsg(Url, PipelineId, SubpageId, IFrameSandboxState),
     NavigateMsg(NavigationDirection),
     RendererReadyMsg(PipelineId),
-    ResizedWindowMsg(TypedSize2D<PagePx, f32>),
+    ResizedWindowMsg(WindowSizeData),
 }
 
 /// Represents the two different ways to which a page can be navigated

--- a/src/components/script/dom/event.rs
+++ b/src/components/script/dom/event.rs
@@ -10,17 +10,16 @@ use dom::bindings::trace::Traceable;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::eventtarget::EventTarget;
 use dom::window::Window;
+use servo_msg::constellation_msg::WindowSizeData;
 use servo_util::str::DOMString;
-use servo_util::geometry::PagePx;
 use std::cell::{Cell, RefCell};
 
 use geom::point::Point2D;
-use geom::size::TypedSize2D;
 
 use time;
 
 pub enum Event_ {
-    ResizeEvent(TypedSize2D<PagePx, f32>),
+    ResizeEvent(WindowSizeData),
     ReflowEvent,
     ClickEvent(uint, Point2D<f32>),
     MouseDownEvent(uint, Point2D<f32>),

--- a/src/components/script/layout_interface.rs
+++ b/src/components/script/layout_interface.rs
@@ -11,10 +11,10 @@ use dom::node::{Node, LayoutDataRef};
 
 use geom::point::Point2D;
 use geom::rect::Rect;
-use geom::size::TypedSize2D;
 use libc::c_void;
 use script_task::{ScriptChan};
-use servo_util::geometry::{Au, PagePx};
+use servo_msg::constellation_msg::WindowSizeData;
+use servo_util::geometry::Au;
 use std::cmp;
 use std::comm::{channel, Receiver, Sender};
 use style::Stylesheet;
@@ -137,7 +137,7 @@ pub struct Reflow {
     /// The channel through which messages can be sent back to the script task.
     pub script_chan: ScriptChan,
     /// The current window size.
-    pub window_size: TypedSize2D<PagePx, f32>,
+    pub window_size: WindowSizeData,
     /// The channel that we send a notification to.
     pub script_join_chan: Sender<()>,
     /// Unique identifier

--- a/src/components/script/page.rs
+++ b/src/components/script/page.rs
@@ -19,14 +19,12 @@ use layout_interface::UntrustedNodeAddress;
 use script_task::ScriptChan;
 
 use geom::point::Point2D;
-use geom::size::TypedSize2D;
 use js::rust::Cx;
 use servo_msg::compositor_msg::PerformingLayout;
 use servo_msg::compositor_msg::ScriptListener;
-use servo_msg::constellation_msg::ConstellationChan;
+use servo_msg::constellation_msg::{ConstellationChan, WindowSizeData};
 use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_net::resource_task::ResourceTask;
-use servo_util::geometry::PagePx;
 use servo_util::namespace::Null;
 use servo_util::str::DOMString;
 use std::cell::{Cell, RefCell, Ref, RefMut};
@@ -62,7 +60,7 @@ pub struct Page {
     damage: Traceable<RefCell<Option<DocumentDamage>>>,
 
     /// The current size of the window, in pixels.
-    pub window_size: Untraceable<Cell<TypedSize2D<PagePx, f32>>>,
+    pub window_size: Untraceable<Cell<WindowSizeData>>,
 
     js_info: Traceable<RefCell<Option<JSPageInfo>>>,
 
@@ -75,7 +73,7 @@ pub struct Page {
     next_subpage_id: Untraceable<Cell<SubpageId>>,
 
     /// Pending resize event, if any.
-    pub resize_event: Untraceable<Cell<Option<TypedSize2D<PagePx, f32>>>>,
+    pub resize_event: Untraceable<Cell<Option<WindowSizeData>>>,
 
     /// Pending scroll to fragment event, if any
     pub fragment_node: Cell<Option<JS<Element>>>,
@@ -119,7 +117,8 @@ impl IterablePage for Rc<Page> {
 impl Page {
     pub fn new(id: PipelineId, subpage_id: Option<SubpageId>,
            layout_chan: LayoutChan,
-           window_size: TypedSize2D<PagePx, f32>, resource_task: ResourceTask,
+           window_size: WindowSizeData,
+           resource_task: ResourceTask,
            constellation_chan: ConstellationChan,
            js_context: Rc<Cx>) -> Page {
         let js_info = JSPageInfo {

--- a/src/components/util/geometry.rs
+++ b/src/components/util/geometry.rs
@@ -33,13 +33,31 @@ pub enum DevicePixel {}
 /// `servo::windowing::WindowMethods::hidpi_factor`.
 pub enum ScreenPx {}
 
+/// One CSS "px" in the coordinate system of the "initial viewport":
+/// http://www.w3.org/TR/css-device-adapt/#initial-viewport
+///
+/// ViewportPx is equal to ScreenPx times a "page zoom" factor controlled by the user.  This is
+/// the desktop-style "full page" zoom that enlarges content but then reflows the layout viewport
+/// so it still exactly fits the visible area.
+///
+/// At the default zoom level of 100%, one PagePx is equal to one ScreenPx.  However, if the
+/// document is zoomed in or out then this scale may be larger or smaller.
+pub enum ViewportPx {}
+
 /// One CSS "px" in the root coordinate system for the content document.
 ///
-///
-/// PagePx is equal to ScreenPx multiplied by a "zoom" factor controlled by the user.  At the
-/// default zoom level of 100%, one PagePx is equal to one ScreenPx.  However, if the document
-/// is zoomed in or out then this scale may be larger or smaller.
+/// PagePx is equal to ViewportPx multiplied by a "viewport zoom" factor controlled by the user.
+/// This is the mobile-style "pinch zoom" that enlarges content without reflowing it.  When the
+/// viewport zoom is not equal to 1.0, then the layout viewport is no longer the same physical size
+/// as the viewable area.
 pub enum PagePx {}
+
+// In summary, the hierarchy of pixel units and the factors to convert from one to the next:
+//
+// DevicePixel
+//   / hidpi_ratio => ScreenPx
+//     / desktop_zoom => ViewportPx
+//       / pinch_zoom => PagePx
 
 // An Au is an "App Unit" and represents 1/60th of a CSS pixel.  It was
 // originally proposed in 2002 as a standard unit of measure in Gecko.


### PR DESCRIPTION
This ensures that the layout viewport responds to each type of zoom correctly, and lays the ground for CSS Media Queries and CSS Device Adaption.

Note: The `device_pixel_ratio` and `visible_viewport` properties are currenty unused, but will be needed in the near future to properly implement `window.devicePixelRatio`, `window.innerWidth`, the `resolution` media query, etc.

Until we have proper touch support, mobile-style "pinch" zoom can be simulated by holding Ctrl while scrolling with a mousewheel or trackpad gesture.
