### PR TITLE
Specialize Document::content_changed

### DIFF
--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -109,8 +109,16 @@ impl Attr {
         let attr = Attr::new_inherited(local_name, value, name, namespace, prefix, owner);
         reflect_dom_object(box attr, &Window(*window), AttrBinding::Wrap)
     }
+}
 
-    pub fn set_value(&self, set_type: AttrSettingType, value: AttrValue) {
+pub trait AttrHelpers {
+    fn set_value(&self, set_type: AttrSettingType, value: AttrValue);
+    fn value<'a>(&'a self) -> Ref<'a, AttrValue>;
+    fn local_name<'a>(&'a self) -> &'a Atom;
+}
+
+impl<'a> AttrHelpers for JSRef<'a, Attr> {
+    fn set_value(&self, set_type: AttrSettingType, value: AttrValue) {
         let owner = self.owner.root();
         let node: &JSRef<Node> = NodeCast::from_ref(&*owner);
         let namespace_is_null = self.namespace == namespace::Null;
@@ -135,11 +143,11 @@ impl Attr {
         }
     }
 
-    pub fn value<'a>(&'a self) -> Ref<'a, AttrValue> {
+    fn value<'a>(&'a self) -> Ref<'a, AttrValue> {
         self.value.deref().borrow()
     }
 
-    pub fn local_name<'a>(&'a self) -> &'a Atom {
+    fn local_name<'a>(&'a self) -> &'a Atom {
         &self.local_name
     }
 }

--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -179,6 +179,7 @@ impl<'a> AttrMethods for JSRef<'a, Attr> {
 pub trait AttrHelpersForLayout {
     unsafe fn value_ref_forever(&self) -> &'static str;
     unsafe fn value_atom_forever(&self) -> Option<Atom>;
+    unsafe fn local_name_forever(&self) -> Atom;
 }
 
 impl AttrHelpersForLayout for Attr {
@@ -195,5 +196,9 @@ impl AttrHelpersForLayout for Attr {
             AtomAttrValue(ref val) => Some(val.clone()),
             _ => None,
         }
+    }
+
+    unsafe fn local_name_forever(&self) -> Atom {
+        self.local_name.clone()
     }
 }

--- a/src/components/script/dom/attr.rs
+++ b/src/components/script/dom/attr.rs
@@ -124,22 +124,14 @@ impl<'a> AttrHelpers for JSRef<'a, Attr> {
         let namespace_is_null = self.namespace == namespace::Null;
 
         match set_type {
-            ReplacedAttr => {
-                if namespace_is_null {
-                    vtable_for(node).before_remove_attr(
-                        self.local_name(),
-                        self.value().as_slice().to_string())
-                }
-            }
-            FirstSetAttr => {}
+            ReplacedAttr if namespace_is_null => vtable_for(node).before_remove_attr(self),
+            _ => ()
         }
 
         *self.value.deref().borrow_mut() = value;
 
         if namespace_is_null {
-            vtable_for(node).after_set_attr(
-                self.local_name(),
-                self.value().as_slice().to_string())
+            vtable_for(node).after_set_attr(self)
         }
     }
 

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -688,7 +688,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
             let element: &JSRef<Element> = ElementCast::to_ref(node).unwrap();
             element.get_attribute(Null, "name").root().map_or(false, |attr| {
-                (*attr).value().as_slice() == name.as_slice()
+                attr.value().as_slice() == name.as_slice()
             })
         })
     }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::DocumentBinding;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
@@ -659,7 +660,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
             let element: &JSRef<Element> = ElementCast::to_ref(node).unwrap();
             element.get_attribute(Null, "name").root().map_or(false, |attr| {
-                attr.value().as_slice() == name.as_slice()
+                (*attr).value().as_slice() == name.as_slice()
             })
         })
     }

--- a/src/components/script/dom/document.rs
+++ b/src/components/script/dom/document.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::AttrHelpers;
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::DocumentBinding;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
@@ -51,7 +51,7 @@ use dom::uievent::UIEvent;
 use dom::window::{Window, WindowHelpers};
 use html::hubbub_html_parser::build_element_from_tag;
 use hubbub::hubbub::{QuirksMode, NoQuirks, LimitedQuirks, FullQuirks};
