### PR TITLE
Remove needless rust-png dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,6 @@ dependencies = [
  "layout 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
- "png 0.1.0 (git+https://github.com/servo/rust-png#f3640b37e71a02ee3e140e181cc9accb0a123e16)",
  "script 0.0.1",
  "util 0.0.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,3 @@ path = "components/layout"
 
 [dependencies.gfx]
 path = "components/gfx"
-
-[dependencies.png]
-git = "https://github.com/servo/rust-png"
-


### PR DESCRIPTION
We don't have to set this `rust-png` dependency in the root.
