### PR TITLE
Update rust-layers, removing a work-around in a test

### DIFF
--- a/src/test/ref/borders_a.html
+++ b/src/test/ref/borders_a.html
@@ -2,9 +2,6 @@
 <html>
 <head>
 <style>
-html {    
-    background-color: white;
-}
 #none{
     border-style: none;
     border-width: 10px;

--- a/src/test/ref/borders_a.html
+++ b/src/test/ref/borders_a.html
@@ -2,6 +2,9 @@
 <html>
 <head>
 <style>
+html {
+    background-color: white;
+}
 #none{
     border-style: none;
     border-width: 10px;


### PR DESCRIPTION
This fixes a regression caused by a previous rust-layers update. We can
now remove the work-around in the reftest.

Fixes #2879.
