### PR TITLE
Add .editorconfig file at root level

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,8 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
+
+# Makefiles use tab indention.
+[*.mk]
+indent_style = tab
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Top-most EditorConfig file.
+root = true
+
+# Unix-style newlines with a newline ending every file.
+[*]
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true


### PR DESCRIPTION
As the first comment states

```
# EditorConfig is awesome: http://EditorConfig.org
```

Editors (e.g. Sublime with the EditorConfig package) use this file to setup the right editing environment (like tab size).

There is also an option to `trim_trailing_whitespace`, but I was not sure if this is useful for the project.
