### PR TITLE
Stop messing with the case of the attribute name in AttributeHandlers::get_attribute.

### DIFF
--- a/tests/wpt/metadata/dom/nodes/attributes.html.ini
+++ b/tests/wpt/metadata/dom/nodes/attributes.html.ini
@@ -1,11 +1,5 @@
 [attributes.html]
   type: testharness
-  [setAttribute should lowercase its name argument (upper case attribute)]
-    expected: FAIL
-
-  [setAttribute should lowercase its name argument (mixed case attribute)]
-    expected: FAIL
-
   [setAttribute should set the attribute with the given qualified name]
     expected: FAIL
 
@@ -13,12 +7,6 @@
     expected: FAIL
 
   [First set attribute is returned by getAttribute]
-    expected: FAIL
-
-  [Only lowercase attributes are returned on HTML elements (upper case attribute)]
-    expected: FAIL
-
-  [Only lowercase attributes are returned on HTML elements (mixed case attribute)]
     expected: FAIL
 
   [First set attribute is returned with mapped attribute set later]

--- a/tests/wpt/metadata/dom/nodes/case.html.ini
+++ b/tests/wpt/metadata/dom/nodes/case.html.ini
@@ -6,13 +6,7 @@
   [createElementNS http://www.w3.org/1999/xhtml,abc,Abc]
     expected: FAIL
 
-  [getAttributeNS http://www.w3.org/1999/xhtml,abc,Abc]
-    expected: FAIL
-
   [createElementNS http://www.w3.org/1999/xhtml,abc,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/1999/xhtml,abc,ABC]
     expected: FAIL
 
   [createElementNS http://www.w3.org/1999/xhtml,abc,\xc3\xa4]
@@ -27,13 +21,7 @@
   [createElementNS http://www.w3.org/1999/xhtml,Abc,Abc]
     expected: FAIL
 
-  [getAttributeNS http://www.w3.org/1999/xhtml,Abc,Abc]
-    expected: FAIL
-
   [createElementNS http://www.w3.org/1999/xhtml,Abc,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/1999/xhtml,Abc,ABC]
     expected: FAIL
 
   [createElementNS http://www.w3.org/1999/xhtml,Abc,\xc3\xa4]
@@ -48,13 +36,7 @@
   [createElementNS http://www.w3.org/1999/xhtml,ABC,Abc]
     expected: FAIL
 
-  [getAttributeNS http://www.w3.org/1999/xhtml,ABC,Abc]
-    expected: FAIL
-
   [createElementNS http://www.w3.org/1999/xhtml,ABC,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/1999/xhtml,ABC,ABC]
     expected: FAIL
 
   [createElementNS http://www.w3.org/1999/xhtml,ABC,\xc3\xa4]
@@ -69,13 +51,7 @@
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\xa4,Abc]
     expected: FAIL
 
-  [getAttributeNS http://www.w3.org/1999/xhtml,\xc3\xa4,Abc]
-    expected: FAIL
-
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\xa4,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/1999/xhtml,\xc3\xa4,ABC]
     expected: FAIL
 
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\xa4,\xc3\xa4]
@@ -90,84 +66,12 @@
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\x84,Abc]
     expected: FAIL
 
-  [getAttributeNS http://www.w3.org/1999/xhtml,\xc3\x84,Abc]
-    expected: FAIL
-
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\x84,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/1999/xhtml,\xc3\x84,ABC]
     expected: FAIL
 
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\x84,\xc3\xa4]
     expected: FAIL
 
   [createElementNS http://www.w3.org/1999/xhtml,\xc3\x84,\xc3\x84]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,abc,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,abc,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,Abc,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,Abc,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,ABC,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,ABC,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,\xc3\xa4,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,\xc3\xa4,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,\xc3\x84,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://www.w3.org/2000/svg,\xc3\x84,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,abc,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,abc,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,Abc,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,Abc,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,ABC,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,ABC,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,\xc3\xa4,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,\xc3\xa4,ABC]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,\xc3\x84,Abc]
-    expected: FAIL
-
-  [getAttributeNS http://FOO,\xc3\x84,ABC]
-    expected: FAIL
-
-  [getAttributeNS Abc]
-    expected: FAIL
-
-  [getAttributeNS ABC]
     expected: FAIL
 


### PR DESCRIPTION
This fixes a bug where GetAttributeNS would incorrectly match lower-case
attributes when called with an upper-case argument.
