### PR TITLE
Switch to threadsafe builds of SpiderMonkey.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,9 @@
 [submodule "src/support/spidermonkey/rust-mozjs"]
 	path = src/support/spidermonkey/rust-mozjs
 	url = https://github.com/servo/rust-mozjs.git
+[submodule "src/support/spidermonkey/nspr"]
+	path = src/support/spidermonkey/nspr
+	url = https://github.com/servo/nspr.git
 [submodule "src/support/harfbuzz/rust-harfbuzz"]
 	path = src/support/harfbuzz/rust-harfbuzz
 	url = https://github.com/servo/rust-harfbuzz.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -298,7 +298,20 @@ DONE_compositing = $(B)src/components/compositing/libcompositing.dummy
 
 DEPS_compositing = $(CRATE_compositing) $(SRC_compositing) $(DONE_util) $(DONE_msg) $(DONE_gfx) $(DONE_script) $(DONE_layout_traits) $(DONE_style)
 
-RFLAGS_servo = $(strip $(CFG_RUSTC_FLAGS)) $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) -L $(B)src/components/gfx -L $(B)src/components/util -L $(B)src/components/net -L $(B)src/components/script -L $(B)src/components/layout_traits -L $(B)src/components/layout -L $(B)src/components/compositing -L $(B)src/components/style -L $(B)src/components/msg -L$(B)src/components/macros
+RFLAGS_servo = \
+  $(strip $(CFG_RUSTC_FLAGS)) \
+  $(addprefix -L $(B)src/,$(DEPS_SUBMODULES)) \
+  -L $(B)src/support/spidermonkey/nspr/dist/lib \
+  -L $(B)src/components/gfx \
+  -L $(B)src/components/util \
+  -L $(B)src/components/net \
+  -L $(B)src/components/script \
+  -L $(B)src/components/layout_traits \
+  -L $(B)src/components/layout \
+  -L $(B)src/components/compositing \
+  -L $(B)src/components/style \
+  -L $(B)src/components/msg \
+  -L$(B)src/components/macros
 
 SRC_servo = $(call rwildcard,$(S)src/components/main/,*.rs)
 CRATE_servo = $(S)src/components/main/servo.rs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install autoconf2.13 curl freeglut3-dev libtool \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    msttcorefonts gperf g++ automake cmake libnspr4-dev
+    msttcorefonts gperf g++ automake cmake
 ```
 
 On Fedora:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install autoconf2.13 curl freeglut3-dev libtool \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    msttcorefonts gperf g++ automake cmake
+    msttcorefonts gperf g++ automake cmake libnspr4-dev
 ```
 
 On Fedora:

--- a/configure
+++ b/configure
@@ -730,7 +730,7 @@ do
                 CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-ndk=${CFG_ANDROID_NDK_PATH}"
                 CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-toolchain=${CFG_ANDROID_CROSS_PATH}"
             fi
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-gczeal"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-gczeal --enable-threadsafe --with-system-nspr"
             ;;
         support/skia/skia)
             # Right now the skia configure script actually ignores --enable-debug and the

--- a/configure
+++ b/configure
@@ -725,11 +725,11 @@ do
             ;;
         support/spidermonkey/nspr)
             if [ ${CFG_OSTYPE} = "linux-androideabi" ]; then
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --target=arm-linux-androideabi"
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-ndk=${CFG_ANDROID_NDK_PATH}"
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-toolchain=${CFG_ANDROID_CROSS_PATH}"
+                CONFIGURE_ARGS="${CONFIGURE_ARGS} --target=arm-linux-androideabi"
+                CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-ndk=${CFG_ANDROID_NDK_PATH}"
+                CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-toolchain=${CFG_ANDROID_CROSS_PATH}"
             else
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-64bit"
+                CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-64bit"
             fi
             ;;
         support/spidermonkey/mozjs)
@@ -741,6 +741,9 @@ do
                 CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-toolchain=${CFG_ANDROID_CROSS_PATH}"
             fi
             CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-gczeal --enable-threadsafe"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-cflags=-I${CFG_BUILD_DIR}src/support/spidermonkey/nspr/dist/include/nspr"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-libs=-L../nspr/dist/lib"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-libs=-lnspr4"
             ;;
         support/skia/skia)
             # Right now the skia configure script actually ignores --enable-debug and the

