### PR TITLE
Basic parsing of `overflow: scroll` and `auto`.

### DIFF
--- a/src/components/layout/fragment.rs
+++ b/src/components/layout/fragment.rs
@@ -1395,9 +1395,12 @@ impl Fragment {
         }
     }
 
-    /// Returns true if the contents should be clipped (i.e. if `overflow` is `hidden`).
+    /// Returns true if the contents should be clipped (i.e. if `overflow` is not `visible`).
     pub fn needs_clip(&self) -> bool {
-        self.style().get_box().overflow == overflow::hidden
+        match self.style().get_box().overflow {
+            overflow::visible => true,
+            overflow::hidden | overflow::auto | overflow::scroll => false,
+        }
     }
 
     /// A helper function to return a debug string describing the side offsets for one of the rect
@@ -1475,13 +1478,13 @@ impl ChildDisplayListAccumulator {
            -> ChildDisplayListAccumulator {
         ChildDisplayListAccumulator {
             clip_display_item: match style.get_box().overflow {
-                overflow::hidden => {
+                overflow::hidden | overflow::auto | overflow::scroll => {
                     Some(box ClipDisplayItem {
                         base: BaseDisplayItem::new(bounds, node, level),
                         children: DisplayList::new(),
                     })
-                }
-                _ => None,
+                },
+                overflow::visible => None,
             }
         }
     }

--- a/src/components/layout/fragment.rs
+++ b/src/components/layout/fragment.rs
@@ -1395,14 +1395,6 @@ impl Fragment {
         }
     }
 
-    /// Returns true if the contents should be clipped (i.e. if `overflow` is not `visible`).
-    pub fn needs_clip(&self) -> bool {
-        match self.style().get_box().overflow {
-            overflow::visible => true,
-            overflow::hidden | overflow::auto | overflow::scroll => false,
-        }
-    }
-
     /// A helper function to return a debug string describing the side offsets for one of the rect
     /// box model properties (border, padding, or margin).
     fn side_offsets_debug_fmt(&self, name: &str,

--- a/src/components/style/properties/mod.rs.mako
+++ b/src/components/style/properties/mod.rs.mako
@@ -515,7 +515,7 @@ pub mod longhands {
 
 
     // CSS 2.1, Section 11 - Visual effects
-    ${single_keyword("overflow", "visible hidden")} // TODO: scroll auto
+    ${single_keyword("overflow", "visible hidden scroll auto")}
 
     ${switch_to_style_struct("InheritedBox")}
 

--- a/src/components/style/properties/mod.rs.mako
+++ b/src/components/style/properties/mod.rs.mako
@@ -515,6 +515,7 @@ pub mod longhands {
 
 
     // CSS 2.1, Section 11 - Visual effects
+    // FIXME: Implement scrolling for `scroll` and `auto` (#2742).
     ${single_keyword("overflow", "visible hidden scroll auto")}
 
     ${switch_to_style_struct("InheritedBox")}

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -76,6 +76,9 @@
 == linebreak_simple_a.html linebreak_simple_b.html
 == linebreak_inline_span_a.html linebreak_inline_span_b.html
 == overconstrained_block.html overconstrained_block_ref.html
+== overflow_auto.html overflow_simple_b.html
+== overflow_scroll.html overflow_simple_b.html
+== overflow_simple_a.html overflow_simple_b.html
 == position_fixed_background_color_a.html position_fixed_background_color_b.html
 == position_fixed_overflow_a.html position_fixed_overflow_b.html
 == noscript.html noscript_ref.html

--- a/src/test/ref/overflow_auto.html
+++ b/src/test/ref/overflow_auto.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <style>
+      #first {
+      height: 100px;
+      width: 100px;
+      overflow: auto;
+      }
+      #second {
+      height: 100px;
+      width: 200px;
+      background: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="first">
+      <div id="second">
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/test/ref/overflow_scroll.html
+++ b/src/test/ref/overflow_scroll.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <style>
+      #first {
+      height: 100px;
+      width: 100px;
+      overflow: scroll;
+      }
+      #second {
+      height: 100px;
+      width: 200px;
+      background: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="first">
+      <div id="second">
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Elements with overflow scroll/auto are not yet scrollable, but they will be clipped correctly (like `overflow: hidden`).
