### PR TITLE
Avoid using message passing for simple JS -> Layout "rpc-like" queries.

### DIFF
--- a/src/components/gfx/font_cache_task.rs
+++ b/src/components/gfx/font_cache_task.rs
@@ -247,7 +247,7 @@ impl FontCacheTask {
         }
     }
 
-    pub fn get_font_template(&mut self, family: String, desc: FontTemplateDescriptor)
+    pub fn get_font_template(&self, family: String, desc: FontTemplateDescriptor)
                                                 -> Arc<FontTemplateData> {
 
         let (response_chan, response_port) = channel();
@@ -262,7 +262,7 @@ impl FontCacheTask {
         }
     }
 
-    pub fn add_web_font(&mut self, family: String, url: Url) {
+    pub fn add_web_font(&self, family: String, url: Url) {
         let (response_chan, response_port) = channel();
         self.chan.send(AddWebFont(family, url, response_chan));
         response_port.recv();

--- a/src/components/script/dom/node.rs
+++ b/src/components/script/dom/node.rs
@@ -43,7 +43,7 @@ use dom::virtualmethods::{VirtualMethods, vtable_for};
 use dom::window::Window;
 use geom::rect::Rect;
 use html::hubbub_html_parser::build_element_from_tag;
-use layout_interface::{ContentBoxQuery, ContentBoxResponse, ContentBoxesQuery, ContentBoxesResponse,
+use layout_interface::{ContentBoxResponse, ContentBoxesResponse, LayoutRPC,
                        LayoutChan, ReapLayoutDataMsg, TrustedNodeAddress, UntrustedNodeAddress};
 use servo_util::geometry::Au;
 use servo_util::str::{DOMString, null_str_as_empty};
@@ -586,18 +586,17 @@ impl<'m, 'n> NodeHelpers<'m, 'n> for JSRef<'n, Node> {
     fn get_bounding_content_box(&self) -> Rect<Au> {
         let window = window_from_node(self).root();
         let page = window.deref().page();
-        let (chan, port) = channel();
         let addr = self.to_trusted_node_address();
-        let ContentBoxResponse(rect) = page.query_layout(ContentBoxQuery(addr, chan), port);
+
+        let ContentBoxResponse(rect) = page.layout_rpc.content_box(addr);
         rect
     }
 
     fn get_content_boxes(&self) -> Vec<Rect<Au>> {
         let window = window_from_node(self).root();
         let page = window.deref().page();
-        let (chan, port) = channel();
         let addr = self.to_trusted_node_address();
-        let ContentBoxesResponse(rects) = page.query_layout(ContentBoxesQuery(addr, chan), port);
+        let ContentBoxesResponse(rects) = page.layout_rpc.content_boxes(addr);
         rects
     }
 


### PR DESCRIPTION
When JS would query the layout with questions like "is this under the cursor?",
we send a message with the question, and a message with the response.

Unfortunately, many javascript benchmarks like to test the layout engine by doing
a ton of these calls in tight loops. This makes servo look bad because of the
message passing overhead.

This pull request adds a simple RPC interface to the layout, which uses a mutex
and shared state to communicate between the threads. It should be a performance
win, as long as it's used sparingly for short queries.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/3164)

<!-- Reviewable:end -->