--- a/configure
+++ b/configure
@@ -521,6 +521,7 @@ CFG_SUBMODULES="\
     support/skia/skia \
     support/spidermonkey/mozjs \
     support/spidermonkey/rust-mozjs \
+    support/spidermonkey/nspr \
     support/stb-image/rust-stb-image \
     support/png/libpng \
     support/png/rust-png \
@@ -722,6 +723,15 @@ do
             CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-default-fonts=${CFG_ANDROID_FONT_PATH}"
             CONFIGURE_ARGS="${CONFIGURE_ARGS} ${EXTRA_CONFIGURE_ARGS}"
             ;;
+        support/spidermonkey/nspr)
+            if [ ${CFG_OSTYPE} = "linux-androideabi" ]; then
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --target=arm-linux-androideabi"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-ndk=${CFG_ANDROID_NDK_PATH}"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-toolchain=${CFG_ANDROID_CROSS_PATH}"
+            else
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-64bit"
+            fi
+            ;;
         support/spidermonkey/mozjs)
             # needed because Spidermonkey configure is in non-standard location
                 CONFIGURE_SCRIPT="${CFG_SRC_DIR}src/${i}/js/src/configure"
@@ -730,7 +740,7 @@ do
                 CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-ndk=${CFG_ANDROID_NDK_PATH}"
                 CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-android-toolchain=${CFG_ANDROID_CROSS_PATH}"
             fi
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-gczeal --enable-threadsafe --with-system-nspr"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-gczeal --enable-threadsafe"
             ;;
         support/skia/skia)
             # Right now the skia configure script actually ignores --enable-debug and the

--- a/configure
+++ b/configure
@@ -742,8 +742,7 @@ do
             fi
             CONFIGURE_ARGS="${CONFIGURE_ARGS} --enable-gczeal --enable-threadsafe"
             CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-cflags=-I${CFG_BUILD_DIR}src/support/spidermonkey/nspr/dist/include/nspr"
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-libs=-L../nspr/dist/lib"
-            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-libs=-lnspr4"
+            CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-nspr-libs='-L../nspr/dist/lib -lnspr4'"
             ;;
         support/skia/skia)
             # Right now the skia configure script actually ignores --enable-debug and the
@@ -775,7 +774,7 @@ do
     fi
 
     if [ -f ${CONFIGURE_SCRIPT} ]; then
-	(sh ${CONFIGURE_SCRIPT} ${CONFIGURE_ARGS}) || exit $?
+        (eval sh ${CONFIGURE_SCRIPT} ${CONFIGURE_ARGS}) || exit $?
     fi
 done
 

--- a/mk/sub.mk
+++ b/mk/sub.mk
@@ -7,6 +7,7 @@ SLOW_TESTS += \
 
 # Tests for these submodules do not exist.
 NO_TESTS += \
+	nspr \
 	$(NULL)
 
 # These submodules will not be cleaned by the `make clean-fast` target.
@@ -23,6 +24,7 @@ NATIVE_BUILDS += \
 	libparserutils \
 	mozjs \
 	skia \
+	nspr \
 	glfw \
 	$(NULL)
 
@@ -79,6 +81,7 @@ DEPS_rust-hubbub += \
 	$(NULL)
 
 DEPS_rust-mozjs += \
+	nspr \
 	mozjs \
 	rust \
 	$(NULL)

--- a/mk/sub.mk
+++ b/mk/sub.mk
@@ -80,8 +80,11 @@ DEPS_rust-hubbub += \
 	rust \
 	$(NULL)
 
-DEPS_rust-mozjs += \
+DEPS_mozjs += \
 	nspr \
+	$(NULL)
+
+DEPS_rust-mozjs += \
 	mozjs \
 	rust \
 	$(NULL)

--- a/src/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/src/components/script/dom/dedicatedworkerglobalscope.rs
@@ -21,7 +21,7 @@ use servo_net::resource_task::{ResourceTask, load_whole_resource};
 
 use servo_util::str::DOMString;
 
-use js::rust::Cx;
+use js::rust::{Cx, JSAutoRequest};
 
 use std::rc::Rc;
 use native;
