### PR TITLE
Make pseudo :before and :after elements inherit style from attached

### DIFF
--- a/src/components/layout/css/matching.rs
+++ b/src/components/layout/css/matching.rs
@@ -553,14 +553,14 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
                                                  applicable_declarations_cache,
                                                  applicable_declarations.normal_shareable);
                 if applicable_declarations.before.len() > 0 {
-                    self.cascade_node_pseudo_element(parent_style,
+                    self.cascade_node_pseudo_element(Some(layout_data.shared_data.style.get_ref()),
                                                      applicable_declarations.before.as_slice(),
                                                      &mut layout_data.data.before_style,
                                                      applicable_declarations_cache,
                                                      false);
                 }
                 if applicable_declarations.after.len() > 0 {
-                    self.cascade_node_pseudo_element(parent_style,
+                    self.cascade_node_pseudo_element(Some(layout_data.shared_data.style.get_ref()),
                                                      applicable_declarations.after.as_slice(),
                                                      &mut layout_data.data.after_style,
                                                      applicable_declarations_cache,

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -82,3 +82,4 @@
 == position_fixed_background_color_a.html position_fixed_background_color_b.html
 == position_fixed_overflow_a.html position_fixed_overflow_b.html
 == noscript.html noscript_ref.html
+== pseudo_inherit.html pseudo_inherit_ref.html

--- a/src/test/ref/pseudo_inherit.html
+++ b/src/test/ref/pseudo_inherit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <style type="text/css">
+      p:before {
+        content: "A";
+      }
+      .big {
+        font-size: 128px;
+      }
+    </style>
+  </head>
+  <body style="color: red; font-size: 64px;">
+    <p style="color: green;" class="big">B</p>
+  </body>
+</html>

--- a/src/test/ref/pseudo_inherit_ref.html
+++ b/src/test/ref/pseudo_inherit_ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <style type="text/css">
+      .big {
+        font-size: 128px;
+      }
+    </style>
+  </head>
+  <body>
+    <p style="color: green;" class="big">AB</p>
+  </body>
+</html>


### PR DESCRIPTION
element, as per http://dev.w3.org/csswg/css2/generate.html, rather
than from the parent element.
