### PR TITLE
Adopt Rect::contains in compositor hit-testing

### DIFF
--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -230,12 +230,11 @@ impl CompositorData {
                 }
                 Some(rect) => {
                     let rect: TypedRect<PagePx, f32> = Rect::from_untyped(&rect);
-                    if cursor.x >= rect.origin.x && cursor.x < rect.origin.x + rect.size.width
-                        && cursor.y >= rect.origin.y && cursor.y < rect.origin.y + rect.size.height
-                        && CompositorData::handle_scroll_event(child.clone(),
-                                                               delta,
-                                                               cursor - rect.origin,
-                                                               rect.size) {
+                    if rect.contains(&cursor) &&
+                       CompositorData::handle_scroll_event(child.clone(),
+                                                           delta,
+                                                           cursor - rect.origin,
+                                                           rect.size) {
                         return true
                     }
                 }
@@ -313,8 +312,7 @@ impl CompositorData {
                 }
                 Some(rect) => {
                     let rect: TypedRect<PagePx, f32> = Rect::from_untyped(&rect);
-                    if cursor.x >= rect.origin.x && cursor.x < rect.origin.x + rect.size.width
-                        && cursor.y >= rect.origin.y && cursor.y < rect.origin.y + rect.size.height {
+                    if rect.contains(&cursor) {
                         CompositorData::send_mouse_event(child.clone(), event, cursor - rect.origin);
                         return;
                     }


### PR DESCRIPTION
This does make hit-testing inclusive in the right/bottom edges, whereas it was only inclusive in the top/left edges before.
