### PR TITLE
Add lint for ensuring proper rooting of JS<T>

### DIFF
--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -8,6 +8,7 @@
 #![feature(globs, macro_rules, phase, thread_local, unsafe_destructor)]
 
 #![deny(unused_imports, unused_variable)]
+#![allow(unrooted_must_root)]
 
 #[phase(plugin, link)]
 extern crate log;

--- a/components/macros/lib.rs
+++ b/components/macros/lib.rs
@@ -16,18 +16,23 @@ extern crate rustc;
 extern crate sync;
 
 use syntax::ast;
+use syntax::attr::AttrMetaMethods;
 use rustc::lint::{Context, LintPass, LintPassObject, LintArray};
 use rustc::plugin::Registry;
 use rustc::middle::ty::expr_ty;
+use rustc::middle::{ty, def};
 use rustc::middle::typeck::astconv::AstConv;
 use rustc::util::ppaux::Repr;
 
 declare_lint!(TRANSMUTE_TYPE_LINT, Allow,
               "Warn and report types being transmuted")
+declare_lint!(UNROOTED_MUST_ROOT, Deny,
+              "Warn and report usage of unrooted jsmanaged objects")
 
-struct Pass;
+struct TransmutePass;
+struct UnrootedPass;
 
-impl LintPass for Pass {
+impl LintPass for TransmutePass {
     fn get_lints(&self) -> LintArray {
         lint_array!(TRANSMUTE_TYPE_LINT)
     }
@@ -56,9 +61,72 @@ impl LintPass for Pass {
     }
 }
 
+fn lint_unrooted_ty(cx: &Context, ty: &ast::Ty, warning: &str) {
+        match ty.node {
+            ast::TyPath(_, _, id) => {
+                match cx.tcx.def_map.borrow().get_copy(&id) {
+                    def::DefTy(def_id) => {
+                        if ty::has_attr(cx.tcx, def_id, "must_root") {
+                            cx.span_lint(UNROOTED_MUST_ROOT, ty.span, warning);
+                        }
+                    }
+                    _ => (),
+                }
+            }
+            _ => (),
+    }
+}
+
+impl LintPass for UnrootedPass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(UNROOTED_MUST_ROOT)
+    }
+
+    fn check_struct_def(&mut self, cx: &Context, def: &ast::StructDef, _i: ast::Ident, _gen: &ast::Generics, id: ast::NodeId) {
+        if cx.tcx.map.expect_item(id).attrs.iter().all(|a| !a.check_name("must_root")) {
+            for ref field in def.fields.iter() {
+                lint_unrooted_ty(cx, &*field.node.ty, "Type must be rooted, use #[must_root] on the struct definition to propagate");
+            }
+        }
+    }
+
+    fn check_variant(&mut self, cx: &Context, var: &ast::Variant, _gen: &ast::Generics) {
+        let ref map = cx.tcx.map;
+        if map.expect_item(map.get_parent(var.node.id)).attrs.iter().all(|a| !a.check_name("must_root")) {
+            match var.node.kind {
+                ast::TupleVariantKind(ref vec) => {
+                    for ty in vec.iter() {
+                        lint_unrooted_ty(cx, &*ty.ty, "Type must be rooted, use #[must_root] on the enum definition to propagate")
+                    }
+                }
+                _ => () // Struct variants already caught by check_struct_def
+            }
+        }
+    }
+
+    fn check_fn(&mut self, cx: &Context, kind: &syntax::visit::FnKind, decl: &ast::FnDecl, block: &ast::Block, _span: syntax::codemap::Span, _id: ast::NodeId) {
+        match *kind {
+            syntax::visit::FkItemFn(i, _, _, _) |
+            syntax::visit::FkMethod(i, _, _) if i.as_str() == "new" || i.as_str() == "new_inherited" => {
+
+            }
+            _ => ()
+        }
+        match block.rules {
+            ast::DefaultBlock => {
+                for arg in decl.inputs.iter() {
+                    lint_unrooted_ty(cx, &*arg.ty, "Type must be rooted, use #[must_root] on the struct definition to propagate")
+                }
+            }
+            _ => () // fn is `unsafe`
+        }
+    }
+}
+
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_lint_pass(box Pass as LintPassObject);
+    reg.register_lint_pass(box TransmutePass as LintPassObject);
+    reg.register_lint_pass(box UnrootedPass as LintPassObject);
 }
 
 #[macro_export]

