### PR TITLE
Treat 'native-threading' option correctly.

### DIFF
--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -173,7 +173,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         None => cmp::max(rt::default_sched_threads() * 3 / 4, 1),
     };
 
-    let native_threading = opt_match.opt_present("h") || opt_match.opt_present("help");
+    let native_threading = opt_match.opt_present("n") || opt_match.opt_present("native-threading");
 
     Some(Opts {
         urls: urls,

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -173,7 +173,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         None => cmp::max(rt::default_sched_threads() * 3 / 4, 1),
     };
 
-    let native_threading = opt_match.opt_present("n") || opt_match.opt_present("native-threading");
+    let native_threading = opt_match.opt_present("n");
 
     Some(Opts {
         urls: urls,


### PR DESCRIPTION
Follow-up: #2609 & [this comment](https://github.com/mozilla/servo/commit/850bd2891de589b95e32dc8f0b59d4043ed1e0a3#commitcomment-6779974)

In this place, I agree that we need not accept the long-hand form of `native-threading` option.
If there is special meaning about we accept the long-hand form of it, I'll revert https://github.com/saneyuki/servo/commit/ad5457ba4b75e98360df05cca4d7d438aa3558c2.
