### PR TITLE
Divide check-ref targets into check-ref-cpu and check-ref-gpu

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -79,12 +79,18 @@ check-servo: $(foreach lib_crate,$(SERVO_LIB_CRATES),check-servo-$(lib_crate)) s
 	@$(call E, check: servo)
 	$(Q)./servo-test
 
-.PHONY: check-ref
-check-ref: reftest
-	@$(call E, check: reftests with GPU rendering)
-	$(Q)./reftest $(S)src/test/ref/*.list
+.PHONY: check-ref-cpu
+check-ref-cpu: reftest
 	@$(call E, check: reftests with CPU rendering)
 	$(Q)./reftest $(S)src/test/ref/*.list -- -c
+
+.PHONY: check-ref-gpu
+check-ref-gpu: reftest
+	@$(call E, check: reftests with GPU rendering)
+	$(Q)./reftest $(S)src/test/ref/*.list
+
+.PHONY: check-ref
+check-ref: check-ref-cpu check-ref-gpu
 
 .PHONY: check-content
 check-content: contenttest


### PR DESCRIPTION
This allows us to run the CPU and GPU tests individually. Also note that I put the CPU tests before the GPU tests. This is because the CPU tests tend to be less buggy, and will catch real errors quicker.
