### PR TITLE
Correct the iterator adaptors used in parsing integers (fixes #3208).

### DIFF
--- a/src/test/wpt/metadata/html/dom/reflection-embedded.html.ini
+++ b/src/test/wpt/metadata/html/dom/reflection-embedded.html.ini
@@ -20376,9 +20376,6 @@
   [canvas.width: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
-  [canvas.width: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
   [canvas.width: setAttribute() to object "3" followed by getAttribute()]
     expected: FAIL
 
@@ -20389,9 +20386,6 @@
     expected: FAIL
 
   [canvas.height: setAttribute() to 4294967295 followed by IDL get]
-    expected: FAIL
-
-  [canvas.height: setAttribute() to 1.5 followed by IDL get]
     expected: FAIL
 
   [canvas.height: setAttribute() to object "3" followed by getAttribute()]

--- a/src/test/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.decimal.html.ini
+++ b/src/test/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.decimal.html.ini
@@ -1,3 +1,5 @@
 [size.attributes.parse.decimal.html]
   type: testharness
-  expected: TIMEOUT
+  [Parsing of non-negative integers]
+    expected: FAIL
+

--- a/src/test/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.decimal.html.ini
+++ b/src/test/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.decimal.html.ini
@@ -1,3 +1,5 @@
 [size.attributes.setAttribute.decimal.html]
   type: testharness
-  expected: TIMEOUT
+  [Parsing of non-negative integers in setAttribute]
+    expected: FAIL
+


### PR DESCRIPTION
This avoids Azure segfaulting trying to set up a 100999px*100999px canvas.

The test still fails due to its use of getComputedStyle.
