### PR TITLE
Track rerender msgs

### DIFF
--- a/src/components/compositing/compositor_task.rs
+++ b/src/components/compositing/compositor_task.rs
@@ -122,6 +122,10 @@ impl RenderListener for CompositorChan {
         }
     }
 
+    fn rerendermsg_discarded(&self) {
+        self.chan.send(ReRenderMsgDiscarded);
+    }
+
     fn set_layer_clip_rect(&self,
                            pipeline_id: PipelineId,
                            layer_id: LayerId,
@@ -184,6 +188,8 @@ pub enum Msg {
     ChangeReadyState(ReadyState),
     /// Alerts the compositor to the current status of rendering.
     ChangeRenderState(RenderState),
+    /// Alerts the compositor that the ReRenderMsg has been discarded.
+    ReRenderMsgDiscarded,
     /// Sets the channel to the current layout and render tasks, along with their id
     SetIds(SendableFrameTree, Sender<()>, ConstellationChan),
     /// The load of a page for a given URL has completed.

--- a/src/components/compositing/headless.rs
+++ b/src/components/compositing/headless.rs
@@ -5,7 +5,7 @@
 use compositor_task::{Msg, Exit, ChangeReadyState, SetIds};
 use compositor_task::{GetGraphicsMetadata, CreateOrUpdateRootLayer, CreateOrUpdateDescendantLayer};
 use compositor_task::{SetLayerClipRect, Paint, ScrollFragmentPoint, LoadComplete};
-use compositor_task::{ShutdownComplete, ChangeRenderState};
+use compositor_task::{ShutdownComplete, ChangeRenderState, ReRenderMsgDiscarded};
 
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
@@ -92,7 +92,7 @@ impl NullCompositor {
                 CreateOrUpdateDescendantLayer(..) |
                 SetLayerClipRect(..) | Paint(..) |
                 ChangeReadyState(..) | ChangeRenderState(..) | ScrollFragmentPoint(..) |
-                LoadComplete(..) => ()
+                LoadComplete(..) | ReRenderMsgDiscarded(..) => ()
             }
         }
     }

--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -242,6 +242,7 @@ impl<C:RenderListener + Send> RenderTask<C> {
                         debug!("render_task: render ready msg");
                         let ConstellationChan(ref mut c) = self.constellation_chan;
                         c.send(RendererReadyMsg(self.id));
+                        self.compositor.rerendermsg_discarded();
                         continue;
                     }
 

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -105,6 +105,7 @@ pub trait RenderListener {
              epoch: Epoch,
              replies: Vec<(LayerId, Box<LayerBufferSet>)>);
 
+    fn rerendermsg_discarded(&self);
     fn set_render_state(&self, render_state: RenderState);
 }
 


### PR DESCRIPTION
If the compositor outputs to a file:
- Track rerender msg ids sent from the compositor to the render tasks.
- Before outputting, wait until all rerender msgs are processed by the
  render tasks.

Fixes issue https://github.com/servo/servo/issues/2871.
