### PR TITLE
Cleanup compositor recursion

### DIFF
--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -348,12 +348,16 @@ impl IOCompositor {
 
     fn set_unrendered_color(&mut self, pipeline_id: PipelineId, layer_id: LayerId, color: Color) {
         match self.scene.root {
-            Some(ref layer) => CompositorData::set_unrendered_color(layer.clone(),
-                                                                    pipeline_id,
-                                                                    layer_id,
-                                                                    color),
-            None => false,
-        };
+            Some(ref root_layer) => {
+                match CompositorData::find_layer_with_pipeline_and_layer_id(root_layer.clone(),
+                                                                            pipeline_id,
+                                                                            layer_id) {
+                    Some(ref layer) => CompositorData::set_unrendered_color(layer.clone(), color),
+                    None => { }
+                }
+            }
+            None => { }
+        }
     }
 
     fn set_ids(&mut self,

--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -772,7 +772,8 @@ impl IOCompositor {
         match self.scene.root {
             Some(ref mut layer) if !layer.extra_data.borrow().hidden => {
                 let rect = Rect(Point2D(0f32, 0f32), page_window.to_untyped());
-                let recomposite = CompositorData::get_buffer_request(layer.clone(),
+                let recomposite =
+                    CompositorData::send_buffer_requests_recursively(layer.clone(),
                                                                      &self.graphics_context,
                                                                      rect,
                                                                      scale.get());

--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -394,7 +394,6 @@ impl IOCompositor {
         };
 
         if layer_id != root_layer_id {
-            let root_pipeline_id = root_pipeline.id;
             let new_compositor_data = CompositorData::new_root(root_pipeline,
                                                                size,
                                                                self.opts.cpu_painting);
@@ -403,21 +402,11 @@ impl IOCompositor {
                                               new_compositor_data));
             new_root.extra_data.borrow_mut().unrendered_color = unrendered_color;
 
-            let parent_layer_id = new_root.extra_data.borrow().id;
-            match CompositorData::find_layer_with_layer_and_pipeline_id(new_root.clone(),
-                                                                        root_pipeline_id,
-                                                                        parent_layer_id) {
-                Some(ref mut parent_layer) => {
-                    CompositorData::add_child_if_necessary(parent_layer.clone(),
-                                                           layer_id,
-                                                           Rect(Point2D(0f32, 0f32), size),
-                                                           size,
-                                                           Scrollable);
-                }
-                None => {
-                    fail!("Compositor: couldn't find parent layer");
-                }
-            }
+            CompositorData::add_child_if_necessary(new_root.clone(),
+                                                   layer_id,
+                                                   Rect(Point2D(0f32, 0f32), size),
+                                                   size,
+                                                   Scrollable);
 
             // Release all tiles from the layer before dropping it.
             match self.scene.root {

--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -146,38 +146,18 @@ impl CompositorData {
     /// Adds a child layer to the layer with the given ID and the given pipeline, if it doesn't
     /// exist yet. The child layer will have the same pipeline, tile size, memory limit, and CPU
     /// painting status as its parent.
-    ///
-    /// Returns:
-    ///   * True if the layer was added;
-    ///   * True if the layer was not added because it already existed;
-    ///   * False if the layer could not be added because no suitable parent layer with the given
-    ///     ID and pipeline could be found.
     pub fn add_child_if_necessary(layer: Rc<Layer<CompositorData>>,
-                                  pipeline_id: PipelineId,
-                                  parent_layer_id: LayerId,
                                   child_layer_id: LayerId,
                                   rect: Rect<f32>,
                                   page_size: Size2D<f32>,
-                                  scroll_policy: ScrollPolicy) -> bool {
-        if layer.extra_data.borrow().pipeline.id != pipeline_id ||
-           layer.extra_data.borrow().id != parent_layer_id {
-            return layer.children().iter().any(|kid| {
-                CompositorData::add_child_if_necessary(kid.clone(),
-                                                       pipeline_id,
-                                                       parent_layer_id,
-                                                       child_layer_id,
-                                                       rect,
-                                                       page_size,
-                                                       scroll_policy)
-            })
-        }
-
+                                  scroll_policy: ScrollPolicy) {
         // See if we've already made this child layer.
+        let pipeline_id = layer.extra_data.borrow().pipeline.id;
         if layer.children().iter().any(|kid| {
                     kid.extra_data.borrow().pipeline.id == pipeline_id &&
                     kid.extra_data.borrow().id == child_layer_id
                 }) {
-            return true
+            return;
         }
 
         let new_compositor_data = CompositorData::new(layer.extra_data.borrow().pipeline.clone(),
@@ -197,8 +177,6 @@ impl CompositorData {
 
         // Place the kid's layer in the container passed in.
         Layer::add_child(layer.clone(), new_kid.clone());
-
-        true
     }
 
     /// Move the layer's descendants that don't want scroll events and scroll by a relative

--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -409,7 +409,7 @@ impl CompositorData {
                              new_rect: Rect<f32>)
                              -> bool {
         debug!("compositor_data: starting set_clipping_rect()");
-        match CompositorData::find_child_with_layer_and_pipeline_id(layer.clone(),
+        match CompositorData::find_child_with_pipeline_and_layer_id(layer.clone(),
                                                                     pipeline_id,
                                                                     layer_id) {
             Some(child_node) => {
@@ -561,7 +561,7 @@ impl CompositorData {
 
 
 
-    fn find_child_with_layer_and_pipeline_id(layer: Rc<Layer<CompositorData>>,
+    fn find_child_with_pipeline_and_layer_id(layer: Rc<Layer<CompositorData>>,
                                              pipeline_id: PipelineId,
                                              layer_id: LayerId)
                                              -> Option<Rc<Layer<CompositorData>>> {
@@ -604,7 +604,7 @@ impl CompositorData {
                      -> bool {
         debug!("compositor_data: starting resize_helper()");
 
-        let found = match CompositorData::find_child_with_layer_and_pipeline_id(layer.clone(),
+        let found = match CompositorData::find_child_with_pipeline_and_layer_id(layer.clone(),
                                                                                 pipeline_id,
                                                                                 layer_id) {
             Some(child) => {

--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -574,6 +574,27 @@ impl CompositorData {
         return None
     }
 
+    pub fn find_layer_with_pipeline_and_layer_id(layer: Rc<Layer<CompositorData>>,
+                                                 pipeline_id: PipelineId,
+                                                 layer_id: LayerId)
+                                                 -> Option<Rc<Layer<CompositorData>>> {
+        if layer.extra_data.borrow().pipeline.id == pipeline_id &&
+           layer.extra_data.borrow().id == layer_id {
+            return Some(layer.clone());
+        }
+
+        for kid in layer.children().iter() {
+            match CompositorData::find_layer_with_pipeline_and_layer_id(kid.clone(),
+                                                                        pipeline_id,
+                                                                        layer_id) {
+                v @ Some(_) => { return v; }
+                None => { }
+            }
+        }
+
+        return None;
+    }
+
     // A helper method to resize sublayers.
     fn resize_helper(layer: Rc<Layer<CompositorData>>,
                      pipeline_id: PipelineId,

--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -813,26 +813,8 @@ impl CompositorData {
         }
     }
 
-    pub fn set_unrendered_color(layer: Rc<Layer<CompositorData>>,
-                                pipeline_id: PipelineId,
-                                layer_id: LayerId,
-                                color: Color)
-                                -> bool {
-        if layer.extra_data.borrow().pipeline.id != pipeline_id ||
-           layer.extra_data.borrow().id != layer_id {
-            for child_layer in layer.children().iter() {
-                if CompositorData::set_unrendered_color(child_layer.clone(),
-                                                        pipeline_id,
-                                                        layer_id,
-                                                        color) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
+    pub fn set_unrendered_color(layer: Rc<Layer<CompositorData>>, color: Color) {
         layer.extra_data.borrow_mut().unrendered_color = color;
-        return true;
     }
 }
 


### PR DESCRIPTION
There's a lot of ad-hoc recursion in the `CompositorData` code. It would make more sense if methods were layer-specific, and a separate function was called to find a specific layer recursively.
