### PR TITLE
Reftest harness walks directory and appends tests for all manifest files

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -86,12 +86,12 @@ check-servo: $(foreach lib_crate,$(SERVO_LIB_CRATES),check-servo-$(lib_crate)) s
 .PHONY: check-ref-cpu
 check-ref-cpu: reftest
 	@$(call E, check: reftests with CPU rendering)
-	$(Q)./reftest cpu $(S)src/test/ref/basic.list $(TESTNAME)
+	$(Q)./reftest cpu $(S)src/test/ref $(TESTNAME)
 
 .PHONY: check-ref-gpu
 check-ref-gpu: reftest
 	@$(call E, check: reftests with GPU rendering)
-	$(Q)./reftest gpu $(S)src/test/ref/basic.list $(TESTNAME)
+	$(Q)./reftest gpu $(S)src/test/ref $(TESTNAME)
 
 .PHONY: check-ref
 check-ref: check-ref-cpu check-ref-gpu


### PR DESCRIPTION
it finds. This is a first step towards importing some of the css-wg reftests.
