### PR TITLE
Revert syntax extension for now, as it causes issues with cross compiling for android.

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -21,13 +21,10 @@ $(foreach submodule,$(SUBMODULES),\
 $(eval $(call DEF_SUBMODULE_TEST_RULES,$(submodule))))
 
 
-DEPS_test_macros = $(DONE_macros)
-RFLAGS_test_macros = -L $(B)src/components/macros
-
 define DEF_LIB_CRATE_TEST_RULES
-servo-test-$(1): $$(DEPS_$(1)) $$(DEPS_test_$(1))
+servo-test-$(1): $$(DEPS_$(1))
 	@$$(call E, compile: servo-test-$(1))
-	$$(Q)$$(RUSTC) $(strip $(TARGET_FLAGS) $(CFG_RUSTC_FLAGS)) $$(RFLAGS_$(1)) $$(RFLAGS_test_$(1)) --test -o $$@ $$<
+	$$(Q)$$(RUSTC) $(strip $(TARGET_FLAGS) $(CFG_RUSTC_FLAGS)) $$(RFLAGS_$(1)) --test -o $$@ $$<
 
 .PHONY: check-servo-$(1)
 check-servo-$(1): servo-test-$(1)

--- a/src/components/macros/macros.rs
+++ b/src/components/macros/macros.rs
@@ -4,132 +4,13 @@
 
 #![crate_name = "macros"]
 #![crate_type = "rlib"]
-#![crate_type = "dylib"]
 
-#![feature(macro_rules, plugin_registrar, quote)]
+#![feature(macro_rules)]
 
 //! Exports macros for use in other Servo crates.
 
 #[cfg(test)]
 extern crate sync;
-
-extern crate rustc;
-extern crate syntax;
- 
-use syntax::ast;
-use syntax::codemap::Span;
-use syntax::ext::base;
-use syntax::ext::base::{ExtCtxt, MacResult};
-use syntax::parse::token;
-use syntax::util::small_vector::SmallVector;
-use rustc::plugin::Registry;
-use std::gc::{Gc, GC};
-
-
-#[plugin_registrar]
-pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_syntax_extension(
-        token::intern("bit_struct"),
-        base::IdentTT(box base::BasicIdentMacroExpander {
-            expander: expand_bit_struct,
-            span: None,
-        }, None));
-}
-
-fn expand_bit_struct(cx: &mut ExtCtxt, sp: Span, name: ast::Ident, tts: Vec<ast::TokenTree>)
-                     -> Box<base::MacResult> {
-    let mut fields = Vec::new();
-    for (i, e) in tts.iter().enumerate() {
-        if i & 1 == 1 {
-            match *e {
-                ast::TTTok(_, token::COMMA) => (),
-                _ => {
-                    cx.span_err(sp, "bit_struct! expecting comma.");
-                    return base::DummyResult::any(sp);
-                }
-            }
-        } else {
-            match *e {
-                ast::TTTok(_, token::IDENT(ident, _)) => {
-                    fields.push(ident)
-                }
-                _ => {
-                    cx.span_err(sp, "bit_struct! requires ident args.");
-                    return base::DummyResult::any(sp);
-                }
-            }
-        }
-    }
-    let bits_per_word =
-        if cfg!(target_word_size = "64") { 64 }
-        else if cfg!(target_word_size = "32") { 32 }
-        else { fail!("Unexpected target word size") };
-    let nb_words = (fields.len() - 1 + bits_per_word) / bits_per_word;
-
-    let struct_def = quote_item!(&*cx,
-        pub struct $name {
-            storage: [uint, ..$nb_words]
-        }
-    ).unwrap();
-    let impl_def = quote_item!(&*cx,
-        impl $name {
-            #[inline]
-            pub fn new() -> $name {
-                $name { storage: [0, ..$nb_words] }
-            }
-        }
-    ).unwrap();
-
-    // Unwrap from Gc<T>, which does not implement DerefMut
-    let mut impl_def = (*impl_def).clone();
-    match impl_def.node {
-        ast::ItemImpl(_, _, _, ref mut methods) => {
-            for (i, field) in fields.iter().enumerate() {
-                let setter_name = "set_".to_string() + field.as_str();
-                let setter = token::str_to_ident(setter_name.as_slice());
-                let word = i / bits_per_word;
-                let bit = i % bits_per_word;
-                let additional_impl = quote_item!(&*cx,
-                    impl $name {
-                        #[allow(non_snake_case_functions)]
-                        pub fn $field(&self) -> bool {
-                            (self.storage[$word] & (1 << $bit)) != 0
-                        }
-                        #[allow(non_snake_case_functions)]
-                        pub fn $setter(&mut self, new_value: bool) {
-                            if new_value {
-                                self.storage[$word] |= 1 << $bit
-                            } else {
-                                self.storage[$word] &= !(1 << $bit)
-                            }
-                        }
-                    }
-                ).unwrap();
-                match additional_impl.node {
-                    ast::ItemImpl(_, _, _, ref additional_methods) => {
-                        methods.push_all(additional_methods.as_slice());
-                    }
-                    _ => fail!()
-                }
-            }
-        }
-        _ => fail!()
-    }
-    // Re-wrap.
-    let impl_def = box(GC) impl_def;
-
-    struct MacItems {
-        items: Vec<Gc<ast::Item>>
-    }
-
-    impl MacResult for MacItems {
-        fn make_items(&self) -> Option<SmallVector<Gc<ast::Item>>> {
-            Some(SmallVector::many(self.items.clone()))
-        }
-    }
-
-    box MacItems { items: vec![struct_def, impl_def] } as Box<MacResult>
-}
 
 
 #[macro_export]

