### PR TITLE
Correct the fallibility of proxy operations in the *Methods trait (fixes #3041).

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4023,7 +4023,7 @@ class CGInterfaceTrait(CGThing):
                     assert len(operation.signatures()) == 1
                     rettype, arguments = operation.signatures()[0]
 
-                    infallible = 'infallible' in descriptor.getExtendedAttributes(m)
+                    infallible = 'infallible' in descriptor.getExtendedAttributes(operation)
                     arguments = method_arguments(rettype, arguments, ("found", "&mut bool"))
                     rettype = return_type(rettype, infallible)
                     yield name, arguments, rettype


### PR DESCRIPTION
A typo caused us to use the fallibility of the last normal method in the
interface.
