### PR TITLE
Implement :enabled & :disabled CSS selectors

### DIFF
--- a/src/components/layout/wrapper.rs
+++ b/src/components/layout/wrapper.rs
@@ -398,6 +398,19 @@ impl<'le> TElement for LayoutElement<'le> {
             self.element.node.get_disabled_state_for_layout()
         }
     }
+
+    fn get_enabled_state(&self) -> bool {
+        unsafe {
+            match self.element.node.type_id {
+                ElementNodeTypeId(HTMLAnchorElementTypeId) |
+                ElementNodeTypeId(HTMLAreaElementTypeId) |
+                ElementNodeTypeId(HTMLLinkElementTypeId) => {
+                    self.element.get_attr_val_for_layout(&namespace::Null, "href").is_some()
+                },
+                _ => !self.element.node.get_disabled_state_for_layout()
+            }
+        }
+    }
 }
 
 fn get_content(content_list: &content::T) -> String {

--- a/src/components/layout/wrapper.rs
+++ b/src/components/layout/wrapper.rs
@@ -392,6 +392,12 @@ impl<'le> TElement for LayoutElement<'le> {
             self.element.node.get_hover_state_for_layout()
         }
     }
+
+    fn get_disabled_state(&self) -> bool {
+        unsafe {
+            self.element.node.get_disabled_state_for_layout()
+        }
+    }
 }
 
 fn get_content(content_list: &content::T) -> String {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -923,4 +923,8 @@ impl<'a> style::TElement for JSRef<'a, Element> {
         let node: &JSRef<Node> = NodeCast::from_ref(self);
         node.get_disabled_state()
     }
+    fn get_enabled_state(&self) -> bool {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.get_enabled_state()
+    }
 }

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -231,7 +231,7 @@ pub trait AttributeHandlers {
     fn parse_attribute(&self, namespace: &Namespace, local_name: &str,
                        value: DOMString) -> AttrValue;
 
-    fn remove_attribute(&self, namespace: Namespace, name: &str) -> ErrorResult;
+    fn remove_attribute(&self, namespace: Namespace, name: &str);
     fn notify_attribute_changed(&self, local_name: DOMString);
     fn has_class(&self, name: &str) -> bool;
 
@@ -314,7 +314,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
         }
     }
 
-    fn remove_attribute(&self, namespace: Namespace, name: &str) -> ErrorResult {
+    fn remove_attribute(&self, namespace: Namespace, name: &str) {
         let (_, local_name) = get_attribute_parts(name);
 
         let idx = self.deref().attrs.borrow().iter().map(|attr| attr.root()).position(|attr| {
@@ -338,8 +338,6 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
                 self.deref().attrs.borrow_mut().remove(idx);
             }
         };
-
-        Ok(())
     }
 
     fn notify_attribute_changed(&self, local_name: DOMString) {
@@ -437,8 +435,8 @@ pub trait ElementMethods {
     fn GetAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) -> Option<DOMString>;
     fn SetAttribute(&self, name: DOMString, value: DOMString) -> ErrorResult;
     fn SetAttributeNS(&self, namespace_url: Option<DOMString>, name: DOMString, value: DOMString) -> ErrorResult;
-    fn RemoveAttribute(&self, name: DOMString) -> ErrorResult;
-    fn RemoveAttributeNS(&self, namespace: Option<DOMString>, localname: DOMString) -> ErrorResult;
+    fn RemoveAttribute(&self, name: DOMString);
+    fn RemoveAttributeNS(&self, namespace: Option<DOMString>, localname: DOMString);
     fn HasAttribute(&self, name: DOMString) -> bool;
     fn HasAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) -> bool;
     fn GetElementsByTagName(&self, localname: DOMString) -> Temporary<HTMLCollection>;
@@ -648,7 +646,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
 
     // http://dom.spec.whatwg.org/#dom-element-removeattribute
     fn RemoveAttribute(&self,
-                       name: DOMString) -> ErrorResult {
+                       name: DOMString) {
         let name = if self.html_element_in_html_document() {
             name.as_slice().to_ascii_lower()
         } else {
@@ -660,7 +658,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     // http://dom.spec.whatwg.org/#dom-element-removeattributens
     fn RemoveAttributeNS(&self,
                          namespace: Option<DOMString>,
-                         localname: DOMString) -> ErrorResult {
+                         localname: DOMString) {
         let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
         self.remove_attribute(namespace, localname.as_slice())
     }

--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -74,6 +74,32 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
         Some(htmlelement as &VirtualMethods+)
     }
 
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(true),
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(false),
+            _ => ()
+        }
+    }
+
     fn handle_event(&self, event: &JSRef<Event>) {
         match self.super_type() {
             Some(s) => {

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -4,13 +4,15 @@
 
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
+use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::HTMLAreaElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -38,6 +40,39 @@ impl HTMLAreaElement {
 }
 
 pub trait HTMLAreaElementMethods {
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(true),
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(false),
+            _ => ()
+        }
+    }
 }
 
 impl Reflectable for HTMLAreaElement {

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -3,15 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLButtonElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLButtonElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId, window_from_node};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -40,12 +42,86 @@ impl HTMLButtonElement {
 
 pub trait HTMLButtonElementMethods {
     fn Validity(&self) -> Temporary<ValidityState>;
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
 }
 
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
         ValidityState::new(&*window)
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_disabled_attribute();
     }
 }
 

