### PR TITLE
Implement HTMLTitleElement.text (closes #3025)

### DIFF
--- a/src/components/script/dom/htmltitleelement.rs
+++ b/src/components/script/dom/htmltitleelement.rs
@@ -3,14 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLTitleElementBinding;
-use dom::bindings::codegen::InheritTypes::HTMLTitleElementDerived;
+use dom::bindings::codegen::Bindings::HTMLTitleElementBinding::HTMLTitleElementMethods;
+use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use dom::bindings::codegen::InheritTypes::{HTMLTitleElementDerived, NodeCast, TextCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::HTMLTitleElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, ElementNodeTypeId};
+use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
+use dom::text::Text;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -34,6 +37,28 @@ impl HTMLTitleElement {
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTitleElement> {
         let element = HTMLTitleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTitleElementBinding::Wrap)
+    }
+}
+
+impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
+    // http://www.whatwg.org/html/#dom-title-text
+    fn Text(&self) -> DOMString {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let mut content = String::new();
+        for child in node.children() {
+            let text: Option<&JSRef<Text>> = TextCast::to_ref(&child);
+            match text {
+                Some(text) => content.push_str(text.characterdata.data.borrow().as_slice()),
+                None => (),
+            }
+        }
+        content
+    }
+
+    // http://www.whatwg.org/html/#dom-title-text
+    fn SetText(&self, value: DOMString) {
+        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        node.SetTextContent(Some(value))
     }
 }
 

--- a/src/components/script/dom/webidls/HTMLTitleElement.webidl
+++ b/src/components/script/dom/webidls/HTMLTitleElement.webidl
@@ -5,5 +5,6 @@
 
 // http://www.whatwg.org/html/#htmltitleelement
 interface HTMLTitleElement : HTMLElement {
-  //         attribute DOMString text;
+    [Pure]
+           attribute DOMString text;
 };


### PR DESCRIPTION
Fix seems identical to fix implemented in #3095, with `Script` replaced with `Title`. Seems like there's a better way to accomplish this without having nearly identical code in two places (maybe more, depending on other `.text` issues). Just adding this for reference.
