### PR TITLE
Handle JSAPI OOM failures by task failure as soon as possible.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1877,10 +1877,8 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
         # if we don't need to create anything, why are we generating this?
         assert needInterfaceObject or needInterfacePrototypeObject
 
-        getParentProto = ("let parentProto: *mut JSObject = %s;\n" +
-                          "if parentProto.is_null() {\n" +
-                          "  return ptr::mut_null();\n" +
-                          "}\n") % getParentProto
+        getParentProto = ("let parentProto: *mut JSObject = %s;\n"
+                          "assert!(parentProto.is_not_null());\n") % getParentProto
 
         if self.descriptor.interface.ctor():
             constructHook = CONSTRUCT_HOOK_NAME
@@ -1953,6 +1951,7 @@ class CGGetPerInterfaceObject(CGAbstractMethod):
   let cachedObject: *mut JSObject = *protoOrIfaceArray.offset(%s as int);
   if cachedObject.is_null() {
     let tmp: *mut JSObject = CreateInterfaceObjects(aCx, aGlobal, aReceiver);
+    assert!(tmp.is_not_null());
     *protoOrIfaceArray.offset(%s as int) = tmp;
     tmp
   } else {


### PR DESCRIPTION
We already ensure to fail the task if GetProtoObject returns null, as we don't
have a useful way to handle OOM, and we don't wish to thread the failure
through to some place where we could handle it in a useful way.

Unfortunately, we cannot ensure through the type system that none of those
functions returns null, so we use assertions to check it dynamically.
