### PR TITLE
Implement CSS selectors :enabled & :disabled (incl. HTML Elements support)

### DIFF
--- a/src/components/layout/wrapper.rs
+++ b/src/components/layout/wrapper.rs
@@ -404,6 +404,12 @@ impl<'le> TElement for LayoutElement<'le> {
             self.element.node.get_disabled_state_for_layout()
         }
     }
+
+    fn get_enabled_state(&self) -> bool {
+        unsafe {
+            self.element.node.get_enabled_state_for_layout()
+        }
+    }
 }
 
 fn get_content(content_list: &content::T) -> String {

--- a/src/components/layout/wrapper.rs
+++ b/src/components/layout/wrapper.rs
@@ -398,6 +398,12 @@ impl<'le> TElement for LayoutElement<'le> {
     fn get_id(&self) -> Option<Atom> {
         unsafe { self.element.get_attr_atom_for_layout(&namespace::Null, "id") }
     }
+
+    fn get_disabled_state(&self) -> bool {
+        unsafe {
+            self.element.node.get_disabled_state_for_layout()
+        }
+    }
 }
 
 fn get_content(content_list: &content::T) -> String {

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -257,6 +257,8 @@ pub trait AttributeHandlers {
     fn set_atomic_attribute(&self, name: &str, value: DOMString);
 
     // http://www.whatwg.org/html/#reflecting-content-attributes-in-idl-attributes
+    fn has_attribute(&self, name: &str) -> bool;
+    fn set_bool_attribute(&self, name: &str, value: bool);
     fn get_url_attribute(&self, name: &str) -> DOMString;
     fn set_url_attribute(&self, name: &str, value: DOMString);
     fn get_string_attribute(&self, name: &str) -> DOMString;
@@ -383,6 +385,25 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
         assert!(name == name.to_ascii_lower().as_slice());
         let value = AttrValue::from_atomic(value);
         self.set_attribute(name, value);
+    }
+
+    fn has_attribute(&self, name: &str) -> bool {
+        let name = match self.html_element_in_html_document() {
+            true => name.to_ascii_lower(),
+            false => name.to_string()
+        };
+        self.deref().attrs.borrow().iter().map(|attr| attr.root()).any(|attr| {
+            name == attr.local_name && attr.namespace == Null
+        })
+    }
+
+    fn set_bool_attribute(&self, name: &str, value: bool) {
+        if self.has_attribute(name) == value { return; }
+        if value {
+            self.set_string_attribute(name, String::new());
+        } else {
+            self.remove_attribute(Null, name);
+        }
     }
 
     fn get_url_attribute(&self, name: &str) -> DOMString {
@@ -664,7 +685,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     // http://dom.spec.whatwg.org/#dom-element-hasattribute
     fn HasAttribute(&self,
                     name: DOMString) -> bool {
-        self.GetAttribute(name).is_some()
+        self.has_attribute(name.as_slice())
     }
 
     // http://dom.spec.whatwg.org/#dom-element-hasattributens
@@ -924,5 +945,9 @@ impl<'a> style::TElement for JSRef<'a, Element> {
                 _ => fail!("`id` attribute should be AtomAttrValue"),
             }
         })
+    }
+    fn get_disabled_state(&self) -> bool {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.get_disabled_state()
     }
 }

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -950,4 +950,8 @@ impl<'a> style::TElement for JSRef<'a, Element> {
         let node: &JSRef<Node> = NodeCast::from_ref(self);
         node.get_disabled_state()
     }
+    fn get_enabled_state(&self) -> bool {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.get_enabled_state()
+    }
 }

