### PR TITLE
Support dumb terminals in bootstrap downloads

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -47,8 +47,11 @@ def download(desc, src, dst):
         print("\rDownloading %s: %5.1f%%" % (desc, pct), end="")
         sys.stdout.flush()
 
-    urllib.urlretrieve(src, dst, report)
-    print()
+    print("Downloading %s..." % desc)
+    dumb = os.environ.get("TERM") == "dumb"
+    urllib.urlretrieve(src, dst, None if dumb else report)
+    if not dumb:
+        print()
 
 def extract(src, dst, movedir=None):
     tarfile.open(src).extractall(dst)


### PR DESCRIPTION
Dumb terminals can only interpret a limited number of control codes,
and rewriting the terminal buffer will make `./mach build` very talkative
on these terminals.

This can be tested by setting the environment variable TERM to "dumb"
as such:

```
TERM=dumb ./mach build
```
