### PR TITLE
Add Fira Sans and DejaVu Sans to the last-resort font families.

### DIFF
--- a/src/components/gfx/platform/linux/font_list.rs
+++ b/src/components/gfx/platform/linux/font_list.rs
@@ -132,7 +132,11 @@ impl FontListHandle {
     }
 
     pub fn get_last_resort_font_families() -> Vec<String> {
-        vec!("Arial".to_string())
+        vec!(
+            "Fira Sans".to_string(),
+            "DejaVu Sans".to_string(),
+            "Arial".to_string()
+        )
     }
 }
 


### PR DESCRIPTION
This is probably not a good long-term solution but it makes things work on fedora and is not too invasive. Fixes #2702.
