### PR TITLE
Stop pretending that CreateInterfaceObjects2 can return the interface object.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1902,14 +1902,13 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
             return "Some(%s.as_slice())" % val
 
         call = """return CreateInterfaceObjects2(aCx, aGlobal, aReceiver, parentProto,
-                               %s, %s, %d,
+                               &PrototypeClass, %s, %d,
                                %s,
                                %s,
                                %s,
                                %s,
                                %s,
                                %s);""" % (
-            "&PrototypeClass" if needInterfacePrototypeObject else "ptr::null()",
             "Some(%s)" % constructHook if needInterfaceObject else "None",
             constructArgs,
             domClass,


### PR DESCRIPTION
We do not currently support the case of a non-callback interface that doesn't
have an interface prototype object. (This case is not allowed by the WebIDL
specification; it was added to Gecko to allow feature-detecting the URL
interface. See https://bugzilla.mozilla.org/show_bug.cgi?id=1026720.)

It follows that, if we call CreateInterfaceObjects2 at all, we will call it
with a protoClass argument, so there is no reason to use a nullable pointer
type for that argument.

Moreover, if we had actually supported that case, the returned interface
object would have been stored in the interface prototype object cache, to ill
effect.
