### PR TITLE
Port `id` attribute to use atom.

### DIFF
--- a/src/components/layout/wrapper.rs
+++ b/src/components/layout/wrapper.rs
@@ -393,6 +393,11 @@ impl<'le> TElement for LayoutElement<'le> {
             self.element.node.get_hover_state_for_layout()
         }
     }
+
+    #[inline]
+    fn get_id(&self) -> Option<Atom> {
+        unsafe { self.element.get_attr_atom_for_layout(&namespace::Null, "id") }
+    }
 }
 
 fn get_content(content_list: &content::T) -> String {

--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -30,6 +30,7 @@ pub enum AttrValue {
     StringAttrValue(DOMString),
     TokenListAttrValue(DOMString, Vec<(uint, uint)>),
     UIntAttrValue(DOMString, u32),
+    AtomAttrValue(Atom),
 }
 
 impl AttrValue {
@@ -50,11 +51,17 @@ impl AttrValue {
         UIntAttrValue(string, result)
     }
 
+    pub fn from_atomic(string: DOMString) -> AttrValue {
+        let value = Atom::from_slice(string.as_slice());
+        AtomAttrValue(value)
+    }
+
     pub fn as_slice<'a>(&'a self) -> &'a str {
         match *self {
             StringAttrValue(ref value) |
             TokenListAttrValue(ref value, _) |
             UIntAttrValue(ref value, _) => value.as_slice(),
+            AtomAttrValue(ref value) => value.as_slice(),
         }
     }
 }

--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -167,6 +167,7 @@ impl<'a> AttrMethods for JSRef<'a, Attr> {
 
 pub trait AttrHelpersForLayout {
     unsafe fn value_ref_forever(&self) -> &'static str;
+    unsafe fn value_atom_forever(&self) -> Option<Atom>;
 }
 
 impl AttrHelpersForLayout for Attr {
@@ -174,5 +175,14 @@ impl AttrHelpersForLayout for Attr {
         // cast to point to T in RefCell<T> directly
         let value = mem::transmute::<&RefCell<AttrValue>, &AttrValue>(self.value.deref());
         value.as_slice()
+    }
+
+    unsafe fn value_atom_forever(&self) -> Option<Atom> {
+        // cast to point to T in RefCell<T> directly
+        let value = mem::transmute::<&RefCell<AttrValue>, &AttrValue>(self.value.deref());
+        match *value {
+            AtomAttrValue(ref val) => Some(val.clone()),
+            _ => None,
+        }
     }
 }

--- a/src/components/style/node.rs
+++ b/src/components/style/node.rs
@@ -26,5 +26,6 @@ pub trait TElement {
     fn get_local_name<'a>(&'a self) -> &'a Atom;
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
     fn get_hover_state(&self) -> bool;
+    fn get_id(&self) -> Option<Atom>;
 }
 

--- a/src/components/style/selector_matching.rs
+++ b/src/components/style/selector_matching.rs
@@ -267,7 +267,7 @@ impl SelectorMap {
             match *ss {
                 // TODO(pradeep): Implement case-sensitivity based on the document type and quirks
                 // mode.
-                IDSelector(ref id) => return Some(id.clone()),
+                IDSelector(ref id) => return Some(id.as_slice().clone().to_string()),
                 _ => {}
             }
         }
@@ -691,9 +691,8 @@ fn matches_simple_selector<E:TElement,
         IDSelector(ref id) => {
             *shareable = false;
             let element = element.as_element();
-            element.get_attr(&namespace::Null, "id")
-                    .map_or(false, |attr| {
-                attr == id.as_slice()
+            element.get_id().map_or(false, |attr| {
+                attr == *id
             })
         }
         // TODO: cache and intern class names on elements.

--- a/src/components/style/selectors.rs
+++ b/src/components/style/selectors.rs
@@ -10,6 +10,7 @@ use sync::Arc;
 use cssparser::ast::*;
 use cssparser::parse_nth;
 
+use servo_util::atom::Atom;
 use servo_util::namespace::Namespace;
 use servo_util::namespace;
 
@@ -56,7 +57,7 @@ pub enum Combinator {
 
 #[deriving(PartialEq, Clone)]
 pub enum SimpleSelector {
-    IDSelector(String),
+    IDSelector(Atom),
     ClassSelector(String),
     LocalNameSelector(String),
     NamespaceSelector(Namespace),
@@ -306,7 +307,7 @@ fn parse_one_simple_selector(iter: &mut Iter, namespaces: &NamespaceMap, inside_
                          -> SimpleSelectorParseResult {
     match iter.peek() {
         Some(&IDHash(_)) => match iter.next() {
-            Some(IDHash(id)) => SimpleSelectorResult(IDSelector(id)),
+            Some(IDHash(id)) => SimpleSelectorResult(IDSelector(Atom::from_slice(id.as_slice()))),
             _ => fail!("Implementation error, this should not happen."),
         },
         Some(&Delim('.')) => {
@@ -572,6 +573,7 @@ fn skip_whitespace(iter: &mut Iter) -> bool {
 mod tests {
     use sync::Arc;
     use cssparser;
+    use servo_util::atom::Atom;
     use servo_util::namespace;
     use namespaces::NamespaceMap;
     use super::*;
@@ -611,7 +613,7 @@ mod tests {
         })))
         assert!(parse("#bar") == Some(vec!(Selector{
             compound_selectors: Arc::new(CompoundSelector {
-                simple_selectors: vec!(IDSelector("bar".to_string())),
+                simple_selectors: vec!(IDSelector(Atom::from_slice("bar"))),
                 next: None,
             }),
             pseudo_element: None,
@@ -621,7 +623,7 @@ mod tests {
             compound_selectors: Arc::new(CompoundSelector {
                 simple_selectors: vec!(LocalNameSelector("e".to_string()),
                                        ClassSelector("foo".to_string()),
-                                       IDSelector("bar".to_string())),
+                                       IDSelector(Atom::from_slice("bar"))),
                 next: None,
             }),
             pseudo_element: None,
@@ -629,7 +631,7 @@ mod tests {
         })))
         assert!(parse("e.foo #bar") == Some(vec!(Selector{
             compound_selectors: Arc::new(CompoundSelector {
-                simple_selectors: vec!(IDSelector("bar".to_string())),
+                simple_selectors: vec!(IDSelector(Atom::from_slice("bar"))),
                 next: Some((box CompoundSelector {
                     simple_selectors: vec!(LocalNameSelector("e".to_string()),
                                            ClassSelector("foo".to_string())),


### PR DESCRIPTION
id selector is used very frequently. So I think it will be more efficiently if we use atom to represent `id` attribute.
