### PR TITLE
Share code between Navigator and WorkerNavigator

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -7,6 +7,7 @@ use dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
 use dom::bindings::global::Window;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::urlhelper::UrlHelper;
 use dom::window::Window;
 use page::Page;
 
@@ -38,23 +39,15 @@ impl Location {
 
 impl<'a> LocationMethods for JSRef<'a, Location> {
     fn Href(&self) -> DOMString {
-        self.page.get_url().serialize()
+        UrlHelper::Href(&self.page.get_url())
     }
 
     fn Search(&self) -> DOMString {
-        match self.page.get_url().query {
-            None => "".to_string(),
-            Some(ref query) if query.as_slice() == "" => "".to_string(),
-            Some(ref query) => "?".to_string().append(query.as_slice())
-        }
+        UrlHelper::Search(&self.page.get_url())
     }
 
     fn Hash(&self) -> DOMString {
-        match self.page.get_url().fragment {
-            None => "".to_string(),
-            Some(ref hash) if hash.as_slice() == "" => "".to_string(),
-            Some(ref hash) => "#".to_string().append(hash.as_slice())
-        }
+        UrlHelper::Hash(&self.page.get_url())
     }
 }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -7,6 +7,7 @@ use dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use dom::bindings::global::Window;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::navigatorinfo::NavigatorInfo;
 use dom::window::Window;
 use servo_util::str::DOMString;
 
@@ -32,23 +33,23 @@ impl Navigator {
 
 impl<'a> NavigatorMethods for JSRef<'a, Navigator> {
     fn Product(&self) -> DOMString {
-        "Gecko".to_string()
+        NavigatorInfo::Product()
     }
 
     fn TaintEnabled(&self) -> bool {
-        false
+        NavigatorInfo::TaintEnabled()
     }
 
     fn AppName(&self) -> DOMString {
-        "Netscape".to_string() // Like Gecko/Webkit
+        NavigatorInfo::AppName()
     }
 
     fn AppCodeName(&self) -> DOMString {
-        "Mozilla".to_string()
+        NavigatorInfo::AppCodeName()
     }
 
     fn Platform(&self) -> DOMString {
-        "".to_string()
+        NavigatorInfo::Platform()
     }
 }
 

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use servo_util::str::DOMString;
+
+pub struct NavigatorInfo;
+
+impl NavigatorInfo {
+    pub fn Product() -> DOMString {
+        "Gecko".to_string()
+    }
+
+    pub fn TaintEnabled() -> bool {
+        false
+    }
+
+    pub fn AppName() -> DOMString {
+        "Netscape".to_string() // Like Gecko/Webkit
+    }
+
+    pub fn AppCodeName() -> DOMString {
+        "Mozilla".to_string()
+    }
+
+    pub fn Platform() -> DOMString {
+        "".to_string()
+    }
+}

--- a/components/script/dom/urlhelper.rs
+++ b/components/script/dom/urlhelper.rs
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use servo_util::str::DOMString;
+use url::Url;
+
+pub struct UrlHelper;
+
+impl UrlHelper {
+    pub fn Href(url: &Url) -> DOMString {
+        url.serialize()
+    }
+
+    pub fn Search(url: &Url) -> DOMString {
+        match url.query {
+            None => "".to_string(),
+            Some(ref query) if query.as_slice() == "" => "".to_string(),
+            Some(ref query) => "?".to_string().append(query.as_slice())
+        }
+    }
+
+    pub fn Hash(url: &Url) -> DOMString {
+        match url.fragment {
+            None => "".to_string(),
+            Some(ref hash) if hash.as_slice() == "" => "".to_string(),
+            Some(ref hash) => "#".to_string().append(hash.as_slice())
+        }
+    }
+}

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -8,6 +8,7 @@ use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::global::Worker;
 use dom::bindings::trace::Untraceable;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::urlhelper::UrlHelper;
 use dom::workerglobalscope::WorkerGlobalScope;
 
 use servo_util::str::DOMString;
@@ -38,23 +39,15 @@ impl WorkerLocation {
 
 impl<'a> WorkerLocationMethods for JSRef<'a, WorkerLocation> {
     fn Href(&self) -> DOMString {
-        self.url.deref().serialize()
+        UrlHelper::Href(self.url.deref())
     }
 
     fn Search(&self) -> DOMString {
-        match self.url.query {
-            None => "".to_string(),
-            Some(ref query) if query.as_slice() == "" => "".to_string(),
-            Some(ref query) => "?".to_string().append(query.as_slice())
-        }
+        UrlHelper::Search(self.url.deref())
     }
 
     fn Hash(&self) -> DOMString {
-        match self.url.fragment {
-            None => "".to_string(),
-            Some(ref hash) if hash.as_slice() == "" => "".to_string(),
-            Some(ref hash) => "#".to_string().append(hash.as_slice())
-        }
+        UrlHelper::Hash(self.url.deref())
     }
 }
 

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -7,6 +7,7 @@ use dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMet
 use dom::bindings::global::Worker;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::navigatorinfo::NavigatorInfo;
 use dom::workerglobalscope::WorkerGlobalScope;
 use servo_util::str::DOMString;
 
@@ -32,23 +33,23 @@ impl WorkerNavigator {
 
 impl<'a> WorkerNavigatorMethods for JSRef<'a, WorkerNavigator> {
     fn Product(&self) -> DOMString {
-        "Gecko".to_string()
+        NavigatorInfo::Product()
     }
 
     fn TaintEnabled(&self) -> bool {
-        false
+        NavigatorInfo::TaintEnabled()
     }
 
     fn AppName(&self) -> DOMString {
-        "Netscape".to_string() // Like Gecko/Webkit
+        NavigatorInfo::AppName()
     }
 
     fn AppCodeName(&self) -> DOMString {
-        "Mozilla".to_string()
+        NavigatorInfo::AppCodeName()
     }
 
     fn Platform(&self) -> DOMString {
-        "".to_string()
+        NavigatorInfo::Platform()
     }
 }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -173,6 +173,7 @@ pub mod dom {
     pub mod mouseevent;
     pub mod namednodemap;
     pub mod navigator;
+    pub mod navigatorinfo;
     pub mod node;
     pub mod nodeiterator;
     pub mod nodelist;
@@ -185,6 +186,7 @@ pub mod dom {
     pub mod text;
     pub mod treewalker;
     pub mod uievent;
+    pub mod urlhelper;
     pub mod urlsearchparams;
     pub mod validitystate;
     pub mod virtualmethods;


### PR DESCRIPTION
Also shares code between Location and WorkerLocation. This has been done by introducing NavigatorInfo and UrlHelper.

Fixes #3159
