### PR TITLE
Move is_void() Element method together with the other struct methods.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -242,6 +242,7 @@ pub trait ElementHelpers {
     fn get_local_name<'a>(&'a self) -> &'a Atom;
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
     fn summarize(&self) -> Vec<AttrInfo>;
+    fn is_void(&self) -> bool;
 }
 
 impl<'a> ElementHelpers for JSRef<'a, Element> {
@@ -268,6 +269,20 @@ impl<'a> ElementHelpers for JSRef<'a, Element> {
             i += 1;
         }
         summarized
+    }
+
+   fn is_void(&self) -> bool {
+        if self.namespace != namespace::HTML {
+            return false
+        }
+        match self.local_name.as_slice() {
+            /* List of void elements from
+            http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#html-fragment-serialization-algorithm */
+            "area" | "base" | "basefont" | "bgsound" | "br" | "col" | "embed" |
+            "frame" | "hr" | "img" | "input" | "keygen" | "link" | "menuitem" |
+            "meta" | "param" | "source" | "track" | "wbr" => true,
+            _ => false
+        }
     }
 }
 
@@ -486,22 +501,6 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
     fn set_uint_attribute(&self, name: &str, value: u32) {
         assert!(name == name.to_ascii_lower().as_slice());
         self.set_attribute(name, UIntAttrValue(value.to_string(), value));
-    }
-}
-
-impl Element {
-    pub fn is_void(&self) -> bool {
-        if self.namespace != namespace::HTML {
-            return false
-        }
-        match self.local_name.as_slice() {
-            /* List of void elements from
-            http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#html-fragment-serialization-algorithm */
-            "area" | "base" | "basefont" | "bgsound" | "br" | "col" | "embed" |
-            "frame" | "hr" | "img" | "input" | "keygen" | "link" | "menuitem" |
-            "meta" | "param" | "source" | "track" | "wbr" => true,
-            _ => false
-        }
     }
 }
 

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -10,7 +10,7 @@ use dom::bindings::js::JSRef;
 use dom::characterdata::CharacterData;
 use dom::comment::Comment;
 use dom::documenttype::DocumentType;
-use dom::element::Element;
+use dom::element::{Element, ElementHelpers};
 use dom::node::{Node, NodeIterator};
 use dom::node::{DoctypeNodeTypeId, DocumentFragmentNodeTypeId, CommentNodeTypeId};
 use dom::node::{DocumentNodeTypeId, ElementNodeTypeId, ProcessingInstructionNodeTypeId};
@@ -131,7 +131,7 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
         _ => {}
     }
 
-    if !elem.deref().is_void() {
+    if !(elem.is_void()) {
         open_elements.push(elem.deref().local_name.as_slice().to_string());
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -929,7 +929,7 @@ impl NodeIterator {
     fn next_child<'b>(&self, node: JSRef<'b, Node>) -> Option<JSRef<'b, Node>> {
         if !self.include_descendants_of_void && node.is_element() {
             let elem: JSRef<Element> = ElementCast::to_ref(node).unwrap();
-            if elem.deref().is_void() {
+            if elem.is_void() {
                 None
             } else {
                 node.first_child().map(|child| (*child.root()).clone())


### PR DESCRIPTION
While reading Element.rs, I noticed that one of its methods is implemented in another position in the file. It makes sense to group in a single point the implemented methods of a struct, which is done with this patch.
