### PR TITLE
Make scrolling tick by device pixels

### DIFF
--- a/src/components/compositing/compositor_data.rs
+++ b/src/components/compositing/compositor_data.rs
@@ -8,7 +8,6 @@ use pipeline::CompositionPipeline;
 
 use azure::azure_hl::Color;
 use geom::point::TypedPoint2D;
-use geom::scale_factor::ScaleFactor;
 use geom::size::{Size2D, TypedSize2D};
 use gfx::render_task::UnusedBufferMsg;
 use layers::layers::{Layer, LayerBufferSet};
@@ -16,7 +15,7 @@ use layers::platform::surface::NativeSurfaceMethods;
 use servo_msg::compositor_msg::{Epoch, LayerId};
 use servo_msg::compositor_msg::ScrollPolicy;
 use servo_msg::constellation_msg::PipelineId;
-use servo_util::geometry::PagePx;
+use servo_util::geometry::DevicePixel;
 use std::rc::Rc;
 
 pub struct CompositorData {
@@ -25,10 +24,6 @@ pub struct CompositorData {
 
     /// The ID of this layer within the pipeline.
     pub id: LayerId,
-
-    /// The offset of the page due to scrolling. (0,0) is when the window sees the
-    /// top left corner of the page.
-    pub scroll_offset: TypedPoint2D<PagePx, f32>,
 
     /// The behavior of this layer when a scroll message is received.
     pub wants_scroll_events: WantsScrollEventsFlag,
@@ -59,7 +54,6 @@ impl CompositorData {
         let new_compositor_data = CompositorData {
             pipeline: pipeline,
             id: layer_properties.id,
-            scroll_offset: TypedPoint2D(0f32, 0f32),
             wants_scroll_events: wants_scroll_events,
             scroll_policy: layer_properties.scroll_policy,
             background_color: layer_properties.background_color,
@@ -76,15 +70,12 @@ impl CompositorData {
         layer.contents_changed();
 
         // Call scroll for bounds checking if the page shrunk. Use (-1, -1) as the
-        // cursor position to make sure the scroll isn't propagated downwards. The
-        // scale factor does not matter here since we are scrolling to 0 offset and
-        // 0 * n == 0.
-        let size: TypedSize2D<PagePx, f32> = Size2D::from_untyped(&layer.bounds.borrow().size);
+        // cursor position to make sure the scroll isn't propagated downwards.
+        let size: TypedSize2D<DevicePixel, f32> = Size2D::from_untyped(&layer.bounds.borrow().size);
         events::handle_scroll_event(layer.clone(),
                                     TypedPoint2D(0f32, 0f32),
                                     TypedPoint2D(-1f32, -1f32),
-                                    size,
-                                    ScaleFactor(1.0));
+                                    size);
     }
 
     pub fn find_layer_with_pipeline_and_layer_id(layer: Rc<Layer<CompositorData>>,

--- a/src/components/compositing/events.rs
+++ b/src/components/compositing/events.rs
@@ -6,12 +6,10 @@ use compositor_data::{CompositorData, WantsScrollEvents};
 use windowing::{MouseWindowEvent, MouseWindowClickEvent, MouseWindowMouseDownEvent};
 use windowing::MouseWindowMouseUpEvent;
 
-use geom::length::Length;
-use geom::matrix::identity;
 use geom::point::{Point2D, TypedPoint2D};
 use geom::rect::{Rect, TypedRect};
 use geom::scale_factor::ScaleFactor;
-use geom::size::TypedSize2D;
+use geom::size::{Size2D, TypedSize2D};
 use layers::layers::Layer;
 use script::dom::event::{ClickEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent};
 use script::script_task::{ScriptChan, SendEventMsg};
@@ -19,6 +17,9 @@ use servo_msg::compositor_msg::{FixedPosition, LayerId};
 use servo_msg::constellation_msg::PipelineId;
 use servo_util::geometry::{DevicePixel, PagePx};
 use std::rc::Rc;
+
+
+use geom::matrix::identity;
 
 trait Clampable {
     fn clamp(&self, mn: &Self, mx: &Self) -> Self;
@@ -43,10 +44,9 @@ impl Clampable for f32 {
 /// mouse is over child layers first. If a layer successfully scrolled, returns true; otherwise
 /// returns false, so a parent layer can scroll instead.
 pub fn handle_scroll_event(layer: Rc<Layer<CompositorData>>,
-                           delta: TypedPoint2D<PagePx, f32>,
-                           cursor: TypedPoint2D<PagePx, f32>,
-                           window_size: TypedSize2D<PagePx, f32>,
-                           page_to_device_pixels_scale: ScaleFactor<PagePx, DevicePixel, f32>)
+                           delta: TypedPoint2D<DevicePixel, f32>,
+                           cursor: TypedPoint2D<DevicePixel, f32>,
+                           window_size: TypedSize2D<DevicePixel, f32>)
                            -> bool {
     // If this layer doesn't want scroll events, neither it nor its children can handle scroll
     // events.
@@ -55,80 +55,80 @@ pub fn handle_scroll_event(layer: Rc<Layer<CompositorData>>,
     }
 
     // Allow children to scroll.
-    let cursor = cursor - layer.extra_data.borrow().scroll_offset;
+    let content_offset: TypedPoint2D<DevicePixel, f32> =
+        Point2D::from_untyped(&*layer.content_offset.borrow());
+    let cursor = cursor - content_offset;
     for child in layer.children().iter() {
-        let rect: TypedRect<PagePx, f32> = Rect::from_untyped(&*child.bounds.borrow());
+        let rect: TypedRect<DevicePixel, f32> = Rect::from_untyped(&*child.bounds.borrow());
         if rect.contains(&cursor) &&
            handle_scroll_event(child.clone(),
                                delta,
                                cursor - rect.origin,
-                               rect.size,
-                               page_to_device_pixels_scale) {
+                               rect.size) {
             return true
         }
     }
 
-    // This scroll event is mine!
-    // Scroll this layer!
-    let old_origin = layer.extra_data.borrow().scroll_offset.clone();
-    layer.extra_data.borrow_mut().scroll_offset = old_origin + delta;
+    clamp_scroll_offset_and_scroll_layer(layer,
+                                         content_offset.to_untyped() + delta.to_untyped(),
+                                         window_size.to_untyped())
 
-    // bounds checking
-    let page_size = layer.bounds.borrow().size;
-    let window_size = window_size.to_untyped();
-    let scroll_offset = layer.extra_data.borrow().scroll_offset.to_untyped();
+}
 
-    let min_x = (window_size.width - page_size.width).min(0.0);
-    layer.extra_data.borrow_mut().scroll_offset.x = Length(scroll_offset.x.clamp(&min_x, &0.0));
+pub fn clamp_scroll_offset_and_scroll_layer(layer: Rc<Layer<CompositorData>>,
+                                            mut new_offset: Point2D<f32>,
+                                            window_size: Size2D<f32>)
+                                            -> bool {
+    let layer_size = layer.bounds.borrow().size;
+    let min_x = (window_size.width - layer_size.width).min(0.0);
+    new_offset.x = new_offset.x.clamp(&min_x, &0.0);
 
-    let min_y = (window_size.height - page_size.height).min(0.0);
-    layer.extra_data.borrow_mut().scroll_offset.y = Length(scroll_offset.y.clamp(&min_y, &0.0));
+    let min_y = (window_size.height - layer_size.height).min(0.0);
+    new_offset.y = new_offset.y.clamp(&min_y, &0.0);
 
-    if old_origin - layer.extra_data.borrow().scroll_offset == TypedPoint2D(0f32, 0f32) {
+    if *layer.content_offset.borrow() == new_offset {
         return false
     }
 
-    let offset = layer.extra_data.borrow().scroll_offset.clone();
-    scroll(layer.clone(), offset, page_to_device_pixels_scale)
+    // FIXME: This allows the base layer to record the current content offset without
+    // updating its transform. This should be replaced with something less strange.
+    *layer.content_offset.borrow_mut() = new_offset;
+    scroll_layer_and_all_child_layers(layer.clone(), new_offset)
 }
 
-/// Actually scrolls the descendants of a layer that scroll. This is called by
-/// `handle_scroll_event` above when it determines that a layer wants to scroll.
-fn scroll(layer: Rc<Layer<CompositorData>>,
-          scroll_offset: TypedPoint2D<PagePx, f32>,
-          page_to_device_pixels_scale: ScaleFactor<PagePx, DevicePixel, f32>)
-          -> bool {
+fn scroll_layer_and_all_child_layers(layer: Rc<Layer<CompositorData>>,
+                                     new_offset: Point2D<f32>)
+                                     -> bool {
     let mut result = false;
 
     // Only scroll this layer if it's not fixed-positioned.
     if layer.extra_data.borrow().scroll_policy != FixedPosition {
-        // Scroll this layer!
-        layer.extra_data.borrow_mut().scroll_offset = scroll_offset;
-
-        let scroll_offset = layer.extra_data.borrow().scroll_offset.clone();
-        *layer.transform.borrow_mut() = identity().translate(scroll_offset.x.get(), scroll_offset.y.get(), 0.0);
-        *layer.content_offset.borrow_mut() = (scroll_offset * page_to_device_pixels_scale).to_untyped();
-
+        *layer.transform.borrow_mut() = identity().translate(new_offset.x, new_offset.y, 0.0);
+        *layer.content_offset.borrow_mut() = new_offset;
         result = true
     }
 
     for child in layer.children().iter() {
-        result = scroll(child.clone(), scroll_offset, page_to_device_pixels_scale) || result;
+        result |= scroll_layer_and_all_child_layers(child.clone(), new_offset);
     }
 
-    result
+    return result;
 }
 
 // Takes in a MouseWindowEvent, determines if it should be passed to children, and
 // sends the event off to the appropriate pipeline. NB: the cursor position is in
 // page coordinates.
 pub fn send_mouse_event(layer: Rc<Layer<CompositorData>>,
-                        event: MouseWindowEvent, cursor: TypedPoint2D<PagePx, f32>) {
-    let cursor = cursor - layer.extra_data.borrow().scroll_offset;
+                        event: MouseWindowEvent,
+                        cursor: TypedPoint2D<PagePx, f32>,
+                        device_pixels_per_page_px: ScaleFactor<PagePx, DevicePixel, f32>) {
+    let content_offset : TypedPoint2D<DevicePixel, f32> =
+        Point2D::from_untyped(&*layer.content_offset.borrow());
+    let cursor = cursor - (content_offset / device_pixels_per_page_px);
     for child in layer.children().iter() {
         let rect: TypedRect<PagePx, f32> = Rect::from_untyped(&*child.bounds.borrow());
         if rect.contains(&cursor) {
-            send_mouse_event(child.clone(), event, cursor - rect.origin);
+            send_mouse_event(child.clone(), event, cursor - rect.origin, device_pixels_per_page_px);
             return;
         }
     }
@@ -154,8 +154,7 @@ pub fn move(layer: Rc<Layer<CompositorData>>,
             pipeline_id: PipelineId,
             layer_id: LayerId,
             origin: Point2D<f32>,
-            window_size: TypedSize2D<PagePx, f32>,
-            page_to_device_pixels_scale: ScaleFactor<PagePx, DevicePixel, f32>)
+            window_size: TypedSize2D<DevicePixel, f32>)
             -> bool {
     // Search children for the right layer to move.
     if layer.extra_data.borrow().pipeline.id != pipeline_id ||
@@ -165,8 +164,7 @@ pub fn move(layer: Rc<Layer<CompositorData>>,
                  pipeline_id,
                  layer_id,
                  origin,
-                 window_size,
-                 page_to_device_pixels_scale)
+                 window_size)
         });
     }
 
@@ -174,25 +172,5 @@ pub fn move(layer: Rc<Layer<CompositorData>>,
         return false
     }
 
-    // Scroll this layer!
-    let old_origin = layer.extra_data.borrow().scroll_offset;
-    layer.extra_data.borrow_mut().scroll_offset = Point2D::from_untyped(&(origin * -1.0));
-
-    // bounds checking
-    let page_size = layer.bounds.borrow().size;
-    let window_size = window_size.to_untyped();
-    let scroll_offset = layer.extra_data.borrow().scroll_offset.to_untyped();
-
-    let min_x = (window_size.width - page_size.width).min(0.0);
-    layer.extra_data.borrow_mut().scroll_offset.x = Length(scroll_offset.x.clamp(&min_x, &0.0));
-    let min_y = (window_size.height - page_size.height).min(0.0);
-    layer.extra_data.borrow_mut().scroll_offset.y = Length(scroll_offset.y.clamp(&min_y, &0.0));
-
-    // check to see if we scrolled
-    if old_origin - layer.extra_data.borrow().scroll_offset == TypedPoint2D(0f32, 0f32) {
-        return false;
-    }
-
-    let offset = layer.extra_data.borrow().scroll_offset.clone();
-    scroll(layer.clone(), offset, page_to_device_pixels_scale)
+    clamp_scroll_offset_and_scroll_layer(layer, origin * -1.0, window_size.to_untyped())
 }


### PR DESCRIPTION
Instead of converting a device offset into a page offset and then
converting back when positioning layers, keep scroll offsets in device
pixels. We still do conversions when calculating the scroll offset for
pinch zoom, but we can remove those when pinch zoom and contents zoom
are fully separated.
