### PR TITLE
Ignore dirty submodules for fontconfig and libexpat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,6 +64,7 @@
 [submodule "src/platform/linux/fontconfig"]
 	path = src/platform/linux/fontconfig
 	url = https://github.com/mozilla-servo/fontconfig.git
+	ignore = dirty
 [submodule "src/support/skia/skia"]
 	path = src/support/skia/skia
 	url = https://github.com/mozilla-servo/skia.git
@@ -94,6 +95,7 @@
 [submodule "src/platform/android/libexpat"]
 	path = src/platform/android/libexpat
 	url = https://github.com/mozilla-servo/libexpat.git
+	ignore = dirty
 [submodule "src/platform/android/libfreetype2"]
 	path = src/platform/android/libfreetype2
 	url = https://github.com/mozilla-servo/libfreetype2.git


### PR DESCRIPTION
Sumbodules which use automatic gitignore generation create a "dirty submodule" change, which can accidentally be committed if you're fond of `git commit -a` et cetera.

This will ignore dirty submodule changes for these, clearing up `git status` and letting you use `git commit -a` with impunity.
