### PR TITLE
Implement HTMLAnchorElement.text

### DIFF
--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -5,6 +5,8 @@
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLAnchorElementBinding;
+use dom::bindings::codegen::Bindings::HTMLAnchorElementBinding::HTMLAnchorElementMethods;
+use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
@@ -112,5 +114,17 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
 impl Reflectable for HTMLAnchorElement {
     fn reflector<'a>(&'a self) -> &'a Reflector {
         self.htmlelement.reflector()
+    }
+}
+
+impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
+    fn Text(&self) -> DOMString {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.GetTextContent().unwrap()
+    }
+
+    fn SetText(&self, value: DOMString) {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.SetTextContent(Some(value))
     }
 }

--- a/src/components/script/dom/webidls/HTMLAnchorElement.webidl
+++ b/src/components/script/dom/webidls/HTMLAnchorElement.webidl
@@ -21,7 +21,8 @@ interface HTMLAnchorElement : HTMLElement {
   //         attribute DOMString hreflang;
   //         attribute DOMString type;
 
-  //         attribute DOMString text;
+  [Pure]
+           attribute DOMString text;
 
   // also has obsolete members
 };


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/3021. I'm not sure about the [Pure] on the text attribute in the webidl, but it's present on Node.textContent, which HTMLAnchorElement.text shadows.
