### PR TITLE
Reftest harness explicitly knows whether to run servo in cpu or gpu mode.

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -82,12 +82,12 @@ check-servo: $(foreach lib_crate,$(SERVO_LIB_CRATES),check-servo-$(lib_crate)) s
 .PHONY: check-ref-cpu
 check-ref-cpu: reftest
 	@$(call E, check: reftests with CPU rendering)
-	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME) -- -c
+	$(Q)./reftest cpu $(S)src/test/ref/basic.list $(TESTNAME)
 
 .PHONY: check-ref-gpu
 check-ref-gpu: reftest
 	@$(call E, check: reftests with GPU rendering)
-	$(Q)./reftest $(S)src/test/ref/basic.list $(TESTNAME)
+	$(Q)./reftest gpu $(S)src/test/ref/basic.list $(TESTNAME)
 
 .PHONY: check-ref
 check-ref: check-ref-cpu check-ref-gpu


### PR DESCRIPTION
This will make it easier to support different expected behaviours depending on the rendering mode.
