### PR TITLE
Enable optimized builds on Travis

### DIFF
--- a/etc/ci/travis.script.sh
+++ b/etc/ci/travis.script.sh
@@ -16,11 +16,11 @@ build_docs() {
 }
 
 build_servo() {
-    ./mach build -j 2
+    ./mach build --release -j 2
 }
 
 build_cef() {
-    ./mach build-cef -j 2
+    ./mach build-cef --release -j 2
 }
 
 IFS="," read -ra tasks <<< "${TASKS}"
@@ -37,10 +37,10 @@ for t in "${tasks[@]}"; do
 
     case $t in
         build)
-            ./mach build -j 2
+            ./mach build --release -j 2
             ;;
         build-cef)
-            ./mach build-cef -j 2
+            ./mach build-cef --release -j 2
             ;;
         test-content)
             ./mach test-content


### PR DESCRIPTION
By default, Cargo builds unoptimized. This changes the default on Travis to optimized builds, since we both find so many of our rust compiler bugs only in optimized builds and optimized is the flavor we would actually ship in the future.

r? @metajack 
