### PR TITLE
adding 2 default arguments to src/test/wpt/run.py

### DIFF
--- a/src/test/wpt/run.py
+++ b/src/test/wpt/run.py
@@ -34,8 +34,8 @@ def set_defaults(args):
     args.include = args.include if args.include else ["/dom", "/XMLHttpRequest"]
     args.binary = args.binary if args.binary else os.path.join(servo_root, "build", "servo")
     args.product = "servo"
-    args.debug_args = ""
-    args.interactive = ""
+    args.debug_args = None
+    args.interactive = False
     return vars(args)
 
 def main():

--- a/src/test/wpt/run.py
+++ b/src/test/wpt/run.py
@@ -34,6 +34,8 @@ def set_defaults(args):
     args.include = args.include if args.include else ["/dom", "/XMLHttpRequest"]
     args.binary = args.binary if args.binary else os.path.join(servo_root, "build", "servo")
     args.product = "servo"
+    args.debug_args = ""
+    args.interactive = ""
     return vars(args)
 
 def main():


### PR DESCRIPTION
Adding 2 new default arguments in the set_defaults(args) method so that make check-wpt does not fail saying KeyError: 'debug_args' or KeyError: 'interactive'.

CC: @jdm, @jgraham
