### PR TITLE
Fix encoding issues for getResponseHeader()

### DIFF
--- a/src/components/script/dom/xmlhttprequest.rs
+++ b/src/components/script/dom/xmlhttprequest.rs
@@ -556,7 +556,8 @@ impl<'a> XMLHttpRequestMethods<'a> for JSRef<'a, XMLHttpRequest> {
         self.response_headers.deref().borrow().iter().find(|h| {
             name.eq_ignore_case(&FromStr::from_str(h.header_name().as_slice()).unwrap())
         }).map(|h| {
-            FromStr::from_str(h.header_value().as_slice()).unwrap()
+            // rust-http doesn't decode properly, we'll convert it back to bytes here
+            ByteString::new(h.header_value().as_slice().chars().map(|c| { assert!(c <= '\u00FF'); c as u8 }).collect())
         })
     }
     fn GetAllResponseHeaders(&self) -> ByteString {

--- a/src/test/wpt/metadata/XMLHttpRequest/getresponseheader-special-characters.htm.ini
+++ b/src/test/wpt/metadata/XMLHttpRequest/getresponseheader-special-characters.htm.ini
@@ -1,5 +1,0 @@
-[getresponseheader-special-characters.htm]
-  type: testharness
-  [XMLHttpRequest: getResponseHeader() funny characters]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes [getresponseheader-special-characters.htm](https://github.com/w3c/web-platform-tests/blob/master/XMLHttpRequest/getresponseheader-special-characters.htm)

h/t @SimonSapin

Blocks #2525
