### PR TITLE
Add overflow to child layer size

### DIFF
--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -77,3 +77,4 @@
 == linebreak_inline_span_a.html linebreak_inline_span_b.html
 == overconstrained_block.html overconstrained_block_ref.html
 == position_fixed_background_color_a.html position_fixed_background_color_b.html
+== position_fixed_overflow_a.html position_fixed_overflow_b.html

--- a/src/test/ref/position_fixed_overflow_a.html
+++ b/src/test/ref/position_fixed_overflow_a.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+    <div style="top: 5px; left: 5px; height: 5px; width: 5px; position: fixed;">
+        <div style="height: 100px; width: 100px; background: black;"></div>
+    </div>
+</body>
+</html>
+

--- a/src/test/ref/position_fixed_overflow_b.html
+++ b/src/test/ref/position_fixed_overflow_b.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <div style="top: 5px; left: 5px; height: 100px; width: 100px; position: absolute; background: black;"></div>
+</body>
+</html>
+


### PR DESCRIPTION
When creating child layers it is important to consider overflow when
determining the size of the layer. This also means that overflow should
not be too large, so also shrink block width down to the size of their
contained fragment. This means that a block that has been explicitly
sized to width:100px should be 100 pixels wide instead of the width of
its containing block.
