### PR TITLE
Allow URLSearchParams to be passed to XHR Send()

### DIFF
--- a/src/components/net/http_loader.rs
+++ b/src/components/net/http_loader.rs
@@ -78,7 +78,7 @@ fn load(load_data: LoadData, start_chan: Sender<LoadResponse>) {
         match load_data.data {
             Some(ref data) => {
                 writer.headers.content_length = Some(data.len());
-                match writer.write(data.clone().into_bytes().as_slice()) {
+                match writer.write(data.as_slice()) {
                     Err(e) => {
                         send_error(url, e.desc.to_string(), start_chan);
                         return;

--- a/src/components/net/resource_task.rs
+++ b/src/components/net/resource_task.rs
@@ -33,7 +33,7 @@ pub struct LoadData {
     pub url: Url,
     pub method: Method,
     pub headers: RequestHeaderCollection,
-    pub data: Option<String>
+    pub data: Option<Vec<u8>>
 }
 
 impl LoadData {

--- a/src/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/src/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -13,6 +13,9 @@
  * http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
  */
 
+// http://fetch.spec.whatwg.org/#fetchbodyinit
+typedef (/*ArrayBuffer or ArrayBufferView or Blob or FormData or */DOMString or URLSearchParams) FetchBodyInit;
+
 enum XMLHttpRequestResponseType {
   "",
   "arraybuffer",
@@ -50,7 +53,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
            attribute boolean withCredentials;
   readonly attribute XMLHttpRequestUpload upload;
   [Throws]
-  void send(optional /*(ArrayBufferView or Blob or Document or [EnsureUTF16] */ DOMString/* or FormData or URLSearchParams)*/? data = null);
+  void send(optional /*Document or*/ FetchBodyInit? data = null);
   void abort();
 
   // response


### PR DESCRIPTION
This also updates us to the new webidl that uses `FetchBodyInit` (from the fetch spec)

I haven't done `FormData` yet since we don't have file support (so it would only work for `DOMString` `FormDatum`s), but the [algorithm](http://www.whatwg.org/specs/web-apps/current-work/multipage/association-of-controls-and-forms.html#multipart/form-data-encoding-algorithm) isn't too complicated.

Blocks #2282