-use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage};
+use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage, MatchSelectorsDocumentDamage};
 use servo_util::namespace;
 use servo_util::namespace::{Namespace, Null};
 use servo_util::str::{DOMString, null_str_as_empty_ref, split_html_space_chars};
@@ -65,6 +65,23 @@ use url::Url;
 pub enum IsHTMLDocument {
     HTMLDocument,
     NonHTMLDocument,
+}
+
+pub enum DOMTreeChangeType<'a, 'b> {
+    DOMTreeLoaded,
+    DOMTreeNodeInserted(&'b JSRef<'a, Node>),
+    DOMTreeNodeRemoved(&'b JSRef<'a, Node>),
+}
+
+pub enum NodeChangeType<'a, 'b> {
+    TextContentChange,
+    ElemAttrInserted(&'b JSRef<'a, Attr>),
+    ElemAttrRemoved(&'b JSRef<'a, Attr>)
+}
+
+pub enum ContentChangeType<'a, 'b> {
+    DOMTreeChange(DOMTreeChangeType<'a, 'b>),
+    NodeChange(NodeChangeType<'a, 'b>)
 }
 
 #[deriving(Encodable)]
@@ -100,7 +117,7 @@ pub trait DocumentHelpers {
     fn quirks_mode(&self) -> QuirksMode;
     fn set_quirks_mode(&self, mode: QuirksMode);
     fn set_encoding_name(&self, name: DOMString);
-    fn content_changed(&self);
+    fn content_changed(&self, change_type: &ContentChangeType);
     fn damage_and_reflow(&self, damage: DocumentDamageLevel);
     fn wait_until_safe_to_modify_dom(&self);
     fn unregister_named_element(&self, to_unregister: &JSRef<Element>, id: DOMString);
@@ -125,8 +142,19 @@ impl<'a> DocumentHelpers for JSRef<'a, Document> {
         *self.encoding_name.deref().borrow_mut() = name;
     }
 
-    fn content_changed(&self) {
-        self.damage_and_reflow(ContentChangedDocumentDamage);
+    fn content_changed(&self, change_type: &ContentChangeType) {
+        let mut damage = ContentChangedDocumentDamage;
+        match *change_type {
+            NodeChange(ElemAttrInserted(ref attr)) |
+            NodeChange(ElemAttrRemoved(ref attr)) => {
+                damage = match attr.local_name().as_slice() {
+                    "style" | "id" | "class" => MatchSelectorsDocumentDamage,
+                    _ => ContentChangedDocumentDamage
+                };
+            },
+            _ => ()
+        }
+        self.damage_and_reflow(damage);
     }
 
     fn damage_and_reflow(&self, damage: DocumentDamageLevel) {

--- a/src/components/script/dom/domtokenlist.rs
+++ b/src/components/script/dom/domtokenlist.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::{Attr, TokenListAttrValue};
+use dom::attr::{Attr, AttrHelpers, TokenListAttrValue};
 use dom::bindings::codegen::Bindings::DOMTokenListBinding;
 use dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenListMethods;
 use dom::bindings::global::Window;

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -175,11 +175,11 @@ impl RawLayoutElementHelpers for Element {
         // cast to point to T in RefCell<T> directly
         let attrs: *const Vec<JS<Attr>> = mem::transmute(&self.attrs);
         (*attrs).iter().find(|attr: & &JS<Attr>| {
-            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
-            name == attr.local_name().as_slice() && attr.namespace == *namespace
+            let attr = attr.unsafe_get();
+            (*attr).local_name_forever().as_slice() == name && (*attr).namespace == *namespace
         }).map(|attr| {
-            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
-            attr.value_ref_forever()
+            let attr = attr.unsafe_get();
+            (*attr).value_ref_forever()
         })
     }
 
@@ -189,11 +189,11 @@ impl RawLayoutElementHelpers for Element {
         // cast to point to T in RefCell<T> directly
         let attrs: *const Vec<JS<Attr>> = mem::transmute(&self.attrs);
         (*attrs).iter().find(|attr: & &JS<Attr>| {
-            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
-            name == attr.local_name().as_slice() && attr.namespace == *namespace
+            let attr = attr.unsafe_get();
+            (*attr).local_name_forever().as_slice() == name && (*attr).namespace == *namespace
         }).and_then(|attr| {
-            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
-            attr.value_atom_forever()
+            let attr = attr.unsafe_get();
+            (*attr).value_atom_forever()
         })
     }
 }

--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -4,7 +4,7 @@
 
 //! Element nodes.
 
-use dom::attr::{Attr, ReplacedAttr, FirstSetAttr, AttrHelpersForLayout};
+use dom::attr::{Attr, ReplacedAttr, FirstSetAttr, AttrHelpers, AttrHelpersForLayout};
 use dom::attr::{AttrValue, StringAttrValue, UIntAttrValue, AtomAttrValue};
 use dom::attrlist::AttrList;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
@@ -177,12 +177,11 @@ impl RawLayoutElementHelpers for Element {
         // cast to point to T in RefCell<T> directly
         let attrs: *const Vec<JS<Attr>> = mem::transmute(&self.attrs);
         (*attrs).iter().find(|attr: & &JS<Attr>| {
-            let attr = attr.unsafe_get();
-            name == (*attr).local_name().as_slice() &&
-            (*attr).namespace == *namespace
+            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
+            name == attr.local_name().as_slice() && attr.namespace == *namespace
         }).map(|attr| {
-            let attr = attr.unsafe_get();
-            (*attr).value_ref_forever()
+            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
+            attr.value_ref_forever()
         })
     }
 
@@ -192,12 +191,11 @@ impl RawLayoutElementHelpers for Element {
         // cast to point to T in RefCell<T> directly
         let attrs: *const Vec<JS<Attr>> = mem::transmute(&self.attrs);
         (*attrs).iter().find(|attr: & &JS<Attr>| {
-            let attr = attr.unsafe_get();
-            name == (*attr).local_name().as_slice() &&
-            (*attr).namespace == *namespace
+            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
+            name == attr.local_name().as_slice() && attr.namespace == *namespace
         }).and_then(|attr| {
-            let attr = attr.unsafe_get();
-            (*attr).value_atom_forever()
+            let attr: &JSRef<Attr> = mem::transmute(attr.unsafe_get());
+            attr.value_atom_forever()
         })
     }
 }

--- a/src/components/script/dom/htmlanchorelement.rs
+++ b/src/components/script/dom/htmlanchorelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLAnchorElementBinding;
@@ -19,7 +20,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::namespace::Null;
 use servo_util::str::DOMString;
 
@@ -76,27 +76,27 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
         }

