### PR TITLE
Cleanup the Travis IRC notifications on builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,27 @@ os:
 - osx
 
 install:
-- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then  ./travis.linux.install.deps.sh; fi
+- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./travis.linux.install.deps.sh; fi
 - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./travis.osx.install.deps.sh; fi
 
 before_script:
   - mkdir -p build
 
-script: 
-- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then  ./travis.linux.script.sh; fi
+script:
+- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./travis.linux.script.sh; fi
 - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./travis.osx.script.sh; fi
 
 git:
   submodules: true
 
 notifications:
-  irc: "irc.mozilla.org#servo"
+  irc:
+    channels: "irc.mozilla.org#servo"
+    on_success: change
+    on_failure: change
+    use_notice: true
   email: false
 
 branches:
   only:
-    - travis
     - master
-
-after_success:


### PR DESCRIPTION
It will now only print notifications about builds of master in #servo if the build transitions from broken -> passing or vice-versa. Since we already are testing PRs before merging, the extra info on every single build was not too useful.

Also some small other cleanups (@ms2ger requested we use notice instead of normal voice; we don't need a travis branch anymore).

r? @metajack
