### PR TITLE
Uppercase element.tagName for HTML elements only

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -491,14 +491,14 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
 
     // http://dom.spec.whatwg.org/#dom-element-tagname
     fn TagName(&self) -> DOMString {
-        match self.prefix {
-            None => {
-                self.local_name.as_slice().to_ascii_upper()
-            }
-            Some(ref prefix_str) => {
-                let s = format!("{}:{}", prefix_str, self.local_name);
-                s.as_slice().to_ascii_upper()
-            }
+        let qualified_name = match self.prefix {
+            Some(ref prefix) => format!("{}:{}", prefix, self.local_name).into_maybe_owned(),
+            None => self.local_name.as_slice().into_maybe_owned()
+        };
+        if self.html_element_in_html_document() {
+            qualified_name.as_slice().to_ascii_upper()
+        } else {
+            qualified_name.into_string()
         }
     }
 

--- a/src/test/content/test_document_body.html
+++ b/src/test/content/test_document_body.html
@@ -43,8 +43,7 @@
 
             // test5: append body to a new document
             {
-                let new_document = new Document();
-                new_document.appendChild(new_document.createElement("html"));
+                let new_document = document.implementation.createHTMLDocument();
                 let new_body = new_document.createElement("body");
 
                 is_not(new_body, null, "test5-0, append body to a new document");
@@ -57,8 +56,7 @@
 
             // test6: append frameset to a new document
             {
-                let new_document = new Document();
-                new_document.appendChild(new_document.createElement("html"));
+                let new_document = document.implementation.createHTMLDocument();
                 let new_frameset = new_document.createElement("frameset");
 
                 is_not(new_frameset, null, "test6-0, append frameset to a new document");

--- a/src/test/content/test_document_head.html
+++ b/src/test/content/test_document_head.html
@@ -19,7 +19,7 @@
 
                 is_not(new_head, null, "test2-0, append head to a new document");
                 is_a(new_head, HTMLHeadElement, "test2-1, append head to a new document");
-                is(new_head && new_head.tagName, "HEAD", "test2-2, append head to a new document");
+                is(new_head && new_head.tagName, "head", "test2-2, append head to a new document");
 
                 // Document::head is read-only.
                 new_document.head = new_head;

--- a/src/test/wpt/metadata/dom/nodes/Document-createElementNS.html.ini
+++ b/src/test/wpt/metadata/dom/nodes/Document-createElementNS.html.ini
@@ -12,24 +12,5 @@
   [Lower-case HTML element with a prefix]
     expected: FAIL
 
-  [Lower-case non-HTML element without a prefix]
-    expected: FAIL
-
-  [Lower-case non-HTML element with a prefix]
-    expected: FAIL
-
   [Upper-case HTML element with a prefix]
     expected: FAIL
-
-  [Upper-case non-HTML element with a prefix]
-    expected: FAIL
-
-  [null namespace]
-    expected: FAIL
-
-  [undefined namespace]
-    expected: FAIL
-
-  [empty string namespace]
-    expected: FAIL
-

--- a/src/test/wpt/metadata/dom/nodes/Element-tagName.html.ini
+++ b/src/test/wpt/metadata/dom/nodes/Element-tagName.html.ini
@@ -3,9 +3,6 @@
   [tagName should upper-case for HTML elements in HTML documents.]
     expected: FAIL
 
-  [tagName should not upper-case for SVG elements in HTML documents.]
-    expected: FAIL
-
   [tagName should be updated when changing ownerDocument]
     expected: FAIL
 


### PR DESCRIPTION
Fixes #3146
