### PR TITLE
Fix unit test failures

### DIFF
--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -484,7 +484,7 @@ impl<'a> GlyphInfo<'a> {
 /// Simple glyphs are stored inline in the `entry_buffer`, detailed glyphs are
 /// stored as pointers into the `detail_store`.
 ///
-/// ~~~
+/// ~~~ignore
 /// +- GlyphStore --------------------------------+
 /// |               +---+---+---+---+---+---+---+ |
 /// | entry_buffer: |   | s |   | s |   | s | s | |  d = detailed

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -109,14 +109,17 @@ pub struct InlineFragmentsConstructionResult {
 /// Represents an {ib} split that has not yet found the containing block that it belongs to. This
 /// is somewhat tricky. An example may be helpful. For this DOM fragment:
 ///
+/// ```html
 ///     <span>
 ///     A
 ///     <div>B</div>
 ///     C
 ///     </span>
+/// ```
 ///
 /// The resulting `ConstructionItem` for the outer `span` will be:
 ///
+/// ```ignore
 ///     InlineFragmentsConstructionItem(Some(~[
 ///         InlineBlockSplit {
 ///             predecessor_fragments: ~[
@@ -128,6 +131,7 @@ pub struct InlineFragmentsConstructionResult {
 ///         }),~[
 ///             C
 ///         ])
+/// ```
 pub struct InlineBlockSplit {
     /// The inline fragments that precede the flow.
     pub predecessors: InlineFragments,

--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -250,7 +250,7 @@ impl CORSCache for CORSCacheSender {
 /// A simple task-based CORS Cache that can be sent messages
 ///
 /// #Example
-/// ```
+/// ```ignore
 /// let task = CORSCacheTask::new();
 /// let builder = TaskBuilder::new().named("XHRTask");
 /// let mut sender = task.get_sender();

--- a/components/style/selectors.rs
+++ b/components/style/selectors.rs
@@ -653,8 +653,8 @@ mod tests {
         assert!(parse_ns("[Foo]", &namespaces) == Ok(vec!(Selector {
             compound_selectors: Arc::new(CompoundSelector {
                 simple_selectors: vec!(AttrExists(AttrSelector {
-                    name: "Foo".to_string(),
-                    lower_name: "foo".to_string(),
+                    name: Atom::from_slice("Foo"),
+                    lower_name: Atom::from_slice("foo"),
                     namespace: SpecificNamespace(namespace::Null),
                 })),
                 next: None,
@@ -668,8 +668,8 @@ mod tests {
         assert!(parse_ns("[Foo]", &namespaces) == Ok(vec!(Selector {
             compound_selectors: Arc::new(CompoundSelector {
                 simple_selectors: vec!(AttrExists(AttrSelector {
-                    name: "Foo".to_string(),
-                    lower_name: "foo".to_string(),
+                    name: Atom::from_slice("Foo"),
+                    lower_name: Atom::from_slice("foo"),
                     namespace: SpecificNamespace(namespace::Null),
                 })),
                 next: None,

--- a/components/util/range.rs
+++ b/components/util/range.rs
@@ -137,7 +137,7 @@ impl<I: RangeIndex> Range<I> {
     /// Create a new range from beginning and length offsets. This could be
     /// denoted as `[begin, begin + length)`.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///    |-- begin ->|-- length ->|
     ///    |           |            |
     /// <- o - - - - - +============+ - - - ->
@@ -154,7 +154,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// The index offset to the beginning of the range.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///    |-- begin ->|
     ///    |           |
     /// <- o - - - - - +============+ - - - ->
@@ -164,7 +164,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// The index offset from the beginning to the end of the range.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///                |-- length ->|
     ///                |            |
     /// <- o - - - - - +============+ - - - ->
@@ -174,7 +174,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// The index offset to the end of the range.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///    |--------- end --------->|
     ///    |                        |
     /// <- o - - - - - +============+ - - - ->
@@ -184,7 +184,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// `true` if the index is between the beginning and the end of the range.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///        false        true      false
     ///          |           |          |
     /// <- o - - + - - +=====+======+ - + - ->
@@ -202,7 +202,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// Shift the entire range by the supplied index delta.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///                     |-- delta ->|
     ///                     |           |
     /// <- o - +============+ - - - - - | - - - ->
@@ -216,7 +216,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// Extend the end of the range by the supplied index delta.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///                     |-- delta ->|
     ///                     |           |
     /// <- o - - - - - +====+ - - - - - | - - - ->
@@ -230,7 +230,7 @@ impl<I: RangeIndex> Range<I> {
 
     /// Move the end of the range to the target index.
     ///
-    /// ~~~
+    /// ~~~ignore
     ///                               target
     ///                                 |
     /// <- o - - - - - +====+ - - - - - | - - - ->

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -33,8 +33,7 @@ pub fn is_whitespace(s: &str) -> bool {
 
 /// A "space character" according to:
 ///
-///     http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#
-///     space-character
+/// http://www.whatwg.org/specs/web-apps/current-work/multipage/common-microsyntaxes.html#space-character
 pub static HTML_SPACE_CHARACTERS: StaticCharVec = &[
     '\u0020',
     '\u0009',


### PR DESCRIPTION
This fixes failures found by running `cp ../../Cargo.lock . && ../../mach cargo test` in each crate in `components/*`.
