### PR TITLE
HTMLStyleElement only applies CSS in the document

### DIFF
--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -9,7 +9,7 @@ use dom::document::Document;
 use dom::element::HTMLStyleElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, NodeMethods, ElementNodeTypeId, window_from_node};
+use dom::node::{Node, NodeMethods, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 use html::cssparse::parse_inline_css;
 use layout_interface::{AddStylesheetMsg, LayoutChan};
@@ -49,6 +49,11 @@ pub trait StyleElementHelpers {
 impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
     fn parse_own_css(&self) {
         let node: &JSRef<Node> = NodeCast::from_ref(self);
+
+        if !node.is_in_doc() {
+            return;
+        }
+
         let win = window_from_node(node).root();
         let url = win.deref().page().get_url();
 
@@ -69,6 +74,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
         match self.super_type() {
             Some(ref s) => s.child_inserted(child),
             _ => (),
+        }
+        self.parse_own_css();
+    }
+
+    fn bind_to_tree(&self) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(),
+            _ => ()
         }
         self.parse_own_css();
     }

--- a/src/test/ref/style_is_in_doc.html
+++ b/src/test/ref/style_is_in_doc.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.from_html { color: blue; }
+.is_not_in_doc { color: grey; }
+</style>
+<script type="text/javascript">
+var append_later = document.createElement('style');
+append_later.textContent = ".append_later { color: green; }";
+document.head.appendChild(append_later);
+
+var text_set_later = document.createElement('style');
+document.head.appendChild(text_set_later);
+text_set_later.textContent = ".text_set_later { color: yellow; }";
+
+var is_not_in_doc = document.createElement('style');
+is_not_in_doc = ".is_not_in_doc { color: red; }";
+</script>
+</head>
+<body>
+<p class="from_html">Style from html element</p>
+<p class="append_later">Style from an element added in javascript</p>
+<p class="text_set_later">Style from an element with content set in javascript</p>
+<p class="is_not_in_doc">Style that is never in the document</p>
+</body>
+</html>

--- a/src/test/ref/style_is_in_doc_ref.html
+++ b/src/test/ref/style_is_in_doc_ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.from_html { color: blue; }
+.append_later { color: green; }
+.text_set_later { color: yellow; }
+.is_not_in_doc { color: grey; }
+</style>
+</head>
+<body>
+<p class="from_html">Style from html element</p>
+<p class="append_later">Style from an element added in javascript</p>
+<p class="text_set_later">Style from an element with content set in javascript</p>
+<p class="is_not_in_doc">Style that is never in the document</p>
+</body>
+</html>


### PR DESCRIPTION
HTMLStyleElement will not parse a style element created in Javascript until it
is attached to the DOM.

This fixes the bug #2107.

I added a reftest for the given cases:
- a style element is defined in the HTML code,
- a style element is created in Javascript, CSS content is added to the
  element and the element is later attached to the document,
- a style element is created in Javascript, attached to the document and
  later CSS content is added to the element,
- a style element is created in Javascript, CSS content is added to the
- element but the element is never attached to the document.
