### PR TITLE
Remove uses of &mut JSRef

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5479,21 +5479,8 @@ class GlobalGenRoots():
   }
 
   #[inline(always)]
-  fn to_mut_ref<'a, 'b, T: ${toBound}+Reflectable>(base: &'a mut JSRef<'b, T>) -> Option<&'a mut JSRef<'b, Self>> {
-    match base.deref().${checkFn}() {
-        true => unsafe { Some(base.transmute_mut()) },
-        false => None
-    }
-  }
-
-  #[inline(always)]
   fn from_ref<'a, 'b, T: ${fromBound}>(derived: &'a JSRef<'b, T>) -> &'a JSRef<'b, Self> {
     unsafe { derived.transmute() }
-  }
-
-  #[inline(always)]
-  fn from_mut_ref<'a, 'b, T: ${fromBound}>(derived: &'a mut JSRef<'b, T>) -> &'a mut JSRef<'b, Self> {
-    unsafe { derived.transmute_mut() }
   }
 
   #[inline(always)]

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1779,7 +1779,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 } else {
                     match prev_text {
                         Some(ref mut text_node) => {
-                            let prev_characterdata: &mut JSRef<CharacterData> = CharacterDataCast::to_mut_ref(text_node).unwrap();
+                            let prev_characterdata: &JSRef<CharacterData> = CharacterDataCast::to_ref(text_node).unwrap();
                             let _ = prev_characterdata.AppendData(characterdata.Data());
                             self.remove_child(&child);
                         },


### PR DESCRIPTION
Since everything with JSRef happens with interior mutability, it doesn't
make any sense to use an &mut JSRef.
