### PR TITLE
Print a more helpful debug message when creating an element in the HTML parser.

### DIFF
--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -369,7 +369,7 @@ pub fn parse_html(page: &Page,
             }
         },
         create_element: |tag: Box<hubbub::Tag>| {
-            debug!("create element {:?}", tag.name.clone());
+            debug!("create element {}", tag.name);
             // NOTE: tmp vars are workaround for lifetime issues. Both required.
             let tmp_borrow = doc_cell.borrow();
             let tmp = &*tmp_borrow;


### PR DESCRIPTION
Using `{:?}` prints a debugging representation such as

```
  collections::string::String{
    vec: collections::vec::Vec<u8>{
      len: 4u,
      cap: 4u,
      ptr: (0x7f75670285d8 as *mut ())
    }
  }
```

which is not very helpful.
