### PR TITLE
Nuke Node's TLayoutData

### DIFF
--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -235,12 +235,6 @@ impl LayoutDataRef {
     }
 }
 
-/// A trait that represents abstract layout data.
-///
-/// FIXME(pcwalton): Very very unsafe!!! We need to send these back to the layout task to be
-/// destroyed when this node is finalized.
-pub trait TLayoutData {}
-
 /// The different types of nodes.
 #[deriving(PartialEq,Encodable)]
 pub enum NodeTypeId {


### PR DESCRIPTION
LayoutData{Ref} structs replaced its usage for quite some time now.
