### PR TITLE
Load bare images within an HTML document (#3108)

### DIFF
--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -526,19 +526,24 @@ pub fn parse_html(page: &Page,
     };
     parser.set_tree_handler(&mut tree_handler);
     debug!("set tree handler");
-
     debug!("loaded page");
-    loop {
-        match load_response.progress_port.recv() {
-            Payload(data) => {
-                debug!("received data");
-                parser.parse_chunk(data.as_slice());
-            }
-            Done(Err(err)) => {
-                fail!("Failed to load page URL {:s}, error: {:s}", url.serialize(), err);
-            }
-            Done(..) => {
-                break;
+    match load_response.metadata.content_type {
+        Some((ref t, _)) if t.as_slice().eq_ignore_ascii_case("image") => {
+            let page = format!("<html><body><img src='{:s}' /></body></html>", base_url.serialize());
+            parser.parse_chunk(page.into_bytes().as_slice());
+        },
+        _ => loop {
+            match load_response.progress_port.recv() {
+                Payload(data) => {
+                    debug!("received data");
+                    parser.parse_chunk(data.as_slice());
+                }
+                Done(Err(err)) => {
+                    fail!("Failed to load page URL {:s}, error: {:s}", url.serialize(), err);
+                }
+                Done(..) => {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
`./servo http://s27.postimg.org/vqbtrolyr/servo.jpg` works now.

This still won't work with local files, since stuff fetched via `file_loader` don't have the MIME type set.

To get this to work with files we'll need to partially implement [The MIME sniffing spec](http://mimesniff.spec.whatwg.org/) and have use it in the resource loaders whenever a MIME type isn't provided.
