### PR TITLE
Implement window.atob/btoa

### DIFF
--- a/src/components/script/dom/webidls/Window.webidl
+++ b/src/components/script/dom/webidls/Window.webidl
@@ -74,6 +74,16 @@ interface WindowTimers {
 };
 Window implements WindowTimers;
 
+// http://www.whatwg.org/html/#atob
+[NoInterfaceObject/*, Exposed=Window,Worker*/]
+interface WindowBase64 {
+  [Throws]
+  DOMString btoa(DOMString btoa);
+  [Throws]
+  DOMString atob(DOMString atob);
+};
+Window implements WindowBase64;
+
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#sec-window.performance-attribute
 partial interface Window {
   /*[Replaceable]*/ readonly attribute Performance performance;


### PR DESCRIPTION
This provides functionality required in https://github.com/servo/servo/issues/3020. The implementation uses serialize::base64, but some preprocessing is required in order to match the HTML spec and pass the wpt tests. It's possible to improve efficiency by performing the extra work inline, within the serialize::base64 implementation, if it's desireable to change the standard library to match the web spec. For now, here's an implementation that passes the wpt tests and uses the Rust library as it is today.
