### PR TITLE
Refactor how LayoutContext structure works (reduce TLS lookups + simplify fns used by seq/parallel code paths).

### DIFF
--- a/src/components/layout/construct.rs
+++ b/src/components/layout/construct.rs
@@ -47,7 +47,6 @@ use wrapper::{PostorderNodeMutTraversal, TLayoutNode, ThreadSafeLayoutNode};
 use wrapper::{Before, BeforeBlock, After, AfterBlock, Normal};
 
 use gfx::display_list::OpaqueNode;
-use gfx::font_context::FontContext;
 use script::dom::element::{HTMLIFrameElementTypeId, HTMLImageElementTypeId};
 use script::dom::element::{HTMLObjectElementTypeId};
 use script::dom::element::{HTMLTableColElementTypeId, HTMLTableDataCellElementTypeId};
@@ -184,45 +183,18 @@ enum WhitespaceStrippingMode {
 }
 
 /// An object that knows how to create flows.
-pub struct FlowConstructor<'a> {
+pub struct FlowConstructor<'a, 'b> {
     /// The layout context.
-    pub layout_context: &'a mut LayoutContext,
-
-    /// An optional font context. If this is `None`, then we fetch the font context from the
-    /// layout context.
-    ///
-    /// FIXME(pcwalton): This is pretty bogus and is basically just a workaround for libgreen
-    /// having slow TLS.
-    pub font_context: Option<Box<FontContext>>,
+    pub layout_context: &'b LayoutContext<'b>,
 }
 
-impl<'a> FlowConstructor<'a> {
+impl<'a, 'b> FlowConstructor<'a, 'b> {
     /// Creates a new flow constructor.
-    pub fn new(layout_context: &'a mut LayoutContext, font_context: Option<Box<FontContext>>)
-               -> FlowConstructor<'a> {
+    pub fn new<'b>(layout_context: &'b LayoutContext)
+               -> FlowConstructor<'a, 'b> {
         FlowConstructor {
             layout_context: layout_context,
-            font_context: font_context,
         }
-    }
-
-    fn font_context<'a>(&'a mut self) -> &'a mut FontContext {
-        match self.font_context {
-            Some(ref mut font_context) => {
-                let font_context: &mut FontContext = &mut **font_context;
-                font_context
-            }
-            None => self.layout_context.font_context(),
-        }
-    }
-
-    /// Destroys this flow constructor and retrieves the font context.
-    pub fn unwrap_font_context(self) -> Option<Box<FontContext>> {
-        let FlowConstructor {
-            font_context,
-            ..
-        } = self;
-        font_context
     }
 
     /// Builds the `ImageFragmentInfo` for the given image. This is out of line to guide inlining.
@@ -233,7 +205,7 @@ impl<'a> FlowConstructor<'a> {
             Some(url) => {
                 // FIXME(pcwalton): The fact that image fragments store the cache within them makes
                 // little sense to me.
-                ImageFragment(ImageFragmentInfo::new(node, url, self.layout_context.image_cache.clone()))
+                ImageFragment(ImageFragmentInfo::new(node, url, self.layout_context.shared.image_cache.clone()))
             }
         }
     }
@@ -293,11 +265,11 @@ impl<'a> FlowConstructor<'a> {
         }
 
         let mut inline_flow = box InlineFlow::from_fragments((*node).clone(), fragments);
-        let (ascent, descent) = inline_flow.compute_minimum_ascent_and_descent(self.font_context(), &**node.style());
+        let (ascent, descent) = inline_flow.compute_minimum_ascent_and_descent(self.layout_context.font_context(), &**node.style());
         inline_flow.minimum_block_size_above_baseline = ascent;
         inline_flow.minimum_depth_below_baseline = descent;
         let mut inline_flow = inline_flow as Box<Flow>;
-        TextRunScanner::new().scan_for_runs(self.font_context(), inline_flow);
+        TextRunScanner::new().scan_for_runs(self.layout_context.font_context(), inline_flow);
         let mut inline_flow = FlowRef::new(inline_flow);
         inline_flow.finish(self.layout_context);
 
@@ -797,7 +769,7 @@ impl<'a> FlowConstructor<'a> {
     }
 }
 
-impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
+impl<'a, 'b> PostorderNodeMutTraversal for FlowConstructor<'a, 'b> {
     // Construct Flow based on 'display', 'position', and 'float' values.
     //
     // CSS 2.1 Section 9.7
@@ -1039,7 +1011,7 @@ pub trait FlowConstructionUtils {
     ///
     /// All flows must be finished at some point, or they will not have their intrinsic inline-sizes
     /// properly computed. (This is not, however, a memory safety problem.)
-    fn finish(&mut self, context: &mut LayoutContext);
+    fn finish(&mut self, context: &LayoutContext);
 }
 
 impl FlowConstructionUtils for FlowRef {
@@ -1066,8 +1038,8 @@ impl FlowConstructionUtils for FlowRef {
     /// properly computed. (This is not, however, a memory safety problem.)
     ///
     /// This must not be public because only the layout constructor can do this.
-    fn finish(&mut self, context: &mut LayoutContext) {
-        if !context.opts.bubble_inline_sizes_separately {
+    fn finish(&mut self, context: &LayoutContext) {
+        if !context.shared.opts.bubble_inline_sizes_separately {
             self.get_mut().bubble_inline_sizes(context)
         }
     }

--- a/src/components/layout/flow.rs
+++ b/src/components/layout/flow.rs
@@ -149,24 +149,24 @@ pub trait Flow: fmt::Show + ToString + Share {
     /// this flow, all child flows have had their minimum and preferred inline-sizes set. This function
     /// must decide minimum/preferred inline-sizes based on its children's inline-sizes and the dimensions of
     /// any boxes it is responsible for flowing.
-    fn bubble_inline_sizes(&mut self, _ctx: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, _ctx: &LayoutContext) {
         fail!("bubble_inline_sizes not yet implemented")
     }
 
     /// Pass 2 of reflow: computes inline-size.
-    fn assign_inline_sizes(&mut self, _ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, _ctx: &LayoutContext) {
         fail!("assign_inline_sizes not yet implemented")
     }
 
     /// Pass 3a of reflow: computes block-size.
-    fn assign_block_size(&mut self, _ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, _ctx: &'a LayoutContext<'a>) {
         fail!("assign_block_size not yet implemented")
     }
 
     /// Assigns block-sizes in-order; or, if this is a float, places the float. The default
     /// implementation simply assigns block-sizes if this flow is impacted by floats. Returns true if
     /// this child was impacted by floats or false otherwise.
-    fn assign_block_size_for_inorder_child_if_necessary(&mut self, layout_context: &mut LayoutContext)
+    fn assign_block_size_for_inorder_child_if_necessary<'a>(&mut self, layout_context: &'a LayoutContext<'a>)
                                                     -> bool {
         let impacted = base(&*self).flags.impacted_by_floats();
         if impacted {
@@ -365,7 +365,7 @@ pub trait MutableFlowUtils {
     // Mutators
 
     /// Computes the overflow region for this flow.
-    fn store_overflow(self, _: &mut LayoutContext);
+    fn store_overflow(self, _: &LayoutContext);
 
     /// Builds the display lists for this flow.
     fn build_display_list(self, layout_context: &LayoutContext);
@@ -963,7 +963,7 @@ impl<'a> MutableFlowUtils for &'a mut Flow {
     /// Assumption: This is called in a bottom-up traversal, so kids' overflows have
     /// already been set.
     /// Assumption: Absolute descendants have had their overflow calculated.
-    fn store_overflow(self, _: &mut LayoutContext) {
+    fn store_overflow(self, _: &LayoutContext) {
         let my_position = mut_base(self).position;
         let mut overflow = my_position;
 

--- a/src/components/layout/fragment.rs
+++ b/src/components/layout/fragment.rs
@@ -660,7 +660,7 @@ impl Fragment {
             Some(ref image_url) => image_url,
         };
 
-        let mut holder = ImageHolder::new(image_url.clone(), layout_context.image_cache.clone());
+        let mut holder = ImageHolder::new(image_url.clone(), layout_context.shared.image_cache.clone());
         let image = match holder.get_image() {
             None => {
                 // No image data at all? Do nothing.
@@ -860,7 +860,7 @@ impl Fragment {
                absolute_fragment_bounds,
                self);
         debug!("Fragment::build_display_list: dirty={}, flow_origin={}",
-               layout_context.dirty,
+               layout_context.shared.dirty,
                flow_origin);
 
         let mut accumulator = ChildDisplayListAccumulator::new(self.style(),
@@ -871,7 +871,7 @@ impl Fragment {
             return accumulator
         }
 
-        if !absolute_fragment_bounds.intersects(&layout_context.dirty) {
+        if !absolute_fragment_bounds.intersects(&layout_context.shared.dirty) {
             debug!("Fragment::build_display_list: Did not intersect...");
             return accumulator
         }
@@ -1431,7 +1431,7 @@ impl Fragment {
                iframe_fragment.pipeline_id,
                iframe_fragment.subpage_id);
         let msg = FrameRectMsg(iframe_fragment.pipeline_id, iframe_fragment.subpage_id, rect);
-        let ConstellationChan(ref chan) = layout_context.constellation_chan;
+        let ConstellationChan(ref chan) = layout_context.shared.constellation_chan;
         chan.send(msg)
     }
 }

--- a/src/components/layout/inline.rs
+++ b/src/components/layout/inline.rs
@@ -932,7 +932,7 @@ impl InlineFlow {
         // FIXME(#2795): Get the real container size
         let container_size = Size2D::zero();
         if !abs_rect.to_physical(self.base.writing_mode, container_size)
-                    .intersects(&layout_context.dirty) {
+                    .intersects(&layout_context.shared.dirty) {
             return
         }
 
@@ -1090,7 +1090,7 @@ impl Flow for InlineFlow {
         self
     }
 
-    fn bubble_inline_sizes(&mut self, _: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, _: &LayoutContext) {
         let writing_mode = self.base.writing_mode;
         for kid in self.base.child_iter() {
             flow::mut_base(kid).floats = Floats::new(writing_mode);
@@ -1115,7 +1115,7 @@ impl Flow for InlineFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments. When called
     /// on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, _: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, _: &LayoutContext) {
         // Initialize content fragment inline-sizes if they haven't been initialized already.
         //
         // TODO: Combine this with `LineBreaker`'s walk in the fragment list, or put this into `Fragment`.
@@ -1144,7 +1144,7 @@ impl Flow for InlineFlow {
     }
 
     /// Calculate and set the block-size of this flow. See CSS 2.1 § 10.6.1.
-    fn assign_block_size(&mut self, _: &mut LayoutContext) {
+    fn assign_block_size(&mut self, _: &LayoutContext) {
         debug!("assign_block_size_inline: assigning block_size for flow");
 
         // Divide the fragments into lines.

--- a/src/components/layout/table.rs
+++ b/src/components/layout/table.rs
@@ -125,7 +125,7 @@ impl TableFlow {
     /// inline(always) because this is only ever called by in-order or non-in-order top-level
     /// methods
     #[inline(always)]
-    fn assign_block_size_table_base(&mut self, layout_context: &mut LayoutContext) {
+    fn assign_block_size_table_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
         self.block_flow.assign_block_size_block_base(layout_context, MarginsMayNotCollapse);
     }
 
@@ -164,7 +164,7 @@ impl Flow for TableFlow {
     /// table layout calculation.
     /// The maximum min/pref inline-sizes of each column are set from the rows for the automatic
     /// table layout calculation.
-    fn bubble_inline_sizes(&mut self, _: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, _: &LayoutContext) {
         let mut min_inline_size = Au(0);
         let mut pref_inline_size = Au(0);
         let mut did_first_row = false;
@@ -235,7 +235,7 @@ impl Flow for TableFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments. When
     /// called on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table");
 
         // The position was set to the containing block by the flow's parent.
@@ -282,7 +282,7 @@ impl Flow for TableFlow {
         self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge, content_inline_size, Some(self.col_inline_sizes.clone()));
     }
 
-    fn assign_block_size(&mut self, ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         debug!("assign_block_size: assigning block_size for table");
         self.assign_block_size_table_base(ctx);
     }
@@ -309,7 +309,7 @@ impl ISizeAndMarginsComputer for InternalTable {
     /// CSS Section 10.4: Minimum and Maximum inline-sizes
     fn compute_used_inline_size(&self,
                           block: &mut BlockFlow,
-                          ctx: &mut LayoutContext,
+                          ctx: &LayoutContext,
                           parent_flow_inline_size: Au) {
         let input = self.compute_inline_size_constraint_inputs(block, parent_flow_inline_size, ctx);
         let solution = self.solve_inline_size_constraints(block, &input);

--- a/src/components/layout/table_caption.rs
+++ b/src/components/layout/table_caption.rs
@@ -47,16 +47,16 @@ impl Flow for TableCaptionFlow {
         &mut self.block_flow
     }
 
-    fn bubble_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, ctx: &LayoutContext) {
         self.block_flow.bubble_inline_sizes(ctx);
     }
 
-    fn assign_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_caption");
         self.block_flow.assign_inline_sizes(ctx);
     }
 
-    fn assign_block_size(&mut self, ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         debug!("assign_block_size: assigning block_size for table_caption");
         self.block_flow.assign_block_size(ctx);
     }

--- a/src/components/layout/table_cell.rs
+++ b/src/components/layout/table_cell.rs
@@ -45,7 +45,7 @@ impl TableCellFlow {
     /// inline(always) because this is only ever called by in-order or non-in-order top-level
     /// methods
     #[inline(always)]
-    fn assign_block_size_table_cell_base(&mut self, layout_context: &mut LayoutContext) {
+    fn assign_block_size_table_cell_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
         self.block_flow.assign_block_size_block_base(layout_context, MarginsMayNotCollapse)
     }
 
@@ -69,7 +69,7 @@ impl Flow for TableCellFlow {
     }
 
     /// Minimum/preferred inline-sizes set by this function are used in automatic table layout calculation.
-    fn bubble_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, ctx: &LayoutContext) {
         self.block_flow.bubble_inline_sizes(ctx);
         let specified_inline_size = MaybeAuto::from_style(self.block_flow.fragment.style().content_inline_size(),
                                                     Au::new(0)).specified_or_zero();
@@ -85,7 +85,7 @@ impl Flow for TableCellFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments. When
     /// called on this context, the context has had its inline-size set by the parent table row.
-    fn assign_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_cell");
 
         // The position was set to the column inline-size by the parent flow, table row flow.
@@ -104,7 +104,7 @@ impl Flow for TableCellFlow {
                                                              None);
     }
 
-    fn assign_block_size(&mut self, ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         debug!("assign_block_size: assigning block_size for table_cell");
         self.assign_block_size_table_cell_base(ctx);
     }

--- a/src/components/layout/table_colgroup.rs
+++ b/src/components/layout/table_colgroup.rs
@@ -52,7 +52,7 @@ impl Flow for TableColGroupFlow {
         self
     }
 
-    fn bubble_inline_sizes(&mut self, _: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, _: &LayoutContext) {
         for fragment in self.cols.iter() {
             // get the specified value from inline-size property
             let inline_size = MaybeAuto::from_style(fragment.style().content_inline_size(),
@@ -70,11 +70,11 @@ impl Flow for TableColGroupFlow {
 
     /// Table column inline-sizes are assigned in table flow and propagated to table row or rowgroup flow.
     /// Therefore, table colgroup flow does not need to assign its inline-size.
-    fn assign_inline_sizes(&mut self, _ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, _ctx: &LayoutContext) {
     }
 
     /// Table column do not have block-size.
-    fn assign_block_size(&mut self, _ctx: &mut LayoutContext) {
+    fn assign_block_size(&mut self, _ctx: &LayoutContext) {
     }
 }
 

--- a/src/components/layout/table_row.rs
+++ b/src/components/layout/table_row.rs
@@ -75,7 +75,7 @@ impl TableRowFlow {
     /// inline(always) because this is only ever called by in-order or non-in-order top-level
     /// methods
     #[inline(always)]
-    fn assign_block_size_table_row_base(&mut self, layout_context: &mut LayoutContext) {
+    fn assign_block_size_table_row_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
         let (block_start_offset, _, _) = self.initialize_offsets();
 
         let /* mut */ cur_y = block_start_offset;
@@ -165,7 +165,7 @@ impl Flow for TableRowFlow {
     /// responsible for flowing.
     /// Min/pref inline-sizes set by this function are used in automatic table layout calculation.
     /// The specified column inline-sizes of children cells are used in fixed table layout calculation.
-    fn bubble_inline_sizes(&mut self, _: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, _: &LayoutContext) {
         let mut min_inline_size = Au(0);
         let mut pref_inline_size = Au(0);
         /* find the specified inline_sizes from child table-cell contexts */
@@ -194,7 +194,7 @@ impl Flow for TableRowFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments. When called
     /// on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_row");
 
         // The position was set to the containing block by the flow's parent.
@@ -208,7 +208,7 @@ impl Flow for TableRowFlow {
         self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge, Au(0), Some(self.col_inline_sizes.clone()));
     }
 
-    fn assign_block_size(&mut self, ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         debug!("assign_block_size: assigning block_size for table_row");
         self.assign_block_size_table_row_base(ctx);
     }

--- a/src/components/layout/table_rowgroup.rs
+++ b/src/components/layout/table_rowgroup.rs
@@ -74,7 +74,7 @@ impl TableRowGroupFlow {
     /// inline(always) because this is only ever called by in-order or non-in-order top-level
     /// methods
     #[inline(always)]
-    fn assign_block_size_table_rowgroup_base(&mut self, layout_context: &mut LayoutContext) {
+    fn assign_block_size_table_rowgroup_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
         let (block_start_offset, _, _) = self.initialize_offsets();
 
         let mut cur_y = block_start_offset;
@@ -133,7 +133,7 @@ impl Flow for TableRowGroupFlow {
     /// Min/pref inline-sizes set by this function are used in automatic table layout calculation.
     /// Also, this function finds the specified column inline-sizes from the first row.
     /// Those are used in fixed table layout calculation
-    fn bubble_inline_sizes(&mut self, _: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, _: &LayoutContext) {
         let mut min_inline_size = Au(0);
         let mut pref_inline_size = Au(0);
 
@@ -175,7 +175,7 @@ impl Flow for TableRowGroupFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments. When
     /// called on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_rowgroup");
 
         // The position was set to the containing block by the flow's parent.
@@ -191,7 +191,7 @@ impl Flow for TableRowGroupFlow {
         self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge, content_inline_size, Some(self.col_inline_sizes.clone()));
     }
 
-    fn assign_block_size(&mut self, ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         debug!("assign_block_size: assigning block_size for table_rowgroup");
         self.assign_block_size_table_rowgroup_base(ctx);
     }

--- a/src/components/layout/table_wrapper.rs
+++ b/src/components/layout/table_wrapper.rs
@@ -100,7 +100,7 @@ impl TableWrapperFlow {
     /// inline(always) because this is only ever called by in-order or non-in-order top-level
     /// methods
     #[inline(always)]
-    fn assign_block_size_table_wrapper_base(&mut self, layout_context: &mut LayoutContext) {
+    fn assign_block_size_table_wrapper_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
         self.block_flow.assign_block_size_block_base(layout_context, MarginsMayNotCollapse);
     }
 
@@ -129,7 +129,7 @@ impl Flow for TableWrapperFlow {
     min/pref inline_sizes based on child context inline_sizes and dimensions of
     any fragments it is responsible for flowing.  */
 
-    fn bubble_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn bubble_inline_sizes(&mut self, ctx: &LayoutContext) {
         // get column inline-sizes info from table flow
         for kid in self.block_flow.base.child_iter() {
             assert!(kid.is_table_caption() || kid.is_table());
@@ -147,7 +147,7 @@ impl Flow for TableWrapperFlow {
     ///
     /// Dual fragments consume some inline-size first, and the remainder is assigned to all child (block)
     /// contexts.
-    fn assign_inline_sizes(&mut self, ctx: &mut LayoutContext) {
+    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow",
                if self.is_float() {
                    "floated table_wrapper"
@@ -178,7 +178,7 @@ impl Flow for TableWrapperFlow {
         self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge, content_inline_size, assigned_col_inline_sizes);
     }
 
-    fn assign_block_size(&mut self, ctx: &mut LayoutContext) {
+    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         if self.is_float() {
             debug!("assign_block_size_float: assigning block_size for floated table_wrapper");
             self.block_flow.assign_block_size_float(ctx);
@@ -208,7 +208,7 @@ struct TableWrapper;
 impl TableWrapper {
     fn compute_used_inline_size_table_wrapper(&self,
                                         table_wrapper: &mut TableWrapperFlow,
-                                        ctx: &mut LayoutContext,
+                                        ctx: &LayoutContext,
                                         parent_flow_inline_size: Au) {
         let input = self.compute_inline_size_constraint_inputs_table_wrapper(table_wrapper,
                                                                        parent_flow_inline_size,
@@ -223,7 +223,7 @@ impl TableWrapper {
     fn compute_inline_size_constraint_inputs_table_wrapper(&self,
                                                      table_wrapper: &mut TableWrapperFlow,
                                                      parent_flow_inline_size: Au,
-                                                     ctx: &mut LayoutContext)
+                                                     ctx: &LayoutContext)
                                                      -> ISizeConstraintInput {
         let mut input = self.compute_inline_size_constraint_inputs(&mut table_wrapper.block_flow,
                                                              parent_flow_inline_size,


### PR DESCRIPTION
- LayoutContext is renamed to SharedLayoutContext.
- SharedLayoutContext is immutable.
- LayoutContext is a wrapper around SharedLayoutContext + access to local caches (font, style etc).
- Creating a LayoutContext does a single local_data lookup to fetch the cache information.
- Android shares same implementation of context.rs as other platforms.
- LayoutContext can be used from both green thread (parallel layout) and native thread (sequential layout).
- Removes the need for other types (such as FontContext, StyleSharingCandidateCache etc) to be passed around.
