### PR TITLE
Avoid trying to trace a null JSVal.

### DIFF
--- a/src/components/script/dom/bindings/trace.rs
+++ b/src/components/script/dom/bindings/trace.rs
@@ -68,7 +68,7 @@ pub trait JSTraceable {
 
 /// Trace a `JSVal`.
 pub fn trace_jsval(tracer: *mut JSTracer, description: &str, val: JSVal) {
-    if !val.is_gcthing() {
+    if !val.is_markable() {
         return;
     }
 

--- a/src/test/content/test_trace_null.html
+++ b/src/test/content/test_trace_null.html
@@ -1,0 +1,7 @@
+<!-- crashtest -->
+<script src=harness.js></script>
+<script>
+new CustomEvent("foo", { detail: null });
+gc();
+finish();
+</script>


### PR DESCRIPTION
JSVal::trace_kind() asserts that it is a markable type; null is a gcthing that
is not markable.
