### PR TITLE
Handle iframe.src with a javascript: URL.

### DIFF
--- a/tests/wpt/metadata/XMLHttpRequest/open-url-javascript-window-2.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-javascript-window-2.htm.ini
@@ -1,3 +1,5 @@
 [open-url-javascript-window-2.htm]
   type: testharness
   expected: TIMEOUT
+  [XMLHttpRequest: open() - resolving URLs (javascript: ]
+    expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/open-url-javascript-window.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-javascript-window.htm.ini
@@ -1,3 +1,5 @@
 [open-url-javascript-window.htm]
   type: testharness
   expected: TIMEOUT
+  [XMLHttpRequest: open() - resolving URLs (javascript: ]
+    expected: TIMEOUT


### PR DESCRIPTION
This change prevents us from crashing on Amazon and other pages with iframe.src="javascript:foo".
