### PR TITLE
Factor out code to call JS_DeletePropertyById2.

### DIFF
--- a/src/components/script/dom/bindings/proxyhandler.rs
+++ b/src/components/script/dom/bindings/proxyhandler.rs
@@ -4,14 +4,14 @@
 
 ///! Utilities for the implementation of JSAPI proxy handlers.
 
+use dom::bindings::utils::delete_property_by_id;
 use dom::bindings::utils::is_dom_proxy;
 use js::jsapi::{JSContext, jsid, JSPropertyDescriptor, JSObject, JSString, jschar};
 use js::jsapi::{JS_GetPropertyDescriptorById, JS_NewUCString, JS_malloc, JS_free};
 use js::jsapi::{JS_DefinePropertyById, JS_NewObjectWithGivenProto};
 use js::jsapi::{JS_ReportErrorFlagsAndNumber, JS_StrictPropertyStub};
 use js::jsapi::{JSREPORT_WARNING, JSREPORT_STRICT, JSREPORT_STRICT_MODE_ERROR};
-use js::jsapi::JS_DeletePropertyById2;
-use js::jsval::{UndefinedValue, ObjectValue};
+use js::jsval::ObjectValue;
 use js::glue::GetProxyExtra;
 use js::glue::{GetObjectProto, GetObjectParent, SetProxyExtra, GetProxyHandler};
 use js::glue::InvokeGetOwnPropertyDescriptor;
@@ -89,13 +89,7 @@ pub extern fn delete_(cx: *mut JSContext, proxy: *mut JSObject, id: jsid,
             return false;
         }
 
-        let mut value = UndefinedValue();
-        if JS_DeletePropertyById2(cx, expando, id, &mut value) == 0 {
-            return false;
-        }
-
-        *bp = value.to_boolean();
-        return true;
+        return delete_property_by_id(cx, expando, id, &mut *bp);
     }
 }
 

--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -39,6 +39,7 @@ use js::jsapi::{JSContext, JSObject, JSBool, jsid, JSClass};
 use js::jsapi::{JSFunctionSpec, JSPropertySpec};
 use js::jsapi::{JS_NewGlobalObject, JS_InitStandardClasses};
 use js::jsapi::{JSString};
+use js::jsapi::JS_DeletePropertyById2;
 use js::jsfriendapi::JS_ObjectToOuterObject;
 use js::jsfriendapi::bindgen::JS_NewObjectWithUniqueType;
 use js::jsval::JSVal;
@@ -680,6 +681,17 @@ fn cx_for_dom_reflector(obj: *mut JSObject) -> *mut JSContext {
 /// this DOM object is on.
 pub fn cx_for_dom_object<T: Reflectable>(obj: &T) -> *mut JSContext {
     cx_for_dom_reflector(obj.reflector().get_jsobject())
+}
+
+pub unsafe fn delete_property_by_id(cx: *mut JSContext, object: *mut JSObject,
+                                    id: jsid, bp: &mut bool) -> bool {
+    let mut value = UndefinedValue();
+    if JS_DeletePropertyById2(cx, object, id, &mut value) == 0 {
+        return false;
+    }
+
+    *bp = value.to_boolean();
+    return true;
 }
 
 /// Results of `xml_name_type`.


### PR DESCRIPTION
I'll need to write the same code again for cross-origin wrappers.
