### PR TITLE
check the type/language of script elements

### DIFF
--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -23,7 +23,7 @@ use servo_net::resource_task::{Load, LoadData, Payload, Done, ResourceTask, load
 use servo_util::atom::Atom;
 use servo_util::namespace;
 use servo_util::namespace::{Namespace, Null};
-use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS};
+use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
 use servo_util::task::spawn_named;
 use std::ascii::StrAsciiExt;
 use std::mem;
@@ -291,6 +291,57 @@ pub fn build_element_from_tag(tag: DOMString, ns: Namespace, document: &JSRef<Do
     return ElementCast::from_temporary(HTMLUnknownElement::new(tag, document));
 }
 
+// List found at http://whatwg.org/html#support-the-scripting-language
+static SCRIPT_JS_MIMES: StaticStringVec = &[
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+];
+
+fn is_javascript(script: &JSRef<Element>) -> bool {
+    match script.get_attribute(Null, "type").root().map(|s| s.Value()) {
+        Some(ref s) if s.is_empty() => {
+            // type attr exists, but empty means js
+            debug!("script type empty, inferring js");
+            true
+        },
+        Some(ref s) => {
+            debug!("script type={:s}", *s);
+            SCRIPT_JS_MIMES.contains(&s.as_slice().trim_chars(HTML_SPACE_CHARACTERS))
+        },
+        None => {
+            debug!("no script type");
+            match script.get_attribute(Null, "language").root().map(|s| s.Value()) {
+                Some(ref s) if s.is_empty() => {
+                    debug!("script language empty, inferring js");
+                    true
+                },
+                Some(ref s) => {
+                    debug!("script language={:s}", *s);
+                    SCRIPT_JS_MIMES.contains(&"text/".to_string().append(s.as_slice()).as_slice())
+                },
+                None => {
+                    debug!("no script type or language, inferring js");
+                    true
+                }
+            }
+        }
+    }
+}
+
 pub fn parse_html(page: &Page,
                   document: &JSRef<Document>,
                   url: Url,
@@ -494,6 +545,11 @@ pub fn parse_html(page: &Page,
         complete_script: |script| {
             unsafe {
                 let script: &JSRef<Element> = &*from_hubbub_node(script).root();
+
+                if !is_javascript(script) {
+                    return;
+                }
+
                 match script.get_attribute(Null, "src").root() {
                     Some(src) => {
                         debug!("found script: {:s}", src.deref().Value());

--- a/src/test/content/harness.js
+++ b/src/test/content/harness.js
@@ -3,12 +3,20 @@ function _oneline(x) {
   return (i == -1) ? x : (x.slice(0, i) + "...");
 }
 
+var _expectations = 0;
+var _tests = 0;
+function expect(num) {
+  _expectations = num;
+}
+
 function _fail(s, m) {
+  _tests++;
   // string split to avoid problems with tests that end up printing the value of window._fail.
   window.alert(_oneline("TEST-UNEXPECTED" + "-FAIL | " + s + ": " + m));
 }
 
 function _pass(s, m) {
+  _tests++;
   window.alert(_oneline("TEST-PASS | " + s + ": " + m));
 }
 
@@ -67,6 +75,9 @@ function check_disabled_selector(elem, disabled) {
 var _test_complete = false;
 var _test_timeout = 10000; //10 seconds
 function finish() {
+  if (_expectations > _tests) {
+    _fail('expected ' + _expectations + ' tests, fullfilled ' + _tests);
+  }
   _test_complete = true;
   window.close();
 }

--- a/src/test/content/test_script_type.html
+++ b/src/test/content/test_script_type.html
@@ -1,0 +1,101 @@
+<html>
+<head>
+  <title></title>
+  <script src="harness.js"></script>
+</head>
+<body>
+  <script>
+    expect(22);
+    function ok(msg) { _pass(msg, ""); }
+    function fail(msg) { _fail(msg, ""); }
+  </script>
+  <script type="">
+    ok('type is empty string');
+  </script>
+  <script language="">
+    ok('language is empty string');
+  </script>
+  <script type="text/javascript" language="vbscript">
+    ok('type is text/javascript, language ignored');
+  </script>
+  <script type="" language="fooscript">
+    ok('type is empty string, language ingored');
+  </script>
+  <script language="javascript">
+    ok('language is javascript');
+  </script>
+  <script language="ecmascript">
+    ok('language is ecmascript');
+  </script>
+
+  <!-- list found at http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting.html#support-the-scripting-language -->
+  <script type="application/ecmascript">
+    ok('type is application/ecmascript');
+  </script>
+  <script type="application/javascript">
+    ok('type is application/javascript');
+  </script>
+  <script type="application/x-ecmascript">
+    ok('type is application/x-ecmascript');
+  </script>
+  <script type="application/x-javascript">
+    ok('type is application/x-javascript');
+  </script>
+  <script type="text/ecmascript">
+    ok('type is text/ecmascript');
+  </script>
+  <script type="text/javascript">
+    ok('type is text/javascript');
+  </script>
+  <script type="text/javascript1.0">
+    ok('type is text/javascript1.0');
+  </script>
+  <script type="text/javascript1.1">
+    ok('type is text/javascript1.1');
+  </script>
+  <script type="text/javascript1.2">
+    ok('type is text/javascript1.2');
+  </script>
+  <script type="text/javascript1.3">
+    ok('type is text/javascript1.3');
+  </script>
+  <script type="text/javascript1.4">
+    ok('type is text/javascript1.4');
+  </script>
+  <script type="text/javascript1.5">
+    ok('type is text/javascript1.5');
+  </script>
+  <script type="text/jscript">
+    ok('type is text/jsscript');
+  </script>
+  <script type="text/livescript">
+    ok('type is text/livescript');
+  </script>
+  <script type="text/x-ecmascript">
+    ok('type is text/x-ecmascript');
+  </script>
+  <script type="text/x-javascript">
+    ok('type is text/x-javascript');
+  </script>
+
+
+  <!-- should not execute -->
+  <script type=" ">
+    fail('type is space');
+  </script>
+  <script type="foo">
+    fail('type is unknown');
+  </script>
+  <script type="text/javascript1.6">
+    fail('type is unknown');
+  </script>
+  <script language="text/javascript">
+    fail('language is text/javascript');
+  </script>
+
+  <script>
+    finish();
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
I tried to prevent allocations, but the slices wouldn't live long enough to check the static array, without duplicating code. Plus, if the `language` attribute is used, a new String is pretty much required.

Maybe if no type and no language are the most common, it'd be worth using `MaybeOwned`, so that `"text/javascript".to_string()` isn't needed?

fixes #2828 
