### PR TITLE
Move the script type and language checks into HTMLScriptElement.

### DIFF
--- a/src/components/script/html/hubbub_html_parser.rs
+++ b/src/components/script/html/hubbub_html_parser.rs
@@ -4,7 +4,8 @@
 
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
-use dom::bindings::codegen::InheritTypes::{NodeBase, NodeCast, TextCast, ElementCast};
+use dom::bindings::codegen::InheritTypes::{NodeBase, NodeCast, TextCast};
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLScriptElementCast};
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable, Root};
 use dom::bindings::utils::Reflectable;
 use dom::document::{Document, DocumentHelpers};
@@ -12,6 +13,7 @@ use dom::element::{AttributeHandlers, HTMLLinkElementTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::htmlheadingelement::{Heading1, Heading2, Heading3, Heading4, Heading5, Heading6};
 use dom::htmlformelement::HTMLFormElement;
+use dom::htmlscriptelement::HTMLScriptElementHelpers;
 use dom::node::{ElementNodeTypeId, NodeHelpers};
 use dom::types::*;
 use html::cssparse::{StylesheetProvenance, UrlProvenance, spawn_css_parser};
@@ -23,7 +25,7 @@ use servo_net::resource_task::{Load, LoadData, Payload, Done, ResourceTask, load
 use servo_util::atom::Atom;
 use servo_util::namespace;
 use servo_util::namespace::{Namespace, Null};
-use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
+use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS};
 use servo_util::task::spawn_named;
 use std::ascii::StrAsciiExt;
 use std::mem;
@@ -291,57 +293,6 @@ pub fn build_element_from_tag(tag: DOMString, ns: Namespace, document: &JSRef<Do
     return ElementCast::from_temporary(HTMLUnknownElement::new(tag, document));
 }
 
-// List found at http://whatwg.org/html#support-the-scripting-language
-static SCRIPT_JS_MIMES: StaticStringVec = &[
-    "application/ecmascript",
-    "application/javascript",
-    "application/x-ecmascript",
-    "application/x-javascript",
-    "text/ecmascript",
-    "text/javascript",
-    "text/javascript1.0",
-    "text/javascript1.1",
-    "text/javascript1.2",
-    "text/javascript1.3",
-    "text/javascript1.4",
-    "text/javascript1.5",
-    "text/jscript",
-    "text/livescript",
-    "text/x-ecmascript",
-    "text/x-javascript",
-];
-
-fn is_javascript(script: &JSRef<Element>) -> bool {
-    match script.get_attribute(Null, "type").root().map(|s| s.Value()) {
-        Some(ref s) if s.is_empty() => {
-            // type attr exists, but empty means js
-            debug!("script type empty, inferring js");
-            true
-        },
-        Some(ref s) => {
-            debug!("script type={:s}", *s);
-            SCRIPT_JS_MIMES.contains(&s.as_slice().trim_chars(HTML_SPACE_CHARACTERS))
-        },
-        None => {
-            debug!("no script type");
-            match script.get_attribute(Null, "language").root().map(|s| s.Value()) {
-                Some(ref s) if s.is_empty() => {
-                    debug!("script language empty, inferring js");
-                    true
-                },
-                Some(ref s) => {
-                    debug!("script language={:s}", *s);
-                    SCRIPT_JS_MIMES.contains(&"text/".to_string().append(s.as_slice()).as_slice())
-                },
-                None => {
-                    debug!("no script type or language, inferring js");
-                    true
-                }
-            }
-        }
-    }
-}
-
 pub fn parse_html(page: &Page,
                   document: &JSRef<Document>,
                   url: Url,
@@ -544,13 +495,16 @@ pub fn parse_html(page: &Page,
         },
         complete_script: |script| {
             unsafe {
-                let script: &JSRef<Element> = &*from_hubbub_node(script).root();
+                let script = from_hubbub_node::<Node>(script).root();
+                let script: Option<&JSRef<HTMLScriptElement>> =
+                    HTMLScriptElementCast::to_ref(&*script);
+                let script = match script {
+                    Some(script) if script.is_javascript() => script,
+                    _ => return,
+                };
 
-                if !is_javascript(script) {
-                    return;
-                }
-
-                match script.get_attribute(Null, "src").root() {
+                let script_element: &JSRef<Element> = ElementCast::from_ref(script);
+                match script_element.get_attribute(Null, "src").root() {
                     Some(src) => {
                         debug!("found script: {:s}", src.deref().Value());
                         match UrlParser::new().base_url(base_url)


### PR DESCRIPTION
This is IMO a more sensible place for them to live, and prepares for the
demise of hubbub_html_parser.rs, as we move to html5ever.
