### PR TITLE
Changes reflecting the latest version of rust-layers

### DIFF
--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -120,7 +120,7 @@ pub struct RenderTask<C> {
     epoch: Epoch,
 
     /// A data structure to store unused LayerBuffers
-    buffer_map: BufferMap<Box<LayerBuffer>>,
+    buffer_map: BufferMap,
 }
 
 // If we implement this as a function, we get borrowck errors from borrowing
@@ -380,6 +380,7 @@ impl<C:RenderListener + Send> RenderTask<C> {
                                 buffer.screen_pos = tile.screen_rect;
                                 buffer.resolution = scale;
                                 buffer.native_surface.mark_wont_leak();
+                                buffer.painted_with_cpu = true;
                                 buffer
                             }
                             None => {
@@ -397,7 +398,8 @@ impl<C:RenderListener + Send> RenderTask<C> {
                                     rect: tile.page_rect,
                                     screen_pos: tile.screen_rect,
                                     resolution: scale,
-                                    stride: (width * 4) as uint
+                                    stride: (width * 4) as uint,
+                                    painted_with_cpu: true,
                                 }
                             }
                         };
@@ -427,7 +429,8 @@ impl<C:RenderListener + Send> RenderTask<C> {
                             rect: tile.page_rect,
                             screen_pos: tile.screen_rect,
                             resolution: scale,
-                            stride: (width * 4) as uint
+                            stride: (width * 4) as uint,
+                            painted_with_cpu: false,
                         }
                     }
                 };


### PR DESCRIPTION
The Tile trait has been removed and TileGrid now keeps Tile structs with
Textures embedded instead of simply buffers. rust-layers now creates
its own textures instead of relying on Servo to do it.
