### PR TITLE
Implements about:blank in an about_loader

### DIFF
--- a/components/net/about_loader.rs
+++ b/components/net/about_loader.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use resource_task::{LoadResponse, Metadata, Done, LoadData, start_sending};
+use file_loader;
+
+use std::os;
+use url::Url;
+use StatusOk = http::status::Ok;
+
+
+pub fn factory(mut load_data: LoadData, start_chan: Sender<LoadResponse>) {
+    match load_data.url.non_relative_scheme_data().unwrap() {
+        "blank" => {
+            let chan = start_sending(start_chan, Metadata {
+                final_url: load_data.url,
+                content_type: Some(("text".to_string(), "html".to_string())),
+                charset: Some("utf-8".to_string()),
+                headers: None,
+                status: StatusOk,
+            });
+            chan.send(Done(Ok(())));
+            return
+        }
+        "crash" => fail!("Loading the about:crash URL."),
+        "failure" => {
+            // FIXME: Find a way to load this without relying on the `../src` directory.
+            let mut path = os::self_exe_path().expect("can't get exe path");
+            path.pop();
+            path.push_many(["src", "test", "html", "failure.html"]);
+            load_data.url = Url::from_file_path(&path).unwrap();
+        }
+        _ => {
+            start_sending(start_chan, Metadata::default(load_data.url))
+                .send(Done(Err("Unknown about: URL.".to_string())));
+            return
+        }
+    };
+    file_loader::factory(load_data, start_chan)
+}

--- a/components/net/data_loader.rs
+++ b/components/net/data_loader.rs
@@ -4,7 +4,7 @@
 
 use std::str;
 
-use resource_task::{Done, Payload, Metadata, LoadData, LoadResponse, LoaderTask, start_sending};
+use resource_task::{Done, Payload, Metadata, LoadData, LoadResponse, start_sending};
 
 use serialize::base64::FromBase64;
 
@@ -13,13 +13,12 @@ use http::headers::content_type::MediaType;
 use url::{percent_decode, NonRelativeSchemeData};
 
 
