### PR TITLE
Support callback return types in codegen

### DIFF
--- a/src/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/src/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1030,7 +1030,7 @@ def typeRetValNeedsRooting(type):
         return False
     if type.nullable():
         type = type.inner
-    return type.isGeckoInterface() and not type.isCallback()
+    return type.isGeckoInterface() and not type.isCallback() and not type.isCallbackInterface()
 
 def memberIsCreator(member):
     return member.getExtendedAttribute("Creator") is not None

--- a/src/components/script/dom/bindings/codegen/Configuration.py
+++ b/src/components/script/dom/bindings/codegen/Configuration.py
@@ -150,7 +150,7 @@ class Descriptor(DescriptorProvider):
         else:
             self.needsRooting = True
 
-        self.returnType = "Temporary<%s>" % ifaceName
+        self.returnType = desc.get('returnType', "Temporary<%s>" % ifaceName)
         self.argumentType = "JSRef<%s>" % ifaceName
         self.memberType = "Root<'a, 'b, %s>" % ifaceName
         self.nativeType = desc.get('nativeType', 'JS<%s>' % ifaceName)


### PR DESCRIPTION
This change gets used for the getter function of TreeWalker.filter, which returns a NodeFilter, which is a callback interface.
