### PR TITLE
Temporarily disable the 'borders' test

### DIFF
--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -16,7 +16,7 @@
 == root_height_a.html root_height_b.html
 == png_rgba_colorspace_a.html png_rgba_colorspace_b.html
 == border_style_none_a.html border_style_none_b.html
-== borders_a.html borders_b.html
+# == borders_a.html borders_b.html
 == acid1_a.html acid1_b.html
 == text_decoration_cached.html text_decoration_cached_ref.html
 # text_decoration_propagation_a.html text_decoration_propagation_b.html


### PR DESCRIPTION
This test has been failing locally on OS X for me for quite some time,
although since #2843 this started affecting the Travis builders as well.
Getting to the root of this problem is tracked by #2848.
