### PR TITLE
Handle generated content with `display: block` correctly during flow

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -351,10 +351,12 @@ impl TableColumnFragmentInfo {
 impl Fragment {
     /// Constructs a new `Fragment` instance for the given node.
     ///
+    /// This does *not* construct the text for generated content. See comments in
+    /// `FlowConstructor::build_specific_fragment_info_for_node()` for more details.
+    ///
     /// Arguments:
     ///
     ///   * `constructor`: The flow constructor.
-    ///
     ///   * `node`: The node to create a fragment for.
     pub fn new(constructor: &mut FlowConstructor, node: &ThreadSafeLayoutNode) -> Fragment {
         let style = node.style().clone();
@@ -373,7 +375,8 @@ impl Fragment {
     }
 
     /// Constructs a new `Fragment` instance from a specific info.
-    pub fn new_from_specific_info(node: &ThreadSafeLayoutNode, specific: SpecificFragmentInfo) -> Fragment {
+    pub fn new_from_specific_info(node: &ThreadSafeLayoutNode, specific: SpecificFragmentInfo)
+                                  -> Fragment {
         let style = node.style().clone();
         let writing_mode = style.writing_mode;
         Fragment {

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -495,7 +495,7 @@ impl<'ln> TLayoutNode for ThreadSafeLayoutNode<'ln> {
 
     /// Returns `None` if this is a pseudo-element.
     fn type_id(&self) -> Option<NodeTypeId> {
-        if self.pseudo == Before || self.pseudo == After {
+        if self.pseudo != Normal {
             return None
         }
 
@@ -511,7 +511,7 @@ impl<'ln> TLayoutNode for ThreadSafeLayoutNode<'ln> {
     }
 
     fn first_child(&self) -> Option<ThreadSafeLayoutNode<'ln>> {
-        if self.pseudo == Before || self.pseudo == After {
+        if self.pseudo != Normal {
             return None
         }
 
@@ -531,11 +531,11 @@ impl<'ln> TLayoutNode for ThreadSafeLayoutNode<'ln> {
     }
 
     fn text(&self) -> String {
-        if self.pseudo == Before || self.pseudo == After {
+        if self.pseudo != Normal {
             let layout_data_ref = self.borrow_layout_data();
             let node_layout_data_wrapper = layout_data_ref.get_ref();
 
-            if self.pseudo == Before {
+            if self.pseudo == Before || self.pseudo == BeforeBlock {
                 let before_style = node_layout_data_wrapper.data.before_style.get_ref();
                 return get_content(&before_style.get_box().content)
             } else {
@@ -748,7 +748,7 @@ impl<'a> Iterator<ThreadSafeLayoutNode<'a>> for ThreadSafeLayoutNodeChildrenIter
                             let pseudo_after_node = if parent_node.is_block(After) && parent_node.pseudo == Normal {
                                 let pseudo_after_node = parent_node.with_pseudo(AfterBlock);
                                 Some(pseudo_after_node)
-                            } else if parent_node.pseudo == Normal || parent_node.pseudo == AfterBlock {
+                            } else if parent_node.pseudo == Normal {
                                 let pseudo_after_node = parent_node.with_pseudo(After);
                                 Some(pseudo_after_node)
                             } else {

--- a/tests/ref/after_block_iteration.html
+++ b/tests/ref/after_block_iteration.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!--
+  Although this test may seem (and is) trivial, it ensures that iteration with generated content
+  with `display: block` is correct during flow construction. Before this commit, this could hang
+  when combined with incremental reflow, since the parallel traversal counters would become
+  corrupted.
+-->
+<title>ack</title>
+<style>
+div.after-portlet-lang:after {
+    display: block;
+}
+</style>
+<body>
+    <div class='after-portlet-lang'><div>x</div></div>
+</body>
+</html>

--- a/tests/ref/after_block_iteration_ref.html
+++ b/tests/ref/after_block_iteration_ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>ack</title>
+<style>
+</style>
+<body>
+    <div>x</div>
+</body>
+</html>
+ 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -134,3 +134,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == inline_block_with_margin_a.html inline_block_with_margin_ref.html
 == table_padding_a.html table_padding_ref.html
 == img_block_display_a.html img_block_display_ref.html
+== after_block_iteration.html after_block_iteration_ref.html


### PR DESCRIPTION
construction.

The iteration was incorrect here. Although it accidentally worked
before, it will cause problems when we have incremental style
recalculation.

The `after_block_iteration` reftest will become interesting once we have
incremental style recalc.

r? @glennw
