### PR TITLE
Make test_wpt params optional

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -140,6 +140,8 @@ class MachCommands(CommandBase):
              allow_all_args=True)
     @CommandArgument('params', default=None, nargs='...',
                      help="Command-line arguments to be passed through to wpt/run.sh")
-    def test_wpt(self, params):
+    def test_wpt(self, params=None):
+        if params is None:
+            params = []
         return subprocess.call(["bash", path.join("tests", "wpt", "run.sh")] + params,
                                env=self.build_env())


### PR DESCRIPTION
Fixes an exception in `mach test`:

```
TypeError: test_wpt() takes exactly 2 arguments (1 given)
```

r? @metajack 
