### PR TITLE
Have http://servo.github.io/servo/ include docs for the Rust version we use.

### DIFF
--- a/travis.linux.script.sh
+++ b/travis.linux.script.sh
@@ -8,6 +8,8 @@ make -j2
 make check-servo
 make check-content
 make check-ref-cpu
+
+mv x86_64-unknown-linux-gnu/rust_snapshot/rust-*/doc .
 make doc
 
 if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]


### PR DESCRIPTION
Closes #3038.
