### PR TITLE
Added more complex profiling metadata.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom#2982b770db6e5e3270305e0fd6b8068f6f80a489)",
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache?ref=pre-rustup#37a5869d4130bf75e2f082bab54767d56d4ba63a)",
  "task_info 0.0.1",
+ "url 0.1.0 (git+https://github.com/servo/rust-url#678bb4d52638b1cfdab78ef8e521566c9240fb1a)",
 ]
 
 [[package]]

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -922,7 +922,7 @@ impl IOCompositor {
     }
 
     fn composite(&mut self) {
-        profile(time::CompositingCategory, self.time_profiler_chan.clone(), || {
+        profile(time::CompositingCategory, None, self.time_profiler_chan.clone(), || {
             debug!("compositor: compositing");
             // Adjust the layer dimensions as necessary to correspond to the size of the window.
             self.scene.size = self.window_size.as_f32().to_untyped();
@@ -993,4 +993,3 @@ impl IOCompositor {
         self.recomposite = result || self.recomposite;
     }
 }
-

--- a/components/gfx/render_task.rs
+++ b/components/gfx/render_task.rs
@@ -287,7 +287,7 @@ impl<C:RenderListener + Send> RenderTask<C> {
               tiles: Vec<BufferRequest>,
               scale: f32,
               layer_id: LayerId) {
-        time::profile(time::RenderingCategory, self.time_profiler_chan.clone(), || {
+        time::profile(time::RenderingCategory, None, self.time_profiler_chan.clone(), || {
             // FIXME: Try not to create a new array here.
             let mut new_buffers = vec!();
 
@@ -350,7 +350,7 @@ impl<C:RenderListener + Send> RenderTask<C> {
                     ctx.clear();
 
                     // Draw the display list.
-                    profile(time::RenderingDrawingCategory, self.time_profiler_chan.clone(), || {
+                    profile(time::RenderingDrawingCategory, None, self.time_profiler_chan.clone(), || {
                         display_list.draw_into_context(&mut ctx, &matrix);
                         ctx.draw_target.flush();
                     });
@@ -439,4 +439,3 @@ impl<C:RenderListener + Send> RenderTask<C> {
         })
     }
 }
-

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -15,6 +15,7 @@ use flow;
 use flow_ref::FlowRef;
 use layout_task::{AssignBSizesAndStoreOverflowTraversal, AssignISizesTraversal};
 use layout_task::{BubbleISizesTraversal};
+use url::Url;
 use util::{LayoutDataAccess, LayoutDataWrapper, OpaqueNodeMethods};
 use wrapper::{layout_node_to_unsafe_layout_node, layout_node_from_unsafe_layout_node, LayoutNode, PostorderNodeMutTraversal};
 use wrapper::{ThreadSafeLayoutNode, UnsafeLayoutNode};
@@ -624,12 +625,15 @@ pub fn recalc_style_for_subtree(root_node: &LayoutNode,
 }
 
 pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
+                                   url: &Url,
+                                   iframe: bool,
+                                   first_reflow: bool,
                                    time_profiler_chan: TimeProfilerChan,
                                    shared_layout_context: &SharedLayoutContext,
                                    queue: &mut WorkQueue<*const SharedLayoutContext,UnsafeFlow>) {
     queue.data = shared_layout_context as *const _;
 
-    profile(time::LayoutParallelWarmupCategory, time_profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, first_reflow)), time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: assign_inline_sizes,
             data: mut_owned_flow_to_unsafe_flow(root),
@@ -642,12 +646,15 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 }
 
 pub fn build_display_list_for_subtree(root: &mut FlowRef,
+                                      url: &Url,
+                                      iframe: bool,
+                                      first_reflow: bool,
                                       time_profiler_chan: TimeProfilerChan,
                                       shared_layout_context: &SharedLayoutContext,
                                       queue: &mut WorkQueue<*const SharedLayoutContext,UnsafeFlow>) {
     queue.data = shared_layout_context as *const _;
 
-    profile(time::LayoutParallelWarmupCategory, time_profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, first_reflow)), time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: compute_absolute_position,
             data: mut_owned_flow_to_unsafe_flow(root),

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -142,6 +142,8 @@ pub struct Reflow {
     pub goal: ReflowGoal,
     /// The URL of the page.
     pub url: Url,
+    /// Is the current reflow of an iframe, as opposed to a root window?
+    pub iframe: bool,
     /// The channel through which messages can be sent back to the script task.
     pub script_chan: ScriptControlChan,
     /// The current window size.

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -347,6 +347,7 @@ impl Page {
                 let reflow = box Reflow {
                     document_root: root.to_trusted_node_address(),
                     url: self.get_url(),
+                    iframe: self.subpage_id.is_some(),
                     goal: goal,
                     window_size: window_size,
                     script_chan: script_chan,

--- a/components/util/Cargo.toml
+++ b/components/util/Cargo.toml
@@ -20,3 +20,5 @@ path = "../../support/rust-task_info"
 git = "https://github.com/servo/string-cache"
 branch = "pre-rustup"
 
+[dependencies.url]
+git = "https://github.com/servo/rust-url"

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -27,6 +27,7 @@ extern crate sync;
 extern crate task_info;
 extern crate std_time = "time";
 extern crate string_cache;
+extern crate url;
 
 pub mod atom;
 pub mod bloom;


### PR DESCRIPTION
This changes the profiling output from:

```
_category_                              _mean (ms)_     _median (ms)_   _min (ms)_      _max (ms)_      _bucket size_
CompositingCategory                :          5.3075          4.7763          1.4280         16.6432              12
LayoutPerformCategory              :        284.9125        202.3233        184.6329        967.9776              19
+ LayoutStyleRecalcCategory        :        242.7735        161.5772        146.5625        922.5363              19
+ LayoutDamagePropagateCategory    :          0.6145          0.5888          0.5176          0.8663              19
+ LayoutMainCategory               :         12.3587         11.3791         10.1172         20.1418              19
| + LayoutParallelWarmupCategory   :          0.0008          0.0008          0.0006          0.0014              38
+ LayoutDispListBuildCategory      :         25.6660         23.7513         21.2865         46.7053              19
RenderingDrawingCategory           :         19.6144         19.5144         11.0669         79.0099             150
RenderingCategory                  :        333.6637        349.5627          0.0053        423.6390              13
```

to:

```
_category_                          _incremental?_ _iframe?_             _url_              _mean (ms)_     _median (ms)_   _min (ms)_      _max (ms)_      _bucket size_
CompositingCategory                     N/A          N/A                  N/A                        5.7452          5.0217          1.6569         19.6917              11
LayoutPerformCategory                incr reflow    page     http://cnn.com/                       283.5427        201.8654        184.0476       1116.7777              18
LayoutPerformCategory               first reflow    page     http://www.cnn.com/                   325.5460        325.5460        325.5460        325.5460               1
+ LayoutStyleRecalcCategory          incr reflow    page     http://cnn.com/                       239.8541        163.0796        144.7337       1080.4143              18
+ LayoutStyleRecalcCategory         first reflow    page     http://www.cnn.com/                   261.4809        261.4809        261.4809        261.4809               1
+ LayoutDamagePropagateCategory      incr reflow    page     http://cnn.com/                         0.6259          0.6168          0.5312          0.8752              18
+ LayoutDamagePropagateCategory     first reflow    page     http://www.cnn.com/                     0.6078          0.6078          0.6078          0.6078               1
+ LayoutMainCategory                 incr reflow    page     http://cnn.com/                        12.3509         11.9542         10.9876         14.1981              18
+ LayoutMainCategory                first reflow    page     http://www.cnn.com/                    11.3846         11.3846         11.3846         11.3846               1
| + LayoutParallelWarmupCategory     incr reflow    page     http://cnn.com/                         0.0009          0.0009          0.0006          0.0022              36
| + LayoutParallelWarmupCategory    first reflow    page     http://www.cnn.com/                     0.0009          0.0011          0.0007          0.0011               2
+ LayoutDispListBuildCategory        incr reflow    page     http://cnn.com/                        28.0712         24.4887         22.8510         73.7452              18
+ LayoutDispListBuildCategory       first reflow    page     http://www.cnn.com/                    50.3867         50.3867         50.3867         50.3867               1
RenderingDrawingCategory                N/A          N/A                  N/A                       22.2310         21.1877         13.1922         74.4110             138
RenderingCategory                       N/A          N/A                  N/A                      372.2654        390.7910          0.0087        489.5884              12
```

This patch will not currently build without a checkout of
`https://github.com/cgaebel/rust-url:cgaebel-servo-backport` listed as an
override in your ~/.cargo/config.

This is blocked on https://github.com/servo/rust-url/pull/29, however, is ready
for review now.
