### PR TITLE
Restructure compositor layers to work with iframes.

### DIFF
--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -76,11 +76,12 @@ impl CompositorData {
     }
 
     pub fn new_root(pipeline: CompositionPipeline,
+                    layer_id: LayerId,
                     epoch: Epoch,
                     cpu_painting: bool,
                     unrendered_color: Color) -> CompositorData {
         CompositorData::new(pipeline,
-                            LayerId::null(),
+                            layer_id,
                             epoch,
                             cpu_painting,
                             WantsScrollEvents,
@@ -89,11 +90,12 @@ impl CompositorData {
     }
 
     /// Adds a child layer to the layer with the given ID and the given pipeline, if it doesn't
-    /// exist yet. The child layer will have the same pipeline, tile size, memory limit, and CPU
+    /// exist yet. The child layer will have the same tile size, memory limit, and CPU
     /// painting status as its parent.
     pub fn add_child(layer: Rc<Layer<CompositorData>>,
-                     layer_properties: LayerProperties) {
-        let new_compositor_data = CompositorData::new(layer.extra_data.borrow().pipeline.clone(),
+                     layer_properties: LayerProperties,
+                     pipeline: CompositionPipeline) {
+        let new_compositor_data = CompositorData::new(pipeline,
                                                       layer_properties.id,
                                                       layer_properties.epoch,
                                                       layer.extra_data.borrow().cpu_painting,
@@ -163,34 +165,6 @@ impl CompositorData {
         layer.children().iter().map(get_child_buffer_request).any(|b| b) || redisplay
     }
 
-    // Move the sublayer to an absolute position in page coordinates relative to its parent,
-    // and clip the layer to the specified size in page coordinates.
-    // This method returns false if the specified layer is not found.
-    pub fn set_clipping_rect(layer: Rc<Layer<CompositorData>>,
-                             pipeline_id: PipelineId,
-                             layer_id: LayerId,
-                             new_rect: Rect<f32>)
-                             -> bool {
-        debug!("compositor_data: starting set_clipping_rect()");
-        match CompositorData::find_child_with_pipeline_and_layer_id(layer.clone(),
-                                                                    pipeline_id,
-                                                                    layer_id) {
-            Some(child_node) => {
-                debug!("compositor_data: node found for set_clipping_rect()");
-                *child_node.bounds.borrow_mut() = new_rect;
-                true
-            }
-            None => {
-                layer.children().iter()
-                    .any(|kid| CompositorData::set_clipping_rect(kid.clone(),
-                                                                 pipeline_id,
-                                                                 layer_id,
-                                                                 new_rect))
-
-            }
-        }
-    }
-
     pub fn update_layer(layer: Rc<Layer<CompositorData>>, layer_properties: LayerProperties) {
         layer.extra_data.borrow_mut().epoch = layer_properties.epoch;
         layer.extra_data.borrow_mut().unrendered_color = layer_properties.background_color;
@@ -205,19 +179,6 @@ impl CompositorData {
                                             TypedPoint2D(0f32, 0f32),
                                             TypedPoint2D(-1f32, -1f32),
                                             size);
-    }
-
-    fn find_child_with_pipeline_and_layer_id(layer: Rc<Layer<CompositorData>>,
-                                             pipeline_id: PipelineId,
-                                             layer_id: LayerId)
-                                             -> Option<Rc<Layer<CompositorData>>> {
-        for kid in layer.children().iter() {
-            if pipeline_id == kid.extra_data.borrow().pipeline.id &&
-               layer_id == kid.extra_data.borrow().id {
-                return Some(kid.clone());
-            }
-        }
-        return None
     }
 
     pub fn find_layer_with_pipeline_and_layer_id(layer: Rc<Layer<CompositorData>>,
@@ -319,4 +280,3 @@ impl CompositorData {
         }
     }
 }
-

--- a/src/components/compositing/compositor_task.rs
+++ b/src/components/compositing/compositor_task.rs
@@ -38,8 +38,8 @@ pub struct CompositorChan {
 
 /// Implementation of the abstract `ScriptListener` interface.
 impl ScriptListener for CompositorChan {
-    fn set_ready_state(&self, ready_state: ReadyState) {
-        let msg = ChangeReadyState(ready_state);
+    fn set_ready_state(&self, pipeline_id: PipelineId, ready_state: ReadyState) {
+        let msg = ChangeReadyState(ready_state, pipeline_id);
         self.chan.send(msg);
     }
 
@@ -117,8 +117,6 @@ impl RenderListener for CompositorChan {
             } else {
                 self.chan.send(CreateOrUpdateDescendantLayer(layer_properties));
             }
-
-            self.chan.send(SetLayerClipRect(pipeline_id, metadata.id, layer_properties.rect));
         }
     }
 
@@ -133,8 +131,10 @@ impl RenderListener for CompositorChan {
         self.chan.send(SetLayerClipRect(pipeline_id, layer_id, new_rect))
     }
 
-    fn set_render_state(&self, render_state: RenderState) {
-        self.chan.send(ChangeRenderState(render_state))
+    fn set_render_state(&self,
+                        render_state: RenderState,
+                        pipeline_id: PipelineId) {
+        self.chan.send(ChangeRenderState(render_state, pipeline_id))
     }
 }
 
@@ -175,15 +175,16 @@ pub enum Msg {
     /// layer with that ID exists).
     CreateOrUpdateDescendantLayer(LayerProperties),
     /// Alerts the compositor that the specified layer's clipping rect has changed.
+    /// If LayerId is LayerId::null() then set the pipeline root layer clipping rect.
     SetLayerClipRect(PipelineId, LayerId, Rect<f32>),
     /// Scroll a page in a window
     ScrollFragmentPoint(PipelineId, LayerId, Point2D<f32>),
     /// Requests that the compositor paint the given layer buffer set for the given page size.
     Paint(PipelineId, Epoch, Vec<(LayerId, Box<LayerBufferSet>)>),
     /// Alerts the compositor to the current status of page loading.
-    ChangeReadyState(ReadyState),
+    ChangeReadyState(ReadyState, PipelineId),
     /// Alerts the compositor to the current status of rendering.
-    ChangeRenderState(RenderState),
+    ChangeRenderState(RenderState, PipelineId),
     /// Sets the channel to the current layout and render tasks, along with their id
     SetIds(SendableFrameTree, Sender<()>, ConstellationChan),
     /// The load of a page for a given URL has completed.

--- a/src/components/compositing/constellation.rs
+++ b/src/components/compositing/constellation.rs
@@ -69,11 +69,13 @@ struct ChildFrameTree {
     pub rect: Option<TypedRect<PagePx, f32>>,
 }
 
+#[deriving(Clone)]
 pub struct SendableFrameTree {
     pub pipeline: CompositionPipeline,
     pub children: Vec<SendableChildFrameTree>,
 }
 
+#[deriving(Clone)]
 pub struct SendableChildFrameTree {
     pub frame_tree: SendableFrameTree,
     pub rect: Option<TypedRect<PagePx, f32>>,

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -14,13 +14,13 @@ use std::fmt;
 use constellation_msg::PipelineId;
 
 /// The status of the renderer.
-#[deriving(PartialEq, Clone)]
+#[deriving(Eq, Ord, PartialOrd, PartialEq, Clone)]
 pub enum RenderState {
-    IdleRenderState,
     RenderingRenderState,
+    IdleRenderState,
 }
 
-#[deriving(PartialEq, Clone)]
+#[deriving(Eq, Ord, PartialOrd, PartialEq, Clone)]
 pub enum ReadyState {
     /// Informs the compositor that nothing has been done yet. Used for setting status
     Blank,
@@ -33,7 +33,7 @@ pub enum ReadyState {
 }
 
 /// A newtype struct for denoting the age of messages; prevents race conditions.
-#[deriving(PartialEq)]
+#[deriving(PartialEq, PartialOrd)]
 pub struct Epoch(pub uint);
 
 impl Epoch {
@@ -105,13 +105,13 @@ pub trait RenderListener {
              epoch: Epoch,
              replies: Vec<(LayerId, Box<LayerBufferSet>)>);
 
-    fn set_render_state(&self, render_state: RenderState);
+    fn set_render_state(&self, render_state: RenderState, pipeline_id: PipelineId);
 }
 
 /// The interface used by the script task to tell the compositor to update its ready state,
 /// which is used in displaying the appropriate message in the window's title.
 pub trait ScriptListener : Clone {
-    fn set_ready_state(&self, ReadyState);
+    fn set_ready_state(&self, pipeline_id: PipelineId, ReadyState);
     fn scroll_fragment_point(&self,
                              pipeline_id: PipelineId,
                              layer_id: LayerId,

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -76,7 +76,7 @@ pub enum NavigationDirection {
     Back,
 }
 
-#[deriving(Clone, PartialEq, Eq, Hash, Encodable)]
+#[deriving(Clone, PartialEq, Eq, Hash, Encodable, Show)]
 pub struct PipelineId(pub uint);
 
 #[deriving(Clone, PartialEq, Eq, Hash, Encodable)]

--- a/src/components/script/page.rs
+++ b/src/components/script/page.rs
@@ -319,7 +319,7 @@ impl Page {
                 self.join_layout();
 
                 // Tell the user that we're performing layout.
-                compositor.set_ready_state(PerformingLayout);
+                compositor.set_ready_state(self.id, PerformingLayout);
 
                 // Layout will let us know when it's done.
                 let (join_chan, join_port) = channel();

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -452,7 +452,7 @@ impl ScriptTask {
             let mut layout_join_port = page.layout_join_port.deref().borrow_mut();
             *layout_join_port = None;
         }
-        self.compositor.set_ready_state(FinishedLoading);
+        self.compositor.set_ready_state(pipeline_id, FinishedLoading);
     }
 
     /// Handles a navigate forward or backward message.
@@ -549,7 +549,7 @@ impl ScriptTask {
         let document = Document::new(&*window, Some(url.clone()), HTMLDocument, None).root();
         window.deref().init_browser_context(&*document);
 
-        self.compositor.set_ready_state(Loading);
+        self.compositor.set_ready_state(pipeline_id, Loading);
         // Parse HTML.
         //
         // Note: We can parse the next document in parallel with any previous documents.

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -35,7 +35,10 @@
 == background_external_stylesheet.html background_ref.html
 == block_image.html 500x300_green.html
 != block_image.html noteq_500x300_white.html
-# == simple_iframe.html simple_iframe_ref.html -- disabled due to iframe crashiness
+# iframe tests
+# commented for failing on os x
+# == iframe/simple_iframe.html iframe/simple_iframe_ref.html
+== iframe/iframe_summit.html iframe/iframe_summit_ref.html
 == object_element_a.html object_element_b.html
 == append_style_a.html append_style_b.html
 == height_compute_reset.html height_compute.html

--- a/src/test/ref/iframe/iframe_summit.html
+++ b/src/test/ref/iframe/iframe_summit.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      html {
+        background-color: #ccc;
+        font-size: 50px;
+      }
+      div.frame {
+        text-align: center;
+        float: left;
+        width: 310px;
+        height: 400px;
+      }
+      iframe {
+        width: 300px;
+        height: 300px;
+        border: solid 1px black;
+        display: block;
+        background-color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+    <div class="frame">
+      <iframe id="frameone" sandbox="allow-scripts" src="summit-two.html">
+      </iframe>
+    </div>
+    <div class="frame">
+      <iframe id="frametwo" sandbox="allow-scripts" src="summit-three.html">
+      </iframe>
+    </div>
+  </body>
+</html>

--- a/src/test/ref/iframe/iframe_summit_ref.html
+++ b/src/test/ref/iframe/iframe_summit_ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      html {
+        background-color: #ccc;
+        font-size: 50px;
+      }
+      div.frame {
+        text-align: center;
+        float: left;
+        width: 310px;
+        height: 400px;
+      }
+      div.iframe {
+        width: 300px;
+        height: 300px;
+        border: solid 1px black;
+        display: block;
+        background-color: white;
+      }
+      iframe {
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+    <div class="frame">
+      <div class="iframe"></div>
+      <!--<iframe id="frameone" sandbox="allow-scripts" src="summit-two.html">
+      </iframe>-->
+    </div>
+    <div class="frame">
+      <div class="iframe"></div>
+    </div>
+  </body>
+</html>

--- a/src/test/ref/iframe/simple_iframe.html
+++ b/src/test/ref/iframe/simple_iframe.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+  <iframe sandbox="" src="data:text/html,%3Cspan%3EJust%20a%20simple%20little%20iframe.%3C%2Fspan%3E"
+          style="display: block; border: 0px solid black; width: 500px; height: 300px; margin-left: 10px; margin-top: 20px;">
+  </iframe>
+</body>
+</html>

--- a/src/test/ref/iframe/simple_iframe_ref.html
+++ b/src/test/ref/iframe/simple_iframe_ref.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-  <div style="border: 1px solid black; width: 500px; height: 300px; margin-left: 10px; margin-top: 20px;">
+  <div style="border: 0px solid black; width: 500px; height: 300px; margin-left: 10px; margin-top: 48px;">
     <div style="margin: 8px; /* matches user-agent body */">Just a simple little iframe.</div>
   </div>
 </body>

--- a/src/test/ref/iframe/summit-three.html
+++ b/src/test/ref/iframe/summit-three.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+    body {
+      font-size: 30px;
+    }
+    </style>
+  </head>
+  <body>
+    <div></div>
+
+    <script>
+function Matrix(ary) {
+    this.mtx = ary
+    this.height = ary.length;
+    this.width = ary[0].length;
+}
+
+Matrix.prototype.toString = function() {
+    var s = []
+    for (var i = 0; i < this.mtx.length; i++)
+        s.push( this.mtx[i].join(",") );
+    return s.join("\n");
+}
+
+Matrix.prototype.mult = function(other) {
+    if (this.width != other.height) {
+        throw "error: incompatible sizes";
+    }
+
+    var result = [];
+    for (var i = 0; i < this.height; i++) {
+        result[i] = [];
+        for (var j = 0; j < other.width; j++) {
+            var sum = 0;
+            for (var k = 0; k < this.width; k++) {
+                sum += this.mtx[i][k] * other.mtx[k][j];
+            }
+            result[i][j] = sum;
+        }
+    }
+    return new Matrix(result);
+}
+
+function run() {
+  var elems = [];
+  for (var i = 0; i < 900; i++) {
+    elems.push(i);
+  }
+  var outer = [];
+  for (var i = 0; i < 900; i++) {
+    outer.push(elems);
+  }
+  var a = new Matrix(outer);
+  var b = new Matrix(outer);
+  var result = a.mult(b);
+}
+
+function say(msg) {
+  var div = document.getElementsByTagName('div')[0];
+  var text = document.createTextNode(msg);
+  var p = document.createElement("p");
+  p.appendChild(text);
+  div.appendChild(p);
+}
+
+//say("multiplying 900x900 matrix");
+setTimeout(function forever() {
+  var now = new Date();
+  run();
+  say("mult 900x900 in " + (new Date() - now));
+  setTimeout(forever, 5000);
+}, 1000);
+    </script>
+  </body>
+</html>

--- a/src/test/ref/iframe/summit-two.html
+++ b/src/test/ref/iframe/summit-two.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+        padding: 30px 47px;
+      }
+      img {
+        width: 206px;
+        height: 206px;
+      }
+    </style>
+  </head>
+  <body>
+    <p><img></p>
+    <script>
+var index = 0;
+function change() {
+document.getElementsByTagName("img")[0].src;
+index = (index + 1) % 8;
+setTimeout(change, 100);
+}
+change();
+    </script>
+  </body>
+</html>

--- a/src/test/ref/simple_iframe.html
+++ b/src/test/ref/simple_iframe.html
@@ -1,7 +1,0 @@
-<html>
-<body>
-  <iframe src="data:text/html,%3Cspan%3EJust%20a%20simple%20little%20iframe.%3C%2Fspan%3E"
-          style="display: block; border: 1px solid black; width: 500px; height: 300px; margin-left: 10px; margin-top: 20px;">
-  </iframe>
-</body>
-</html>


### PR DESCRIPTION
When a frame is selected via set_ids, a tree of root compositor layers is
also created, matching the tree of pipelines in the frame. This
decouples the chronological ordering dependency for parent frames and child iframes when they
send CreateOrUpdateRootLayer & CreateOrUpdateDescendentLayer
messages.

Gotchas:
- iframes dont render when using the -o option (the compositor doesnt
  wait for the child iframe to render before exiting).
- layout task or script task failure on exit ("task \* failed at sending on a
  closed channel"), this happens if the child iframe
  shares the same script task as the parent and can be avoided by adding
  the sandbox attribute to the iframe.

@pcwalton & @mrobinson

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/2819)

<!-- Reviewable:end -->
