### PR TITLE
Replaced constant fixed-length u8 vectors with byte strings (fixes #3257)

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -681,7 +681,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
 
             default = (
                 "static data: &'static [u8] = b\"%s\";\n"
-                "%s" % (defaultValue.value + "\\0"))
+                "%s" % (defaultValue.value + "\\0"), value)
 
         declType = "DOMString"
         if type.nullable():

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1285,7 +1285,7 @@ class ConstDefiner(PropertyDefiner):
 
         def stringDecl(const):
             name = const.identifier.name
-            return "static %s_name: &'static [u8] = b\"%s;\"\n" % (name, name + "\\0")
+            return "static %s_name: &'static [u8] = b\"%s\";\n" % (name, name + "\\0")
         
         decls = ''.join([stringDecl(m) for m in array])
 

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -681,7 +681,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
 
             default = (
                 "static data: &'static [u8] = b\"%s\";\n"
-                "%s" % (defaultValue.value + "\\0"), value)
+                "%s" % (defaultValue.value + "\\0", value))
 
         declType = "DOMString"
         if type.nullable():

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -177,9 +177,8 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
         let lineno = 0; //XXXjdm need to get a real number here
 
         let nargs = 1; //XXXjdm not true for onerror
-        static arg_name: [c_char, ..6] =
-            ['e' as c_char, 'v' as c_char, 'e' as c_char, 'n' as c_char, 't' as c_char, 0];
-        static arg_names: [*const c_char, ..1] = [&arg_name as *const c_char];
+        let arg_name: &[u8] = b"event\0";
+        let arg_names: [*const c_char, ..1] = [arg_name.as_ptr() as *const u8 as *const c_char];
 
         let source: Vec<u16> = source.as_slice().utf16_units().collect();
         let handler = unsafe {
@@ -187,7 +186,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
                                      ptr::mut_null(),
                                      name.as_ptr(),
                                      nargs,
-                                     &arg_names as *const *const i8 as *mut *const i8,
+                                     arg_names.as_ptr() as *mut *const c_char,
                                      source.as_ptr(),
                                      source.len() as size_t,
                                      url.as_ptr(),


### PR DESCRIPTION
Replaced constant fixed-length u8 vectors in CodegenRust.py with byte strings (fixes #3257).

@jdm said that there is also an occurrence of a fixed-length vector in eventtarget.rs. I found this one, but when I tried to replace it, it gave errors (because it is not a `u8` vector but a `c_char` vector). When I replaced it with `b"..."`, it said:

```
dom/eventtarget.rs:182:46: 182:56 error: mismatched types: expected `&'static [i8]` but found `&'static [u8]` (expected i8 but found u8)
```

And when I did the same but with dropping the `b` (so, by changing it to `"..."`), it said:

```
dom/eventtarget.rs:182:46: 182:55 error: mismatched types: expected `&'static [i8]` but found `&'static str` (expected vector but found str)
```

I don't know whether there are other prefixes for the strings to make this work, but if there are, let me know and I'll use it there.
