### PR TITLE
Disable same-origin.html for intermittent failures (fixes #3180).

### DIFF
--- a/src/test/wpt/metadata/workers/constructors/Worker/same-origin.html.ini
+++ b/src/test/wpt/metadata/workers/constructors/Worker/same-origin.html.ini
@@ -1,26 +1,3 @@
 [same-origin.html]
   type: testharness
-  [unsupported_scheme]
-    expected: FAIL
-
-  [about_blank]
-    expected: FAIL
-
-  [example_invalid]
-    expected: FAIL
-
-  [port_81]
-    expected: FAIL
-
-  [https_port_80]
-    expected: FAIL
-
-  [https_port_8000]
-    expected: FAIL
-
-  [http_post_8012]
-    expected: FAIL
-
-  [javascript_url]
-    expected: FAIL
-
+  disabled: intermittent failures


### PR DESCRIPTION
We don't currently implement the same-origin restriction at all, so there's
little point in running this test.
