### PR TITLE
Fix line splitting in `white-space: pre` flows

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -499,7 +499,7 @@ impl LineBreaker {
                 debug!("LineBreaker: Deferring the fragment to the inline_end of the new-line \
                        character to the line.");
                 let mut inline_end = split_fragment(inline_end);
-                inline_end.new_line_pos = in_fragment.new_line_pos.clone();
+                inline_end.new_line_pos.remove(0);
                 self.work_list.push_front(inline_end);
             }
             false

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -95,6 +95,7 @@ experimental == vertical-lr-blocks.html vertical-lr-blocks_ref.html
 == table_auto_width.html table_auto_width_ref.html
 == inline_whitespace_b.html inline_whitespace_ref.html
 == inline_whitespace_a.html inline_whitespace_ref.html
+== whitespace_pre.html whitespace_pre_ref.html
 == line_height_a.html line_height_ref.html
 == block_replaced_content_a.html block_replaced_content_ref.html
 == block_replaced_content_b.html block_replaced_content_ref.html

--- a/tests/ref/whitespace_pre.html
+++ b/tests/ref/whitespace_pre.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>whitespace pre test</title>
+    <style>
+      div { white-space: pre; }
+    </style>
+  </head>
+  <body>
+
+<div>a
+  b
+c</div>
+
+  </body>
+</html>

--- a/tests/ref/whitespace_pre_ref.html
+++ b/tests/ref/whitespace_pre_ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>whitespace pre test</title>
+  </head>
+  <body>
+
+<div>a</div>
+<div>&nbsp;&nbsp;b</div>
+<div>c</div>
+
+  </body>
+</html>


### PR DESCRIPTION
The newline position from one line was getting used repeatedly, causing extra
"phantom" newlines in the following lines.  Fixes #3413.  r? @glennw 