--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -72,6 +72,32 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(true),
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(false),
+            _ => ()
+        }
+    }
+
     fn handle_event(&self, event: &JSRef<Event>) {
         match self.super_type() {
             Some(s) => {

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -4,13 +4,15 @@
 
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
+use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::HTMLAreaElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -34,6 +36,39 @@ impl HTMLAreaElement {
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAreaElement> {
         let element = HTMLAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAreaElementBinding::Wrap)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(true),
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(false),
+            _ => ()
+        }
     }
 }
 

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -4,15 +4,17 @@
 
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
-use dom::bindings::codegen::InheritTypes::HTMLButtonElementDerived;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLButtonElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLButtonElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLButtonElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId, window_from_node};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -43,6 +45,82 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
         ValidityState::new(&*window)
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
+            node.check_ancestors_disabled_state_for_form_control();
+        } else {
+            node.check_disabled_attribute();
+        }
     }
 }
 

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -3,14 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding;
-use dom::bindings::codegen::InheritTypes::HTMLInputElementDerived;
+use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLInputElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLInputElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLInputElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -34,6 +37,84 @@ impl HTMLInputElement {
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLInputElement> {
         let element = HTMLInputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLInputElementBinding::Wrap)
+    }
+}
+
+impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
+            node.check_ancestors_disabled_state_for_form_control();
+        } else {
+            node.check_disabled_attribute();
+        }
     }
 }
 

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -4,13 +4,15 @@
 
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
+use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::HTMLLinkElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -34,6 +36,39 @@ impl HTMLLinkElement {
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLinkElement> {
         let element = HTMLLinkElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLinkElementBinding::Wrap)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(true),
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "href" => node.set_enabled_state(false),
+            _ => ()
+        }
     }
 }
 

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -3,14 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLOptionElementBinding;
+use dom::bindings::codegen::Bindings::HTMLOptionElementBinding::HTMLOptionElementMethods;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLOptionElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLOptionElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -34,6 +37,84 @@ impl HTMLOptionElement {
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptionElement> {
         let element = HTMLOptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptionElementBinding::Wrap)
+    }
+}
+
+impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
+    // http://www.whatwg.org/html/#dom-option-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-option-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_parent_disabled_state_for_option();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_parent_disabled_state_for_option();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        if node.parent_node().is_some() {
+            node.check_parent_disabled_state_for_option();
+        } else {
+            node.check_disabled_attribute();
+        }
     }
 }
 

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -4,17 +4,19 @@
 
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding;
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElementMethods;
-use dom::bindings::codegen::InheritTypes::HTMLSelectElementDerived;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLSelectElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::codegen::UnionTypes::HTMLElementOrLong::HTMLElementOrLong;
 use dom::bindings::codegen::UnionTypes::HTMLOptionElementOrHTMLOptGroupElement::HTMLOptionElementOrHTMLOptGroupElement;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLSelectElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLSelectElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId, window_from_node};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -49,6 +51,82 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
 
     // Note: this function currently only exists for test_union.html.
     fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) {
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
+            node.check_ancestors_disabled_state_for_form_control();
+        } else {
+            node.check_disabled_attribute();
+        }
     }
 }
 

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -3,14 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding;
-use dom::bindings::codegen::InheritTypes::HTMLTextAreaElementDerived;
+use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::HTMLTextAreaElementTypeId;
+use dom::element::{AttributeHandlers, Element, HTMLTextAreaElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -34,6 +37,84 @@ impl HTMLTextAreaElement {
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTextAreaElement> {
         let element = HTMLTextAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTextAreaElementBinding::Wrap)
+    }
+}
+
+impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn Disabled(&self) -> bool {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.has_attribute("disabled")
+    }
+
+    // http://www.whatwg.org/html/#dom-fe-disabled
+    fn SetDisabled(&self, disabled: bool) {
+        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        elem.set_bool_attribute("disabled", disabled)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(name.clone(), value.clone()),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(true);
+                node.set_enabled_state(false);
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, name: DOMString, value: DOMString) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(name.clone(), value),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        match name.as_slice() {
+            "disabled" => {
+                node.set_disabled_state(false);
+                node.set_enabled_state(true);
+                node.check_ancestors_disabled_state_for_form_control();
+            },
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.bind_to_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        match self.super_type() {
+            Some(ref s) => s.unbind_from_tree(tree_in_doc),
+            _ => (),
+        }
+
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
+            node.check_ancestors_disabled_state_for_form_control();
+        } else {
+            node.check_disabled_attribute();
+        }
     }
 }
 

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -6,6 +6,7 @@ use dom::attr::{AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
@@ -14,13 +15,19 @@ use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
-use dom::element::{ElementTypeId, HTMLAnchorElementTypeId};
-use dom::element::{HTMLBodyElementTypeId, HTMLCanvasElementTypeId};
-use dom::element::{HTMLIFrameElementTypeId, HTMLImageElementTypeId};
-use dom::element::{HTMLObjectElementTypeId, HTMLStyleElementTypeId};
+use dom::element::ElementTypeId;
+use dom::element::HTMLAnchorElementTypeId;
+use dom::element::HTMLBodyElementTypeId;
+use dom::element::HTMLButtonElementTypeId;
+use dom::element::HTMLCanvasElementTypeId;
+use dom::element::HTMLIFrameElementTypeId;
+use dom::element::HTMLImageElementTypeId;
+use dom::element::HTMLObjectElementTypeId;
+use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlbodyelement::HTMLBodyElement;
+use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlcanvaselement::HTMLCanvasElement;
 use dom::htmlelement::HTMLElement;
 use dom::htmliframeelement::HTMLIFrameElement;
@@ -113,6 +120,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {
             let element: &JSRef<HTMLBodyElement> = HTMLBodyElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLButtonElementTypeId) => {
+            let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLCanvasElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -15,6 +15,7 @@ use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
@@ -29,6 +30,7 @@ use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLOptGroupElementTypeId;
+use dom::element::HTMLOptionElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -42,6 +44,7 @@ use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmloptgroupelement::HTMLOptGroupElement;
+use dom::htmloptionelement::HTMLOptionElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
@@ -161,6 +164,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLOptGroupElementTypeId) => {
             let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLOptionElementTypeId) => {
+            let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -18,6 +18,7 @@ use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLSelectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLTextAreaElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
 use dom::element::ElementTypeId;
@@ -34,6 +35,7 @@ use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLOptionElementTypeId;
 use dom::element::HTMLSelectElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
+use dom::element::HTMLTextAreaElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmlbodyelement::HTMLBodyElement;
@@ -49,6 +51,7 @@ use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmloptionelement::HTMLOptionElement;
 use dom::htmlselectelement::HTMLSelectElement;
 use dom::htmlstyleelement::HTMLStyleElement;
+use dom::htmltextareaelement::HTMLTextAreaElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
@@ -179,6 +182,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {
             let element: &JSRef<HTMLStyleElement> = HTMLStyleElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLTextAreaElementTypeId) => {
+            let element: &JSRef<HTMLTextAreaElement> = HTMLTextAreaElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(ElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -12,6 +12,7 @@ use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
@@ -24,6 +25,7 @@ use dom::element::HTMLCanvasElementTypeId;
 use dom::element::HTMLFieldSetElementTypeId;
 use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
+use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
@@ -35,6 +37,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
+use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
@@ -143,6 +146,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLIFrameElementTypeId) => {
             let element: &JSRef<HTMLIFrameElement> = HTMLIFrameElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLInputElementTypeId) => {
+            let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -9,6 +9,7 @@ use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
@@ -20,6 +21,7 @@ use dom::element::HTMLAnchorElementTypeId;
 use dom::element::HTMLBodyElementTypeId;
 use dom::element::HTMLButtonElementTypeId;
 use dom::element::HTMLCanvasElementTypeId;
+use dom::element::HTMLFieldSetElementTypeId;
 use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
@@ -30,6 +32,7 @@ use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlcanvaselement::HTMLCanvasElement;
 use dom::htmlelement::HTMLElement;
+use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlobjectelement::HTMLObjectElement;
@@ -128,6 +131,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLCanvasElementTypeId) => {
             let element: &JSRef<HTMLCanvasElement> = HTMLCanvasElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLFieldSetElementTypeId) => {
+            let element: &JSRef<HTMLFieldSetElement> = HTMLFieldSetElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLImageElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -5,6 +5,7 @@
 use dom::attr::{AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLAreaElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementCast;
@@ -23,6 +24,7 @@ use dom::bindings::js::JSRef;
 use dom::element::Element;
 use dom::element::ElementTypeId;
 use dom::element::HTMLAnchorElementTypeId;
+use dom::element::HTMLAreaElementTypeId;
 use dom::element::HTMLBodyElementTypeId;
 use dom::element::HTMLButtonElementTypeId;
 use dom::element::HTMLCanvasElementTypeId;
@@ -38,6 +40,7 @@ use dom::element::HTMLStyleElementTypeId;
 use dom::element::HTMLTextAreaElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
+use dom::htmlareaelement::HTMLAreaElement;
 use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlcanvaselement::HTMLCanvasElement;
@@ -134,6 +137,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
     match node.type_id() {
         ElementNodeTypeId(HTMLAnchorElementTypeId) => {
             let element: &JSRef<HTMLAnchorElement> = HTMLAnchorElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLAreaElementTypeId) => {
+            let element: &JSRef<HTMLAreaElement> = HTMLAreaElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -16,6 +16,7 @@ use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLSelectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
@@ -31,6 +32,7 @@ use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLOptionElementTypeId;
+use dom::element::HTMLSelectElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -45,6 +47,7 @@ use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmloptionelement::HTMLOptionElement;
+use dom::htmlselectelement::HTMLSelectElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
@@ -168,6 +171,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLOptionElementTypeId) => {
             let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLSelectElementTypeId) => {
+            let element: &JSRef<HTMLSelectElement> = HTMLSelectElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -14,6 +14,7 @@ use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLStyleElementCast;
 use dom::bindings::js::JSRef;
 use dom::element::Element;
@@ -27,6 +28,7 @@ use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLInputElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
+use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLStyleElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -39,6 +41,7 @@ use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlinputelement::HTMLInputElement;
 use dom::htmlobjectelement::HTMLObjectElement;
+use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmlstyleelement::HTMLStyleElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
@@ -154,6 +157,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {
             let element: &JSRef<HTMLObjectElement> = HTMLObjectElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLOptGroupElementTypeId) => {
+            let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -14,6 +14,7 @@ use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLLinkElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
@@ -32,6 +33,7 @@ use dom::element::HTMLFieldSetElementTypeId;
 use dom::element::HTMLIFrameElementTypeId;
 use dom::element::HTMLImageElementTypeId;
 use dom::element::HTMLInputElementTypeId;
+use dom::element::HTMLLinkElementTypeId;
 use dom::element::HTMLObjectElementTypeId;
 use dom::element::HTMLOptGroupElementTypeId;
 use dom::element::HTMLOptionElementTypeId;
@@ -49,6 +51,7 @@ use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmliframeelement::HTMLIFrameElement;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::htmlinputelement::HTMLInputElement;
+use dom::htmllinkelement::HTMLLinkElement;
 use dom::htmlobjectelement::HTMLObjectElement;
 use dom::htmloptgroupelement::HTMLOptGroupElement;
 use dom::htmloptionelement::HTMLOptionElement;
@@ -169,6 +172,10 @@ pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
         }
         ElementNodeTypeId(HTMLInputElementTypeId) => {
             let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_ref(node).unwrap();
+            element as &VirtualMethods
+        }
+        ElementNodeTypeId(HTMLLinkElementTypeId) => {
+            let element: &JSRef<HTMLLinkElement> = HTMLLinkElementCast::to_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {

--- a/src/components/script/dom/webidls/HTMLButtonElement.webidl
+++ b/src/components/script/dom/webidls/HTMLButtonElement.webidl
@@ -6,7 +6,7 @@
 // http://www.whatwg.org/html/#htmlbuttonelement
 interface HTMLButtonElement : HTMLElement {
   //         attribute boolean autofocus;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString formAction;
   //         attribute DOMString formEnctype;

--- a/src/components/script/dom/webidls/HTMLFieldSetElement.webidl
+++ b/src/components/script/dom/webidls/HTMLFieldSetElement.webidl
@@ -5,7 +5,7 @@
 
 // http://www.whatwg.org/html/#htmlfieldsetelement
 interface HTMLFieldSetElement : HTMLElement {
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString name;
 

--- a/src/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/src/components/script/dom/webidls/HTMLInputElement.webidl
@@ -12,7 +12,7 @@ interface HTMLInputElement : HTMLElement {
   //         attribute boolean defaultChecked;
   //         attribute boolean checked;
   //         attribute DOMString dirName;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //readonly attribute FileList? files;
   //         attribute DOMString formAction;

--- a/src/components/script/dom/webidls/HTMLOptGroupElement.webidl
+++ b/src/components/script/dom/webidls/HTMLOptGroupElement.webidl
@@ -5,6 +5,6 @@
 
 // http://www.whatwg.org/html/#htmloptgroupelement
 interface HTMLOptGroupElement : HTMLElement {
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //         attribute DOMString label;
 };

--- a/src/components/script/dom/webidls/HTMLOptionElement.webidl
+++ b/src/components/script/dom/webidls/HTMLOptionElement.webidl
@@ -6,7 +6,7 @@
 // http://www.whatwg.org/html/#htmloptionelement
 //[NamedConstructor=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
 interface HTMLOptionElement : HTMLElement {
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString label;
   //         attribute boolean defaultSelected;

--- a/src/components/script/dom/webidls/HTMLSelectElement.webidl
+++ b/src/components/script/dom/webidls/HTMLSelectElement.webidl
@@ -6,7 +6,7 @@
 // http://www.whatwg.org/html/#htmlselectelement
 interface HTMLSelectElement : HTMLElement {
   //         attribute boolean autofocus;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute boolean multiple;
   //         attribute DOMString name;

--- a/src/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/src/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -9,7 +9,7 @@ interface HTMLTextAreaElement : HTMLElement {
   //         attribute boolean autofocus;
   //         attribute unsigned long cols;
   //         attribute DOMString dirName;
-  //         attribute boolean disabled;
+           attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString inputMode;
   //         attribute long maxLength;

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -28,5 +28,6 @@ pub trait TElement {
     fn get_hover_state(&self) -> bool;
     fn get_id(&self) -> Option<Atom>;
     fn get_disabled_state(&self) -> bool;
+    fn get_enabled_state(&self) -> bool;
 }
 

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -27,5 +27,6 @@ pub trait TElement {
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
     fn get_hover_state(&self) -> bool;
     fn get_id(&self) -> Option<Atom>;
+    fn get_disabled_state(&self) -> bool;
 }
 

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -784,6 +784,12 @@ fn matches_simple_selector<E:TElement,
             let elem = element.as_element();
             elem.get_disabled_state()
         },
+        // http://www.whatwg.org/html/#selector-enabled
+        Enabled => {
+            *shareable = false;
+            let elem = element.as_element();
+            elem.get_enabled_state()
+        },
         FirstChild => {
             *shareable = false;
             matches_first_child(element)

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -778,6 +778,12 @@ fn matches_simple_selector<E:TElement,
             let elem = element.as_element();
             elem.get_hover_state()
         },
+        // http://www.whatwg.org/html/#selector-disabled
+        Disabled => {
+            *shareable = false;
+            let elem = element.as_element();
+            elem.get_disabled_state()
+        },
         FirstChild => {
             *shareable = false;
             matches_first_child(element)

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -78,6 +78,7 @@ pub enum SimpleSelector {
     Visited,
     Hover,
     Disabled,
+    Enabled,
     FirstChild, LastChild, OnlyChild,
 //    Empty,
     Root,
@@ -219,7 +220,7 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 &ClassSelector(..)
                 | &AttrExists(..) | &AttrEqual(..) | &AttrIncludes(..) | &AttrDashMatch(..)
                 | &AttrPrefixMatch(..) | &AttrSubstringMatch(..) | &AttrSuffixMatch(..)
-                | &AnyLink | &Link | &Visited | &Hover | &Disabled
+                | &AnyLink | &Link | &Visited | &Hover | &Disabled | &Enabled
                 | &FirstChild | &LastChild | &OnlyChild | &Root
 //                | &Empty | &Lang(*)
                 | &NthChild(..) | &NthLastChild(..)
@@ -481,6 +482,7 @@ fn parse_simple_pseudo_class(name: &str) -> Option<SimpleSelector> {
         "visited" => Some(Visited),
         "hover" => Some(Hover),
         "disabled" => Some(Disabled),
+        "enabled" => Some(Enabled),
         "first-child" => Some(FirstChild),
         "last-child"  => Some(LastChild),
         "only-child"  => Some(OnlyChild),

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -77,6 +77,7 @@ pub enum SimpleSelector {
     Link,
     Visited,
     Hover,
+    Disabled,
     FirstChild, LastChild, OnlyChild,
 //    Empty,
     Root,
@@ -218,7 +219,7 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 &ClassSelector(..)
                 | &AttrExists(..) | &AttrEqual(..) | &AttrIncludes(..) | &AttrDashMatch(..)
                 | &AttrPrefixMatch(..) | &AttrSubstringMatch(..) | &AttrSuffixMatch(..)
-                | &AnyLink | &Link | &Visited | &Hover
+                | &AnyLink | &Link | &Visited | &Hover | &Disabled
                 | &FirstChild | &LastChild | &OnlyChild | &Root
 //                | &Empty | &Lang(*)
                 | &NthChild(..) | &NthLastChild(..)
@@ -479,6 +480,7 @@ fn parse_simple_pseudo_class(name: &str) -> Option<SimpleSelector> {
         "link" => Some(Link),
         "visited" => Some(Visited),
         "hover" => Some(Hover),
+        "disabled" => Some(Disabled),
         "first-child" => Some(FirstChild),
         "last-child"  => Some(LastChild),
         "only-child"  => Some(OnlyChild),

--- a/src/test/content/harness.js
+++ b/src/test/content/harness.js
@@ -55,6 +55,15 @@ function should_not_throw(f) {
   }
 }
 
+function check_selector(elem, selector, matches) {
+    is(elem.matches(selector), matches);
+}
+
+function check_disabled_selector(elem, disabled) {
+    check_selector(elem, ":disabled", disabled);
+    check_selector(elem, ":enabled", !disabled);
+}
+
 var _test_complete = false;
 var _test_timeout = 10000; //10 seconds
 function finish() {

--- a/src/test/content/test_enabled_disabled_selectors.html
+++ b/src/test/content/test_enabled_disabled_selectors.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Tests for :enabled and :disabled selectors</title>
+        <script src="harness.js"></script>
+        <script>
+            { // Simple initialization checks.
+                var list, i, elem;
+
+                // Examples of elements which are never :enabled or :disabled.
+                list = ['div', 'p', 'body', 'head', 'span'];
+                for(i = 0; i < list.length; i++) {
+                    elem = document.createElement(list[i]);
+                    check_selector(elem, ":enabled", false);
+                    check_selector(elem, ":disabled", false);
+                }
+
+                // Anchor, Area and Link are :enabled with an href, but never :disabled.
+                list = ["a", "area", "link"];
+                for(i = 0; i < list.length; i++) {
+                    elem = document.createElement(list[i]);
+                    check_selector(elem, ":enabled", false);
+                    check_selector(elem, ":disabled", false);
+                    elem.setAttribute("href", "");
+                    check_selector(elem, ":enabled", true);
+                    check_selector(elem, ":disabled", false);
+                }
+
+                // These are :enabled (and not :disabled) by default.
+                // XXX: Add 'menuitem' here whenever available.
+                list = ['button', 'input', 'select', 'textarea', 'optgroup', 'option', 'fieldset'];
+                for(i = 0; i < list.length; i++) {
+                    elem = document.createElement(list[i]);
+                    check_disabled_selector(elem, false);
+                }
+            }
+
+            { // Document elements tests.
+                var click_count = 0;
+                var click_event = new Event('click', {bubbles: true, cancelable: true});
+                var list, elem1, elem2, elem3, elem4, elem5;
+
+                function on_click(ev) { click_count++; }
+
+                list = ['button', 'input', 'option', 'select', 'textarea'];
+                for(i = 0; i < list.length; i++) {
+                    click_count = 0;
+
+                    elem1 = document.getElementById(list[i] + "-1");
+                    is(elem1.disabled, false);
+
+                    elem1.addEventListener('click', on_click);
+                    elem1.dispatchEvent(click_event);
+                    is(click_count, 1);
+
+                    elem2 = document.getElementById(list[i] + "-2");
+                    is(elem2.disabled, true);
+
+                    // Only user-generated click events are prevented.
+                    elem2.addEventListener('click', on_click);
+                    elem2.dispatchEvent(click_event);
+                    is(click_count, 2);
+
+                    // This should look disabled, though - missing UA's CSS for :disabled?
+                    elem3 = document.getElementById(list[i] + "-3");
+                    is(elem3.disabled, false);
+
+                    if (list[i] == 'option') { continue; }
+
+                    elem4 = document.getElementById(list[i] + "-4");
+                    is(elem4.disabled, false);
+
+                    // This should look disabled, though - missing UA's CSS for :disabled?
+                    elem5 = document.getElementById(list[i] + "-5");
+                    is(elem5.disabled, false);
+                }
+            }
+
+            { // JS tests (Button, Input, Select, TextArea).
+                var list = ['button', 'input', 'select', 'textarea'];
+                var fieldset = document.createElement("fieldset");
+                fieldset.disabled = true;
+                var div = document.createElement("div");
+                var elem;
+
+                for(i = 0; i < list.length; i++) {
+                    elem = document.createElement(list[i]);
+                    check_disabled_selector(elem, false);
+
+                    div.appendChild(elem);
+                    check_disabled_selector(elem, false);
+
+                    fieldset.appendChild(div);
+                    check_disabled_selector(elem, true);
+
+                    document.body.appendChild(fieldset);
+                    check_disabled_selector(elem, true);
+
+                    document.body.removeChild(fieldset);
+                    check_disabled_selector(elem, true);
+
+                    fieldset.removeChild(div);
+                    check_disabled_selector(elem, false);
+
+                    div.removeChild(elem);
+                    check_disabled_selector(elem, false);
+                }
+            }
+
+            { // JS tests (Option).
+                var optgroup = document.createElement("optgroup");
+                optgroup.disabled = true;
+
+                var option = document.createElement("option");
+                check_disabled_selector(option, false);
+
+                optgroup.appendChild(option);
+                check_disabled_selector(option, true);
+
+                document.body.appendChild(optgroup);
+                check_disabled_selector(option, true);
+
+                document.body.removeChild(optgroup);
+                check_disabled_selector(option, true);
+
+                optgroup.removeChild(option);
+                check_disabled_selector(option, false);
+            }
+
+            finish();
+        </script>
+    </head>
+    <body>
+        <button id="button-1"></button>
+        <button id="button-2" disabled></button>
+
+        <input id="input-1"></input>
+        <input id="input-2" disabled></input>
+
+        <option id="option-1"></option>
+        <option id="option-2" disabled></option>
+
+        <select id="select-1"></select>
+        <select id="select-2" disabled></select>
+
+        <textarea id="textarea-1"></textarea>
+        <textarea id="textarea-2" disabled></textarea>
+
+        <optgroup disabled>
+            <option id="option-3"></option>
+        </optgroup>
+
+        <fieldset disabled>
+            <fieldset>
+                <button id="button-3"></button>
+                <input id="input-3"></input>
+                <select id="select-3"></select>
+                <textarea id="textarea-3"></textarea>
+            </fieldset>
+        </fieldset>
+
+        <fieldset disabled>
+            <legend>
+                <button id="button-4"></button>
+                <input id="input-4"></input>
+                <select id="select-4"></select>
+                <textarea id="textarea-4"></textarea>
+            </legend>
+        </fieldset>
+
+        <fieldset disabled>
+            <legend></legend>
+            <legend>
+                <button id="button-5"></button>
+                <input id="input-5"></input>
+                <select id="select-5"></select>
+                <textarea id="textarea-5"></textarea>
+            </legend>
+        </fieldset>
+    </body>
+</html>


### PR DESCRIPTION
Specs:
http://www.whatwg.org/html/#selector-enabled
http://www.whatwg.org/html/#selector-disabled
http://www.whatwg.org/html/#concept-element-disabled
http://www.whatwg.org/html/#concept-fe-disabled
http://www.whatwg.org/html/#concept-option-disabled
http://www.whatwg.org/html/#attr-optgroup-disabled
http://www.whatwg.org/html/#attr-fieldset-disabled
http://www.whatwg.org/html/#attr-menuitem-disabled

HTMLMenuItemElement to be implemented in #2673.
