### PR TITLE
Emergency fix for broken tree (mozlog update)

### DIFF
--- a/src/test/wpt/metadata/XMLHttpRequest/status-basic.htm.ini
+++ b/src/test/wpt/metadata/XMLHttpRequest/status-basic.htm.ini
@@ -1,8 +1,3 @@
 [status-basic.htm]
   type: testharness
-  [XMLHttpRequest: status/statusText - various responses 7 (GET 402)]
-    expected: FAIL
-
-  [XMLHttpRequest: status/statusText - various responses 9 (CHICKEN 402)]
-    expected: FAIL
-
+  disabled: true

--- a/src/test/wpt/run.sh
+++ b/src/test/wpt/run.sh
@@ -16,6 +16,8 @@ source _virtualenv/bin/activate
 if [[ $* == *--update-manifest* ]]; then
     (python -c "import html5lib" &>/dev/null) || pip install html5lib
 fi
+
+(python -c "import mozlog"  &>/dev/null) || pip install mozlog==2.1 #Temporary fix for broken tree
 (python -c "import wptrunner"  &>/dev/null) || pip install 'wptrunner==1.0'
 
 python $servo_root/src/test/wpt/run.py \


### PR DESCRIPTION
Same as #3006, but also disables a failing test.

Closes #3006.
