### PR TITLE
Fix inline size bubbling with fixed width block. Improve intrinsic inline size calculation for text fragments.

### DIFF
--- a/src/components/layout/fragment.rs
+++ b/src/components/layout/fragment.rs
@@ -1105,11 +1105,9 @@ impl Fragment {
                 let range = &text_fragment_info.range;
                 let min_line_inline_size = text_fragment_info.run.min_width_for_range(range);
 
-                let mut max_line_inline_size = Au::new(0);
-                for line_range in text_fragment_info.run.iter_natural_lines_for_range(range) {
-                    let line_metrics = text_fragment_info.run.metrics_for_range(&line_range);
-                    max_line_inline_size = Au::max(max_line_inline_size, line_metrics.advance_width);
-                }
+                // See http://dev.w3.org/csswg/css-sizing/#max-content-inline-size.
+                // TODO: Account for soft wrap opportunities.
+                let max_line_inline_size = text_fragment_info.run.metrics_for_range(range).advance_width;
 
                 result.minimum_inline_size = geometry::max(result.minimum_inline_size, min_line_inline_size);
                 result.preferred_inline_size = geometry::max(result.preferred_inline_size, max_line_inline_size);

--- a/src/test/ref/basic.list
+++ b/src/test/ref/basic.list
@@ -107,3 +107,6 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 
 != inline_background_a.html inline_background_ref.html
 == inline_element_border_a.html inline_element_border_ref.html
+== float_intrinsic_width_a.html float_intrinsic_width_ref.html
+== float_right_intrinsic_width_a.html float_right_intrinsic_width_ref.html
+== fixed_width_overrides_child_intrinsic_width_a.html fixed_width_overrides_child_intrinsic_width_ref.html

--- a/src/test/ref/fixed_width_overrides_child_intrinsic_width_a.html
+++ b/src/test/ref/fixed_width_overrides_child_intrinsic_width_a.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            @font-face {
+                font-family: 'ahem';
+                src: url('fonts/ahem/ahem.ttf');
+            }
+            body {
+                font-family: 'ahem';
+                font-size: 100px;
+                margin: 0;
+                line-height: 1;
+            }
+            .fr {
+                float: right;
+            }
+            .green {
+                color: green;
+            }
+            .fixed {
+                width: 100px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fr">
+            <div class="fixed">
+                <span class="green">X X</span>
+            </div>
+        </div>
+    </body>
+</html>

--- a/src/test/ref/fixed_width_overrides_child_intrinsic_width_ref.html
+++ b/src/test/ref/fixed_width_overrides_child_intrinsic_width_ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            .fr {
+                float: right;
+            }
+            .green {
+                background-color: green;
+            }
+            .fixed {
+                width: 100px;
+                height: 200px;
+            }
+            body {
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fr green fixed"></div>
+    </body>
+</html>

--- a/src/test/ref/float_intrinsic_width_a.html
+++ b/src/test/ref/float_intrinsic_width_a.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            @font-face {
+                font-family: 'ahem';
+                src: url('fonts/ahem/ahem.ttf');
+            }
+            body {
+                font-family: 'ahem';
+                font-size: 100px;
+                margin: 0;
+                line-height: 1;
+            }
+            .fl {
+                float: left;
+            }
+            .green {
+                color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fl green">X X</div>
+    </body>
+</html>

--- a/src/test/ref/float_intrinsic_width_ref.html
+++ b/src/test/ref/float_intrinsic_width_ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            .fl {
+                float: left;
+            }
+            .green {
+                background-color: green;
+            }
+            .fixed {
+                width: 100px;
+                height: 100px;
+            }
+            body {
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fl green fixed"></div>
+        <div class="fl fixed"></div>
+        <div class="fl green fixed"></div>
+    </body>
+</html>

--- a/src/test/ref/float_right_intrinsic_width_a.html
+++ b/src/test/ref/float_right_intrinsic_width_a.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            @font-face {
+                font-family: 'ahem';
+                src: url(fonts/ahem/ahem.ttf);
+            }
+            .fr {
+                float: right;
+            }
+            .green {
+                color: green;
+            }
+            body {
+                font-family: 'ahem';
+                font-size: 100px;
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fr green">X X</div>
+    </body>
+</html>

--- a/src/test/ref/float_right_intrinsic_width_ref.html
+++ b/src/test/ref/float_right_intrinsic_width_ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            .fr {
+                float: right;
+            }
+            .green {
+                background-color: green;
+            }
+            .fixed {
+                width: 100px;
+                height: 100px;
+            }
+            body {
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="fr green fixed"></div>
+        <div class="fr fixed"></div>
+        <div class="fr green fixed"></div>
+    </body>
+</html>


### PR DESCRIPTION
These two fixes are related to the wikipedia metabug #2554.

They don't make the wikipedia page look better (they cause a slight regression in the top caption table), but they are prerequisites for fixing some of the other layout issues that remain.

Added reftests for each of the three cases I have come across that this patch solves.
