### PR TITLE
Fix HTMLImageElement setters.

### DIFF
--- a/src/components/script/dom/htmlimageelement.rs
+++ b/src/components/script/dom/htmlimageelement.rs
@@ -113,14 +113,14 @@ impl<'a> HTMLImageElementMethods for JSRef<'a, HTMLImageElement> {
 
     fn SetUseMap(&self, use_map: DOMString) {
         let element: &JSRef<Element> = ElementCast::from_ref(self);
-        element.set_string_attribute("useMap", use_map)
+        element.set_string_attribute("usemap", use_map)
     }
 
     make_bool_getter!(IsMap)
 
     fn SetIsMap(&self, is_map: bool) {
         let element: &JSRef<Element> = ElementCast::from_ref(self);
-        element.set_string_attribute("isMap", is_map.to_string())
+        element.set_string_attribute("ismap", is_map.to_string())
     }
 
     fn Width(&self) -> u32 {

--- a/src/test/wpt/metadata/html/dom/reflection-embedded.html.ini
+++ b/src/test/wpt/metadata/html/dom/reflection-embedded.html.ini
@@ -1,3 +1,26522 @@
 [reflection-embedded.html]
   type: testharness
-  expected: TIMEOUT
+  [img.title: typeof IDL attribute]
+    expected: FAIL
+
+  [img.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [img.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [img.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [img.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [img.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [img.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [img.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [img.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [img.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [img.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [img.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [img.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [img.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: typeof IDL attribute]
+    expected: FAIL
+
+  [img.srcset: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: typeof IDL attribute]
+    expected: FAIL
+
+  [img.crossOrigin: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "anonymous" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "xanonymous" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "anonymous\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "nonymous" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "ANONYMOUS" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "use-credentials" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "xuse-credentials" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "use-credentials\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "se-credentials" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: setAttribute() to "USE-CREDENTIALS" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "anonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "xanonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "xanonymous" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "anonymous\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "anonymous\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "nonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "nonymous" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "ANONYMOUS" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "ANONYMOUS" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "use-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "xuse-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "xuse-credentials" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "use-credentials\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "use-credentials\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "se-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "se-credentials" followed by IDL get]
+    expected: FAIL
+
+  [img.crossOrigin: IDL set to "USE-CREDENTIALS" followed by IDL get]
+    expected: FAIL
+
+  [img.isMap: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [img.isMap: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.isMap: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [img.isMap: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.isMap: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [img.isMap: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.isMap: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [img.isMap: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.isMap: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [img.isMap: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: typeof IDL attribute]
+    expected: FAIL
+
+  [img.lowsrc: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.hspace: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [img.hspace: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [img.hspace: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.hspace: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [img.hspace: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [img.vspace: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [img.vspace: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [img.vspace: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.vspace: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [img.vspace: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.longDesc: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [img.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [img.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [img.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [img.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [img.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [img.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [img.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [iframe.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.srcdoc: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.name: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.name: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.seamless: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: setAttribute() to "seamless" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.seamless: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: setAttribute() to "allowFullscreen" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.allowFullscreen: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.width: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.width: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.height: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.height: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.align: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.scrolling: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.frameBorder: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.longDesc: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [embed.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.src: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.type: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.type: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.type: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.width: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.width: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.width: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.height: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.height: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.height: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.align: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.align: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.align: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.align: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.name: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.name: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.name: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.title: typeof IDL attribute]
+    expected: FAIL
+
+  [object.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [object.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [object.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [object.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [object.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [object.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [object.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [object.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [object.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [object.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [object.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [object.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: typeof IDL attribute]
+    expected: FAIL
+
+  [object.data: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.data: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.data: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.data: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.data: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.type: typeof IDL attribute]
+    expected: FAIL
+
+  [object.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.type: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.type: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.type: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.type: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: typeof IDL attribute]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: setAttribute() to "typeMustMatch" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.typeMustMatch: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.name: typeof IDL attribute]
+    expected: FAIL
+
+  [object.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.name: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.name: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.name: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.name: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: typeof IDL attribute]
+    expected: FAIL
+
+  [object.useMap: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.width: typeof IDL attribute]
+    expected: FAIL
+
+  [object.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.width: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.width: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.width: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.width: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.height: typeof IDL attribute]
+    expected: FAIL
+
+  [object.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.height: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.height: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.height: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.height: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.align: typeof IDL attribute]
+    expected: FAIL
+
+  [object.align: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.align: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.align: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.align: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.align: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: typeof IDL attribute]
+    expected: FAIL
+
+  [object.archive: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.archive: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.archive: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.archive: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.code: typeof IDL attribute]
+    expected: FAIL
+
+  [object.code: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.code: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.code: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.code: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.code: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: typeof IDL attribute]
+    expected: FAIL
+
+  [object.declare: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "declare" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [object.declare: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [object.declare: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [object.declare: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [object.declare: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [object.declare: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.declare: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: typeof IDL attribute]
+    expected: FAIL
+
+  [object.hspace: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -2147483649 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 257 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 4294967296 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [object.hspace: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [object.hspace: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [object.hspace: IDL set to 257 followed by getAttribute()]
+    expected: FAIL
+
+  [object.hspace: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [object.hspace: IDL set to "-0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.hspace: IDL set to "-0" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: typeof IDL attribute]
+    expected: FAIL
+
+  [object.standby: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.standby: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.standby: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.standby: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: typeof IDL attribute]
+    expected: FAIL
+
+  [object.vspace: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -2147483649 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 257 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 4294967296 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [object.vspace: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [object.vspace: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [object.vspace: IDL set to 257 followed by getAttribute()]
+    expected: FAIL
+
+  [object.vspace: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [object.vspace: IDL set to "-0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.vspace: IDL set to "-0" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: typeof IDL attribute]
+    expected: FAIL
+
+  [object.codeBase: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: typeof IDL attribute]
+    expected: FAIL
+
+  [object.codeType: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.border: typeof IDL attribute]
+    expected: FAIL
+
+  [object.border: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.border: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.border: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.border: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.border: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [object.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [object.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [object.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [object.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [object.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [object.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [object.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.title: typeof IDL attribute]
+    expected: FAIL
+
+  [param.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [param.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [param.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [param.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [param.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [param.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [param.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [param.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [param.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [param.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [param.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [param.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: typeof IDL attribute]
+    expected: FAIL
+
+  [param.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.name: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.name: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.name: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.name: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.value: typeof IDL attribute]
+    expected: FAIL
+
+  [param.value: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.value: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.value: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.value: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.value: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.type: typeof IDL attribute]
+    expected: FAIL
+
+  [param.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.type: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.type: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.type: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.type: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: typeof IDL attribute]
+    expected: FAIL
+
+  [param.valueType: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [param.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [param.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [param.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [param.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [param.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [param.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [param.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [param.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [param.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.title: typeof IDL attribute]
+    expected: FAIL
+
+  [video.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [video.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [video.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [video.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [video.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [video.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [video.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [video.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [video.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [video.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [video.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [video.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: typeof IDL attribute]
+    expected: FAIL
+
+  [video.src: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: typeof IDL attribute]
+    expected: FAIL
+
+  [video.crossOrigin: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "anonymous" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "xanonymous" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "anonymous\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "nonymous" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "ANONYMOUS" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "use-credentials" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "xuse-credentials" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "use-credentials\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "se-credentials" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: setAttribute() to "USE-CREDENTIALS" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "anonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "xanonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "xanonymous" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "anonymous\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "anonymous\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "nonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "nonymous" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "ANONYMOUS" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "ANONYMOUS" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "use-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "xuse-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "xuse-credentials" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "use-credentials\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "use-credentials\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "se-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "se-credentials" followed by IDL get]
+    expected: FAIL
+
+  [video.crossOrigin: IDL set to "USE-CREDENTIALS" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: typeof IDL attribute]
+    expected: FAIL
+
+  [video.preload: setAttribute() to "none" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: setAttribute() to "NONE" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: setAttribute() to "metadata" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: setAttribute() to "METADATA" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "none" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "xnone" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "none\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "one" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "NONE" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "NONE" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: IDL set to "metadata" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "xmetadata" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "metadata\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "etadata" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "METADATA" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "METADATA" followed by IDL get]
+    expected: FAIL
+
+  [video.preload: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [video.preload: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: typeof IDL attribute]
+    expected: FAIL
+
+  [video.autoplay: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: setAttribute() to "autoplay" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [video.autoplay: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [video.autoplay: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [video.autoplay: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [video.autoplay: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [video.autoplay: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.autoplay: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: typeof IDL attribute]
+    expected: FAIL
+
+  [video.loop: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.loop: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: setAttribute() to "loop" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [video.loop: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [video.loop: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [video.loop: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [video.loop: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [video.loop: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.loop: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: typeof IDL attribute]
+    expected: FAIL
+
+  [video.mediaGroup: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.mediaGroup: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: typeof IDL attribute]
+    expected: FAIL
+
+  [video.controls: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.controls: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: setAttribute() to "controls" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [video.controls: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [video.controls: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [video.controls: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [video.controls: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [video.controls: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.controls: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): typeof IDL attribute]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): setAttribute() to "muted" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.defaultMuted (<video muted>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.width: typeof IDL attribute]
+    expected: FAIL
+
+  [video.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.width: setAttribute() to -2147483649 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 257 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 4294967296 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [video.width: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [video.width: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [video.width: IDL set to 257 followed by getAttribute()]
+    expected: FAIL
+
+  [video.width: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [video.width: IDL set to "-0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.width: IDL set to "-0" followed by IDL get]
+    expected: FAIL
+
+  [video.height: typeof IDL attribute]
+    expected: FAIL
+
+  [video.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.height: setAttribute() to -2147483649 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 257 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 4294967296 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [video.height: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [video.height: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [video.height: IDL set to 257 followed by getAttribute()]
+    expected: FAIL
+
+  [video.height: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [video.height: IDL set to "-0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.height: IDL set to "-0" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: typeof IDL attribute]
+    expected: FAIL
+
+  [video.poster: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.poster: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.poster: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [video.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [video.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [video.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [video.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [video.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [video.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [video.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [audio.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.src: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "anonymous" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "xanonymous" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "anonymous\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "nonymous" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "ANONYMOUS" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "use-credentials" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "xuse-credentials" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "use-credentials\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "se-credentials" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: setAttribute() to "USE-CREDENTIALS" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "anonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "xanonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "xanonymous" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "anonymous\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "anonymous\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "nonymous" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "nonymous" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "ANONYMOUS" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "ANONYMOUS" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "use-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "xuse-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "xuse-credentials" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "use-credentials\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "use-credentials\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "se-credentials" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "se-credentials" followed by IDL get]
+    expected: FAIL
+
+  [audio.crossOrigin: IDL set to "USE-CREDENTIALS" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.preload: setAttribute() to "none" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: setAttribute() to "NONE" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: setAttribute() to "metadata" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: setAttribute() to "METADATA" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "none" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "xnone" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "none\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "one" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "NONE" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "NONE" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: IDL set to "metadata" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "xmetadata" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "metadata\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "etadata" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "METADATA" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "METADATA" followed by IDL get]
+    expected: FAIL
+
+  [audio.preload: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.preload: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.autoplay: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: setAttribute() to "autoplay" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.autoplay: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.loop: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: setAttribute() to "loop" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.loop: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.loop: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.loop: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.loop: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.loop: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.loop: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.mediaGroup: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.controls: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: setAttribute() to "controls" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.controls: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.controls: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.controls: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.controls: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.controls: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.controls: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): typeof IDL attribute]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): setAttribute() to "muted" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.defaultMuted (<audio muted>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.title: typeof IDL attribute]
+    expected: FAIL
+
+  [source.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [source.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [source.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [source.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [source.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [source.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [source.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [source.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [source.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [source.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [source.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [source.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: typeof IDL attribute]
+    expected: FAIL
+
+  [source.src: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.type: typeof IDL attribute]
+    expected: FAIL
+
+  [source.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.type: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.type: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.type: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.type: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.media: typeof IDL attribute]
+    expected: FAIL
+
+  [source.media: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.media: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.media: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.media: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.media: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [source.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [source.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [source.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [source.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [source.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [source.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [source.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.title: typeof IDL attribute]
+    expected: FAIL
+
+  [track.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [track.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [track.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [track.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [track.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [track.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [track.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [track.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [track.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [track.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [track.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [track.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: typeof IDL attribute]
+    expected: FAIL
+
+  [track.kind: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "subtitles" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "xsubtitles" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "subtitles\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "ubtitles" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "SUBTITLES" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "captions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "xcaptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "captions\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "aptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "CAPTIONS" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "descriptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "xdescriptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "descriptions\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "escriptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "DESCRIPTIONS" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "chapters" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "xchapters" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "chapters\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "hapters" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "CHAPTERS" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "metadata" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "xmetadata" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "metadata\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "etadata" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: setAttribute() to "METADATA" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "subtitles" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xsubtitles" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xsubtitles" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "subtitles\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "subtitles\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "ubtitles" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "ubtitles" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "SUBTITLES" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "SUBTITLES" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "captions" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xcaptions" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xcaptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "captions\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "captions\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "aptions" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "aptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "CAPTIONS" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "CAPTIONS" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "descriptions" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xdescriptions" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xdescriptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "descriptions\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "descriptions\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "escriptions" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "escriptions" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "DESCRIPTIONS" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "DESCRIPTIONS" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "chapters" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xchapters" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xchapters" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "chapters\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "chapters\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "hapters" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "hapters" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "CHAPTERS" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "CHAPTERS" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "metadata" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xmetadata" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "xmetadata" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "metadata\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "metadata\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "etadata" followed by getAttribute()]
+    expected: FAIL
+
+  [track.kind: IDL set to "etadata" followed by IDL get]
+    expected: FAIL
+
+  [track.kind: IDL set to "METADATA" followed by IDL get]
+    expected: FAIL
+
+  [track.src: typeof IDL attribute]
+    expected: FAIL
+
+  [track.src: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.src: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.src: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.src: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.src: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: typeof IDL attribute]
+    expected: FAIL
+
+  [track.srclang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.srclang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.srclang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.label: typeof IDL attribute]
+    expected: FAIL
+
+  [track.label: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.label: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.label: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.label: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.label: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.default: typeof IDL attribute]
+    expected: FAIL
+
+  [track.default: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.default: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.default: setAttribute() to "default" followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [track.default: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [track.default: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [track.default: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [track.default: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [track.default: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.default: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [track.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [track.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [track.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [track.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [track.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [track.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [track.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [canvas.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.width: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [canvas.width: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [canvas.width: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.width: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.width: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [canvas.height: setAttribute() to 2147483648 followed by IDL get]
+    expected: FAIL
+
+  [canvas.height: setAttribute() to 4294967295 followed by IDL get]
+    expected: FAIL
+
+  [canvas.height: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.height: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.height: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [canvas.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.title: typeof IDL attribute]
+    expected: FAIL
+
+  [map.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [map.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [map.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [map.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [map.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [map.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [map.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [map.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [map.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [map.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [map.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [map.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [map.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [map.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: typeof IDL attribute]
+    expected: FAIL
+
+  [map.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.name: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.name: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [map.name: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.name: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [map.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [map.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [map.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [map.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [map.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [map.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [map.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [map.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [map.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.title: typeof IDL attribute]
+    expected: FAIL
+
+  [area.title: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.title: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.title: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.title: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.title: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: typeof IDL attribute]
+    expected: FAIL
+
+  [area.lang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.lang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.lang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.lang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: typeof IDL attribute]
+    expected: FAIL
+
+  [area.dir: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "ltr" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "tr" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "rtl" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "tl" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "auto" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "uto" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: setAttribute() to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to object "test-valueOf" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "ltr" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "xltr" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "xltr" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "ltr\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "ltr\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "tr" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "tr" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "LTR" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "LTR" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "rtl" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "xrtl" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "xrtl" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "rtl\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "rtl\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "tl" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "tl" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "RTL" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "RTL" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "auto" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "xauto" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "xauto" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "auto\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "auto\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "uto" followed by getAttribute()]
+    expected: FAIL
+
+  [area.dir: IDL set to "uto" followed by IDL get]
+    expected: FAIL
+
+  [area.dir: IDL set to "AUTO" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: typeof IDL attribute]
+    expected: FAIL
+
+  [area.hidden: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: setAttribute() to "hidden" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [area.hidden: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [area.hidden: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [area.hidden: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [area.hidden: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [area.hidden: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.hidden: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [area.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to -36 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to -1 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 0 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 1 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 2147483647 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to -2147483648 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "-1" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "0" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "1" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to object "2" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to object "3" followed by getAttribute()]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to object "3" followed by IDL get]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to -36 followed by getAttribute()]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to -1 followed by getAttribute()]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to 0 followed by getAttribute()]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to 1 followed by getAttribute()]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to 2147483647 followed by getAttribute()]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to -2147483648 followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: typeof IDL attribute]
+    expected: FAIL
+
+  [area.alt: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.alt: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.alt: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.alt: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: typeof IDL attribute]
+    expected: FAIL
+
+  [area.coords: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.coords: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.coords: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.coords: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: typeof IDL attribute]
+    expected: FAIL
+
+  [area.shape: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.shape: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.shape: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.shape: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.target: typeof IDL attribute]
+    expected: FAIL
+
+  [area.target: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.target: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.target: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.target: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.target: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.download: typeof IDL attribute]
+    expected: FAIL
+
+  [area.download: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.download: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.download: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.download: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.download: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: typeof IDL attribute]
+    expected: FAIL
+
+  [area.ping: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to " foo   " followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "http://site.example/ foo  bar   baz" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to " foo   " followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to " foo   " followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to "http://site.example/ foo  bar   baz" followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to "http://site.example/ foo  bar   baz" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.ping: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.ping: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: typeof IDL attribute]
+    expected: FAIL
+
+  [area.rel: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.rel: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.rel: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.rel: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: typeof IDL attribute]
+    expected: FAIL
+
+  [area.hreflang: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.hreflang: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.hreflang: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.type: typeof IDL attribute]
+    expected: FAIL
+
+  [area.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.type: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.type: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.type: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.type: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.href: typeof IDL attribute]
+    expected: FAIL
+
+  [area.href: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.href: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.href: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.href: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.href: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: typeof IDL attribute]
+    expected: FAIL
+
+  [area.noHref: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "noHref" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [area.noHref: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [area.noHref: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [area.noHref: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [area.noHref: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [area.noHref: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.noHref: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: typeof IDL attribute]
+    expected: FAIL
+
+  [area.itemScope: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: setAttribute() to "itemScope" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to "" followed by hasAttribute()]
+    expected: FAIL
+
+  [area.itemScope: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to undefined followed by hasAttribute()]
+    expected: FAIL
+
+  [area.itemScope: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to null followed by hasAttribute()]
+    expected: FAIL
+
+  [area.itemScope: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to false followed by hasAttribute()]
+    expected: FAIL
+
+  [area.itemScope: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to NaN followed by hasAttribute()]
+    expected: FAIL
+
+  [area.itemScope: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.itemScope: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: typeof IDL attribute]
+    expected: FAIL
+
+  [area.itemId: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemId: IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.itemId: IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): typeof IDL attribute]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [meta.itemValue (<meta content>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): typeof IDL attribute]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [audio.itemValue (<audio src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): typeof IDL attribute]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [embed.itemValue (<embed src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [iframe.itemValue (<iframe src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): typeof IDL attribute]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [img.itemValue (<img src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): typeof IDL attribute]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [source.itemValue (<source src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): typeof IDL attribute]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [track.itemValue (<track src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): typeof IDL attribute]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [video.itemValue (<video src>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): typeof IDL attribute]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [a.itemValue (<a href>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): typeof IDL attribute]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [area.itemValue (<area href>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): typeof IDL attribute]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [link.itemValue (<link href>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): typeof IDL attribute]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to " foo " followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to " foo " followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "http://site.example/" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "http://site.example/" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "//site.example/path???@#l" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "//site.example/path???@#l" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [object.itemValue (<object data>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): typeof IDL attribute]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to "" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to undefined followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to 7 followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to true followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to false followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to NaN followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to Infinity followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to "\\0" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to null followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): setAttribute() to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to "" followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to undefined followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to undefined followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to 7 followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to 7 followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to 1.5 followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to 1.5 followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to true followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to true followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to false followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to false followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to object "[object Object\]" followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to object "[object Object\]" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to NaN followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to NaN followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to Infinity followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to -Infinity followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to -Infinity followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to "\\0" followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to null followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to null followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to object "test-toString" followed by getAttribute()]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to object "test-toString" followed by IDL get]
+    expected: FAIL
+
+  [data.itemValue (<data value>): IDL set to object "test-valueOf" followed by IDL get]
+    expected: FAIL
+


### PR DESCRIPTION
These would crash because the functions they call assert that they receive
lower-case names.

Fixing the crash allows reflection-embedded.html to finish successfully.