--- a/src/components/macros/macros.rs
+++ b/src/components/macros/macros.rs
@@ -6,16 +6,12 @@
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 
-#![feature(macro_rules, plugin_registrar, quote, phase)]
+#![feature(macro_rules, plugin_registrar, quote)]
 
 //! Exports macros for use in other Servo crates.
 
 #[cfg(test)]
 extern crate sync;
-
-#[cfg(test)]
-#[phase(plugin)]
-extern crate macros;
 
 extern crate rustc;
 extern crate syntax;
@@ -185,12 +181,9 @@ macro_rules! lazy_init(
 )
 
 
-#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     use std::collections::hashmap::HashMap;
-    use std::mem::size_of;
-
     lazy_init! {
         static ref NUMBER: uint = times_two(3);
         static ref VEC: [Box<uint>, ..3] = [box 1, box 2, box 3];
@@ -222,73 +215,5 @@ mod tests {
         assert_eq!(*NUMBER, 6);
         assert_eq!(*NUMBER, 6);
         assert_eq!(*NUMBER, 6);
-    }
-
-    bit_struct! TestStruct64 {
-        f01, f02, f03, f04, f05, f06, f07, f08, f09, f10,
-        f11, f12, f13, f14, f15, f16, f17, f18, f19, f20,
-        f21, f22, f23, f24, f25, f26, f27, f28, f29, f30,
-        f31, f32, f33, f34, f35, f36, f37, f38, f39, f40,
-        f41, f42, f43, f44, f45, f46, f47, f48, f49, f50,
-        f51, f52, f53, f54, f55, f56, f57, f58, f59, f60,
-        f61, f62, f63, f64,
-    }
-
-    bit_struct! TestStruct65 {
-        f01, f02, f03, f04, f05, f06, f07, f08, f09, f10,
-        f11, f12, f13, f14, f15, f16, f17, f18, f19, f20,
-        f21, f22, f23, f24, f25, f26, f27, f28, f29, f30,
-        f31, f32, f33, f34, f35, f36, f37, f38, f39, f40,
-        f41, f42, f43, f44, f45, f46, f47, f48, f49, f50,
-        f51, f52, f53, f54, f55, f56, f57, f58, f59, f60,
-        f61, f62, f63, f64, f65,
-    }
-
-    #[test]
-    fn test_bit_struct() {
-        if cfg!(target_word_size = "64") {
-            // One and two 8-byte words
-            assert_eq!(size_of::<TestStruct64>(), 8)
-            assert_eq!(size_of::<TestStruct65>(), 16)
-        } else {
-            // Two and three 4-byte words
-            assert_eq!(size_of::<TestStruct64>(), 8)
-            assert_eq!(size_of::<TestStruct65>(), 12)
-        }
-
-        let mut foo = TestStruct65::new();
-        assert_eq!(foo.f01(), false);
-        assert_eq!(foo.f32(), false);
-        assert_eq!(foo.f33(), false);
-        assert_eq!(foo.f64(), false);
-        assert_eq!(foo.f65(), false);
-
-        foo.set_f33(true);
-        assert_eq!(foo.f01(), false);
-        assert_eq!(foo.f32(), false);
-        assert_eq!(foo.f33(), true);
-        assert_eq!(foo.f64(), false);
-        assert_eq!(foo.f65(), false);
-
-        foo.set_f01(false);
-        assert_eq!(foo.f01(), false);
-        assert_eq!(foo.f32(), false);
-        assert_eq!(foo.f33(), true);
-        assert_eq!(foo.f64(), false);
-        assert_eq!(foo.f65(), false);
-
-        foo.set_f65(true);
-        assert_eq!(foo.f01(), false);
-        assert_eq!(foo.f32(), false);
-        assert_eq!(foo.f33(), true);
-        assert_eq!(foo.f64(), false);
-        assert_eq!(foo.f65(), true);
-
-        foo.set_f33(false);
-        assert_eq!(foo.f01(), false);
-        assert_eq!(foo.f32(), false);
-        assert_eq!(foo.f33(), false);
-        assert_eq!(foo.f64(), false);
-        assert_eq!(foo.f65(), true);
     }
 }

--- a/src/components/macros/macros.rs
+++ b/src/components/macros/macros.rs
@@ -15,7 +15,7 @@ extern crate sync;
 
 extern crate rustc;
 extern crate syntax;
-
+ 
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base;
@@ -92,12 +92,10 @@ fn expand_bit_struct(cx: &mut ExtCtxt, sp: Span, name: ast::Ident, tts: Vec<ast:
                 let additional_impl = quote_item!(&*cx,
                     impl $name {
                         #[allow(non_snake_case_functions)]
-                        #[inline]
                         pub fn $field(&self) -> bool {
                             (self.storage[$word] & (1 << $bit)) != 0
                         }
                         #[allow(non_snake_case_functions)]
-                        #[inline]
                         pub fn $setter(&mut self, new_value: bool) {
                             if new_value {
                                 self.storage[$word] |= 1 << $bit
@@ -120,8 +118,6 @@ fn expand_bit_struct(cx: &mut ExtCtxt, sp: Span, name: ast::Ident, tts: Vec<ast:
     // Re-wrap.
     let impl_def = box(GC) impl_def;
 
-    // FIXME(SimonSapin) replace this with something from libsyntax
-    // if/when https://github.com/rust-lang/rust/issues/16723 is fixed
     struct MacItems {
         items: Vec<Gc<ast::Item>>
     }


### PR DESCRIPTION
Simon suggested that it's fine to roll back these commits for now, as it's unlikely we'll be moving away from mako in the near future.

It's probably easiest to roll these back rather than create a special crate for the syntax extensions, unless there is another way I'm missing?
