### PR TITLE
taking into account TESTNAME variable in reftest (see #41)

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -82,12 +82,12 @@ check-servo: $(foreach lib_crate,$(SERVO_LIB_CRATES),check-servo-$(lib_crate)) s
 .PHONY: check-ref-cpu
 check-ref-cpu: reftest
 	@$(call E, check: reftests with CPU rendering)
-	$(Q)./reftest $(S)src/test/ref/*.list -- -c
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c
 
 .PHONY: check-ref-gpu
 check-ref-gpu: reftest
 	@$(call E, check: reftests with GPU rendering)
-	$(Q)./reftest $(S)src/test/ref/*.list
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME)
 
 .PHONY: check-ref
 check-ref: check-ref-cpu check-ref-gpu


### PR DESCRIPTION
With this patch, reftest now accepts as arguments a single test file (src/ref/basic.list), followed by the content of the TESTNAME variable, followed by -- and additional flags given to servo. It is no longer possible to use multiple test files. However, only one such file exists in src/ref.
