### PR TITLE
Introduce ConstantSpec::get_value.

### DIFF
--- a/src/components/script/dom/bindings/utils.rs
+++ b/src/components/script/dom/bindings/utils.rs
@@ -222,6 +222,20 @@ pub struct ConstantSpec {
     pub value: ConstantVal
 }
 
+impl ConstantSpec {
+    /// Returns a `JSVal` that represents the value of this `ConstantSpec`.
+    pub fn get_value(&self) -> JSVal {
+        match self.value {
+            NullVal => NullValue(),
+            IntVal(i) => Int32Value(i),
+            UintVal(u) => UInt32Value(u),
+            DoubleVal(d) => DoubleValue(d),
+            BoolVal(b) => BooleanValue(b),
+            VoidVal => UndefinedValue(),
+        }
+    }
+}
+
 /// Helper structure for cross-origin wrappers for DOM binding objects.
 pub struct NativePropertyHooks {
     /// The property arrays for this interface.
@@ -349,17 +363,9 @@ fn CreateInterfaceObject(cx: *mut JSContext, global: *mut JSObject, receiver: *m
 /// Fails on JSAPI failure.
 fn DefineConstants(cx: *mut JSContext, obj: *mut JSObject, constants: &'static [ConstantSpec]) {
     for spec in constants.iter() {
-        let jsval = match spec.value {
-            NullVal => NullValue(),
-            IntVal(i) => Int32Value(i),
-            UintVal(u) => UInt32Value(u),
-            DoubleVal(d) => DoubleValue(d),
-            BoolVal(b) => BooleanValue(b),
-            VoidVal => UndefinedValue(),
-        };
         unsafe {
             assert!(JS_DefineProperty(cx, obj, spec.name.as_ptr() as *const libc::c_char,
-                                      jsval, None, None,
+                                      spec.get_value(), None, None,
                                       JSPROP_ENUMERATE | JSPROP_READONLY |
                                       JSPROP_PERMANENT) != 0);
         }


### PR DESCRIPTION
I'll need it for cross-origin wrappers as well.
