### PR TITLE
Add a basic memory profiler, invoked with -m.

### DIFF
--- a/src/components/embedding/core.rs
+++ b/src/components/embedding/core.rs
@@ -52,6 +52,7 @@ pub extern "C" fn cef_run_message_loop() {
         tile_size: 512,
         device_pixels_per_px: None,
         profiler_period: None,
+        memory_profiler_period: None,
         layout_threads: 1,
         //layout_threads: cmp::max(rt::default_sched_threads() * 3 / 4, 1),
         exit_after_load: false,

--- a/src/components/embedding/core.rs
+++ b/src/components/embedding/core.rs
@@ -51,7 +51,7 @@ pub extern "C" fn cef_run_message_loop() {
         cpu_painting: false,
         tile_size: 512,
         device_pixels_per_px: None,
-        profiler_period: None,
+        time_profiler_period: None,
         memory_profiler_period: None,
         layout_threads: 1,
         //layout_threads: cmp::max(rt::default_sched_threads() * 3 / 4, 1),

--- a/src/components/gfx/font_context.rs
+++ b/src/components/gfx/font_context.rs
@@ -11,7 +11,7 @@ use platform::font_context::FontContextHandle;
 use azure::azure_hl::BackendType;
 use collections::hashmap::HashMap;
 use servo_util::cache::{Cache, LRUCache};
-use servo_util::time::ProfilerChan;
+use servo_util::time::TimeProfilerChan;
 
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -25,8 +25,8 @@ pub struct FontContextInfo {
     /// Whether we need a font list.
     pub needs_font_list: bool,
 
-    /// A channel up to the profiler.
-    pub profiler_chan: ProfilerChan,
+    /// A channel up to the time profiler.
+    pub time_profiler_chan: TimeProfilerChan,
 }
 
 pub trait FontContextHandleMethods {
@@ -40,14 +40,14 @@ pub struct FontContext {
     pub handle: FontContextHandle,
     pub backend: BackendType,
     pub generic_fonts: HashMap<String,String>,
-    pub profiler_chan: ProfilerChan,
+    pub time_profiler_chan: TimeProfilerChan,
 }
 
 impl FontContext {
     pub fn new(info: FontContextInfo) -> FontContext {
         let handle = FontContextHandle::new();
         let font_list = if info.needs_font_list {
-            Some(FontList::new(&handle, info.profiler_chan.clone()))
+            Some(FontList::new(&handle, info.time_profiler_chan.clone()))
         } else {
             None
         };
@@ -67,7 +67,7 @@ impl FontContext {
             handle: handle,
             backend: info.backend,
             generic_fonts: generic_fonts,
-            profiler_chan: info.profiler_chan.clone(),
+            time_profiler_chan: info.time_profiler_chan.clone(),
         }
     }
 

--- a/src/components/gfx/font_list.rs
+++ b/src/components/gfx/font_list.rs
@@ -10,7 +10,7 @@ use platform::font_context::FontContextHandle;
 use platform::font_list::FontListHandle;
 use style::computed_values::{font_weight, font_style};
 
-use servo_util::time::{ProfilerChan, profile};
+use servo_util::time::{TimeProfilerChan, profile};
 use servo_util::time;
 
 pub type FontFamilyMap = HashMap<String, FontFamily>;
@@ -25,18 +25,18 @@ trait FontListHandleMethods {
 pub struct FontList {
     family_map: FontFamilyMap,
     handle: FontListHandle,
-    prof_chan: ProfilerChan,
+    time_profiler_chan: TimeProfilerChan,
 }
 
 impl FontList {
     pub fn new(fctx: &FontContextHandle,
-           prof_chan: ProfilerChan)
+           time_profiler_chan: TimeProfilerChan)
            -> FontList {
         let handle = FontListHandle::new(fctx);
         let mut list = FontList {
             handle: handle,
             family_map: HashMap::new(),
-            prof_chan: prof_chan.clone(),
+            time_profiler_chan: time_profiler_chan.clone(),
         };
         list.refresh(fctx);
         list
@@ -47,7 +47,7 @@ impl FontList {
         // changed.  Does OSX have a notification for this event?
         //
         // Should font families with entries be invalidated/refreshed too?
-        profile(time::GfxRegenAvailableFontsCategory, self.prof_chan.clone(), || {
+        profile(time::GfxRegenAvailableFontsCategory, self.time_profiler_chan.clone(), || {
             self.family_map = self.handle.get_available_families();
         });
     }

--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -16,6 +16,7 @@ use layers::platform::surface::{NativeCompositingGraphicsContext, NativeGraphics
 use servo_msg::compositor_msg::{Epoch, LayerBufferSet, LayerId, LayerMetadata, ReadyState};
 use servo_msg::compositor_msg::{RenderListener, RenderState, ScriptListener, ScrollPolicy};
 use servo_msg::constellation_msg::{ConstellationChan, PipelineId};
+use servo_util::memory::MemoryProfilerChan;
 use servo_util::opts::Opts;
 use servo_util::time::ProfilerChan;
 use std::comm::{channel, Sender, Receiver};
@@ -224,7 +225,8 @@ impl CompositorTask {
     pub fn create(opts: Opts,
                   port: Receiver<Msg>,
                   constellation_chan: ConstellationChan,
-                  profiler_chan: ProfilerChan) {
+                  profiler_chan: ProfilerChan,
+                  memory_profiler_chan: MemoryProfilerChan) {
 
         let compositor = CompositorTask::new(opts.headless);
 
@@ -234,12 +236,14 @@ impl CompositorTask {
                                                  opts,
                                                  port,
                                                  constellation_chan.clone(),
-                                                 profiler_chan)
+                                                 profiler_chan,
+                                                 memory_profiler_chan)
             }
             Headless => {
                 headless::NullCompositor::create(port,
                                                  constellation_chan.clone(),
-                                                 profiler_chan)
+                                                 profiler_chan,
+                                                 memory_profiler_chan)
             }
         };
     }

--- a/src/components/main/compositing/compositor_task.rs
+++ b/src/components/main/compositing/compositor_task.rs
@@ -18,7 +18,7 @@ use servo_msg::compositor_msg::{RenderListener, RenderState, ScriptListener, Scr
 use servo_msg::constellation_msg::{ConstellationChan, PipelineId};
 use servo_util::memory::MemoryProfilerChan;
 use servo_util::opts::Opts;
-use servo_util::time::ProfilerChan;
+use servo_util::time::TimeProfilerChan;
 use std::comm::{channel, Sender, Receiver};
 
 use url::Url;
@@ -225,7 +225,7 @@ impl CompositorTask {
     pub fn create(opts: Opts,
                   port: Receiver<Msg>,
                   constellation_chan: ConstellationChan,
-                  profiler_chan: ProfilerChan,
+                  time_profiler_chan: TimeProfilerChan,
                   memory_profiler_chan: MemoryProfilerChan) {
 
         let compositor = CompositorTask::new(opts.headless);
@@ -236,13 +236,13 @@ impl CompositorTask {
                                                  opts,
                                                  port,
                                                  constellation_chan.clone(),
-                                                 profiler_chan,
+                                                 time_profiler_chan,
                                                  memory_profiler_chan)
             }
             Headless => {
                 headless::NullCompositor::create(port,
                                                  constellation_chan.clone(),
-                                                 profiler_chan,
+                                                 time_profiler_chan,
                                                  memory_profiler_chan)
             }
         };

--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -9,7 +9,7 @@ use geom::size::TypedSize2D;
 use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, ResizedWindowMsg, WindowSizeData};
 use servo_util::memory::MemoryProfilerChan;
 use servo_util::memory;
-use servo_util::time::ProfilerChan;
+use servo_util::time::TimeProfilerChan;
 use servo_util::time;
 
 /// Starts the compositor, which listens for messages on the specified port.
@@ -30,7 +30,7 @@ impl NullCompositor {
 
     pub fn create(port: Receiver<Msg>,
                   constellation_chan: ConstellationChan,
-                  profiler_chan: ProfilerChan,
+                  time_profiler_chan: TimeProfilerChan,
                   memory_profiler_chan: MemoryProfilerChan) {
         let compositor = NullCompositor::new(port);
 
@@ -54,7 +54,7 @@ impl NullCompositor {
             }
         }
 
-        profiler_chan.send(time::ExitMsg);
+        time_profiler_chan.send(time::ExitMsg);
         memory_profiler_chan.send(memory::ExitMsg);
     }
 

--- a/src/components/main/compositing/headless.rs
+++ b/src/components/main/compositing/headless.rs
@@ -7,6 +7,8 @@ use compositing::*;
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use servo_msg::constellation_msg::{ConstellationChan, ExitMsg, ResizedWindowMsg, WindowSizeData};
+use servo_util::memory::MemoryProfilerChan;
+use servo_util::memory;
 use servo_util::time::ProfilerChan;
 use servo_util::time;
 
@@ -28,7 +30,8 @@ impl NullCompositor {
 
     pub fn create(port: Receiver<Msg>,
                   constellation_chan: ConstellationChan,
-                  profiler_chan: ProfilerChan) {
+                  profiler_chan: ProfilerChan,
+                  memory_profiler_chan: MemoryProfilerChan) {
         let compositor = NullCompositor::new(port);
 
         // Tell the constellation about the initial fake size.
@@ -52,6 +55,7 @@ impl NullCompositor {
         }
 
         profiler_chan.send(time::ExitMsg);
+        memory_profiler_chan.send(memory::ExitMsg);
     }
 
     fn handle_message(&self, constellation_chan: ConstellationChan) {

--- a/src/components/main/constellation.rs
+++ b/src/components/main/constellation.rs
@@ -27,7 +27,7 @@ use servo_net::resource_task::ResourceTask;
 use servo_net::resource_task;
 use servo_util::geometry::PagePx;
 use servo_util::opts::Opts;
-use servo_util::time::ProfilerChan;
+use servo_util::time::TimeProfilerChan;
 use servo_util::url::parse_url;
 use servo_util::task::spawn_named;
 use std::cell::RefCell;
@@ -48,7 +48,7 @@ pub struct Constellation {
     next_pipeline_id: PipelineId,
     pending_frames: Vec<FrameChange>,
     pending_sizes: HashMap<(PipelineId, SubpageId), TypedRect<PagePx, f32>>,
-    pub profiler_chan: ProfilerChan,
+    pub time_profiler_chan: TimeProfilerChan,
     pub window_size: WindowSizeData,
     pub opts: Opts,
 }
@@ -244,7 +244,7 @@ impl Constellation {
                  opts: &Opts,
                  resource_task: ResourceTask,
                  image_cache_task: ImageCacheTask,
-                 profiler_chan: ProfilerChan)
+                 time_profiler_chan: TimeProfilerChan)
                  -> ConstellationChan {
         let (constellation_port, constellation_chan) = ConstellationChan::new();
         let constellation_chan_clone = constellation_chan.clone();
@@ -261,7 +261,7 @@ impl Constellation {
                 next_pipeline_id: PipelineId(0),
                 pending_frames: vec!(),
                 pending_sizes: HashMap::new(),
-                profiler_chan: profiler_chan,
+                time_profiler_chan: time_profiler_chan,
                 window_size: WindowSizeData {
                     visible_viewport: TypedSize2D(800_f32, 600_f32),
                     initial_viewport: TypedSize2D(800_f32, 600_f32),
@@ -424,7 +424,7 @@ impl Constellation {
                                         self.compositor_chan.clone(),
                                         self.image_cache_task.clone(),
                                         self.resource_task.clone(),
-                                        self.profiler_chan.clone(),
+                                        self.time_profiler_chan.clone(),
                                         self.window_size,
                                         self.opts.clone(),
                                         parse_url("about:failure", None));
@@ -451,7 +451,7 @@ impl Constellation {
                                         self.compositor_chan.clone(),
                                         self.image_cache_task.clone(),
                                         self.resource_task.clone(),
-                                        self.profiler_chan.clone(),
+                                        self.time_profiler_chan.clone(),
                                         self.window_size,
                                         self.opts.clone(),
                                         url);
@@ -576,7 +576,7 @@ impl Constellation {
                                   self.chan.clone(),
                                   self.compositor_chan.clone(),
                                   self.image_cache_task.clone(),
-                                  self.profiler_chan.clone(),
+                                  self.time_profiler_chan.clone(),
                                   self.opts.clone(),
                                   source_pipeline.clone(),
                                   url)
@@ -589,7 +589,7 @@ impl Constellation {
                              self.compositor_chan.clone(),
                              self.image_cache_task.clone(),
                              self.resource_task.clone(),
-                             self.profiler_chan.clone(),
+                             self.time_profiler_chan.clone(),
                              self.window_size,
                              self.opts.clone(),
                              url)
@@ -645,7 +645,7 @@ impl Constellation {
                                         self.compositor_chan.clone(),
                                         self.image_cache_task.clone(),
                                         self.resource_task.clone(),
-                                        self.profiler_chan.clone(),
+                                        self.time_profiler_chan.clone(),
                                         self.window_size,
                                         self.opts.clone(),
                                         url);

--- a/src/components/main/layout/parallel.rs
+++ b/src/components/main/layout/parallel.rs
@@ -20,7 +20,7 @@ use layout::wrapper::{layout_node_to_unsafe_layout_node, layout_node_from_unsafe
 use layout::wrapper::{ThreadSafeLayoutNode, UnsafeLayoutNode};
 
 use gfx::display_list::OpaqueNode;
-use servo_util::time::{ProfilerChan, profile};
+use servo_util::time::{TimeProfilerChan, profile};
 use servo_util::time;
 use servo_util::workqueue::{WorkQueue, WorkUnit, WorkerProxy};
 use std::mem;
@@ -526,14 +526,14 @@ pub fn recalc_style_for_subtree(root_node: &LayoutNode,
 }
 
 pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
-                                   profiler_chan: ProfilerChan,
+                                   time_profiler_chan: TimeProfilerChan,
                                    layout_context: &mut LayoutContext,
                                    queue: &mut WorkQueue<*mut LayoutContext,UnsafeFlow>) {
     unsafe {
         queue.data = mem::transmute(layout_context)
     }
 
-    profile(time::LayoutParallelWarmupCategory, profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: assign_widths,
             data: mut_owned_flow_to_unsafe_flow(root),
@@ -546,14 +546,14 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 }
 
 pub fn build_display_list_for_subtree(root: &mut FlowRef,
-                                      profiler_chan: ProfilerChan,
+                                      time_profiler_chan: TimeProfilerChan,
                                       layout_context: &mut LayoutContext,
                                       queue: &mut WorkQueue<*mut LayoutContext,UnsafeFlow>) {
     unsafe {
         queue.data = mem::transmute(layout_context)
     }
 
-    profile(time::LayoutParallelWarmupCategory, profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: compute_absolute_position,
             data: mut_owned_flow_to_unsafe_flow(root),

--- a/src/components/main/pipeline.rs
+++ b/src/components/main/pipeline.rs
@@ -16,7 +16,7 @@ use servo_msg::constellation_msg::WindowSizeData;
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
 use servo_util::opts::Opts;
-use servo_util::time::ProfilerChan;
+use servo_util::time::TimeProfilerChan;
 use std::rc::Rc;
 use url::Url;
 
@@ -49,7 +49,7 @@ impl Pipeline {
                        constellation_chan: ConstellationChan,
                        compositor_chan: CompositorChan,
                        image_cache_task: ImageCacheTask,
-                       profiler_chan: ProfilerChan,
+                       time_profiler_chan: TimeProfilerChan,
                        opts: Opts,
                        script_pipeline: Rc<Pipeline>,
                        url: Url)
@@ -70,7 +70,7 @@ impl Pipeline {
                            constellation_chan.clone(),
                            failure.clone(),
                            opts.clone(),
-                           profiler_chan.clone(),
+                           time_profiler_chan.clone(),
                            render_shutdown_chan);
 
         LayoutTask::create(id,
@@ -82,7 +82,7 @@ impl Pipeline {
                            render_chan.clone(),
                            image_cache_task.clone(),
                            opts.clone(),
-                           profiler_chan,
+                           time_profiler_chan,
                            layout_shutdown_chan);
 
         let new_layout_info = NewLayoutInfo {
@@ -111,7 +111,7 @@ impl Pipeline {
                   compositor_chan: CompositorChan,
                   image_cache_task: ImageCacheTask,
                   resource_task: ResourceTask,
-                  profiler_chan: ProfilerChan,
+                  time_profiler_chan: TimeProfilerChan,
                   window_size: WindowSizeData,
                   opts: Opts,
                   url: Url)
@@ -152,7 +152,7 @@ impl Pipeline {
                            constellation_chan.clone(),
                            failure.clone(),
                            opts.clone(),
-                           profiler_chan.clone(),
+                           time_profiler_chan.clone(),
                            render_shutdown_chan);
 
         LayoutTask::create(id,
@@ -164,7 +164,7 @@ impl Pipeline {
                            render_chan.clone(),
                            image_cache_task,
                            opts.clone(),
-                           profiler_chan,
+                           time_profiler_chan,
                            layout_shutdown_chan);
 
         pipeline

--- a/src/components/main/servo.rs
+++ b/src/components/main/servo.rs
@@ -63,7 +63,7 @@ use servo_net::image_cache_task::{ImageCacheTask, SyncImageCacheTask};
 #[cfg(not(test))]
 use servo_net::resource_task::ResourceTask;
 #[cfg(not(test))]
-use servo_util::time::Profiler;
+use servo_util::time::TimeProfiler;
 #[cfg(not(test))]
 use servo_util::memory::MemoryProfiler;
 
@@ -170,11 +170,11 @@ pub fn run(opts: opts::Opts) {
     let mut pool = green::SchedPool::new(pool_config);
 
     let (compositor_port, compositor_chan) = CompositorChan::new();
-    let profiler_chan = Profiler::create(opts.profiler_period);
+    let time_profiler_chan = TimeProfiler::create(opts.time_profiler_period);
     let memory_profiler_chan = MemoryProfiler::create(opts.memory_profiler_period);
 
     let opts_clone = opts.clone();
-    let profiler_chan_clone = profiler_chan.clone();
+    let time_profiler_chan_clone = time_profiler_chan.clone();
 
     let (result_chan, result_port) = channel();
     pool.spawn(TaskOpts::new(), proc() {
@@ -193,7 +193,7 @@ pub fn run(opts: opts::Opts) {
                                                       opts,
                                                       resource_task,
                                                       image_cache_task,
-                                                      profiler_chan_clone);
+                                                      time_profiler_chan_clone);
 
         // Send the URL command to the constellation.
         for filename in opts.urls.iter() {
@@ -220,7 +220,7 @@ pub fn run(opts: opts::Opts) {
     CompositorTask::create(opts,
                            compositor_port,
                            constellation_chan,
-                           profiler_chan,
+                           time_profiler_chan,
                            memory_profiler_chan);
 
     pool.shutdown();

--- a/src/components/main/servo.rs
+++ b/src/components/main/servo.rs
@@ -64,6 +64,8 @@ use servo_net::image_cache_task::{ImageCacheTask, SyncImageCacheTask};
 use servo_net::resource_task::ResourceTask;
 #[cfg(not(test))]
 use servo_util::time::Profiler;
+#[cfg(not(test))]
+use servo_util::memory::MemoryProfiler;
 
 #[cfg(not(test))]
 use servo_util::opts;
@@ -169,6 +171,7 @@ pub fn run(opts: opts::Opts) {
 
     let (compositor_port, compositor_chan) = CompositorChan::new();
     let profiler_chan = Profiler::create(opts.profiler_period);
+    let memory_profiler_chan = MemoryProfiler::create(opts.memory_profiler_period);
 
     let opts_clone = opts.clone();
     let profiler_chan_clone = profiler_chan.clone();
@@ -217,7 +220,8 @@ pub fn run(opts: opts::Opts) {
     CompositorTask::create(opts,
                            compositor_port,
                            constellation_chan,
-                           profiler_chan);
+                           profiler_chan,
+                           memory_profiler_chan);
 
     pool.shutdown();
 }

--- a/src/components/util/memory.rs
+++ b/src/components/util/memory.rs
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Memory profiling functions.
+
+use std::io::timer::sleep;
+#[cfg(target_os="linux")]
+use std::io::File;
+#[cfg(target_os="linux")]
+use std::os::page_size;
+use task::spawn_named;
+
+pub struct MemoryProfilerChan(pub Sender<MemoryProfilerMsg>);
+
+impl MemoryProfilerChan {
+    pub fn send(&self, msg: MemoryProfilerMsg) {
+        let MemoryProfilerChan(ref c) = *self;
+        c.send(msg);
+    }
+}
+
+pub enum MemoryProfilerMsg {
+    /// Message used to force print the memory profiling metrics.
+    PrintMsg,
+    /// Tells the memory profiler to shut down.
+    ExitMsg,
+}
+
+pub struct MemoryProfiler {
+    pub port: Receiver<MemoryProfilerMsg>,
+}
+
+impl MemoryProfiler {
+    pub fn create(period: Option<f64>) -> MemoryProfilerChan {
+        let (chan, port) = channel();
+        match period {
+            Some(period) => {
+                let period = (period * 1000f64) as u64;
+                let chan = chan.clone();
+                spawn_named("Memory profiler timer", proc() {
+                    loop {
+                        sleep(period);
+                        if chan.send_opt(PrintMsg).is_err() {
+                            break;
+                        }
+                    }
+                });
+                // Spawn the memory profiler.
+                spawn_named("Memory profiler", proc() {
+                    let memory_profiler = MemoryProfiler::new(port);
+                    memory_profiler.start();
+                });
+            }
+            None => {
+                // No-op to handle profiler messages when the memory profiler
+                // is inactive.
+                spawn_named("Memory profiler", proc() {
+                    loop {
+                        match port.recv_opt() {
+                            Err(_) | Ok(ExitMsg) => break,
+                            _ => {}
+                        }
+                    }
+                });
+            }
+        }
+
+        MemoryProfilerChan(chan)
+    }
+
+    pub fn new(port: Receiver<MemoryProfilerMsg>) -> MemoryProfiler {
+        MemoryProfiler {
+            port: port
+        }
+    }
+
+    pub fn start(&self) {
+        loop {
+            match self.port.recv_opt() {
+               Ok(msg) => {
+                   if !self.handle_msg(msg) {
+                       break
+                   }
+               }
+               _ => break
+            }
+        }
+    }
+
+    fn handle_msg(&self, msg: MemoryProfilerMsg) -> bool {
+        match msg {
+            PrintMsg => {
+                self.handle_print_msg();
+                true
+            },
+            ExitMsg => false
+        }
+    }
+
+    fn print_measurement(path: &str, nbytes: Option<i64>) {
+        match nbytes {
+            Some(nbytes) => {
+                let mebi = 1024f64 * 1024f64;
+                println!("{:12s}: {:12.2f}", path, (nbytes as f64) / mebi);
+            }
+            None => {
+                println!("{:12s}: {:>12s}", path, "???");
+            }
+        }
+    }
+
+    fn handle_print_msg(&self) {
+        println!("{:12s}: {:12s}", "_category_", "_size (MiB)_");
+        MemoryProfiler::print_measurement("vsize",    get_vsize());
+        MemoryProfiler::print_measurement("resident", get_resident());
+        println!("");
+    }
+}
+
+// Like std::macros::try!, but for Option<>.
+macro_rules! option_try(
+    ($e:expr) => (match $e { Some(e) => e, None => return None })
+)
+
+#[cfg(target_os="linux")]
+fn get_proc_self_statm_field(field: uint) -> Option<i64> {
+    let mut f = File::open(&Path::new("/proc/self/statm"));
+    match f.read_to_str() {
+        Ok(contents) => {
+            let s = option_try!(contents.as_slice().words().nth(field));
+            let npages: i64 = option_try!(from_str(s));
+            Some(npages * (page_size() as i64))
+        }
+        Err(_) => None
+    }
+}
+
+#[cfg(target_os="linux")]
+fn get_vsize() -> Option<i64> {
+    get_proc_self_statm_field(0)
+}
+
+#[cfg(not(target_os="linux"))]
+fn get_vsize() -> Option<i64> {
+    None
+}
+
+#[cfg(target_os="linux")]
+fn get_resident() -> Option<i64> {
+    get_proc_self_statm_field(1)
+}
+
+#[cfg(not(target_os="linux"))]
+fn get_resident() -> Option<i64> {
+    None
+}
+

--- a/src/components/util/memory.rs
+++ b/src/components/util/memory.rs
@@ -53,8 +53,8 @@ impl MemoryProfiler {
                 });
             }
             None => {
-                // No-op to handle profiler messages when the memory profiler
-                // is inactive.
+                // No-op to handle messages when the memory profiler is
+                // inactive.
                 spawn_named("Memory profiler", proc() {
                     loop {
                         match port.recv_opt() {

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -41,9 +41,9 @@ pub struct Opts {
     /// platform default setting.
     pub device_pixels_per_px: Option<ScaleFactor<ScreenPx, DevicePixel, f32>>,
 
-    /// `None` to disable the profiler or `Some` with an interval in seconds to enable it and cause
-    /// it to produce output on that interval (`-p`).
-    pub profiler_period: Option<f64>,
+    /// `None` to disable the time profiler or `Some` with an interval in seconds to enable it and
+    /// cause it to produce output on that interval (`-p`).
+    pub time_profiler_period: Option<f64>,
 
     /// `None` to disable the memory profiler or `Some` with an interval in seconds to enable it 
     /// and cause it to produce output on that interval (`-m`).
@@ -153,7 +153,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
     };
 
     // If only the flag is present, default to a 5 second period for both profilers.
-    let profiler_period = opt_match.opt_default("p", "5").map(|period| {
+    let time_profiler_period = opt_match.opt_default("p", "5").map(|period| {
         from_str(period.as_slice()).unwrap()
     });
     let memory_profiler_period = opt_match.opt_default("m", "5").map(|period| {
@@ -174,7 +174,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         cpu_painting: cpu_painting,
         tile_size: tile_size,
         device_pixels_per_px: device_pixels_per_px,
-        profiler_period: profiler_period,
+        time_profiler_period: time_profiler_period,
         memory_profiler_period: memory_profiler_period,
         layout_threads: layout_threads,
         exit_after_load: opt_match.opt_present("x"),

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -45,6 +45,10 @@ pub struct Opts {
     /// it to produce output on that interval (`-p`).
     pub profiler_period: Option<f64>,
 
+    /// `None` to disable the memory profiler or `Some` with an interval in seconds to enable it 
+    /// and cause it to produce output on that interval (`-m`).
+    pub memory_profiler_period: Option<f64>,
+
     /// The number of threads to use for layout (`-y`). Defaults to 1, which results in a recursive
     /// sequential algorithm.
     pub layout_threads: uint,
@@ -85,6 +89,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         getopts::optopt("", "device-pixel-ratio", "Device pixels per px", ""),
         getopts::optopt("t", "threads", "Number of render threads", "1"),
         getopts::optflagopt("p", "profile", "Profiler flag and output interval", "10"),
+        getopts::optflagopt("m", "memory-profile", "Memory profiler flag and output interval", "10"),
         getopts::optflag("x", "exit", "Exit after load flag"),
         getopts::optopt("y", "layout-threads", "Number of threads to use for layout", "1"),
         getopts::optflag("z", "headless", "Headless mode"),
@@ -147,8 +152,11 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         None => 1,      // FIXME: Number of cores.
     };
 
-    // if only flag is present, default to 5 second period
+    // If only the flag is present, default to a 5 second period for both profilers.
     let profiler_period = opt_match.opt_default("p", "5").map(|period| {
+        from_str(period.as_slice()).unwrap()
+    });
+    let memory_profiler_period = opt_match.opt_default("m", "5").map(|period| {
         from_str(period.as_slice()).unwrap()
     });
 
@@ -167,6 +175,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         tile_size: tile_size,
         device_pixels_per_px: device_pixels_per_px,
         profiler_period: profiler_period,
+        memory_profiler_period: memory_profiler_period,
         layout_threads: layout_threads,
         exit_after_load: opt_match.opt_present("x"),
         output_file: opt_match.opt_str("o"),

--- a/src/components/util/util.rs
+++ b/src/components/util/util.rs
@@ -29,6 +29,7 @@ extern crate std_url = "url";
 pub mod cache;
 pub mod debug_utils;
 pub mod geometry;
+pub mod memory;
 pub mod namespace;
 pub mod opts;
 pub mod range;


### PR DESCRIPTION
This adds a basic memory profiler. It's invoked with the -m option. Sample
output:

> _category_  : _size (MiB)_
> vsize       :      1355.47
> resident    :        50.85

It currently only works on Linux. On other platforms, "???" will be printed
instead.

I chose to make the memory profiler entirely separate from the existing 
profiler, as opposed to augmenting it. They are/will be different enough beasts
that this seemed the right thing to do. But it did result in a bit of copy &
pasting. And if you run with both -p and -m, the output can be interleaved,
which isn't ideal.

Something I didn't do, which might make sense, is to rename Profiler (and all
related names) as TimeProfiler. That name would nicely match the |time| module
name.

The option_try! macro might be a useful thing to add to Rust's std::macros.
