### PR TITLE
255 -> 1.0 for color::rgba + remove dead code lint

### DIFF
--- a/src/components/layout/block.rs
+++ b/src/components/layout/block.rs
@@ -1291,7 +1291,7 @@ impl BlockFlow {
             id: self.layer_id(0),
             display_list: Arc::new(display_list.flatten(ContentStackingLevel)),
             position: Rect(origin, size),
-            background_color: color::rgba(255.0, 255.0, 255.0, 0.0),
+            background_color: color::rgba(1.0, 1.0, 1.0, 0.0),
             scroll_policy: scroll_policy,
         };
         self.base.layers.push_back(new_layer)

--- a/src/components/layout/layout_task.rs
+++ b/src/components/layout/layout_task.rs
@@ -689,7 +689,7 @@ impl LayoutTask {
 
                 // FIXME(pcwalton): This is really ugly and can't handle overflow: scroll. Refactor
                 // it with extreme prejudice.
-                let mut color = color::rgba(255.0, 255.0, 255.0, 255.0);
+                let mut color = color::rgba(1.0, 1.0, 1.0, 1.0);
                 for child in node.traverse_preorder() {
                     if child.type_id() == Some(ElementNodeTypeId(HTMLHtmlElementTypeId)) ||
                             child.type_id() == Some(ElementNodeTypeId(HTMLBodyElementTypeId)) {

--- a/src/components/script/cors.rs
+++ b/src/components/script/cors.rs
@@ -312,6 +312,7 @@ impl CORSCacheEntry {
 
 impl CORSCache {
     /// http://fetch.spec.whatwg.org/#concept-cache-clear
+    #[allow(dead_code)]
     fn clear (&mut self, request: &CORSRequest) {
         let CORSCache(buf) = self.clone();
         let new_buf: Vec<CORSCacheEntry> = buf.move_iter().filter(|e| e.origin == request.origin && request.destination == e.url).collect();


### PR DESCRIPTION
In build_display_list_abs (block.rs) and handle_reflow (layout_task.rs)
255 is incorrectly used instead of 1.0 for color::rgba (255 is correct
with color::rgb but _not_ color::rgba).

In cors.rs remove the dead code warning for fn clear.
The function shouldn't be removed since it'll be used in the future
(fn clear is an implementation of http://fetch.spec.whatwg.org/#concept-cache-clear).

CC @zwarich, @mrobinson 
CC @Manishearth (cors.rs)
