### PR TITLE
Un-blacklist the layout crate from rustdoc.

### DIFF
--- a/mk/doc.mk
+++ b/mk/doc.mk
@@ -23,7 +23,7 @@ doc/$(1)/index.html: $$(DEPS_$(1)) $$(RUSTDOC_DEPS)
 else
 
 .PHONY: doc/$(1)/index.html
-doc/$(1)/index.html: $$(DEPS_$(1))
+doc/$(1)/index.html:
 	@echo SKIPPED: blacklisted rustdoc: $$@
 
 endif

--- a/mk/doc.mk
+++ b/mk/doc.mk
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+RUSTDOC_HTML_IN_HEADER = $(S)/src/etc/rustdoc-style.html
+RUSTDOC_FLAGS = --html-in-header $(RUSTDOC_HTML_IN_HEADER)
+RUSTDOC_DEPS = $(RUSTDOC_HTML_IN_HEADER)
+
 # FIXME(#2924) These crates make rustdoc fail for undetermined reasons.
 DOC_BLACKLISTED := style
 
@@ -11,9 +16,9 @@ doc-$(1): doc/$(1)/index.html
 
 ifeq (,$(filter $(1),$(DOC_BLACKLISTED)))
 
-doc/$(1)/index.html: $$(DEPS_$(1))
+doc/$(1)/index.html: $$(DEPS_$(1)) $$(RUSTDOC_DEPS)
 	@$$(call E, rustdoc: $$@)
-	$$(Q)$$(RUSTDOC) $$(RFLAGS_$(1)) $$<
+	$$(Q)$$(RUSTDOC) $$(RUSTDOC_FLAGS) $$(RFLAGS_$(1)) $$<
 
 else
 

--- a/mk/doc.mk
+++ b/mk/doc.mk
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # FIXME(#2924) These crates make rustdoc fail for undetermined reasons.
-DOC_BLACKLISTED := style layout
+DOC_BLACKLISTED := style
 
 define DEF_DOC_RULES
 .PHONY: doc-$(1)

--- a/src/components/layout/inline.rs
+++ b/src/components/layout/inline.rs
@@ -84,8 +84,6 @@ pub struct Line {
     ///
     /// The ranges that describe these lines would be:
     ///
-    /// <style>.content style ~ table th, style ~ table td { border: 1px solid #888 }
-    ///        .content style ~ table { border-collapse: collapse }</style>
     /// | [0.0, 1.4) | [1.5, 2.0)  | [2.0, 3.4)  | [3.4, 4.0) |
     /// |------------|-------------|-------------|------------|
     /// | 'I like'   | 'truffles,' | '<img> yes' | 'I do.'    |
@@ -164,8 +162,6 @@ pub struct LineIndices {
     ///
     /// The fragments would be indexed as follows:
     ///
-    /// <style>.content style ~ table th, style ~ table td { border: 1px solid #888 }
-    ///        .content style ~ table { border-collapse: collapse }</style>
     /// |  0   |        1         |    2    |       3      |
     /// |------|------------------|---------|--------------|
     /// | 'I ' | 'like truffles,' | `<img>` | ' yes I do.' |
@@ -182,8 +178,6 @@ pub struct LineIndices {
     ///
     /// The characters would be indexed as follows:
     ///
-    /// <style>.content style ~ table th, style ~ table td { border: 1px solid #888 }
-    ///        .content style ~ table { border-collapse: collapse }</style>
     /// | 0 | 1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 |
     /// |---|---|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|
     /// | I |   | l | i | k | e |   | t | r | u | f | f | l  | e  | s  | ,  |    |

--- a/src/components/layout/inline.rs
+++ b/src/components/layout/inline.rs
@@ -71,7 +71,7 @@ pub struct Line {
     /// <span>I <span>like truffles, <img></span> yes I do.</span>
     /// ~~~
     ///
-    /// ~~~
+    /// ~~~text
     /// +------------+
     /// | I like     |
     /// | truffles,  |
@@ -84,11 +84,11 @@ pub struct Line {
     ///
     /// The ranges that describe these lines would be:
     ///
-    /// ~~~
+    /// <style>.content style ~ table th, style ~ table td { border: 1px solid #888 }
+    ///        .content style ~ table { border-collapse: collapse }</style>
     /// | [0.0, 1.4) | [1.5, 2.0)  | [2.0, 3.4)  | [3.4, 4.0) |
     /// |------------|-------------|-------------|------------|
     /// | 'I like'   | 'truffles,' | '<img> yes' | 'I do.'    |
-    /// ~~~
     pub range: Range<LineIndices>,
     /// The bounds are the exact position and extents of the line with respect
     /// to the parent box.
@@ -101,7 +101,7 @@ pub struct Line {
     ///
     /// ...the bounds would be:
     ///
-    /// ~~~
+    /// ~~~text
     /// +-----------------------------------------------------------+
     /// |               ^                                           |
     /// |               |                                           |
@@ -123,7 +123,7 @@ pub struct Line {
     /// The green zone is the greatest extent from wich a line can extend to
     /// before it collides with a float.
     ///
-    /// ~~~
+    /// ~~~text
     /// +-----------------------+
     /// |:::::::::::::::::      |
     /// |:::::::::::::::::FFFFFF|
@@ -164,11 +164,11 @@ pub struct LineIndices {
     ///
     /// The fragments would be indexed as follows:
     ///
-    /// ~~~
-    /// |  0   |        1         |   2   |       3      |
-    /// |------|------------------|-------|--------------|
-    /// | 'I ' | 'like truffles,' | <img> | ' yes I do.' |
-    /// ~~~
+    /// <style>.content style ~ table th, style ~ table td { border: 1px solid #888 }
+    ///        .content style ~ table { border-collapse: collapse }</style>
+    /// |  0   |        1         |    2    |       3      |
+    /// |------|------------------|---------|--------------|
+    /// | 'I ' | 'like truffles,' | `<img>` | ' yes I do.' |
     pub fragment_index: FragmentIndex,
     /// The index of a character in a DOM fragment. Continuous runs of whitespace
     /// are treated as single characters. Non-breakable DOM fragments such as
@@ -182,15 +182,15 @@ pub struct LineIndices {
     ///
     /// The characters would be indexed as follows:
     ///
-    /// ~~~
+    /// <style>.content style ~ table th, style ~ table td { border: 1px solid #888 }
+    ///        .content style ~ table { border-collapse: collapse }</style>
     /// | 0 | 1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 |
     /// |---|---|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|
     /// | I |   | l | i | k | e |   | t | r | u | f | f | l  | e  | s  | ,  |    |
     ///
-    /// |   0   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
-    /// |-------|---|---|---|---|---|---|---|---|---|---|
-    /// | <img> |   | y | e | s |   | I |   | d | o | . |
-    /// ~~~
+    /// |    0    | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+    /// |---------|---|---|---|---|---|---|---|---|---|---|
+    /// | `<img>` |   | y | e | s |   | I |   | d | o | . |
     pub char_index: CharIndex,
 }
 

--- a/src/etc/rustdoc-style.html
+++ b/src/etc/rustdoc-style.html
@@ -1,0 +1,8 @@
+<style>
+.docblock table {
+    border-collapse: collapse;
+}
+.docblock table th, .docblock table td {
+    border: 1px solid #888;
+}
+</style>


### PR DESCRIPTION
See #2924. Whatever rustdoc bug we used to hit was solved by the Rust upgrade. (The style crate still causes rustdoc to overflow its stack.)

Also use Markdown tables rather than ASCII diagrams in inlines.rs. Not only does this look nicer, this works around rustdoc trying (and failing) to parse them as Rust code.
