### PR TITLE
Fixes #3353: rust snapshot downloads to home directory

### DIFF
--- a/etc/ci/travis.script.sh
+++ b/etc/ci/travis.script.sh
@@ -37,7 +37,7 @@ for t in "${tasks[@]}"; do
             if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]
             then
                 mkdir -p target/doc
-                cp -R rust/doc/* target/doc/
+                cp -R ~/.servo/$(cat rust-snapshot-hash)/doc/* target/doc/
                 cp etc/doc.servo.org/* target/doc/
                 ./mach doc  # After copying rust/doc, so that the crate index is correct.
                 sudo pip install ghp-import

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -85,7 +85,7 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Force download even if a snapshot already exists')
     def bootstrap_rustc(self, force=False):
-        rust_dir = path.join(self.context.topdir, "rust")
+        rust_dir = path.join(self.context.sharedir, ".servo", "rust")
         if not force and path.exists(path.join(rust_dir, "bin", "rustc")):
             print("Snapshot Rust compiler already downloaded.", end=" ")
             print("Use |bootstrap_rust --force| to download again.")
@@ -93,7 +93,7 @@ class MachCommands(CommandBase):
 
         if path.isdir(rust_dir):
             shutil.rmtree(rust_dir)
-        os.mkdir(rust_dir)
+        os.makedirs(rust_dir)
 
         snapshot_hash = open(path.join(self.context.topdir, "rust-snapshot-hash")).read().strip()
         snapshot_path = "%s-%s.tar.gz" % (snapshot_hash, host_triple())
@@ -115,7 +115,7 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Force download even if cargo already exists')
     def bootstrap_cargo(self, force=False):
-        cargo_dir = path.join(self.context.topdir, "cargo")
+        cargo_dir = path.join(self.context.sharedir, "cargo")
         if not force and path.exists(path.join(cargo_dir, "bin", "cargo")):
             print("Cargo already downloaded.", end=" ")
             print("Use |bootstrap_cargo --force| to download again.")

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -85,7 +85,8 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Force download even if a snapshot already exists')
     def bootstrap_rustc(self, force=False):
-        rust_dir = path.join(self.context.sharedir, ".servo", "rust")
+        snapshot_hash = open(path.join(self.context.topdir, "rust-snapshot-hash")).read().strip()
+        rust_dir = path.join(self.context.sharedir, snapshot_hash)
         if not force and path.exists(path.join(rust_dir, "bin", "rustc")):
             print("Snapshot Rust compiler already downloaded.", end=" ")
             print("Use |bootstrap_rust --force| to download again.")
@@ -95,7 +96,6 @@ class MachCommands(CommandBase):
             shutil.rmtree(rust_dir)
         os.makedirs(rust_dir)
 
-        snapshot_hash = open(path.join(self.context.topdir, "rust-snapshot-hash")).read().strip()
         snapshot_path = "%s-%s.tar.gz" % (snapshot_hash, host_triple())
         snapshot_url = "https://servo-rust.s3.amazonaws.com/%s" % snapshot_path
         tgz_file = path.join(rust_dir, path.basename(snapshot_path))

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -31,7 +31,7 @@ class CommandBase(object):
 
         if not hasattr(self.context, "shareddir"):
             self.context.sharedir = path.join(path.expanduser("~/"), ".servo")
-
+        
         config_path = path.join(context.topdir, ".servobuild")
         if path.exists(config_path):
             self.config = toml.loads(open(config_path).read())
@@ -88,8 +88,9 @@ class CommandBase(object):
                 subprocess.check_call(["git", "submodule", "update",
                                        "--init", "--recursive", "--", module_path])
 
+        snapshot_hash = open(path.join(self.context.topdir, "rust-snapshot-hash")).read().strip()
         if not self.config["tools"]["system-rust"] and \
-           not path.exists(path.join(self.context.sharedir, "rust", "bin", "rustc")):
+           not path.exists(path.join(self.context.sharedir, snapshot_hash, "bin", "rustc")):
             Registrar.dispatch("bootstrap-rust", context=self.context)
         if not self.config["tools"]["system-cargo"] and \
            not path.exists(path.join(self.context.sharedir, "cargo", "bin", "cargo")):

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -45,7 +45,8 @@ class CommandBase(object):
         self.config["tools"].setdefault("rust-root", "")
         self.config["tools"].setdefault("cargo-root", "")
         if not self.config["tools"]["system-rust"]:
-            self.config["tools"]["rust-root"] = path.join(context.sharedir, "rust")
+            snapshot_hash = open(path.join(self.context.topdir, "rust-snapshot-hash")).read().strip()
+            self.config["tools"]["rust-root"] = path.join(context.sharedir, snapshot_hash)
         if not self.config["tools"]["system-cargo"]:
             self.config["tools"]["cargo-root"] = path.join(context.sharedir, "cargo")
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -29,6 +29,9 @@ class CommandBase(object):
         if not hasattr(self.context, "bootstrapped"):
             self.context.bootstrapped = False
 
+        if not hasattr(self.context, "shareddir"):
+            self.context.sharedir = path.join(path.expanduser("~/"), ".servo")
+
         config_path = path.join(context.topdir, ".servobuild")
         if path.exists(config_path):
             self.config = toml.loads(open(config_path).read())
@@ -42,9 +45,9 @@ class CommandBase(object):
         self.config["tools"].setdefault("rust-root", "")
         self.config["tools"].setdefault("cargo-root", "")
         if not self.config["tools"]["system-rust"]:
-            self.config["tools"]["rust-root"] = path.join(context.topdir, "rust")
+            self.config["tools"]["rust-root"] = path.join(context.sharedir, "rust")
         if not self.config["tools"]["system-cargo"]:
-            self.config["tools"]["cargo-root"] = path.join(context.topdir, "cargo")
+            self.config["tools"]["cargo-root"] = path.join(context.sharedir, "cargo")
 
     def build_env(self):
         """Return an extended environment dictionary."""
@@ -85,10 +88,10 @@ class CommandBase(object):
                                        "--init", "--recursive", "--", module_path])
 
         if not self.config["tools"]["system-rust"] and \
-           not path.exists(path.join(self.context.topdir, "rust", "bin", "rustc")):
+           not path.exists(path.join(self.context.sharedir, "rust", "bin", "rustc")):
             Registrar.dispatch("bootstrap-rust", context=self.context)
         if not self.config["tools"]["system-cargo"] and \
-           not path.exists(path.join(self.context.topdir, "cargo", "bin", "cargo")):
+           not path.exists(path.join(self.context.sharedir, "cargo", "bin", "cargo")):
             Registrar.dispatch("bootstrap-cargo", context=self.context)
 
         self.context.bootstrapped = True


### PR DESCRIPTION
Moves the default rust snapshot and cargo directories to ~/.servo to build across multiple clones of the repository.
