### PR TITLE
Use "Fedora" instead of "Fedora Core" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo apt-get install autoconf2.13 curl freeglut3-dev libtool \
     msttcorefonts gperf g++ automake cmake
 ```
 
-On Fedora Core:
+On Fedora:
 
 ``` sh
 sudo yum install autoconf213 curl freeglut-devel libtool \


### PR DESCRIPTION
As the [Fedora wiki](http://fedoraproject.org/wiki/Core) puts it:

> Since Fedora 7, there no longer are separate Core and Extras repositories. ... Please do not refer to Fedora as "Fedora Core" anymore. 
