### PR TITLE
Rename AttrList to NamedNodeMap

### DIFF
--- a/src/components/script/dom/element.rs
+++ b/src/components/script/dom/element.rs
@@ -6,7 +6,7 @@
 
 use dom::attr::{Attr, ReplacedAttr, FirstSetAttr, AttrHelpersForLayout};
 use dom::attr::{AttrValue, StringAttrValue, UIntAttrValue, AtomAttrValue};
-use dom::attrlist::AttrList;
+use dom::namednodemap::NamedNodeMap;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::ElementBinding;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -49,7 +49,7 @@ pub struct Element {
     pub prefix: Option<DOMString>,
     pub attrs: RefCell<Vec<JS<Attr>>>,
     pub style_attribute: Traceable<RefCell<Option<style::PropertyDeclarationBlock>>>,
-    pub attr_list: Cell<Option<JS<AttrList>>>,
+    pub attr_list: Cell<Option<JS<NamedNodeMap>>>,
     class_list: Cell<Option<JS<DOMTokenList>>>,
 }
 
@@ -535,7 +535,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-attributes
-    fn Attributes(&self) -> Temporary<AttrList> {
+    fn Attributes(&self) -> Temporary<NamedNodeMap> {
         match self.attr_list.get() {
             None => (),
             Some(ref list) => return Temporary::new(list.clone()),
@@ -546,7 +546,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
             node.owner_doc().root()
         };
         let window = doc.deref().window.root();
-        let list = AttrList::new(&*window, self);
+        let list = NamedNodeMap::new(&*window, self);
         self.attr_list.assign(Some(list));
         Temporary::new(self.attr_list.get().get_ref().clone())
     }

--- a/src/components/script/dom/namednodemap.rs
+++ b/src/components/script/dom/namednodemap.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::attr::Attr;
-use dom::bindings::codegen::Bindings::AttrListBinding;
-use dom::bindings::codegen::Bindings::AttrListBinding::AttrListMethods;
+use dom::bindings::codegen::Bindings::NamedNodeMapBinding;
+use dom::bindings::codegen::Bindings::NamedNodeMapBinding::NamedNodeMapMethods;
 use dom::bindings::global::Window;
 use dom::bindings::js::{JS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
@@ -12,26 +12,26 @@ use dom::element::Element;
 use dom::window::Window;
 
 #[deriving(Encodable)]
-pub struct AttrList {
+pub struct NamedNodeMap {
     reflector_: Reflector,
     owner: JS<Element>,
 }
 
-impl AttrList {
-    pub fn new_inherited(elem: &JSRef<Element>) -> AttrList {
-        AttrList {
+impl NamedNodeMap {
+    pub fn new_inherited(elem: &JSRef<Element>) -> NamedNodeMap {
+        NamedNodeMap {
             reflector_: Reflector::new(),
             owner: JS::from_rooted(elem),
         }
     }
 
-    pub fn new(window: &JSRef<Window>, elem: &JSRef<Element>) -> Temporary<AttrList> {
-        reflect_dom_object(box AttrList::new_inherited(elem),
-                           &Window(*window), AttrListBinding::Wrap)
+    pub fn new(window: &JSRef<Window>, elem: &JSRef<Element>) -> Temporary<NamedNodeMap> {
+        reflect_dom_object(box NamedNodeMap::new_inherited(elem),
+                           &Window(*window), NamedNodeMapBinding::Wrap)
     }
 }
 
-impl<'a> AttrListMethods for JSRef<'a, AttrList> {
+impl<'a> NamedNodeMapMethods for JSRef<'a, NamedNodeMap> {
     fn Length(&self) -> u32 {
         self.owner.root().attrs.borrow().len() as u32
     }
@@ -47,7 +47,7 @@ impl<'a> AttrListMethods for JSRef<'a, AttrList> {
     }
 }
 
-impl Reflectable for AttrList {
+impl Reflectable for NamedNodeMap {
     fn reflector<'a>(&'a self) -> &'a Reflector {
         &self.reflector_
     }

--- a/src/components/script/dom/webidls/Element.webidl
+++ b/src/components/script/dom/webidls/Element.webidl
@@ -32,7 +32,7 @@ interface Element : Node {
   readonly attribute DOMTokenList classList;
 
   [Constant]
-  readonly attribute AttrList attributes;
+  readonly attribute NamedNodeMap attributes;
   DOMString? getAttribute(DOMString name);
   DOMString? getAttributeNS(DOMString? namespace, DOMString localName);
   [Throws]

--- a/src/components/script/dom/webidls/NamedNodeMap.webidl
+++ b/src/components/script/dom/webidls/NamedNodeMap.webidl
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-[NoInterfaceObject]
-interface AttrList {
+interface NamedNodeMap {
   readonly attribute unsigned long length;
   getter Attr? item(unsigned long index);
 };

--- a/src/components/script/script.rs
+++ b/src/components/script/script.rs
@@ -76,7 +76,6 @@ pub mod dom {
     pub mod macros;
 
     pub mod attr;
-    pub mod attrlist;
     pub mod blob;
     pub mod browsercontext;
     pub mod canvasrenderingcontext2d;
@@ -173,6 +172,7 @@ pub mod dom {
     pub mod location;
     pub mod messageevent;
     pub mod mouseevent;
+    pub mod namednodemap;
     pub mod navigator;
     pub mod node;
     pub mod nodeiterator;

--- a/src/test/content/test_interfaces.html
+++ b/src/test/content/test_interfaces.html
@@ -144,6 +144,7 @@ var interfaceNamesInGlobalScope = [
   "Location",
   "MessageEvent",
   "MouseEvent",
+  "NamedNodeMap",
   "Navigator",
   "Node",
   "NodeIterator",

--- a/src/test/wpt/metadata/dom/historical.html.ini
+++ b/src/test/wpt/metadata/dom/historical.html.ini
@@ -1,0 +1,5 @@
+[historical.html]
+  type: testharness
+  [Historical DOM features must be removed: NamedNodeMap]
+    expected: FAIL
+


### PR DESCRIPTION
This PR renames AttrList to NamedNodeMap, to comply with the HTML DOM spec.
