### PR TITLE
Move get_buffer_requests into rust-layers from Servo and do some minor cleanup

### DIFF
--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -223,7 +223,7 @@ impl IOCompositor {
             // If a pinch-zoom happened recently, ask for tiles at the new resolution
             if self.zoom_action && precise_time_s() - self.zoom_time > 0.3 {
                 self.zoom_action = false;
-                self.ask_for_tiles();
+                self.send_buffer_requests_for_all_layers();
             }
 
         }
@@ -438,7 +438,7 @@ impl IOCompositor {
 
         self.scroll_layer_to_fragment_point_if_necessary(layer_properties.pipeline_id,
                                                          layer_properties.id);
-        self.ask_for_tiles();
+        self.send_buffer_requests_for_all_layers();
     }
 
     fn create_or_update_descendant_layer(&mut self, mut layer_properties: LayerProperties) {
@@ -448,7 +448,7 @@ impl IOCompositor {
         }
         self.scroll_layer_to_fragment_point_if_necessary(layer_properties.pipeline_id,
                                                          layer_properties.id);
-        self.ask_for_tiles();
+        self.send_buffer_requests_for_all_layers();
     }
 
     fn create_descendant_layer(&self, layer_properties: LayerProperties) {
@@ -534,7 +534,7 @@ impl IOCompositor {
         };
 
         if should_ask_for_tiles {
-            self.ask_for_tiles();
+            self.send_buffer_requests_for_all_layers();
         }
     }
 
@@ -602,7 +602,7 @@ impl IOCompositor {
 
         if ask {
             self.recomposite_if(move);
-            self.ask_for_tiles();
+            self.send_buffer_requests_for_all_layers();
         }
     }
 
@@ -735,7 +735,7 @@ impl IOCompositor {
             None => { }
         }
         self.recomposite_if(scroll);
-        self.ask_for_tiles();
+        self.send_buffer_requests_for_all_layers();
     }
 
     fn device_pixels_per_screen_px(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32> {
@@ -853,8 +853,7 @@ impl IOCompositor {
         }
     }
 
-    /// Get BufferRequests from each layer.
-    fn ask_for_tiles(&mut self) {
+    fn send_buffer_requests_for_all_layers(&mut self) {
         let mut layers_and_requests = Vec::new();
         self.scene.get_buffer_requests(&mut layers_and_requests,
                                        Rect(Point2D(0f32, 0f32),

--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -68,18 +68,6 @@ impl CompositorData {
         Rc::new(Layer::new(layer_properties.rect, tile_size, new_compositor_data))
     }
 
-    /// Adds a child layer to the layer with the given ID and the given pipeline, if it doesn't
-    /// exist yet. The child layer will have the same pipeline, tile size, memory limit, and CPU
-    /// painting status as its parent.
-    pub fn add_child(layer: Rc<Layer<CompositorData>>,
-                     layer_properties: LayerProperties) {
-        let new_kid = CompositorData::new_layer(layer.extra_data.borrow().pipeline.clone(),
-                                                layer_properties,
-                                                DoesntWantScrollEvents,
-                                                layer.tile_size);
-        layer.add_child(new_kid.clone());
-    }
-
     pub fn update_layer(layer: Rc<Layer<CompositorData>>, layer_properties: LayerProperties) {
         layer.extra_data.borrow_mut().epoch = layer_properties.epoch;
         layer.extra_data.borrow_mut().background_color = layer_properties.background_color;

--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -8,11 +8,10 @@ use pipeline::CompositionPipeline;
 
 use azure::azure_hl::Color;
 use geom::point::TypedPoint2D;
-use geom::rect::Rect;
 use geom::scale_factor::ScaleFactor;
 use geom::size::{Size2D, TypedSize2D};
 use gfx::render_task::UnusedBufferMsg;
-use layers::layers::{BufferRequest, Layer, LayerBuffer, LayerBufferSet};
+use layers::layers::{Layer, LayerBufferSet};
 use layers::platform::surface::NativeSurfaceMethods;
 use servo_msg::compositor_msg::{Epoch, LayerId};
 use servo_msg::compositor_msg::ScrollPolicy;
@@ -79,43 +78,6 @@ impl CompositorData {
                                                 DoesntWantScrollEvents,
                                                 layer.tile_size);
         layer.add_child(new_kid.clone());
-    }
-
-    // Given the current window size, determine which tiles need to be (re-)rendered and sends them
-    // off the the appropriate renderer. Returns true if and only if the scene should be repainted.
-    pub fn get_buffer_requests_recursively(requests: &mut Vec<(Rc<Layer<CompositorData>>,
-                                                               Vec<BufferRequest>)>,
-                                           unused_buffers: &mut Vec<Box<LayerBuffer>>,
-                                           layer: Rc<Layer<CompositorData>>,
-                                           window_rect_in_device_pixels: Rect<f32>) {
-        let (request, unused) = layer.get_tile_rects_page(window_rect_in_device_pixels);
-        unused_buffers.push_all_move(unused);
-
-        if !request.is_empty() {
-            requests.push((layer.clone(), request));
-        }
-
-        for kid in layer.children().iter() {
-            let mut new_rect = window_rect_in_device_pixels;
-            let content_offset = kid.content_offset.borrow();
-            new_rect.origin.x = new_rect.origin.x - content_offset.x;
-            new_rect.origin.y = new_rect.origin.y - content_offset.y;
-
-            match new_rect.intersection(&*kid.bounds.borrow()) {
-                Some(new_rect) => {
-                    // Child layers act as if they are rendered at (0,0), so we
-                    // subtract the layer's (x,y) coords in its containing page
-                    // to make the child_rect appear in coordinates local to it.
-                    let child_rect = Rect(new_rect.origin.sub(&kid.bounds.borrow().origin),
-                                          new_rect.size);
-                    CompositorData::get_buffer_requests_recursively(requests,
-                                                                    unused_buffers,
-                                                                    kid.clone(),
-                                                                    child_rect);
-                }
-                None => {}
-            }
-        };
     }
 
     pub fn update_layer(layer: Rc<Layer<CompositorData>>, layer_properties: LayerProperties) {


### PR DESCRIPTION
It's fitting that rust-layers knows how to gather buffer requests for its own layer hierarchy and everything is in place for this now.
