### PR TITLE
Enable email notifications from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ notifications:
     on_success: change
     on_failure: change
     use_notice: true
-  email: false
 
 branches:
   only:


### PR DESCRIPTION
http://docs.travis-ci.com/user/notifications/

> By default, email notifications will be sent to the committer and the commit author, if they are members of the repository (that is, they have push or admin permissions for public repositories, or if they have pull, push or admin permissions for private repositories).
> 
> And it will by default send emails when, on the given branch:
> - a build was just broken or still is broken
> - a previously broken build was just fixed

r? @manishearth or @larsbergstrom