--- a/src/components/script/dom/htmlareaelement.rs
+++ b/src/components/script/dom/htmlareaelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
@@ -14,7 +15,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -47,27 +47,27 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
         }

--- a/src/components/script/dom/htmlbodyelement.rs
+++ b/src/components/script/dom/htmlbodyelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::HTMLBodyElementBinding;
 use dom::bindings::codegen::Bindings::HTMLBodyElementBinding::HTMLBodyElementMethods;
@@ -17,7 +18,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -62,12 +62,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
         Some(element as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
+        let name = attr.local_name();
         if name.as_slice().starts_with("on") {
             static forwarded_events: &'static [&'static str] =
                 &["onfocus", "onload", "onscroll", "onafterprint", "onbeforeprint",
@@ -86,7 +87,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
                 };
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.as_slice().slice_from(2),
-                                                  value);
+                                                  attr.value().as_slice().to_string());
         }
     }
 }

--- a/src/components/script/dom/htmlbuttonelement.rs
+++ b/src/components/script/dom/htmlbuttonelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -16,7 +17,6 @@ use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, wind
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -68,14 +68,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -84,14 +84,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/htmlcanvaselement.rs
+++ b/src/components/script/dom/htmlcanvaselement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLCanvasElementBinding;
 use dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::HTMLCanvasElementMethods;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementDerived;
