### PR TITLE
Change layout to handle whitespace between inline elements in HTML file.

### DIFF
--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -88,3 +88,5 @@
 == pseudo_inherit.html pseudo_inherit_ref.html
 == float_intrinsic_height.html float_intrinsic_height_ref.html
 == table_auto_width.html table_auto_width_ref.html
+== inline_whitespace_b.html inline_whitespace_ref.html
+== inline_whitespace_a.html inline_whitespace_ref.html

--- a/src/test/ref/inline_whitespace_a.html
+++ b/src/test/ref/inline_whitespace_a.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<style type="text/css">
+			body {
+				background-color: #f6f6f6;
+				font-size: 128px;
+			}
+		</style>
+	</head>
+	<body>
+		<span>A</span> <span>B</span>
+	</body>
+</html>

--- a/src/test/ref/inline_whitespace_b.html
+++ b/src/test/ref/inline_whitespace_b.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<style type="text/css">
+			body {
+				background-color: #f6f6f6;
+				font-size: 128px;
+			}
+		</style>
+	</head>
+	<body>
+		<span>A</span>
+		<span>B</span>
+	</body>
+</html>

--- a/src/test/ref/inline_whitespace_ref.html
+++ b/src/test/ref/inline_whitespace_ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<style type="text/css">
+			body {
+				background-color: #f6f6f6;
+				font-size: 128px;
+			}
+		</style>
+	</head>
+	<body>
+		<span>A B</span>
+	</body>
+</html>


### PR DESCRIPTION
This matches the behaviour of other browsers.
