### PR TITLE
Build docs on Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,17 @@ env:
     - LD_LIBRARY_PATH: /usr/local/lib
     - secure: "C/9/o+5KdTY1LZ4qZGE1+gY6mEGamG/VDHP69Om9dklfchJD6C+j8K8dvmE26FeRnLhSL7eGf1b3m6lfgkTZeVFjjiZE0Exvf1yI9Y3QPWR7ViaFxWk1z1I4HaSu4fpBo++e8FW+0EGjIkIrRtAn+bav3eDpAhgSih10KmAx4a8="
   matrix:
-    - TASKS=build,test-content,test-ref,build-cef
+    - TASKS: dummy
 
 matrix:
   include:
+    - os: linux
+      env: TASKS=build,test-content,doc,test-ref,build-cef
+    - os: osx
+      env: TASKS=build,test-content,test-ref,build-cef
     - os: osx
       env: TASKS=build,test-wpt1
     - os: osx
       env: TASKS=build,test-wpt2
+  exclude:
+    - env: TASKS=dummy

--- a/etc/ci/travis.script.sh
+++ b/etc/ci/travis.script.sh
@@ -3,6 +3,7 @@
 set -e
 
 build_docs() {
+    echo "Uploading documentation"
     ./mach doc
     cp etc/doc.servo.org/* target/doc/
     cp -R rust/doc/* target/doc/
@@ -13,14 +14,6 @@ build_docs() {
         ghp-import -n target/doc
         git push -qf https://${TOKEN}@github.com/servo/doc.servo.org.git gh-pages
     fi
-}
-
-build_servo() {
-    ./mach build -j 2
-}
-
-build_cef() {
-    ./mach build-cef -j 2
 }
 
 IFS="," read -ra tasks <<< "${TASKS}"
@@ -41,6 +34,9 @@ for t in "${tasks[@]}"; do
             ;;
         build-cef)
             ./mach build-cef -j 2
+            ;;
+        doc)
+            build_docs
             ;;
         test-content)
             ./mach test-content


### PR DESCRIPTION
We stopped building docs on Travis when we switched to mach.

This adds the doc task to test-content (only for linux)

PR from branch instead of fork because I can't see the result of stuff requiring Travis secure env variables from a fork.

I've put an if in the switch-case itself, however I'm open to restructuring the build matrix.
