### PR TITLE
Return a Temporary from *Binding::Wrap.

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1792,7 +1792,7 @@ class CGWrapMethod(CGAbstractMethod):
         else:
             args = [Argument('*mut JSContext', 'aCx'),
                     Argument("Box<%s>" % descriptor.concreteType, 'aObject', mutable=True)]
-        retval = 'JS<%s>' % descriptor.concreteType
+        retval = 'Temporary<%s>' % descriptor.concreteType
         CGAbstractMethod.__init__(self, descriptor, 'Wrap', retval, args, pub=True)
 
     def definition_body(self):
@@ -1809,7 +1809,7 @@ assert!(proto.is_not_null());
 
 raw.reflector().set_jsobject(obj);
 
-return raw;""" % CreateBindingJSObject(self.descriptor, "scope"))
+Temporary::new(raw)""" % CreateBindingJSObject(self.descriptor, "scope"))
         else:
             return CGGeneric("""\
 %s
@@ -1818,7 +1818,8 @@ with_compartment(aCx, obj, || {
   JS_SetPrototype(aCx, obj, proto);
 });
 raw.reflector().set_jsobject(obj);
-return raw;""" % CreateBindingJSObject(self.descriptor))
+
+Temporary::new(raw)""" % CreateBindingJSObject(self.descriptor))
 
 
 class CGIDLInterface(CGThing):

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -377,9 +377,9 @@ pub trait Reflectable {
 pub fn reflect_dom_object<T: Reflectable>
         (obj:     Box<T>,
          window:  &JSRef<window::Window>,
-         wrap_fn: extern "Rust" fn(*mut JSContext, &JSRef<window::Window>, Box<T>) -> JS<T>)
+         wrap_fn: extern "Rust" fn(*mut JSContext, &JSRef<window::Window>, Box<T>) -> Temporary<T>)
          -> Temporary<T> {
-    Temporary::new(wrap_fn(window.deref().get_cx(), window, obj))
+    wrap_fn(window.get_cx(), window, obj)
 }
 
 #[allow(raw_pointer_deriving)]

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -907,13 +907,10 @@ impl Node {
     pub fn reflect_node<N: Reflectable+NodeBase>
             (node:      Box<N>,
              document:  &JSRef<Document>,
-             wrap_fn:   extern "Rust" fn(*mut JSContext, &JSRef<Window>, Box<N>) -> JS<N>)
+             wrap_fn:   extern "Rust" fn(*mut JSContext, &JSRef<Window>, Box<N>) -> Temporary<N>)
              -> Temporary<N> {
-        assert!(node.reflector().get_jsobject().is_null());
-        let window = document.deref().window.root();
-        let node = reflect_dom_object(node, &window.root_ref(), wrap_fn).root();
-        assert!(node.deref().reflector().get_jsobject().is_not_null());
-        Temporary::from_rooted(&*node)
+        let window = document.window.root();
+        reflect_dom_object(node, &*window, wrap_fn)
     }
 
     pub fn new_inherited(type_id: NodeTypeId, doc: &JSRef<Document>) -> Node {

--- a/src/components/script/dom/window.rs
+++ b/src/components/script/dom/window.rs
@@ -388,7 +388,7 @@ impl Window {
                script_chan: ScriptChan,
                compositor: Box<ScriptListener>,
                image_cache_task: ImageCacheTask)
-               -> JS<Window> {
+               -> Temporary<Window> {
         let win = box Window {
             eventtarget: EventTarget::new_inherited(WindowTypeId),
             script_chan: script_chan,


### PR DESCRIPTION
Returning a JS<T> is GC-unsafe.

This commit also includes some cleanup around Node and Document reflection.