@@ -18,7 +19,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 use geom::size::Size2D;
@@ -99,13 +99,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
         Some(element as &VirtualMethods)
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
-        let recreate = match name.as_slice() {
+        let recreate = match attr.local_name().as_slice() {
             "width" => {
                 self.width.set(DefaultWidth);
                 true
@@ -126,13 +126,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
         }
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
-        let recreate = match name.as_slice() {
+        let value = attr.value();
+        let recreate = match attr.local_name().as_slice() {
             "width" => {
                 self.width.set(num::from_str_radix(value.as_slice(), 10).unwrap());
                 true

--- a/src/components/script/dom/htmlfieldsetelement.rs
+++ b/src/components/script/dom/htmlfieldsetelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLFieldSetElementDerived, NodeCast};
@@ -18,7 +19,6 @@ use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, wind
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::{DOMString, StaticStringVec};
 
 #[deriving(Encodable)]
@@ -87,14 +87,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -119,14 +119,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/htmliframeelement.rs
+++ b/src/components/script/dom/htmliframeelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLIFrameElementBinding;
 use dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast};

--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::AttrValue;
+use dom::attr::{Attr, AttrHelpers, AttrValue};
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageElementMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLElementCast, HTMLImageElementDerived};
@@ -17,7 +17,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, ElementNodeTypeId, NodeHelpers, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 use servo_net::image_cache_task;
-use servo_util::atom::Atom;
 use servo_util::geometry::to_px;
 use servo_util::str::DOMString;
 
@@ -194,26 +193,26 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
-        if "src" == name.as_slice() {
+        if "src" == attr.local_name().as_slice() {
             let window = window_from_node(self).root();
             let url = window.deref().get_url();
-            self.update_image(Some((value, &url)));
+            self.update_image(Some((attr.value().as_slice().to_string(), &url)));
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
-        if "src" == name.as_slice() {
+        if "src" == attr.local_name().as_slice() {
             self.update_image(None);
         }
     }

--- a/src/components/script/dom/htmlinputelement.rs
+++ b/src/components/script/dom/htmlinputelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding;
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -15,7 +16,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -62,14 +62,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -78,14 +78,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/htmllinkelement.rs
+++ b/src/components/script/dom/htmllinkelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
@@ -14,7 +15,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -47,27 +47,27 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
         }

--- a/src/components/script/dom/htmlobjectelement.rs
+++ b/src/components/script/dom/htmlobjectelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::HTMLObjectElementBinding;
 use dom::bindings::codegen::Bindings::HTMLObjectElementBinding::HTMLObjectElementMethods;
@@ -20,7 +21,6 @@ use dom::virtualmethods::VirtualMethods;
 
 use servo_net::image_cache_task;
 use servo_net::image_cache_task::ImageCacheTask;
-use servo_util::atom::Atom;
 use servo_util::namespace::Null;
 use servo_util::str::DOMString;
 
@@ -93,13 +93,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
-        if "data" == name.as_slice() {
+        if "data" == attr.local_name().as_slice() {
             let window = window_from_node(self).root();
             self.process_data_url(window.deref().image_cache_task.clone());
         }

--- a/src/components/script/dom/htmloptgroupelement.rs
+++ b/src/components/script/dom/htmloptgroupelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding::HTMLOptGroupElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -15,7 +16,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -62,14 +62,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -82,14 +82,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/htmloptionelement.rs
+++ b/src/components/script/dom/htmloptionelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLOptionElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOptionElementBinding::HTMLOptionElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -15,7 +16,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -62,14 +62,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -78,14 +78,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/htmlselectelement.rs
+++ b/src/components/script/dom/htmlselectelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding;
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -18,7 +19,6 @@ use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId, wind
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -74,14 +74,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -90,14 +90,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/htmlserializer.rs
+++ b/src/components/script/dom/htmlserializer.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::Attr;
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::InheritTypes::{ElementCast, TextCast, CommentCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{DocumentTypeCast, CharacterDataCast};
 use dom::bindings::codegen::InheritTypes::ProcessingInstructionCast;
@@ -153,7 +153,7 @@ fn serialize_attr(attr: &JSRef<Attr>, html: &mut String) {
         html.push_str(attr.deref().name.as_slice());
     };
     html.push_str("=\"");
-    escape(attr.deref().value().as_slice(), true, html);
+    escape(attr.value().as_slice(), true, html);
     html.push_char('"');
 }
 

--- a/src/components/script/dom/htmltextareaelement.rs
+++ b/src/components/script/dom/htmltextareaelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -15,7 +16,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
@@ -62,14 +62,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
@@ -78,14 +78,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
         let node: &JSRef<Node> = NodeCast::from_ref(self);
-        match name.as_slice() {
+        match attr.local_name().as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -4,7 +4,7 @@
 
 //! The core DOM types. Defines the basic DOM hierarchy as well as all the HTML elements.
 
-use dom::attr::Attr;
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -28,6 +28,8 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::characterdata::CharacterData;
 use dom::comment::Comment;
 use dom::document::{Document, DocumentHelpers, HTMLDocument, NonHTMLDocument};
+use dom::document::{DOMTreeChange, DOMTreeNodeInserted, DOMTreeNodeRemoved};
+use dom::document::{NodeChange, TextContentChange};
 use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
 use dom::element::{AttributeHandlers, Element, ElementTypeId};
@@ -274,7 +276,7 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
         let parent = self.parent_node().root();
         parent.map(|parent| vtable_for(&*parent).child_inserted(self));
 
-        document.deref().content_changed();
+        document.deref().content_changed(&DOMTreeChange(DOMTreeNodeInserted(self)));
     }
 
     // http://dom.spec.whatwg.org/#node-is-removed
@@ -286,7 +288,7 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
             vtable_for(&node).unbind_from_tree(parent_in_doc);
         }
 
-        document.deref().content_changed();
+        document.deref().content_changed(&DOMTreeChange(DOMTreeNodeRemoved(self)));
     }
 
     //
@@ -1608,7 +1610,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
                 // Notify the document that the content of this node is different
                 let document = self.owner_doc().root();
-                document.deref().content_changed();
+                document.deref().content_changed(&NodeChange(TextContentChange));
             }
             DoctypeNodeTypeId |
             DocumentNodeTypeId => {}

--- a/src/components/script/dom/virtualmethods.rs
+++ b/src/components/script/dom/virtualmethods.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::{AttrValue, StringAttrValue};
+use dom::attr::{Attr, AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementCast;
@@ -60,7 +60,6 @@ use dom::htmlstyleelement::HTMLStyleElement;
 use dom::htmltextareaelement::HTMLTextAreaElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 /// Trait to allow DOM nodes to opt-in to overriding (or adding to) common
@@ -72,18 +71,18 @@ pub trait VirtualMethods {
 
     /// Called when changing or adding attributes, after the attribute's value
     /// has been updated.
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
     }
 
     /// Called when changing or removing attributes, before any modification
     /// has taken place.
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr<'a>(&self, attr: &JSRef<'a, Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
     }

--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{NodeBase, NodeCast, TextCast, ElementCast};

--- a/src/components/script/page.rs
+++ b/src/components/script/page.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast};
 use dom::bindings::js::{JS, JSRef, Temporary};