@@ -87,10 +87,13 @@ impl DedicatedWorkerGlobalScope {
             let global = DedicatedWorkerGlobalScope::new(
                 worker_url, js_context.clone(), receiver, resource_task,
                 script_chan).root();
-            match js_context.evaluate_script(
-                global.reflector().get_jsobject(), source, url.serialize(), 1) {
-                Ok(_) => (),
-                Err(_) => println!("evaluate_script failed")
+            {
+                let _ar = JSAutoRequest::new(js_context.ptr);
+                match js_context.evaluate_script(
+                    global.reflector().get_jsobject(), source, url.serialize(), 1) {
+                    Ok(_) => (),
+                    Err(_) => println!("evaluate_script failed")
+                }
             }
 
             let scope: &JSRef<WorkerGlobalScope> =

--- a/src/components/script/dom/eventtarget.rs
+++ b/src/components/script/dom/eventtarget.rs
@@ -15,15 +15,19 @@ use dom::node::NodeTypeId;
 use dom::workerglobalscope::WorkerGlobalScopeId;
 use dom::xmlhttprequest::XMLHttpRequestId;
 use dom::virtualmethods::VirtualMethods;
+
+use servo_util::str::DOMString;
+
 use js::jsapi::{JS_CompileUCFunction, JS_GetFunctionObject, JS_CloneFunctionObject};
 use js::jsapi::{JSContext, JSObject};
-use servo_util::str::DOMString;
+use js::rust::JSAutoRequest;
+
 use libc::{c_char, size_t};
 use std::cell::RefCell;
+use std::collections::hashmap::HashMap;
 use std::ptr;
 use url::Url;
 
-use std::collections::hashmap::HashMap;
 
 #[deriving(PartialEq,Encodable)]
 pub enum ListenerPhase {
@@ -179,6 +183,8 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
         static arg_name: [c_char, ..6] =
             ['e' as c_char, 'v' as c_char, 'e' as c_char, 'n' as c_char, 't' as c_char, 0];
         static arg_names: [*c_char, ..1] = [&arg_name as *c_char];
+
+        let _ar = JSAutoRequest::new(cx);
 
         let source = source.to_utf16();
         let handler = name.with_ref(|name| {

--- a/src/components/script/dom/messageevent.rs
+++ b/src/components/script/dom/messageevent.rs
@@ -17,6 +17,7 @@ use servo_util::str::DOMString;
 
 use js::jsapi::JSContext;
 use js::jsval::JSVal;
+use js::rust::JSAutoRequest;
 
 #[deriving(Encodable)]
 pub struct MessageEvent {
@@ -69,10 +70,14 @@ impl MessageEvent {
     pub fn dispatch(target: &JSRef<EventTarget>,
                     scope: &GlobalRef,
                     message: DOMString) {
+        let message = {
+            let cx = scope.get_cx();
+            let _ar = JSAutoRequest::new(cx);
+            message.to_jsval(cx)
+        };
         let messageevent = MessageEvent::new(
             scope, "message".to_string(), false, false,
-            message.to_jsval(scope.get_cx()),
-            "".to_string(), "".to_string()).root();
+            message, "".to_string(), "".to_string()).root();
         let event: &JSRef<Event> = EventCast::from_ref(&*messageevent);
         target.dispatch_event_with_target(None, &*event).unwrap();
     }

--- a/src/test/content/test_global.html
+++ b/src/test/content/test_global.html
@@ -2,6 +2,7 @@
 <head>
 <script src="harness.js"></script>
 <script>
+gc();
 is(window, window.window);
 is(window, this);
 for (var key in this) {

--- a/travis.linux.install.deps.sh
+++ b/travis.linux.install.deps.sh
@@ -1,5 +1,5 @@
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -q
-sudo apt-get install -qq --force-yes -y autoconf2.13 gperf libxxf86vm-dev libglfw-dev libstdc++6-4.7-dev
+sudo apt-get install -qq --force-yes -y autoconf2.13 gperf libxxf86vm-dev libglfw-dev libstdc++6-4.7-dev libnspr4-dev
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 sudo apt-get install ttf-mscorefonts-installer > /dev/null

--- a/travis.linux.install.deps.sh
+++ b/travis.linux.install.deps.sh
@@ -1,5 +1,5 @@
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -q
-sudo apt-get install -qq --force-yes -y autoconf2.13 gperf libxxf86vm-dev libglfw-dev libstdc++6-4.7-dev libnspr4-dev
+sudo apt-get install -qq --force-yes -y autoconf2.13 gperf libxxf86vm-dev libglfw-dev libstdc++6-4.7-dev
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 sudo apt-get install ttf-mscorefonts-installer > /dev/null


### PR DESCRIPTION
In order to support this, JSAutoRequest is instantiated where necessary, and
the script task is spawned on a native task.

Threadsafe builds have assertions to ensure that we don't call into a
JSRuntime from the wrong OS thread, and are the only supported configuration
in recent SpiderMonkey versions.
