### PR TITLE
return null from GetNamespaceURI, not the empty string

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -471,8 +471,11 @@ impl Element {
 
 impl<'a> ElementMethods for JSRef<'a, Element> {
     // http://dom.spec.whatwg.org/#dom-element-namespaceuri
-    fn NamespaceURI(&self) -> DOMString {
-        self.namespace.to_str().to_string()
+    fn GetNamespaceURI(&self) -> Option<DOMString> {
+        match self.namespace {
+            Null => None,
+            ref ns => Some(ns.to_str().to_string())
+        }
     }
 
     fn LocalName(&self) -> DOMString {

--- a/src/components/script/dom/webidls/Element.webidl
+++ b/src/components/script/dom/webidls/Element.webidl
@@ -19,7 +19,7 @@ interface Element : Node {
   readonly attribute DOMString localName;
 
   [Constant]
-  readonly attribute DOMString namespaceURI;
+  readonly attribute DOMString? namespaceURI;
   // Not [Constant] because it depends on which document we're in
   [Pure]
   readonly attribute DOMString tagName;

--- a/src/test/wpt/metadata/dom/nodes/DOMImplementation-createDocument.html.ini
+++ b/src/test/wpt/metadata/dom/nodes/DOMImplementation-createDocument.html.ini
@@ -1,45 +1,10 @@
 [DOMImplementation-createDocument.html]
   type: testharness
-  [createDocument test 2: null,undefined,null,null]
-    expected: FAIL
-
-  [createDocument test 4: null,"foo",null,null]
-    expected: FAIL
-
-  [createDocument test 6: null,"f1oo",null,null]
-    expected: FAIL
-
-  [createDocument test 7: null,"foo1",null,null]
-    expected: FAIL
-
-  [createDocument test 11: null,"xml",null,null]
-    expected: FAIL
 
   [createDocument test 12: null,"xmlns",null,"NAMESPACE_ERR"]
     expected: FAIL
 
-  [createDocument test 13: null,"xmlfoo",null,null]
-    expected: FAIL
-
-  [createDocument test 18: undefined,undefined,undefined,null]
-    expected: FAIL
-
-  [createDocument test 20: undefined,"foo",undefined,null]
-    expected: FAIL
-
-  [createDocument test 22: undefined,"f1oo",undefined,null]
-    expected: FAIL
-
-  [createDocument test 23: undefined,"foo1",undefined,null]
-    expected: FAIL
-
-  [createDocument test 27: undefined,"xml",undefined,null]
-    expected: FAIL
-
   [createDocument test 28: undefined,"xmlns",undefined,"NAMESPACE_ERR"]
-    expected: FAIL
-
-  [createDocument test 29: undefined,"xmlfoo",undefined,null]
     expected: FAIL
 
   [createDocument test 41: "http://example.com/","foo:",null,"NAMESPACE_ERR"]
@@ -76,8 +41,5 @@
     expected: FAIL
 
   [createDocument test 106: "foo:","xmlns:foo",null,"NAMESPACE_ERR"]
-    expected: FAIL
-
-  [createDocument test 113: null,"foo",DocumentType node,null]
     expected: FAIL
 


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/3140

I tried changing the ini file for the Document-createElementNS.html test. I expected that changing the last three tests (the null / undefined / empty string namespace ones) to PASS would work, but apparently the tagName assert makes them fail. I guess that's a separate issue, so I left the ini file as it was.
