### PR TITLE
Suppress the compiler warning about raw_pointer_deriving in layout/context.rs

### DIFF
--- a/src/components/main/layout/context.rs
+++ b/src/components/main/layout/context.rs
@@ -52,6 +52,7 @@ static mut STYLE_SHARING_CANDIDATE_CACHE: *mut StyleSharingCandidateCache =
 local_data_key!(style_sharing_candidate_cache: *mut StyleSharingCandidateCache)
 
 /// Data shared by all layout workers.
+#[allow(raw_pointer_deriving)]
 #[deriving(Clone)]
 pub struct LayoutContext {
     /// The local image cache.


### PR DESCRIPTION
This suppress the following compile warning:

```
compile: servo
src/components/main/layout/context.rs:75:18: 75:26 warning: use of `#[deriving]` with a raw pointer, #[warn(raw_pointer_deriving)] on by default
src/components/main/layout/context.rs:75     pub stylist: *Stylist,
                                                          ^~~~~~~~
```