-pub fn factory() -> LoaderTask {
-    proc(url, start_chan) {
-        // NB: we don't spawn a new task.
-        // Hypothesis: data URLs are too small for parallel base64 etc. to be worth it.
-        // Should be tested at some point.
-        load(url, start_chan)
-    }
+pub fn factory(load_data: LoadData, start_chan: Sender<LoadResponse>) {
+    // NB: we don't spawn a new task.
+    // Hypothesis: data URLs are too small for parallel base64 etc. to be worth it.
+    // Should be tested at some point.
+    // Left in separate function to allow easy moving to a task, if desired.
+    load(url, start_chan)
 }
 
 fn load(load_data: LoadData, start_chan: Sender<LoadResponse>) {

--- a/components/net/data_loader.rs
+++ b/components/net/data_loader.rs
@@ -18,7 +18,7 @@ pub fn factory(load_data: LoadData, start_chan: Sender<LoadResponse>) {
     // Hypothesis: data URLs are too small for parallel base64 etc. to be worth it.
     // Should be tested at some point.
     // Left in separate function to allow easy moving to a task, if desired.
-    load(url, start_chan)
+    load(load_data, start_chan)
 }
 
 fn load(load_data: LoadData, start_chan: Sender<LoadResponse>) {

--- a/components/net/file_loader.rs
+++ b/components/net/file_loader.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use resource_task::{ProgressMsg, Metadata, Payload, Done, start_sending};
+use resource_task::{ProgressMsg, Metadata, Payload, Done, LoadData, start_sending};
+use resource_task::{LoadResponse};
 
 use std::io;
 use std::io::File;

--- a/components/net/file_loader.rs
+++ b/components/net/file_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use resource_task::{ProgressMsg, Metadata, Payload, Done, LoaderTask, start_sending};
+use resource_task::{ProgressMsg, Metadata, Payload, Done, start_sending};
 
 use std::io;
 use std::io::File;
@@ -29,30 +29,27 @@ fn read_all(reader: &mut io::Stream, progress_chan: &Sender<ProgressMsg>)
     }
 }
 
-pub fn factory() -> LoaderTask {
-    let f: LoaderTask = proc(load_data, start_chan) {
-        let url = load_data.url;
-        assert!("file" == url.scheme.as_slice());
-        let progress_chan = start_sending(start_chan, Metadata::default(url.clone()));
-        spawn_named("file_loader", proc() {
-            let file_path: Result<Path, ()> = url.to_file_path();
-            match file_path {
-                Ok(file_path) => {
-                    match File::open_mode(&Path::new(file_path), io::Open, io::Read) {
-                        Ok(ref mut reader) => {
-                            let res = read_all(reader as &mut io::Stream, &progress_chan);
-                            progress_chan.send(Done(res));
-                        }
-                        Err(e) => {
-                            progress_chan.send(Done(Err(e.desc.to_string())));
-                        }
+pub fn factory(load_data: LoadData, start_chan: Sender<LoadResponse>) {
+    let url = load_data.url;
+    assert!("file" == url.scheme.as_slice());
+    let progress_chan = start_sending(start_chan, Metadata::default(url.clone()));
+    spawn_named("file_loader", proc() {
+        let file_path: Result<Path, ()> = url.to_file_path();
+        match file_path {
+            Ok(file_path) => {
+                match File::open_mode(&Path::new(file_path), io::Open, io::Read) {
+                    Ok(ref mut reader) => {
+                        let res = read_all(reader as &mut io::Stream, &progress_chan);
+                        progress_chan.send(Done(res));
+                    }
+                    Err(e) => {
+                        progress_chan.send(Done(Err(e.desc.to_string())));
                     }
                 }
-                Err(_) => {
-                    progress_chan.send(Done(Err(url.to_string())));
-                }
             }
-        });
-    };
-    f
+            Err(_) => {
+                progress_chan.send(Done(Err(url.to_string())));
+            }
+        }
+    });
 }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use resource_task::{Metadata, Payload, Done, LoadResponse, LoadData, LoaderTask, start_sending_opt};
+use resource_task::{Metadata, Payload, Done, LoadResponse, LoadData, start_sending_opt};
 
 use std::collections::hashmap::HashSet;
 use http::client::{RequestWriter, NetworkStream};
@@ -11,11 +11,8 @@ use std::io::Reader;
 use servo_util::task::spawn_named;
 use url::Url;
 
-pub fn factory() -> LoaderTask {
-    let f: LoaderTask = proc(url, start_chan) {
-        spawn_named("http_loader", proc() load(url, start_chan))
-    };
-    f
+pub fn factory(load_data: LoadData, start_chan: Sender<LoadResponse>) {
+    spawn_named("http_loader", proc() load(url, start_chan))
 }
 
 fn send_error(url: Url, err: String, start_chan: Sender<LoadResponse>) {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -12,7 +12,7 @@ use servo_util::task::spawn_named;
 use url::Url;
 
 pub fn factory(load_data: LoadData, start_chan: Sender<LoadResponse>) {
-    spawn_named("http_loader", proc() load(url, start_chan))
+    spawn_named("http_loader", proc() load(load_data, start_chan))
 }
 
 fn send_error(url: Url, err: String, start_chan: Sender<LoadResponse>) {

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -28,6 +28,7 @@ pub mod image {
     pub mod holder;
 }
 
+pub mod about_loader;
 pub mod file_loader;
 pub mod http_loader;
 pub mod data_loader;

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -4,13 +4,13 @@
 
 //! A task that takes a URL and streams back the binary data.
 
+use about_loader;
+use data_loader;
 use file_loader;
 use http_loader;
-use data_loader;
 
 use std::comm::{channel, Receiver, Sender};
 use std::task::TaskBuilder;
-use std::os;
 use http::headers::content_type::MediaType;
 use ResponseHeaderCollection = http::headers::response::HeaderCollection;
 use RequestHeaderCollection = http::headers::request::HeaderCollection;
@@ -201,29 +201,12 @@ impl ResourceManager {
         }
     }
 
-    fn load(&self, mut load_data: LoadData, start_chan: Sender<LoadResponse>) {
+    fn load(&self, load_data: LoadData, start_chan: Sender<LoadResponse>) {
         let loader = match load_data.url.scheme.as_slice() {
             "file" => file_loader::factory,
             "http" | "https" => http_loader::factory,
             "data" => data_loader::factory,
-            "about" => {
-                match load_data.url.non_relative_scheme_data().unwrap() {
-                    "crash" => fail!("Loading the about:crash URL."),
-                    "failure" => {
-                        // FIXME: Find a way to load this without relying on the `../src` directory.
-                        let mut path = os::self_exe_path().expect("can't get exe path");
-                        path.pop();
-                        path.push_many(["src", "test", "html", "failure.html"]);
-                        load_data.url = Url::from_file_path(&path).unwrap();
-                        file_loader::factory
-                    }
-                    _ => {
-                        start_sending(start_chan, Metadata::default(load_data.url))
-                            .send(Done(Err("Unknown about: URL.".to_string())));
-                        return
-                    }
-                }
-            },
+            "about" => about_loader::factory,
             _ => {
                 debug!("resource_task: no loader for scheme {:s}", load_data.url.scheme);
                 start_sending(start_chan, Metadata::default(load_data.url))

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -163,16 +163,6 @@ pub fn load_whole_resource(resource_task: &ResourceTask, url: Url)
 /// Handle to a resource task
 pub type ResourceTask = Sender<ControlMsg>;
 
-pub type LoaderTask = proc(load_data: LoadData, Sender<LoadResponse>);
-
-/**
-Creates a task to load a specific resource
-
-The ResourceManager delegates loading to a different type of loader task for
-each URL scheme
-*/
-type LoaderTaskFactory = extern "Rust" fn() -> LoaderTask;
-
 /// Create a ResourceTask
 pub fn new_resource_task() -> ResourceTask {
     let (setup_chan, setup_port) = channel();
@@ -213,9 +203,9 @@ impl ResourceManager {
 
     fn load(&self, mut load_data: LoadData, start_chan: Sender<LoadResponse>) {
         let loader = match load_data.url.scheme.as_slice() {
-            "file" => file_loader::factory(),
-            "http" | "https" => http_loader::factory(),
-            "data" => data_loader::factory(),
+            "file" => file_loader::factory,
+            "http" | "https" => http_loader::factory,
+            "data" => data_loader::factory,
             "about" => {
                 match load_data.url.non_relative_scheme_data().unwrap() {
                     "crash" => fail!("Loading the about:crash URL."),
@@ -225,7 +215,7 @@ impl ResourceManager {
                         path.pop();
                         path.push_many(["src", "test", "html", "failure.html"]);
                         load_data.url = Url::from_file_path(&path).unwrap();
-                        file_loader::factory()
+                        file_loader::factory
                     }
                     _ => {
                         start_sending(start_chan, Metadata::default(load_data.url))

--- a/tests/wpt/metadata/XMLHttpRequest/open-url-about-blank-window.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-about-blank-window.htm.ini
@@ -1,3 +1,4 @@
 [open-url-about-blank-window.htm]
   type: testharness
-  expected: TIMEOUT
+  [XMLHttpRequest: open() resolving URLs (about:blank iframe)]
+    expected: FAIL

--- a/tests/wpt/metadata/dom/errors/exceptions.html.ini
+++ b/tests/wpt/metadata/dom/errors/exceptions.html.ini
@@ -1,3 +1,7 @@
 [exceptions.html]
   type: testharness
   expected: TIMEOUT
+  [exception.hasOwnProperty("message")]
+    expected: FAIL
+  [Object.getOwnPropertyDescriptor(exception, "message")]
+    expected: FAIL

--- a/tests/wpt/metadata/dom/nodes/Node-appendChild.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-appendChild.html.ini
@@ -1,3 +1,8 @@
 [Node-appendChild.html]
   type: testharness
-  expected: TIMEOUT
+  [Appending a document]
+    expected: FAIL
+  [Adopting an orphan]
+    expected: FAIL
+  [Adopting a non-orphan]
+    expected: FAIL

--- a/tests/wpt/metadata/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-03.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-03.html.ini
@@ -1,3 +1,4 @@
 [indexed-browsing-contexts-03.html]
   type: testharness
-  expected: TIMEOUT
+  [Indexed child browsing contexts]
+    expected: FAIL


### PR DESCRIPTION
1. First commit removes a redundant `proc` being created, as it wasn't closing over any variables. Instead, `*_loader::factory` can be called directly, _that_ can spawn a task or what-have-you.
2. Without a dedicated "shipped content" location, I wasn't sure where to put an `about_blank.html` file. The `FIXME` in the same module seems to imply that it should not be in `src/test/html/about_blank.html`. Besides that, `about:blank` seems to be loaded quite often (many iframes seem to point to it), that it seemed worth skipping the IO overhead, and just keep the few bytes as a static.

Fixes #3012 
