### PR TITLE
layout: Don't crash on floated generated content.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -833,7 +833,9 @@ impl<'a, 'b> PostorderNodeMutTraversal for FlowConstructor<'a, 'b> {
             }
 
             // Inline items contribute inline fragment construction results.
-            (display::inline, float::none, _) => {
+            //
+            // FIXME(pcwalton, #3307): This is not sufficient to handle floated generated content.
+            (display::inline, _, _) => {
                 let construction_result = self.build_fragments_for_inline(node);
                 node.set_flow_construction_result(construction_result)
             }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -118,3 +118,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 
 == iframe/simple.html iframe/simple_ref.html
 == iframe/multiple_external.html iframe/multiple_external_ref.html
+== floated_generated_content_a.html floated_generated_content_b.html

--- a/tests/ref/floated_generated_content_a.html
+++ b/tests/ref/floated_generated_content_a.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.stand:before {
+    content: "";
+    float: left;
+}
+</style>
+</head>
+<body>
+<div class="stand">Toast! Toast! Toast!</div>
+</body>
+</html>
+

--- a/tests/ref/floated_generated_content_b.html
+++ b/tests/ref/floated_generated_content_b.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<div class="stand">Toast! Toast! Toast!</div>
+</body>
+</html>
+


### PR DESCRIPTION
It doesn't construct the float correctly, but at least it doesn't crash
anymore.

Fixes Reddit.

Closes #3287.

r? @metajack
