### PR TITLE
Update the description about Rust compiler which we uses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Cross-compilation for Android:
 Basically, pre-installed Android tools are needed.
 See wiki for [details](https://github.com/mozilla/servo/wiki/Building-for-Android)
 
+## The Rust compiler
+
 Servo builds its own copy of Rust, so there is no need to provide a Rust
 compiler.
+If you'd like to know the snapshot revision of Rust which we use, see `./rust-snapshot-hash`.
 
 ## Building
 

--- a/src/README.md
+++ b/src/README.md
@@ -8,10 +8,6 @@ crate or library.
 * `components/net`: Networking, caching, image decoding.
 * `components/util`: Various utility functions used by other Servo components.
 
-## The Rust compiler
-
-* `compiler/rust`: The Rust compiler.
-
 ## Supporting libraries
 
 These libraries are used in all Servo ports. In keeping with Servo's philosophy of modularity,


### PR DESCRIPTION
After #3130 , we're not hosting rust repository in our tree. This pull request updates about it.
