### PR TITLE
Prevent margin collapse in the root flow

### DIFF
--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -93,3 +93,4 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == line_height_a.html line_height_ref.html
 == block_replaced_content_a.html block_replaced_content_ref.html
 == block_replaced_content_b.html block_replaced_content_ref.html
+== root_margin_collapse_a.html root_margin_collapse_b.html

--- a/src/test/ref/root_margin_collapse_a.html
+++ b/src/test/ref/root_margin_collapse_a.html
@@ -1,0 +1,5 @@
+<html style="margin-top: 10px;">
+    <body style="margin-top: 10px;">
+        <div style="width: 100px; height: 100px; background: black;"></div>
+    </body>
+</html>

--- a/src/test/ref/root_margin_collapse_b.html
+++ b/src/test/ref/root_margin_collapse_b.html
@@ -1,0 +1,5 @@
+<html>
+    <body style="margin-top: 20px;">
+        <div style="width: 100px; height: 100px; background: black;"></div>
+    </body>
+</html>


### PR DESCRIPTION
According to the CSS specification, section 8.3.1, margins of the root
element's box do not collapse. Ensure that root flow margins do not
collapse during the assign heights phase.
