### PR TITLE
Update to png::Image::pixels as an enum.

### DIFF
--- a/src/components/compositing/compositor.rs
+++ b/src/components/compositing/compositor.rs
@@ -895,8 +895,7 @@ impl IOCompositor {
             let mut img = png::Image {
                 width: width as u32,
                 height: height as u32,
-                color_type: png::RGB8,
-                pixels: pixels,
+                pixels: png::RGB8(pixels),
             };
             let res = png::store_png(&mut img, &path);
             assert!(res.is_ok());

--- a/src/components/gfx/render_context.rs
+++ b/src/components/gfx/render_context.rs
@@ -15,7 +15,7 @@ use geom::size::Size2D;
 use geom::side_offsets::SideOffsets2D;
 use libc::types::common::c99::uint16_t;
 use libc::size_t;
-use png::{RGBA8, K8, KA8};
+use png::{RGB8, RGBA8, K8, KA8};
 use servo_net::image::base::Image;
 use servo_util::geometry::Au;
 use servo_util::opts::Opts;
@@ -100,17 +100,15 @@ impl<'a> RenderContext<'a>  {
 
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<Image>>) {
         let size = Size2D(image.width as i32, image.height as i32);
-        let pixel_width = match image.color_type {
-            RGBA8 => 4,
-            K8    => 1,
-            KA8   => 2,
-            _     => fail!("color type not supported"),
+        let (pixel_width, pixels) = match image.pixels {
+            RGBA8(ref pixels) => (4, pixels.as_slice()),
+            RGB8(_) | K8(_) | KA8(_) => fail!("color type not supported"),
         };
         let stride = image.width * pixel_width;
 
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
-        let azure_surface = draw_target_ref.create_source_surface_from_data(image.pixels.as_slice(),
+        let azure_surface = draw_target_ref.create_source_surface_from_data(pixels,
                                                                             size,
                                                                             stride as i32,
                                                                             B8G8R8A8);

--- a/src/test/harness/reftest/reftest.rs
+++ b/src/test/harness/reftest/reftest.rs
@@ -205,7 +205,7 @@ fn make_test(reftest: Reftest) -> TestDescAndFn {
     }
 }
 
-fn capture(reftest: &Reftest, side: uint) -> png::Image {
+fn capture(reftest: &Reftest, side: uint) -> (u32, u32, Vec<u8>) {
     let filename = format!("/tmp/servo-reftest-{:06u}-{:u}.png", reftest.id, side);
     let mut args = reftest.servo_args.clone();
     // GPU rendering is the default
@@ -220,14 +220,22 @@ fn capture(reftest: &Reftest, side: uint) -> png::Image {
     };
     assert!(retval == ExitStatus(0));
 
-    png::load_png(&from_str::<Path>(filename.as_slice()).unwrap()).unwrap()
+    let image = png::load_png(&from_str::<Path>(filename.as_slice()).unwrap()).unwrap();
+    let rgba8_bytes = match image.pixels {
+        png::RGBA8(pixels) => pixels,
+        _ => fail!(),
+    };
+    (image.width, image.height, rgba8_bytes)
 }
 
 fn check_reftest(reftest: Reftest) {
-    let left  = capture(&reftest, 0);
-    let right = capture(&reftest, 1);
+    let (left_width, left_height, left_bytes) = capture(&reftest, 0);
+    let (right_width, right_height, right_bytes) = capture(&reftest, 1);
 
-    let pixels = left.pixels.iter().zip(right.pixels.iter()).map(|(&a, &b)| {
+    assert_eq!(left_width, right_width);
+    assert_eq!(left_height, right_height);
+
+    let pixels = left_bytes.iter().zip(right_bytes.iter()).map(|(&a, &b)| {
         if a as i8 - b as i8 == 0 {
             // White for correct
             0xFF
@@ -245,10 +253,9 @@ fn check_reftest(reftest: Reftest) {
         let output = from_str::<Path>(output_str.as_slice()).unwrap();
 
         let mut img = png::Image {
-            width: left.width,
-            height: left.height,
-            color_type: png::RGBA8,
-            pixels: pixels,
+            width: left_width,
+            height: left_height,
+            pixels: png::RGBA8(pixels),
         };
         let res = png::store_png(&mut img, &output);
         assert!(res.is_ok());


### PR DESCRIPTION
https://github.com/servo/rust-png/pull/42

This does _not_ fix the issue in #3154, but makes it fail!() instead of (maybe?) reading uninitalized memory.

r? @metajack 
