### PR TITLE
Disable intermittently failing Document-characterSet-normalization.html (fixes #3209).

### DIFF
--- a/src/test/wpt/metadata/dom/nodes/Document-characterSet-normalization.html.ini
+++ b/src/test/wpt/metadata/dom/nodes/Document-characterSet-normalization.html.ini
@@ -1,3 +1,3 @@
 [Document-characterSet-normalization.html]
   type: testharness
-  expected: TIMEOUT
+  disabled: fails intermittently


### PR DESCRIPTION
As we currently don't support anything but utf-8, this is not a particularly
useful test to run.
