### PR TITLE
Include some jemalloc stats in the -m measurements.

### DIFF
--- a/src/components/util/util.rs
+++ b/src/components/util/util.rs
@@ -19,6 +19,7 @@ extern crate azure;
 extern crate collections;
 extern crate geom;
 extern crate getopts;
+extern crate libc;
 extern crate native;
 extern crate rand;
 extern crate rustrt;


### PR DESCRIPTION
get_jemalloc_stat() is gnarly, but it seems hard to avoid given je_malltcl()'s strange type signature.
