### PR TITLE
Use fixed number of threads and sequential mode for reftests

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -81,16 +81,26 @@ check-servo: $(foreach lib_crate,$(SERVO_LIB_CRATES),check-servo-$(lib_crate)) s
 
 .PHONY: check-ref-cpu
 check-ref-cpu: reftest
-	@$(call E, check: reftests with CPU rendering)
-	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c
+	@$(call E, check: reftests with CPU rendering (using multiple threads))
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c -t 4 -y 4
+
+.PHONY: check-ref-cpu-sequential
+check-ref-cpu-sequential: reftest
+	@$(call E, check: reftests with CPU rendering  (using single thread))
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c -t 1 -y 1
 
 .PHONY: check-ref-gpu
 check-ref-gpu: reftest
-	@$(call E, check: reftests with GPU rendering)
-	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME)
+	@$(call E, check: reftests with GPU rendering (using multiple threads))
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -t 4 -y 4
+
+.PHONY: check-ref-gpu-sequential
+check-ref-gpu-sequential: reftest
+	@$(call E, check: reftests with GPU rendering (using single thread))
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -t 1 -y 1
 
 .PHONY: check-ref
-check-ref: check-ref-cpu check-ref-gpu
+check-ref: check-ref-cpu check-ref-gpu check-ref-cpu-sequential check-ref-gpu-sequential
 
 .PHONY: check-content
 check-content: contenttest

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -81,23 +81,23 @@ check-servo: $(foreach lib_crate,$(SERVO_LIB_CRATES),check-servo-$(lib_crate)) s
 
 .PHONY: check-ref-cpu
 check-ref-cpu: reftest
-	@$(call E, check: reftests with CPU rendering (using multiple threads))
+	@$(call E, check: reftests with CPU rendering \(using multiple threads\))
 	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c -t 4 -y 4
 
 .PHONY: check-ref-cpu-sequential
 check-ref-cpu-sequential: reftest
-	@$(call E, check: reftests with CPU rendering (using single thread))
+	@$(call E, check: reftests with CPU rendering \(using single thread\))
 	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c -t 1 -y 1
 
 .PHONY: check-ref-gpu
 check-ref-gpu: reftest
-	@$(call E, check: reftests with GPU rendering (using multiple threads))
-	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -t 4 -y 4
+	@$(call E, check: reftests with GPU rendering \(using multiple threads\))
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -t 4 -y 4
 
 .PHONY: check-ref-gpu-sequential
 check-ref-gpu-sequential: reftest
-	@$(call E, check: reftests with GPU rendering (using single thread))
-	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -t 1 -y 1
+	@$(call E, check: reftests with GPU rendering \(using single thread\))
+	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -t 1 -y 1
 
 .PHONY: check-ref
 check-ref: check-ref-cpu check-ref-gpu check-ref-cpu-sequential check-ref-gpu-sequential

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -86,7 +86,7 @@ check-ref-cpu: reftest
 
 .PHONY: check-ref-cpu-sequential
 check-ref-cpu-sequential: reftest
-	@$(call E, check: reftests with CPU rendering  (using single thread))
+	@$(call E, check: reftests with CPU rendering (using single thread))
 	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c -t 1 -y 1
 
 .PHONY: check-ref-gpu


### PR DESCRIPTION
This fixes #1975 and #2577.

The reference tests use now 4 threads for rendering and layout. The number is quite random. In terms of performance it would be better to choose the thread number based on the given hardware, but on the other hand a fixed number might make the tests more reproduceable. I went with the later.

Also, this PR addes new `check-ref-cpu-sequential` and `check-ref-gpu-sequential` make/test targets, which will run the tests with only one layout and render thread.
