### PR TITLE
Add 'set -e' to the Travis OSX script.

### DIFF
--- a/travis.osx.script.sh
+++ b/travis.osx.script.sh
@@ -1,4 +1,9 @@
+set -e
 cd build
 ../configure
-make tidy && make -j2 && make check-servo && make check-content && make check-ref-cpu
+make tidy
+make -j2
+make check-servo
+make check-content
+make check-ref-cpu
 WPTARGS="--processes=4" make check-wpt


### PR DESCRIPTION
This ensures that the script actually fails if the build didn't succeed.