--- a/src/components/script/dom/htmlfieldsetelement.rs
+++ b/src/components/script/dom/htmlfieldsetelement.rs
@@ -3,16 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding;
-use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLFieldSetElementDerived, NodeCast};
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLLegendElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::{Element, HTMLFieldSetElementTypeId};
+use dom::element::{AttributeHandlers, Element, HTMLFieldSetElementTypeId, HTMLButtonElementTypeId};
+use dom::element::{HTMLInputElementTypeId, HTMLSelectElementTypeId, HTMLTextAreaElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlcollection::{HTMLCollection, CollectionFilter};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId, window_from_node};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::{DOMString, StaticStringVec};
 
 #[deriving(Encodable)]
@@ -42,6 +45,8 @@ impl HTMLFieldSetElement {
 pub trait HTMLFieldSetElementMethods {
     fn Elements(&self) -> Temporary<HTMLCollection>;
     fn Validity(&self) -> Temporary<ValidityState>;
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
 }
 
 impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
@@ -65,6 +70,99 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
         ValidityState::new(&*window)
+    }
+
+    // http://www.whatwg.org/html/#dom-fieldset-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fieldset-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+                let maybe_legend = node.children().find(|node| node.is_htmllegendelement());
+                for descendant in node.traverse_preorder() {
+                    match descendant.type_id() {
+                        ElementNodeTypeId(HTMLButtonElementTypeId) |
+                        ElementNodeTypeId(HTMLInputElementTypeId) |
+                        ElementNodeTypeId(HTMLSelectElementTypeId) |
+                        ElementNodeTypeId(HTMLTextAreaElementTypeId) => {
+                            match maybe_legend {
+                                Some(ref legend) => {
+                                    if descendant.ancestors().any(|ancestor| ancestor == *legend) {
+                                        continue;
+                                    }
+                                },
+                                None => ()
+                            }
+                            descendant.set_disabled_state(true);
+                            descendant.set_enabled_state(false);
+                        },
+                        _ => ()
+                    }
+                }
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                let maybe_legend = node.children().find(|node| node.is_htmllegendelement());
+                for descendant in node.traverse_preorder() {
+                    match descendant.type_id() {
+                        ElementNodeTypeId(HTMLButtonElementTypeId) |
+                        ElementNodeTypeId(HTMLInputElementTypeId) |
+                        ElementNodeTypeId(HTMLSelectElementTypeId) |
+                        ElementNodeTypeId(HTMLTextAreaElementTypeId) => {
+                            match maybe_legend {
+                                Some(ref legend) => {
+                                    if descendant.ancestors().any(|ancestor| ancestor == *legend) {
+                                        continue;
+                                    }
+                                },
+                                None => ()
+                            }
+                            descendant.check_disabled_attribute();
+                            descendant.check_ancestors_disabled_state_for_form_control();
+                        },
+                        _ => ()
+                    }
+                }
+            },
+            _ => ()
+        }
     }
 }
 

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -3,14 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLInputElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLInputElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLInputElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -38,6 +40,82 @@ impl HTMLInputElement {
 }
 
 pub trait HTMLInputElementMethods {
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
+}
+
+impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_disabled_attribute();
+    }
 }
 
 impl Reflectable for HTMLInputElement {

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -4,13 +4,15 @@
 
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
+use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::HTMLLinkElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -38,6 +40,39 @@ impl HTMLLinkElement {
 }
 
 pub trait HTMLLinkElementMethods {
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(true),
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(false),
+            _ => ()
+        }
+    }
 }
 
 impl Reflectable for HTMLLinkElement {

--- a/src/components/script/dom/htmloptgroupelement.rs
+++ b/src/components/script/dom/htmloptgroupelement.rs
@@ -3,14 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding;
-use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementDerived;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLOptGroupElementDerived, HTMLOptionElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLOptGroupElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLOptGroupElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -38,6 +40,71 @@ impl HTMLOptGroupElement {
 }
 
 pub trait HTMLOptGroupElementMethods {
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
+}
+
+impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
+    // http://www.whatwg.org/html#dom-optgroup-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html#dom-optgroup-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+                for descendant in node.traverse_preorder()
+                                      .filter(|descendant| descendant.is_htmloptionelement()) {
+                    descendant.set_disabled_state(true);
+                    descendant.set_enabled_state(false);
+                }
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                for descendant in node.traverse_preorder()
+                                      .filter(|descendant| descendant.is_htmloptionelement()) {
+                    descendant.check_disabled_attribute();
+                    descendant.check_ancestors_disabled_state_for_form_control();
+                }
+            },
+            _ => ()
+        }
+    }
 }
 
 impl Reflectable for HTMLOptGroupElement {

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -3,14 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLOptionElementBinding;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLOptionElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLOptionElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -38,6 +40,82 @@ impl HTMLOptionElement {
 }
 
 pub trait HTMLOptionElementMethods {
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
+}
+
+impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
+    // http://www.whatwg.org/html/#dom-option-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-option-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_option();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_disabled_attribute();
+    }
 }
 
 impl Reflectable for HTMLOptionElement {

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -3,17 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLSelectElementDerived;
 use dom::bindings::codegen::UnionTypes::HTMLElementOrLong::HTMLElementOrLong;
 use dom::bindings::codegen::UnionTypes::HTMLOptionElementOrHTMLOptGroupElement::HTMLOptionElementOrHTMLOptGroupElement;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLSelectElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLSelectElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId, window_from_node};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -43,6 +45,8 @@ impl HTMLSelectElement {
 pub trait HTMLSelectElementMethods {
     fn Validity(&self) -> Temporary<ValidityState>;
     fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>);
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
 }
 
 impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
