### PR TITLE
Fix warning in gfx: "variable does not need to be mutable"

### DIFF
--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -301,7 +301,6 @@ impl<C:RenderListener + Send> RenderTask<C> {
 
             spawn(proc() {
                 let mut buffer_map = buffer_map;
-                let mut native_graphics_context = native_graphics_context;
                 loop {
                     let render_msg: WorkerMsg = rx.recv();
                     let render_data = match render_msg {


### PR DESCRIPTION
Fix this warning:

```
compile: src/servo/build/x86_64-apple-darwin/src/components/gfx/libgfx.dummy
src/servo/src/components/gfx/render_task.rs:304:21: 304:48 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/servo/src/components/gfx/render_task.rs:304                 let mut native_graphics_context = native_graphics_context;
                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
