### PR TITLE
Start using more typed units in the compositor

### DIFF
--- a/src/components/compositing/platform/common/glfw_windowing.rs
+++ b/src/components/compositing/platform/common/glfw_windowing.rs
@@ -22,9 +22,10 @@ use std::rc::Rc;
 use geom::point::{Point2D, TypedPoint2D};
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
+use layers::geometry::DevicePixel;
 use servo_msg::compositor_msg::{IdleRenderState, RenderState, RenderingRenderState};
 use servo_msg::compositor_msg::{FinishedLoading, Blank, Loading, PerformingLayout, ReadyState};
-use servo_util::geometry::{ScreenPx, DevicePixel};
+use servo_util::geometry::ScreenPx;
 
 use glfw;
 use glfw::Context;

--- a/src/components/compositing/platform/common/glut_windowing.rs
+++ b/src/components/compositing/platform/common/glut_windowing.rs
@@ -17,9 +17,10 @@ use std::rc::Rc;
 use geom::point::{Point2D, TypedPoint2D};
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
+use layers::geometry::DevicePixel;
 use servo_msg::compositor_msg::{IdleRenderState, RenderState, RenderingRenderState};
 use servo_msg::compositor_msg::{FinishedLoading, Blank, ReadyState};
-use servo_util::geometry::{ScreenPx, DevicePixel};
+use servo_util::geometry::ScreenPx;
 
 use glut::glut::{ACTIVE_SHIFT, DOUBLE, WindowHeight};
 use glut::glut::WindowWidth;

--- a/src/components/compositing/windowing.rs
+++ b/src/components/compositing/windowing.rs
@@ -7,8 +7,9 @@
 use geom::point::TypedPoint2D;
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
+use layers::geometry::DevicePixel;
 use servo_msg::compositor_msg::{ReadyState, RenderState};
-use servo_util::geometry::{ScreenPx, DevicePixel};
+use servo_util::geometry::ScreenPx;
 use std::rc::Rc;
 
 pub enum MouseWindowEvent {

--- a/src/components/msg/constellation_msg.rs
+++ b/src/components/msg/constellation_msg.rs
@@ -8,8 +8,9 @@
 use geom::rect::Rect;
 use geom::size::TypedSize2D;
 use geom::scale_factor::ScaleFactor;
+use layers::geometry::DevicePixel;
 use serialize::Encodable;
-use servo_util::geometry::{DevicePixel, PagePx, ViewportPx};
+use servo_util::geometry::{PagePx, ViewportPx};
 use std::comm::{channel, Sender, Receiver};
 use url::Url;
 

--- a/src/components/util/geometry.rs
+++ b/src/components/util/geometry.rs
@@ -13,12 +13,6 @@ use std::fmt;
 
 // Units for use with geom::length and geom::scale_factor.
 
-/// One hardware pixel.
-///
-/// This unit corresponds to the smallest addressable element of the display hardware.
-#[deriving(Encodable)]
-pub enum DevicePixel {}
-
 /// A normalized "pixel" at the default resolution for the display.
 ///
 /// Like the CSS "px" unit, the exact physical size of this unit may vary between devices, but it

--- a/src/components/util/opts.rs
+++ b/src/components/util/opts.rs
@@ -5,11 +5,12 @@
 //! Configuration options for a single run of the servo application. Created
 //! from command line arguments.
 
-use geometry::{DevicePixel, ScreenPx};
+use geometry::ScreenPx;
 
 use azure::azure_hl::{BackendType, CairoBackend, CoreGraphicsBackend};
 use azure::azure_hl::{CoreGraphicsAcceleratedBackend, Direct2DBackend, SkiaBackend};
 use geom::scale_factor::ScaleFactor;
+use layers::geometry::DevicePixel;
 use getopts;
 use std::cmp;
 use std::io;

--- a/src/components/util/util.rs
+++ b/src/components/util/util.rs
@@ -18,6 +18,7 @@ extern crate azure;
 extern crate collections;
 extern crate geom;
 extern crate getopts;
+extern crate layers;
 extern crate libc;
 extern crate native;
 extern crate rand;


### PR DESCRIPTION
Now that rust-layers is starting to support typed units, we can use
them more thoroughly in the compositor. This is a step toward removing
as many untyped units as possible.
