### PR TITLE
Use extended attributes to define which interfaces are globals (fixes #1053).

### DIFF
--- a/src/components/script/dom/bindings/codegen/Bindings.conf
+++ b/src/components/script/dom/bindings/codegen/Bindings.conf
@@ -15,14 +15,10 @@
 
 DOMInterfaces = {
 
-'DedicatedWorkerGlobalScope': {
-    'createGlobal': True,
-},
 'EventListener': {
     'nativeType': 'EventListenerBinding::EventListener',
 },
 'Window': {
-    'createGlobal': True,
     'outerObjectHook': 'Some(bindings::utils::outerize_global)',
 },
 

--- a/src/components/script/dom/bindings/codegen/Configuration.py
+++ b/src/components/script/dom/bindings/codegen/Configuration.py
@@ -155,7 +155,6 @@ class Descriptor(DescriptorProvider):
         self.memberType = "Root<'a, 'b, %s>" % ifaceName
         self.nativeType = desc.get('nativeType', 'JS<%s>' % ifaceName)
         self.concreteType = desc.get('concreteType', ifaceName)
-        self.createGlobal = desc.get('createGlobal', False)
         self.register = desc.get('register', True)
         self.outerObjectHook = desc.get('outerObjectHook', 'None')
 
@@ -280,6 +279,15 @@ class Descriptor(DescriptorProvider):
             throws = member.getExtendedAttribute(throwsAttr)
         maybeAppendInfallibleToAttrs(attrs, throws)
         return attrs
+
+    def isGlobal(self):
+        """
+        Returns true if this is the primary interface for a global object
+        of some sort.
+        """
+        return (self.interface.getExtendedAttribute("Global") or
+                self.interface.getExtendedAttribute("PrimaryGlobal"))
+
 
 # Some utility methods
 def getTypesFromDescriptor(descriptor):

--- a/src/components/script/dom/webidls/Window.webidl
+++ b/src/components/script/dom/webidls/Window.webidl
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // http://www.whatwg.org/html/#window
-//[PrimaryGlobal]
+[PrimaryGlobal]
 /*sealed*/ interface Window : EventTarget {
   // the current browsing context
   //[Unforgeable] readonly attribute WindowProxy window;


### PR DESCRIPTION
This makes our approach consistent with Gecko's.