--- a/components/macros/lib.rs
+++ b/components/macros/lib.rs
@@ -62,6 +62,12 @@ impl LintPass for TransmutePass {
 }
 
 fn lint_unrooted_ty(cx: &Context, ty: &ast::Ty, warning: &str) {
+        let ty = match ty.node {
+            ast::TyBox(ref t) | ast::TyUniq(ref t) |
+            ast::TyVec(ref t) | ast::TyFixedLengthVec(ref t, _) |
+            ast::TyPtr(ast::MutTy { ty: ref t, ..}) | ast::TyRptr(_, ast::MutTy { ty: ref t, ..}) => &**t,
+            _ => ty
+        };
         match ty.node {
             ast::TyPath(_, _, id) => {
                 match cx.tcx.def_map.borrow().get_copy(&id) {

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -71,6 +71,7 @@ impl Str for AttrValue {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Attr {
     reflector_: Reflector,
     local_name: Atom,

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -108,8 +108,8 @@ impl Attr {
     pub fn new(window: &JSRef<Window>, local_name: Atom, value: AttrValue,
                name: Atom, namespace: Namespace,
                prefix: Option<DOMString>, owner: &JSRef<Element>) -> Temporary<Attr> {
-        let attr = Attr::new_inherited(local_name, value, name, namespace, prefix, owner);
-        reflect_dom_object(box attr, &Window(*window), AttrBinding::Wrap)
+        reflect_dom_object(box Attr::new_inherited(local_name, value, name, namespace, prefix, owner),
+                           &Window(*window), AttrBinding::Wrap)
     }
 }
 

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -139,6 +139,7 @@ pub struct CallSetup {
 
 impl CallSetup {
     /// Performs the setup needed to make a call.
+    #[allow(unrooted_must_root)]
     pub fn new<T: CallbackContainer>(callback: &T, handling: ExceptionHandling) -> CallSetup {
         let global = global_object_for_js_object(callback.callback());
         let global = global.root();

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2868,7 +2868,10 @@ class CGUnionStruct(CGThing):
         enumConversions = [
             "            e%s(ref inner) => inner.to_jsval(cx)," % v["name"] for v in templateVars
         ]
-        return ("""pub enum %s {
+        # XXXManishearth The following should be #[must_root],
+        # however we currently allow it till #2661 is fixed
+        return ("""#[allow(unrooted_must_root)]
+pub enum %s {
 %s
 }
 

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -34,6 +34,7 @@ pub enum GlobalRoot<'a, 'b> {
 /// A traced reference to a global object, for use in fields of traced Rust
 /// structures.
 #[deriving(Encodable)]
+#[must_root]
 pub enum GlobalField {
     WindowField(JS<Window>),
     WorkerField(JS<WorkerGlobalScope>),

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -61,6 +61,7 @@ use std::mem;
 /// Importantly, it requires explicit rooting in order to interact with the inner value.
 /// Can be assigned into JS-owned member fields (i.e. `JS<T>` types) safely via the
 /// `JS<T>::assign` method or `OptionalSettable::assign` (for `Option<JS<T>>` fields).
+#[allow(unrooted_must_root)]
 pub struct Temporary<T> {
     inner: JS<T>,
     /// On-stack JS pointer to assuage conservative stack scanner
@@ -106,6 +107,7 @@ impl<T: Reflectable> Temporary<T> {
 }
 
 /// A rooted, JS-owned value. Must only be used as a field in other JS-owned types.
+#[must_root]
 pub struct JS<T> {
     ptr: *const T
 }

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -113,6 +113,7 @@ pub struct JS<T> {
 }
 
 impl<T> PartialEq for JS<T> {
+    #[allow(unrooted_must_root)]
     fn eq(&self, other: &JS<T>) -> bool {
         self.ptr == other.ptr
     }
@@ -373,6 +374,7 @@ impl RootCollection {
     }
 
     /// Create a new stack-bounded root that will not outlive this collection
+    #[allow(unrooted_must_root)]
     fn new_root<'a, 'b, T: Reflectable>(&'a self, unrooted: &JS<T>) -> Root<'a, 'b, T> {
         Root::new(self, unrooted)
     }

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -83,6 +83,7 @@ pub fn trace_jsval(tracer: *mut JSTracer, description: &str, val: JSVal) {
 }
 
 /// Trace the `JSObject` held by `reflector`.
+#[allow(unrooted_must_root)]
 pub fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
     trace_object(tracer, description, reflector.get_jsobject())
 }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -668,6 +668,7 @@ pub extern fn outerize_global(_cx: *mut JSContext, obj: JSHandleObject) -> *mut 
 }
 
 /// Returns the global object of the realm that the given JS object was created in.
+#[allow(unrooted_must_root)]
 pub fn global_object_for_js_object(obj: *mut JSObject) -> GlobalField {
     unsafe {
         let global = GetGlobalForObjectCrossCompartment(obj);
@@ -689,6 +690,7 @@ pub fn global_object_for_js_object(obj: *mut JSObject) -> GlobalField {
 
 /// Get the `JSContext` for the `JSRuntime` associated with the thread
 /// this object is on.
+#[allow(unrooted_must_root)]
 fn cx_for_dom_reflector(obj: *mut JSObject) -> *mut JSContext {
     let global = global_object_for_js_object(obj);
     let global = global.root();

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -455,8 +455,9 @@ pub fn reflect_dom_object<T: Reflectable>
 }
 
 /// A struct to store a reference to the reflector of a DOM object.
-#[allow(raw_pointer_deriving)]
+#[allow(raw_pointer_deriving, unrooted_must_root)]
 #[deriving(PartialEq)]
+#[must_root]
 pub struct Reflector {
     object: Cell<*mut JSObject>,
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -16,6 +16,7 @@ pub enum BlobType {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Blob {
     reflector_: Reflector,
     type_: BlobType

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -67,6 +67,7 @@ impl BrowserContext {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct SessionHistoryEntry {
     document: JS<Document>,
     children: Vec<BrowserContext>

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -17,6 +17,7 @@ use geom::size::Size2D;
 use canvas::canvas_render_task::{CanvasMsg, CanvasRenderTask, ClearRect, Close, FillRect, Recreate, StrokeRect};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct CanvasRenderingContext2D {
     reflector_: Reflector,
     global: GlobalField,

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -18,6 +18,7 @@ use servo_util::str::DOMString;
 use std::cell::RefCell;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct CharacterData {
     pub node: Node,
     pub data: Traceable<RefCell<DOMString>>,

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -17,6 +17,7 @@ use servo_util::str::DOMString;
 
 /// An HTML comment.
 #[deriving(Encodable)]
+#[must_root]
 pub struct Comment {
     pub characterdata: CharacterData,
 }
@@ -35,8 +36,8 @@ impl Comment {
     }
 
     pub fn new(text: DOMString, document: &JSRef<Document>) -> Temporary<Comment> {
-        let node = Comment::new_inherited(text, document);
-        Node::reflect_node(box node, document, CommentBinding::Wrap)
+        Node::reflect_node(box Comment::new_inherited(text, document),
+                           document, CommentBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef, data: DOMString) -> Fallible<Temporary<Comment>> {

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -10,6 +10,7 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Console {
     pub reflector_: Reflector
 }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -19,6 +19,7 @@ use servo_util::str::DOMString;
 use std::cell::Cell;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct CustomEvent {
     event: Event,
     detail: Traceable<Cell<Traceable<JSVal>>>,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -37,6 +37,7 @@ use native::task::NativeTaskBuilder;
 use url::Url;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DedicatedWorkerGlobalScope {
     workerglobalscope: WorkerGlobalScope,
     receiver: Untraceable<Receiver<ScriptMsg>>,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -69,6 +69,7 @@ pub enum IsHTMLDocument {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Document {
     pub node: Node,
     reflector_: Reflector,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -310,8 +310,8 @@ impl Document {
     }
 
     pub fn new(window: &JSRef<Window>, url: Option<Url>, doctype: IsHTMLDocument, content_type: Option<DOMString>) -> Temporary<Document> {
-        let document = Document::new_inherited(window, url, doctype, content_type);
-        let document = reflect_dom_object(box document, &Window(*window),
+        let document = reflect_dom_object(box Document::new_inherited(window, url, doctype, content_type),
+                                          &Window(*window),
                                           DocumentBinding::Wrap).root();
 
         let node: &JSRef<Node> = NodeCast::from_ref(&*document);

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -19,6 +19,7 @@ use dom::nodelist::NodeList;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DocumentFragment {
     pub node: Node,
 }
@@ -38,8 +39,8 @@ impl DocumentFragment {
     }
 
     pub fn new(document: &JSRef<Document>) -> Temporary<DocumentFragment> {
-        let node = DocumentFragment::new_inherited(document);
-        Node::reflect_node(box node, document, DocumentFragmentBinding::Wrap)
+        Node::reflect_node(box DocumentFragment::new_inherited(document),
+                           document, DocumentFragmentBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef) -> Fallible<Temporary<DocumentFragment>> {

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -14,6 +14,7 @@ use servo_util::str::DOMString;
 
 /// The `DOCTYPE` tag.
 #[deriving(Encodable)]
+#[must_root]
 pub struct DocumentType {
     pub node: Node,
     pub name: DOMString,
@@ -40,7 +41,7 @@ impl DocumentType {
             system_id: system_id.unwrap_or("".to_string())
         }
     }
-
+    #[allow(unrooted_must_root)]
     pub fn new(name: DOMString,
                public_id: Option<DOMString>,
                system_id: Option<DOMString>,

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -60,6 +60,7 @@ impl DOMErrorName {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DOMException {
     pub code: DOMErrorName,
     pub reflector_: Reflector

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -23,6 +23,7 @@ use dom::text::Text;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DOMImplementation {
     document: JS<Document>,
     reflector_: Reflector,

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -14,6 +14,7 @@ use dom::window::Window;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DOMParser {
     window: JS<Window>, //XXXjdm Document instead?
     reflector_: Reflector

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -11,6 +11,7 @@ use dom::window::Window;
 use servo_util::geometry::Au;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DOMRect {
     reflector_: Reflector,
     top: f32,
@@ -34,8 +35,8 @@ impl DOMRect {
     pub fn new(window: &JSRef<Window>,
                top: Au, bottom: Au,
                left: Au, right: Au) -> Temporary<DOMRect> {
-        let rect = DOMRect::new_inherited(top, bottom, left, right);
-        reflect_dom_object(box rect, &Window(*window), DOMRectBinding::Wrap)
+        reflect_dom_object(box DOMRect::new_inherited(top, bottom, left, right),
+                           &Window(*window), DOMRectBinding::Wrap)
     }
 }
 

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -11,6 +11,7 @@ use dom::domrect::DOMRect;
 use dom::window::Window;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DOMRectList {
     reflector_: Reflector,
     rects: Vec<JS<DOMRect>>,

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -17,6 +17,7 @@ use servo_util::namespace::Null;
 use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct DOMTokenList {
     reflector_: Reflector,
     element: JS<Element>,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -220,6 +220,7 @@ pub trait LayoutElementHelpers {
 }
 
 impl LayoutElementHelpers for JS<Element> {
+    #[allow(unrooted_must_root)]
     unsafe fn html_element_in_html_document_for_layout(&self) -> bool {
         if (*self.unsafe_get()).namespace != namespace::HTML {
             return false

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -42,6 +42,7 @@ use std::cell::{Cell, RefCell};
 use std::mem;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Element {
     pub node: Node,
     pub local_name: Atom,
@@ -160,8 +161,8 @@ impl Element {
     }
 
     pub fn new(local_name: DOMString, namespace: Namespace, prefix: Option<DOMString>, document: &JSRef<Document>) -> Temporary<Element> {
-        let element = Element::new_inherited(ElementTypeId, local_name, namespace, prefix, document);
-        Node::reflect_node(box element, document, ElementBinding::Wrap)
+        Node::reflect_node(box Element::new_inherited(ElementTypeId, local_name, namespace, prefix, document),
+                           document, ElementBinding::Wrap)
     }
 }
 
@@ -173,6 +174,7 @@ pub trait RawLayoutElementHelpers {
 
 impl RawLayoutElementHelpers for Element {
     #[inline]
+    #[allow(unrooted_must_root)]
     unsafe fn get_attr_val_for_layout(&self, namespace: &Namespace, name: &str)
                                       -> Option<&'static str> {
         // cast to point to T in RefCell<T> directly
@@ -188,6 +190,7 @@ impl RawLayoutElementHelpers for Element {
     }
 
     #[inline]
+    #[allow(unrooted_must_root)]
     unsafe fn get_attr_atom_for_layout(&self, namespace: &Namespace, name: &str)
                                       -> Option<Atom> {
         // cast to point to T in RefCell<T> directly
@@ -203,6 +206,7 @@ impl RawLayoutElementHelpers for Element {
     }
 
     #[inline]
+    #[allow(unrooted_must_root)]
     unsafe fn has_class_for_layout(&self, name: &str) -> bool {
         let attrs: *const Vec<JS<Attr>> = mem::transmute(&self.attrs);
         (*attrs).iter().find(|attr: & &JS<Attr>| {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -35,6 +35,7 @@ pub enum EventTypeId {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Event {
     pub type_id: EventTypeId,
     reflector_: Reflector,

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -62,6 +62,7 @@ pub struct EventListenerEntry {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct EventTarget {
     pub type_id: EventTargetTypeId,
     reflector_: Reflector,

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -11,6 +11,7 @@ use dom::blob::{Blob, BlobType, FileTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct File {
     pub blob: Blob,
     pub name: DOMString,

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -19,12 +19,14 @@ use std::cell::RefCell;
 use std::collections::hashmap::HashMap;
 
 #[deriving(Encodable, Clone)]
+#[must_root]
 pub enum FormDatum {
     StringData(DOMString),
     FileData(JS<File>)
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct FormData {
     data: Traceable<RefCell<HashMap<DOMString, Vec<FormDatum>>>>,
     reflector_: Reflector,

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -55,6 +55,7 @@ impl FormData {
 }
 
 impl<'a> FormDataMethods for JSRef<'a, FormData> {
+    #[allow(unrooted_must_root)]
     fn Append(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
         let file = FileData(JS::from_rooted(&self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert_or_update_with(name.clone(), vec!(file.clone()),
@@ -86,7 +87,7 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
     fn Has(&self, name: DOMString) -> bool {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
-
+    #[allow(unrooted_must_root)]
     fn Set(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
         let file = FileData(JS::from_rooted(&self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert(name, vec!(file));

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -24,6 +24,7 @@ use servo_util::namespace::Null;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLAnchorElement {
     pub htmlelement: HTMLElement
 }
@@ -41,6 +42,7 @@ impl HTMLAnchorElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAnchorElement> {
         let element = HTMLAnchorElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAnchorElementBinding::Wrap)

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLAppletElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLAppletElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAppletElement> {
         let element = HTMLAppletElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAppletElementBinding::Wrap)

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -18,6 +18,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLAreaElement {
     pub htmlelement: HTMLElement
 }
@@ -35,6 +36,7 @@ impl HTMLAreaElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAreaElement> {
         let element = HTMLAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAreaElementBinding::Wrap)

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLAudioElement {
     pub htmlmediaelement: HTMLMediaElement
 }
@@ -31,6 +32,7 @@ impl HTMLAudioElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAudioElement> {
         let element = HTMLAudioElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAudioElementBinding::Wrap)

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLBaseElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLBaseElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBaseElement> {
         let element = HTMLBaseElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBaseElementBinding::Wrap)

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -21,6 +21,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLBodyElement {
     pub htmlelement: HTMLElement
 }
@@ -38,6 +39,7 @@ impl HTMLBodyElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBodyElement> {
         let element = HTMLBodyElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBodyElementBinding::Wrap)

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLBRElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLBRElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBRElement> {
         let element = HTMLBRElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBRElementBinding::Wrap)

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -20,6 +20,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLButtonElement {
     pub htmlelement: HTMLElement
 }
@@ -37,6 +38,7 @@ impl HTMLButtonElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLButtonElement> {
         let element = HTMLButtonElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLButtonElementBinding::Wrap)

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -29,6 +29,7 @@ static DefaultWidth: u32 = 300;
 static DefaultHeight: u32 = 150;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLCanvasElement {
     pub htmlelement: HTMLElement,
     context: Traceable<Cell<Option<JS<CanvasRenderingContext2D>>>>,
@@ -52,6 +53,7 @@ impl HTMLCanvasElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLCanvasElement> {
         let element = HTMLCanvasElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLCanvasElementBinding::Wrap)

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -30,12 +30,14 @@ impl<S: Encoder<E>, E> Encodable<S, E> for Box<CollectionFilter> {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub enum CollectionTypeId {
     Static(Vec<JS<Element>>),
     Live(JS<Node>, Box<CollectionFilter>)
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLCollection {
     collection: CollectionTypeId,
     reflector_: Reflector,

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLDataElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLDataElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDataElement> {
         let element = HTMLDataElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDataElementBinding::Wrap)

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -17,6 +17,7 @@ use dom::node::{Node, ElementNodeTypeId, window_from_node};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLDataListElement {
     pub htmlelement: HTMLElement
 }
@@ -34,6 +35,7 @@ impl HTMLDataListElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDataListElement> {
         let element = HTMLDataListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDataListElementBinding::Wrap)

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLDirectoryElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLDirectoryElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDirectoryElement> {
         let element = HTMLDirectoryElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDirectoryElementBinding::Wrap)

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLDivElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLDivElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDivElement> {
         let element = HTMLDivElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDivElementBinding::Wrap)

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLDListElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLDListElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDListElement> {
         let element = HTMLDListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDListElementBinding::Wrap)

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -22,7 +22,7 @@ use servo_util::namespace;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
-#[allow(unrooted_must_root)]
+#[must_root]
 pub struct HTMLElement {
     pub element: Element
 }
@@ -44,6 +44,7 @@ impl HTMLElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLElement> {
         let element = HTMLElement::new_inherited(HTMLElementTypeId, localName, document);
         Node::reflect_node(box element, document, HTMLElementBinding::Wrap)

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -22,6 +22,7 @@ use servo_util::namespace;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[allow(unrooted_must_root)]
 pub struct HTMLElement {
     pub element: Element
 }

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLEmbedElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLEmbedElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLEmbedElement> {
         let element = HTMLEmbedElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLEmbedElementBinding::Wrap)

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -22,6 +22,7 @@ use servo_util::atom::Atom;
 use servo_util::str::{DOMString, StaticStringVec};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLFieldSetElement {
     pub htmlelement: HTMLElement
 }
@@ -39,6 +40,7 @@ impl HTMLFieldSetElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFieldSetElement> {
         let element = HTMLFieldSetElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFieldSetElementBinding::Wrap)

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLFontElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLFontElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFontElement> {
         let element = HTMLFontElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFontElementBinding::Wrap)

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLFormElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLFormElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFormElement> {
         let element = HTMLFormElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFormElementBinding::Wrap)

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLFrameElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLFrameElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFrameElement> {
         let element = HTMLFrameElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFrameElementBinding::Wrap)

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLFrameSetElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLFrameSetElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFrameSetElement> {
         let element = HTMLFrameSetElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFrameSetElementBinding::Wrap)

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLHeadElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLHeadElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHeadElement> {
         let element = HTMLHeadElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHeadElementBinding::Wrap)

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -24,6 +24,7 @@ pub enum HeadingLevel {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLHeadingElement {
     pub htmlelement: HTMLElement,
     pub level: HeadingLevel,
@@ -43,6 +44,7 @@ impl HTMLHeadingElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>, level: HeadingLevel) -> Temporary<HTMLHeadingElement> {
         let element = HTMLHeadingElement::new_inherited(localName, document, level);
         Node::reflect_node(box element, document, HTMLHeadingElementBinding::Wrap)

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLHRElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLHRElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHRElement> {
         let element = HTMLHRElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHRElementBinding::Wrap)

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLHtmlElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLHtmlElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHtmlElement> {
         let element = HTMLHtmlElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHtmlElementBinding::Wrap)

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -42,6 +42,7 @@ enum SandboxAllowance {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLIFrameElement {
     pub htmlelement: HTMLElement,
     pub size: Traceable<Cell<Option<IFrameSize>>>,
@@ -117,6 +118,7 @@ impl HTMLIFrameElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLIFrameElement> {
         let element = HTMLIFrameElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLIFrameElementBinding::Wrap)

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -26,6 +26,7 @@ use url::{Url, UrlParser};
 use std::cell::RefCell;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLImageElement {
     pub htmlelement: HTMLElement,
     image: Untraceable<RefCell<Option<Url>>>,
@@ -78,6 +79,7 @@ impl HTMLImageElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLImageElement> {
         let element = HTMLImageElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLImageElementBinding::Wrap)

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -19,6 +19,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLInputElement {
     pub htmlelement: HTMLElement,
 }
@@ -36,6 +37,7 @@ impl HTMLInputElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLInputElement> {
         let element = HTMLInputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLInputElementBinding::Wrap)

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLLabelElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLLabelElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLabelElement> {
         let element = HTMLLabelElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLabelElementBinding::Wrap)

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLLegendElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLLegendElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLegendElement> {
         let element = HTMLLegendElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLegendElementBinding::Wrap)

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLLIElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLLIElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLIElement> {
         let element = HTMLLIElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLIElementBinding::Wrap)

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -18,6 +18,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLLinkElement {
     pub htmlelement: HTMLElement,
 }
@@ -35,6 +36,7 @@ impl HTMLLinkElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLinkElement> {
         let element = HTMLLinkElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLinkElementBinding::Wrap)

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLMapElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLMapElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMapElement> {
         let element = HTMLMapElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMapElementBinding::Wrap)

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -13,6 +13,7 @@ use dom::node::ElementNodeTypeId;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLMediaElement {
     pub htmlelement: HTMLElement,
 }

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLMetaElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLMetaElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMetaElement> {
         let element = HTMLMetaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMetaElementBinding::Wrap)

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLMeterElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLMeterElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMeterElement> {
         let element = HTMLMeterElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMeterElementBinding::Wrap)

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLModElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLModElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLModElement> {
         let element = HTMLModElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLModElementBinding::Wrap)

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -27,6 +27,7 @@ use servo_util::str::DOMString;
 use url::Url;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLObjectElement {
     pub htmlelement: HTMLElement,
 }
@@ -44,6 +45,7 @@ impl HTMLObjectElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLObjectElement> {
         let element = HTMLObjectElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLObjectElementBinding::Wrap)

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLOListElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLOListElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOListElement> {
         let element = HTMLOListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOListElementBinding::Wrap)

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -19,6 +19,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLOptGroupElement {
     pub htmlelement: HTMLElement
 }
@@ -36,6 +37,7 @@ impl HTMLOptGroupElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptGroupElement> {
         let element = HTMLOptGroupElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptGroupElementBinding::Wrap)

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -19,6 +19,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLOptionElement {
     pub htmlelement: HTMLElement
 }
@@ -36,6 +37,7 @@ impl HTMLOptionElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptionElement> {
         let element = HTMLOptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptionElementBinding::Wrap)

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -16,6 +16,7 @@ use dom::validitystate::ValidityState;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLOutputElement {
     pub htmlelement: HTMLElement
 }
@@ -33,6 +34,7 @@ impl HTMLOutputElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOutputElement> {
         let element = HTMLOutputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOutputElementBinding::Wrap)

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLParagraphElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLParagraphElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLParagraphElement> {
         let element = HTMLParagraphElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLParagraphElementBinding::Wrap)

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLParamElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLParamElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLParamElement> {
         let element = HTMLParamElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLParamElementBinding::Wrap)

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLPreElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLPreElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLPreElement> {
         let element = HTMLPreElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLPreElementBinding::Wrap)

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLProgressElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLProgressElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLProgressElement> {
         let element = HTMLProgressElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLProgressElementBinding::Wrap)

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLQuoteElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLQuoteElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLQuoteElement> {
         let element = HTMLQuoteElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLQuoteElementBinding::Wrap)

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -20,6 +20,7 @@ use servo_util::namespace::Null;
 use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLScriptElement {
     pub htmlelement: HTMLElement,
 }
@@ -37,6 +38,7 @@ impl HTMLScriptElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLScriptElement> {
         let element = HTMLScriptElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLScriptElementBinding::Wrap)

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -22,6 +22,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLSelectElement {
     pub htmlelement: HTMLElement
 }
@@ -39,6 +40,7 @@ impl HTMLSelectElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSelectElement> {
         let element = HTMLSelectElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSelectElementBinding::Wrap)

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -21,6 +21,7 @@ use dom::text::Text;
 use servo_util::atom::Atom;
 use servo_util::namespace;
 
+#[allow(unrooted_must_root)]
 pub fn serialize(iterator: &mut NodeIterator) -> String {
     let mut html = String::new();
     let mut open_elements: Vec<String> = vec!();

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLSourceElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLSourceElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSourceElement> {
         let element = HTMLSourceElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSourceElementBinding::Wrap)

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLSpanElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLSpanElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSpanElement> {
         let element = HTMLSpanElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSpanElementBinding::Wrap)

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -18,6 +18,7 @@ use layout_interface::{AddStylesheetMsg, LayoutChan};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLStyleElement {
     pub htmlelement: HTMLElement,
 }
@@ -35,6 +36,7 @@ impl HTMLStyleElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLStyleElement> {
         let element = HTMLStyleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLStyleElementBinding::Wrap)

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableCaptionElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLTableCaptionElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableCaptionElement> {
         let element = HTMLTableCaptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableCaptionElementBinding::Wrap)

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -13,6 +13,7 @@ use dom::node::ElementNodeTypeId;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableCellElement {
     pub htmlelement: HTMLElement,
 }

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableColElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTableColElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableColElement> {
         let element = HTMLTableColElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableColElementBinding::Wrap)

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableDataCellElement {
     pub htmltablecellelement: HTMLTableCellElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTableDataCellElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableDataCellElement> {
         let element = HTMLTableDataCellElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableDataCellElementBinding::Wrap)

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -18,6 +18,7 @@ use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableElement {
     pub htmlelement: HTMLElement,
 }
@@ -35,6 +36,7 @@ impl HTMLTableElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableElement> {
         let element = HTMLTableElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableElementBinding::Wrap)

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableHeaderCellElement {
     pub htmltablecellelement: HTMLTableCellElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTableHeaderCellElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableHeaderCellElement> {
         let element = HTMLTableHeaderCellElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableHeaderCellElementBinding::Wrap)

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableRowElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTableRowElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableRowElement> {
         let element = HTMLTableRowElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableRowElementBinding::Wrap)

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTableSectionElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTableSectionElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableSectionElement> {
         let element = HTMLTableSectionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableSectionElementBinding::Wrap)

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTemplateElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTemplateElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTemplateElement> {
         let element = HTMLTemplateElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTemplateElementBinding::Wrap)

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -19,6 +19,7 @@ use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTextAreaElement {
     pub htmlelement: HTMLElement,
 }
@@ -36,6 +37,7 @@ impl HTMLTextAreaElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTextAreaElement> {
         let element = HTMLTextAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTextAreaElementBinding::Wrap)

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTimeElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLTimeElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTimeElement> {
         let element = HTMLTimeElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTimeElementBinding::Wrap)

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -17,6 +17,7 @@ use dom::text::Text;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTitleElement {
     pub htmlelement: HTMLElement,
 }
@@ -34,6 +35,7 @@ impl HTMLTitleElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTitleElement> {
         let element = HTMLTitleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTitleElementBinding::Wrap)

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLTrackElement {
     pub htmlelement: HTMLElement,
 }
@@ -31,6 +32,7 @@ impl HTMLTrackElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTrackElement> {
         let element = HTMLTrackElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTrackElementBinding::Wrap)

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLUListElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLUListElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLUListElement> {
         let element = HTMLUListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLUListElementBinding::Wrap)

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLUnknownElement {
     pub htmlelement: HTMLElement
 }
@@ -31,6 +32,7 @@ impl HTMLUnknownElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLUnknownElement> {
         let element = HTMLUnknownElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLUnknownElementBinding::Wrap)

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -14,6 +14,7 @@ use dom::node::{Node, ElementNodeTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct HTMLVideoElement {
     pub htmlmediaelement: HTMLMediaElement
 }
@@ -31,6 +32,7 @@ impl HTMLVideoElement {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLVideoElement> {
         let element = HTMLVideoElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLVideoElementBinding::Wrap)

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -15,6 +15,7 @@ use servo_util::str::DOMString;
 use std::rc::Rc;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Location {
     reflector_: Reflector, //XXXjdm cycle: window->Location->window
     page: Rc<Page>,

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -20,6 +20,7 @@ use js::jsapi::JSContext;
 use js::jsval::JSVal;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct MessageEvent {
     event: Event,
     data: Traceable<JSVal>,

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -19,6 +19,7 @@ use servo_util::str::DOMString;
 use std::cell::Cell;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct MouseEvent {
     pub mouseevent: UIEvent,
     pub screen_x: Traceable<Cell<i32>>,

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -12,6 +12,7 @@ use dom::element::Element;
 use dom::window::Window;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct NamedNodeMap {
     reflector_: Reflector,
     owner: JS<Element>,

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -11,6 +11,7 @@ use dom::window::Window;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Navigator {
     pub reflector_: Reflector //XXXjdm cycle: window->navigator->window
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -850,6 +850,7 @@ impl<'a> Iterator<JSRef<'a, Node>> for TreeIterator<'a> {
     }
 }
 
+#[must_root]
 pub struct NodeIterator {
     pub start_node: JS<Node>,
     pub current_node: Option<JS<Node>>,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -68,6 +68,7 @@ use serialize::{Encoder, Encodable};
 
 /// An HTML node.
 #[deriving(Encodable)]
+#[must_root]
 pub struct Node {
     /// The JavaScript reflector for this node.
     pub eventtarget: EventTarget,

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -9,6 +9,7 @@ use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct NodeIterator {
     pub reflector_: Reflector
 }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -11,18 +11,21 @@ use dom::node::{Node, NodeHelpers};
 use dom::window::Window;
 
 #[deriving(Encodable)]
+#[must_root]
 pub enum NodeListType {
     Simple(Vec<JS<Node>>),
     Children(JS<Node>)
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct NodeList {
     list_type: NodeListType,
     reflector_: Reflector,
 }
 
 impl NodeList {
+    #[allow(unrooted_must_root)]
     pub fn new_inherited(list_type: NodeListType) -> NodeList {
         NodeList {
             list_type: list_type,
@@ -30,6 +33,7 @@ impl NodeList {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(window: &JSRef<Window>,
                list_type: NodeListType) -> Temporary<NodeList> {
         reflect_dom_object(box NodeList::new_inherited(list_type),

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -25,7 +25,6 @@ pub struct NodeList {
 }
 
 impl NodeList {
-    #[allow(unrooted_must_root)]
     pub fn new_inherited(list_type: NodeListType) -> NodeList {
         NodeList {
             list_type: list_type,
@@ -33,7 +32,6 @@ impl NodeList {
         }
     }
 
-    #[allow(unrooted_must_root)]
     pub fn new(window: &JSRef<Window>,
                list_type: NodeListType) -> Temporary<NodeList> {
         reflect_dom_object(box NodeList::new_inherited(list_type),

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -14,6 +14,7 @@ use time;
 pub type DOMHighResTimeStamp = f64;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Performance {
     reflector_: Reflector,
     timing: JS<PerformanceTiming>,

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -29,8 +29,8 @@ impl Performance {
     }
 
     pub fn new(window: &JSRef<Window>) -> Temporary<Performance> {
-        let performance = Performance::new_inherited(window);
-        reflect_dom_object(box performance, &Window(*window),
+        reflect_dom_object(box Performance::new_inherited(window),
+                           &Window(*window),
                            PerformanceBinding::Wrap)
     }
 }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -10,6 +10,7 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct PerformanceTiming {
     reflector_: Reflector,
     navigationStart: u64,
@@ -26,6 +27,7 @@ impl PerformanceTiming {
         }
     }
 
+    #[allow(unrooted_must_root)]
     pub fn new(window: &JSRef<Window>) -> Temporary<PerformanceTiming> {
         let timing = PerformanceTiming::new_inherited(window.navigationStart,
                                                       window.navigationStartPrecise);

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -15,6 +15,7 @@ use servo_util::str::DOMString;
 
 /// An HTML processing instruction node.
 #[deriving(Encodable)]
+#[must_root]
 pub struct ProcessingInstruction {
     pub characterdata: CharacterData,
     pub target: DOMString,

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -36,8 +36,8 @@ impl ProcessingInstruction {
     }
 
     pub fn new(target: DOMString, data: DOMString, document: &JSRef<Document>) -> Temporary<ProcessingInstruction> {
-        let node = ProcessingInstruction::new_inherited(target, data, document);
-        Node::reflect_node(box node, document, ProcessingInstructionBinding::Wrap)
+        Node::reflect_node(box ProcessingInstruction::new_inherited(target, data, document),
+                           document, ProcessingInstructionBinding::Wrap)
     }
 }
 

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -14,6 +14,7 @@ use dom::event::{Event, ProgressEventTypeId};
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct ProgressEvent {
     event: Event,
     length_computable: bool,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -12,6 +12,7 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::document::Document;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Range {
     reflector_: Reflector
 }

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -10,6 +10,7 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Screen {
     reflector_: Reflector,
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -19,6 +19,7 @@ use js::jsapi::JSContext;
 use js::jsval::{JSVal, NullValue};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct TestBinding {
     reflector: Reflector,
     global: GlobalField,

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -17,6 +17,7 @@ use servo_util::str::DOMString;
 
 /// An HTML text node.
 #[deriving(Encodable)]
+#[must_root]
 pub struct Text {
     pub characterdata: CharacterData,
 }

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -36,8 +36,8 @@ impl Text {
     }
 
     pub fn new(text: DOMString, document: &JSRef<Document>) -> Temporary<Text> {
-        let node = Text::new_inherited(text, document);
-        Node::reflect_node(box node, document, TextBinding::Wrap)
+        Node::reflect_node(box Text::new_inherited(text, document),
+                           document, TextBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef, text: DOMString) -> Fallible<Temporary<Text>> {

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -9,6 +9,7 @@ use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct TreeWalker {
     pub reflector_: Reflector
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -18,6 +18,7 @@ use servo_util::str::DOMString;
 use std::cell::Cell;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct UIEvent {
     pub event: Event,
     view: Cell<Option<JS<Window>>>,

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -22,6 +22,7 @@ use std::fmt::radix;
 use std::ascii::OwnedStrAsciiExt;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct URLSearchParams {
     data: Traceable<RefCell<HashMap<DOMString, Vec<DOMString>>>>,
     reflector_: Reflector,

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -9,6 +9,7 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::window::Window;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct ValidityState {
     reflector_: Reflector,
     state: u8,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -73,6 +73,7 @@ impl TimerHandle {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Window {
     eventtarget: EventTarget,
     pub script_chan: ScriptChan,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -30,6 +30,7 @@ use std::ptr;
 pub struct TrustedWorkerAddress(pub *const c_void);
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct Worker {
     eventtarget: EventTarget,
     refcount: Cell<uint>,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -30,6 +30,7 @@ pub enum WorkerGlobalScopeId {
 }
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct WorkerGlobalScope {
     pub eventtarget: EventTarget,
     worker_url: Untraceable<Url>,

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -15,6 +15,7 @@ use servo_util::str::DOMString;
 use url::Url;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct WorkerLocation {
     reflector_: Reflector,
     url: Untraceable<Url>,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -11,6 +11,7 @@ use dom::workerglobalscope::WorkerGlobalScope;
 use servo_util::str::DOMString;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct WorkerNavigator {
     reflector_: Reflector,
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -133,7 +133,7 @@ pub struct XMLHttpRequest {
 
 impl XMLHttpRequest {
     pub fn new_inherited(global: &GlobalRef) -> XMLHttpRequest {
-        let xhr = XMLHttpRequest {
+        XMLHttpRequest {
             eventtarget: XMLHttpRequestEventTarget::new_inherited(XMLHttpRequestTypeId),
             ready_state: Traceable::new(Cell::new(Unsent)),
             timeout: Traceable::new(Cell::new(0u32)),
@@ -163,8 +163,7 @@ impl XMLHttpRequest {
             fetch_time: Traceable::new(Cell::new(0)),
             timeout_pinned: Traceable::new(Cell::new(false)),
             terminate_sender: Untraceable::new(RefCell::new(None)),
-        };
-        xhr
+        }
     }
     pub fn new(global: &GlobalRef) -> Temporary<XMLHttpRequest> {
         reflect_dom_object(box XMLHttpRequest::new_inherited(global),

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -98,6 +98,7 @@ enum SyncOrAsync<'a, 'b> {
 
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct XMLHttpRequest {
     eventtarget: XMLHttpRequestEventTarget,
     ready_state: Traceable<Cell<XMLHttpRequestState>>,

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -12,6 +12,7 @@ use dom::eventtarget::{EventTarget, EventTargetHelpers, XMLHttpRequestTargetType
 use dom::xmlhttprequest::XMLHttpRequestId;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct XMLHttpRequestEventTarget {
     pub eventtarget: EventTarget,
 }

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -12,6 +12,7 @@ use dom::xmlhttprequest::{XMLHttpRequestUploadTypeId};
 use dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
 
 #[deriving(Encodable)]
+#[must_root]
 pub struct XMLHttpRequestUpload {
     eventtarget: XMLHttpRequestEventTarget
 }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -58,6 +58,7 @@ pub mod dom {
 
         /// Generated JS-Rust bindings.
         pub mod codegen {
+            #[allow(unrooted_must_root)]
             pub mod Bindings;
             pub mod InterfaceTypes;
             pub mod InheritTypes;

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -425,6 +425,7 @@ impl Page {
 
 /// Information for one frame in the browsing context.
 #[deriving(Encodable)]
+#[must_root]
 pub struct Frame {
     /// The document for this frame.
     pub document: JS<Document>,


### PR DESCRIPTION
This adds the `unrooted_must_root` lint. Any type containing a type annotated with `#[must_root]` 
must either `allow` this lint (in case it is a safe wrapper like `Temporary<T>`)
or have a `#[must_root]` attribute itself. This gives us an annotation on all types which contain unrooted JS-managed data, starting with `JS<T>`.

The main use case is to prevent usage of `JS<T>` and objects containing it to be used on the stack without rooting.
To accomplish this, the lint enforces:
- Functions aside from `new()` and `new_inherited()` are not allowed to have unrooted objects in their arguments.
- Let/for bindings to an unrooted value are similarly disallowed (in case of safe usage, use `#[allow(unrooted_must_root)]` on the surrounding block; single statements can't be annotated)
