### PR TITLE
Added 'parent is/was in tree' param to bind_to_tree/unbind_from_tree

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -836,11 +836,13 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
         }
     }
 
-    fn bind_to_tree(&self) {
+    fn bind_to_tree(&self, tree_in_doc: bool) {
         match self.super_type() {
-            Some(ref s) => s.bind_to_tree(),
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
             _ => (),
         }
+
+        if !tree_in_doc { return; }
 
         match self.get_attribute(Null, "id").root() {
             Some(attr) => {
@@ -851,11 +853,13 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
         }
     }
 
-    fn unbind_from_tree(&self) {
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
         match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(),
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
             _ => (),
         }
+
+        if !tree_in_doc { return; }
 
         match self.get_attribute(Null, "id").root() {
             Some(attr) => {

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -176,11 +176,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
         }
     }
 
-    fn bind_to_tree(&self) {
+    fn bind_to_tree(&self, tree_in_doc: bool) {
         match self.super_type() {
-            Some(ref s) => s.bind_to_tree(),
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
             _ => (),
         }
+
+        if !tree_in_doc { return; }
 
         match self.get_url() {
             Some(url) => {

--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -79,9 +79,9 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
         self.parse_own_css();
     }
 
-    fn bind_to_tree(&self) {
+    fn bind_to_tree(&self, tree_in_doc: bool) {
         match self.super_type() {
-            Some(ref s) => s.bind_to_tree(),
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
             _ => ()
         }
         self.parse_own_css();

--- a/src/components/script/dom/htmlstyleelement.rs
+++ b/src/components/script/dom/htmlstyleelement.rs
@@ -50,10 +50,7 @@ pub trait StyleElementHelpers {
 impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
     fn parse_own_css(&self) {
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-
-        if !node.is_in_doc() {
-            return;
-        }
+        assert!(node.is_in_doc());
 
         let win = window_from_node(node).root();
         let url = win.deref().page().get_url();
@@ -76,7 +73,11 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
             Some(ref s) => s.child_inserted(child),
             _ => (),
         }
-        self.parse_own_css();
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        if node.is_in_doc() {
+            self.parse_own_css();
+        }
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
@@ -84,7 +85,10 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
             Some(ref s) => s.bind_to_tree(tree_in_doc),
             _ => ()
         }
-        self.parse_own_css();
+
+        if tree_in_doc {
+            self.parse_own_css();
+        }
     }
 }
 

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -60,18 +60,20 @@ pub trait VirtualMethods {
         }
     }
 
-    /// Called when a Node is appended to a tree that is part of a Document.
-    fn bind_to_tree(&self) {
+    /// Called when a Node is appended to a tree, where 'tree_in_doc' indicates
+    /// whether the tree is part of a Document.
+    fn bind_to_tree(&self, tree_in_doc: bool) {
         match self.super_type() {
-            Some(ref s) => s.bind_to_tree(),
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
             _ => (),
         }
     }
 
-    /// Called when a Node is removed from a tree that is part of a Document.
-    fn unbind_from_tree(&self) {
+    /// Called when a Node is removed from a tree, where 'tree_in_doc'
+    /// indicates whether the tree is part of a Document.
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
         match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(),
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
             _ => (),
         }
     }


### PR DESCRIPTION
According to a talk with Ms2ger, both bind_to_tree / unbind_from_tree should be called regardless if the tree is part of a Document. This information is now passed as a parameter to their respective virtual methods.
