### PR TITLE
Move RenderState manipulation out of a loop so that we thrash it less

### DIFF
--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -246,6 +246,8 @@ impl<C:RenderListener + Send> RenderTask<C> {
                         continue;
                     }
 
+                    self.compositor.set_render_state(RenderingRenderState);
+
                     let mut replies = Vec::new();
                     for ReRenderRequest { buffer_requests, scale, layer_id, epoch }
                           in requests.move_iter() {
@@ -255,6 +257,8 @@ impl<C:RenderListener + Send> RenderTask<C> {
                             debug!("renderer epoch mismatch: {:?} != {:?}", self.epoch, epoch);
                         }
                     }
+
+                    self.compositor.set_render_state(IdleRenderState);
 
                     debug!("render_task: returning surfaces");
                     self.compositor.paint(self.id, self.epoch, replies);
@@ -305,8 +309,6 @@ impl<C:RenderListener + Send> RenderTask<C> {
                 Some(render_layer) => render_layer,
                 None => return,
             };
-
-            self.compositor.set_render_state(RenderingRenderState);
 
             // Divide up the layer into tiles.
             for tile in tiles.iter() {
@@ -444,7 +446,6 @@ impl<C:RenderListener + Send> RenderTask<C> {
             };
 
             replies.push((render_layer.id, layer_buffer_set));
-            self.compositor.set_render_state(IdleRenderState);
         })
     }
 }


### PR DESCRIPTION
It doesn't really make sense to say that we're idle when we're
potentially still rendering.
