### PR TITLE
Fix layout of Create Account / Login when rendering Wikipedia.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -61,7 +61,7 @@ use std::iter::Zip;
 use std::raw;
 use std::sync::atomics::{AtomicUint, Relaxed, SeqCst};
 use std::slice::MutItems;
-use style::computed_values::{clear, position, text_align};
+use style::computed_values::{clear, float, position, text_align};
 
 /// Virtual methods that make up a float context.
 ///
@@ -193,6 +193,10 @@ pub trait Flow: fmt::Show + ToString + Share {
     /// Returns the direction that this flow clears floats in, if any.
     fn float_clearance(&self) -> clear::T {
         clear::none
+    }
+
+    fn float_kind(&self) -> float::T {
+        float::none
     }
 
     /// Returns true if this float is a block formatting context and false otherwise. The default

--- a/tests/ref/abs_float_pref_width_a.html
+++ b/tests/ref/abs_float_pref_width_a.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <style type="text/css">
+        @font-face {
+            font-family: 'ahem';
+            src: url(fonts/ahem/ahem.ttf);
+        }
+        body {
+            margin: 0;
+            font-family: 'ahem';
+            font-size: 100px;
+            color: green;
+        }
+        div {
+            position: absolute;
+            left: 100px;
+        }
+        span {
+            float: left;
+        }
+    </style>
+    </head>
+    <body>
+        <div>
+            <span>X</span>
+            <span>X</span>
+        </div>
+    </body>
+</html>

--- a/tests/ref/abs_float_pref_width_ref.html
+++ b/tests/ref/abs_float_pref_width_ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <style type="text/css">
+        body {
+            margin: 0;
+        }
+        div {
+            position: absolute;
+            left: 100px;
+            width: 200px;
+            height: 100px;
+            background-color: green;
+        }
+    </style>
+    </head>
+    <body>
+        <div>
+        </div>
+    </body>
+</html>

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -110,3 +110,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == float_intrinsic_width_a.html float_intrinsic_width_ref.html
 == float_right_intrinsic_width_a.html float_right_intrinsic_width_ref.html
 == fixed_width_overrides_child_intrinsic_width_a.html fixed_width_overrides_child_intrinsic_width_ref.html
+== abs_float_pref_width_a.html abs_float_pref_width_ref.html


### PR DESCRIPTION
When calculating the preferred width for a block, accumulate
the left and right float widths of children separately, which
is then max'ed with the normal flow widths later on.

Ref bug #2554 - improves the layout of the top bar.
