### PR TITLE
Fix `<br>` support

### DIFF
--- a/src/components/layout/fragment.rs
+++ b/src/components/layout/fragment.rs
@@ -1421,8 +1421,10 @@ impl Fragment {
     pub fn can_merge_with_fragment(&self, other: &Fragment) -> bool {
         match (&self.specific, &other.specific) {
             (&UnscannedTextFragment(_), &UnscannedTextFragment(_)) => {
+                /// FIXME: Should probably use a whitelist of styles that can safely differ (#3165)
                 self.font_style() == other.font_style() &&
-                    self.text_decoration() == other.text_decoration()
+                    self.text_decoration() == other.text_decoration() &&
+                    self.white_space() == other.white_space()
             }
             _ => false,
         }

--- a/src/components/style/user-agent.css
+++ b/src/components/style/user-agent.css
@@ -85,7 +85,7 @@ ol[type="i"]        { list-style-type: lower-roman; }
 ol[type="I"]        { list-style-type: upper-roman; }
 
 u, ins              { text-decoration: underline }
-br:before           { content: "\A"; white-space: pre-line }
+br:before           { content: "\A"; white-space: pre }
 
 center              { text-align: center }
 a:link,

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -1,4 +1,5 @@
 == basic_width_px.html basic_width_em.html
+== br.html br-ref.html
 == hello_a.html hello_b.html
 == margin_a.html margin_b.html
 == root_pseudo_a.html root_pseudo_b.html

--- a/src/test/ref/br-ref.html
+++ b/src/test/ref/br-ref.html
@@ -1,0 +1,11 @@
+<!doctype HTML>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>br reference</title>
+  </head>
+  <body>
+    <div>A</div>
+    <div>B</div>
+  </body>
+</html>

--- a/src/test/ref/br.html
+++ b/src/test/ref/br.html
@@ -1,0 +1,10 @@
+<!doctype HTML>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>br test</title>
+  </head>
+  <body>
+    A<br>B
+  </body>
+</html>


### PR DESCRIPTION
This adds a working implementation of `<br>`, though as discussed in links found at #2362, this pure CSS implementation is not 100% interoperable with existing implementations.

This fixes two problems with the version previously in the UA stylesheet:
- Servo doesn't yet support the `whitespace: pre-line` value.  Fixed by using `pre` instead.
- Pseudo-elements lose their `whitespace` values if merged with other text fragments.  Fixed by preventing merging when `whitespace` differs.

I'm not sure whether the second item points to broader changes needed in `Fragment::can_merge_with_fragment`.
