### PR TITLE
Stop calling Scene::set_transform

### DIFF
--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -674,7 +674,7 @@ impl IOCompositor {
 
     fn update_zoom_transform(&mut self) {
         let scale = self.device_pixels_per_page_px();
-        self.scene.set_transform(identity().scale(scale.get(), scale.get(), 1f32));
+        self.scene.transform = identity().scale(scale.get(), scale.get(), 1f32);
     }
 
     fn on_zoom_window_event(&mut self, magnification: f32) {


### PR DESCRIPTION
The Scene::set_transform method was only introduced because of an old
rustc bug around mutating properties across crates. Now that the rustc
bug is fixed, we can stop calling this method.
