### PR TITLE
Paralellize test runs (Fixes #2980) [Do not merge]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,12 @@ before_script:
 - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./travis.osx.before_script.sh; fi
 
 script:
-- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./travis.linux.script.sh; fi
-- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./travis.osx.script.sh; fi
+- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then set -e; fi
+- cd build; ../configure
+- make tidy
+- make -j2
+- if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ../travis.linux.script.sh $AFTER_BUILD; fi
+- if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ../travis.osx.script.sh $AFTER_BUILD; fi
 
 git:
   submodules: true
@@ -32,4 +36,18 @@ branches:
     - master
 
 env:
-  - secure: qSjs06HEBF6A7ZyCWdltko+LkVz6OpNZQnEbr0nHB3rSl9mzwwjjH6v0VOKYNgvSPTgD8eHa/nnTeTcUJPaBB3mok+X43xkEUQWHLnW/X30QU0c8Xn+7db4hCgsaUupc1XaJhzpLDj3qV8dqDiGNKIwXJHlMzIuxSW424XL1CNc=
+  global:
+    - secure: qSjs06HEBF6A7ZyCWdltko+LkVz6OpNZQnEbr0nHB3rSl9mzwwjjH6v0VOKYNgvSPTgD8eHa/nnTeTcUJPaBB3mok+X43xkEUQWHLnW/X30QU0c8Xn+7db4hCgsaUupc1XaJhzpLDj3qV8dqDiGNKIwXJHlMzIuxSW424XL1CNc=
+  matrix:
+    - AFTER_BUILD=unit
+    - AFTER_BUILD=content
+    - AFTER_BUILD=ref
+    - AFTER_BUILD=wpt
+    - AFTER_BUILD=doc
+
+matrix:
+  exclude:
+    - os: linux
+      env: AFTER_BUILD=wpt
+    - os: osx
+      env: AFTER_BUILD=doc

--- a/travis.linux.script.sh
+++ b/travis.linux.script.sh
@@ -1,14 +1,10 @@
-set -e
-cd build
-../configure
 export DISPLAY=:1.0
 export RUST_TEST_TASKS=1
-make tidy
-make -j2
-make check-servo
-make check-content
-make check-ref-cpu
-make doc
+case $1 in
+unit) make check-servo ;;
+content) make check-content ;;
+ref) make check-ref-cpu ;;
+doc) make doc
 
 if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]
 then
@@ -17,3 +13,6 @@ then
     ghp-import -n doc
     git push -fq https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
 fi
+;;
+*) echo "Task $1 not enabled for Linux"
+esac

--- a/travis.osx.script.sh
+++ b/travis.osx.script.sh
@@ -1,4 +1,7 @@
-cd build
-../configure
-make tidy && make -j2 && make check-servo && make check-content && make check-ref-cpu
-WPTARGS="--processes=4" make check-wpt
+case $1 in
+unit) make check-servo ;;
+content) make check-content ;;
+ref) make check-ref-cpu ;;
+wpt) WPTARGS="--processes=4" make check-wpt ;;
+*) echo "Task $1 not enabled for OSX"
+esac


### PR DESCRIPTION
Also makes the build step a separate `script` step (makes it easier to collapse, and keeps the script files solely for testing)
