### PR TITLE
Add support for backgrounds on inline elements. Fix fixup() by removing it.

### DIFF
--- a/src/components/layout/block.rs
+++ b/src/components/layout/block.rs
@@ -1107,8 +1107,7 @@ impl BlockFlow {
         let rel_offset =
             self.fragment.relative_position(&self.base
                                              .absolute_position_info
-                                             .relative_containing_block_size,
-                                        None);
+                                             .relative_containing_block_size);
 
         // FIXME(#2795): Get the real container size
         let container_size = Size2D::zero();
@@ -1120,8 +1119,7 @@ impl BlockFlow {
             layout_context,
             self.base.abs_position + (offset + rel_offset).to_physical(
                 self.base.writing_mode, container_size),
-            background_border_level,
-            None);
+            background_border_level);
 
         let mut child_layers = DList::new();
         for kid in self.base.child_iter() {
@@ -1470,7 +1468,7 @@ impl Flow for BlockFlow {
             flags.union_floated_descendants_flags(child_base.flags);
         }
 
-        let fragment_intrinsic_inline_sizes = self.fragment.intrinsic_inline_sizes(None);
+        let fragment_intrinsic_inline_sizes = self.fragment.intrinsic_inline_sizes();
         intrinsic_inline_sizes.minimum_inline_size = geometry::max(intrinsic_inline_sizes.minimum_inline_size,
                                                        fragment_intrinsic_inline_sizes.minimum_inline_size);
         intrinsic_inline_sizes.preferred_inline_size = geometry::max(intrinsic_inline_sizes.preferred_inline_size,
@@ -1624,8 +1622,7 @@ impl Flow for BlockFlow {
         let relative_offset =
             self.fragment.relative_position(&self.base
                                                  .absolute_position_info
-                                                 .relative_containing_block_size,
-                                            None);
+                                                 .relative_containing_block_size);
         if self.is_positioned() {
             self.base.absolute_position_info.absolute_containing_block_position =
                 self.base.abs_position
@@ -1811,7 +1808,7 @@ pub trait ISizeAndMarginsComputer {
         let containing_block_inline_size = self.containing_block_inline_size(block, parent_flow_inline_size, ctx);
         let computed_inline_size = self.initial_computed_inline_size(block, parent_flow_inline_size, ctx);
 
-        block.fragment.compute_border_padding_margins(containing_block_inline_size, None);
+        block.fragment.compute_border_padding_margins(containing_block_inline_size);
 
         let style = block.fragment.style();
 
@@ -2257,7 +2254,7 @@ impl ISizeAndMarginsComputer for AbsoluteReplaced {
                               -> MaybeAuto {
         let containing_block_inline_size = block.containing_block_size(ctx.shared.screen_size).inline;
         let fragment = block.fragment();
-        fragment.assign_replaced_inline_size_if_necessary(containing_block_inline_size, None);
+        fragment.assign_replaced_inline_size_if_necessary(containing_block_inline_size);
         // For replaced absolute flow, the rest of the constraint solving will
         // take inline-size to be specified as the value computed here.
         Specified(fragment.content_inline_size())
@@ -2306,7 +2303,7 @@ impl ISizeAndMarginsComputer for BlockReplaced {
                               _: &LayoutContext)
                               -> MaybeAuto {
         let fragment = block.fragment();
-        fragment.assign_replaced_inline_size_if_necessary(parent_flow_inline_size, None);
+        fragment.assign_replaced_inline_size_if_necessary(parent_flow_inline_size);
         // For replaced block flow, the rest of the constraint solving will
         // take inline-size to be specified as the value computed here.
         Specified(fragment.content_inline_size())
@@ -2362,7 +2359,7 @@ impl ISizeAndMarginsComputer for FloatReplaced {
                               _: &LayoutContext)
                               -> MaybeAuto {
         let fragment = block.fragment();
-        fragment.assign_replaced_inline_size_if_necessary(parent_flow_inline_size, None);
+        fragment.assign_replaced_inline_size_if_necessary(parent_flow_inline_size);
         // For replaced block flow, the rest of the constraint solving will
         // take inline-size to be specified as the value computed here.
         Specified(fragment.content_inline_size())

--- a/src/components/layout/text.rs
+++ b/src/components/layout/text.rs
@@ -75,7 +75,7 @@ impl TextRunScanner {
 
         debug!("TextRunScanner: swapping out fragments.");
 
-        fragments.fixup(new_fragments);
+        fragments.fragments = new_fragments;
     }
 
     /// A "clump" is a range of inline flow leaves that can be merged together into a single

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -103,3 +103,5 @@ experimental == vertical-lr-blocks.html vertical-lr-blocks_ref.html
 # FIXME: use the real test when pixel-snapping for scrolling is fixed.
 #== ../html/acid2.html#top acid2_ref_broken.html
 flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
+
+!= inline_background_a.html inline_background_ref.html

--- a/src/test/ref/inline_background_a.html
+++ b/src/test/ref/inline_background_a.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+    <head>
+        <style type="text/css">
+        .white {
+            color: white;
+        }
+        .bggreen {
+            background-color: green;
+        }
+        body {
+            margin: 0;
+        }
+        </style>
+    </head>
+    <body><span class="bggreen white">White text on a green background</span></body>
+</html>

--- a/src/test/ref/inline_background_ref.html
+++ b/src/test/ref/inline_background_ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+    <head>
+        <style type="text/css">
+        .white {
+            color: white;
+        }
+        body {
+            margin: 0;
+        }
+        </style>
+    </head>
+    <body><span class="white">White text on a green background</span></body>
+</html>


### PR DESCRIPTION
The code that managed ranges was buggy - failing on edge cases such as a span within a span. I have refactored the code so that the context information for inline formatting can optionally be stored within a fragment. This seems cleaner to me, and fixes the bugs encountered when making these changes by removing the need for the fixup() functionality (and ranges).

If there is an issue with storing the inline context as I have changed it to, let me know and I'll try to fix the existing range based code instead.
