### PR TITLE
First steps of &JSRef -> JSRef conversion

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -95,7 +95,7 @@ impl Reflectable for Attr {
 impl Attr {
     fn new_inherited(local_name: Atom, value: AttrValue,
                      name: Atom, namespace: Namespace,
-                     prefix: Option<DOMString>, owner: &JSRef<Element>) -> Attr {
+                     prefix: Option<DOMString>, owner: JSRef<Element>) -> Attr {
         Attr {
             reflector_: Reflector::new(),
             local_name: local_name,
@@ -107,11 +107,11 @@ impl Attr {
         }
     }
 
-    pub fn new(window: &JSRef<Window>, local_name: Atom, value: AttrValue,
+    pub fn new(window: JSRef<Window>, local_name: Atom, value: AttrValue,
                name: Atom, namespace: Namespace,
-               prefix: Option<DOMString>, owner: &JSRef<Element>) -> Temporary<Attr> {
+               prefix: Option<DOMString>, owner: JSRef<Element>) -> Temporary<Attr> {
         reflect_dom_object(box Attr::new_inherited(local_name, value, name, namespace, prefix, owner),
-                           &Window(*window), AttrBinding::Wrap)
+                           &Window(window), AttrBinding::Wrap)
     }
 }
 
@@ -157,13 +157,13 @@ pub trait AttrHelpers {
 impl<'a> AttrHelpers for JSRef<'a, Attr> {
     fn set_value(&self, set_type: AttrSettingType, value: AttrValue) {
         let owner = self.owner.root();
-        let node: &JSRef<Node> = NodeCast::from_ref(&*owner);
+        let node: JSRef<Node> = NodeCast::from_ref(*owner);
         let namespace_is_null = self.namespace == namespace::Null;
 
         match set_type {
             ReplacedAttr => {
                 if namespace_is_null {
-                    vtable_for(node).before_remove_attr(
+                    vtable_for(&node).before_remove_attr(
                         self.local_name(),
                         self.value().as_slice().to_string())
                 }
@@ -174,7 +174,7 @@ impl<'a> AttrHelpers for JSRef<'a, Attr> {
         *self.value.deref().borrow_mut() = value;
 
         if namespace_is_null {
-            vtable_for(node).after_set_attr(
+            vtable_for(&node).after_set_attr(
                 self.local_name(),
                 self.value().as_slice().to_string())
         }

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -115,7 +115,7 @@ impl CallbackInterface {
 
 /// Wraps the reflector for `p` into the compartment of `cx`.
 pub fn WrapCallThisObject<T: Reflectable>(cx: *mut JSContext,
-                                          p: &JSRef<T>) -> *mut JSObject {
+                                          p: JSRef<T>) -> *mut JSObject {
     let mut obj = p.reflector().get_jsobject();
     assert!(obj.is_not_null());
 
@@ -140,7 +140,7 @@ pub struct CallSetup {
 impl CallSetup {
     /// Performs the setup needed to make a call.
     #[allow(unrooted_must_root)]
-    pub fn new<T: CallbackContainer>(callback: &T, handling: ExceptionHandling) -> CallSetup {
+    pub fn new<T: CallbackContainer>(callback: T, handling: ExceptionHandling) -> CallSetup {
         let global = global_object_for_js_object(callback.callback());
         let global = global.root();
         let cx = global.root_ref().get_cx();

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -52,9 +52,9 @@ impl<'a> GlobalRef<'a> {
 
     /// Extract a `Window`, causing task failure if the global object is not
     /// a `Window`.
-    pub fn as_window<'b>(&'b self) -> &'b JSRef<'b, Window> {
+    pub fn as_window<'b>(&'b self) -> JSRef<'b, Window> {
         match *self {
-            Window(ref window) => window,
+            Window(window) => window,
             Worker(_) => fail!("expected a Window scope"),
         }
     }
@@ -107,8 +107,8 @@ impl GlobalField {
     /// Create a new `GlobalField` from a rooted reference.
     pub fn from_rooted(global: &GlobalRef) -> GlobalField {
         match *global {
-            Window(ref window) => WindowField(JS::from_rooted(window)),
-            Worker(ref worker) => WorkerField(JS::from_rooted(worker)),
+            Window(window) => WindowField(JS::from_rooted(window)),
+            Worker(worker) => WorkerField(JS::from_rooted(worker)),
         }
     }
 

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -24,7 +24,7 @@ pub struct BrowserContext {
 }
 
 impl BrowserContext {
-    pub fn new(document: &JSRef<Document>) -> BrowserContext {
+    pub fn new(document: JSRef<Document>) -> BrowserContext {
         let mut context = BrowserContext {
             history: vec!(SessionHistoryEntry::new(document)),
             active_index: 0,
@@ -74,7 +74,7 @@ pub struct SessionHistoryEntry {
 }
 
 impl SessionHistoryEntry {
-    fn new(document: &JSRef<Document>) -> SessionHistoryEntry {
+    fn new(document: JSRef<Document>) -> SessionHistoryEntry {
         SessionHistoryEntry {
             document: JS::from_rooted(document),
             children: vec!()

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -26,7 +26,7 @@ pub struct CanvasRenderingContext2D {
 }
 
 impl CanvasRenderingContext2D {
-    pub fn new_inherited(global: &GlobalRef, canvas: &JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> CanvasRenderingContext2D {
+    pub fn new_inherited(global: &GlobalRef, canvas: JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> CanvasRenderingContext2D {
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             global: GlobalField::from_rooted(global),
@@ -35,7 +35,7 @@ impl CanvasRenderingContext2D {
         }
     }
 
-    pub fn new(global: &GlobalRef, canvas: &JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> Temporary<CanvasRenderingContext2D> {
+    pub fn new(global: &GlobalRef, canvas: JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> Temporary<CanvasRenderingContext2D> {
         reflect_dom_object(box CanvasRenderingContext2D::new_inherited(global, canvas, size),
                            global, CanvasRenderingContext2DBinding::Wrap)
     }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -36,7 +36,7 @@ impl CharacterDataDerived for EventTarget {
 }
 
 impl CharacterData {
-    pub fn new_inherited(id: NodeTypeId, data: DOMString, document: &JSRef<Document>) -> CharacterData {
+    pub fn new_inherited(id: NodeTypeId, data: DOMString, document: JSRef<Document>) -> CharacterData {
         CharacterData {
             node: Node::new_inherited(id, document),
             data: Traceable::new(RefCell::new(data)),
@@ -95,7 +95,7 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
     fn Remove(&self) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.remove_self();
     }
 }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -29,20 +29,20 @@ impl CommentDerived for EventTarget {
 }
 
 impl Comment {
-    pub fn new_inherited(text: DOMString, document: &JSRef<Document>) -> Comment {
+    pub fn new_inherited(text: DOMString, document: JSRef<Document>) -> Comment {
         Comment {
             characterdata: CharacterData::new_inherited(CommentNodeTypeId, text, document)
         }
     }
 
-    pub fn new(text: DOMString, document: &JSRef<Document>) -> Temporary<Comment> {
+    pub fn new(text: DOMString, document: JSRef<Document>) -> Temporary<Comment> {
         Node::reflect_node(box Comment::new_inherited(text, document),
                            document, CommentBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef, data: DOMString) -> Fallible<Temporary<Comment>> {
         let document = global.as_window().Document().root();
-        Ok(Comment::new(data, &*document))
+        Ok(Comment::new(data, *&*document))
     }
 }
 

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -47,7 +47,7 @@ impl CustomEvent {
     pub fn new(global: &GlobalRef, type_: DOMString, bubbles: bool, cancelable: bool, detail: JSVal) -> Temporary<CustomEvent> {
         let ev = CustomEvent::new_uninitialized(global).root();
         ev.deref().InitCustomEvent(global.get_cx(), type_, bubbles, cancelable, detail);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
     pub fn Constructor(global: &GlobalRef,
                        type_: DOMString,
@@ -68,7 +68,7 @@ impl<'a> CustomEventMethods for JSRef<'a, CustomEvent> {
                        cancelable: bool,
                        detail: JSVal) {
         self.detail.deref().set(Traceable::new(detail));
-        let event: &JSRef<Event> = EventCast::from_ref(self);
+        let event: JSRef<Event> = EventCast::from_ref(*self);
         event.InitEvent(type_, can_bubble, cancelable);
     }
 }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -115,10 +115,10 @@ impl DedicatedWorkerGlobalScope {
             }
             global.delayed_release_worker();
 
-            let scope: &JSRef<WorkerGlobalScope> =
-                WorkerGlobalScopeCast::from_ref(&*global);
-            let target: &JSRef<EventTarget> =
-                EventTargetCast::from_ref(&*global);
+            let scope: JSRef<WorkerGlobalScope> =
+                WorkerGlobalScopeCast::from_ref(*global);
+            let target: JSRef<EventTarget> =
+                EventTargetCast::from_ref(*global);
             loop {
                 match global.receiver.recv_opt() {
                     Ok(DOMMessage(data, nbytes)) => {
@@ -130,7 +130,7 @@ impl DedicatedWorkerGlobalScope {
                                 ptr::null(), ptr::mut_null()) != 0);
                         }
 
-                        MessageEvent::dispatch_jsval(target, &Worker(*scope), message);
+                        MessageEvent::dispatch_jsval(target, &Worker(scope), message);
                         global.delayed_release_worker();
                     },
                     Ok(XHRProgressMsg(addr, progress)) => {
@@ -164,12 +164,12 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalSc
     }
 
     fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("message")
     }
 
     fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -32,13 +32,13 @@ impl DocumentFragmentDerived for EventTarget {
 
 impl DocumentFragment {
     /// Creates a new DocumentFragment.
-    pub fn new_inherited(document: &JSRef<Document>) -> DocumentFragment {
+    pub fn new_inherited(document: JSRef<Document>) -> DocumentFragment {
         DocumentFragment {
             node: Node::new_inherited(DocumentFragmentNodeTypeId, document),
         }
     }
 
-    pub fn new(document: &JSRef<Document>) -> Temporary<DocumentFragment> {
+    pub fn new(document: JSRef<Document>) -> Temporary<DocumentFragment> {
         Node::reflect_node(box DocumentFragment::new_inherited(document),
                            document, DocumentFragmentBinding::Wrap)
     }
@@ -47,26 +47,26 @@ impl DocumentFragment {
         let document = global.as_window().Document();
         let document = document.root();
 
-        Ok(DocumentFragment::new(&document.root_ref()))
+        Ok(DocumentFragment::new(*document))
     }
 }
 
 impl<'a> DocumentFragmentMethods for JSRef<'a, DocumentFragment> {
     // http://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> Temporary<HTMLCollection> {
-        let window = window_from_node(self).root();
-        HTMLCollection::children(&window.root_ref(), NodeCast::from_ref(self))
+        let window = window_from_node(*self).root();
+        HTMLCollection::children(*window, NodeCast::from_ref(*self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
     fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: &JSRef<Node> = NodeCast::from_ref(self);
+        let root: JSRef<Node> = NodeCast::from_ref(*self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
     fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: &JSRef<Node> = NodeCast::from_ref(self);
+        let root: JSRef<Node> = NodeCast::from_ref(*self);
         root.query_selector_all(selectors)
     }
 

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -32,7 +32,7 @@ impl DocumentType {
     pub fn new_inherited(name: DOMString,
                          public_id: Option<DOMString>,
                          system_id: Option<DOMString>,
-                         document: &JSRef<Document>)
+                         document: JSRef<Document>)
             -> DocumentType {
         DocumentType {
             node: Node::new_inherited(DoctypeNodeTypeId, document),
@@ -45,7 +45,7 @@ impl DocumentType {
     pub fn new(name: DOMString,
                public_id: Option<DOMString>,
                system_id: Option<DOMString>,
-               document: &JSRef<Document>)
+               document: JSRef<Document>)
                -> Temporary<DocumentType> {
         let documenttype = DocumentType::new_inherited(name,
                                                        public_id,
@@ -70,7 +70,7 @@ impl<'a> DocumentTypeMethods for JSRef<'a, DocumentType> {
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
     fn Remove(&self) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.remove_self();
     }
 }

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -21,15 +21,15 @@ pub struct DOMParser {
 }
 
 impl DOMParser {
-    pub fn new_inherited(window: &JSRef<Window>) -> DOMParser {
+    pub fn new_inherited(window: JSRef<Window>) -> DOMParser {
         DOMParser {
             window: JS::from_rooted(window),
             reflector_: Reflector::new()
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<DOMParser> {
-        reflect_dom_object(box DOMParser::new_inherited(window), &Window(*window),
+    pub fn new(window: JSRef<Window>) -> Temporary<DOMParser> {
+        reflect_dom_object(box DOMParser::new_inherited(window), &Window(window),
                            DOMParserBinding::Wrap)
     }
 
@@ -46,10 +46,10 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
         let window = self.window.root();
         match ty {
             Text_html => {
-                Ok(Document::new(&window.root_ref(), None, HTMLDocument, Some("text/html".to_string())))
+                Ok(Document::new(*window, None, HTMLDocument, Some("text/html".to_string())))
             }
             Text_xml => {
-                Ok(Document::new(&window.root_ref(), None, NonHTMLDocument, Some("text/xml".to_string())))
+                Ok(Document::new(*window, None, NonHTMLDocument, Some("text/xml".to_string())))
             }
             _ => {
                 Err(FailureUnknown)

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -32,11 +32,11 @@ impl DOMRect {
         }
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                top: Au, bottom: Au,
                left: Au, right: Au) -> Temporary<DOMRect> {
         reflect_dom_object(box DOMRect::new_inherited(top, bottom, left, right),
-                           &Window(*window), DOMRectBinding::Wrap)
+                           &Window(window), DOMRectBinding::Wrap)
     }
 }
 

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -19,9 +19,9 @@ pub struct DOMRectList {
 }
 
 impl DOMRectList {
-    pub fn new_inherited(window: &JSRef<Window>,
+    pub fn new_inherited(window: JSRef<Window>,
                          rects: Vec<JSRef<DOMRect>>) -> DOMRectList {
-        let rects = rects.iter().map(|rect| JS::from_rooted(rect)).collect();
+        let rects = rects.iter().map(|rect| JS::from_rooted(*rect)).collect();
         DOMRectList {
             reflector_: Reflector::new(),
             rects: rects,
@@ -29,10 +29,10 @@ impl DOMRectList {
         }
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                rects: Vec<JSRef<DOMRect>>) -> Temporary<DOMRectList> {
         reflect_dom_object(box DOMRectList::new_inherited(window, rects),
-                           &Window(*window), DOMRectListBinding::Wrap)
+                           &Window(window), DOMRectListBinding::Wrap)
     }
 }
 

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -25,7 +25,7 @@ pub struct DOMTokenList {
 }
 
 impl DOMTokenList {
-    pub fn new_inherited(element: &JSRef<Element>,
+    pub fn new_inherited(element: JSRef<Element>,
                          local_name: &'static str) -> DOMTokenList {
         DOMTokenList {
             reflector_: Reflector::new(),
@@ -34,7 +34,7 @@ impl DOMTokenList {
         }
     }
 
-    pub fn new(element: &JSRef<Element>,
+    pub fn new(element: JSRef<Element>,
                local_name: &'static str) -> Temporary<DOMTokenList> {
         let window = window_from_node(element).root();
         reflect_dom_object(box DOMTokenList::new_inherited(element, local_name),

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -87,7 +87,7 @@ impl Event {
                cancelable: bool) -> Temporary<Event> {
         let event = Event::new_uninitialized(global).root();
         event.deref().InitEvent(type_, can_bubble, cancelable);
-        Temporary::from_rooted(&*event)
+        Temporary::from_rooted(*event)
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -96,7 +96,7 @@ impl EventTarget {
 pub trait EventTargetHelpers {
     fn dispatch_event_with_target<'a>(&self,
                                       target: Option<JSRef<'a, EventTarget>>,
-                                      event: &JSRef<Event>) -> Fallible<bool>;
+                                      event: JSRef<Event>) -> Fallible<bool>;
     fn set_inline_event_listener(&self,
                                  ty: DOMString,
                                  listener: Option<EventListener>);
@@ -117,11 +117,11 @@ pub trait EventTargetHelpers {
 impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
     fn dispatch_event_with_target<'b>(&self,
                                       target: Option<JSRef<'b, EventTarget>>,
-                                      event: &JSRef<Event>) -> Fallible<bool> {
+                                      event: JSRef<Event>) -> Fallible<bool> {
         if event.deref().dispatching.deref().get() || !event.deref().initialized.deref().get() {
             return Err(InvalidState);
         }
-        Ok(dispatch_event(self, target, event))
+        Ok(dispatch_event(*self, target, event))
     }
 
     fn set_inline_event_listener(&self,
@@ -270,7 +270,7 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
         }
     }
 
-    fn DispatchEvent(&self, event: &JSRef<Event>) -> Fallible<bool> {
+    fn DispatchEvent(&self, event: JSRef<Event>) -> Fallible<bool> {
         self.dispatch_event_with_target(None, event)
     }
 }

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -19,7 +19,7 @@ pub struct File {
 }
 
 impl File {
-    pub fn new_inherited(_file_bits: &JSRef<Blob>, name: DOMString) -> File {
+    pub fn new_inherited(_file_bits: JSRef<Blob>, name: DOMString) -> File {
         File {
             blob: Blob::new_inherited(),
             name: name,
@@ -29,7 +29,7 @@ impl File {
         // the relevant subfields of file_bits should be copied over
     }
 
-    pub fn new(global: &GlobalRef, file_bits: &JSRef<Blob>, name: DOMString) -> Temporary<File> {
+    pub fn new(global: &GlobalRef, file_bits: JSRef<Blob>, name: DOMString) -> Temporary<File> {
         reflect_dom_object(box File::new_inherited(file_bits, name),
                            global,
                            FileBinding::Wrap)

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -40,7 +40,7 @@ impl FormData {
             data: Traceable::new(RefCell::new(HashMap::new())),
             reflector_: Reflector::new(),
             global: GlobalField::from_rooted(global),
-            form: form.map(|f| JS::from_rooted(&f)),
+            form: form.map(|f| JS::from_rooted(f)),
         }
     }
 
@@ -56,8 +56,8 @@ impl FormData {
 
 impl<'a> FormDataMethods for JSRef<'a, FormData> {
     #[allow(unrooted_must_root)]
-    fn Append(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
-        let file = FileData(JS::from_rooted(&self.get_file_from_blob(value, filename)));
+    fn Append(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+        let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert_or_update_with(name.clone(), vec!(file.clone()),
                                         |_k, v| {v.push(file.clone());});
     }
@@ -88,8 +88,8 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
     #[allow(unrooted_must_root)]
-    fn Set(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
-        let file = FileData(JS::from_rooted(&self.get_file_from_blob(value, filename)));
+    fn Set(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+        let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert(name, vec!(file));
     }
 
@@ -105,13 +105,13 @@ impl Reflectable for FormData {
 }
 
 trait PrivateFormDataHelpers{
-  fn get_file_from_blob(&self, value: &JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File>;
+  fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File>;
 }
 
 impl PrivateFormDataHelpers for FormData {
-    fn get_file_from_blob(&self, value: &JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File> {
+    fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File> {
         let global = self.global.root();
-        let f: Option<&JSRef<File>> = FileCast::to_ref(value);
+        let f: Option<JSRef<File>> = FileCast::to_ref(value);
         let name = filename.unwrap_or(f.map(|inner| inner.name.clone()).unwrap_or("blob".to_string()));
         File::new(&global.root_ref(), value, name)
     }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -36,33 +36,33 @@ impl HTMLAnchorElementDerived for EventTarget {
 }
 
 impl HTMLAnchorElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAnchorElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAnchorElement {
         HTMLAnchorElement {
             htmlelement: HTMLElement::new_inherited(HTMLAnchorElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAnchorElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAnchorElement> {
         let element = HTMLAnchorElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAnchorElementBinding::Wrap)
     }
 }
 
 trait PrivateHTMLAnchorElementHelpers {
-    fn handle_event_impl(&self, event: &JSRef<Event>);
+    fn handle_event_impl(&self, event: JSRef<Event>);
 }
 
 impl<'a> PrivateHTMLAnchorElementHelpers for JSRef<'a, HTMLAnchorElement> {
-    fn handle_event_impl(&self, event: &JSRef<Event>) {
+    fn handle_event_impl(&self, event: JSRef<Event>) {
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             let attr = element.get_attribute(Null, "href").root();
             match attr {
                 Some(ref href) => {
                     let value = href.Value();
                     debug!("clicked on link to {:s}", value);
-                    let node: &JSRef<Node> = NodeCast::from_ref(self);
+                    let node: JSRef<Node> = NodeCast::from_ref(*self);
                     let doc = node.owner_doc().root();
                     doc.load_anchor_href(value);
                 }
@@ -74,7 +74,7 @@ impl<'a> PrivateHTMLAnchorElementHelpers for JSRef<'a, HTMLAnchorElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -84,7 +84,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
@@ -97,14 +97,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
         }
     }
 
-    fn handle_event(&self, event: &JSRef<Event>) {
+    fn handle_event(&self, event: JSRef<Event>) {
         match self.super_type() {
             Some(s) => {
                 s.handle_event(event);
@@ -123,12 +123,12 @@ impl Reflectable for HTMLAnchorElement {
 
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
     fn Text(&self) -> DOMString {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.GetTextContent().unwrap()
     }
 
     fn SetText(&self, value: DOMString) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -26,14 +26,14 @@ impl HTMLAppletElementDerived for EventTarget {
 }
 
 impl HTMLAppletElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAppletElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAppletElement {
         HTMLAppletElement {
             htmlelement: HTMLElement::new_inherited(HTMLAppletElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAppletElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAppletElement> {
         let element = HTMLAppletElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAppletElementBinding::Wrap)
     }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -30,14 +30,14 @@ impl HTMLAreaElementDerived for EventTarget {
 }
 
 impl HTMLAreaElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAreaElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAreaElement {
         HTMLAreaElement {
             htmlelement: HTMLElement::new_inherited(HTMLAreaElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAreaElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAreaElement> {
         let element = HTMLAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAreaElementBinding::Wrap)
     }
@@ -45,7 +45,7 @@ impl HTMLAreaElement {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -55,7 +55,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
@@ -68,7 +68,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -26,14 +26,14 @@ impl HTMLAudioElementDerived for EventTarget {
 }
 
 impl HTMLAudioElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAudioElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAudioElement {
         HTMLAudioElement {
             htmlmediaelement: HTMLMediaElement::new_inherited(HTMLAudioElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAudioElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAudioElement> {
         let element = HTMLAudioElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAudioElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -26,14 +26,14 @@ impl HTMLBaseElementDerived for EventTarget {
 }
 
 impl HTMLBaseElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLBaseElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLBaseElement {
         HTMLBaseElement {
             htmlelement: HTMLElement::new_inherited(HTMLBaseElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBaseElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLBaseElement> {
         let element = HTMLBaseElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBaseElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -33,14 +33,14 @@ impl HTMLBodyElementDerived for EventTarget {
 }
 
 impl HTMLBodyElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLBodyElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLBodyElement {
         HTMLBodyElement {
             htmlelement: HTMLElement::new_inherited(HTMLBodyElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBodyElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLBodyElement> {
         let element = HTMLBodyElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBodyElementBinding::Wrap)
     }
@@ -48,19 +48,19 @@ impl HTMLBodyElement {
 
 impl<'a> HTMLBodyElementMethods for JSRef<'a, HTMLBodyElement> {
     fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let win = window_from_node(self).root();
+        let win = window_from_node(*self).root();
         win.deref().GetOnunload()
     }
 
     fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let win = window_from_node(self).root();
+        let win = window_from_node(*self).root();
         win.deref().SetOnunload(listener)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let element: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let element: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
     }
 
@@ -76,15 +76,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
                   "onbeforeunload", "onhashchange", "onlanguagechange", "onmessage",
                   "onoffline", "ononline", "onpagehide", "onpageshow", "onpopstate",
                   "onstorage", "onresize", "onunload", "onerror"];
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let (cx, url, reflector) = (window.get_cx(),
                                         window.get_url(),
                                         window.reflector().get_jsobject());
-            let evtarget: &JSRef<EventTarget> =
+            let evtarget: JSRef<EventTarget> =
                 if forwarded_events.iter().any(|&event| name.as_slice() == event) {
-                    EventTargetCast::from_ref(&*window)
+                    EventTargetCast::from_ref(*window)
                 } else {
-                    EventTargetCast::from_ref(self)
+                    EventTargetCast::from_ref(*self)
                 };
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.as_slice().slice_from(2),

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -26,14 +26,14 @@ impl HTMLBRElementDerived for EventTarget {
 }
 
 impl HTMLBRElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLBRElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLBRElement {
         HTMLBRElement {
             htmlelement: HTMLElement::new_inherited(HTMLBRElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBRElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLBRElement> {
         let element = HTMLBRElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBRElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -32,14 +32,14 @@ impl HTMLButtonElementDerived for EventTarget {
 }
 
 impl HTMLButtonElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLButtonElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLButtonElement {
         HTMLButtonElement {
             htmlelement: HTMLElement::new_inherited(HTMLButtonElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLButtonElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLButtonElement> {
         let element = HTMLButtonElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLButtonElementBinding::Wrap)
     }
@@ -47,8 +47,8 @@ impl HTMLButtonElement {
 
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 
     // http://www.whatwg.org/html/#dom-fe-disabled
@@ -56,14 +56,14 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -73,7 +73,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -89,7 +89,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -106,7 +106,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -116,7 +116,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -44,7 +44,7 @@ impl HTMLCanvasElementDerived for EventTarget {
 }
 
 impl HTMLCanvasElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLCanvasElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLCanvasElement {
         HTMLCanvasElement {
             htmlelement: HTMLElement::new_inherited(HTMLCanvasElementTypeId, localName, document),
             context: Traceable::new(Cell::new(None)),
@@ -54,7 +54,7 @@ impl HTMLCanvasElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLCanvasElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLCanvasElement> {
         let element = HTMLCanvasElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLCanvasElementBinding::Wrap)
     }
@@ -66,7 +66,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn SetWidth(&self, width: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("width", width)
     }
 
@@ -75,7 +75,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn SetHeight(&self, height: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("height", height)
     }
 
@@ -85,9 +85,9 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
         }
 
         if self.context.get().is_none() {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            let context = CanvasRenderingContext2D::new(&Window(*window), self, Size2D(w, h));
+            let context = CanvasRenderingContext2D::new(&Window(*window), *self, Size2D(w, h));
             self.context.assign(Some(context));
         }
         self.context.get().map(|context| Temporary::new(context))
@@ -96,7 +96,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let element: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let element: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
     }
 

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -26,14 +26,14 @@ impl HTMLDataElementDerived for EventTarget {
 }
 
 impl HTMLDataElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDataElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDataElement {
         HTMLDataElement {
             htmlelement: HTMLElement::new_inherited(HTMLDataElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDataElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDataElement> {
         let element = HTMLDataElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDataElementBinding::Wrap)
     }

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -29,14 +29,14 @@ impl HTMLDataListElementDerived for EventTarget {
 }
 
 impl HTMLDataListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDataListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDataListElement {
         HTMLDataListElement {
             htmlelement: HTMLElement::new_inherited(HTMLDataListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDataListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDataListElement> {
         let element = HTMLDataListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDataListElementBinding::Wrap)
     }
@@ -46,14 +46,14 @@ impl<'a> HTMLDataListElementMethods for JSRef<'a, HTMLDataListElement> {
     fn Options(&self) -> Temporary<HTMLCollection> {
         struct HTMLDataListOptionsFilter;
         impl CollectionFilter for HTMLDataListOptionsFilter {
-            fn filter(&self, elem: &JSRef<Element>, _root: &JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 elem.is_htmloptionelement()
             }
         }
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let filter = box HTMLDataListOptionsFilter;
         let window = window_from_node(node).root();
-        HTMLCollection::create(&*window, node, filter)
+        HTMLCollection::create(*window, node, filter)
     }
 }
 

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -26,14 +26,14 @@ impl HTMLDirectoryElementDerived for EventTarget {
 }
 
 impl HTMLDirectoryElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDirectoryElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDirectoryElement {
         HTMLDirectoryElement {
             htmlelement: HTMLElement::new_inherited(HTMLDirectoryElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDirectoryElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDirectoryElement> {
         let element = HTMLDirectoryElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDirectoryElementBinding::Wrap)
     }

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -26,14 +26,14 @@ impl HTMLDivElementDerived for EventTarget {
 }
 
 impl HTMLDivElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDivElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDivElement {
         HTMLDivElement {
             htmlelement: HTMLElement::new_inherited(HTMLDivElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDivElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDivElement> {
         let element = HTMLDivElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDivElementBinding::Wrap)
     }

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -26,14 +26,14 @@ impl HTMLDListElementDerived for EventTarget {
 }
 
 impl HTMLDListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDListElement {
         HTMLDListElement {
             htmlelement: HTMLElement::new_inherited(HTMLDListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDListElement> {
         let element = HTMLDListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDListElementBinding::Wrap)
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -38,14 +38,14 @@ impl HTMLElementDerived for EventTarget {
 }
 
 impl HTMLElement {
-    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: &JSRef<Document>) -> HTMLElement {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: JSRef<Document>) -> HTMLElement {
         HTMLElement {
             element: Element::new_inherited(type_id, tag_name, namespace::HTML, None, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLElement> {
         let element = HTMLElement::new_inherited(HTMLElementTypeId, localName, document);
         Node::reflect_node(box element, document, HTMLElementBinding::Wrap)
     }
@@ -57,25 +57,25 @@ trait PrivateHTMLElementHelpers {
 
 impl<'a> PrivateHTMLElementHelpers for JSRef<'a, HTMLElement> {
     fn is_body_or_frameset(&self) -> bool {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.is_htmlbodyelement() || eventtarget.is_htmlframesetelement()
     }
 }
 
 impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("click")
     }
 
     fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
     fn GetOnload(&self) -> Option<EventHandlerNonNull> {
         if self.is_body_or_frameset() {
-            let win = window_from_node(self).root();
+            let win = window_from_node(*self).root();
             win.deref().GetOnload()
         } else {
             None
@@ -84,7 +84,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
 
     fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
         if self.is_body_or_frameset() {
-            let win = window_from_node(self).root();
+            let win = window_from_node(*self).root();
             win.deref().SetOnload(listener)
         }
     }
@@ -92,7 +92,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: &JSRef<Element> = ElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
     }
 
@@ -103,11 +103,11 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
         }
 
         if name.as_slice().starts_with("on") {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let (cx, url, reflector) = (window.get_cx(),
                                         window.get_url(),
                                         window.reflector().get_jsobject());
-            let evtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+            let evtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.as_slice().slice_from(2),
                                                   value);

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -26,14 +26,14 @@ impl HTMLEmbedElementDerived for EventTarget {
 }
 
 impl HTMLEmbedElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLEmbedElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLEmbedElement {
         HTMLEmbedElement {
             htmlelement: HTMLElement::new_inherited(HTMLEmbedElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLEmbedElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLEmbedElement> {
         let element = HTMLEmbedElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLEmbedElementBinding::Wrap)
     }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -34,14 +34,14 @@ impl HTMLFieldSetElementDerived for EventTarget {
 }
 
 impl HTMLFieldSetElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFieldSetElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFieldSetElement {
         HTMLFieldSetElement {
             htmlelement: HTMLElement::new_inherited(HTMLFieldSetElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFieldSetElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFieldSetElement> {
         let element = HTMLFieldSetElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFieldSetElementBinding::Wrap)
     }
@@ -52,22 +52,22 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     fn Elements(&self) -> Temporary<HTMLCollection> {
         struct ElementsFilter;
         impl CollectionFilter for ElementsFilter {
-            fn filter(&self, elem: &JSRef<Element>, root: &JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
                 static tag_names: StaticStringVec = &["button", "fieldset", "input",
                     "keygen", "object", "output", "select", "textarea"];
-                let root: &JSRef<Element> = ElementCast::to_ref(root).unwrap();
+                let root: JSRef<Element> = ElementCast::to_ref(root).unwrap();
                 elem != root && tag_names.iter().any(|&tag_name| tag_name == elem.deref().local_name.as_slice())
             }
         }
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let filter = box ElementsFilter;
         let window = window_from_node(node).root();
-        HTMLCollection::create(&*window, node, filter)
+        HTMLCollection::create(*window, node, filter)
     }
 
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled
@@ -75,14 +75,14 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -92,7 +92,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -124,7 +124,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -26,14 +26,14 @@ impl HTMLFontElementDerived for EventTarget {
 }
 
 impl HTMLFontElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFontElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFontElement {
         HTMLFontElement {
             htmlelement: HTMLElement::new_inherited(HTMLFontElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFontElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFontElement> {
         let element = HTMLFontElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFontElementBinding::Wrap)
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -26,14 +26,14 @@ impl HTMLFormElementDerived for EventTarget {
 }
 
 impl HTMLFormElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFormElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFormElement {
         HTMLFormElement {
             htmlelement: HTMLElement::new_inherited(HTMLFormElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFormElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFormElement> {
         let element = HTMLFormElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFormElementBinding::Wrap)
     }

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -26,14 +26,14 @@ impl HTMLFrameElementDerived for EventTarget {
 }
 
 impl HTMLFrameElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFrameElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFrameElement {
         HTMLFrameElement {
             htmlelement: HTMLElement::new_inherited(HTMLFrameElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFrameElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFrameElement> {
         let element = HTMLFrameElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFrameElementBinding::Wrap)
     }

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -26,14 +26,14 @@ impl HTMLFrameSetElementDerived for EventTarget {
 }
 
 impl HTMLFrameSetElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFrameSetElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFrameSetElement {
         HTMLFrameSetElement {
             htmlelement: HTMLElement::new_inherited(HTMLFrameSetElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFrameSetElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFrameSetElement> {
         let element = HTMLFrameSetElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFrameSetElementBinding::Wrap)
     }

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -26,14 +26,14 @@ impl HTMLHeadElementDerived for EventTarget {
 }
 
 impl HTMLHeadElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLHeadElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLHeadElement {
         HTMLHeadElement {
             htmlelement: HTMLElement::new_inherited(HTMLHeadElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHeadElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLHeadElement> {
         let element = HTMLHeadElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHeadElementBinding::Wrap)
     }

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -37,7 +37,7 @@ impl HTMLHeadingElementDerived for EventTarget {
 }
 
 impl HTMLHeadingElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>, level: HeadingLevel) -> HTMLHeadingElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>, level: HeadingLevel) -> HTMLHeadingElement {
         HTMLHeadingElement {
             htmlelement: HTMLElement::new_inherited(HTMLHeadingElementTypeId, localName, document),
             level: level,
@@ -45,7 +45,7 @@ impl HTMLHeadingElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>, level: HeadingLevel) -> Temporary<HTMLHeadingElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>, level: HeadingLevel) -> Temporary<HTMLHeadingElement> {
         let element = HTMLHeadingElement::new_inherited(localName, document, level);
         Node::reflect_node(box element, document, HTMLHeadingElementBinding::Wrap)
     }

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -26,14 +26,14 @@ impl HTMLHRElementDerived for EventTarget {
 }
 
 impl HTMLHRElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLHRElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLHRElement {
         HTMLHRElement {
             htmlelement: HTMLElement::new_inherited(HTMLHRElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHRElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLHRElement> {
         let element = HTMLHRElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHRElementBinding::Wrap)
     }

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -26,14 +26,14 @@ impl HTMLHtmlElementDerived for EventTarget {
 }
 
 impl HTMLHtmlElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLHtmlElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLHtmlElement {
         HTMLHtmlElement {
             htmlelement: HTMLElement::new_inherited(HTMLHtmlElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHtmlElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLHtmlElement> {
         let element = HTMLHtmlElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHtmlElementBinding::Wrap)
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -74,13 +74,13 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn get_url(&self) -> Option<Url> {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_attribute(Null, "src").root().and_then(|src| {
             let url = src.deref().value();
             if url.as_slice().is_empty() {
                 None
             } else {
-                let window = window_from_node(self).root();
+                let window = window_from_node(*self).root();
                 UrlParser::new().base_url(&window.deref().page().get_url())
                     .parse(url.as_slice()).ok()
             }
@@ -100,7 +100,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
         };
 
         // Subpage Id
-        let window = window_from_node(self).root();
+        let window = window_from_node(*self).root();
         let page = window.deref().page();
         let subpage_id = page.get_next_subpage_id();
 
@@ -115,7 +115,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
 }
 
 impl HTMLIFrameElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLIFrameElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLIFrameElement {
         HTMLIFrameElement {
             htmlelement: HTMLElement::new_inherited(HTMLIFrameElementTypeId, localName, document),
             size: Traceable::new(Cell::new(None)),
@@ -124,7 +124,7 @@ impl HTMLIFrameElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLIFrameElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLIFrameElement> {
         let element = HTMLIFrameElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLIFrameElementBinding::Wrap)
     }
@@ -132,28 +132,28 @@ impl HTMLIFrameElement {
 
 impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
     fn Src(&self) -> DOMString {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_string_attribute("src")
     }
 
     fn SetSrc(&self, src: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_url_attribute("src", src)
     }
 
     fn Sandbox(&self) -> DOMString {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_string_attribute("sandbox")
     }
 
     fn SetSandbox(&self, sandbox: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("sandbox", sandbox);
     }
 
     fn GetContentWindow(&self) -> Option<Temporary<Window>> {
         self.size.deref().get().and_then(|size| {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let children = &*window.deref().page.children.deref().borrow();
             let child = children.iter().find(|child| {
                 child.subpage_id.unwrap() == size.subpage_id
@@ -169,7 +169,7 @@ impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -196,7 +196,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
         }
 
         if "src" == name.as_slice() {
-            let node: &JSRef<Node> = NodeCast::from_ref(self);
+            let node: JSRef<Node> = NodeCast::from_ref(*self);
             if node.is_in_doc() {
                 self.process_the_iframe_attributes()
             }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -46,7 +46,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
     /// Makes the local `image` member match the status of the `src` attribute and starts
     /// prefetching the image. This method must be called after `src` is changed.
     fn update_image(&self, value: Option<(DOMString, &Url)>) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let document = node.owner_doc().root();
         let window = document.deref().window.root();
         let image_cache = &window.image_cache_task;
@@ -72,7 +72,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
 }
 
 impl HTMLImageElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLImageElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLImageElement {
         HTMLImageElement {
             htmlelement: HTMLElement::new_inherited(HTMLImageElementTypeId, localName, document),
             image: Untraceable::new(RefCell::new(None)),
@@ -80,7 +80,7 @@ impl HTMLImageElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLImageElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLImageElement> {
         let element = HTMLImageElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLImageElementBinding::Wrap)
     }
@@ -100,99 +100,99 @@ impl<'a> HTMLImageElementMethods for JSRef<'a, HTMLImageElement> {
     make_getter!(Alt)
 
     fn SetAlt(&self, alt: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("alt", alt)
     }
 
     make_getter!(Src)
 
     fn SetSrc(&self, src: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_url_attribute("src", src)
     }
 
     make_getter!(UseMap)
 
     fn SetUseMap(&self, use_map: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("usemap", use_map)
     }
 
     make_bool_getter!(IsMap)
 
     fn SetIsMap(&self, is_map: bool) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("ismap", is_map.to_string())
     }
 
     fn Width(&self) -> u32 {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.width) as u32
     }
 
     fn SetWidth(&self, width: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("width", width)
     }
 
     fn Height(&self) -> u32 {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.height) as u32
     }
 
     fn SetHeight(&self, height: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("height", height)
     }
 
     make_getter!(Name)
 
     fn SetName(&self, name: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("name", name)
     }
 
     make_getter!(Align)
 
     fn SetAlign(&self, align: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("align", align)
     }
 
     make_uint_getter!(Hspace)
 
     fn SetHspace(&self, hspace: u32) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_uint_attribute("hspace", hspace)
     }
 
     make_uint_getter!(Vspace)
 
     fn SetVspace(&self, vspace: u32) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_uint_attribute("vspace", vspace)
     }
 
     make_getter!(LongDesc)
 
     fn SetLongDesc(&self, longdesc: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("longdesc", longdesc)
     }
 
     make_getter!(Border)
 
     fn SetBorder(&self, border: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("border", border)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -203,7 +203,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
         }
 
         if "src" == name.as_slice() {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let url = window.deref().get_url();
             self.update_image(Some((value, &url)));
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -31,14 +31,14 @@ impl HTMLInputElementDerived for EventTarget {
 }
 
 impl HTMLInputElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLInputElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLInputElement {
         HTMLInputElement {
             htmlelement: HTMLElement::new_inherited(HTMLInputElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLInputElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLInputElement> {
         let element = HTMLInputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLInputElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -83,7 +83,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -100,7 +100,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -110,7 +110,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -26,14 +26,14 @@ impl HTMLLabelElementDerived for EventTarget {
 }
 
 impl HTMLLabelElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLabelElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLabelElement {
         HTMLLabelElement {
             htmlelement: HTMLElement::new_inherited(HTMLLabelElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLabelElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLabelElement> {
         let element = HTMLLabelElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLabelElementBinding::Wrap)
     }

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -26,14 +26,14 @@ impl HTMLLegendElementDerived for EventTarget {
 }
 
 impl HTMLLegendElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLegendElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLegendElement {
         HTMLLegendElement {
             htmlelement: HTMLElement::new_inherited(HTMLLegendElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLegendElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLegendElement> {
         let element = HTMLLegendElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLegendElementBinding::Wrap)
     }

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -26,14 +26,14 @@ impl HTMLLIElementDerived for EventTarget {
 }
 
 impl HTMLLIElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLIElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLIElement {
         HTMLLIElement {
             htmlelement: HTMLElement::new_inherited(HTMLLIElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLIElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLIElement> {
         let element = HTMLLIElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLIElementBinding::Wrap)
     }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -35,14 +35,14 @@ impl HTMLLinkElementDerived for EventTarget {
 }
 
 impl HTMLLinkElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLinkElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLinkElement {
         HTMLLinkElement {
             htmlelement: HTMLElement::new_inherited(HTMLLinkElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLinkElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLinkElement> {
         let element = HTMLLinkElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLinkElementBinding::Wrap)
     }
@@ -50,7 +50,7 @@ impl HTMLLinkElement {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -60,7 +60,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
@@ -73,7 +73,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
@@ -87,7 +87,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
         }
 
         if tree_in_doc {
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
 
             // FIXME: workaround for https://github.com/mozilla/rust/issues/13246;
             // we get unrooting order failures if these are inside the match.
@@ -119,7 +119,7 @@ trait PrivateHTMLLinkElementHelpers {
 
 impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
     fn handle_stylesheet_url(&self, href: &str) {
-        let window = window_from_node(self).root();
+        let window = window_from_node(*self).root();
         match UrlParser::new().base_url(&window.deref().page().get_url()).parse(href) {
             Ok(url) => {
                 let LayoutChan(ref layout_chan) = *window.deref().page().layout_chan;

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -26,14 +26,14 @@ impl HTMLMapElementDerived for EventTarget {
 }
 
 impl HTMLMapElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLMapElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLMapElement {
         HTMLMapElement {
             htmlelement: HTMLElement::new_inherited(HTMLMapElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMapElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLMapElement> {
         let element = HTMLMapElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMapElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -29,7 +29,7 @@ impl HTMLMediaElementDerived for EventTarget {
 }
 
 impl HTMLMediaElement {
-    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: &JSRef<Document>) -> HTMLMediaElement {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: JSRef<Document>) -> HTMLMediaElement {
         HTMLMediaElement {
             htmlelement: HTMLElement::new_inherited(type_id, tag_name, document)
         }

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -26,14 +26,14 @@ impl HTMLMetaElementDerived for EventTarget {
 }
 
 impl HTMLMetaElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLMetaElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLMetaElement {
         HTMLMetaElement {
             htmlelement: HTMLElement::new_inherited(HTMLMetaElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMetaElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLMetaElement> {
         let element = HTMLMetaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMetaElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -26,14 +26,14 @@ impl HTMLMeterElementDerived for EventTarget {
 }
 
 impl HTMLMeterElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLMeterElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLMeterElement {
         HTMLMeterElement {
             htmlelement: HTMLElement::new_inherited(HTMLMeterElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMeterElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLMeterElement> {
         let element = HTMLMeterElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMeterElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -26,14 +26,14 @@ impl HTMLModElementDerived for EventTarget {
 }
 
 impl HTMLModElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLModElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLModElement {
         HTMLModElement {
             htmlelement: HTMLElement::new_inherited(HTMLModElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLModElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLModElement> {
         let element = HTMLModElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLModElementBinding::Wrap)
     }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -39,14 +39,14 @@ impl HTMLObjectElementDerived for EventTarget {
 }
 
 impl HTMLObjectElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLObjectElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLObjectElement {
         HTMLObjectElement {
             htmlelement: HTMLElement::new_inherited(HTMLObjectElementTypeId, localName, document),
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLObjectElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLObjectElement> {
         let element = HTMLObjectElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLObjectElementBinding::Wrap)
     }
@@ -60,7 +60,7 @@ impl<'a> ProcessDataURL for JSRef<'a, HTMLObjectElement> {
     // Makes the local `data` member match the status of the `data` attribute and starts
     /// prefetching the image. This method must be called after `data` is changed.
     fn process_data_url(&self, image_cache: ImageCacheTask) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
 
         // TODO: support other values
         match (elem.get_attribute(Null, "type").map(|x| x.root().Value()),
@@ -84,14 +84,14 @@ pub fn is_image_data(uri: &str) -> bool {
 
 impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -102,7 +102,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
         }
 
         if "data" == name.as_slice() {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             self.process_data_url(window.deref().image_cache_task.clone());
         }
     }

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -26,14 +26,14 @@ impl HTMLOListElementDerived for EventTarget {
 }
 
 impl HTMLOListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOListElement {
         HTMLOListElement {
             htmlelement: HTMLElement::new_inherited(HTMLOListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOListElement> {
         let element = HTMLOListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOListElementBinding::Wrap)
     }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -31,14 +31,14 @@ impl HTMLOptGroupElementDerived for EventTarget {
 }
 
 impl HTMLOptGroupElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOptGroupElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOptGroupElement {
         HTMLOptGroupElement {
             htmlelement: HTMLElement::new_inherited(HTMLOptGroupElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptGroupElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOptGroupElement> {
         let element = HTMLOptGroupElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptGroupElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
 
     // http://www.whatwg.org/html#dom-optgroup-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -87,7 +87,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -31,14 +31,14 @@ impl HTMLOptionElementDerived for EventTarget {
 }
 
 impl HTMLOptionElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOptionElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOptionElement {
         HTMLOptionElement {
             htmlelement: HTMLElement::new_inherited(HTMLOptionElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptionElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOptionElement> {
         let element = HTMLOptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptionElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
 
     // http://www.whatwg.org/html/#dom-option-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -83,7 +83,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -100,7 +100,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_parent_disabled_state_for_option();
     }
 
@@ -110,7 +110,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.parent_node().is_some() {
             node.check_parent_disabled_state_for_option();
         } else {

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -28,14 +28,14 @@ impl HTMLOutputElementDerived for EventTarget {
 }
 
 impl HTMLOutputElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOutputElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOutputElement {
         HTMLOutputElement {
             htmlelement: HTMLElement::new_inherited(HTMLOutputElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOutputElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOutputElement> {
         let element = HTMLOutputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOutputElementBinding::Wrap)
     }
@@ -43,8 +43,8 @@ impl HTMLOutputElement {
 
 impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 }
 

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -26,14 +26,14 @@ impl HTMLParagraphElementDerived for EventTarget {
 }
 
 impl HTMLParagraphElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLParagraphElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLParagraphElement {
         HTMLParagraphElement {
             htmlelement: HTMLElement::new_inherited(HTMLParagraphElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLParagraphElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLParagraphElement> {
         let element = HTMLParagraphElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLParagraphElementBinding::Wrap)
     }

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -26,14 +26,14 @@ impl HTMLParamElementDerived for EventTarget {
 }
 
 impl HTMLParamElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLParamElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLParamElement {
         HTMLParamElement {
             htmlelement: HTMLElement::new_inherited(HTMLParamElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLParamElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLParamElement> {
         let element = HTMLParamElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLParamElementBinding::Wrap)
     }

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -26,14 +26,14 @@ impl HTMLPreElementDerived for EventTarget {
 }
 
 impl HTMLPreElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLPreElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLPreElement {
         HTMLPreElement {
             htmlelement: HTMLElement::new_inherited(HTMLPreElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLPreElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLPreElement> {
         let element = HTMLPreElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLPreElementBinding::Wrap)
     }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -26,14 +26,14 @@ impl HTMLProgressElementDerived for EventTarget {
 }
 
 impl HTMLProgressElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLProgressElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLProgressElement {
         HTMLProgressElement {
             htmlelement: HTMLElement::new_inherited(HTMLProgressElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLProgressElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLProgressElement> {
         let element = HTMLProgressElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLProgressElementBinding::Wrap)
     }

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -26,14 +26,14 @@ impl HTMLQuoteElementDerived for EventTarget {
 }
 
 impl HTMLQuoteElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLQuoteElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLQuoteElement {
         HTMLQuoteElement {
             htmlelement: HTMLElement::new_inherited(HTMLQuoteElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLQuoteElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLQuoteElement> {
         let element = HTMLQuoteElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLQuoteElementBinding::Wrap)
     }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -32,14 +32,14 @@ impl HTMLScriptElementDerived for EventTarget {
 }
 
 impl HTMLScriptElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLScriptElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLScriptElement {
         HTMLScriptElement {
             htmlelement: HTMLElement::new_inherited(HTMLScriptElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLScriptElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLScriptElement> {
         let element = HTMLScriptElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLScriptElementBinding::Wrap)
     }
@@ -74,7 +74,7 @@ static SCRIPT_JS_MIMES: StaticStringVec = &[
 
 impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
     fn is_javascript(&self) -> bool {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         match element.get_attribute(Null, "type").root().map(|s| s.Value()) {
             Some(ref s) if s.is_empty() => {
                 // type attr exists, but empty means js
@@ -108,19 +108,19 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 
 impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
     fn Src(&self) -> DOMString {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_url_attribute("src")
     }
 
     // http://www.whatwg.org/html/#dom-script-text
     fn Text(&self) -> DOMString {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         Node::collect_text_contents(node.children())
     }
 
     // http://www.whatwg.org/html/#dom-script-text
     fn SetText(&self, value: DOMString) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -34,14 +34,14 @@ impl HTMLSelectElementDerived for EventTarget {
 }
 
 impl HTMLSelectElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLSelectElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLSelectElement {
         HTMLSelectElement {
             htmlelement: HTMLElement::new_inherited(HTMLSelectElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSelectElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLSelectElement> {
         let element = HTMLSelectElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSelectElementBinding::Wrap)
     }
@@ -49,8 +49,8 @@ impl HTMLSelectElement {
 
 impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 
     // Note: this function currently only exists for test_union.html.
@@ -62,14 +62,14 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -79,7 +79,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -95,7 +95,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -112,7 +112,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -122,7 +122,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -34,24 +34,24 @@ pub fn serialize(iterator: &mut NodeIterator) -> String {
         }
         match node.type_id() {
             ElementNodeTypeId(..) => {
-                let elem: &JSRef<Element> = ElementCast::to_ref(&node).unwrap();
+                let elem: JSRef<Element> = ElementCast::to_ref(node).unwrap();
                 serialize_elem(elem, &mut open_elements, &mut html)
             }
             CommentNodeTypeId => {
-                let comment: &JSRef<Comment> = CommentCast::to_ref(&node).unwrap();
+                let comment: JSRef<Comment> = CommentCast::to_ref(node).unwrap();
                 serialize_comment(comment, &mut html)
             }
             TextNodeTypeId => {
-                let text: &JSRef<Text> = TextCast::to_ref(&node).unwrap();
+                let text: JSRef<Text> = TextCast::to_ref(node).unwrap();
                 serialize_text(text, &mut html)
             }
             DoctypeNodeTypeId => {
-                let doctype: &JSRef<DocumentType> = DocumentTypeCast::to_ref(&node).unwrap();
+                let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
                 serialize_doctype(doctype, &mut html)
             }
             ProcessingInstructionNodeTypeId => {
-                let processing_instruction: &JSRef<ProcessingInstruction> =
-                    ProcessingInstructionCast::to_ref(&node).unwrap();
+                let processing_instruction: JSRef<ProcessingInstruction> =
+                    ProcessingInstructionCast::to_ref(node).unwrap();
                 serialize_processing_instruction(processing_instruction, &mut html)
             }
             DocumentFragmentNodeTypeId => {}
@@ -68,17 +68,17 @@ pub fn serialize(iterator: &mut NodeIterator) -> String {
     html
 }
 
-fn serialize_comment(comment: &JSRef<Comment>, html: &mut String) {
+fn serialize_comment(comment: JSRef<Comment>, html: &mut String) {
     html.push_str("<!--");
     html.push_str(comment.deref().characterdata.data.deref().borrow().as_slice());
     html.push_str("-->");
 }
 
-fn serialize_text(text: &JSRef<Text>, html: &mut String) {
-    let text_node: &JSRef<Node> = NodeCast::from_ref(text);
+fn serialize_text(text: JSRef<Text>, html: &mut String) {
+    let text_node: JSRef<Node> = NodeCast::from_ref(text);
     match text_node.parent_node().map(|node| node.root()) {
         Some(ref parent) if parent.is_element() => {
-            let elem: &JSRef<Element> = ElementCast::to_ref(&**parent).unwrap();
+            let elem: JSRef<Element> = ElementCast::to_ref(**parent).unwrap();
             match elem.deref().local_name.as_slice() {
                 "style" | "script" | "xmp" | "iframe" |
                 "noembed" | "noframes" | "plaintext" |
@@ -91,7 +91,7 @@ fn serialize_text(text: &JSRef<Text>, html: &mut String) {
     }
 }
 
-fn serialize_processing_instruction(processing_instruction: &JSRef<ProcessingInstruction>,
+fn serialize_processing_instruction(processing_instruction: JSRef<ProcessingInstruction>,
                                     html: &mut String) {
     html.push_str("<?");
     html.push_str(processing_instruction.deref().target.as_slice());
@@ -100,27 +100,27 @@ fn serialize_processing_instruction(processing_instruction: &JSRef<ProcessingIns
     html.push_str("?>");
 }
 
-fn serialize_doctype(doctype: &JSRef<DocumentType>, html: &mut String) {
+fn serialize_doctype(doctype: JSRef<DocumentType>, html: &mut String) {
     html.push_str("<!DOCTYPE");
     html.push_str(doctype.deref().name.as_slice());
     html.push_char('>');
 }
 
-fn serialize_elem(elem: &JSRef<Element>, open_elements: &mut Vec<String>, html: &mut String) {
+fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &mut String) {
     html.push_char('<');
     html.push_str(elem.deref().local_name.as_slice());
     for attr in elem.deref().attrs.borrow().iter() {
         let attr = attr.root();
-        serialize_attr(&*attr, html);
+        serialize_attr(*attr, html);
     };
     html.push_char('>');
 
     match elem.deref().local_name.as_slice() {
         "pre" | "listing" | "textarea" if elem.deref().namespace == namespace::HTML => {
-            let node: &JSRef<Node> = NodeCast::from_ref(elem);
+            let node: JSRef<Node> = NodeCast::from_ref(elem);
             match node.first_child().map(|child| child.root()) {
                 Some(ref child) if child.is_text() => {
-                    let text: &JSRef<CharacterData> = CharacterDataCast::to_ref(&**child).unwrap();
+                    let text: JSRef<CharacterData> = CharacterDataCast::to_ref(**child).unwrap();
                     if text.deref().data.deref().borrow().len() > 0 && text.deref().data.deref().borrow().as_slice().char_at(0) == '\n' {
                         html.push_char('\x0A');
                     }
@@ -136,7 +136,7 @@ fn serialize_elem(elem: &JSRef<Element>, open_elements: &mut Vec<String>, html: 
     }
 }
 
-fn serialize_attr(attr: &JSRef<Attr>, html: &mut String) {
+fn serialize_attr(attr: JSRef<Attr>, html: &mut String) {
     html.push_char(' ');
     if attr.deref().namespace == namespace::XML {
         html.push_str("xml:");

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -26,14 +26,14 @@ impl HTMLSourceElementDerived for EventTarget {
 }
 
 impl HTMLSourceElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLSourceElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLSourceElement {
         HTMLSourceElement {
             htmlelement: HTMLElement::new_inherited(HTMLSourceElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSourceElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLSourceElement> {
         let element = HTMLSourceElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSourceElementBinding::Wrap)
     }

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -26,14 +26,14 @@ impl HTMLSpanElementDerived for EventTarget {
 }
 
 impl HTMLSpanElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLSpanElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLSpanElement {
         HTMLSpanElement {
             htmlelement: HTMLElement::new_inherited(HTMLSpanElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSpanElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLSpanElement> {
         let element = HTMLSpanElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSpanElementBinding::Wrap)
     }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -30,14 +30,14 @@ impl HTMLStyleElementDerived for EventTarget {
 }
 
 impl HTMLStyleElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLStyleElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLStyleElement {
         HTMLStyleElement {
             htmlelement: HTMLElement::new_inherited(HTMLStyleElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLStyleElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLStyleElement> {
         let element = HTMLStyleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLStyleElementBinding::Wrap)
     }
@@ -49,7 +49,7 @@ pub trait StyleElementHelpers {
 
 impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
     fn parse_own_css(&self) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         assert!(node.is_in_doc());
 
         let win = window_from_node(node).root();
@@ -64,17 +64,17 @@ impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn child_inserted(&self, child: &JSRef<Node>) {
+    fn child_inserted(&self, child: JSRef<Node>) {
         match self.super_type() {
             Some(ref s) => s.child_inserted(child),
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.is_in_doc() {
             self.parse_own_css();
         }

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableCaptionElementDerived for EventTarget {
 }
 
 impl HTMLTableCaptionElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableCaptionElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableCaptionElement {
         HTMLTableCaptionElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableCaptionElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableCaptionElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableCaptionElement> {
         let element = HTMLTableCaptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableCaptionElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -29,7 +29,7 @@ impl HTMLTableCellElementDerived for EventTarget {
 }
 
 impl HTMLTableCellElement {
-    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: &JSRef<Document>) -> HTMLTableCellElement {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: JSRef<Document>) -> HTMLTableCellElement {
         HTMLTableCellElement {
             htmlelement: HTMLElement::new_inherited(type_id, tag_name, document)
         }

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableColElementDerived for EventTarget {
 }
 
 impl HTMLTableColElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableColElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableColElement {
         HTMLTableColElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableColElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableColElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableColElement> {
         let element = HTMLTableColElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableColElementBinding::Wrap)
     }

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableDataCellElementDerived for EventTarget {
 }
 
 impl HTMLTableDataCellElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableDataCellElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableDataCellElement {
         HTMLTableDataCellElement {
             htmltablecellelement: HTMLTableCellElement::new_inherited(HTMLTableDataCellElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableDataCellElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableDataCellElement> {
         let element = HTMLTableDataCellElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableDataCellElementBinding::Wrap)
     }

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -30,14 +30,14 @@ impl HTMLTableElementDerived for EventTarget {
 }
 
 impl HTMLTableElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableElement {
         HTMLTableElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableElement> {
         let element = HTMLTableElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableElementBinding::Wrap)
     }
@@ -53,30 +53,30 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
 
     //  http://www.whatwg.org/html/#dom-table-caption
     fn GetCaption(&self) -> Option<Temporary<HTMLTableCaptionElement>> {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.children().find(|child| {
             child.type_id() == ElementNodeTypeId(HTMLTableCaptionElementTypeId)
         }).map(|node| {
-            Temporary::from_rooted(HTMLTableCaptionElementCast::to_ref(&node).unwrap())
+            Temporary::from_rooted(HTMLTableCaptionElementCast::to_ref(node).unwrap())
         })
     }
 
     // http://www.whatwg.org/html/#dom-table-caption
     fn SetCaption(&self, new_caption: Option<JSRef<HTMLTableCaptionElement>>) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let old_caption = self.GetCaption();
 
         match old_caption {
             Some(htmlelem) => {
                 let htmlelem_jsref = &*htmlelem.root();
-                let old_caption_node: &JSRef<Node> = NodeCast::from_ref(htmlelem_jsref);
+                let old_caption_node: JSRef<Node> = NodeCast::from_ref(*htmlelem_jsref);
                 assert!(node.RemoveChild(old_caption_node).is_ok());
             }
             None => ()
         }
 
         new_caption.map(|caption| {
-            let new_caption_node: &JSRef<Node> = NodeCast::from_ref(&caption);
+            let new_caption_node: JSRef<Node> = NodeCast::from_ref(caption);
             assert!(node.AppendChild(new_caption_node).is_ok());
         });
     }

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableHeaderCellElementDerived for EventTarget {
 }
 
 impl HTMLTableHeaderCellElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableHeaderCellElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableHeaderCellElement {
         HTMLTableHeaderCellElement {
             htmltablecellelement: HTMLTableCellElement::new_inherited(HTMLTableHeaderCellElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableHeaderCellElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableHeaderCellElement> {
         let element = HTMLTableHeaderCellElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableHeaderCellElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableRowElementDerived for EventTarget {
 }
 
 impl HTMLTableRowElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableRowElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableRowElement {
         HTMLTableRowElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableRowElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableRowElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableRowElement> {
         let element = HTMLTableRowElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableRowElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableSectionElementDerived for EventTarget {
 }
 
 impl HTMLTableSectionElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableSectionElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableSectionElement {
         HTMLTableSectionElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableSectionElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableSectionElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableSectionElement> {
         let element = HTMLTableSectionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableSectionElementBinding::Wrap)
     }

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -26,14 +26,14 @@ impl HTMLTemplateElementDerived for EventTarget {
 }
 
 impl HTMLTemplateElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTemplateElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTemplateElement {
         HTMLTemplateElement {
             htmlelement: HTMLElement::new_inherited(HTMLTemplateElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTemplateElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTemplateElement> {
         let element = HTMLTemplateElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTemplateElementBinding::Wrap)
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -31,14 +31,14 @@ impl HTMLTextAreaElementDerived for EventTarget {
 }
 
 impl HTMLTextAreaElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTextAreaElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTextAreaElement {
         HTMLTextAreaElement {
             htmlelement: HTMLElement::new_inherited(HTMLTextAreaElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTextAreaElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTextAreaElement> {
         let element = HTMLTextAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTextAreaElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -83,7 +83,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -100,7 +100,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -110,7 +110,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -26,14 +26,14 @@ impl HTMLTimeElementDerived for EventTarget {
 }
 
 impl HTMLTimeElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTimeElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTimeElement {
         HTMLTimeElement {
             htmlelement: HTMLElement::new_inherited(HTMLTimeElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTimeElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTimeElement> {
         let element = HTMLTimeElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTimeElementBinding::Wrap)
     }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -29,14 +29,14 @@ impl HTMLTitleElementDerived for EventTarget {
 }
 
 impl HTMLTitleElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTitleElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTitleElement {
         HTMLTitleElement {
             htmlelement: HTMLElement::new_inherited(HTMLTitleElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTitleElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTitleElement> {
         let element = HTMLTitleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTitleElementBinding::Wrap)
     }
@@ -45,10 +45,10 @@ impl HTMLTitleElement {
 impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     // http://www.whatwg.org/html/#dom-title-text
     fn Text(&self) -> DOMString {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let mut content = String::new();
         for child in node.children() {
-            let text: Option<&JSRef<Text>> = TextCast::to_ref(&child);
+            let text: Option<JSRef<Text>> = TextCast::to_ref(child);
             match text {
                 Some(text) => content.push_str(text.characterdata.data.borrow().as_slice()),
                 None => (),
@@ -59,7 +59,7 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
 
     // http://www.whatwg.org/html/#dom-title-text
     fn SetText(&self, value: DOMString) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -26,14 +26,14 @@ impl HTMLTrackElementDerived for EventTarget {
 }
 
 impl HTMLTrackElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTrackElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTrackElement {
         HTMLTrackElement {
             htmlelement: HTMLElement::new_inherited(HTMLTrackElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTrackElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTrackElement> {
         let element = HTMLTrackElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTrackElementBinding::Wrap)
     }

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -26,14 +26,14 @@ impl HTMLUListElementDerived for EventTarget {
 }
 
 impl HTMLUListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLUListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLUListElement {
         HTMLUListElement {
             htmlelement: HTMLElement::new_inherited(HTMLUListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLUListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLUListElement> {
         let element = HTMLUListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLUListElementBinding::Wrap)
     }

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -26,14 +26,14 @@ impl HTMLUnknownElementDerived for EventTarget {
 }
 
 impl HTMLUnknownElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLUnknownElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLUnknownElement {
         HTMLUnknownElement {
             htmlelement: HTMLElement::new_inherited(HTMLUnknownElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLUnknownElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLUnknownElement> {
         let element = HTMLUnknownElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLUnknownElementBinding::Wrap)
     }

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -26,14 +26,14 @@ impl HTMLVideoElementDerived for EventTarget {
 }
 
 impl HTMLVideoElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLVideoElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLVideoElement {
         HTMLVideoElement {
             htmlmediaelement: HTMLMediaElement::new_inherited(HTMLVideoElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLVideoElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLVideoElement> {
         let element = HTMLVideoElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLVideoElementBinding::Wrap)
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -29,9 +29,9 @@ impl Location {
         }
     }
 
-    pub fn new(window: &JSRef<Window>, page: Rc<Page>) -> Temporary<Location> {
+    pub fn new(window: JSRef<Window>, page: Rc<Page>) -> Temporary<Location> {
         reflect_dom_object(box Location::new_inherited(page),
-                           &Window(*window),
+                           &Window(window),
                            LocationBinding::Wrap)
     }
 }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -11,7 +11,7 @@ macro_rules! make_getter(
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             element.get_string_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -24,7 +24,7 @@ macro_rules! make_bool_getter(
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             element.has_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -37,7 +37,7 @@ macro_rules! make_uint_getter(
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             element.get_uint_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -52,9 +52,9 @@ impl MessageEvent {
         let ev = reflect_dom_object(box MessageEvent::new_inherited(data, origin, lastEventId),
                                     global,
                                     MessageEventBinding::Wrap).root();
-        let event: &JSRef<Event> = EventCast::from_ref(&*ev);
+        let event: JSRef<Event> = EventCast::from_ref(*ev);
         event.InitEvent(type_, bubbles, cancelable);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -68,14 +68,14 @@ impl MessageEvent {
 }
 
 impl MessageEvent {
-    pub fn dispatch_jsval(target: &JSRef<EventTarget>,
+    pub fn dispatch_jsval(target: JSRef<EventTarget>,
                           scope: &GlobalRef,
                           message: JSVal) {
         let messageevent = MessageEvent::new(
             scope, "message".to_string(), false, false, message,
             "".to_string(), "".to_string()).root();
-        let event: &JSRef<Event> = EventCast::from_ref(&*messageevent);
-        target.dispatch_event_with_target(None, &*event).unwrap();
+        let event: JSRef<Event> = EventCast::from_ref(*messageevent);
+        target.dispatch_event_with_target(None, event).unwrap();
     }
 }
 

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -57,13 +57,13 @@ impl MouseEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &JSRef<Window>) -> Temporary<MouseEvent> {
+    pub fn new_uninitialized(window: JSRef<Window>) -> Temporary<MouseEvent> {
         reflect_dom_object(box MouseEvent::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            MouseEventBinding::Wrap)
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                type_: DOMString,
                canBubble: bool,
                cancelable: bool,
@@ -84,7 +84,7 @@ impl MouseEvent {
                                   screenX, screenY, clientX, clientY,
                                   ctrlKey, altKey, shiftKey, metaKey,
                                   button, relatedTarget);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -160,7 +160,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
                       metaKeyArg: bool,
                       buttonArg: i16,
                       relatedTargetArg: Option<JSRef<EventTarget>>) {
-        let uievent: &JSRef<UIEvent> = UIEventCast::from_ref(self);
+        let uievent: JSRef<UIEvent> = UIEventCast::from_ref(*self);
         uievent.InitUIEvent(typeArg, canBubbleArg, cancelableArg, viewArg, detailArg);
         self.screen_x.deref().set(screenXArg);
         self.screen_y.deref().set(screenYArg);

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -19,16 +19,16 @@ pub struct NamedNodeMap {
 }
 
 impl NamedNodeMap {
-    pub fn new_inherited(elem: &JSRef<Element>) -> NamedNodeMap {
+    pub fn new_inherited(elem: JSRef<Element>) -> NamedNodeMap {
         NamedNodeMap {
             reflector_: Reflector::new(),
             owner: JS::from_rooted(elem),
         }
     }
 
-    pub fn new(window: &JSRef<Window>, elem: &JSRef<Element>) -> Temporary<NamedNodeMap> {
+    pub fn new(window: JSRef<Window>, elem: JSRef<Element>) -> Temporary<NamedNodeMap> {
         reflect_dom_object(box NamedNodeMap::new_inherited(elem),
-                           &Window(*window), NamedNodeMapBinding::Wrap)
+                           &Window(window), NamedNodeMapBinding::Wrap)
     }
 }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -23,9 +23,9 @@ impl Navigator {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<Navigator> {
+    pub fn new(window: JSRef<Window>) -> Temporary<Navigator> {
         reflect_dom_object(box Navigator::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            NavigatorBinding::Wrap)
     }
 }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -32,17 +32,17 @@ impl NodeList {
         }
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                list_type: NodeListType) -> Temporary<NodeList> {
         reflect_dom_object(box NodeList::new_inherited(list_type),
-                           &Window(*window), NodeListBinding::Wrap)
+                           &Window(window), NodeListBinding::Wrap)
     }
 
-    pub fn new_simple_list(window: &JSRef<Window>, elements: Vec<JSRef<Node>>) -> Temporary<NodeList> {
-        NodeList::new(window, Simple(elements.iter().map(|element| JS::from_rooted(element)).collect()))
+    pub fn new_simple_list(window: JSRef<Window>, elements: Vec<JSRef<Node>>) -> Temporary<NodeList> {
+        NodeList::new(window, Simple(elements.iter().map(|element| JS::from_rooted(*element)).collect()))
     }
 
-    pub fn new_child_list(window: &JSRef<Window>, node: &JSRef<Node>) -> Temporary<NodeList> {
+    pub fn new_child_list(window: JSRef<Window>, node: JSRef<Node>) -> Temporary<NodeList> {
         NodeList::new(window, Children(JS::from_rooted(node)))
     }
 }
@@ -65,7 +65,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
             Children(ref node) => {
                 let node = node.root();
                 node.deref().children().nth(index as uint)
-                                       .map(|child| Temporary::from_rooted(&child))
+                                       .map(|child| Temporary::from_rooted(child))
             }
         }
     }

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -21,16 +21,16 @@ pub struct Performance {
 }
 
 impl Performance {
-    fn new_inherited(window: &JSRef<Window>) -> Performance {
+    fn new_inherited(window: JSRef<Window>) -> Performance {
         Performance {
             reflector_: Reflector::new(),
-            timing: JS::from_rooted(&PerformanceTiming::new(window)),
+            timing: JS::from_rooted(PerformanceTiming::new(window)),
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<Performance> {
+    pub fn new(window: JSRef<Window>) -> Temporary<Performance> {
         reflect_dom_object(box Performance::new_inherited(window),
-                           &Window(*window),
+                           &Window(window),
                            PerformanceBinding::Wrap)
     }
 }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -28,10 +28,10 @@ impl PerformanceTiming {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(window: &JSRef<Window>) -> Temporary<PerformanceTiming> {
+    pub fn new(window: JSRef<Window>) -> Temporary<PerformanceTiming> {
         let timing = PerformanceTiming::new_inherited(window.navigationStart,
                                                       window.navigationStartPrecise);
-        reflect_dom_object(box timing, &Window(*window),
+        reflect_dom_object(box timing, &Window(window),
                            PerformanceTimingBinding::Wrap)
     }
 }

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -28,14 +28,14 @@ impl ProcessingInstructionDerived for EventTarget {
 }
 
 impl ProcessingInstruction {
-    pub fn new_inherited(target: DOMString, data: DOMString, document: &JSRef<Document>) -> ProcessingInstruction {
+    pub fn new_inherited(target: DOMString, data: DOMString, document: JSRef<Document>) -> ProcessingInstruction {
         ProcessingInstruction {
             characterdata: CharacterData::new_inherited(ProcessingInstructionNodeTypeId, data, document),
             target: target
         }
     }
 
-    pub fn new(target: DOMString, data: DOMString, document: &JSRef<Document>) -> Temporary<ProcessingInstruction> {
+    pub fn new(target: DOMString, data: DOMString, document: JSRef<Document>) -> Temporary<ProcessingInstruction> {
         Node::reflect_node(box ProcessingInstruction::new_inherited(target, data, document),
                            document, ProcessingInstructionBinding::Wrap)
     }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -43,9 +43,9 @@ impl ProgressEvent {
         let ev = reflect_dom_object(box ProgressEvent::new_inherited(length_computable, loaded, total),
                                     global,
                                     ProgressEventBinding::Wrap).root();
-        let event: &JSRef<Event> = EventCast::from_ref(&*ev);
+        let event: JSRef<Event> = EventCast::from_ref(*ev);
         event.InitEvent(type_, can_bubble, cancelable);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
     pub fn Constructor(global: &GlobalRef,
                        type_: DOMString,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -24,7 +24,7 @@ impl Range {
         }
     }
 
-    pub fn new(document: &JSRef<Document>) -> Temporary<Range> {
+    pub fn new(document: JSRef<Document>) -> Temporary<Range> {
         let window = document.window.root();
         reflect_dom_object(box Range::new_inherited(),
                            &Window(*window),
@@ -33,7 +33,7 @@ impl Range {
 
     pub fn Constructor(global: &GlobalRef) -> Fallible<Temporary<Range>> {
         let document = global.as_window().Document().root();
-        Ok(Range::new(&*document))
+        Ok(Range::new(*document))
     }
 }
 

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -22,9 +22,9 @@ impl Screen {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<Screen> {
+    pub fn new(window: JSRef<Window>) -> Temporary<Screen> {
         reflect_dom_object(box Screen::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            ScreenBinding::Wrap)
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -58,7 +58,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
         let global = self.global.root();
         Blob::new(&global.root_ref())
     }
-    fn SetInterfaceAttribute(&self, _: &JSRef<Blob>) {}
+    fn SetInterfaceAttribute(&self, _: JSRef<Blob>) {}
     fn UnionAttribute(&self) -> HTMLElementOrLong { eLong(0) }
     fn SetUnionAttribute(&self, _: HTMLElementOrLong) {}
     fn Union2Attribute(&self) -> EventOrString { eString("".to_string()) }
@@ -160,7 +160,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn PassString(&self, _: DOMString) {}
     fn PassByteString(&self, _: ByteString) {}
     fn PassEnum(&self, _: TestEnum) {}
-    fn PassInterface(&self, _: &JSRef<Blob>) {}
+    fn PassInterface(&self, _: JSRef<Blob>) {}
     fn PassUnion(&self, _: HTMLElementOrLong) {}
     fn PassUnion2(&self, _: EventOrString) {}
     fn PassUnion3(&self, _: BlobOrString) {}

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -29,20 +29,20 @@ impl TextDerived for EventTarget {
 }
 
 impl Text {
-    pub fn new_inherited(text: DOMString, document: &JSRef<Document>) -> Text {
+    pub fn new_inherited(text: DOMString, document: JSRef<Document>) -> Text {
         Text {
             characterdata: CharacterData::new_inherited(TextNodeTypeId, text, document)
         }
     }
 
-    pub fn new(text: DOMString, document: &JSRef<Document>) -> Temporary<Text> {
+    pub fn new(text: DOMString, document: JSRef<Document>) -> Temporary<Text> {
         Node::reflect_node(box Text::new_inherited(text, document),
                            document, TextBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef, text: DOMString) -> Fallible<Temporary<Text>> {
         let document = global.as_window().Document().root();
-        Ok(Text::new(text, &*document))
+        Ok(Text::new(text, *document))
     }
 }
 

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -40,13 +40,13 @@ impl UIEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &JSRef<Window>) -> Temporary<UIEvent> {
+    pub fn new_uninitialized(window: JSRef<Window>) -> Temporary<UIEvent> {
         reflect_dom_object(box UIEvent::new_inherited(UIEventTypeId),
-                           &Window(*window),
+                           &Window(window),
                            UIEventBinding::Wrap)
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                type_: DOMString,
                can_bubble: bool,
                cancelable: bool,
@@ -54,7 +54,7 @@ impl UIEvent {
                detail: i32) -> Temporary<UIEvent> {
         let ev = UIEvent::new_uninitialized(window).root();
         ev.deref().InitUIEvent(type_, can_bubble, cancelable, view, detail);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -82,7 +82,7 @@ impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
                    cancelable: bool,
                    view: Option<JSRef<Window>>,
                    detail: i32) {
-        let event: &JSRef<Event> = EventCast::from_ref(self);
+        let event: JSRef<Event> = EventCast::from_ref(*self);
         event.InitEvent(type_, can_bubble, cancelable);
         self.view.assign(view);
         self.detail.deref().set(detail);

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -56,7 +56,7 @@ impl URLSearchParams {
             },
             None => {}
         }
-        Ok(Temporary::from_rooted(&*usp))
+        Ok(Temporary::from_rooted(*usp))
     }
 }
 

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -23,9 +23,9 @@ impl ValidityState {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<ValidityState> {
+    pub fn new(window: JSRef<Window>) -> Temporary<ValidityState> {
         reflect_dom_object(box ValidityState::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            ValidityStateBinding::Wrap)
     }
 }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -116,7 +116,7 @@ pub trait VirtualMethods {
     }
 
     /// Called on the parent when a node is added to its child list.
-    fn child_inserted(&self, child: &JSRef<Node>) {
+    fn child_inserted(&self, child: JSRef<Node>) {
         match self.super_type() {
             Some(ref s) => s.child_inserted(child),
             _ => (),
@@ -124,7 +124,7 @@ pub trait VirtualMethods {
     }
 
     /// Called during event dispatch after the bubbling phase completes.
-    fn handle_event(&self, event: &JSRef<Event>) {
+    fn handle_event(&self, event: JSRef<Event>) {
         match self.super_type() {
             Some(s) => {
                 s.handle_event(event);
@@ -141,75 +141,75 @@ pub trait VirtualMethods {
 pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
     match node.type_id() {
         ElementNodeTypeId(HTMLAnchorElementTypeId) => {
-            let element: &JSRef<HTMLAnchorElement> = HTMLAnchorElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLAnchorElement> = HTMLAnchorElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLAreaElementTypeId) => {
-            let element: &JSRef<HTMLAreaElement> = HTMLAreaElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLAreaElement> = HTMLAreaElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {
-            let element: &JSRef<HTMLBodyElement> = HTMLBodyElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLBodyElement> = HTMLBodyElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLButtonElementTypeId) => {
-            let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLCanvasElementTypeId) => {
-            let element: &JSRef<HTMLCanvasElement> = HTMLCanvasElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLCanvasElement> = HTMLCanvasElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLFieldSetElementTypeId) => {
-            let element: &JSRef<HTMLFieldSetElement> = HTMLFieldSetElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLFieldSetElement> = HTMLFieldSetElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLImageElementTypeId) => {
-            let element: &JSRef<HTMLImageElement> = HTMLImageElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLImageElement> = HTMLImageElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLIFrameElementTypeId) => {
-            let element: &JSRef<HTMLIFrameElement> = HTMLIFrameElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLIFrameElement> = HTMLIFrameElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLInputElementTypeId) => {
-            let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLLinkElementTypeId) => {
-            let element: &JSRef<HTMLLinkElement> = HTMLLinkElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLLinkElement> = HTMLLinkElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {
-            let element: &JSRef<HTMLObjectElement> = HTMLObjectElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLObjectElement> = HTMLObjectElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLOptGroupElementTypeId) => {
-            let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLOptionElementTypeId) => {
-            let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLSelectElementTypeId) => {
-            let element: &JSRef<HTMLSelectElement> = HTMLSelectElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLSelectElement> = HTMLSelectElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {
-            let element: &JSRef<HTMLStyleElement> = HTMLStyleElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLStyleElement> = HTMLStyleElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLTextAreaElementTypeId) => {
-            let element: &JSRef<HTMLTextAreaElement> = HTMLTextAreaElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLTextAreaElement> = HTMLTextAreaElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(ElementTypeId) => {
-            let element: &JSRef<Element> = ElementCast::to_ref(node).unwrap();
+            let element: &JSRef<Element> = ElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(_) => {
-            let element: &JSRef<HTMLElement> = HTMLElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLElement> = HTMLElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         _ => {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -220,7 +220,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
     fn Location(&self) -> Temporary<Location> {
         if self.location.get().is_none() {
             let page = self.deref().page.clone();
-            let location = Location::new(self, page);
+            let location = Location::new(*self, page);
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
@@ -236,7 +236,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
 
     fn Navigator(&self) -> Temporary<Navigator> {
         if self.navigator.get().is_none() {
-            let navigator = Navigator::new(self);
+            let navigator = Navigator::new(*self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())
@@ -265,7 +265,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
     }
 
     fn Window(&self) -> Temporary<Window> {
-        Temporary::from_rooted(self)
+        Temporary::from_rooted(*self)
     }
 
     fn Self(&self) -> Temporary<Window> {
@@ -284,55 +284,55 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
 
     fn Performance(&self) -> Temporary<Performance> {
         if self.performance.get().is_none() {
-            let performance = Performance::new(self);
+            let performance = Performance::new(*self);
             self.performance.assign(Some(performance));
         }
         Temporary::new(self.performance.get().get_ref().clone())
     }
 
     fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("click")
     }
 
     fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
     fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("load")
     }
 
     fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
     fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("unload")
     }
 
     fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("unload", listener)
     }
 
     fn GetOnerror(&self) -> Option<OnErrorEventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("error")
     }
 
     fn SetOnerror(&self, listener: Option<OnErrorEventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
     fn Screen(&self) -> Temporary<Screen> {
         if self.screen.get().is_none() {
-            let screen = Screen::new(self);
+            let screen = Screen::new(*self);
             self.screen.assign(Some(screen));
         }
         Temporary::new(self.screen.get().get_ref().clone())
@@ -367,7 +367,7 @@ pub trait WindowHelpers {
     fn damage_and_reflow(&self, damage: DocumentDamageLevel);
     fn flush_layout(&self, goal: ReflowGoal);
     fn wait_until_safe_to_modify_dom(&self);
-    fn init_browser_context(&self, doc: &JSRef<Document>);
+    fn init_browser_context(&self, doc: JSRef<Document>);
     fn load_url(&self, href: DOMString);
     fn handle_fire_timer(&self, timer_id: TimerId, cx: *mut JSContext);
     fn evaluate_js_with_result(&self, code: &str) -> JSVal;
@@ -412,7 +412,7 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         self.page().join_layout();
     }
 
-    fn init_browser_context(&self, doc: &JSRef<Document>) {
+    fn init_browser_context(&self, doc: JSRef<Document>) {
         *self.browser_context.deref().borrow_mut() = Some(BrowserContext::new(doc));
     }
 

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -75,7 +75,7 @@ impl Worker {
             worker_url, worker_ref, resource_task, global.script_chan().clone(),
             sender, receiver);
 
-        Ok(Temporary::from_rooted(&*worker))
+        Ok(Temporary::from_rooted(*worker))
     }
 
     pub fn handle_message(address: TrustedWorkerAddress,
@@ -92,7 +92,7 @@ impl Worker {
                 ptr::null(), ptr::mut_null()) != 0);
         }
 
-        let target: &JSRef<EventTarget> = EventTargetCast::from_ref(&*worker);
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(*worker);
         MessageEvent::dispatch_jsval(target, &global.root_ref(), message);
     }
 }
@@ -144,12 +144,12 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
     }
 
     fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("message")
     }
 
     fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -80,12 +80,12 @@ impl WorkerGlobalScope {
 
 impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
     fn Self(&self) -> Temporary<WorkerGlobalScope> {
-        Temporary::from_rooted(self)
+        Temporary::from_rooted(*self)
     }
 
     fn Location(&self) -> Temporary<WorkerLocation> {
         if self.location.get().is_none() {
-            let location = WorkerLocation::new(self, self.worker_url.clone());
+            let location = WorkerLocation::new(*self, self.worker_url.clone());
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
@@ -125,7 +125,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
 
     fn Navigator(&self) -> Temporary<WorkerNavigator> {
         if self.navigator.get().is_none() {
-            let navigator = WorkerNavigator::new(self);
+            let navigator = WorkerNavigator::new(*self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -29,9 +29,9 @@ impl WorkerLocation {
         }
     }
 
-    pub fn new(global: &JSRef<WorkerGlobalScope>, url: Url) -> Temporary<WorkerLocation> {
+    pub fn new(global: JSRef<WorkerGlobalScope>, url: Url) -> Temporary<WorkerLocation> {
         reflect_dom_object(box WorkerLocation::new_inherited(url),
-                           &Worker(*global),
+                           &Worker(global),
                            WorkerLocationBinding::Wrap)
     }
 }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -23,9 +23,9 @@ impl WorkerNavigator {
         }
     }
 
-    pub fn new(global: &JSRef<WorkerGlobalScope>) -> Temporary<WorkerNavigator> {
+    pub fn new(global: JSRef<WorkerGlobalScope>) -> Temporary<WorkerNavigator> {
         reflect_dom_object(box WorkerNavigator::new_inherited(),
-                           &Worker(*global),
+                           &Worker(global),
                            WorkerNavigatorBinding::Wrap)
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -138,7 +138,7 @@ impl XMLHttpRequest {
             ready_state: Traceable::new(Cell::new(Unsent)),
             timeout: Traceable::new(Cell::new(0u32)),
             with_credentials: Traceable::new(Cell::new(false)),
-            upload: JS::from_rooted(&XMLHttpRequestUpload::new(global)),
+            upload: JS::from_rooted(XMLHttpRequestUpload::new(global)),
             response_url: "".to_string(),
             status: Traceable::new(Cell::new(0)),
             status_text: Traceable::new(RefCell::new(ByteString::new(vec!()))),
@@ -260,12 +260,12 @@ impl XMLHttpRequest {
 
 impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
     fn GetOnreadystatechange(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("readystatechange")
     }
 
     fn SetOnreadystatechange(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("readystatechange", listener)
     }
 
@@ -467,8 +467,8 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             }
 
             // Step 8
-            let upload_target = &*self.upload.root();
-            let event_target: &JSRef<EventTarget> = EventTargetCast::from_ref(upload_target);
+            let upload_target = *self.upload.root();
+            let event_target: JSRef<EventTarget> = EventTargetCast::from_ref(upload_target);
             if event_target.has_handlers() {
                 self.upload_events.deref().set(true);
             }
@@ -741,8 +741,8 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         let event = Event::new(&global.root_ref(),
                                "readystatechange".to_string(),
                                false, true).root();
-        let target: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.dispatch_event_with_target(None, &*event).ok();
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+        target.dispatch_event_with_target(None, *event).ok();
     }
 
     fn process_partial_response(&self, progress: XHRProgress) {
@@ -859,17 +859,17 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
 
     fn dispatch_progress_event(&self, upload: bool, type_: DOMString, loaded: u64, total: Option<u64>) {
         let global = self.global.root();
-        let upload_target = &*self.upload.root();
+        let upload_target = *self.upload.root();
         let progressevent = ProgressEvent::new(&global.root_ref(),
                                                type_, false, false,
                                                total.is_some(), loaded,
                                                total.unwrap_or(0)).root();
-        let target: &JSRef<EventTarget> = if upload {
+        let target: JSRef<EventTarget> = if upload {
             EventTargetCast::from_ref(upload_target)
         } else {
-            EventTargetCast::from_ref(self)
+            EventTargetCast::from_ref(*self)
         };
-        let event: &JSRef<Event> = EventCast::from_ref(&*progressevent);
+        let event: JSRef<Event> = EventCast::from_ref(*progressevent);
         target.dispatch_event_with_target(None, event).ok();
     }
 

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -42,72 +42,72 @@ impl Reflectable for XMLHttpRequestEventTarget {
 
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
     fn GetOnloadstart(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("loadstart")
     }
 
     fn SetOnloadstart(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("loadstart", listener)
     }
 
     fn GetOnprogress(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("progress")
     }
 
     fn SetOnprogress(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("progress", listener)
     }
 
     fn GetOnabort(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("abort")
     }
 
     fn SetOnabort(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("abort", listener)
     }
 
     fn GetOnerror(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("error")
     }
 
     fn SetOnerror(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
     fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("load")
     }
 
     fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
     fn GetOntimeout(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("timeout")
     }
 
     fn SetOntimeout(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("timeout", listener)
     }
 
     fn GetOnloadend(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("loadend")
     }
 
     fn SetOnloadend(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("loadend", listener)
     }
 }

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -271,7 +271,7 @@ impl Page {
         match root.root() {
             None => {},
             Some(root) => {
-                let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+                let root: JSRef<Node> = NodeCast::from_ref(*root);
                 let mut damage = *self.damage.deref().borrow_mut();
                 match damage {
                     None => {}
@@ -366,7 +366,7 @@ impl Page {
                 let last_reflow_id = self.last_reflow_id.deref();
                 last_reflow_id.set(last_reflow_id.get() + 1);
 
-                let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+                let root: JSRef<Node> = NodeCast::from_ref(*root);
                 let mut damage = self.damage.deref().borrow_mut();
                 let window_size = self.window_size.deref().get();
 
@@ -397,15 +397,15 @@ impl Page {
         match document.deref().GetElementById(fragid.to_string()) {
             Some(node) => Some(node),
             None => {
-                let doc_node: &JSRef<Node> = NodeCast::from_ref(&*document);
+                let doc_node: JSRef<Node> = NodeCast::from_ref(*document);
                 let mut anchors = doc_node.traverse_preorder()
                                           .filter(|node| node.is_anchor_element());
                 anchors.find(|node| {
-                    let elem: &JSRef<Element> = ElementCast::to_ref(node).unwrap();
+                    let elem: JSRef<Element> = ElementCast::to_ref(*node).unwrap();
                     elem.get_attribute(Null, "name").root().map_or(false, |attr| {
                         attr.deref().value().as_slice() == fragid.as_slice()
                     })
-                }).map(|node| Temporary::from_rooted(ElementCast::to_ref(&node).unwrap()))
+                }).map(|node| Temporary::from_rooted(ElementCast::to_ref(node).unwrap()))
             }
         }
     }
@@ -418,7 +418,7 @@ impl Page {
             return None;
         }
         let root = root.unwrap();
-        let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+        let root: JSRef<Node> = NodeCast::from_ref(*root);
         let address = match self.layout().hit_test(root.to_trusted_node_address(), *point) {
             Ok(HitTestResponse(node_address)) => {
                 Some(node_address)
@@ -439,7 +439,7 @@ impl Page {
             return None;
         }
         let root = root.unwrap();
-        let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+        let root: JSRef<Node> = NodeCast::from_ref(*root);
         let address = match self.layout().mouse_over(root.to_trusted_node_address(), *point) {
             Ok(MouseOverResponse(node_address)) => {
                 Some(node_address)


### PR DESCRIPTION
Replace &JSRef with JSRef in the bulk of the generated code. This will
remove a level of indirection throughout all DOM code.

This patch doesn't change methods implemented on JSRef<T> to take `self`
rather than `&self`, and it leaves a few other uses of &JSRef, but those
changes can be made incrementally.