@@ -53,6 +57,78 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
 
     // Note: this function currently only exists for test_union.html.
     fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) {
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_disabled_attribute();
     }
 }
 

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -3,14 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLTextAreaElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLTextAreaElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLTextAreaElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -38,6 +40,82 @@ impl HTMLTextAreaElement {
 }
 
 pub trait HTMLTextAreaElementMethods {
+    fn Disabled(&self) -> bool;
+    fn SetDisabled(&self, disabled: bool);
+}
+
+impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods+> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods+)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_disabled_attribute();
+    }
 }
 
 impl Reflectable for HTMLTextAreaElement {

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -421,7 +421,7 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
 
     /// Returns a string that describes this node.
     fn debug_str(&self) -> String {
-        format!("{:?}", self.type_id())
+        format!("{:?}", self.type_id)
     }
 
     fn is_in_doc(&self) -> bool {
@@ -465,12 +465,12 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
 
     #[inline]
     fn is_document(&self) -> bool {
-        self.type_id() == DocumentNodeTypeId
+        self.type_id == DocumentNodeTypeId
     }
 
     #[inline]
     fn is_anchor_element(&self) -> bool {
-        self.type_id() == ElementNodeTypeId(HTMLAnchorElementTypeId)
+        self.type_id == ElementNodeTypeId(HTMLAnchorElementTypeId)
     }
 
     #[inline]
@@ -480,7 +480,7 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
 
     #[inline]
     fn is_text(&self) -> bool {
-        self.type_id() == TextNodeTypeId
+        self.type_id == TextNodeTypeId
     }
 
     fn get_hover_state(&self) -> bool {
@@ -1600,7 +1600,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     fn ReplaceChild(&self, node: &JSRef<Node>, child: &JSRef<Node>) -> Fallible<Temporary<Node>> {
 
         // Step 1.
-        match self.type_id() {
+        match self.type_id {
             DocumentNodeTypeId |
             DocumentFragmentNodeTypeId |
             ElementNodeTypeId(..) => (),
@@ -1631,7 +1631,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         }
 
         // Step 6.
-        match self.type_id() {
+        match self.type_id {
             DocumentNodeTypeId => {
                 match node.type_id() {
                     // Step 6.1

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -10,6 +10,7 @@ use dom::bindings::codegen::InheritTypes::{CommentCast, DocumentCast, DocumentTy
 use dom::bindings::codegen::InheritTypes::{ElementCast, TextCast, NodeCast, ElementDerived};
 use dom::bindings::codegen::InheritTypes::{CharacterDataCast, NodeBase, NodeDerived};
 use dom::bindings::codegen::InheritTypes::{ProcessingInstructionCast, EventTargetCast};
+use dom::bindings::codegen::InheritTypes::{HTMLLegendElementDerived, HTMLFieldSetElementDerived, HTMLOptGroupElementDerived};
 use dom::bindings::codegen::Bindings::NodeBinding::NodeConstants;
 use dom::bindings::error::{ErrorResult, Fallible, NotFound, HierarchyRequest, Syntax};
 use dom::bindings::global::{GlobalRef, Window};
@@ -24,8 +25,8 @@ use dom::comment::Comment;
 use dom::document::{Document, DocumentMethods, DocumentHelpers, HTMLDocument, NonHTMLDocument};
 use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
-use dom::element::{AttributeHandlers, Element, ElementMethods, ElementTypeId};
-use dom::element::{HTMLAnchorElementTypeId, ElementHelpers};
+use dom::element::{AttributeHandlers, Element, ElementHelpers, ElementMethods, ElementTypeId};
+use dom::element::{HTMLAnchorElementTypeId, HTMLAreaElementTypeId, HTMLLinkElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::nodelist::{NodeList};
 use dom::processinginstruction::{ProcessingInstruction, ProcessingInstructionMethods};
@@ -37,6 +38,7 @@ use html::hubbub_html_parser::build_element_from_tag;
 use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery, ContentBoxesResponse,
                        LayoutChan, ReapLayoutDataMsg, TrustedNodeAddress, UntrustedNodeAddress};
 use servo_util::geometry::Au;
+use servo_util::namespace::Null;
 use servo_util::str::{DOMString, null_str_as_empty};
 use style::{parse_selector_list, matches_compound_selector, NamespaceMap};
 
@@ -118,8 +120,10 @@ bitflags! {
     flags NodeFlags: u8 {
         #[doc = "Specifies whether this node is in a document."]
         static IsInDoc = 0x01,
-        #[doc = "Specifies whether this node is hover state for this node"]
-        static InHoverState = 0x02
+        #[doc = "Specifies whether this node is in hover state."]
+        static InHoverState = 0x02,
+        #[doc = "Specifies whether this node is in disabled state."]
+        static InDisabledState = 0x04
     }
 }
 
@@ -378,6 +382,9 @@ pub trait NodeHelpers {
     fn get_hover_state(&self) -> bool;
     fn set_hover_state(&self, state: bool);
 
+    fn get_disabled_state(&self) -> bool;
+    fn set_disabled_state(&self, state: bool);
+
     fn dump(&self);
     fn dump_indent(&self, indent: uint);
     fn debug_str(&self) -> String;
@@ -492,6 +499,18 @@ impl<'a> NodeHelpers for JSRef<'a, Node> {
             self.flags.deref().borrow_mut().insert(InHoverState);
         } else {
             self.flags.deref().borrow_mut().remove(InHoverState);
+        }
+    }
+
+    fn get_disabled_state(&self) -> bool {
+        self.flags.deref().borrow().contains(InDisabledState)
+    }
+
+    fn set_disabled_state(&self, state: bool) {
+        if state {
+            self.flags.deref().borrow_mut().insert(InDisabledState);
+        } else {
+            self.flags.deref().borrow_mut().remove(InDisabledState);
         }
     }
 
@@ -723,11 +742,15 @@ impl LayoutNodeHelpers for JS<Node> {
 
 pub trait RawLayoutNodeHelpers {
     unsafe fn get_hover_state_for_layout(&self) -> bool;
+    unsafe fn get_disabled_state_for_layout(&self) -> bool;
 }
 
 impl RawLayoutNodeHelpers for Node {
     unsafe fn get_hover_state_for_layout(&self) -> bool {
         self.flags.deref().borrow().contains(InHoverState)
+    }
+    unsafe fn get_disabled_state_for_layout(&self) -> bool {
+        self.flags.deref().borrow().contains(InDisabledState)
     }
 }
 
@@ -1990,5 +2013,50 @@ impl<'a> style::TNode<JSRef<'a, Element>> for JSRef<'a, Node> {
             // FIXME: https://github.com/mozilla/servo/issues/1558
             style::AnyNamespace => false,
         }
+    }
+}
+
+pub trait DisabledStateHelpers {
+    fn check_ancestors_disabled_state_for_form_control(&self);
+    fn check_ancestors_disabled_state_for_option(&self);
+    fn check_disabled_attribute(&self);
+}
+
+impl<'a> DisabledStateHelpers for JSRef<'a, Node> {
+    fn check_ancestors_disabled_state_for_form_control(&self) {
+        if self.get_disabled_state() { return; }
+        for ancestor in self.ancestors().filter(|ancestor| ancestor.is_htmlfieldsetelement()) {
+            if !ancestor.get_disabled_state() { continue; }
+            if ancestor.is_parent_of(self) {
+                self.set_disabled_state(true);
+                return;
+            }
+            match ancestor.children().find(|child| child.is_htmllegendelement()) {
+                Some(ref legend) => {
+                    // XXXabinader: should we save previous ancestor to avoid this iteration?
+                    if self.ancestors().any(|ancestor| ancestor == *legend) { continue; }
+                },
+                None => ()
+            }
+            self.set_disabled_state(true);
+            return;
+        }
+    }
+
+    fn check_ancestors_disabled_state_for_option(&self) {
+        if self.get_disabled_state() { return; }
+        for ancestor in self.ancestors().filter(|ancestor| ancestor.is_htmloptgroupelement()) {
+            if ancestor.get_disabled_state() {
+                self.set_disabled_state(true);
+                return;
+            }
+        }
+    }
+
+    fn check_disabled_attribute(&self) {
+        assert!(self.is_element());
+        let elem: &JSRef<'a, Element> = ElementCast::to_ref(self).unwrap();
+        let has_disabled_attrib = elem.has_attribute("disabled");
+        self.set_disabled_state(has_disabled_attrib);
     }
 }

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -13,6 +13,7 @@ use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
@@ -25,6 +26,7 @@ use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
+use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -36,6 +38,7 @@ use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
+use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
@@ -147,6 +150,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {
             let element: &JSRef<HTMLObjectElement> = HTMLObjectElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLOptGroupElementTypeId) => {
+            let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -8,6 +8,7 @@ use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
@@ -18,6 +19,7 @@ use dom::element::ElementTypeId;
 use dom::element::HTMLAnchorElementTypeId;
 use dom::element::HTMLBodyElementTypeId;
 use dom::element::HTMLButtonElementTypeId;
+use dom::element::HTMLFieldSetElementTypeId;
 use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
@@ -27,6 +29,7 @@ use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlelement::HTMLElement;
+use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlobjectelement::HTMLObjectElement;
@@ -121,6 +124,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLButtonElementTypeId) => {
             let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLFieldSetElementTypeId) => {
+            let element: &JSRef<HTMLFieldSetElement> = HTMLFieldSetElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLImageElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -11,6 +11,7 @@ use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
@@ -22,6 +23,7 @@ use dom::element::HTMLButtonElementTypeId;
 use dom::element::HTMLFieldSetElementTypeId;
 use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
+use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
@@ -32,6 +34,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
+use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
@@ -136,6 +139,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLIFrameElementTypeId) => {
             let element: &JSRef<HTMLIFrameElement> = HTMLIFrameElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLInputElementTypeId) => {
+            let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -14,6 +14,7 @@ use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
@@ -27,6 +28,7 @@ use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLOptGroupElementTypeId;
+use dom::element::HTMLOptionElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -39,6 +41,7 @@ use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmloptgroupelement::HTMLOptGroupElement;
+use dom::htmloptionelement::HTMLOptionElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
@@ -154,6 +157,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLOptGroupElementTypeId) => {
             let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLOptionElementTypeId) => {
+            let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -6,6 +6,7 @@ use dom::attr::{AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
@@ -13,11 +14,18 @@ use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
-use dom::element::{ElementTypeId, HTMLAnchorElementTypeId, HTMLBodyElementTypeId, HTMLImageElementTypeId};
-use dom::element::{HTMLIFrameElementTypeId, HTMLObjectElementTypeId, HTMLStyleElementTypeId};
+use dom::element::ElementTypeId;
+use dom::element::HTMLAnchorElementTypeId;
+use dom::element::HTMLBodyElementTypeId;
+use dom::element::HTMLButtonElementTypeId;
+use dom::element::HTMLIFrameElementTypeId;
+use dom::element::HTMLImageElementTypeId;
+use dom::element::HTMLObjectElementTypeId;
+use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlbodyelement::HTMLBodyElement;
+use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlelement::HTMLElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
@@ -109,6 +117,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {
             let element: &JSRef<HTMLBodyElement> = HTMLBodyElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLButtonElementTypeId) => {
+            let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLImageElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -5,6 +5,7 @@
 use dom::attr::{AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLAreaElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
@@ -22,6 +23,7 @@ use dom::bindings::js::JSRef;
 use dom::element::Element;
 use dom::element::ElementTypeId;
 use dom::element::HTMLAnchorElementTypeId;
+use dom::element::HTMLAreaElementTypeId;
 use dom::element::HTMLBodyElementTypeId;
 use dom::element::HTMLButtonElementTypeId;
 use dom::element::HTMLFieldSetElementTypeId;
@@ -36,6 +38,7 @@ use dom::element::HTMLStyleElementTypeId;
 use dom::element::HTMLTextAreaElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
+use dom::htmlareaelement::HTMLAreaElement;
 use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlelement::HTMLElement;
@@ -131,6 +134,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
     match node.type_id() {
         ElementNodeTypeId(HTMLAnchorElementTypeId) => {
             let element: &JSRef<HTMLAnchorElement> = HTMLAnchorElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLAreaElementTypeId) => {
+            let element: &JSRef<HTMLAreaElement> = HTMLAreaElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -17,6 +17,7 @@ use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLSelectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLTextAreaElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
 use dom::element::ElementTypeId;
@@ -32,6 +33,7 @@ use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLOptionElementTypeId;
 use dom::element::HTMLSelectElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
+use dom::element::HTMLTextAreaElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlbodyelement::HTMLBodyElement;
@@ -46,6 +48,7 @@ use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmloptionelement::HTMLOptionElement;
 use dom::htmlselectelement::HTMLSelectElement;
 use dom::htmlstyleelement::HTMLStyleElement;
+use dom::htmltextareaelement::HTMLTextAreaElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
@@ -172,6 +175,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {
             let element: &JSRef<HTMLStyleElement> = HTMLStyleElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLTextAreaElementTypeId) => {
+            let element: &JSRef<HTMLTextAreaElement> = HTMLTextAreaElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(ElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -15,6 +15,7 @@ use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLSelectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
@@ -29,6 +30,7 @@ use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLOptionElementTypeId;
+use dom::element::HTMLSelectElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -42,6 +44,7 @@ use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmloptionelement::HTMLOptionElement;
+use dom::htmlselectelement::HTMLSelectElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
@@ -161,6 +164,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLOptionElementTypeId) => {
             let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLSelectElementTypeId) => {
+            let element: &JSRef<HTMLSelectElement> = HTMLSelectElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -13,6 +13,7 @@ use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLLinkElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
@@ -30,6 +31,7 @@ use dom::element::HTMLFieldSetElementTypeId;
 use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLInputElementTypeId;
+use dom::element::HTMLLinkElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLOptionElementTypeId;
@@ -46,6 +48,7 @@ use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlinputelement::HTMLInputElement;
+use dom::htmllinkelement::HTMLLinkElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmloptionelement::HTMLOptionElement;
@@ -162,6 +165,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods+ {
         }
         ElementNodeTypeId(HTMLInputElementTypeId) => {
             let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods+
+        }
+        ElementNodeTypeId(HTMLLinkElementTypeId) => {
+            let element: &JSRef<HTMLLinkElement> = HTMLLinkElementCast::to_ref(node).unwrap();
             element as &VirtualMethods+
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {

--- a/src/components/script/dom/webidls/Element.webidl
+++ b/src/components/script/dom/webidls/Element.webidl
@@ -39,9 +39,7 @@ interface Element : Node {
   void setAttribute(DOMString name, DOMString value);
   [Throws]
   void setAttributeNS(DOMString? namespace, DOMString name, DOMString value);
-  [Throws]
   void removeAttribute(DOMString name);
-  [Throws]
   void removeAttributeNS(DOMString? namespace, DOMString localName);
   boolean hasAttribute(DOMString name);
   boolean hasAttributeNS(DOMString? namespace, DOMString localName);

--- a/src/components/script/dom/webidls/HTMLButtonElement.webidl
+++ b/src/components/script/dom/webidls/HTMLButtonElement.webidl
@@ -6,7 +6,7 @@
 // http://www.whatwg.org/html/#htmlbuttonelement
 interface HTMLButtonElement : HTMLElement {
   //         attribute boolean autofocus;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString formAction;
   //         attribute DOMString formEnctype;

--- a/src/components/script/dom/webidls/HTMLFieldSetElement.webidl
+++ b/src/components/script/dom/webidls/HTMLFieldSetElement.webidl
@@ -5,7 +5,7 @@
 
 // http://www.whatwg.org/html/#htmlfieldsetelement
 interface HTMLFieldSetElement : HTMLElement {
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString name;
 

--- a/src/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/src/components/script/dom/webidls/HTMLInputElement.webidl
@@ -12,7 +12,7 @@ interface HTMLInputElement : HTMLElement {
   //         attribute boolean defaultChecked;
   //         attribute boolean checked;
   //         attribute DOMString dirName;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //readonly attribute FileList? files;
   //         attribute DOMString formAction;

--- a/src/components/script/dom/webidls/HTMLOptGroupElement.webidl
+++ b/src/components/script/dom/webidls/HTMLOptGroupElement.webidl
@@ -5,6 +5,6 @@
 
 // http://www.whatwg.org/html/#htmloptgroupelement
 interface HTMLOptGroupElement : HTMLElement {
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //         attribute DOMString label;
 };

--- a/src/components/script/dom/webidls/HTMLOptionElement.webidl
+++ b/src/components/script/dom/webidls/HTMLOptionElement.webidl
@@ -6,7 +6,7 @@
 // http://www.whatwg.org/html/#htmloptionelement
 //[NamedConstructor=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
 interface HTMLOptionElement : HTMLElement {
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString label;
   //         attribute boolean defaultSelected;

--- a/src/components/script/dom/webidls/HTMLSelectElement.webidl
+++ b/src/components/script/dom/webidls/HTMLSelectElement.webidl
@@ -6,7 +6,7 @@
 // http://www.whatwg.org/html/#htmlselectelement
 interface HTMLSelectElement : HTMLElement {
   //         attribute boolean autofocus;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute boolean multiple;
   //         attribute DOMString name;

--- a/src/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/src/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -9,7 +9,7 @@ interface HTMLTextAreaElement : HTMLElement {
   //         attribute boolean autofocus;
   //         attribute unsigned long cols;
   //         attribute DOMString dirName;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString inputMode;
   //         attribute long maxLength;

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -12,13 +12,14 @@ use dom::bindings::js::OptionalRootable;
 use dom::bindings::utils::Reflectable;
 use dom::bindings::utils::{wrap_for_same_compartment, pre_wrap};
 use dom::document::{Document, HTMLDocument, DocumentHelpers};
-use dom::element::{Element};
+use dom::element::{Element, HTMLButtonElementTypeId, HTMLInputElementTypeId};
+use dom::element::{HTMLSelectElementTypeId, HTMLTextAreaElementTypeId};
 use dom::event::{Event_, ResizeEvent, ReflowEvent, ClickEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent};
 use dom::event::Event;
 use dom::uievent::UIEvent;
 use dom::eventtarget::{EventTarget, EventTargetHelpers};
 use dom::node;
-use dom::node::{Node, NodeHelpers};
+use dom::node::{ElementNodeTypeId, Node, NodeHelpers};
 use dom::window::{TimerId, Window, WindowHelpers};
 use dom::xmlhttprequest::{TrustedXHRAddress, XMLHttpRequest, XHRProgress};
 use html::hubbub_html_parser::HtmlParserResult;
@@ -193,6 +194,23 @@ impl<'a> Drop for ScriptMemoryFailsafe<'a> {
                 *owner.js_context.borrow_mut() = None;
             }
             None => (),
+        }
+    }
+}
+
+trait PrivateScriptTaskHelpers {
+    fn click_event_filter_by_disabled_state(&self) -> bool;
+}
+
+impl<'a> PrivateScriptTaskHelpers for JSRef<'a, Node> {
+    fn click_event_filter_by_disabled_state(&self) -> bool {
+        match self.type_id {
+            ElementNodeTypeId(HTMLButtonElementTypeId) |
+            ElementNodeTypeId(HTMLInputElementTypeId) |
+            // ElementNodeTypeId(HTMLKeygenElementTypeId) |
+            ElementNodeTypeId(HTMLSelectElementTypeId) |
+            ElementNodeTypeId(HTMLTextAreaElementTypeId) if self.get_disabled_state() => true,
+            _ => false
         }
     }
 }
@@ -717,6 +735,8 @@ impl ScriptTask {
                         match maybe_node {
                             Some(node) => {
                                 debug!("clicked on {:s}", node.debug_str());
+                                // Prevent click event if form control element is disabled.
+                                if node.click_event_filter_by_disabled_state() { return; }
                                 match *page.frame() {
                                     Some(ref frame) => {
                                         let window = frame.window.root();

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -25,5 +25,6 @@ pub trait TElement {
     fn get_local_name<'a>(&'a self) -> &'a str;
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
     fn get_hover_state(&self) -> bool;
+    fn get_disabled_state(&self) -> bool;
 }
 

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -26,5 +26,6 @@ pub trait TElement {
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
     fn get_hover_state(&self) -> bool;
     fn get_disabled_state(&self) -> bool;
+    fn get_enabled_state(&self) -> bool;
 }
 

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -785,6 +785,12 @@ fn matches_simple_selector<E:TElement,
             let elem = element.as_element();
             elem.get_disabled_state()
         },
+        // http://www.whatwg.org/html/#selector-enabled
+        Enabled => {
+            *shareable = false;
+            let elem = element.as_element();
+            elem.get_enabled_state()
+        },
         FirstChild => {
             *shareable = false;
             matches_first_child(element)

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -779,6 +779,12 @@ fn matches_simple_selector<E:TElement,
             let elem = element.as_element();
             elem.get_hover_state()
         },
+        // http://www.whatwg.org/html/#selector-disabled
+        Disabled => {
+            *shareable = false;
+            let elem = element.as_element();
+            elem.get_disabled_state()
+        },
         FirstChild => {
             *shareable = false;
             matches_first_child(element)

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -76,6 +76,7 @@ pub enum SimpleSelector {
     Link,
     Visited,
     Hover,
+    Disabled,
     FirstChild, LastChild, OnlyChild,
 //    Empty,
     Root,
@@ -217,7 +218,7 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 &ClassSelector(..)
                 | &AttrExists(..) | &AttrEqual(..) | &AttrIncludes(..) | &AttrDashMatch(..)
                 | &AttrPrefixMatch(..) | &AttrSubstringMatch(..) | &AttrSuffixMatch(..)
-                | &AnyLink | &Link | &Visited | &Hover
+                | &AnyLink | &Link | &Visited | &Hover | &Disabled
                 | &FirstChild | &LastChild | &OnlyChild | &Root
 //                | &Empty | &Lang(*)
                 | &NthChild(..) | &NthLastChild(..)
@@ -478,6 +479,7 @@ fn parse_simple_pseudo_class(name: &str) -> Option<SimpleSelector> {
         "link" => Some(Link),
         "visited" => Some(Visited),
         "hover" => Some(Hover),
+        "disabled" => Some(Disabled),
         "first-child" => Some(FirstChild),
         "last-child"  => Some(LastChild),
         "only-child"  => Some(OnlyChild),

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -77,6 +77,7 @@ pub enum SimpleSelector {
     Visited,
     Hover,
     Disabled,
+    Enabled,
     FirstChild, LastChild, OnlyChild,
 //    Empty,
     Root,
@@ -218,7 +219,7 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 &ClassSelector(..)
                 | &AttrExists(..) | &AttrEqual(..) | &AttrIncludes(..) | &AttrDashMatch(..)
                 | &AttrPrefixMatch(..) | &AttrSubstringMatch(..) | &AttrSuffixMatch(..)
-                | &AnyLink | &Link | &Visited | &Hover | &Disabled
+                | &AnyLink | &Link | &Visited | &Hover | &Disabled | &Enabled
                 | &FirstChild | &LastChild | &OnlyChild | &Root
 //                | &Empty | &Lang(*)
                 | &NthChild(..) | &NthLastChild(..)
@@ -480,6 +481,7 @@ fn parse_simple_pseudo_class(name: &str) -> Option<SimpleSelector> {
         "visited" => Some(Visited),
         "hover" => Some(Hover),
         "disabled" => Some(Disabled),
+        "enabled" => Some(Enabled),
         "first-child" => Some(FirstChild),
         "last-child"  => Some(LastChild),
         "only-child"  => Some(OnlyChild),

--- a/src/test/content/test_htmlbuttonelement_disabled.html
+++ b/src/test/content/test_htmlbuttonelement_disabled.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>HTMLButtonElement disabled test</title>
+        <script src="harness.js"></script>
+        <script>
+            { // document child tests
+                let click_count = 0;
+                function on_click(ev) { click_count++; }
+
+                let click_event = new Event('click', {bubbles: true, cancelable: true});
+
+                let button1 = document.getElementById("button-1");
+                is(button1.disabled, false);
+
+                button1.addEventListener('click', on_click);
+                button1.dispatchEvent(click_event);
+                is(click_count, 1);
+
+                let button2 = document.getElementById("button-2");
+                is(button2.disabled, true);
+
+                // Only user-generated click events are prevented.
+                button2.addEventListener('click', on_click);
+                button2.dispatchEvent(click_event);
+                is(click_count, 2);
+
+                // This should look disabled, though - missing UA's CSS for :disabled?
+                let button3 = document.getElementById("button-3");
+                is(button3.disabled, false);
+
+                let button4 = document.getElementById("button-4");
+                is(button4.disabled, false);
+
+                // This should look disabled, though - missing UA's CSS for :disabled?
+                let button5 = document.getElementById("button-5");
+                is(button5.disabled, false);
+            }
+
+            { // JS tests
+                let button = document.createElement("button");
+                is(button.disabled, false);
+
+                button.disabled = true;
+                is(button.disabled, true);
+
+                button.removeAttribute("disabled");
+                is(button.disabled, false);
+
+                button.setAttribute("disabled", "");
+                is(button.disabled, true);
+            }
+
+            finish();
+        </script>
+    </head>
+    <body>
+        <button id="button-1"></button>
+
+        <button id="button-2" disabled></button>
+
+        <fieldset disabled>
+            <fieldset>
+                <button id="button-3"></button>
+            </fieldset>
+        </fieldset>
+
+        <fieldset disabled>
+            <legend>
+                <button id="button-4"></button>
+            </legend>
+        </fieldset>
+
+        <fieldset disabled>
+            <legend></legend>
+            <legend>
+                <button id="button-5"></button>
+            </legend>
+        </fieldset>
+    </body>
+</html>


### PR DESCRIPTION
Specs:
http://www.whatwg.org/specs/web-apps/current-work/multipage/selectors.html#selector-enabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/selectors.html#selector-disabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/common-idioms.html#concept-element-disabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/association-of-controls-and-forms.html#concept-fe-disabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#concept-option-disabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#attr-optgroup-disabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#attr-fieldset-disabled
http://www.whatwg.org/specs/web-apps/current-work/multipage/interactive-elements.html#attr-menuitem-disabled

HTMLMenuItemElement to be implemented in #2673.
