### PR TITLE
node.textContent and node.nodeValue should not throw

### DIFF
--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -18,7 +18,7 @@ use dom::bindings::codegen::InheritTypes::{CharacterDataCast, NodeBase, NodeDeri
 use dom::bindings::codegen::InheritTypes::{ProcessingInstructionCast, EventTargetCast};
 use dom::bindings::codegen::InheritTypes::{HTMLLegendElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementDerived;
-use dom::bindings::error::{ErrorResult, Fallible, NotFound, HierarchyRequest, Syntax};
+use dom::bindings::error::{Fallible, NotFound, HierarchyRequest, Syntax};
 use dom::bindings::global::{GlobalRef, Window};
 use dom::bindings::js::{JS, JSRef, RootedReference, Temporary, Root, OptionalUnrootable};
 use dom::bindings::js::{OptionalSettable, TemporaryPushable, OptionalRootedRootable};
@@ -1557,14 +1557,14 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodevalue
-    fn SetNodeValue(&self, val: Option<DOMString>) -> ErrorResult {
+    fn SetNodeValue(&self, val: Option<DOMString>) {
         match self.type_id {
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
                 self.SetTextContent(val)
             }
-            _ => Ok(())
+            _ => {}
         }
     }
 
@@ -1596,7 +1596,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-textcontent
-    fn SetTextContent(&self, value: Option<DOMString>) -> ErrorResult {
+    fn SetTextContent(&self, value: Option<DOMString>) {
         let value = null_str_as_empty(&value);
         match self.type_id {
             DocumentFragmentNodeTypeId |
@@ -1627,7 +1627,6 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             DoctypeNodeTypeId |
             DocumentNodeTypeId => {}
         }
-        Ok(())
     }
 
     // http://dom.spec.whatwg.org/#dom-node-insertbefore

--- a/src/components/script/dom/webidls/Node.webidl
+++ b/src/components/script/dom/webidls/Node.webidl
@@ -46,9 +46,9 @@ interface Node : EventTarget {
   [Pure]
   readonly attribute Node? nextSibling;
 
-  [SetterThrows, Pure]
+  [Pure]
            attribute DOMString? nodeValue;
-  [SetterThrows, Pure]
+  [Pure]
            attribute DOMString? textContent;
   void normalize();
 


### PR DESCRIPTION
[`node.textContent`](http://dom.spec.whatwg.org/#dom-node-textcontent) and [`node.nodeValue`](http://dom.spec.whatwg.org/#dom-node-nodevalue) both don't throw anything according to the spec.
