### PR TITLE
Rename messages used in rendering

### DIFF
--- a/src/components/compositing/compositor_task.rs
+++ b/src/components/compositing/compositor_task.rs
@@ -122,8 +122,8 @@ impl RenderListener for CompositorChan {
         }
     }
 
-    fn rerendermsg_discarded(&self) {
-        self.chan.send(ReRenderMsgDiscarded);
+    fn render_msg_discarded(&self) {
+        self.chan.send(RenderMsgDiscarded);
     }
 
     fn set_layer_clip_rect(&self,
@@ -188,8 +188,8 @@ pub enum Msg {
     ChangeReadyState(ReadyState),
     /// Alerts the compositor to the current status of rendering.
     ChangeRenderState(RenderState),
-    /// Alerts the compositor that the ReRenderMsg has been discarded.
-    ReRenderMsgDiscarded,
+    /// Alerts the compositor that the RenderMsg has been discarded.
+    RenderMsgDiscarded,
     /// Sets the channel to the current layout and render tasks, along with their id
     SetIds(SendableFrameTree, Sender<()>, ConstellationChan),
     /// The load of a page for a given URL has completed.

--- a/src/components/compositing/headless.rs
+++ b/src/components/compositing/headless.rs
@@ -5,7 +5,7 @@
 use compositor_task::{Msg, Exit, ChangeReadyState, SetIds};
 use compositor_task::{GetGraphicsMetadata, CreateOrUpdateRootLayer, CreateOrUpdateDescendantLayer};
 use compositor_task::{SetLayerClipRect, Paint, ScrollFragmentPoint, LoadComplete};
-use compositor_task::{ShutdownComplete, ChangeRenderState, ReRenderMsgDiscarded};
+use compositor_task::{ShutdownComplete, ChangeRenderState, RenderMsgDiscarded};
 
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
@@ -92,7 +92,7 @@ impl NullCompositor {
                 CreateOrUpdateDescendantLayer(..) |
                 SetLayerClipRect(..) | Paint(..) |
                 ChangeReadyState(..) | ChangeRenderState(..) | ScrollFragmentPoint(..) |
-                LoadComplete(..) | ReRenderMsgDiscarded(..) => ()
+                LoadComplete(..) | RenderMsgDiscarded(..) => ()
             }
         }
     }

--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -50,7 +50,7 @@ pub struct RenderLayer {
     pub scroll_policy: ScrollPolicy,
 }
 
-pub struct ReRenderRequest {
+pub struct RenderRequest {
     pub buffer_requests: Vec<BufferRequest>,
     pub scale: f32,
     pub layer_id: LayerId,
@@ -59,7 +59,7 @@ pub struct ReRenderRequest {
 
 pub enum Msg {
     RenderInitMsg(SmallVec1<RenderLayer>),
-    ReRenderMsg(Vec<ReRenderRequest>),
+    RenderMsg(Vec<RenderRequest>),
     UnusedBufferMsg(Vec<Box<LayerBuffer>>),
     PaintPermissionGranted,
     PaintPermissionRevoked,
@@ -237,19 +237,19 @@ impl<C:RenderListener + Send> RenderTask<C> {
                                       self.epoch,
                                       self.render_layers.as_slice());
                 }
-                ReRenderMsg(requests) => {
+                RenderMsg(requests) => {
                     if !self.paint_permission {
                         debug!("render_task: render ready msg");
                         let ConstellationChan(ref mut c) = self.constellation_chan;
                         c.send(RendererReadyMsg(self.id));
-                        self.compositor.rerendermsg_discarded();
+                        self.compositor.render_msg_discarded();
                         continue;
                     }
 
                     self.compositor.set_render_state(RenderingRenderState);
 
                     let mut replies = Vec::new();
-                    for ReRenderRequest { buffer_requests, scale, layer_id, epoch }
+                    for RenderRequest { buffer_requests, scale, layer_id, epoch }
                           in requests.move_iter() {
                         if self.epoch == epoch {
                             self.render(&mut replies, buffer_requests, scale, layer_id);

--- a/src/components/gfx/render_task.rs
+++ b/src/components/gfx/render_task.rs
@@ -58,7 +58,7 @@ pub struct ReRenderRequest {
 }
 
 pub enum Msg {
-    RenderMsg(SmallVec1<RenderLayer>),
+    RenderInitMsg(SmallVec1<RenderLayer>),
     ReRenderMsg(Vec<ReRenderRequest>),
     UnusedBufferMsg(Vec<Box<LayerBuffer>>),
     PaintPermissionGranted,
@@ -221,7 +221,7 @@ impl<C:RenderListener + Send> RenderTask<C> {
 
         loop {
             match self.port.recv() {
-                RenderMsg(render_layers) => {
+                RenderInitMsg(render_layers) => {
                     self.epoch.next();
                     self.render_layers = render_layers;
 

--- a/src/components/layout/layout_task.rs
+++ b/src/components/layout/layout_task.rs
@@ -28,7 +28,7 @@ use geom::size::Size2D;
 use gfx::display_list::{ClipDisplayItemClass, ContentStackingLevel, DisplayItem};
 use gfx::display_list::{DisplayItemIterator, DisplayList, OpaqueNode};
 use gfx::font_context::FontContext;
-use gfx::render_task::{RenderMsg, RenderChan, RenderLayer};
+use gfx::render_task::{RenderInitMsg, RenderChan, RenderLayer};
 use gfx::{render_task, color};
 use layout_traits::LayoutTaskFactory;
 use script::dom::bindings::js::JS;
@@ -736,7 +736,7 @@ impl LayoutTask {
 
                 debug!("Layout done!");
 
-                self.render_chan.send(RenderMsg(layers));
+                self.render_chan.send(RenderInitMsg(layers));
             });
         }
 

--- a/src/components/msg/compositor_msg.rs
+++ b/src/components/msg/compositor_msg.rs
@@ -105,7 +105,7 @@ pub trait RenderListener {
              epoch: Epoch,
              replies: Vec<(LayerId, Box<LayerBufferSet>)>);
 
-    fn rerendermsg_discarded(&self);
+    fn render_msg_discarded(&self);
     fn set_render_state(&self, render_state: RenderState);
 }
 


### PR DESCRIPTION
Rename `RenderMsg` to `RenderInitMsg` and `ReRenderMsg` to `RenderMsg` to better match their actual purpose.