--- a/src/components/script/script_task.rs
+++ b/src/components/script/script_task.rs
@@ -11,7 +11,7 @@ use dom::bindings::js::{JS, JSRef, RootCollection, Temporary, OptionalSettable};
 use dom::bindings::js::OptionalRootable;
 use dom::bindings::utils::Reflectable;
 use dom::bindings::utils::{wrap_for_same_compartment, pre_wrap};
-use dom::document::{Document, HTMLDocument, DocumentHelpers};
+use dom::document::{Document, HTMLDocument, DocumentHelpers, DOMTreeChange, DOMTreeLoaded};
 use dom::element::{Element, HTMLButtonElementTypeId, HTMLInputElementTypeId};
 use dom::element::{HTMLSelectElementTypeId, HTMLTextAreaElementTypeId, HTMLOptionElementTypeId};
 use dom::event::Event;
@@ -653,7 +653,7 @@ impl ScriptTask {
         }
 
         // Kick off the initial reflow of the page.
-        document.deref().content_changed();
+        document.deref().content_changed(&DOMTreeChange(DOMTreeLoaded));
 
         let fragment = url.fragment.as_ref().map(|ref fragment| fragment.to_string());
 


### PR DESCRIPTION
Changes:
- `Attr`'s getters/setters moved to `AttrHelpers` trait;
- Cleanup in `VirtualMethods`' `before_remove_attr`, `after_set_attr` to use `&JSRef<'a, Attr>`;
- Specialize Document::content_changed;
- Move Document-specific logic from Element::notify_attribute_change to Document::content_changed;
