### PR TITLE
Fixes #3386.

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -79,6 +79,10 @@ pub struct SharedLayoutContext {
 
     /// The dirty rectangle, used during display list building.
     pub dirty: Rect<Au>,
+
+    /// Starts at zero, and increased by one every time a layout completes.
+    /// This can be used to easily check for invalid stale data.
+    pub generation: uint,
 }
 
 pub struct LayoutContext<'a> {

--- a/components/layout/css/matching.rs
+++ b/components/layout/css/matching.rs
@@ -17,6 +17,7 @@ use servo_util::cache::{Cache, LRUCache, SimpleHashCache};
 use servo_util::namespace::Null;
 use servo_util::smallvec::{SmallVec, SmallVec16};
 use servo_util::str::DOMString;
+use servo_util::tid::tid;
 use std::mem;
 use std::hash::{Hash, sip};
 use std::slice::Items;

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -88,6 +88,10 @@ pub struct LayoutTaskData {
 
     /// The dirty rect. Used during display list construction.
     pub dirty: Rect<Au>,
+
+    /// Starts at zero, and increased by one every time a layout completes.
+    /// This can be used to easily check for invalid stale data.
+    pub generation: uint,
 }
 
 /// Information needed by the layout task.
@@ -413,6 +417,7 @@ impl LayoutTask {
                     stylist: box Stylist::new(),
                     parallel_traversal: parallel_traversal,
                     dirty: Rect::zero(),
+                    generation: 0,
               })),
         }
     }
@@ -443,6 +448,7 @@ impl LayoutTask {
             reflow_root: OpaqueNodeMethods::from_layout_node(reflow_root),
             opts: self.opts.clone(),
             dirty: Rect::zero(),
+            generation: rw_data.generation,
         }
     }
 
@@ -924,6 +930,8 @@ impl LayoutTask {
         if self.opts.trace_layout {
             layout_debug::end_trace();
         }
+
+        rw_data.generation += 1;
 
         // Tell script that we're done.
         //

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -44,6 +44,7 @@ pub mod smallvec;
 pub mod sort;
 pub mod str;
 pub mod task;
+pub mod tid;
 pub mod time;
 pub mod vec;
 pub mod workqueue;

--- a/components/util/namespace.rs
+++ b/components/util/namespace.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[deriving(Eq, PartialEq, Clone, Encodable, Hash)]
+#[deriving(Eq, PartialEq, Clone, Encodable, Hash, Show)]
 pub enum Namespace {
     Null,
     HTML,

--- a/components/util/tid.rs
+++ b/components/util/tid.rs
@@ -1,0 +1,18 @@
+use std::sync::atomics::{AtomicUint, INIT_ATOMIC_UINT, SeqCst};
+
+static mut next_tid: AtomicUint = INIT_ATOMIC_UINT;
+
+local_data_key!(task_local_tid: uint)
+
+/// Every task gets one, that's unique.
+pub fn tid() -> uint {
+    let ret =
+        match task_local_tid.replace(None) {
+            None => unsafe { next_tid.fetch_add(1, SeqCst) },
+            Some(x) => x,
+        };
+
+    task_local_tid.replace(Some(ret));
+
+    ret
+}


### PR DESCRIPTION
The reason we were getting the task failures was because a stale bloom filter from a previous reflow was being used, and it just so happened to be for the same node id. This fixes it by bumping a generation number every reflow, for each layout task.

@jdm can you confirm this work?

@pcwalton @jack can one or both of you review this for me?
