### PR TITLE
Add support for showing debug borders

### DIFF
--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -143,11 +143,13 @@ impl IOCompositor {
         let window_size = window.framebuffer_size();
         let hidpi_factor = window.hidpi_factor();
 
+        let show_debug_borders = opts.show_debug_borders;
         IOCompositor {
             window: window,
             port: port,
             opts: opts,
-            context: rendergl::init_render_context(CompositorTask::create_graphics_context()),
+            context: rendergl::RenderContext::new(CompositorTask::create_graphics_context(),
+                                                  show_debug_borders),
             root_pipeline: None,
             scene: Scene::new(window_size.as_f32().to_untyped(), identity()),
             window_size: window_size,

--- a/src/components/embedding/core.rs
+++ b/src/components/embedding/core.rs
@@ -64,6 +64,7 @@ pub extern "C" fn cef_run_message_loop() {
         headless: false,
         hard_fail: false,
         bubble_inline_sizes_separately: false,
+        show_debug_borders: false,
     };
     native::start(0, 0 as **u8, proc() {
        servo::run(opts);

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -68,6 +68,10 @@ pub struct Opts {
     /// may wish to turn this flag on in order to benchmark style recalculation against other
     /// browser engines.
     pub bubble_inline_sizes_separately: bool,
+
+    /// True if we should show borders on all layers and tiles for
+    /// debugging purposes (`--show-debug-borders`).
+    pub show_debug_borders: bool,
 }
 
 fn print_usage(app: &str, opts: &[getopts::OptGroup]) {
@@ -99,6 +103,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         getopts::optflag("z", "headless", "Headless mode"),
         getopts::optflag("f", "hard-fail", "Exit on task failure instead of displaying about:failure"),
         getopts::optflag("b", "bubble-widths", "Bubble intrinsic widths separately like other engines"),
+        getopts::optflag("", "show-debug-borders", "Show debugging borders on layers and tiles."),
         getopts::optflag("h", "help", "Print this message")
     );
 
@@ -187,6 +192,7 @@ pub fn from_cmdline_args(args: &[String]) -> Option<Opts> {
         headless: opt_match.opt_present("z"),
         hard_fail: opt_match.opt_present("f"),
         bubble_inline_sizes_separately: opt_match.opt_present("b"),
+        show_debug_borders: opt_match.opt_present("show-debug-borders"),
     })
 }
 


### PR DESCRIPTION
This can help debug issues with the compositor and show when a page is
creating layers.
