### PR TITLE
More progress in the &JSRef -> JSRef conversion

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -95,7 +95,7 @@ impl Reflectable for Attr {
 impl Attr {
     fn new_inherited(local_name: Atom, value: AttrValue,
                      name: Atom, namespace: Namespace,
-                     prefix: Option<DOMString>, owner: &JSRef<Element>) -> Attr {
+                     prefix: Option<DOMString>, owner: JSRef<Element>) -> Attr {
         Attr {
             reflector_: Reflector::new(),
             local_name: local_name,
@@ -107,11 +107,11 @@ impl Attr {
         }
     }
 
-    pub fn new(window: &JSRef<Window>, local_name: Atom, value: AttrValue,
+    pub fn new(window: JSRef<Window>, local_name: Atom, value: AttrValue,
                name: Atom, namespace: Namespace,
-               prefix: Option<DOMString>, owner: &JSRef<Element>) -> Temporary<Attr> {
+               prefix: Option<DOMString>, owner: JSRef<Element>) -> Temporary<Attr> {
         reflect_dom_object(box Attr::new_inherited(local_name, value, name, namespace, prefix, owner),
-                           &Window(*window), AttrBinding::Wrap)
+                           &Window(window), AttrBinding::Wrap)
     }
 }
 
@@ -157,13 +157,13 @@ pub trait AttrHelpers {
 impl<'a> AttrHelpers for JSRef<'a, Attr> {
     fn set_value(&self, set_type: AttrSettingType, value: AttrValue) {
         let owner = self.owner.root();
-        let node: &JSRef<Node> = NodeCast::from_ref(&*owner);
+        let node: JSRef<Node> = NodeCast::from_ref(*owner);
         let namespace_is_null = self.namespace == namespace::Null;
 
         match set_type {
             ReplacedAttr => {
                 if namespace_is_null {
-                    vtable_for(node).before_remove_attr(
+                    vtable_for(&node).before_remove_attr(
                         self.local_name(),
                         self.value().as_slice().to_string())
                 }
@@ -174,7 +174,7 @@ impl<'a> AttrHelpers for JSRef<'a, Attr> {
         *self.value.deref().borrow_mut() = value;
 
         if namespace_is_null {
-            vtable_for(node).after_set_attr(
+            vtable_for(&node).after_set_attr(
                 self.local_name(),
                 self.value().as_slice().to_string())
         }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -116,33 +116,32 @@ impl Attr {
 }
 
 impl<'a> AttrMethods for JSRef<'a, Attr> {
-    fn LocalName(&self) -> DOMString {
+    fn LocalName(self) -> DOMString {
         self.local_name().as_slice().to_string()
     }
 
-    fn Value(&self) -> DOMString {
+    fn Value(self) -> DOMString {
         self.value().as_slice().to_string()
     }
 
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(self, value: DOMString) {
         let owner = self.owner.root();
-        let value = owner.deref().parse_attribute(
-            &self.namespace, self.local_name(), value);
+        let value = owner.deref().parse_attribute(&self.namespace, self.local_name(), value);
         self.set_value(ReplacedAttr, value);
     }
 
-    fn Name(&self) -> DOMString {
+    fn Name(self) -> DOMString {
         self.name.as_slice().to_string()
     }
 
-    fn GetNamespaceURI(&self) -> Option<DOMString> {
+    fn GetNamespaceURI(self) -> Option<DOMString> {
         match self.namespace.to_str() {
             "" => None,
             url => Some(url.to_string()),
         }
     }
 
-    fn GetPrefix(&self) -> Option<DOMString> {
+    fn GetPrefix(self) -> Option<DOMString> {
         self.prefix.clone()
     }
 }

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -115,7 +115,7 @@ impl CallbackInterface {
 
 /// Wraps the reflector for `p` into the compartment of `cx`.
 pub fn WrapCallThisObject<T: Reflectable>(cx: *mut JSContext,
-                                          p: &JSRef<T>) -> *mut JSObject {
+                                          p: JSRef<T>) -> *mut JSObject {
     let mut obj = p.reflector().get_jsobject();
     assert!(obj.is_not_null());
 
@@ -140,7 +140,7 @@ pub struct CallSetup {
 impl CallSetup {
     /// Performs the setup needed to make a call.
     #[allow(unrooted_must_root)]
-    pub fn new<T: CallbackContainer>(callback: &T, handling: ExceptionHandling) -> CallSetup {
+    pub fn new<T: CallbackContainer>(callback: T, handling: ExceptionHandling) -> CallSetup {
         let global = global_object_for_js_object(callback.callback());
         let global = global.root();
         let cx = global.root_ref().get_cx();

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2186,7 +2186,7 @@ class CGCallGenerator(CGThing):
         if static:
             call = CGWrapper(call, pre="%s::" % descriptorProvider.interface.identifier.name)
         else: 
-            call = CGWrapper(call, pre="(*%s)." % object)
+            call = CGWrapper(call, pre="%s." % object)
         call = CGList([call, CGWrapper(args, pre="(", post=")")])
 
         self.cgRoot.append(CGList([
@@ -4064,7 +4064,7 @@ class CGInterfaceTrait(CGThing):
             return "".join(", %s: %s" % argument for argument in arguments)
 
         methods = CGList([
-            CGGeneric("fn %s(&self%s) -> %s;\n" % (name, fmt(arguments), rettype))
+            CGGeneric("fn %s(self%s) -> %s;\n" % (name, fmt(arguments), rettype))
             for name, arguments, rettype in members()
         ], "")
         self.cgRoot = CGWrapper(CGIndenter(methods),

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -52,9 +52,9 @@ impl<'a> GlobalRef<'a> {
 
     /// Extract a `Window`, causing task failure if the global object is not
     /// a `Window`.
-    pub fn as_window<'b>(&'b self) -> &'b JSRef<'b, Window> {
+    pub fn as_window<'b>(&'b self) -> JSRef<'b, Window> {
         match *self {
-            Window(ref window) => window,
+            Window(window) => window,
             Worker(_) => fail!("expected a Window scope"),
         }
     }
@@ -107,8 +107,8 @@ impl GlobalField {
     /// Create a new `GlobalField` from a rooted reference.
     pub fn from_rooted(global: &GlobalRef) -> GlobalField {
         match *global {
-            Window(ref window) => WindowField(JS::from_rooted(window)),
-            Worker(ref worker) => WorkerField(JS::from_rooted(worker)),
+            Window(window) => WindowField(JS::from_rooted(window)),
+            Worker(worker) => WorkerField(JS::from_rooted(worker)),
         }
     }
 

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -24,7 +24,7 @@ pub struct BrowserContext {
 }
 
 impl BrowserContext {
-    pub fn new(document: &JSRef<Document>) -> BrowserContext {
+    pub fn new(document: JSRef<Document>) -> BrowserContext {
         let mut context = BrowserContext {
             history: vec!(SessionHistoryEntry::new(document)),
             active_index: 0,
@@ -74,7 +74,7 @@ pub struct SessionHistoryEntry {
 }
 
 impl SessionHistoryEntry {
-    fn new(document: &JSRef<Document>) -> SessionHistoryEntry {
+    fn new(document: JSRef<Document>) -> SessionHistoryEntry {
         SessionHistoryEntry {
             document: JS::from_rooted(document),
             children: vec!()

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -26,7 +26,7 @@ pub struct CanvasRenderingContext2D {
 }
 
 impl CanvasRenderingContext2D {
-    pub fn new_inherited(global: &GlobalRef, canvas: &JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> CanvasRenderingContext2D {
+    pub fn new_inherited(global: &GlobalRef, canvas: JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> CanvasRenderingContext2D {
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             global: GlobalField::from_rooted(global),
@@ -35,7 +35,7 @@ impl CanvasRenderingContext2D {
         }
     }
 
-    pub fn new(global: &GlobalRef, canvas: &JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> Temporary<CanvasRenderingContext2D> {
+    pub fn new(global: &GlobalRef, canvas: JSRef<HTMLCanvasElement>, size: Size2D<i32>) -> Temporary<CanvasRenderingContext2D> {
         reflect_dom_object(box CanvasRenderingContext2D::new_inherited(global, canvas, size),
                            global, CanvasRenderingContext2DBinding::Wrap)
     }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -46,21 +46,21 @@ impl CanvasRenderingContext2D {
 }
 
 impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D> {
-    fn Canvas(&self) -> Temporary<HTMLCanvasElement> {
+    fn Canvas(self) -> Temporary<HTMLCanvasElement> {
         Temporary::new(self.canvas)
     }
 
-    fn FillRect(&self, x: f64, y: f64, width: f64, height: f64) {
+    fn FillRect(self, x: f64, y: f64, width: f64, height: f64) {
         let rect = Rect(Point2D(x as f32, y as f32), Size2D(width as f32, height as f32));
         self.renderer.send(FillRect(rect));
     }
 
-    fn ClearRect(&self, x: f64, y: f64, width: f64, height: f64) {
+    fn ClearRect(self, x: f64, y: f64, width: f64, height: f64) {
         let rect = Rect(Point2D(x as f32, y as f32), Size2D(width as f32, height as f32));
         self.renderer.send(ClearRect(rect));
     }
 
-    fn StrokeRect(&self, x: f64, y: f64, width: f64, height: f64) {
+    fn StrokeRect(self, x: f64, y: f64, width: f64, height: f64) {
         let rect = Rect(Point2D(x as f32, y as f32), Size2D(width as f32, height as f32));
         self.renderer.send(StrokeRect(rect));
     }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -36,7 +36,7 @@ impl CharacterDataDerived for EventTarget {
 }
 
 impl CharacterData {
-    pub fn new_inherited(id: NodeTypeId, data: DOMString, document: &JSRef<Document>) -> CharacterData {
+    pub fn new_inherited(id: NodeTypeId, data: DOMString, document: JSRef<Document>) -> CharacterData {
         CharacterData {
             node: Node::new_inherited(id, document),
             data: Traceable::new(RefCell::new(data)),
@@ -95,7 +95,7 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
     fn Remove(&self) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.remove_self();
     }
 }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -45,37 +45,37 @@ impl CharacterData {
 }
 
 impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
-    fn Data(&self) -> DOMString {
+    fn Data(self) -> DOMString {
         self.data.deref().borrow().clone()
     }
 
-    fn SetData(&self, arg: DOMString) -> ErrorResult {
+    fn SetData(self, arg: DOMString) -> ErrorResult {
         *self.data.deref().borrow_mut() = arg;
         Ok(())
     }
 
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.data.deref().borrow().len() as u32
     }
 
-    fn SubstringData(&self, offset: u32, count: u32) -> Fallible<DOMString> {
+    fn SubstringData(self, offset: u32, count: u32) -> Fallible<DOMString> {
         Ok(self.data.deref().borrow().as_slice().slice(offset as uint, count as uint).to_string())
     }
 
-    fn AppendData(&self, arg: DOMString) -> ErrorResult {
+    fn AppendData(self, arg: DOMString) -> ErrorResult {
         self.data.deref().borrow_mut().push_str(arg.as_slice());
         Ok(())
     }
 
-    fn InsertData(&self, offset: u32, arg: DOMString) -> ErrorResult {
+    fn InsertData(self, offset: u32, arg: DOMString) -> ErrorResult {
         self.ReplaceData(offset, 0, arg)
     }
 
-    fn DeleteData(&self, offset: u32, count: u32) -> ErrorResult {
+    fn DeleteData(self, offset: u32, count: u32) -> ErrorResult {
         self.ReplaceData(offset, count, "".to_string())
     }
 
-    fn ReplaceData(&self, offset: u32, count: u32, arg: DOMString) -> ErrorResult {
+    fn ReplaceData(self, offset: u32, count: u32, arg: DOMString) -> ErrorResult {
         let length = self.data.deref().borrow().len() as u32;
         if offset > length {
             return Err(IndexSize);
@@ -94,8 +94,8 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
     }
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Remove(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.remove_self();
     }
 }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -29,20 +29,20 @@ impl CommentDerived for EventTarget {
 }
 
 impl Comment {
-    pub fn new_inherited(text: DOMString, document: &JSRef<Document>) -> Comment {
+    pub fn new_inherited(text: DOMString, document: JSRef<Document>) -> Comment {
         Comment {
             characterdata: CharacterData::new_inherited(CommentNodeTypeId, text, document)
         }
     }
 
-    pub fn new(text: DOMString, document: &JSRef<Document>) -> Temporary<Comment> {
+    pub fn new(text: DOMString, document: JSRef<Document>) -> Temporary<Comment> {
         Node::reflect_node(box Comment::new_inherited(text, document),
                            document, CommentBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef, data: DOMString) -> Fallible<Temporary<Comment>> {
         let document = global.as_window().Document().root();
-        Ok(Comment::new(data, &*document))
+        Ok(Comment::new(data, *&*document))
     }
 }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -28,27 +28,27 @@ impl Console {
 }
 
 impl<'a> ConsoleMethods for JSRef<'a, Console> {
-    fn Log(&self, message: DOMString) {
+    fn Log(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Debug(&self, message: DOMString) {
+    fn Debug(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Info(&self, message: DOMString) {
+    fn Info(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Warn(&self, message: DOMString) {
+    fn Warn(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Error(&self, message: DOMString) {
+    fn Error(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Assert(&self, condition: bool, message: Option<DOMString>) {
+    fn Assert(self, condition: bool, message: Option<DOMString>) {
         if !condition {
             let message = match message {
                 Some(ref message) => message.as_slice(),

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -57,18 +57,18 @@ impl CustomEvent {
 }
 
 impl<'a> CustomEventMethods for JSRef<'a, CustomEvent> {
-    fn Detail(&self, _cx: *mut JSContext) -> JSVal {
+    fn Detail(self, _cx: *mut JSContext) -> JSVal {
         *self.detail.deref().get()
     }
 
-    fn InitCustomEvent(&self,
+    fn InitCustomEvent(self,
                        _cx: *mut JSContext,
                        type_: DOMString,
                        can_bubble: bool,
                        cancelable: bool,
                        detail: JSVal) {
         self.detail.deref().set(Traceable::new(detail));
-        let event: JSRef<Event> = EventCast::from_ref(*self);
+        let event: JSRef<Event> = EventCast::from_ref(self);
         event.InitEvent(type_, can_bubble, cancelable);
     }
 }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -47,7 +47,7 @@ impl CustomEvent {
     pub fn new(global: &GlobalRef, type_: DOMString, bubbles: bool, cancelable: bool, detail: JSVal) -> Temporary<CustomEvent> {
         let ev = CustomEvent::new_uninitialized(global).root();
         ev.deref().InitCustomEvent(global.get_cx(), type_, bubbles, cancelable, detail);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
     pub fn Constructor(global: &GlobalRef,
                        type_: DOMString,
@@ -68,7 +68,7 @@ impl<'a> CustomEventMethods for JSRef<'a, CustomEvent> {
                        cancelable: bool,
                        detail: JSVal) {
         self.detail.deref().set(Traceable::new(detail));
-        let event: &JSRef<Event> = EventCast::from_ref(self);
+        let event: JSRef<Event> = EventCast::from_ref(*self);
         event.InitEvent(type_, can_bubble, cancelable);
     }
 }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -115,10 +115,10 @@ impl DedicatedWorkerGlobalScope {
             }
             global.delayed_release_worker();
 
-            let scope: &JSRef<WorkerGlobalScope> =
-                WorkerGlobalScopeCast::from_ref(&*global);
-            let target: &JSRef<EventTarget> =
-                EventTargetCast::from_ref(&*global);
+            let scope: JSRef<WorkerGlobalScope> =
+                WorkerGlobalScopeCast::from_ref(*global);
+            let target: JSRef<EventTarget> =
+                EventTargetCast::from_ref(*global);
             loop {
                 match global.receiver.recv_opt() {
                     Ok(DOMMessage(data, nbytes)) => {
@@ -130,7 +130,7 @@ impl DedicatedWorkerGlobalScope {
                                 ptr::null(), ptr::mut_null()) != 0);
                         }
 
-                        MessageEvent::dispatch_jsval(target, &Worker(*scope), message);
+                        MessageEvent::dispatch_jsval(target, &Worker(scope), message);
                         global.delayed_release_worker();
                     },
                     Ok(XHRProgressMsg(addr, progress)) => {
@@ -164,12 +164,12 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalSc
     }
 
     fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("message")
     }
 
     fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -151,7 +151,7 @@ impl DedicatedWorkerGlobalScope {
 }
 
 impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalScope> {
-    fn PostMessage(&self, cx: *mut JSContext, message: JSVal) {
+    fn PostMessage(self, cx: *mut JSContext, message: JSVal) {
         let mut data = ptr::mut_null();
         let mut nbytes = 0;
         unsafe {
@@ -163,13 +163,13 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalSc
         sender.send(WorkerPostMessage(*self.worker, data, nbytes));
     }
 
-    fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnmessage(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("message")
     }
 
-    fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnmessage(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -367,25 +367,25 @@ impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
 
 impl<'a> DocumentMethods for JSRef<'a, Document> {
     // http://dom.spec.whatwg.org/#dom-document-implementation
-    fn Implementation(&self) -> Temporary<DOMImplementation> {
+    fn Implementation(self) -> Temporary<DOMImplementation> {
         if self.implementation.get().is_none() {
-            self.implementation.assign(Some(DOMImplementation::new(*self)));
+            self.implementation.assign(Some(DOMImplementation::new(self)));
         }
         Temporary::new(self.implementation.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-document-url
-    fn URL(&self) -> DOMString {
+    fn URL(self) -> DOMString {
         self.url().serialize()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-documenturi
-    fn DocumentURI(&self) -> DOMString {
+    fn DocumentURI(self) -> DOMString {
         self.URL()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-compatmode
-    fn CompatMode(&self) -> DOMString {
+    fn CompatMode(self) -> DOMString {
         match self.quirks_mode.deref().get() {
             LimitedQuirks | NoQuirks => "CSS1Compat".to_string(),
             FullQuirks => "BackCompat".to_string()
@@ -393,18 +393,18 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-characterset
-    fn CharacterSet(&self) -> DOMString {
+    fn CharacterSet(self) -> DOMString {
         self.encoding_name.deref().borrow().as_slice().to_ascii_lower()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-content_type
-    fn ContentType(&self) -> DOMString {
+    fn ContentType(self) -> DOMString {
         self.content_type.clone()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-doctype
-    fn GetDoctype(&self) -> Option<Temporary<DocumentType>> {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetDoctype(self) -> Option<Temporary<DocumentType>> {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.children().find(|child| {
             child.is_doctype()
         }).map(|node| {
@@ -414,32 +414,32 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-documentelement
-    fn GetDocumentElement(&self) -> Option<Temporary<Element>> {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetDocumentElement(self) -> Option<Temporary<Element>> {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.child_elements().next().map(|elem| Temporary::from_rooted(elem))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbytagname
-    fn GetElementsByTagName(&self, tag_name: DOMString) -> Temporary<HTMLCollection> {
+    fn GetElementsByTagName(self, tag_name: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(*self), tag_name)
+        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(self), tag_name)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbytagnamens
-    fn GetElementsByTagNameNS(&self, maybe_ns: Option<DOMString>, tag_name: DOMString) -> Temporary<HTMLCollection> {
+    fn GetElementsByTagNameNS(self, maybe_ns: Option<DOMString>, tag_name: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(*self), tag_name, maybe_ns)
+        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(self), tag_name, maybe_ns)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbyclassname
-    fn GetElementsByClassName(&self, classes: DOMString) -> Temporary<HTMLCollection> {
+    fn GetElementsByClassName(self, classes: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
 
-        HTMLCollection::by_class_name(*window, NodeCast::from_ref(*self), classes)
+        HTMLCollection::by_class_name(*window, NodeCast::from_ref(self), classes)
     }
 
     // http://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid
-    fn GetElementById(&self, id: DOMString) -> Option<Temporary<Element>> {
+    fn GetElementById(self, id: DOMString) -> Option<Temporary<Element>> {
         match self.idmap.deref().borrow().find_equiv(&id) {
             None => None,
             Some(ref elements) => Some(Temporary::new((*elements)[0].clone())),
@@ -447,17 +447,17 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createelement
-    fn CreateElement(&self, local_name: DOMString) -> Fallible<Temporary<Element>> {
+    fn CreateElement(self, local_name: DOMString) -> Fallible<Temporary<Element>> {
         if xml_name_type(local_name.as_slice()) == InvalidXMLName {
             debug!("Not a valid element name");
             return Err(InvalidCharacter);
         }
         let local_name = local_name.as_slice().to_ascii_lower();
-        Ok(build_element_from_tag(local_name, namespace::HTML, *self))
+        Ok(build_element_from_tag(local_name, namespace::HTML, self))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createelementns
-    fn CreateElementNS(&self,
+    fn CreateElementNS(self,
                        namespace: Option<DOMString>,
                        qualified_name: DOMString) -> Fallible<Temporary<Element>> {
         let ns = Namespace::from_str(null_str_as_empty_ref(&namespace));
@@ -497,31 +497,31 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         }
 
         if ns == namespace::HTML {
-            Ok(build_element_from_tag(local_name_from_qname.to_string(), ns, *self))
+            Ok(build_element_from_tag(local_name_from_qname.to_string(), ns, self))
         } else {
             Ok(Element::new(local_name_from_qname.to_string(), ns,
-                            prefix_from_qname.map(|s| s.to_string()), *self))
+                            prefix_from_qname.map(|s| s.to_string()), self))
         }
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createdocumentfragment
-    fn CreateDocumentFragment(&self) -> Temporary<DocumentFragment> {
-        DocumentFragment::new(*self)
+    fn CreateDocumentFragment(self) -> Temporary<DocumentFragment> {
+        DocumentFragment::new(self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createtextnode
-    fn CreateTextNode(&self, data: DOMString)
+    fn CreateTextNode(self, data: DOMString)
                           -> Temporary<Text> {
-        Text::new(data, *self)
+        Text::new(data, self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createcomment
-    fn CreateComment(&self, data: DOMString) -> Temporary<Comment> {
-        Comment::new(data, *self)
+    fn CreateComment(self, data: DOMString) -> Temporary<Comment> {
+        Comment::new(data, self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
-    fn CreateProcessingInstruction(&self, target: DOMString,
+    fn CreateProcessingInstruction(self, target: DOMString,
                                        data: DOMString) -> Fallible<Temporary<ProcessingInstruction>> {
         // Step 1.
         if xml_name_type(target.as_slice()) == InvalidXMLName {
@@ -534,11 +534,11 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         }
 
         // Step 3.
-        Ok(ProcessingInstruction::new(target, data, *self))
+        Ok(ProcessingInstruction::new(target, data, self))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-importnode
-    fn ImportNode(&self, node: JSRef<Node>, deep: bool) -> Fallible<Temporary<Node>> {
+    fn ImportNode(self, node: JSRef<Node>, deep: bool) -> Fallible<Temporary<Node>> {
         // Step 1.
         if node.is_document() {
             return Err(NotSupported);
@@ -550,25 +550,25 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             false => DoNotCloneChildren
         };
 
-        Ok(Node::clone(node, Some(*self), clone_children))
+        Ok(Node::clone(node, Some(self), clone_children))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-adoptnode
-    fn AdoptNode(&self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
+    fn AdoptNode(self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
         // Step 1.
         if node.is_document() {
             return Err(NotSupported);
         }
 
         // Step 2.
-        Node::adopt(node, *self);
+        Node::adopt(node, self);
 
         // Step 3.
         Ok(Temporary::from_rooted(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createevent
-    fn CreateEvent(&self, interface: DOMString) -> Fallible<Temporary<Event>> {
+    fn CreateEvent(self, interface: DOMString) -> Fallible<Temporary<Event>> {
         let window = self.window.root();
 
         match interface.as_slice().to_ascii_lower().as_slice() {
@@ -581,7 +581,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/html/#dom-document-lastmodified
-    fn LastModified(&self) -> DOMString {
+    fn LastModified(self) -> DOMString {
         match *self.last_modified.borrow() {
             Some(ref t) => t.clone(),
             None => time::now().strftime("%m/%d/%Y %H:%M:%S"),
@@ -589,18 +589,18 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createrange
-    fn CreateRange(&self) -> Temporary<Range> {
-        Range::new(*self)
+    fn CreateRange(self) -> Temporary<Range> {
+        Range::new(self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createtreewalker
-    fn CreateTreeWalker(&self, root: JSRef<Node>, whatToShow: u32, filter: Option<NodeFilter>)
+    fn CreateTreeWalker(self, root: JSRef<Node>, whatToShow: u32, filter: Option<NodeFilter>)
                         -> Temporary<TreeWalker> {
-        TreeWalker::new(*self, root, whatToShow, filter)
+        TreeWalker::new(self, root, whatToShow, filter)
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#document.title
-    fn Title(&self) -> DOMString {
+    fn Title(self) -> DOMString {
         let mut title = String::new();
         self.GetDocumentElement().root().map(|root| {
             let root: JSRef<Node> = NodeCast::from_ref(*root);
@@ -620,7 +620,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#document.title
-    fn SetTitle(&self, title: DOMString) -> ErrorResult {
+    fn SetTitle(self, title: DOMString) -> ErrorResult {
         self.GetDocumentElement().root().map(|root| {
             let root: JSRef<Node> = NodeCast::from_ref(*root);
             let head_node = root.traverse_preorder().find(|child| {
@@ -642,7 +642,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                         }
                     },
                     None => {
-                        let new_title = HTMLTitleElement::new("title".to_string(), *self).root();
+                        let new_title = HTMLTitleElement::new("title".to_string(), self).root();
                         let new_title: JSRef<Node> = NodeCast::from_ref(*new_title);
 
                         if !title.is_empty() {
@@ -658,7 +658,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-head
-    fn GetHead(&self) -> Option<Temporary<HTMLHeadElement>> {
+    fn GetHead(self) -> Option<Temporary<HTMLHeadElement>> {
         self.get_html_element().and_then(|root| {
             let root = root.root();
             let node: JSRef<Node> = NodeCast::from_ref(*root);
@@ -671,7 +671,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-body
-    fn GetBody(&self) -> Option<Temporary<HTMLElement>> {
+    fn GetBody(self) -> Option<Temporary<HTMLElement>> {
         self.get_html_element().and_then(|root| {
             let root = root.root();
             let node: JSRef<Node> = NodeCast::from_ref(*root);
@@ -688,7 +688,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-body
-    fn SetBody(&self, new_body: Option<JSRef<HTMLElement>>) -> ErrorResult {
+    fn SetBody(self, new_body: Option<JSRef<HTMLElement>>) -> ErrorResult {
         // Step 1.
         match new_body {
             Some(ref htmlelem) => {
@@ -731,7 +731,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-getelementsbyname
-    fn GetElementsByName(&self, name: DOMString) -> Temporary<NodeList> {
+    fn GetElementsByName(self, name: DOMString) -> Temporary<NodeList> {
         self.createNodeList(|node| {
             if !node.is_element() {
                 return false;
@@ -744,121 +744,121 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         })
     }
 
-    fn Images(&self) -> Temporary<HTMLCollection> {
+    fn Images(self) -> Temporary<HTMLCollection> {
         if self.images.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box ImagesFilter;
             self.images.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.images.get().get_ref().clone())
     }
 
-    fn Embeds(&self) -> Temporary<HTMLCollection> {
+    fn Embeds(self) -> Temporary<HTMLCollection> {
         if self.embeds.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box EmbedsFilter;
             self.embeds.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.embeds.get().get_ref().clone())
     }
 
-    fn Plugins(&self) -> Temporary<HTMLCollection> {
+    fn Plugins(self) -> Temporary<HTMLCollection> {
         self.Embeds()
     }
 
-    fn Links(&self) -> Temporary<HTMLCollection> {
+    fn Links(self) -> Temporary<HTMLCollection> {
         if self.links.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box LinksFilter;
             self.links.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.links.get().get_ref().clone())
     }
 
-    fn Forms(&self) -> Temporary<HTMLCollection> {
+    fn Forms(self) -> Temporary<HTMLCollection> {
         if self.forms.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box FormsFilter;
             self.forms.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.forms.get().get_ref().clone())
     }
 
-    fn Scripts(&self) -> Temporary<HTMLCollection> {
+    fn Scripts(self) -> Temporary<HTMLCollection> {
         if self.scripts.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box ScriptsFilter;
             self.scripts.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.scripts.get().get_ref().clone())
     }
 
-    fn Anchors(&self) -> Temporary<HTMLCollection> {
+    fn Anchors(self) -> Temporary<HTMLCollection> {
         if self.anchors.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box AnchorsFilter;
             self.anchors.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.anchors.get().get_ref().clone())
     }
 
-    fn Applets(&self) -> Temporary<HTMLCollection> {
+    fn Applets(self) -> Temporary<HTMLCollection> {
         // FIXME: This should be return OBJECT elements containing applets.
         if self.applets.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box AppletsFilter;
             self.applets.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.applets.get().get_ref().clone())
     }
 
-    fn Location(&self) -> Temporary<Location> {
+    fn Location(self) -> Temporary<Location> {
         let window = self.window.root();
         window.Location()
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> Temporary<HTMLCollection> {
+    fn Children(self) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::children(*window, NodeCast::from_ref(*self))
+        HTMLCollection::children(*window, NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
-    fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelector(self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
-    fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelectorAll(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector_all(selectors)
     }
 
-    fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("click")
     }
 
-    fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("load")
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("load", listener)
     }
 }

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -32,13 +32,13 @@ impl DocumentFragmentDerived for EventTarget {
 
 impl DocumentFragment {
     /// Creates a new DocumentFragment.
-    pub fn new_inherited(document: &JSRef<Document>) -> DocumentFragment {
+    pub fn new_inherited(document: JSRef<Document>) -> DocumentFragment {
         DocumentFragment {
             node: Node::new_inherited(DocumentFragmentNodeTypeId, document),
         }
     }
 
-    pub fn new(document: &JSRef<Document>) -> Temporary<DocumentFragment> {
+    pub fn new(document: JSRef<Document>) -> Temporary<DocumentFragment> {
         Node::reflect_node(box DocumentFragment::new_inherited(document),
                            document, DocumentFragmentBinding::Wrap)
     }
@@ -47,26 +47,26 @@ impl DocumentFragment {
         let document = global.as_window().Document();
         let document = document.root();
 
-        Ok(DocumentFragment::new(&document.root_ref()))
+        Ok(DocumentFragment::new(*document))
     }
 }
 
 impl<'a> DocumentFragmentMethods for JSRef<'a, DocumentFragment> {
     // http://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> Temporary<HTMLCollection> {
-        let window = window_from_node(self).root();
-        HTMLCollection::children(&window.root_ref(), NodeCast::from_ref(self))
+        let window = window_from_node(*self).root();
+        HTMLCollection::children(*window, NodeCast::from_ref(*self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
     fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: &JSRef<Node> = NodeCast::from_ref(self);
+        let root: JSRef<Node> = NodeCast::from_ref(*self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
     fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: &JSRef<Node> = NodeCast::from_ref(self);
+        let root: JSRef<Node> = NodeCast::from_ref(*self);
         root.query_selector_all(selectors)
     }
 

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -53,23 +53,22 @@ impl DocumentFragment {
 
 impl<'a> DocumentFragmentMethods for JSRef<'a, DocumentFragment> {
     // http://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::children(*window, NodeCast::from_ref(*self))
+    fn Children(self) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::children(*window, NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
-    fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelector(self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
-    fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelectorAll(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector_all(selectors)
     }
-
 }
 
 impl Reflectable for DocumentFragment {

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -56,21 +56,21 @@ impl DocumentType {
 }
 
 impl<'a> DocumentTypeMethods for JSRef<'a, DocumentType> {
-    fn Name(&self) -> DOMString {
+    fn Name(self) -> DOMString {
         self.name.clone()
     }
 
-    fn PublicId(&self) -> DOMString {
+    fn PublicId(self) -> DOMString {
         self.public_id.clone()
     }
 
-    fn SystemId(&self) -> DOMString {
+    fn SystemId(self) -> DOMString {
         self.system_id.clone()
     }
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Remove(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.remove_self();
     }
 }

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -32,7 +32,7 @@ impl DocumentType {
     pub fn new_inherited(name: DOMString,
                          public_id: Option<DOMString>,
                          system_id: Option<DOMString>,
-                         document: &JSRef<Document>)
+                         document: JSRef<Document>)
             -> DocumentType {
         DocumentType {
             node: Node::new_inherited(DoctypeNodeTypeId, document),
@@ -45,7 +45,7 @@ impl DocumentType {
     pub fn new(name: DOMString,
                public_id: Option<DOMString>,
                system_id: Option<DOMString>,
-               document: &JSRef<Document>)
+               document: JSRef<Document>)
                -> Temporary<DocumentType> {
         let documenttype = DocumentType::new_inherited(name,
                                                        public_id,
@@ -70,7 +70,7 @@ impl<'a> DocumentTypeMethods for JSRef<'a, DocumentType> {
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
     fn Remove(&self) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.remove_self();
     }
 }

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -91,7 +91,7 @@ impl Reflectable for DOMException {
 
 impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
     // http://dom.spec.whatwg.org/#dom-domexception-code
-    fn Code(&self) -> u16 {
+    fn Code(self) -> u16 {
         match self.code {
             // http://dom.spec.whatwg.org/#concept-throw
             EncodingError => 0,
@@ -100,12 +100,12 @@ impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
     }
 
     // http://dom.spec.whatwg.org/#error-names-0
-    fn Name(&self) -> DOMString {
+    fn Name(self) -> DOMString {
         self.code.to_string()
     }
 
     // http://dom.spec.whatwg.org/#error-names-0
-    fn Message(&self) -> DOMString {
+    fn Message(self) -> DOMString {
         match self.code {
             IndexSizeError => "The index is not in the allowed range.".to_string(),
             HierarchyRequestError => "The operation would yield an incorrect node tree.".to_string(),

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -54,7 +54,7 @@ impl Reflectable for DOMImplementation {
 // http://dom.spec.whatwg.org/#domimplementation
 impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     // http://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype
-    fn CreateDocumentType(&self, qname: DOMString, pubid: DOMString, sysid: DOMString) -> Fallible<Temporary<DocumentType>> {
+    fn CreateDocumentType(self, qname: DOMString, pubid: DOMString, sysid: DOMString) -> Fallible<Temporary<DocumentType>> {
         match xml_name_type(qname.as_slice()) {
             // Step 1.
             InvalidXMLName => Err(InvalidCharacter),
@@ -69,7 +69,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     }
 
     // http://dom.spec.whatwg.org/#dom-domimplementation-createdocument
-    fn CreateDocument(&self, namespace: Option<DOMString>, qname: DOMString,
+    fn CreateDocument(self, namespace: Option<DOMString>, qname: DOMString,
                       maybe_doctype: Option<JSRef<DocumentType>>) -> Fallible<Temporary<Document>> {
         let doc = self.document.root();
         let win = doc.window.root();
@@ -115,7 +115,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     }
 
     // http://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-    fn CreateHTMLDocument(&self, title: Option<DOMString>) -> Temporary<Document> {
+    fn CreateHTMLDocument(self, title: Option<DOMString>) -> Temporary<Document> {
         let document = self.document.root();
         let win = document.window.root();
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -21,15 +21,15 @@ pub struct DOMParser {
 }
 
 impl DOMParser {
-    pub fn new_inherited(window: &JSRef<Window>) -> DOMParser {
+    pub fn new_inherited(window: JSRef<Window>) -> DOMParser {
         DOMParser {
             window: JS::from_rooted(window),
             reflector_: Reflector::new()
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<DOMParser> {
-        reflect_dom_object(box DOMParser::new_inherited(window), &Window(*window),
+    pub fn new(window: JSRef<Window>) -> Temporary<DOMParser> {
+        reflect_dom_object(box DOMParser::new_inherited(window), &Window(window),
                            DOMParserBinding::Wrap)
     }
 
@@ -46,10 +46,10 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
         let window = self.window.root();
         match ty {
             Text_html => {
-                Ok(Document::new(&window.root_ref(), None, HTMLDocument, Some("text/html".to_string())))
+                Ok(Document::new(*window, None, HTMLDocument, Some("text/html".to_string())))
             }
             Text_xml => {
-                Ok(Document::new(&window.root_ref(), None, NonHTMLDocument, Some("text/xml".to_string())))
+                Ok(Document::new(*window, None, NonHTMLDocument, Some("text/xml".to_string())))
             }
             _ => {
                 Err(FailureUnknown)

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -39,7 +39,7 @@ impl DOMParser {
 }
 
 impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
-    fn ParseFromString(&self,
+    fn ParseFromString(self,
                        _s: DOMString,
                        ty: DOMParserBinding::SupportedType)
                        -> Fallible<Temporary<Document>> {

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -32,11 +32,11 @@ impl DOMRect {
         }
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                top: Au, bottom: Au,
                left: Au, right: Au) -> Temporary<DOMRect> {
         reflect_dom_object(box DOMRect::new_inherited(top, bottom, left, right),
-                           &Window(*window), DOMRectBinding::Wrap)
+                           &Window(window), DOMRectBinding::Wrap)
     }
 }
 

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -41,27 +41,27 @@ impl DOMRect {
 }
 
 impl<'a> DOMRectMethods for JSRef<'a, DOMRect> {
-    fn Top(&self) -> f32 {
+    fn Top(self) -> f32 {
         self.top
     }
 
-    fn Bottom(&self) -> f32 {
+    fn Bottom(self) -> f32 {
         self.bottom
     }
 
-    fn Left(&self) -> f32 {
+    fn Left(self) -> f32 {
         self.left
     }
 
-    fn Right(&self) -> f32 {
+    fn Right(self) -> f32 {
         self.right
     }
 
-    fn Width(&self) -> f32 {
+    fn Width(self) -> f32 {
         (self.right - self.left).abs()
     }
 
-    fn Height(&self) -> f32 {
+    fn Height(self) -> f32 {
         (self.bottom - self.top).abs()
     }
 }

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -19,9 +19,9 @@ pub struct DOMRectList {
 }
 
 impl DOMRectList {
-    pub fn new_inherited(window: &JSRef<Window>,
+    pub fn new_inherited(window: JSRef<Window>,
                          rects: Vec<JSRef<DOMRect>>) -> DOMRectList {
-        let rects = rects.iter().map(|rect| JS::from_rooted(rect)).collect();
+        let rects = rects.iter().map(|rect| JS::from_rooted(*rect)).collect();
         DOMRectList {
             reflector_: Reflector::new(),
             rects: rects,
@@ -29,10 +29,10 @@ impl DOMRectList {
         }
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                rects: Vec<JSRef<DOMRect>>) -> Temporary<DOMRectList> {
         reflect_dom_object(box DOMRectList::new_inherited(window, rects),
-                           &Window(*window), DOMRectListBinding::Wrap)
+                           &Window(window), DOMRectListBinding::Wrap)
     }
 }
 

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -37,11 +37,11 @@ impl DOMRectList {
 }
 
 impl<'a> DOMRectListMethods for JSRef<'a, DOMRectList> {
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.rects.len() as u32
     }
 
-    fn Item(&self, index: u32) -> Option<Temporary<DOMRect>> {
+    fn Item(self, index: u32) -> Option<Temporary<DOMRect>> {
         let rects = &self.rects;
         if index < rects.len() as u32 {
             Some(Temporary::new(rects[index as uint].clone()))
@@ -50,7 +50,7 @@ impl<'a> DOMRectListMethods for JSRef<'a, DOMRectList> {
         }
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<DOMRect>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<DOMRect>> {
         *found = index < self.rects.len() as u32;
         self.Item(index)
     }

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -25,7 +25,7 @@ pub struct DOMTokenList {
 }
 
 impl DOMTokenList {
-    pub fn new_inherited(element: &JSRef<Element>,
+    pub fn new_inherited(element: JSRef<Element>,
                          local_name: &'static str) -> DOMTokenList {
         DOMTokenList {
             reflector_: Reflector::new(),
@@ -34,7 +34,7 @@ impl DOMTokenList {
         }
     }
 
-    pub fn new(element: &JSRef<Element>,
+    pub fn new(element: JSRef<Element>,
                local_name: &'static str) -> Temporary<DOMTokenList> {
         let window = window_from_node(element).root();
         reflect_dom_object(box DOMTokenList::new_inherited(element, local_name),

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -71,27 +71,27 @@ impl<'a> PrivateDOMTokenListHelpers for JSRef<'a, DOMTokenList> {
 // http://dom.spec.whatwg.org/#domtokenlist
 impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     // http://dom.spec.whatwg.org/#dom-domtokenlist-length
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.attribute().root().map(|attr| {
             attr.value().tokens().map(|tokens| tokens.len()).unwrap_or(0)
         }).unwrap_or(0) as u32
     }
 
     // http://dom.spec.whatwg.org/#dom-domtokenlist-item
-    fn Item(&self, index: u32) -> Option<DOMString> {
+    fn Item(self, index: u32) -> Option<DOMString> {
         self.attribute().root().and_then(|attr| attr.value().tokens().and_then(|mut tokens| {
             tokens.idx(index as uint).map(|token| token.as_slice().to_string())
         }))
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<DOMString> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<DOMString> {
         let item = self.Item(index);
         *found = item.is_some();
         item
     }
 
     // http://dom.spec.whatwg.org/#dom-domtokenlist-contains
-    fn Contains(&self, token: DOMString) -> Fallible<bool> {
+    fn Contains(self, token: DOMString) -> Fallible<bool> {
         self.check_token_exceptions(token.as_slice()).map(|slice| {
             self.attribute().root().and_then(|attr| attr.value().tokens().map(|mut tokens| {
                 let atom = Atom::from_slice(slice);

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -507,24 +507,24 @@ impl Element {
 
 impl<'a> ElementMethods for JSRef<'a, Element> {
     // http://dom.spec.whatwg.org/#dom-element-namespaceuri
-    fn GetNamespaceURI(&self) -> Option<DOMString> {
+    fn GetNamespaceURI(self) -> Option<DOMString> {
         match self.namespace {
             Null => None,
             ref ns => Some(ns.to_str().to_string())
         }
     }
 
-    fn LocalName(&self) -> DOMString {
+    fn LocalName(self) -> DOMString {
         self.local_name.as_slice().to_string()
     }
 
     // http://dom.spec.whatwg.org/#dom-element-prefix
-    fn GetPrefix(&self) -> Option<DOMString> {
+    fn GetPrefix(self) -> Option<DOMString> {
         self.prefix.clone()
     }
 
     // http://dom.spec.whatwg.org/#dom-element-tagname
-    fn TagName(&self) -> DOMString {
+    fn TagName(self) -> DOMString {
         let qualified_name = match self.prefix {
             Some(ref prefix) => format!("{}:{}", prefix, self.local_name).into_maybe_owned(),
             None => self.local_name.as_slice().into_maybe_owned()
@@ -537,31 +537,31 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-id
-    fn Id(&self) -> DOMString {
+    fn Id(self) -> DOMString {
         self.get_string_attribute("id")
     }
 
     // http://dom.spec.whatwg.org/#dom-element-id
-    fn SetId(&self, id: DOMString) {
+    fn SetId(self, id: DOMString) {
         self.set_atomic_attribute("id", id);
     }
 
     // http://dom.spec.whatwg.org/#dom-element-classname
-    fn ClassName(&self) -> DOMString {
+    fn ClassName(self) -> DOMString {
         self.get_string_attribute("class")
     }
 
     // http://dom.spec.whatwg.org/#dom-element-classname
-    fn SetClassName(&self, class: DOMString) {
+    fn SetClassName(self, class: DOMString) {
         self.set_tokenlist_attribute("class", class);
     }
 
     // http://dom.spec.whatwg.org/#dom-element-classlist
-    fn ClassList(&self) -> Temporary<DOMTokenList> {
+    fn ClassList(self) -> Temporary<DOMTokenList> {
         match self.class_list.get() {
             Some(class_list) => Temporary::new(class_list),
             None => {
-                let class_list = DOMTokenList::new(*self, "class").root();
+                let class_list = DOMTokenList::new(self, "class").root();
                 self.class_list.assign(Some(class_list.deref().clone()));
                 Temporary::from_rooted(*class_list)
             }
@@ -569,24 +569,24 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-attributes
-    fn Attributes(&self) -> Temporary<NamedNodeMap> {
+    fn Attributes(self) -> Temporary<NamedNodeMap> {
         match self.attr_list.get() {
             None => (),
             Some(ref list) => return Temporary::new(list.clone()),
         }
 
         let doc = {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
+            let node: JSRef<Node> = NodeCast::from_ref(self);
             node.owner_doc().root()
         };
         let window = doc.deref().window.root();
-        let list = NamedNodeMap::new(*window, *self);
+        let list = NamedNodeMap::new(*window, self);
         self.attr_list.assign(Some(list));
         Temporary::new(self.attr_list.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-element-getattribute
-    fn GetAttribute(&self, name: DOMString) -> Option<DOMString> {
+    fn GetAttribute(self, name: DOMString) -> Option<DOMString> {
         let name = if self.html_element_in_html_document() {
             name.as_slice().to_ascii_lower()
         } else {
@@ -597,7 +597,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-getattributens
-    fn GetAttributeNS(&self,
+    fn GetAttributeNS(self,
                       namespace: Option<DOMString>,
                       local_name: DOMString) -> Option<DOMString> {
         let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
@@ -606,11 +606,11 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-setattribute
-    fn SetAttribute(&self,
+    fn SetAttribute(self,
                     name: DOMString,
                     value: DOMString) -> ErrorResult {
         {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
+            let node: JSRef<Node> = NodeCast::from_ref(self);
             node.wait_until_safe_to_modify_dom();
         }
 
@@ -637,12 +637,12 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-setattributens
-    fn SetAttributeNS(&self,
+    fn SetAttributeNS(self,
                       namespace_url: Option<DOMString>,
                       name: DOMString,
                       value: DOMString) -> ErrorResult {
         {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
+            let node: JSRef<Node> = NodeCast::from_ref(self);
             node.wait_until_safe_to_modify_dom();
         }
 
@@ -706,7 +706,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-removeattribute
-    fn RemoveAttribute(&self, name: DOMString) {
+    fn RemoveAttribute(self, name: DOMString) {
         let name = if self.html_element_in_html_document() {
             name.as_slice().to_ascii_lower()
         } else {
@@ -716,7 +716,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-removeattributens
-    fn RemoveAttributeNS(&self,
+    fn RemoveAttributeNS(self,
                          namespace: Option<DOMString>,
                          localname: DOMString) {
         let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
@@ -724,38 +724,38 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-hasattribute
-    fn HasAttribute(&self,
+    fn HasAttribute(self,
                     name: DOMString) -> bool {
         self.has_attribute(name.as_slice())
     }
 
     // http://dom.spec.whatwg.org/#dom-element-hasattributens
-    fn HasAttributeNS(&self,
+    fn HasAttributeNS(self,
                       namespace: Option<DOMString>,
                       local_name: DOMString) -> bool {
         self.GetAttributeNS(namespace, local_name).is_some()
     }
 
-    fn GetElementsByTagName(&self, localname: DOMString) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(*self), localname)
+    fn GetElementsByTagName(self, localname: DOMString) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(self), localname)
     }
 
-    fn GetElementsByTagNameNS(&self, maybe_ns: Option<DOMString>,
+    fn GetElementsByTagNameNS(self, maybe_ns: Option<DOMString>,
                               localname: DOMString) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(*self), localname, maybe_ns)
+        let window = window_from_node(self).root();
+        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(self), localname, maybe_ns)
     }
 
-    fn GetElementsByClassName(&self, classes: DOMString) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::by_class_name(*window, NodeCast::from_ref(*self), classes)
+    fn GetElementsByClassName(self, classes: DOMString) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::by_class_name(*window, NodeCast::from_ref(self), classes)
     }
 
     // http://dev.w3.org/csswg/cssom-view/#dom-element-getclientrects
-    fn GetClientRects(&self) -> Temporary<DOMRectList> {
-        let win = window_from_node(*self).root();
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetClientRects(self) -> Temporary<DOMRectList> {
+        let win = window_from_node(self).root();
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rects = node.get_content_boxes();
         let rects: Vec<Root<DOMRect>> = rects.iter().map(|r| {
             DOMRect::new(
@@ -770,9 +770,9 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dev.w3.org/csswg/cssom-view/#dom-element-getboundingclientrect
-    fn GetBoundingClientRect(&self) -> Temporary<DOMRect> {
-        let win = window_from_node(*self).root();
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetBoundingClientRect(self) -> Temporary<DOMRect> {
+        let win = window_from_node(self).root();
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rect = node.get_bounding_content_box();
         DOMRect::new(
             *win,
@@ -782,45 +782,45 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
             rect.origin.x + rect.size.width)
     }
 
-    fn GetInnerHTML(&self) -> Fallible<DOMString> {
+    fn GetInnerHTML(self) -> Fallible<DOMString> {
         //XXX TODO: XML case
-        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(*self), false, false)))
+        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(self), false, false)))
     }
 
-    fn GetOuterHTML(&self) -> Fallible<DOMString> {
-        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(*self), true, false)))
+    fn GetOuterHTML(self) -> Fallible<DOMString> {
+        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(self), true, false)))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::children(*window, NodeCast::from_ref(*self))
+    fn Children(self) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::children(*window, NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
-    fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelector(self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
-    fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelectorAll(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector_all(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Remove(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.remove_self();
     }
 
     // http://dom.spec.whatwg.org/#dom-element-matches
-    fn Matches(&self, selectors: DOMString) -> Fallible<bool> {
+    fn Matches(self, selectors: DOMString) -> Fallible<bool> {
         match parse_selector_list_from_str(selectors.as_slice()) {
             Err(()) => Err(Syntax),
             Ok(ref selectors) => {
-                let root: JSRef<Node> = NodeCast::from_ref(*self);
+                let root: JSRef<Node> = NodeCast::from_ref(self);
                 Ok(matches(selectors, &root, &mut None))
             }
         }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -98,54 +98,54 @@ impl Event {
 }
 
 impl<'a> EventMethods for JSRef<'a, Event> {
-    fn EventPhase(&self) -> u16 {
+    fn EventPhase(self) -> u16 {
         self.phase.deref().get() as u16
     }
 
-    fn Type(&self) -> DOMString {
+    fn Type(self) -> DOMString {
         self.type_.deref().borrow().clone()
     }
 
-    fn GetTarget(&self) -> Option<Temporary<EventTarget>> {
+    fn GetTarget(self) -> Option<Temporary<EventTarget>> {
         self.target.get().as_ref().map(|target| Temporary::new(target.clone()))
     }
 
-    fn GetCurrentTarget(&self) -> Option<Temporary<EventTarget>> {
+    fn GetCurrentTarget(self) -> Option<Temporary<EventTarget>> {
         self.current_target.get().as_ref().map(|target| Temporary::new(target.clone()))
     }
 
-    fn DefaultPrevented(&self) -> bool {
+    fn DefaultPrevented(self) -> bool {
         self.canceled.deref().get()
     }
 
-    fn PreventDefault(&self) {
+    fn PreventDefault(self) {
         if self.cancelable.deref().get() {
             self.canceled.deref().set(true)
         }
     }
 
-    fn StopPropagation(&self) {
+    fn StopPropagation(self) {
         self.stop_propagation.deref().set(true);
     }
 
-    fn StopImmediatePropagation(&self) {
+    fn StopImmediatePropagation(self) {
         self.stop_immediate.deref().set(true);
         self.stop_propagation.deref().set(true);
     }
 
-    fn Bubbles(&self) -> bool {
+    fn Bubbles(self) -> bool {
         self.bubbles.deref().get()
     }
 
-    fn Cancelable(&self) -> bool {
+    fn Cancelable(self) -> bool {
         self.cancelable.deref().get()
     }
 
-    fn TimeStamp(&self) -> u64 {
+    fn TimeStamp(self) -> u64 {
         self.timestamp
     }
 
-    fn InitEvent(&self,
+    fn InitEvent(self,
                  type_: DOMString,
                  bubbles: bool,
                  cancelable: bool) {
@@ -163,7 +163,7 @@ impl<'a> EventMethods for JSRef<'a, Event> {
         self.cancelable.deref().set(cancelable);
     }
 
-    fn IsTrusted(&self) -> bool {
+    fn IsTrusted(self) -> bool {
         self.trusted.deref().get()
     }
 }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -87,7 +87,7 @@ impl Event {
                cancelable: bool) -> Temporary<Event> {
         let event = Event::new_uninitialized(global).root();
         event.deref().InitEvent(type_, can_bubble, cancelable);
-        Temporary::from_rooted(&*event)
+        Temporary::from_rooted(*event)
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -96,7 +96,7 @@ impl EventTarget {
 pub trait EventTargetHelpers {
     fn dispatch_event_with_target<'a>(&self,
                                       target: Option<JSRef<'a, EventTarget>>,
-                                      event: &JSRef<Event>) -> Fallible<bool>;
+                                      event: JSRef<Event>) -> Fallible<bool>;
     fn set_inline_event_listener(&self,
                                  ty: DOMString,
                                  listener: Option<EventListener>);
@@ -117,11 +117,11 @@ pub trait EventTargetHelpers {
 impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
     fn dispatch_event_with_target<'b>(&self,
                                       target: Option<JSRef<'b, EventTarget>>,
-                                      event: &JSRef<Event>) -> Fallible<bool> {
+                                      event: JSRef<Event>) -> Fallible<bool> {
         if event.deref().dispatching.deref().get() || !event.deref().initialized.deref().get() {
             return Err(InvalidState);
         }
-        Ok(dispatch_event(self, target, event))
+        Ok(dispatch_event(*self, target, event))
     }
 
     fn set_inline_event_listener(&self,
@@ -270,7 +270,7 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
         }
     }
 
-    fn DispatchEvent(&self, event: &JSRef<Event>) -> Fallible<bool> {
+    fn DispatchEvent(&self, event: JSRef<Event>) -> Fallible<bool> {
         self.dispatch_event_with_target(None, event)
     }
 }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -225,7 +225,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
 }
 
 impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
-    fn AddEventListener(&self,
+    fn AddEventListener(self,
                         ty: DOMString,
                         listener: Option<EventListener>,
                         capture: bool) {
@@ -246,7 +246,7 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
         }
     }
 
-    fn RemoveEventListener(&self,
+    fn RemoveEventListener(self,
                            ty: DOMString,
                            listener: Option<EventListener>,
                            capture: bool) {
@@ -270,7 +270,7 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
         }
     }
 
-    fn DispatchEvent(&self, event: JSRef<Event>) -> Fallible<bool> {
+    fn DispatchEvent(self, event: JSRef<Event>) -> Fallible<bool> {
         self.dispatch_event_with_target(None, event)
     }
 }

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -19,7 +19,7 @@ pub struct File {
 }
 
 impl File {
-    pub fn new_inherited(_file_bits: &JSRef<Blob>, name: DOMString) -> File {
+    pub fn new_inherited(_file_bits: JSRef<Blob>, name: DOMString) -> File {
         File {
             blob: Blob::new_inherited(),
             name: name,
@@ -29,7 +29,7 @@ impl File {
         // the relevant subfields of file_bits should be copied over
     }
 
-    pub fn new(global: &GlobalRef, file_bits: &JSRef<Blob>, name: DOMString) -> Temporary<File> {
+    pub fn new(global: &GlobalRef, file_bits: JSRef<Blob>, name: DOMString) -> Temporary<File> {
         reflect_dom_object(box File::new_inherited(file_bits, name),
                            global,
                            FileBinding::Wrap)

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -36,8 +36,8 @@ impl File {
     }
 }
 
-impl FileMethods for File {
-    fn Name(&self) -> DOMString {
+impl<'a> FileMethods for JSRef<'a, File> {
+    fn Name(self) -> DOMString {
         self.name.clone()
     }
 }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -56,22 +56,22 @@ impl FormData {
 
 impl<'a> FormDataMethods for JSRef<'a, FormData> {
     #[allow(unrooted_must_root)]
-    fn Append(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+    fn Append(self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
         let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert_or_update_with(name.clone(), vec!(file.clone()),
                                         |_k, v| {v.push(file.clone());});
     }
 
-    fn Append_(&self, name: DOMString, value: DOMString) {
+    fn Append_(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert_or_update_with(name, vec!(StringData(value.clone())),
                                         |_k, v| {v.push(StringData(value.clone()));});
     }
 
-    fn Delete(&self, name: DOMString) {
+    fn Delete(self, name: DOMString) {
         self.data.deref().borrow_mut().remove(&name);
     }
 
-    fn Get(&self, name: DOMString) -> Option<FileOrString> {
+    fn Get(self, name: DOMString) -> Option<FileOrString> {
         if self.data.deref().borrow().contains_key_equiv(&name) {
             match self.data.deref().borrow().get(&name)[0].clone() {
                 StringData(ref s) => Some(eString(s.clone())),
@@ -84,16 +84,16 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
         }
     }
 
-    fn Has(&self, name: DOMString) -> bool {
+    fn Has(self, name: DOMString) -> bool {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
     #[allow(unrooted_must_root)]
-    fn Set(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+    fn Set(self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
         let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert(name, vec!(file));
     }
 
-    fn Set_(&self, name: DOMString, value: DOMString) {
+    fn Set_(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert(name, vec!(StringData(value)));
     }
 }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -40,7 +40,7 @@ impl FormData {
             data: Traceable::new(RefCell::new(HashMap::new())),
             reflector_: Reflector::new(),
             global: GlobalField::from_rooted(global),
-            form: form.map(|f| JS::from_rooted(&f)),
+            form: form.map(|f| JS::from_rooted(f)),
         }
     }
 
@@ -56,8 +56,8 @@ impl FormData {
 
 impl<'a> FormDataMethods for JSRef<'a, FormData> {
     #[allow(unrooted_must_root)]
-    fn Append(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
-        let file = FileData(JS::from_rooted(&self.get_file_from_blob(value, filename)));
+    fn Append(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+        let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert_or_update_with(name.clone(), vec!(file.clone()),
                                         |_k, v| {v.push(file.clone());});
     }
@@ -88,8 +88,8 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
     #[allow(unrooted_must_root)]
-    fn Set(&self, name: DOMString, value: &JSRef<Blob>, filename: Option<DOMString>) {
-        let file = FileData(JS::from_rooted(&self.get_file_from_blob(value, filename)));
+    fn Set(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+        let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert(name, vec!(file));
     }
 
@@ -105,13 +105,13 @@ impl Reflectable for FormData {
 }
 
 trait PrivateFormDataHelpers{
-  fn get_file_from_blob(&self, value: &JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File>;
+  fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File>;
 }
 
 impl PrivateFormDataHelpers for FormData {
-    fn get_file_from_blob(&self, value: &JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File> {
+    fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File> {
         let global = self.global.root();
-        let f: Option<&JSRef<File>> = FileCast::to_ref(value);
+        let f: Option<JSRef<File>> = FileCast::to_ref(value);
         let name = filename.unwrap_or(f.map(|inner| inner.name.clone()).unwrap_or("blob".to_string()));
         File::new(&global.root_ref(), value, name)
     }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -36,33 +36,33 @@ impl HTMLAnchorElementDerived for EventTarget {
 }
 
 impl HTMLAnchorElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAnchorElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAnchorElement {
         HTMLAnchorElement {
             htmlelement: HTMLElement::new_inherited(HTMLAnchorElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAnchorElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAnchorElement> {
         let element = HTMLAnchorElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAnchorElementBinding::Wrap)
     }
 }
 
 trait PrivateHTMLAnchorElementHelpers {
-    fn handle_event_impl(&self, event: &JSRef<Event>);
+    fn handle_event_impl(&self, event: JSRef<Event>);
 }
 
 impl<'a> PrivateHTMLAnchorElementHelpers for JSRef<'a, HTMLAnchorElement> {
-    fn handle_event_impl(&self, event: &JSRef<Event>) {
+    fn handle_event_impl(&self, event: JSRef<Event>) {
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             let attr = element.get_attribute(Null, "href").root();
             match attr {
                 Some(ref href) => {
                     let value = href.Value();
                     debug!("clicked on link to {:s}", value);
-                    let node: &JSRef<Node> = NodeCast::from_ref(self);
+                    let node: JSRef<Node> = NodeCast::from_ref(*self);
                     let doc = node.owner_doc().root();
                     doc.load_anchor_href(value);
                 }
@@ -74,7 +74,7 @@ impl<'a> PrivateHTMLAnchorElementHelpers for JSRef<'a, HTMLAnchorElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -84,7 +84,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
@@ -97,14 +97,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
         }
     }
 
-    fn handle_event(&self, event: &JSRef<Event>) {
+    fn handle_event(&self, event: JSRef<Event>) {
         match self.super_type() {
             Some(s) => {
                 s.handle_event(event);
@@ -123,12 +123,12 @@ impl Reflectable for HTMLAnchorElement {
 
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
     fn Text(&self) -> DOMString {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.GetTextContent().unwrap()
     }
 
     fn SetText(&self, value: DOMString) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -122,13 +122,13 @@ impl Reflectable for HTMLAnchorElement {
 }
 
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
-    fn Text(&self) -> DOMString {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Text(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.GetTextContent().unwrap()
     }
 
-    fn SetText(&self, value: DOMString) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetText(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -26,14 +26,14 @@ impl HTMLAppletElementDerived for EventTarget {
 }
 
 impl HTMLAppletElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAppletElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAppletElement {
         HTMLAppletElement {
             htmlelement: HTMLElement::new_inherited(HTMLAppletElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAppletElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAppletElement> {
         let element = HTMLAppletElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAppletElementBinding::Wrap)
     }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -30,14 +30,14 @@ impl HTMLAreaElementDerived for EventTarget {
 }
 
 impl HTMLAreaElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAreaElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAreaElement {
         HTMLAreaElement {
             htmlelement: HTMLElement::new_inherited(HTMLAreaElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAreaElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAreaElement> {
         let element = HTMLAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAreaElementBinding::Wrap)
     }
@@ -45,7 +45,7 @@ impl HTMLAreaElement {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -55,7 +55,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
@@ -68,7 +68,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -26,14 +26,14 @@ impl HTMLAudioElementDerived for EventTarget {
 }
 
 impl HTMLAudioElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLAudioElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLAudioElement {
         HTMLAudioElement {
             htmlmediaelement: HTMLMediaElement::new_inherited(HTMLAudioElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLAudioElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAudioElement> {
         let element = HTMLAudioElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAudioElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -26,14 +26,14 @@ impl HTMLBaseElementDerived for EventTarget {
 }
 
 impl HTMLBaseElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLBaseElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLBaseElement {
         HTMLBaseElement {
             htmlelement: HTMLElement::new_inherited(HTMLBaseElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBaseElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLBaseElement> {
         let element = HTMLBaseElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBaseElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -47,13 +47,13 @@ impl HTMLBodyElement {
 }
 
 impl<'a> HTMLBodyElementMethods for JSRef<'a, HTMLBodyElement> {
-    fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let win = window_from_node(*self).root();
+    fn GetOnunload(self) -> Option<EventHandlerNonNull> {
+        let win = window_from_node(self).root();
         win.deref().GetOnunload()
     }
 
-    fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let win = window_from_node(*self).root();
+    fn SetOnunload(self, listener: Option<EventHandlerNonNull>) {
+        let win = window_from_node(self).root();
         win.deref().SetOnunload(listener)
     }
 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -33,14 +33,14 @@ impl HTMLBodyElementDerived for EventTarget {
 }
 
 impl HTMLBodyElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLBodyElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLBodyElement {
         HTMLBodyElement {
             htmlelement: HTMLElement::new_inherited(HTMLBodyElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBodyElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLBodyElement> {
         let element = HTMLBodyElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBodyElementBinding::Wrap)
     }
@@ -48,19 +48,19 @@ impl HTMLBodyElement {
 
 impl<'a> HTMLBodyElementMethods for JSRef<'a, HTMLBodyElement> {
     fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let win = window_from_node(self).root();
+        let win = window_from_node(*self).root();
         win.deref().GetOnunload()
     }
 
     fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let win = window_from_node(self).root();
+        let win = window_from_node(*self).root();
         win.deref().SetOnunload(listener)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let element: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let element: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
     }
 
@@ -76,15 +76,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
                   "onbeforeunload", "onhashchange", "onlanguagechange", "onmessage",
                   "onoffline", "ononline", "onpagehide", "onpageshow", "onpopstate",
                   "onstorage", "onresize", "onunload", "onerror"];
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let (cx, url, reflector) = (window.get_cx(),
                                         window.get_url(),
                                         window.reflector().get_jsobject());
-            let evtarget: &JSRef<EventTarget> =
+            let evtarget: JSRef<EventTarget> =
                 if forwarded_events.iter().any(|&event| name.as_slice() == event) {
-                    EventTargetCast::from_ref(&*window)
+                    EventTargetCast::from_ref(*window)
                 } else {
-                    EventTargetCast::from_ref(self)
+                    EventTargetCast::from_ref(*self)
                 };
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.as_slice().slice_from(2),

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -26,14 +26,14 @@ impl HTMLBRElementDerived for EventTarget {
 }
 
 impl HTMLBRElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLBRElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLBRElement {
         HTMLBRElement {
             htmlelement: HTMLElement::new_inherited(HTMLBRElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLBRElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLBRElement> {
         let element = HTMLBRElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLBRElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -32,14 +32,14 @@ impl HTMLButtonElementDerived for EventTarget {
 }
 
 impl HTMLButtonElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLButtonElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLButtonElement {
         HTMLButtonElement {
             htmlelement: HTMLElement::new_inherited(HTMLButtonElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLButtonElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLButtonElement> {
         let element = HTMLButtonElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLButtonElementBinding::Wrap)
     }
@@ -47,8 +47,8 @@ impl HTMLButtonElement {
 
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 
     // http://www.whatwg.org/html/#dom-fe-disabled
@@ -56,14 +56,14 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -73,7 +73,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -89,7 +89,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -106,7 +106,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -116,7 +116,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -46,8 +46,8 @@ impl HTMLButtonElement {
 }
 
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 
@@ -55,8 +55,8 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -61,33 +61,33 @@ impl HTMLCanvasElement {
 }
 
 impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
-    fn Width(&self) -> u32 {
+    fn Width(self) -> u32 {
         self.width.get()
     }
 
-    fn SetWidth(&self, width: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetWidth(self, width: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("width", width)
     }
 
-    fn Height(&self) -> u32 {
+    fn Height(self) -> u32 {
         self.height.get()
     }
 
-    fn SetHeight(&self, height: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetHeight(self, height: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("height", height)
     }
 
-    fn GetContext(&self, id: DOMString) -> Option<Temporary<CanvasRenderingContext2D>> {
+    fn GetContext(self, id: DOMString) -> Option<Temporary<CanvasRenderingContext2D>> {
         if id.as_slice() != "2d" {
             return None;
         }
 
         if self.context.get().is_none() {
-            let window = window_from_node(*self).root();
+            let window = window_from_node(self).root();
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            let context = CanvasRenderingContext2D::new(&Window(*window), *self, Size2D(w, h));
+            let context = CanvasRenderingContext2D::new(&Window(*window), self, Size2D(w, h));
             self.context.assign(Some(context));
         }
         self.context.get().map(|context| Temporary::new(context))

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -44,7 +44,7 @@ impl HTMLCanvasElementDerived for EventTarget {
 }
 
 impl HTMLCanvasElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLCanvasElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLCanvasElement {
         HTMLCanvasElement {
             htmlelement: HTMLElement::new_inherited(HTMLCanvasElementTypeId, localName, document),
             context: Traceable::new(Cell::new(None)),
@@ -54,7 +54,7 @@ impl HTMLCanvasElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLCanvasElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLCanvasElement> {
         let element = HTMLCanvasElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLCanvasElementBinding::Wrap)
     }
@@ -66,7 +66,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn SetWidth(&self, width: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("width", width)
     }
 
@@ -75,7 +75,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn SetHeight(&self, height: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("height", height)
     }
 
@@ -85,9 +85,9 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
         }
 
         if self.context.get().is_none() {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            let context = CanvasRenderingContext2D::new(&Window(*window), self, Size2D(w, h));
+            let context = CanvasRenderingContext2D::new(&Window(*window), *self, Size2D(w, h));
             self.context.assign(Some(context));
         }
         self.context.get().map(|context| Temporary::new(context))
@@ -96,7 +96,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let element: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let element: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
     }
 

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -172,7 +172,7 @@ impl HTMLCollection {
 
 impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     // http://dom.spec.whatwg.org/#dom-htmlcollection-length
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         match self.collection {
             Static(ref elems) => elems.len() as u32,
             Live(ref root, ref filter) => {
@@ -187,7 +187,7 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     }
 
     // http://dom.spec.whatwg.org/#dom-htmlcollection-item
-    fn Item(&self, index: u32) -> Option<Temporary<Element>> {
+    fn Item(self, index: u32) -> Option<Temporary<Element>> {
         match self.collection {
             Static(ref elems) => elems
                 .as_slice()
@@ -209,7 +209,7 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     }
 
     // http://dom.spec.whatwg.org/#dom-htmlcollection-nameditem
-    fn NamedItem(&self, key: DOMString) -> Option<Temporary<Element>> {
+    fn NamedItem(self, key: DOMString) -> Option<Temporary<Element>> {
         // Step 1.
         if key.is_empty() {
             return None;
@@ -239,13 +239,13 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
         }
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Element>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Element>> {
         let maybe_elem = self.Item(index);
         *found = maybe_elem.is_some();
         maybe_elem
     }
 
-    fn NamedGetter(&self, name: DOMString, found: &mut bool) -> Option<Temporary<Element>> {
+    fn NamedGetter(self, name: DOMString, found: &mut bool) -> Option<Temporary<Element>> {
         let maybe_elem = self.NamedItem(name);
         *found = maybe_elem.is_some();
         maybe_elem

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -26,14 +26,14 @@ impl HTMLDataElementDerived for EventTarget {
 }
 
 impl HTMLDataElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDataElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDataElement {
         HTMLDataElement {
             htmlelement: HTMLElement::new_inherited(HTMLDataElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDataElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDataElement> {
         let element = HTMLDataElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDataElementBinding::Wrap)
     }

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -29,14 +29,14 @@ impl HTMLDataListElementDerived for EventTarget {
 }
 
 impl HTMLDataListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDataListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDataListElement {
         HTMLDataListElement {
             htmlelement: HTMLElement::new_inherited(HTMLDataListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDataListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDataListElement> {
         let element = HTMLDataListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDataListElementBinding::Wrap)
     }
@@ -46,14 +46,14 @@ impl<'a> HTMLDataListElementMethods for JSRef<'a, HTMLDataListElement> {
     fn Options(&self) -> Temporary<HTMLCollection> {
         struct HTMLDataListOptionsFilter;
         impl CollectionFilter for HTMLDataListOptionsFilter {
-            fn filter(&self, elem: &JSRef<Element>, _root: &JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 elem.is_htmloptionelement()
             }
         }
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let filter = box HTMLDataListOptionsFilter;
         let window = window_from_node(node).root();
-        HTMLCollection::create(&*window, node, filter)
+        HTMLCollection::create(*window, node, filter)
     }
 }
 

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -43,14 +43,14 @@ impl HTMLDataListElement {
 }
 
 impl<'a> HTMLDataListElementMethods for JSRef<'a, HTMLDataListElement> {
-    fn Options(&self) -> Temporary<HTMLCollection> {
+    fn Options(self) -> Temporary<HTMLCollection> {
         struct HTMLDataListOptionsFilter;
         impl CollectionFilter for HTMLDataListOptionsFilter {
             fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 elem.is_htmloptionelement()
             }
         }
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let filter = box HTMLDataListOptionsFilter;
         let window = window_from_node(node).root();
         HTMLCollection::create(*window, node, filter)

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -26,14 +26,14 @@ impl HTMLDirectoryElementDerived for EventTarget {
 }
 
 impl HTMLDirectoryElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDirectoryElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDirectoryElement {
         HTMLDirectoryElement {
             htmlelement: HTMLElement::new_inherited(HTMLDirectoryElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDirectoryElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDirectoryElement> {
         let element = HTMLDirectoryElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDirectoryElementBinding::Wrap)
     }

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -26,14 +26,14 @@ impl HTMLDivElementDerived for EventTarget {
 }
 
 impl HTMLDivElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDivElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDivElement {
         HTMLDivElement {
             htmlelement: HTMLElement::new_inherited(HTMLDivElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDivElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDivElement> {
         let element = HTMLDivElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDivElementBinding::Wrap)
     }

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -26,14 +26,14 @@ impl HTMLDListElementDerived for EventTarget {
 }
 
 impl HTMLDListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLDListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLDListElement {
         HTMLDListElement {
             htmlelement: HTMLElement::new_inherited(HTMLDListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLDListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLDListElement> {
         let element = HTMLDListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLDListElementBinding::Wrap)
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -38,14 +38,14 @@ impl HTMLElementDerived for EventTarget {
 }
 
 impl HTMLElement {
-    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: &JSRef<Document>) -> HTMLElement {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: JSRef<Document>) -> HTMLElement {
         HTMLElement {
             element: Element::new_inherited(type_id, tag_name, namespace::HTML, None, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLElement> {
         let element = HTMLElement::new_inherited(HTMLElementTypeId, localName, document);
         Node::reflect_node(box element, document, HTMLElementBinding::Wrap)
     }
@@ -57,25 +57,25 @@ trait PrivateHTMLElementHelpers {
 
 impl<'a> PrivateHTMLElementHelpers for JSRef<'a, HTMLElement> {
     fn is_body_or_frameset(&self) -> bool {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.is_htmlbodyelement() || eventtarget.is_htmlframesetelement()
     }
 }
 
 impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("click")
     }
 
     fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
     fn GetOnload(&self) -> Option<EventHandlerNonNull> {
         if self.is_body_or_frameset() {
-            let win = window_from_node(self).root();
+            let win = window_from_node(*self).root();
             win.deref().GetOnload()
         } else {
             None
@@ -84,7 +84,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
 
     fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
         if self.is_body_or_frameset() {
-            let win = window_from_node(self).root();
+            let win = window_from_node(*self).root();
             win.deref().SetOnload(listener)
         }
     }
@@ -92,7 +92,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: &JSRef<Element> = ElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
     }
 
@@ -103,11 +103,11 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
         }
 
         if name.as_slice().starts_with("on") {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let (cx, url, reflector) = (window.get_cx(),
                                         window.get_url(),
                                         window.reflector().get_jsobject());
-            let evtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+            let evtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.as_slice().slice_from(2),
                                                   value);

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -63,28 +63,28 @@ impl<'a> PrivateHTMLElementHelpers for JSRef<'a, HTMLElement> {
 }
 
 impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
-    fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("click")
     }
 
-    fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
         if self.is_body_or_frameset() {
-            let win = window_from_node(*self).root();
+            let win = window_from_node(self).root();
             win.deref().GetOnload()
         } else {
             None
         }
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
         if self.is_body_or_frameset() {
-            let win = window_from_node(*self).root();
+            let win = window_from_node(self).root();
             win.deref().SetOnload(listener)
         }
     }

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -26,14 +26,14 @@ impl HTMLEmbedElementDerived for EventTarget {
 }
 
 impl HTMLEmbedElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLEmbedElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLEmbedElement {
         HTMLEmbedElement {
             htmlelement: HTMLElement::new_inherited(HTMLEmbedElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLEmbedElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLEmbedElement> {
         let element = HTMLEmbedElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLEmbedElementBinding::Wrap)
     }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -49,7 +49,7 @@ impl HTMLFieldSetElement {
 
 impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     // http://www.whatwg.org/html/#dom-fieldset-elements
-    fn Elements(&self) -> Temporary<HTMLCollection> {
+    fn Elements(self) -> Temporary<HTMLCollection> {
         struct ElementsFilter;
         impl CollectionFilter for ElementsFilter {
             fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
@@ -59,14 +59,14 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
                 elem != root && tag_names.iter().any(|&tag_name| tag_name == elem.deref().local_name.as_slice())
             }
         }
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let filter = box ElementsFilter;
         let window = window_from_node(node).root();
         HTMLCollection::create(*window, node, filter)
     }
 
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 
@@ -74,8 +74,8 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -34,14 +34,14 @@ impl HTMLFieldSetElementDerived for EventTarget {
 }
 
 impl HTMLFieldSetElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFieldSetElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFieldSetElement {
         HTMLFieldSetElement {
             htmlelement: HTMLElement::new_inherited(HTMLFieldSetElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFieldSetElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFieldSetElement> {
         let element = HTMLFieldSetElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFieldSetElementBinding::Wrap)
     }
@@ -52,22 +52,22 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     fn Elements(&self) -> Temporary<HTMLCollection> {
         struct ElementsFilter;
         impl CollectionFilter for ElementsFilter {
-            fn filter(&self, elem: &JSRef<Element>, root: &JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
                 static tag_names: StaticStringVec = &["button", "fieldset", "input",
                     "keygen", "object", "output", "select", "textarea"];
-                let root: &JSRef<Element> = ElementCast::to_ref(root).unwrap();
+                let root: JSRef<Element> = ElementCast::to_ref(root).unwrap();
                 elem != root && tag_names.iter().any(|&tag_name| tag_name == elem.deref().local_name.as_slice())
             }
         }
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let filter = box ElementsFilter;
         let window = window_from_node(node).root();
-        HTMLCollection::create(&*window, node, filter)
+        HTMLCollection::create(*window, node, filter)
     }
 
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled
@@ -75,14 +75,14 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -92,7 +92,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -124,7 +124,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -26,14 +26,14 @@ impl HTMLFontElementDerived for EventTarget {
 }
 
 impl HTMLFontElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFontElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFontElement {
         HTMLFontElement {
             htmlelement: HTMLElement::new_inherited(HTMLFontElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFontElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFontElement> {
         let element = HTMLFontElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFontElementBinding::Wrap)
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -26,14 +26,14 @@ impl HTMLFormElementDerived for EventTarget {
 }
 
 impl HTMLFormElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFormElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFormElement {
         HTMLFormElement {
             htmlelement: HTMLElement::new_inherited(HTMLFormElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFormElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFormElement> {
         let element = HTMLFormElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFormElementBinding::Wrap)
     }

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -26,14 +26,14 @@ impl HTMLFrameElementDerived for EventTarget {
 }
 
 impl HTMLFrameElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFrameElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFrameElement {
         HTMLFrameElement {
             htmlelement: HTMLElement::new_inherited(HTMLFrameElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFrameElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFrameElement> {
         let element = HTMLFrameElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFrameElementBinding::Wrap)
     }

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -26,14 +26,14 @@ impl HTMLFrameSetElementDerived for EventTarget {
 }
 
 impl HTMLFrameSetElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLFrameSetElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLFrameSetElement {
         HTMLFrameSetElement {
             htmlelement: HTMLElement::new_inherited(HTMLFrameSetElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLFrameSetElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLFrameSetElement> {
         let element = HTMLFrameSetElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLFrameSetElementBinding::Wrap)
     }

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -26,14 +26,14 @@ impl HTMLHeadElementDerived for EventTarget {
 }
 
 impl HTMLHeadElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLHeadElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLHeadElement {
         HTMLHeadElement {
             htmlelement: HTMLElement::new_inherited(HTMLHeadElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHeadElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLHeadElement> {
         let element = HTMLHeadElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHeadElementBinding::Wrap)
     }

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -37,7 +37,7 @@ impl HTMLHeadingElementDerived for EventTarget {
 }
 
 impl HTMLHeadingElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>, level: HeadingLevel) -> HTMLHeadingElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>, level: HeadingLevel) -> HTMLHeadingElement {
         HTMLHeadingElement {
             htmlelement: HTMLElement::new_inherited(HTMLHeadingElementTypeId, localName, document),
             level: level,
@@ -45,7 +45,7 @@ impl HTMLHeadingElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>, level: HeadingLevel) -> Temporary<HTMLHeadingElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>, level: HeadingLevel) -> Temporary<HTMLHeadingElement> {
         let element = HTMLHeadingElement::new_inherited(localName, document, level);
         Node::reflect_node(box element, document, HTMLHeadingElementBinding::Wrap)
     }

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -26,14 +26,14 @@ impl HTMLHRElementDerived for EventTarget {
 }
 
 impl HTMLHRElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLHRElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLHRElement {
         HTMLHRElement {
             htmlelement: HTMLElement::new_inherited(HTMLHRElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHRElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLHRElement> {
         let element = HTMLHRElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHRElementBinding::Wrap)
     }

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -26,14 +26,14 @@ impl HTMLHtmlElementDerived for EventTarget {
 }
 
 impl HTMLHtmlElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLHtmlElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLHtmlElement {
         HTMLHtmlElement {
             htmlelement: HTMLElement::new_inherited(HTMLHtmlElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLHtmlElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLHtmlElement> {
         let element = HTMLHtmlElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLHtmlElementBinding::Wrap)
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -74,13 +74,13 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn get_url(&self) -> Option<Url> {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_attribute(Null, "src").root().and_then(|src| {
             let url = src.deref().value();
             if url.as_slice().is_empty() {
                 None
             } else {
-                let window = window_from_node(self).root();
+                let window = window_from_node(*self).root();
                 UrlParser::new().base_url(&window.deref().page().get_url())
                     .parse(url.as_slice()).ok()
             }
@@ -100,7 +100,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
         };
 
         // Subpage Id
-        let window = window_from_node(self).root();
+        let window = window_from_node(*self).root();
         let page = window.deref().page();
         let subpage_id = page.get_next_subpage_id();
 
@@ -115,7 +115,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
 }
 
 impl HTMLIFrameElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLIFrameElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLIFrameElement {
         HTMLIFrameElement {
             htmlelement: HTMLElement::new_inherited(HTMLIFrameElementTypeId, localName, document),
             size: Traceable::new(Cell::new(None)),
@@ -124,7 +124,7 @@ impl HTMLIFrameElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLIFrameElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLIFrameElement> {
         let element = HTMLIFrameElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLIFrameElementBinding::Wrap)
     }
@@ -132,28 +132,28 @@ impl HTMLIFrameElement {
 
 impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
     fn Src(&self) -> DOMString {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_string_attribute("src")
     }
 
     fn SetSrc(&self, src: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_url_attribute("src", src)
     }
 
     fn Sandbox(&self) -> DOMString {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_string_attribute("sandbox")
     }
 
     fn SetSandbox(&self, sandbox: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("sandbox", sandbox);
     }
 
     fn GetContentWindow(&self) -> Option<Temporary<Window>> {
         self.size.deref().get().and_then(|size| {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let children = &*window.deref().page.children.deref().borrow();
             let child = children.iter().find(|child| {
                 child.subpage_id.unwrap() == size.subpage_id
@@ -169,7 +169,7 @@ impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -196,7 +196,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
         }
 
         if "src" == name.as_slice() {
-            let node: &JSRef<Node> = NodeCast::from_ref(self);
+            let node: JSRef<Node> = NodeCast::from_ref(*self);
             if node.is_in_doc() {
                 self.process_the_iframe_attributes()
             }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -131,29 +131,29 @@ impl HTMLIFrameElement {
 }
 
 impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
-    fn Src(&self) -> DOMString {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn Src(self) -> DOMString {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_string_attribute("src")
     }
 
-    fn SetSrc(&self, src: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetSrc(self, src: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_url_attribute("src", src)
     }
 
-    fn Sandbox(&self) -> DOMString {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn Sandbox(self) -> DOMString {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_string_attribute("sandbox")
     }
 
-    fn SetSandbox(&self, sandbox: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetSandbox(self, sandbox: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("sandbox", sandbox);
     }
 
-    fn GetContentWindow(&self) -> Option<Temporary<Window>> {
+    fn GetContentWindow(self) -> Option<Temporary<Window>> {
         self.size.deref().get().and_then(|size| {
-            let window = window_from_node(*self).root();
+            let window = window_from_node(self).root();
             let children = &*window.deref().page.children.deref().borrow();
             let child = children.iter().find(|child| {
                 child.subpage_id.unwrap() == size.subpage_id

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -46,7 +46,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
     /// Makes the local `image` member match the status of the `src` attribute and starts
     /// prefetching the image. This method must be called after `src` is changed.
     fn update_image(&self, value: Option<(DOMString, &Url)>) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let document = node.owner_doc().root();
         let window = document.deref().window.root();
         let image_cache = &window.image_cache_task;
@@ -72,7 +72,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
 }
 
 impl HTMLImageElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLImageElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLImageElement {
         HTMLImageElement {
             htmlelement: HTMLElement::new_inherited(HTMLImageElementTypeId, localName, document),
             image: Untraceable::new(RefCell::new(None)),
@@ -80,7 +80,7 @@ impl HTMLImageElement {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLImageElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLImageElement> {
         let element = HTMLImageElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLImageElementBinding::Wrap)
     }
@@ -100,99 +100,99 @@ impl<'a> HTMLImageElementMethods for JSRef<'a, HTMLImageElement> {
     make_getter!(Alt)
 
     fn SetAlt(&self, alt: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("alt", alt)
     }
 
     make_getter!(Src)
 
     fn SetSrc(&self, src: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_url_attribute("src", src)
     }
 
     make_getter!(UseMap)
 
     fn SetUseMap(&self, use_map: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("usemap", use_map)
     }
 
     make_bool_getter!(IsMap)
 
     fn SetIsMap(&self, is_map: bool) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("ismap", is_map.to_string())
     }
 
     fn Width(&self) -> u32 {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.width) as u32
     }
 
     fn SetWidth(&self, width: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("width", width)
     }
 
     fn Height(&self) -> u32 {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.height) as u32
     }
 
     fn SetHeight(&self, height: u32) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_uint_attribute("height", height)
     }
 
     make_getter!(Name)
 
     fn SetName(&self, name: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("name", name)
     }
 
     make_getter!(Align)
 
     fn SetAlign(&self, align: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("align", align)
     }
 
     make_uint_getter!(Hspace)
 
     fn SetHspace(&self, hspace: u32) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_uint_attribute("hspace", hspace)
     }
 
     make_uint_getter!(Vspace)
 
     fn SetVspace(&self, vspace: u32) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_uint_attribute("vspace", vspace)
     }
 
     make_getter!(LongDesc)
 
     fn SetLongDesc(&self, longdesc: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("longdesc", longdesc)
     }
 
     make_getter!(Border)
 
     fn SetBorder(&self, border: DOMString) {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.set_string_attribute("border", border)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -203,7 +203,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
         }
 
         if "src" == name.as_slice() {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             let url = window.deref().get_url();
             self.update_image(Some((value, &url)));
         }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -99,93 +99,93 @@ impl LayoutHTMLImageElementHelpers for JS<HTMLImageElement> {
 impl<'a> HTMLImageElementMethods for JSRef<'a, HTMLImageElement> {
     make_getter!(Alt)
 
-    fn SetAlt(&self, alt: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetAlt(self, alt: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("alt", alt)
     }
 
     make_getter!(Src)
 
-    fn SetSrc(&self, src: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetSrc(self, src: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_url_attribute("src", src)
     }
 
     make_getter!(UseMap)
 
-    fn SetUseMap(&self, use_map: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetUseMap(self, use_map: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("usemap", use_map)
     }
 
     make_bool_getter!(IsMap)
 
-    fn SetIsMap(&self, is_map: bool) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetIsMap(self, is_map: bool) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("ismap", is_map.to_string())
     }
 
-    fn Width(&self) -> u32 {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Width(self) -> u32 {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.width) as u32
     }
 
-    fn SetWidth(&self, width: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetWidth(self, width: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("width", width)
     }
 
-    fn Height(&self) -> u32 {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Height(self) -> u32 {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.height) as u32
     }
 
-    fn SetHeight(&self, height: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetHeight(self, height: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("height", height)
     }
 
     make_getter!(Name)
 
-    fn SetName(&self, name: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetName(self, name: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("name", name)
     }
 
     make_getter!(Align)
 
-    fn SetAlign(&self, align: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetAlign(self, align: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("align", align)
     }
 
     make_uint_getter!(Hspace)
 
-    fn SetHspace(&self, hspace: u32) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetHspace(self, hspace: u32) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_uint_attribute("hspace", hspace)
     }
 
     make_uint_getter!(Vspace)
 
-    fn SetVspace(&self, vspace: u32) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetVspace(self, vspace: u32) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_uint_attribute("vspace", vspace)
     }
 
     make_getter!(LongDesc)
 
-    fn SetLongDesc(&self, longdesc: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetLongDesc(self, longdesc: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("longdesc", longdesc)
     }
 
     make_getter!(Border)
 
-    fn SetBorder(&self, border: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetBorder(self, border: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("border", border)
     }
 }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -31,14 +31,14 @@ impl HTMLInputElementDerived for EventTarget {
 }
 
 impl HTMLInputElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLInputElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLInputElement {
         HTMLInputElement {
             htmlelement: HTMLElement::new_inherited(HTMLInputElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLInputElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLInputElement> {
         let element = HTMLInputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLInputElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -83,7 +83,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -100,7 +100,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -110,7 +110,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -26,14 +26,14 @@ impl HTMLLabelElementDerived for EventTarget {
 }
 
 impl HTMLLabelElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLabelElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLabelElement {
         HTMLLabelElement {
             htmlelement: HTMLElement::new_inherited(HTMLLabelElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLabelElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLabelElement> {
         let element = HTMLLabelElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLabelElementBinding::Wrap)
     }

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -26,14 +26,14 @@ impl HTMLLegendElementDerived for EventTarget {
 }
 
 impl HTMLLegendElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLegendElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLegendElement {
         HTMLLegendElement {
             htmlelement: HTMLElement::new_inherited(HTMLLegendElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLegendElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLegendElement> {
         let element = HTMLLegendElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLegendElementBinding::Wrap)
     }

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -26,14 +26,14 @@ impl HTMLLIElementDerived for EventTarget {
 }
 
 impl HTMLLIElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLIElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLIElement {
         HTMLLIElement {
             htmlelement: HTMLElement::new_inherited(HTMLLIElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLIElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLIElement> {
         let element = HTMLLIElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLIElementBinding::Wrap)
     }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -35,14 +35,14 @@ impl HTMLLinkElementDerived for EventTarget {
 }
 
 impl HTMLLinkElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLLinkElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLLinkElement {
         HTMLLinkElement {
             htmlelement: HTMLElement::new_inherited(HTMLLinkElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLLinkElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLLinkElement> {
         let element = HTMLLinkElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLLinkElementBinding::Wrap)
     }
@@ -50,7 +50,7 @@ impl HTMLLinkElement {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -60,7 +60,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(true),
             _ => ()
@@ -73,7 +73,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "href" => node.set_enabled_state(false),
             _ => ()
@@ -87,7 +87,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
         }
 
         if tree_in_doc {
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
 
             // FIXME: workaround for https://github.com/mozilla/rust/issues/13246;
             // we get unrooting order failures if these are inside the match.
@@ -119,7 +119,7 @@ trait PrivateHTMLLinkElementHelpers {
 
 impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
     fn handle_stylesheet_url(&self, href: &str) {
-        let window = window_from_node(self).root();
+        let window = window_from_node(*self).root();
         match UrlParser::new().base_url(&window.deref().page().get_url()).parse(href) {
             Ok(url) => {
                 let LayoutChan(ref layout_chan) = *window.deref().page().layout_chan;

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -26,14 +26,14 @@ impl HTMLMapElementDerived for EventTarget {
 }
 
 impl HTMLMapElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLMapElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLMapElement {
         HTMLMapElement {
             htmlelement: HTMLElement::new_inherited(HTMLMapElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMapElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLMapElement> {
         let element = HTMLMapElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMapElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -29,7 +29,7 @@ impl HTMLMediaElementDerived for EventTarget {
 }
 
 impl HTMLMediaElement {
-    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: &JSRef<Document>) -> HTMLMediaElement {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: JSRef<Document>) -> HTMLMediaElement {
         HTMLMediaElement {
             htmlelement: HTMLElement::new_inherited(type_id, tag_name, document)
         }

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -26,14 +26,14 @@ impl HTMLMetaElementDerived for EventTarget {
 }
 
 impl HTMLMetaElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLMetaElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLMetaElement {
         HTMLMetaElement {
             htmlelement: HTMLElement::new_inherited(HTMLMetaElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMetaElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLMetaElement> {
         let element = HTMLMetaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMetaElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -26,14 +26,14 @@ impl HTMLMeterElementDerived for EventTarget {
 }
 
 impl HTMLMeterElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLMeterElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLMeterElement {
         HTMLMeterElement {
             htmlelement: HTMLElement::new_inherited(HTMLMeterElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLMeterElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLMeterElement> {
         let element = HTMLMeterElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLMeterElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -26,14 +26,14 @@ impl HTMLModElementDerived for EventTarget {
 }
 
 impl HTMLModElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLModElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLModElement {
         HTMLModElement {
             htmlelement: HTMLElement::new_inherited(HTMLModElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLModElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLModElement> {
         let element = HTMLModElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLModElementBinding::Wrap)
     }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -83,8 +83,8 @@ pub fn is_image_data(uri: &str) -> bool {
 }
 
 impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -39,14 +39,14 @@ impl HTMLObjectElementDerived for EventTarget {
 }
 
 impl HTMLObjectElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLObjectElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLObjectElement {
         HTMLObjectElement {
             htmlelement: HTMLElement::new_inherited(HTMLObjectElementTypeId, localName, document),
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLObjectElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLObjectElement> {
         let element = HTMLObjectElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLObjectElementBinding::Wrap)
     }
@@ -60,7 +60,7 @@ impl<'a> ProcessDataURL for JSRef<'a, HTMLObjectElement> {
     // Makes the local `data` member match the status of the `data` attribute and starts
     /// prefetching the image. This method must be called after `data` is changed.
     fn process_data_url(&self, image_cache: ImageCacheTask) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
 
         // TODO: support other values
         match (elem.get_attribute(Null, "type").map(|x| x.root().Value()),
@@ -84,14 +84,14 @@ pub fn is_image_data(uri: &str) -> bool {
 
 impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -102,7 +102,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
         }
 
         if "data" == name.as_slice() {
-            let window = window_from_node(self).root();
+            let window = window_from_node(*self).root();
             self.process_data_url(window.deref().image_cache_task.clone());
         }
     }

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -26,14 +26,14 @@ impl HTMLOListElementDerived for EventTarget {
 }
 
 impl HTMLOListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOListElement {
         HTMLOListElement {
             htmlelement: HTMLElement::new_inherited(HTMLOListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOListElement> {
         let element = HTMLOListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOListElementBinding::Wrap)
     }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -31,14 +31,14 @@ impl HTMLOptGroupElementDerived for EventTarget {
 }
 
 impl HTMLOptGroupElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOptGroupElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOptGroupElement {
         HTMLOptGroupElement {
             htmlelement: HTMLElement::new_inherited(HTMLOptGroupElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptGroupElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOptGroupElement> {
         let element = HTMLOptGroupElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptGroupElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
 
     // http://www.whatwg.org/html#dom-optgroup-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -87,7 +87,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html#dom-optgroup-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -31,14 +31,14 @@ impl HTMLOptionElementDerived for EventTarget {
 }
 
 impl HTMLOptionElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOptionElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOptionElement {
         HTMLOptionElement {
             htmlelement: HTMLElement::new_inherited(HTMLOptionElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOptionElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOptionElement> {
         let element = HTMLOptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOptionElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
 
     // http://www.whatwg.org/html/#dom-option-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -83,7 +83,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -100,7 +100,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_parent_disabled_state_for_option();
     }
 
@@ -110,7 +110,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.parent_node().is_some() {
             node.check_parent_disabled_state_for_option();
         } else {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-option-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -42,8 +42,8 @@ impl HTMLOutputElement {
 }
 
 impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -28,14 +28,14 @@ impl HTMLOutputElementDerived for EventTarget {
 }
 
 impl HTMLOutputElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLOutputElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLOutputElement {
         HTMLOutputElement {
             htmlelement: HTMLElement::new_inherited(HTMLOutputElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLOutputElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLOutputElement> {
         let element = HTMLOutputElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLOutputElementBinding::Wrap)
     }
@@ -43,8 +43,8 @@ impl HTMLOutputElement {
 
 impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 }
 

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -26,14 +26,14 @@ impl HTMLParagraphElementDerived for EventTarget {
 }
 
 impl HTMLParagraphElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLParagraphElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLParagraphElement {
         HTMLParagraphElement {
             htmlelement: HTMLElement::new_inherited(HTMLParagraphElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLParagraphElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLParagraphElement> {
         let element = HTMLParagraphElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLParagraphElementBinding::Wrap)
     }

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -26,14 +26,14 @@ impl HTMLParamElementDerived for EventTarget {
 }
 
 impl HTMLParamElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLParamElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLParamElement {
         HTMLParamElement {
             htmlelement: HTMLElement::new_inherited(HTMLParamElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLParamElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLParamElement> {
         let element = HTMLParamElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLParamElementBinding::Wrap)
     }

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -26,14 +26,14 @@ impl HTMLPreElementDerived for EventTarget {
 }
 
 impl HTMLPreElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLPreElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLPreElement {
         HTMLPreElement {
             htmlelement: HTMLElement::new_inherited(HTMLPreElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLPreElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLPreElement> {
         let element = HTMLPreElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLPreElementBinding::Wrap)
     }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -26,14 +26,14 @@ impl HTMLProgressElementDerived for EventTarget {
 }
 
 impl HTMLProgressElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLProgressElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLProgressElement {
         HTMLProgressElement {
             htmlelement: HTMLElement::new_inherited(HTMLProgressElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLProgressElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLProgressElement> {
         let element = HTMLProgressElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLProgressElementBinding::Wrap)
     }

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -26,14 +26,14 @@ impl HTMLQuoteElementDerived for EventTarget {
 }
 
 impl HTMLQuoteElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLQuoteElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLQuoteElement {
         HTMLQuoteElement {
             htmlelement: HTMLElement::new_inherited(HTMLQuoteElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLQuoteElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLQuoteElement> {
         let element = HTMLQuoteElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLQuoteElementBinding::Wrap)
     }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -32,14 +32,14 @@ impl HTMLScriptElementDerived for EventTarget {
 }
 
 impl HTMLScriptElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLScriptElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLScriptElement {
         HTMLScriptElement {
             htmlelement: HTMLElement::new_inherited(HTMLScriptElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLScriptElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLScriptElement> {
         let element = HTMLScriptElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLScriptElementBinding::Wrap)
     }
@@ -74,7 +74,7 @@ static SCRIPT_JS_MIMES: StaticStringVec = &[
 
 impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
     fn is_javascript(&self) -> bool {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         match element.get_attribute(Null, "type").root().map(|s| s.Value()) {
             Some(ref s) if s.is_empty() => {
                 // type attr exists, but empty means js
@@ -108,19 +108,19 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 
 impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
     fn Src(&self) -> DOMString {
-        let element: &JSRef<Element> = ElementCast::from_ref(self);
+        let element: JSRef<Element> = ElementCast::from_ref(*self);
         element.get_url_attribute("src")
     }
 
     // http://www.whatwg.org/html/#dom-script-text
     fn Text(&self) -> DOMString {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         Node::collect_text_contents(node.children())
     }
 
     // http://www.whatwg.org/html/#dom-script-text
     fn SetText(&self, value: DOMString) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -107,20 +107,20 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 }
 
 impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
-    fn Src(&self) -> DOMString {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn Src(self) -> DOMString {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_url_attribute("src")
     }
 
     // http://www.whatwg.org/html/#dom-script-text
-    fn Text(&self) -> DOMString {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Text(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         Node::collect_text_contents(node.children())
     }
 
     // http://www.whatwg.org/html/#dom-script-text
-    fn SetText(&self, value: DOMString) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetText(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -48,21 +48,21 @@ impl HTMLSelectElement {
 }
 
 impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 
     // Note: this function currently only exists for test_union.html.
-    fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) {
+    fn Add(self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) {
     }
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -34,14 +34,14 @@ impl HTMLSelectElementDerived for EventTarget {
 }
 
 impl HTMLSelectElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLSelectElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLSelectElement {
         HTMLSelectElement {
             htmlelement: HTMLElement::new_inherited(HTMLSelectElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSelectElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLSelectElement> {
         let element = HTMLSelectElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSelectElementBinding::Wrap)
     }
@@ -49,8 +49,8 @@ impl HTMLSelectElement {
 
 impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
     fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(self).root();
-        ValidityState::new(&*window)
+        let window = window_from_node(*self).root();
+        ValidityState::new(*window)
     }
 
     // Note: this function currently only exists for test_union.html.
@@ -62,14 +62,14 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -79,7 +79,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -95,7 +95,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -112,7 +112,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -122,7 +122,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -34,24 +34,24 @@ pub fn serialize(iterator: &mut NodeIterator) -> String {
         }
         match node.type_id() {
             ElementNodeTypeId(..) => {
-                let elem: &JSRef<Element> = ElementCast::to_ref(&node).unwrap();
+                let elem: JSRef<Element> = ElementCast::to_ref(node).unwrap();
                 serialize_elem(elem, &mut open_elements, &mut html)
             }
             CommentNodeTypeId => {
-                let comment: &JSRef<Comment> = CommentCast::to_ref(&node).unwrap();
+                let comment: JSRef<Comment> = CommentCast::to_ref(node).unwrap();
                 serialize_comment(comment, &mut html)
             }
             TextNodeTypeId => {
-                let text: &JSRef<Text> = TextCast::to_ref(&node).unwrap();
+                let text: JSRef<Text> = TextCast::to_ref(node).unwrap();
                 serialize_text(text, &mut html)
             }
             DoctypeNodeTypeId => {
-                let doctype: &JSRef<DocumentType> = DocumentTypeCast::to_ref(&node).unwrap();
+                let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
                 serialize_doctype(doctype, &mut html)
             }
             ProcessingInstructionNodeTypeId => {
-                let processing_instruction: &JSRef<ProcessingInstruction> =
-                    ProcessingInstructionCast::to_ref(&node).unwrap();
+                let processing_instruction: JSRef<ProcessingInstruction> =
+                    ProcessingInstructionCast::to_ref(node).unwrap();
                 serialize_processing_instruction(processing_instruction, &mut html)
             }
             DocumentFragmentNodeTypeId => {}
@@ -68,17 +68,17 @@ pub fn serialize(iterator: &mut NodeIterator) -> String {
     html
 }
 
-fn serialize_comment(comment: &JSRef<Comment>, html: &mut String) {
+fn serialize_comment(comment: JSRef<Comment>, html: &mut String) {
     html.push_str("<!--");
     html.push_str(comment.deref().characterdata.data.deref().borrow().as_slice());
     html.push_str("-->");
 }
 
-fn serialize_text(text: &JSRef<Text>, html: &mut String) {
-    let text_node: &JSRef<Node> = NodeCast::from_ref(text);
+fn serialize_text(text: JSRef<Text>, html: &mut String) {
+    let text_node: JSRef<Node> = NodeCast::from_ref(text);
     match text_node.parent_node().map(|node| node.root()) {
         Some(ref parent) if parent.is_element() => {
-            let elem: &JSRef<Element> = ElementCast::to_ref(&**parent).unwrap();
+            let elem: JSRef<Element> = ElementCast::to_ref(**parent).unwrap();
             match elem.deref().local_name.as_slice() {
                 "style" | "script" | "xmp" | "iframe" |
                 "noembed" | "noframes" | "plaintext" |
@@ -91,7 +91,7 @@ fn serialize_text(text: &JSRef<Text>, html: &mut String) {
     }
 }
 
-fn serialize_processing_instruction(processing_instruction: &JSRef<ProcessingInstruction>,
+fn serialize_processing_instruction(processing_instruction: JSRef<ProcessingInstruction>,
                                     html: &mut String) {
     html.push_str("<?");
     html.push_str(processing_instruction.deref().target.as_slice());
@@ -100,27 +100,27 @@ fn serialize_processing_instruction(processing_instruction: &JSRef<ProcessingIns
     html.push_str("?>");
 }
 
-fn serialize_doctype(doctype: &JSRef<DocumentType>, html: &mut String) {
+fn serialize_doctype(doctype: JSRef<DocumentType>, html: &mut String) {
     html.push_str("<!DOCTYPE");
     html.push_str(doctype.deref().name.as_slice());
     html.push_char('>');
 }
 
-fn serialize_elem(elem: &JSRef<Element>, open_elements: &mut Vec<String>, html: &mut String) {
+fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &mut String) {
     html.push_char('<');
     html.push_str(elem.deref().local_name.as_slice());
     for attr in elem.deref().attrs.borrow().iter() {
         let attr = attr.root();
-        serialize_attr(&*attr, html);
+        serialize_attr(*attr, html);
     };
     html.push_char('>');
 
     match elem.deref().local_name.as_slice() {
         "pre" | "listing" | "textarea" if elem.deref().namespace == namespace::HTML => {
-            let node: &JSRef<Node> = NodeCast::from_ref(elem);
+            let node: JSRef<Node> = NodeCast::from_ref(elem);
             match node.first_child().map(|child| child.root()) {
                 Some(ref child) if child.is_text() => {
-                    let text: &JSRef<CharacterData> = CharacterDataCast::to_ref(&**child).unwrap();
+                    let text: JSRef<CharacterData> = CharacterDataCast::to_ref(**child).unwrap();
                     if text.deref().data.deref().borrow().len() > 0 && text.deref().data.deref().borrow().as_slice().char_at(0) == '\n' {
                         html.push_char('\x0A');
                     }
@@ -136,7 +136,7 @@ fn serialize_elem(elem: &JSRef<Element>, open_elements: &mut Vec<String>, html: 
     }
 }
 
-fn serialize_attr(attr: &JSRef<Attr>, html: &mut String) {
+fn serialize_attr(attr: JSRef<Attr>, html: &mut String) {
     html.push_char(' ');
     if attr.deref().namespace == namespace::XML {
         html.push_str("xml:");

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -26,14 +26,14 @@ impl HTMLSourceElementDerived for EventTarget {
 }
 
 impl HTMLSourceElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLSourceElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLSourceElement {
         HTMLSourceElement {
             htmlelement: HTMLElement::new_inherited(HTMLSourceElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSourceElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLSourceElement> {
         let element = HTMLSourceElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSourceElementBinding::Wrap)
     }

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -26,14 +26,14 @@ impl HTMLSpanElementDerived for EventTarget {
 }
 
 impl HTMLSpanElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLSpanElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLSpanElement {
         HTMLSpanElement {
             htmlelement: HTMLElement::new_inherited(HTMLSpanElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLSpanElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLSpanElement> {
         let element = HTMLSpanElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLSpanElementBinding::Wrap)
     }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -30,14 +30,14 @@ impl HTMLStyleElementDerived for EventTarget {
 }
 
 impl HTMLStyleElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLStyleElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLStyleElement {
         HTMLStyleElement {
             htmlelement: HTMLElement::new_inherited(HTMLStyleElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLStyleElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLStyleElement> {
         let element = HTMLStyleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLStyleElementBinding::Wrap)
     }
@@ -49,7 +49,7 @@ pub trait StyleElementHelpers {
 
 impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
     fn parse_own_css(&self) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         assert!(node.is_in_doc());
 
         let win = window_from_node(node).root();
@@ -64,17 +64,17 @@ impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn child_inserted(&self, child: &JSRef<Node>) {
+    fn child_inserted(&self, child: JSRef<Node>) {
         match self.super_type() {
             Some(ref s) => s.child_inserted(child),
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.is_in_doc() {
             self.parse_own_css();
         }

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableCaptionElementDerived for EventTarget {
 }
 
 impl HTMLTableCaptionElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableCaptionElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableCaptionElement {
         HTMLTableCaptionElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableCaptionElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableCaptionElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableCaptionElement> {
         let element = HTMLTableCaptionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableCaptionElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -29,7 +29,7 @@ impl HTMLTableCellElementDerived for EventTarget {
 }
 
 impl HTMLTableCellElement {
-    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: &JSRef<Document>) -> HTMLTableCellElement {
+    pub fn new_inherited(type_id: ElementTypeId, tag_name: DOMString, document: JSRef<Document>) -> HTMLTableCellElement {
         HTMLTableCellElement {
             htmlelement: HTMLElement::new_inherited(type_id, tag_name, document)
         }

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableColElementDerived for EventTarget {
 }
 
 impl HTMLTableColElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableColElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableColElement {
         HTMLTableColElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableColElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableColElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableColElement> {
         let element = HTMLTableColElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableColElementBinding::Wrap)
     }

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableDataCellElementDerived for EventTarget {
 }
 
 impl HTMLTableDataCellElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableDataCellElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableDataCellElement {
         HTMLTableDataCellElement {
             htmltablecellelement: HTMLTableCellElement::new_inherited(HTMLTableDataCellElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableDataCellElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableDataCellElement> {
         let element = HTMLTableDataCellElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableDataCellElementBinding::Wrap)
     }

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -30,14 +30,14 @@ impl HTMLTableElementDerived for EventTarget {
 }
 
 impl HTMLTableElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableElement {
         HTMLTableElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableElement> {
         let element = HTMLTableElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableElementBinding::Wrap)
     }
@@ -53,30 +53,30 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
 
     //  http://www.whatwg.org/html/#dom-table-caption
     fn GetCaption(&self) -> Option<Temporary<HTMLTableCaptionElement>> {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.children().find(|child| {
             child.type_id() == ElementNodeTypeId(HTMLTableCaptionElementTypeId)
         }).map(|node| {
-            Temporary::from_rooted(HTMLTableCaptionElementCast::to_ref(&node).unwrap())
+            Temporary::from_rooted(HTMLTableCaptionElementCast::to_ref(node).unwrap())
         })
     }
 
     // http://www.whatwg.org/html/#dom-table-caption
     fn SetCaption(&self, new_caption: Option<JSRef<HTMLTableCaptionElement>>) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let old_caption = self.GetCaption();
 
         match old_caption {
             Some(htmlelem) => {
                 let htmlelem_jsref = &*htmlelem.root();
-                let old_caption_node: &JSRef<Node> = NodeCast::from_ref(htmlelem_jsref);
+                let old_caption_node: JSRef<Node> = NodeCast::from_ref(*htmlelem_jsref);
                 assert!(node.RemoveChild(old_caption_node).is_ok());
             }
             None => ()
         }
 
         new_caption.map(|caption| {
-            let new_caption_node: &JSRef<Node> = NodeCast::from_ref(&caption);
+            let new_caption_node: JSRef<Node> = NodeCast::from_ref(caption);
             assert!(node.AppendChild(new_caption_node).is_ok());
         });
     }

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -50,10 +50,9 @@ impl Reflectable for HTMLTableElement {
 }
 
 impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
-
     //  http://www.whatwg.org/html/#dom-table-caption
-    fn GetCaption(&self) -> Option<Temporary<HTMLTableCaptionElement>> {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetCaption(self) -> Option<Temporary<HTMLTableCaptionElement>> {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.children().find(|child| {
             child.type_id() == ElementNodeTypeId(HTMLTableCaptionElementTypeId)
         }).map(|node| {
@@ -62,8 +61,8 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
     }
 
     // http://www.whatwg.org/html/#dom-table-caption
-    fn SetCaption(&self, new_caption: Option<JSRef<HTMLTableCaptionElement>>) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetCaption(self, new_caption: Option<JSRef<HTMLTableCaptionElement>>) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let old_caption = self.GetCaption();
 
         match old_caption {

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableHeaderCellElementDerived for EventTarget {
 }
 
 impl HTMLTableHeaderCellElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableHeaderCellElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableHeaderCellElement {
         HTMLTableHeaderCellElement {
             htmltablecellelement: HTMLTableCellElement::new_inherited(HTMLTableHeaderCellElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableHeaderCellElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableHeaderCellElement> {
         let element = HTMLTableHeaderCellElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableHeaderCellElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableRowElementDerived for EventTarget {
 }
 
 impl HTMLTableRowElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableRowElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableRowElement {
         HTMLTableRowElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableRowElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableRowElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableRowElement> {
         let element = HTMLTableRowElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableRowElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -26,14 +26,14 @@ impl HTMLTableSectionElementDerived for EventTarget {
 }
 
 impl HTMLTableSectionElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTableSectionElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTableSectionElement {
         HTMLTableSectionElement {
             htmlelement: HTMLElement::new_inherited(HTMLTableSectionElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTableSectionElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTableSectionElement> {
         let element = HTMLTableSectionElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTableSectionElementBinding::Wrap)
     }

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -26,14 +26,14 @@ impl HTMLTemplateElementDerived for EventTarget {
 }
 
 impl HTMLTemplateElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTemplateElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTemplateElement {
         HTMLTemplateElement {
             htmlelement: HTMLElement::new_inherited(HTMLTemplateElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTemplateElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTemplateElement> {
         let element = HTMLTemplateElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTemplateElementBinding::Wrap)
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -31,14 +31,14 @@ impl HTMLTextAreaElementDerived for EventTarget {
 }
 
 impl HTMLTextAreaElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTextAreaElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTextAreaElement {
         HTMLTextAreaElement {
             htmlelement: HTMLElement::new_inherited(HTMLTextAreaElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTextAreaElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTextAreaElement> {
         let element = HTMLTextAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTextAreaElementBinding::Wrap)
     }
@@ -50,14 +50,14 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     fn SetDisabled(&self, disabled: bool) {
-        let elem: &JSRef<Element> = ElementCast::from_ref(self);
+        let elem: JSRef<Element> = ElementCast::from_ref(*self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }
 
 impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_ref(self);
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
     }
 
@@ -67,7 +67,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(true);
@@ -83,7 +83,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         match name.as_slice() {
             "disabled" => {
                 node.set_disabled_state(false);
@@ -100,7 +100,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
     }
 
@@ -110,7 +110,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             _ => (),
         }
 
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.is_htmlfieldsetelement()) {
             node.check_ancestors_disabled_state_for_form_control();
         } else {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -26,14 +26,14 @@ impl HTMLTimeElementDerived for EventTarget {
 }
 
 impl HTMLTimeElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTimeElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTimeElement {
         HTMLTimeElement {
             htmlelement: HTMLElement::new_inherited(HTMLTimeElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTimeElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTimeElement> {
         let element = HTMLTimeElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTimeElementBinding::Wrap)
     }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -29,14 +29,14 @@ impl HTMLTitleElementDerived for EventTarget {
 }
 
 impl HTMLTitleElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTitleElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTitleElement {
         HTMLTitleElement {
             htmlelement: HTMLElement::new_inherited(HTMLTitleElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTitleElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTitleElement> {
         let element = HTMLTitleElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTitleElementBinding::Wrap)
     }
@@ -45,10 +45,10 @@ impl HTMLTitleElement {
 impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     // http://www.whatwg.org/html/#dom-title-text
     fn Text(&self) -> DOMString {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         let mut content = String::new();
         for child in node.children() {
-            let text: Option<&JSRef<Text>> = TextCast::to_ref(&child);
+            let text: Option<JSRef<Text>> = TextCast::to_ref(child);
             match text {
                 Some(text) => content.push_str(text.characterdata.data.borrow().as_slice()),
                 None => (),
@@ -59,7 +59,7 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
 
     // http://www.whatwg.org/html/#dom-title-text
     fn SetText(&self, value: DOMString) {
-        let node: &JSRef<Node> = NodeCast::from_ref(self);
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -44,8 +44,8 @@ impl HTMLTitleElement {
 
 impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     // http://www.whatwg.org/html/#dom-title-text
-    fn Text(&self) -> DOMString {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Text(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let mut content = String::new();
         for child in node.children() {
             let text: Option<JSRef<Text>> = TextCast::to_ref(child);
@@ -58,8 +58,8 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     }
 
     // http://www.whatwg.org/html/#dom-title-text
-    fn SetText(&self, value: DOMString) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetText(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -26,14 +26,14 @@ impl HTMLTrackElementDerived for EventTarget {
 }
 
 impl HTMLTrackElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLTrackElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLTrackElement {
         HTMLTrackElement {
             htmlelement: HTMLElement::new_inherited(HTMLTrackElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLTrackElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLTrackElement> {
         let element = HTMLTrackElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLTrackElementBinding::Wrap)
     }

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -26,14 +26,14 @@ impl HTMLUListElementDerived for EventTarget {
 }
 
 impl HTMLUListElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLUListElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLUListElement {
         HTMLUListElement {
             htmlelement: HTMLElement::new_inherited(HTMLUListElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLUListElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLUListElement> {
         let element = HTMLUListElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLUListElementBinding::Wrap)
     }

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -26,14 +26,14 @@ impl HTMLUnknownElementDerived for EventTarget {
 }
 
 impl HTMLUnknownElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLUnknownElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLUnknownElement {
         HTMLUnknownElement {
             htmlelement: HTMLElement::new_inherited(HTMLUnknownElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLUnknownElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLUnknownElement> {
         let element = HTMLUnknownElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLUnknownElementBinding::Wrap)
     }

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -26,14 +26,14 @@ impl HTMLVideoElementDerived for EventTarget {
 }
 
 impl HTMLVideoElement {
-    pub fn new_inherited(localName: DOMString, document: &JSRef<Document>) -> HTMLVideoElement {
+    pub fn new_inherited(localName: DOMString, document: JSRef<Document>) -> HTMLVideoElement {
         HTMLVideoElement {
             htmlmediaelement: HTMLMediaElement::new_inherited(HTMLVideoElementTypeId, localName, document)
         }
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(localName: DOMString, document: &JSRef<Document>) -> Temporary<HTMLVideoElement> {
+    pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLVideoElement> {
         let element = HTMLVideoElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLVideoElementBinding::Wrap)
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -29,9 +29,9 @@ impl Location {
         }
     }
 
-    pub fn new(window: &JSRef<Window>, page: Rc<Page>) -> Temporary<Location> {
+    pub fn new(window: JSRef<Window>, page: Rc<Page>) -> Temporary<Location> {
         reflect_dom_object(box Location::new_inherited(page),
-                           &Window(*window),
+                           &Window(window),
                            LocationBinding::Wrap)
     }
 }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -37,11 +37,11 @@ impl Location {
 }
 
 impl<'a> LocationMethods for JSRef<'a, Location> {
-    fn Href(&self) -> DOMString {
+    fn Href(self) -> DOMString {
         self.page.get_url().serialize()
     }
 
-    fn Search(&self) -> DOMString {
+    fn Search(self) -> DOMString {
         match self.page.get_url().query {
             None => "".to_string(),
             Some(ref query) if query.as_slice() == "" => "".to_string(),
@@ -49,7 +49,7 @@ impl<'a> LocationMethods for JSRef<'a, Location> {
         }
     }
 
-    fn Hash(&self) -> DOMString {
+    fn Hash(self) -> DOMString {
         match self.page.get_url().fragment {
             None => "".to_string(),
             Some(ref hash) if hash.as_slice() == "" => "".to_string(),

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -11,7 +11,7 @@ macro_rules! make_getter(
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             element.get_string_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -24,7 +24,7 @@ macro_rules! make_bool_getter(
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             element.has_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -37,7 +37,7 @@ macro_rules! make_uint_getter(
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: &JSRef<Element> = ElementCast::from_ref(self);
+            let element: JSRef<Element> = ElementCast::from_ref(*self);
             element.get_uint_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -7,11 +7,11 @@
 #[macro_export]
 macro_rules! make_getter(
     ( $attr:ident ) => (
-        fn $attr(&self) -> DOMString {
+        fn $attr(self) -> DOMString {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             element.get_string_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -20,11 +20,11 @@ macro_rules! make_getter(
 #[macro_export]
 macro_rules! make_bool_getter(
     ( $attr:ident ) => (
-        fn $attr(&self) -> bool {
+        fn $attr(self) -> bool {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             element.has_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -33,11 +33,11 @@ macro_rules! make_bool_getter(
 #[macro_export]
 macro_rules! make_uint_getter(
     ( $attr:ident ) => (
-        fn $attr(&self) -> u32 {
+        fn $attr(self) -> u32 {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             element.get_uint_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -80,15 +80,15 @@ impl MessageEvent {
 }
 
 impl<'a> MessageEventMethods for JSRef<'a, MessageEvent> {
-    fn Data(&self, _cx: *mut JSContext) -> JSVal {
+    fn Data(self, _cx: *mut JSContext) -> JSVal {
         *self.data
     }
 
-    fn Origin(&self) -> DOMString {
+    fn Origin(self) -> DOMString {
         self.origin.clone()
     }
 
-    fn LastEventId(&self) -> DOMString {
+    fn LastEventId(self) -> DOMString {
         self.lastEventId.clone()
     }
 }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -52,9 +52,9 @@ impl MessageEvent {
         let ev = reflect_dom_object(box MessageEvent::new_inherited(data, origin, lastEventId),
                                     global,
                                     MessageEventBinding::Wrap).root();
-        let event: &JSRef<Event> = EventCast::from_ref(&*ev);
+        let event: JSRef<Event> = EventCast::from_ref(*ev);
         event.InitEvent(type_, bubbles, cancelable);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -68,14 +68,14 @@ impl MessageEvent {
 }
 
 impl MessageEvent {
-    pub fn dispatch_jsval(target: &JSRef<EventTarget>,
+    pub fn dispatch_jsval(target: JSRef<EventTarget>,
                           scope: &GlobalRef,
                           message: JSVal) {
         let messageevent = MessageEvent::new(
             scope, "message".to_string(), false, false, message,
             "".to_string(), "".to_string()).root();
-        let event: &JSRef<Event> = EventCast::from_ref(&*messageevent);
-        target.dispatch_event_with_target(None, &*event).unwrap();
+        let event: JSRef<Event> = EventCast::from_ref(*messageevent);
+        target.dispatch_event_with_target(None, event).unwrap();
     }
 }
 

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -57,13 +57,13 @@ impl MouseEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &JSRef<Window>) -> Temporary<MouseEvent> {
+    pub fn new_uninitialized(window: JSRef<Window>) -> Temporary<MouseEvent> {
         reflect_dom_object(box MouseEvent::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            MouseEventBinding::Wrap)
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                type_: DOMString,
                canBubble: bool,
                cancelable: bool,
@@ -84,7 +84,7 @@ impl MouseEvent {
                                   screenX, screenY, clientX, clientY,
                                   ctrlKey, altKey, shiftKey, metaKey,
                                   button, relatedTarget);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -160,7 +160,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
                       metaKeyArg: bool,
                       buttonArg: i16,
                       relatedTargetArg: Option<JSRef<EventTarget>>) {
-        let uievent: &JSRef<UIEvent> = UIEventCast::from_ref(self);
+        let uievent: JSRef<UIEvent> = UIEventCast::from_ref(*self);
         uievent.InitUIEvent(typeArg, canBubbleArg, cancelableArg, viewArg, detailArg);
         self.screen_x.deref().set(screenXArg);
         self.screen_y.deref().set(screenYArg);

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -104,47 +104,47 @@ impl MouseEvent {
 }
 
 impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
-    fn ScreenX(&self) -> i32 {
+    fn ScreenX(self) -> i32 {
         self.screen_x.deref().get()
     }
 
-    fn ScreenY(&self) -> i32 {
+    fn ScreenY(self) -> i32 {
         self.screen_y.deref().get()
     }
 
-    fn ClientX(&self) -> i32 {
+    fn ClientX(self) -> i32 {
         self.client_x.deref().get()
     }
 
-    fn ClientY(&self) -> i32 {
+    fn ClientY(self) -> i32 {
         self.client_y.deref().get()
     }
 
-    fn CtrlKey(&self) -> bool {
+    fn CtrlKey(self) -> bool {
         self.ctrl_key.deref().get()
     }
 
-    fn ShiftKey(&self) -> bool {
+    fn ShiftKey(self) -> bool {
         self.shift_key.deref().get()
     }
 
-    fn AltKey(&self) -> bool {
+    fn AltKey(self) -> bool {
         self.alt_key.deref().get()
     }
 
-    fn MetaKey(&self) -> bool {
+    fn MetaKey(self) -> bool {
         self.meta_key.deref().get()
     }
 
-    fn Button(&self) -> i16 {
+    fn Button(self) -> i16 {
         self.button.deref().get()
     }
 
-    fn GetRelatedTarget(&self) -> Option<Temporary<EventTarget>> {
+    fn GetRelatedTarget(self) -> Option<Temporary<EventTarget>> {
         self.related_target.get().clone().map(|target| Temporary::new(target))
     }
 
-    fn InitMouseEvent(&self,
+    fn InitMouseEvent(self,
                       typeArg: DOMString,
                       canBubbleArg: bool,
                       cancelableArg: bool,
@@ -160,7 +160,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
                       metaKeyArg: bool,
                       buttonArg: i16,
                       relatedTargetArg: Option<JSRef<EventTarget>>) {
-        let uievent: JSRef<UIEvent> = UIEventCast::from_ref(*self);
+        let uievent: JSRef<UIEvent> = UIEventCast::from_ref(self);
         uievent.InitUIEvent(typeArg, canBubbleArg, cancelableArg, viewArg, detailArg);
         self.screen_x.deref().set(screenXArg);
         self.screen_y.deref().set(screenYArg);

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -33,15 +33,15 @@ impl NamedNodeMap {
 }
 
 impl<'a> NamedNodeMapMethods for JSRef<'a, NamedNodeMap> {
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.owner.root().attrs.borrow().len() as u32
     }
 
-    fn Item(&self, index: u32) -> Option<Temporary<Attr>> {
+    fn Item(self, index: u32) -> Option<Temporary<Attr>> {
         self.owner.root().attrs.borrow().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {
         let item = self.Item(index);
         *found = item.is_some();
         item

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -19,16 +19,16 @@ pub struct NamedNodeMap {
 }
 
 impl NamedNodeMap {
-    pub fn new_inherited(elem: &JSRef<Element>) -> NamedNodeMap {
+    pub fn new_inherited(elem: JSRef<Element>) -> NamedNodeMap {
         NamedNodeMap {
             reflector_: Reflector::new(),
             owner: JS::from_rooted(elem),
         }
     }
 
-    pub fn new(window: &JSRef<Window>, elem: &JSRef<Element>) -> Temporary<NamedNodeMap> {
+    pub fn new(window: JSRef<Window>, elem: JSRef<Element>) -> Temporary<NamedNodeMap> {
         reflect_dom_object(box NamedNodeMap::new_inherited(elem),
-                           &Window(*window), NamedNodeMapBinding::Wrap)
+                           &Window(window), NamedNodeMapBinding::Wrap)
     }
 }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -23,9 +23,9 @@ impl Navigator {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<Navigator> {
+    pub fn new(window: JSRef<Window>) -> Temporary<Navigator> {
         reflect_dom_object(box Navigator::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            NavigatorBinding::Wrap)
     }
 }

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -31,23 +31,23 @@ impl Navigator {
 }
 
 impl<'a> NavigatorMethods for JSRef<'a, Navigator> {
-    fn Product(&self) -> DOMString {
+    fn Product(self) -> DOMString {
         "Gecko".to_string()
     }
 
-    fn TaintEnabled(&self) -> bool {
+    fn TaintEnabled(self) -> bool {
         false
     }
 
-    fn AppName(&self) -> DOMString {
+    fn AppName(self) -> DOMString {
         "Netscape".to_string() // Like Gecko/Webkit
     }
 
-    fn AppCodeName(&self) -> DOMString {
+    fn AppCodeName(self) -> DOMString {
         "Mozilla".to_string()
     }
 
-    fn Platform(&self) -> DOMString {
+    fn Platform(self) -> DOMString {
         "".to_string()
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1485,7 +1485,7 @@ impl Node {
 
 impl<'a> NodeMethods for JSRef<'a, Node> {
     // http://dom.spec.whatwg.org/#dom-node-nodetype
-    fn NodeType(&self) -> u16 {
+    fn NodeType(self) -> u16 {
         match self.type_id {
             ElementNodeTypeId(_)            => NodeConstants::ELEMENT_NODE,
             TextNodeTypeId                  => NodeConstants::TEXT_NODE,
@@ -1498,21 +1498,21 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodename
-    fn NodeName(&self) -> DOMString {
+    fn NodeName(self) -> DOMString {
         match self.type_id {
             ElementNodeTypeId(..) => {
-                let elem: JSRef<Element> = ElementCast::to_ref(*self).unwrap();
+                let elem: JSRef<Element> = ElementCast::to_ref(self).unwrap();
                 elem.TagName()
             }
             TextNodeTypeId => "#text".to_string(),
             ProcessingInstructionNodeTypeId => {
                 let processing_instruction: JSRef<ProcessingInstruction> =
-                    ProcessingInstructionCast::to_ref(*self).unwrap();
+                    ProcessingInstructionCast::to_ref(self).unwrap();
                 processing_instruction.Target()
             }
             CommentNodeTypeId => "#comment".to_string(),
             DoctypeNodeTypeId => {
-                let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(*self).unwrap();
+                let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(self).unwrap();
                 doctype.deref().name.clone()
             },
             DocumentFragmentNodeTypeId => "#document-fragment".to_string(),
@@ -1521,13 +1521,13 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-baseuri
-    fn GetBaseURI(&self) -> Option<DOMString> {
+    fn GetBaseURI(self) -> Option<DOMString> {
         // FIXME (#1824) implement.
         None
     }
 
     // http://dom.spec.whatwg.org/#dom-node-ownerdocument
-    fn GetOwnerDocument(&self) -> Option<Temporary<Document>> {
+    fn GetOwnerDocument(self) -> Option<Temporary<Document>> {
         match self.type_id {
             ElementNodeTypeId(..) |
             CommentNodeTypeId |
@@ -1540,12 +1540,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-parentnode
-    fn GetParentNode(&self) -> Option<Temporary<Node>> {
+    fn GetParentNode(self) -> Option<Temporary<Node>> {
         self.parent_node.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-parentelement
-    fn GetParentElement(&self) -> Option<Temporary<Element>> {
+    fn GetParentElement(self) -> Option<Temporary<Element>> {
         self.parent_node.get()
                         .and_then(|parent| {
                             let parent = parent.root();
@@ -1556,12 +1556,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-haschildnodes
-    fn HasChildNodes(&self) -> bool {
+    fn HasChildNodes(self) -> bool {
         self.first_child.get().is_some()
     }
 
     // http://dom.spec.whatwg.org/#dom-node-childnodes
-    fn ChildNodes(&self) -> Temporary<NodeList> {
+    fn ChildNodes(self) -> Temporary<NodeList> {
         match self.child_list.get() {
             None => (),
             Some(ref list) => return Temporary::new(list.clone()),
@@ -1569,38 +1569,38 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
         let doc = self.owner_doc().root();
         let window = doc.deref().window.root();
-        let child_list = NodeList::new_child_list(*window, *self);
+        let child_list = NodeList::new_child_list(*window, self);
         self.child_list.assign(Some(child_list));
         Temporary::new(self.child_list.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-node-firstchild
-    fn GetFirstChild(&self) -> Option<Temporary<Node>> {
+    fn GetFirstChild(self) -> Option<Temporary<Node>> {
         self.first_child.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lastchild
-    fn GetLastChild(&self) -> Option<Temporary<Node>> {
+    fn GetLastChild(self) -> Option<Temporary<Node>> {
         self.last_child.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-previoussibling
-    fn GetPreviousSibling(&self) -> Option<Temporary<Node>> {
+    fn GetPreviousSibling(self) -> Option<Temporary<Node>> {
         self.prev_sibling.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nextsibling
-    fn GetNextSibling(&self) -> Option<Temporary<Node>> {
+    fn GetNextSibling(self) -> Option<Temporary<Node>> {
         self.next_sibling.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodevalue
-    fn GetNodeValue(&self) -> Option<DOMString> {
+    fn GetNodeValue(self) -> Option<DOMString> {
         match self.type_id {
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
-                let chardata: JSRef<CharacterData> = CharacterDataCast::to_ref(*self).unwrap();
+                let chardata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
                 Some(chardata.Data())
             }
             _ => {
@@ -1610,7 +1610,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodevalue
-    fn SetNodeValue(&self, val: Option<DOMString>) {
+    fn SetNodeValue(self, val: Option<DOMString>) {
         match self.type_id {
             CommentNodeTypeId |
             TextNodeTypeId |
@@ -1622,7 +1622,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-textcontent
-    fn GetTextContent(&self) -> Option<DOMString> {
+    fn GetTextContent(self) -> Option<DOMString> {
         match self.type_id {
             DocumentFragmentNodeTypeId |
             ElementNodeTypeId(..) => {
@@ -1632,7 +1632,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
-                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(*self).unwrap();
+                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
                 Some(characterdata.Data())
             }
             DoctypeNodeTypeId |
@@ -1643,7 +1643,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-textcontent
-    fn SetTextContent(&self, value: Option<DOMString>) {
+    fn SetTextContent(self, value: Option<DOMString>) {
         let value = null_str_as_empty(&value);
         match self.type_id {
             DocumentFragmentNodeTypeId |
@@ -1657,14 +1657,14 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 }.root();
 
                 // Step 3.
-                Node::replace_all(node.root_ref(), *self);
+                Node::replace_all(node.root_ref(), self);
             }
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
                 self.wait_until_safe_to_modify_dom();
 
-                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(*self).unwrap();
+                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
                 *characterdata.data.deref().borrow_mut() = value;
 
                 // Notify the document that the content of this node is different
@@ -1677,17 +1677,17 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-insertbefore
-    fn InsertBefore(&self, node: JSRef<Node>, child: Option<JSRef<Node>>) -> Fallible<Temporary<Node>> {
-        Node::pre_insert(node, *self, child)
+    fn InsertBefore(self, node: JSRef<Node>, child: Option<JSRef<Node>>) -> Fallible<Temporary<Node>> {
+        Node::pre_insert(node, self, child)
     }
 
     // http://dom.spec.whatwg.org/#dom-node-appendchild
-    fn AppendChild(&self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
-        Node::pre_insert(node, *self, None)
+    fn AppendChild(self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
+        Node::pre_insert(node, self, None)
     }
 
     // http://dom.spec.whatwg.org/#concept-node-replace
-    fn ReplaceChild(&self, node: JSRef<Node>, child: JSRef<Node>) -> Fallible<Temporary<Node>> {
+    fn ReplaceChild(self, node: JSRef<Node>, child: JSRef<Node>) -> Fallible<Temporary<Node>> {
 
         // Step 1.
         match self.type_id {
@@ -1698,7 +1698,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         }
 
         // Step 2.
-        if node.is_inclusive_ancestor_of(*self) {
+        if node.is_inclusive_ancestor_of(self) {
             return Err(HierarchyRequest);
         }
 
@@ -1789,15 +1789,15 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         };
 
         // Step 9.
-        let document = document_from_node(*self).root();
+        let document = document_from_node(self).root();
         Node::adopt(node, *document);
 
         {
             // Step 10.
-            Node::remove(child, *self, Suppressed);
+            Node::remove(child, self, Suppressed);
 
             // Step 11.
-            Node::insert(node, *self, reference_child, Suppressed);
+            Node::insert(node, self, reference_child, Suppressed);
         }
 
         // Step 12-14.
@@ -1816,13 +1816,13 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-removechild
-    fn RemoveChild(&self, node: JSRef<Node>)
+    fn RemoveChild(self, node: JSRef<Node>)
                        -> Fallible<Temporary<Node>> {
-        Node::pre_remove(node, *self)
+        Node::pre_remove(node, self)
     }
 
     // http://dom.spec.whatwg.org/#dom-node-normalize
-    fn Normalize(&self) {
+    fn Normalize(self) {
         let mut prev_text = None;
         for child in self.children() {
             if child.is_text() {
@@ -1848,15 +1848,15 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-clonenode
-    fn CloneNode(&self, deep: bool) -> Temporary<Node> {
+    fn CloneNode(self, deep: bool) -> Temporary<Node> {
         match deep {
-            true => Node::clone(*self, None, CloneChildren),
-            false => Node::clone(*self, None, DoNotCloneChildren)
+            true => Node::clone(self, None, CloneChildren),
+            false => Node::clone(self, None, DoNotCloneChildren)
         }
     }
 
     // http://dom.spec.whatwg.org/#dom-node-isequalnode
-    fn IsEqualNode(&self, maybe_node: Option<JSRef<Node>>) -> bool {
+    fn IsEqualNode(self, maybe_node: Option<JSRef<Node>>) -> bool {
         fn is_equal_doctype(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
             let other_doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(other).unwrap();
@@ -1931,13 +1931,13 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             // Step 1.
             None => false,
             // Step 2-6.
-            Some(node) => is_equal_node(*self, node)
+            Some(node) => is_equal_node(self, node)
         }
     }
 
     // http://dom.spec.whatwg.org/#dom-node-comparedocumentposition
-    fn CompareDocumentPosition(&self, other: JSRef<Node>) -> u16 {
-        if *self == other {
+    fn CompareDocumentPosition(self, other: JSRef<Node>) -> u16 {
+        if self == other {
             // step 2.
             0
         } else {
@@ -1952,7 +1952,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 lastself = ancestor.clone();
             }
             for ancestor in other.ancestors() {
-                if ancestor == *self {
+                if ancestor == self {
                     // step 5.
                     return NodeConstants::DOCUMENT_POSITION_CONTAINED_BY +
                            NodeConstants::DOCUMENT_POSITION_FOLLOWING;
@@ -1961,7 +1961,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             }
 
             if lastself != lastother {
-                let abstract_uint: uintptr_t = as_uintptr(&*self);
+                let abstract_uint: uintptr_t = as_uintptr(&self);
                 let other_uint: uintptr_t = as_uintptr(&*other);
 
                 let random = if abstract_uint < other_uint {
@@ -1980,7 +1980,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                     // step 6.
                     return NodeConstants::DOCUMENT_POSITION_PRECEDING;
                 }
-                if child == *self {
+                if child == self {
                     // step 7.
                     return NodeConstants::DOCUMENT_POSITION_FOLLOWING;
                 }
@@ -1990,7 +1990,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-contains
-    fn Contains(&self, maybe_other: Option<JSRef<Node>>) -> bool {
+    fn Contains(self, maybe_other: Option<JSRef<Node>>) -> bool {
         match maybe_other {
             None => false,
             Some(other) => self.is_inclusive_ancestor_of(other)
@@ -1998,19 +1998,19 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lookupprefix
-    fn LookupPrefix(&self, _prefix: Option<DOMString>) -> Option<DOMString> {
+    fn LookupPrefix(self, _prefix: Option<DOMString>) -> Option<DOMString> {
         // FIXME (#1826) implement.
         None
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lookupnamespaceuri
-    fn LookupNamespaceURI(&self, _namespace: Option<DOMString>) -> Option<DOMString> {
+    fn LookupNamespaceURI(self, _namespace: Option<DOMString>) -> Option<DOMString> {
         // FIXME (#1826) implement.
         None
     }
 
     // http://dom.spec.whatwg.org/#dom-node-isdefaultnamespace
-    fn IsDefaultNamespace(&self, _namespace: Option<DOMString>) -> bool {
+    fn IsDefaultNamespace(self, _namespace: Option<DOMString>) -> bool {
         // FIXME (#1826) implement.
         false
     }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -48,7 +48,7 @@ impl NodeList {
 }
 
 impl<'a> NodeListMethods for JSRef<'a, NodeList> {
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         match self.list_type {
             Simple(ref elems) => elems.len() as u32,
             Children(ref node) => {
@@ -58,7 +58,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
         }
     }
 
-    fn Item(&self, index: u32) -> Option<Temporary<Node>> {
+    fn Item(self, index: u32) -> Option<Temporary<Node>> {
         match self.list_type {
             _ if index >= self.Length() => None,
             Simple(ref elems) => Some(Temporary::new(elems[index as uint].clone())),
@@ -70,7 +70,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
         }
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Node>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Node>> {
         let item = self.Item(index);
         *found = item.is_some();
         item

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -32,17 +32,17 @@ impl NodeList {
         }
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                list_type: NodeListType) -> Temporary<NodeList> {
         reflect_dom_object(box NodeList::new_inherited(list_type),
-                           &Window(*window), NodeListBinding::Wrap)
+                           &Window(window), NodeListBinding::Wrap)
     }
 
-    pub fn new_simple_list(window: &JSRef<Window>, elements: Vec<JSRef<Node>>) -> Temporary<NodeList> {
-        NodeList::new(window, Simple(elements.iter().map(|element| JS::from_rooted(element)).collect()))
+    pub fn new_simple_list(window: JSRef<Window>, elements: Vec<JSRef<Node>>) -> Temporary<NodeList> {
+        NodeList::new(window, Simple(elements.iter().map(|element| JS::from_rooted(*element)).collect()))
     }
 
-    pub fn new_child_list(window: &JSRef<Window>, node: &JSRef<Node>) -> Temporary<NodeList> {
+    pub fn new_child_list(window: JSRef<Window>, node: JSRef<Node>) -> Temporary<NodeList> {
         NodeList::new(window, Children(JS::from_rooted(node)))
     }
 }
@@ -65,7 +65,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
             Children(ref node) => {
                 let node = node.root();
                 node.deref().children().nth(index as uint)
-                                       .map(|child| Temporary::from_rooted(&child))
+                                       .map(|child| Temporary::from_rooted(child))
             }
         }
     }

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -36,11 +36,11 @@ impl Performance {
 }
 
 impl<'a> PerformanceMethods for JSRef<'a, Performance> {
-    fn Timing(&self) -> Temporary<PerformanceTiming> {
+    fn Timing(self) -> Temporary<PerformanceTiming> {
         Temporary::new(self.timing.clone())
     }
 
-    fn Now(&self) -> DOMHighResTimeStamp {
+    fn Now(self) -> DOMHighResTimeStamp {
         let navStart = self.timing.root().NavigationStartPrecise() as f64;
         (time::precise_time_s() - navStart) as DOMHighResTimeStamp
     }

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -21,16 +21,16 @@ pub struct Performance {
 }
 
 impl Performance {
-    fn new_inherited(window: &JSRef<Window>) -> Performance {
+    fn new_inherited(window: JSRef<Window>) -> Performance {
         Performance {
             reflector_: Reflector::new(),
-            timing: JS::from_rooted(&PerformanceTiming::new(window)),
+            timing: JS::from_rooted(PerformanceTiming::new(window)),
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<Performance> {
+    pub fn new(window: JSRef<Window>) -> Temporary<Performance> {
         reflect_dom_object(box Performance::new_inherited(window),
-                           &Window(*window),
+                           &Window(window),
                            PerformanceBinding::Wrap)
     }
 }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -28,10 +28,10 @@ impl PerformanceTiming {
     }
 
     #[allow(unrooted_must_root)]
-    pub fn new(window: &JSRef<Window>) -> Temporary<PerformanceTiming> {
+    pub fn new(window: JSRef<Window>) -> Temporary<PerformanceTiming> {
         let timing = PerformanceTiming::new_inherited(window.navigationStart,
                                                       window.navigationStartPrecise);
-        reflect_dom_object(box timing, &Window(*window),
+        reflect_dom_object(box timing, &Window(window),
                            PerformanceTimingBinding::Wrap)
     }
 }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -37,7 +37,7 @@ impl PerformanceTiming {
 }
 
 impl<'a> PerformanceTimingMethods for JSRef<'a, PerformanceTiming> {
-    fn NavigationStart(&self) -> u64 {
+    fn NavigationStart(self) -> u64 {
         self.navigationStart
     }
 }

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -42,7 +42,7 @@ impl ProcessingInstruction {
 }
 
 impl<'a> ProcessingInstructionMethods for JSRef<'a, ProcessingInstruction> {
-    fn Target(&self) -> DOMString {
+    fn Target(self) -> DOMString {
         self.target.clone()
     }
 }

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -28,14 +28,14 @@ impl ProcessingInstructionDerived for EventTarget {
 }
 
 impl ProcessingInstruction {
-    pub fn new_inherited(target: DOMString, data: DOMString, document: &JSRef<Document>) -> ProcessingInstruction {
+    pub fn new_inherited(target: DOMString, data: DOMString, document: JSRef<Document>) -> ProcessingInstruction {
         ProcessingInstruction {
             characterdata: CharacterData::new_inherited(ProcessingInstructionNodeTypeId, data, document),
             target: target
         }
     }
 
-    pub fn new(target: DOMString, data: DOMString, document: &JSRef<Document>) -> Temporary<ProcessingInstruction> {
+    pub fn new(target: DOMString, data: DOMString, document: JSRef<Document>) -> Temporary<ProcessingInstruction> {
         Node::reflect_node(box ProcessingInstruction::new_inherited(target, data, document),
                            document, ProcessingInstructionBinding::Wrap)
     }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -58,13 +58,13 @@ impl ProgressEvent {
 }
 
 impl<'a> ProgressEventMethods for JSRef<'a, ProgressEvent> {
-    fn LengthComputable(&self) -> bool {
+    fn LengthComputable(self) -> bool {
         self.length_computable
     }
-    fn Loaded(&self) -> u64{
+    fn Loaded(self) -> u64{
         self.loaded
     }
-    fn Total(&self) -> u64 {
+    fn Total(self) -> u64 {
         self.total
     }
 }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -43,9 +43,9 @@ impl ProgressEvent {
         let ev = reflect_dom_object(box ProgressEvent::new_inherited(length_computable, loaded, total),
                                     global,
                                     ProgressEventBinding::Wrap).root();
-        let event: &JSRef<Event> = EventCast::from_ref(&*ev);
+        let event: JSRef<Event> = EventCast::from_ref(*ev);
         event.InitEvent(type_, can_bubble, cancelable);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
     pub fn Constructor(global: &GlobalRef,
                        type_: DOMString,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -39,7 +39,7 @@ impl Range {
 
 impl<'a> RangeMethods for JSRef<'a, Range> {
     /// http://dom.spec.whatwg.org/#dom-range-detach
-    fn Detach(&self) {
+    fn Detach(self) {
         // This method intentionally left blank.
     }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -24,7 +24,7 @@ impl Range {
         }
     }
 
-    pub fn new(document: &JSRef<Document>) -> Temporary<Range> {
+    pub fn new(document: JSRef<Document>) -> Temporary<Range> {
         let window = document.window.root();
         reflect_dom_object(box Range::new_inherited(),
                            &Window(*window),
@@ -33,7 +33,7 @@ impl Range {
 
     pub fn Constructor(global: &GlobalRef) -> Fallible<Temporary<Range>> {
         let document = global.as_window().Document().root();
-        Ok(Range::new(&*document))
+        Ok(Range::new(*document))
     }
 }
 

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -22,9 +22,9 @@ impl Screen {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<Screen> {
+    pub fn new(window: JSRef<Window>) -> Temporary<Screen> {
         reflect_dom_object(box Screen::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            ScreenBinding::Wrap)
     }
 }

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -30,11 +30,11 @@ impl Screen {
 }
 
 impl<'a> ScreenMethods for JSRef<'a, Screen> {
-    fn ColorDepth(&self) -> u32 {
+    fn ColorDepth(self) -> u32 {
         24
     }
 
-    fn PixelDepth(&self) -> u32 {
+    fn PixelDepth(self) -> u32 {
         24
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -26,265 +26,265 @@ pub struct TestBinding {
 }
 
 impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
-    fn BooleanAttribute(&self) -> bool { false }
-    fn SetBooleanAttribute(&self, _: bool) {}
-    fn ByteAttribute(&self) -> i8 { 0 }
-    fn SetByteAttribute(&self, _: i8) {}
-    fn OctetAttribute(&self) -> u8 { 0 }
-    fn SetOctetAttribute(&self, _: u8) {}
-    fn ShortAttribute(&self) -> i16 { 0 }
-    fn SetShortAttribute(&self, _: i16) {}
-    fn UnsignedShortAttribute(&self) -> u16 { 0 }
-    fn SetUnsignedShortAttribute(&self, _: u16) {}
-    fn LongAttribute(&self) -> i32 { 0 }
-    fn SetLongAttribute(&self, _: i32) {}
-    fn UnsignedLongAttribute(&self) -> u32 { 0 }
-    fn SetUnsignedLongAttribute(&self, _: u32) {}
-    fn LongLongAttribute(&self) -> i64 { 0 }
-    fn SetLongLongAttribute(&self, _: i64) {}
-    fn UnsignedLongLongAttribute(&self) -> u64 { 0 }
-    fn SetUnsignedLongLongAttribute(&self, _: u64) {}
-    fn FloatAttribute(&self) -> f32 { 0. }
-    fn SetFloatAttribute(&self, _: f32) {}
-    fn DoubleAttribute(&self) -> f64 { 0. }
-    fn SetDoubleAttribute(&self, _: f64) {}
-    fn StringAttribute(&self) -> DOMString { "".to_string() }
-    fn SetStringAttribute(&self, _: DOMString) {}
-    fn ByteStringAttribute(&self) -> ByteString { ByteString::new(vec!()) }
-    fn SetByteStringAttribute(&self, _: ByteString) {}
-    fn EnumAttribute(&self) -> TestEnum { _empty }
-    fn SetEnumAttribute(&self, _: TestEnum) {}
-    fn InterfaceAttribute(&self) -> Temporary<Blob> {
+    fn BooleanAttribute(self) -> bool { false }
+    fn SetBooleanAttribute(self, _: bool) {}
+    fn ByteAttribute(self) -> i8 { 0 }
+    fn SetByteAttribute(self, _: i8) {}
+    fn OctetAttribute(self) -> u8 { 0 }
+    fn SetOctetAttribute(self, _: u8) {}
+    fn ShortAttribute(self) -> i16 { 0 }
+    fn SetShortAttribute(self, _: i16) {}
+    fn UnsignedShortAttribute(self) -> u16 { 0 }
+    fn SetUnsignedShortAttribute(self, _: u16) {}
+    fn LongAttribute(self) -> i32 { 0 }
+    fn SetLongAttribute(self, _: i32) {}
+    fn UnsignedLongAttribute(self) -> u32 { 0 }
+    fn SetUnsignedLongAttribute(self, _: u32) {}
+    fn LongLongAttribute(self) -> i64 { 0 }
+    fn SetLongLongAttribute(self, _: i64) {}
+    fn UnsignedLongLongAttribute(self) -> u64 { 0 }
+    fn SetUnsignedLongLongAttribute(self, _: u64) {}
+    fn FloatAttribute(self) -> f32 { 0. }
+    fn SetFloatAttribute(self, _: f32) {}
+    fn DoubleAttribute(self) -> f64 { 0. }
+    fn SetDoubleAttribute(self, _: f64) {}
+    fn StringAttribute(self) -> DOMString { "".to_string() }
+    fn SetStringAttribute(self, _: DOMString) {}
+    fn ByteStringAttribute(self) -> ByteString { ByteString::new(vec!()) }
+    fn SetByteStringAttribute(self, _: ByteString) {}
+    fn EnumAttribute(self) -> TestEnum { _empty }
+    fn SetEnumAttribute(self, _: TestEnum) {}
+    fn InterfaceAttribute(self) -> Temporary<Blob> {
         let global = self.global.root();
         Blob::new(&global.root_ref())
     }
-    fn SetInterfaceAttribute(&self, _: JSRef<Blob>) {}
-    fn UnionAttribute(&self) -> HTMLElementOrLong { eLong(0) }
-    fn SetUnionAttribute(&self, _: HTMLElementOrLong) {}
-    fn Union2Attribute(&self) -> EventOrString { eString("".to_string()) }
-    fn SetUnion2Attribute(&self, _: EventOrString) {}
-    fn AnyAttribute(&self, _: *mut JSContext) -> JSVal { NullValue() }
-    fn SetAnyAttribute(&self, _: *mut JSContext, _: JSVal) {}
+    fn SetInterfaceAttribute(self, _: JSRef<Blob>) {}
+    fn UnionAttribute(self) -> HTMLElementOrLong { eLong(0) }
+    fn SetUnionAttribute(self, _: HTMLElementOrLong) {}
+    fn Union2Attribute(self) -> EventOrString { eString("".to_string()) }
+    fn SetUnion2Attribute(self, _: EventOrString) {}
+    fn AnyAttribute(self, _: *mut JSContext) -> JSVal { NullValue() }
+    fn SetAnyAttribute(self, _: *mut JSContext, _: JSVal) {}
 
-    fn GetBooleanAttributeNullable(&self) -> Option<bool> { Some(false) }
-    fn SetBooleanAttributeNullable(&self, _: Option<bool>) {}
-    fn GetByteAttributeNullable(&self) -> Option<i8> { Some(0) }
-    fn SetByteAttributeNullable(&self, _: Option<i8>) {}
-    fn GetOctetAttributeNullable(&self) -> Option<u8> { Some(0) }
-    fn SetOctetAttributeNullable(&self, _: Option<u8>) {}
-    fn GetShortAttributeNullable(&self) -> Option<i16> { Some(0) }
-    fn SetShortAttributeNullable(&self, _: Option<i16>) {}
-    fn GetUnsignedShortAttributeNullable(&self) -> Option<u16> { Some(0) }
-    fn SetUnsignedShortAttributeNullable(&self, _: Option<u16>) {}
-    fn GetLongAttributeNullable(&self) -> Option<i32> { Some(0) }
-    fn SetLongAttributeNullable(&self, _: Option<i32>) {}
-    fn GetUnsignedLongAttributeNullable(&self) -> Option<u32> { Some(0) }
-    fn SetUnsignedLongAttributeNullable(&self, _: Option<u32>) {}
-    fn GetLongLongAttributeNullable(&self) -> Option<i64> { Some(0) }
-    fn SetLongLongAttributeNullable(&self, _: Option<i64>) {}
-    fn GetUnsignedLongLongAttributeNullable(&self) -> Option<u64> { Some(0) }
-    fn SetUnsignedLongLongAttributeNullable(&self, _: Option<u64>) {}
-    fn GetFloatAttributeNullable(&self) -> Option<f32> { Some(0.) }
-    fn SetFloatAttributeNullable(&self, _: Option<f32>) {}
-    fn GetDoubleAttributeNullable(&self) -> Option<f64> { Some(0.) }
-    fn SetDoubleAttributeNullable(&self, _: Option<f64>) {}
-    fn GetByteStringAttributeNullable(&self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
-    fn SetByteStringAttributeNullable(&self, _: Option<ByteString>) {}
-    fn GetStringAttributeNullable(&self) -> Option<DOMString> { Some("".to_string()) }
-    fn SetStringAttributeNullable(&self, _: Option<DOMString>) {}
-    fn GetEnumAttributeNullable(&self) -> Option<TestEnum> { Some(_empty) }
-    fn GetInterfaceAttributeNullable(&self) -> Option<Temporary<Blob>> {
+    fn GetBooleanAttributeNullable(self) -> Option<bool> { Some(false) }
+    fn SetBooleanAttributeNullable(self, _: Option<bool>) {}
+    fn GetByteAttributeNullable(self) -> Option<i8> { Some(0) }
+    fn SetByteAttributeNullable(self, _: Option<i8>) {}
+    fn GetOctetAttributeNullable(self) -> Option<u8> { Some(0) }
+    fn SetOctetAttributeNullable(self, _: Option<u8>) {}
+    fn GetShortAttributeNullable(self) -> Option<i16> { Some(0) }
+    fn SetShortAttributeNullable(self, _: Option<i16>) {}
+    fn GetUnsignedShortAttributeNullable(self) -> Option<u16> { Some(0) }
+    fn SetUnsignedShortAttributeNullable(self, _: Option<u16>) {}
+    fn GetLongAttributeNullable(self) -> Option<i32> { Some(0) }
+    fn SetLongAttributeNullable(self, _: Option<i32>) {}
+    fn GetUnsignedLongAttributeNullable(self) -> Option<u32> { Some(0) }
+    fn SetUnsignedLongAttributeNullable(self, _: Option<u32>) {}
+    fn GetLongLongAttributeNullable(self) -> Option<i64> { Some(0) }
+    fn SetLongLongAttributeNullable(self, _: Option<i64>) {}
+    fn GetUnsignedLongLongAttributeNullable(self) -> Option<u64> { Some(0) }
+    fn SetUnsignedLongLongAttributeNullable(self, _: Option<u64>) {}
+    fn GetFloatAttributeNullable(self) -> Option<f32> { Some(0.) }
+    fn SetFloatAttributeNullable(self, _: Option<f32>) {}
+    fn GetDoubleAttributeNullable(self) -> Option<f64> { Some(0.) }
+    fn SetDoubleAttributeNullable(self, _: Option<f64>) {}
+    fn GetByteStringAttributeNullable(self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
+    fn SetByteStringAttributeNullable(self, _: Option<ByteString>) {}
+    fn GetStringAttributeNullable(self) -> Option<DOMString> { Some("".to_string()) }
+    fn SetStringAttributeNullable(self, _: Option<DOMString>) {}
+    fn GetEnumAttributeNullable(self) -> Option<TestEnum> { Some(_empty) }
+    fn GetInterfaceAttributeNullable(self) -> Option<Temporary<Blob>> {
         let global = self.global.root();
         Some(Blob::new(&global.root_ref()))
     }
-    fn SetInterfaceAttributeNullable(&self, _: Option<JSRef<Blob>>) {}
-    fn GetUnionAttributeNullable(&self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
-    fn SetUnionAttributeNullable(&self, _: Option<HTMLElementOrLong>) {}
-    fn GetUnion2AttributeNullable(&self) -> Option<EventOrString> { Some(eString("".to_string())) }
-    fn SetUnion2AttributeNullable(&self, _: Option<EventOrString>) {}
-    fn ReceiveVoid(&self) -> () {}
-    fn ReceiveBoolean(&self) -> bool { false }
-    fn ReceiveByte(&self) -> i8 { 0 }
-    fn ReceiveOctet(&self) -> u8 { 0 }
-    fn ReceiveShort(&self) -> i16 { 0 }
-    fn ReceiveUnsignedShort(&self) -> u16 { 0 }
-    fn ReceiveLong(&self) -> i32 { 0 }
-    fn ReceiveUnsignedLong(&self) -> u32 { 0 }
-    fn ReceiveLongLong(&self) -> i64 { 0 }
-    fn ReceiveUnsignedLongLong(&self) -> u64 { 0 }
-    fn ReceiveFloat(&self) -> f32 { 0. }
-    fn ReceiveDouble(&self) -> f64 { 0. }
-    fn ReceiveString(&self) -> DOMString { "".to_string() }
-    fn ReceiveByteString(&self) -> ByteString { ByteString::new(vec!()) }
-    fn ReceiveEnum(&self) -> TestEnum { _empty }
-    fn ReceiveInterface(&self) -> Temporary<Blob> {
+    fn SetInterfaceAttributeNullable(self, _: Option<JSRef<Blob>>) {}
+    fn GetUnionAttributeNullable(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
+    fn SetUnionAttributeNullable(self, _: Option<HTMLElementOrLong>) {}
+    fn GetUnion2AttributeNullable(self) -> Option<EventOrString> { Some(eString("".to_string())) }
+    fn SetUnion2AttributeNullable(self, _: Option<EventOrString>) {}
+    fn ReceiveVoid(self) -> () {}
+    fn ReceiveBoolean(self) -> bool { false }
+    fn ReceiveByte(self) -> i8 { 0 }
+    fn ReceiveOctet(self) -> u8 { 0 }
+    fn ReceiveShort(self) -> i16 { 0 }
+    fn ReceiveUnsignedShort(self) -> u16 { 0 }
+    fn ReceiveLong(self) -> i32 { 0 }
+    fn ReceiveUnsignedLong(self) -> u32 { 0 }
+    fn ReceiveLongLong(self) -> i64 { 0 }
+    fn ReceiveUnsignedLongLong(self) -> u64 { 0 }
+    fn ReceiveFloat(self) -> f32 { 0. }
+    fn ReceiveDouble(self) -> f64 { 0. }
+    fn ReceiveString(self) -> DOMString { "".to_string() }
+    fn ReceiveByteString(self) -> ByteString { ByteString::new(vec!()) }
+    fn ReceiveEnum(self) -> TestEnum { _empty }
+    fn ReceiveInterface(self) -> Temporary<Blob> {
         let global = self.global.root();
         Blob::new(&global.root_ref())
     }
-    fn ReceiveAny(&self, _: *mut JSContext) -> JSVal { NullValue() }
-    fn ReceiveUnion(&self) -> HTMLElementOrLong { eLong(0) }
-    fn ReceiveUnion2(&self) -> EventOrString { eString("".to_string()) }
+    fn ReceiveAny(self, _: *mut JSContext) -> JSVal { NullValue() }
+    fn ReceiveUnion(self) -> HTMLElementOrLong { eLong(0) }
+    fn ReceiveUnion2(self) -> EventOrString { eString("".to_string()) }
 
-    fn ReceiveNullableBoolean(&self) -> Option<bool> { Some(false) }
-    fn ReceiveNullableByte(&self) -> Option<i8> { Some(0) }
-    fn ReceiveNullableOctet(&self) -> Option<u8> { Some(0) }
-    fn ReceiveNullableShort(&self) -> Option<i16> { Some(0) }
-    fn ReceiveNullableUnsignedShort(&self) -> Option<u16> { Some(0) }
-    fn ReceiveNullableLong(&self) -> Option<i32> { Some(0) }
-    fn ReceiveNullableUnsignedLong(&self) -> Option<u32> { Some(0) }
-    fn ReceiveNullableLongLong(&self) -> Option<i64> { Some(0) }
-    fn ReceiveNullableUnsignedLongLong(&self) -> Option<u64> { Some(0) }
-    fn ReceiveNullableFloat(&self) -> Option<f32> { Some(0.) }
-    fn ReceiveNullableDouble(&self) -> Option<f64> { Some(0.) }
-    fn ReceiveNullableString(&self) -> Option<DOMString> { Some("".to_string()) }
-    fn ReceiveNullableByteString(&self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
-    fn ReceiveNullableEnum(&self) -> Option<TestEnum> { Some(_empty) }
-    fn ReceiveNullableInterface(&self) -> Option<Temporary<Blob>> {
+    fn ReceiveNullableBoolean(self) -> Option<bool> { Some(false) }
+    fn ReceiveNullableByte(self) -> Option<i8> { Some(0) }
+    fn ReceiveNullableOctet(self) -> Option<u8> { Some(0) }
+    fn ReceiveNullableShort(self) -> Option<i16> { Some(0) }
+    fn ReceiveNullableUnsignedShort(self) -> Option<u16> { Some(0) }
+    fn ReceiveNullableLong(self) -> Option<i32> { Some(0) }
+    fn ReceiveNullableUnsignedLong(self) -> Option<u32> { Some(0) }
+    fn ReceiveNullableLongLong(self) -> Option<i64> { Some(0) }
+    fn ReceiveNullableUnsignedLongLong(self) -> Option<u64> { Some(0) }
+    fn ReceiveNullableFloat(self) -> Option<f32> { Some(0.) }
+    fn ReceiveNullableDouble(self) -> Option<f64> { Some(0.) }
+    fn ReceiveNullableString(self) -> Option<DOMString> { Some("".to_string()) }
+    fn ReceiveNullableByteString(self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
+    fn ReceiveNullableEnum(self) -> Option<TestEnum> { Some(_empty) }
+    fn ReceiveNullableInterface(self) -> Option<Temporary<Blob>> {
         let global = self.global.root();
         Some(Blob::new(&global.root_ref()))
     }
-    fn ReceiveNullableUnion(&self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
-    fn ReceiveNullableUnion2(&self) -> Option<EventOrString> { Some(eString("".to_string())) }
+    fn ReceiveNullableUnion(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
+    fn ReceiveNullableUnion2(self) -> Option<EventOrString> { Some(eString("".to_string())) }
 
-    fn PassBoolean(&self, _: bool) {}
-    fn PassByte(&self, _: i8) {}
-    fn PassOctet(&self, _: u8) {}
-    fn PassShort(&self, _: i16) {}
-    fn PassUnsignedShort(&self, _: u16) {}
-    fn PassLong(&self, _: i32) {}
-    fn PassUnsignedLong(&self, _: u32) {}
-    fn PassLongLong(&self, _: i64) {}
-    fn PassUnsignedLongLong(&self, _: u64) {}
-    fn PassFloat(&self, _: f32) {}
-    fn PassDouble(&self, _: f64) {}
-    fn PassString(&self, _: DOMString) {}
-    fn PassByteString(&self, _: ByteString) {}
-    fn PassEnum(&self, _: TestEnum) {}
-    fn PassInterface(&self, _: JSRef<Blob>) {}
-    fn PassUnion(&self, _: HTMLElementOrLong) {}
-    fn PassUnion2(&self, _: EventOrString) {}
-    fn PassUnion3(&self, _: BlobOrString) {}
-    fn PassAny(&self, _: *mut JSContext, _: JSVal) {}
+    fn PassBoolean(self, _: bool) {}
+    fn PassByte(self, _: i8) {}
+    fn PassOctet(self, _: u8) {}
+    fn PassShort(self, _: i16) {}
+    fn PassUnsignedShort(self, _: u16) {}
+    fn PassLong(self, _: i32) {}
+    fn PassUnsignedLong(self, _: u32) {}
+    fn PassLongLong(self, _: i64) {}
+    fn PassUnsignedLongLong(self, _: u64) {}
+    fn PassFloat(self, _: f32) {}
+    fn PassDouble(self, _: f64) {}
+    fn PassString(self, _: DOMString) {}
+    fn PassByteString(self, _: ByteString) {}
+    fn PassEnum(self, _: TestEnum) {}
+    fn PassInterface(self, _: JSRef<Blob>) {}
+    fn PassUnion(self, _: HTMLElementOrLong) {}
+    fn PassUnion2(self, _: EventOrString) {}
+    fn PassUnion3(self, _: BlobOrString) {}
+    fn PassAny(self, _: *mut JSContext, _: JSVal) {}
 
-    fn PassNullableBoolean(&self, _: Option<bool>) {}
-    fn PassNullableByte(&self, _: Option<i8>) {}
-    fn PassNullableOctet(&self, _: Option<u8>) {}
-    fn PassNullableShort(&self, _: Option<i16>) {}
-    fn PassNullableUnsignedShort(&self, _: Option<u16>) {}
-    fn PassNullableLong(&self, _: Option<i32>) {}
-    fn PassNullableUnsignedLong(&self, _: Option<u32>) {}
-    fn PassNullableLongLong(&self, _: Option<i64>) {}
-    fn PassNullableUnsignedLongLong(&self, _: Option<u64>) {}
-    fn PassNullableFloat(&self, _: Option<f32>) {}
-    fn PassNullableDouble(&self, _: Option<f64>) {}
-    fn PassNullableString(&self, _: Option<DOMString>) {}
-    fn PassNullableByteString(&self, _: Option<ByteString>) {}
-    // fn PassNullableEnum(&self, _: Option<TestEnum>) {}
-    fn PassNullableInterface(&self, _: Option<JSRef<Blob>>) {}
-    fn PassNullableUnion(&self, _: Option<HTMLElementOrLong>) {}
-    fn PassNullableUnion2(&self, _: Option<EventOrString>) {}
+    fn PassNullableBoolean(self, _: Option<bool>) {}
+    fn PassNullableByte(self, _: Option<i8>) {}
+    fn PassNullableOctet(self, _: Option<u8>) {}
+    fn PassNullableShort(self, _: Option<i16>) {}
+    fn PassNullableUnsignedShort(self, _: Option<u16>) {}
+    fn PassNullableLong(self, _: Option<i32>) {}
+    fn PassNullableUnsignedLong(self, _: Option<u32>) {}
+    fn PassNullableLongLong(self, _: Option<i64>) {}
+    fn PassNullableUnsignedLongLong(self, _: Option<u64>) {}
+    fn PassNullableFloat(self, _: Option<f32>) {}
+    fn PassNullableDouble(self, _: Option<f64>) {}
+    fn PassNullableString(self, _: Option<DOMString>) {}
+    fn PassNullableByteString(self, _: Option<ByteString>) {}
+    // fn PassNullableEnum(self, _: Option<TestEnum>) {}
+    fn PassNullableInterface(self, _: Option<JSRef<Blob>>) {}
+    fn PassNullableUnion(self, _: Option<HTMLElementOrLong>) {}
+    fn PassNullableUnion2(self, _: Option<EventOrString>) {}
 
-    fn PassOptionalBoolean(&self, _: Option<bool>) {}
-    fn PassOptionalByte(&self, _: Option<i8>) {}
-    fn PassOptionalOctet(&self, _: Option<u8>) {}
-    fn PassOptionalShort(&self, _: Option<i16>) {}
-    fn PassOptionalUnsignedShort(&self, _: Option<u16>) {}
-    fn PassOptionalLong(&self, _: Option<i32>) {}
-    fn PassOptionalUnsignedLong(&self, _: Option<u32>) {}
-    fn PassOptionalLongLong(&self, _: Option<i64>) {}
-    fn PassOptionalUnsignedLongLong(&self, _: Option<u64>) {}
-    fn PassOptionalFloat(&self, _: Option<f32>) {}
-    fn PassOptionalDouble(&self, _: Option<f64>) {}
-    fn PassOptionalString(&self, _: Option<DOMString>) {}
-    fn PassOptionalByteString(&self, _: Option<ByteString>) {}
-    fn PassOptionalEnum(&self, _: Option<TestEnum>) {}
-    fn PassOptionalInterface(&self, _: Option<JSRef<Blob>>) {}
-    fn PassOptionalUnion(&self, _: Option<HTMLElementOrLong>) {}
-    fn PassOptionalUnion2(&self, _: Option<EventOrString>) {}
-    fn PassOptionalAny(&self, _: *mut JSContext, _: JSVal) {}
+    fn PassOptionalBoolean(self, _: Option<bool>) {}
+    fn PassOptionalByte(self, _: Option<i8>) {}
+    fn PassOptionalOctet(self, _: Option<u8>) {}
+    fn PassOptionalShort(self, _: Option<i16>) {}
+    fn PassOptionalUnsignedShort(self, _: Option<u16>) {}
+    fn PassOptionalLong(self, _: Option<i32>) {}
+    fn PassOptionalUnsignedLong(self, _: Option<u32>) {}
+    fn PassOptionalLongLong(self, _: Option<i64>) {}
+    fn PassOptionalUnsignedLongLong(self, _: Option<u64>) {}
+    fn PassOptionalFloat(self, _: Option<f32>) {}
+    fn PassOptionalDouble(self, _: Option<f64>) {}
+    fn PassOptionalString(self, _: Option<DOMString>) {}
+    fn PassOptionalByteString(self, _: Option<ByteString>) {}
+    fn PassOptionalEnum(self, _: Option<TestEnum>) {}
+    fn PassOptionalInterface(self, _: Option<JSRef<Blob>>) {}
+    fn PassOptionalUnion(self, _: Option<HTMLElementOrLong>) {}
+    fn PassOptionalUnion2(self, _: Option<EventOrString>) {}
+    fn PassOptionalAny(self, _: *mut JSContext, _: JSVal) {}
 
-    fn PassOptionalNullableBoolean(&self, _: Option<Option<bool>>) {}
-    fn PassOptionalNullableByte(&self, _: Option<Option<i8>>) {}
-    fn PassOptionalNullableOctet(&self, _: Option<Option<u8>>) {}
-    fn PassOptionalNullableShort(&self, _: Option<Option<i16>>) {}
-    fn PassOptionalNullableUnsignedShort(&self, _: Option<Option<u16>>) {}
-    fn PassOptionalNullableLong(&self, _: Option<Option<i32>>) {}
-    fn PassOptionalNullableUnsignedLong(&self, _: Option<Option<u32>>) {}
-    fn PassOptionalNullableLongLong(&self, _: Option<Option<i64>>) {}
-    fn PassOptionalNullableUnsignedLongLong(&self, _: Option<Option<u64>>) {}
-    fn PassOptionalNullableFloat(&self, _: Option<Option<f32>>) {}
-    fn PassOptionalNullableDouble(&self, _: Option<Option<f64>>) {}
-    fn PassOptionalNullableString(&self, _: Option<Option<DOMString>>) {}
-    fn PassOptionalNullableByteString(&self, _: Option<Option<ByteString>>) {}
-    // fn PassOptionalNullableEnum(&self, _: Option<Option<TestEnum>>) {}
-    fn PassOptionalNullableInterface(&self, _: Option<Option<JSRef<Blob>>>) {}
-    fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
-    fn PassOptionalNullableUnion2(&self, _: Option<Option<EventOrString>>) {}
+    fn PassOptionalNullableBoolean(self, _: Option<Option<bool>>) {}
+    fn PassOptionalNullableByte(self, _: Option<Option<i8>>) {}
+    fn PassOptionalNullableOctet(self, _: Option<Option<u8>>) {}
+    fn PassOptionalNullableShort(self, _: Option<Option<i16>>) {}
+    fn PassOptionalNullableUnsignedShort(self, _: Option<Option<u16>>) {}
+    fn PassOptionalNullableLong(self, _: Option<Option<i32>>) {}
+    fn PassOptionalNullableUnsignedLong(self, _: Option<Option<u32>>) {}
+    fn PassOptionalNullableLongLong(self, _: Option<Option<i64>>) {}
+    fn PassOptionalNullableUnsignedLongLong(self, _: Option<Option<u64>>) {}
+    fn PassOptionalNullableFloat(self, _: Option<Option<f32>>) {}
+    fn PassOptionalNullableDouble(self, _: Option<Option<f64>>) {}
+    fn PassOptionalNullableString(self, _: Option<Option<DOMString>>) {}
+    fn PassOptionalNullableByteString(self, _: Option<Option<ByteString>>) {}
+    // fn PassOptionalNullableEnum(self, _: Option<Option<TestEnum>>) {}
+    fn PassOptionalNullableInterface(self, _: Option<Option<JSRef<Blob>>>) {}
+    fn PassOptionalNullableUnion(self, _: Option<Option<HTMLElementOrLong>>) {}
+    fn PassOptionalNullableUnion2(self, _: Option<Option<EventOrString>>) {}
 
-    fn PassOptionalBooleanWithDefault(&self, _: bool) {}
-    fn PassOptionalByteWithDefault(&self, _: i8) {}
-    fn PassOptionalOctetWithDefault(&self, _: u8) {}
-    fn PassOptionalShortWithDefault(&self, _: i16) {}
-    fn PassOptionalUnsignedShortWithDefault(&self, _: u16) {}
-    fn PassOptionalLongWithDefault(&self, _: i32) {}
-    fn PassOptionalUnsignedLongWithDefault(&self, _: u32) {}
-    fn PassOptionalLongLongWithDefault(&self, _: i64) {}
-    fn PassOptionalUnsignedLongLongWithDefault(&self, _: u64) {}
-    fn PassOptionalStringWithDefault(&self, _: DOMString) {}
-    fn PassOptionalEnumWithDefault(&self, _: TestEnum) {}
+    fn PassOptionalBooleanWithDefault(self, _: bool) {}
+    fn PassOptionalByteWithDefault(self, _: i8) {}
+    fn PassOptionalOctetWithDefault(self, _: u8) {}
+    fn PassOptionalShortWithDefault(self, _: i16) {}
+    fn PassOptionalUnsignedShortWithDefault(self, _: u16) {}
+    fn PassOptionalLongWithDefault(self, _: i32) {}
+    fn PassOptionalUnsignedLongWithDefault(self, _: u32) {}
+    fn PassOptionalLongLongWithDefault(self, _: i64) {}
+    fn PassOptionalUnsignedLongLongWithDefault(self, _: u64) {}
+    fn PassOptionalStringWithDefault(self, _: DOMString) {}
+    fn PassOptionalEnumWithDefault(self, _: TestEnum) {}
 
-    fn PassOptionalNullableBooleanWithDefault(&self, _: Option<bool>) {}
-    fn PassOptionalNullableByteWithDefault(&self, _: Option<i8>) {}
-    fn PassOptionalNullableOctetWithDefault(&self, _: Option<u8>) {}
-    fn PassOptionalNullableShortWithDefault(&self, _: Option<i16>) {}
-    fn PassOptionalNullableUnsignedShortWithDefault(&self, _: Option<u16>) {}
-    fn PassOptionalNullableLongWithDefault(&self, _: Option<i32>) {}
-    fn PassOptionalNullableUnsignedLongWithDefault(&self, _: Option<u32>) {}
-    fn PassOptionalNullableLongLongWithDefault(&self, _: Option<i64>) {}
-    fn PassOptionalNullableUnsignedLongLongWithDefault(&self, _: Option<u64>) {}
-    // fn PassOptionalNullableFloatWithDefault(&self, _: Option<f32>) {}
-    // fn PassOptionalNullableDoubleWithDefault(&self, _: Option<f64>) {}
-    fn PassOptionalNullableStringWithDefault(&self, _: Option<DOMString>) {}
-    fn PassOptionalNullableByteStringWithDefault(&self, _: Option<ByteString>) {}
-    // fn PassOptionalNullableEnumWithDefault(&self, _: Option<TestEnum>) {}
-    fn PassOptionalNullableInterfaceWithDefault(&self, _: Option<JSRef<Blob>>) {}
-    fn PassOptionalNullableUnionWithDefault(&self, _: Option<HTMLElementOrLong>) {}
-    fn PassOptionalNullableUnion2WithDefault(&self, _: Option<EventOrString>) {}
-    fn PassOptionalAnyWithDefault(&self, _: *mut JSContext, _: JSVal) {}
+    fn PassOptionalNullableBooleanWithDefault(self, _: Option<bool>) {}
+    fn PassOptionalNullableByteWithDefault(self, _: Option<i8>) {}
+    fn PassOptionalNullableOctetWithDefault(self, _: Option<u8>) {}
+    fn PassOptionalNullableShortWithDefault(self, _: Option<i16>) {}
+    fn PassOptionalNullableUnsignedShortWithDefault(self, _: Option<u16>) {}
+    fn PassOptionalNullableLongWithDefault(self, _: Option<i32>) {}
+    fn PassOptionalNullableUnsignedLongWithDefault(self, _: Option<u32>) {}
+    fn PassOptionalNullableLongLongWithDefault(self, _: Option<i64>) {}
+    fn PassOptionalNullableUnsignedLongLongWithDefault(self, _: Option<u64>) {}
+    // fn PassOptionalNullableFloatWithDefault(self, _: Option<f32>) {}
+    // fn PassOptionalNullableDoubleWithDefault(self, _: Option<f64>) {}
+    fn PassOptionalNullableStringWithDefault(self, _: Option<DOMString>) {}
+    fn PassOptionalNullableByteStringWithDefault(self, _: Option<ByteString>) {}
+    // fn PassOptionalNullableEnumWithDefault(self, _: Option<TestEnum>) {}
+    fn PassOptionalNullableInterfaceWithDefault(self, _: Option<JSRef<Blob>>) {}
+    fn PassOptionalNullableUnionWithDefault(self, _: Option<HTMLElementOrLong>) {}
+    fn PassOptionalNullableUnion2WithDefault(self, _: Option<EventOrString>) {}
+    fn PassOptionalAnyWithDefault(self, _: *mut JSContext, _: JSVal) {}
 
-    fn PassOptionalNullableBooleanWithNonNullDefault(&self, _: Option<bool>) {}
-    fn PassOptionalNullableByteWithNonNullDefault(&self, _: Option<i8>) {}
-    fn PassOptionalNullableOctetWithNonNullDefault(&self, _: Option<u8>) {}
-    fn PassOptionalNullableShortWithNonNullDefault(&self, _: Option<i16>) {}
-    fn PassOptionalNullableUnsignedShortWithNonNullDefault(&self, _: Option<u16>) {}
-    fn PassOptionalNullableLongWithNonNullDefault(&self, _: Option<i32>) {}
-    fn PassOptionalNullableUnsignedLongWithNonNullDefault(&self, _: Option<u32>) {}
-    fn PassOptionalNullableLongLongWithNonNullDefault(&self, _: Option<i64>) {}
-    fn PassOptionalNullableUnsignedLongLongWithNonNullDefault(&self, _: Option<u64>) {}
-    // fn PassOptionalNullableFloatWithNonNullDefault(&self, _: Option<f32>) {}
-    // fn PassOptionalNullableDoubleWithNonNullDefault(&self, _: Option<f64>) {}
-    fn PassOptionalNullableStringWithNonNullDefault(&self, _: Option<DOMString>) {}
-    // fn PassOptionalNullableEnumWithNonNullDefault(&self, _: Option<TestEnum>) {}
+    fn PassOptionalNullableBooleanWithNonNullDefault(self, _: Option<bool>) {}
+    fn PassOptionalNullableByteWithNonNullDefault(self, _: Option<i8>) {}
+    fn PassOptionalNullableOctetWithNonNullDefault(self, _: Option<u8>) {}
+    fn PassOptionalNullableShortWithNonNullDefault(self, _: Option<i16>) {}
+    fn PassOptionalNullableUnsignedShortWithNonNullDefault(self, _: Option<u16>) {}
+    fn PassOptionalNullableLongWithNonNullDefault(self, _: Option<i32>) {}
+    fn PassOptionalNullableUnsignedLongWithNonNullDefault(self, _: Option<u32>) {}
+    fn PassOptionalNullableLongLongWithNonNullDefault(self, _: Option<i64>) {}
+    fn PassOptionalNullableUnsignedLongLongWithNonNullDefault(self, _: Option<u64>) {}
+    // fn PassOptionalNullableFloatWithNonNullDefault(self, _: Option<f32>) {}
+    // fn PassOptionalNullableDoubleWithNonNullDefault(self, _: Option<f64>) {}
+    fn PassOptionalNullableStringWithNonNullDefault(self, _: Option<DOMString>) {}
+    // fn PassOptionalNullableEnumWithNonNullDefault(self, _: Option<TestEnum>) {}
 
-    fn PassVariadicBoolean(&self, _: Vec<bool>) {}
-    fn PassVariadicByte(&self, _: Vec<i8>) {}
-    fn PassVariadicOctet(&self, _: Vec<u8>) {}
-    fn PassVariadicShort(&self, _: Vec<i16>) {}
-    fn PassVariadicUnsignedShort(&self, _: Vec<u16>) {}
-    fn PassVariadicLong(&self, _: Vec<i32>) {}
-    fn PassVariadicUnsignedLong(&self, _: Vec<u32>) {}
-    fn PassVariadicLongLong(&self, _: Vec<i64>) {}
-    fn PassVariadicUnsignedLongLong(&self, _: Vec<u64>) {}
-    fn PassVariadicFloat(&self, _: Vec<f32>) {}
-    fn PassVariadicDouble(&self, _: Vec<f64>) {}
-    fn PassVariadicString(&self, _: Vec<DOMString>) {}
-    fn PassVariadicByteString(&self, _: Vec<ByteString>) {}
-    fn PassVariadicEnum(&self, _: Vec<TestEnum>) {}
-    // fn PassVariadicInterface(&self, _: Vec<JSRef<Blob>>) {}
-    fn PassVariadicUnion(&self, _: Vec<HTMLElementOrLong>) {}
-    fn PassVariadicUnion2(&self, _: Vec<EventOrString>) {}
-    fn PassVariadicUnion3(&self, _: Vec<BlobOrString>) {}
-    fn PassVariadicAny(&self, _: *mut JSContext, _: Vec<JSVal>) {}
+    fn PassVariadicBoolean(self, _: Vec<bool>) {}
+    fn PassVariadicByte(self, _: Vec<i8>) {}
+    fn PassVariadicOctet(self, _: Vec<u8>) {}
+    fn PassVariadicShort(self, _: Vec<i16>) {}
+    fn PassVariadicUnsignedShort(self, _: Vec<u16>) {}
+    fn PassVariadicLong(self, _: Vec<i32>) {}
+    fn PassVariadicUnsignedLong(self, _: Vec<u32>) {}
+    fn PassVariadicLongLong(self, _: Vec<i64>) {}
+    fn PassVariadicUnsignedLongLong(self, _: Vec<u64>) {}
+    fn PassVariadicFloat(self, _: Vec<f32>) {}
+    fn PassVariadicDouble(self, _: Vec<f64>) {}
+    fn PassVariadicString(self, _: Vec<DOMString>) {}
+    fn PassVariadicByteString(self, _: Vec<ByteString>) {}
+    fn PassVariadicEnum(self, _: Vec<TestEnum>) {}
+    // fn PassVariadicInterface(self, _: Vec<JSRef<Blob>>) {}
+    fn PassVariadicUnion(self, _: Vec<HTMLElementOrLong>) {}
+    fn PassVariadicUnion2(self, _: Vec<EventOrString>) {}
+    fn PassVariadicUnion3(self, _: Vec<BlobOrString>) {}
+    fn PassVariadicAny(self, _: *mut JSContext, _: Vec<JSVal>) {}
 }
 
 impl TestBinding {

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -58,7 +58,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
         let global = self.global.root();
         Blob::new(&global.root_ref())
     }
-    fn SetInterfaceAttribute(&self, _: &JSRef<Blob>) {}
+    fn SetInterfaceAttribute(&self, _: JSRef<Blob>) {}
     fn UnionAttribute(&self) -> HTMLElementOrLong { eLong(0) }
     fn SetUnionAttribute(&self, _: HTMLElementOrLong) {}
     fn Union2Attribute(&self) -> EventOrString { eString("".to_string()) }
@@ -160,7 +160,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn PassString(&self, _: DOMString) {}
     fn PassByteString(&self, _: ByteString) {}
     fn PassEnum(&self, _: TestEnum) {}
-    fn PassInterface(&self, _: &JSRef<Blob>) {}
+    fn PassInterface(&self, _: JSRef<Blob>) {}
     fn PassUnion(&self, _: HTMLElementOrLong) {}
     fn PassUnion2(&self, _: EventOrString) {}
     fn PassUnion3(&self, _: BlobOrString) {}

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -29,20 +29,20 @@ impl TextDerived for EventTarget {
 }
 
 impl Text {
-    pub fn new_inherited(text: DOMString, document: &JSRef<Document>) -> Text {
+    pub fn new_inherited(text: DOMString, document: JSRef<Document>) -> Text {
         Text {
             characterdata: CharacterData::new_inherited(TextNodeTypeId, text, document)
         }
     }
 
-    pub fn new(text: DOMString, document: &JSRef<Document>) -> Temporary<Text> {
+    pub fn new(text: DOMString, document: JSRef<Document>) -> Temporary<Text> {
         Node::reflect_node(box Text::new_inherited(text, document),
                            document, TextBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef, text: DOMString) -> Fallible<Temporary<Text>> {
         let document = global.as_window().Document().root();
-        Ok(Text::new(text, &*document))
+        Ok(Text::new(text, *document))
     }
 }
 

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -69,15 +69,15 @@ impl TreeWalker {
 }
 
 impl<'a> TreeWalkerMethods for JSRef<'a, TreeWalker> {
-    fn Root(&self) -> Temporary<Node> {
+    fn Root(self) -> Temporary<Node> {
         Temporary::new(self.root_node)
     }
 
-    fn WhatToShow(&self) -> u32 {
+    fn WhatToShow(self) -> u32 {
         self.what_to_show
     }
 
-    fn GetFilter(&self) -> Option<NodeFilter> {
+    fn GetFilter(self) -> Option<NodeFilter> {
         match self.filter {
             FilterNone => None,
             FilterJS(nf) => Some(nf),
@@ -85,41 +85,41 @@ impl<'a> TreeWalkerMethods for JSRef<'a, TreeWalker> {
         }
     }
 
-    fn CurrentNode(&self) -> Temporary<Node> {
+    fn CurrentNode(self) -> Temporary<Node> {
         Temporary::new(self.current_node.get())
     }
 
-    fn SetCurrentNode(&self, node: JSRef<Node>) -> ErrorResult {
+    fn SetCurrentNode(self, node: JSRef<Node>) -> ErrorResult {
         // XXX Future: check_same_origin(root_node, node) (throws)
         self.current_node.set(JS::from_rooted(node));
         Ok(())
     }
 
-    fn ParentNode(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn ParentNode(self) -> Fallible<Option<Temporary<Node>>> {
         self.parent_node()
     }
 
-    fn FirstChild(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn FirstChild(self) -> Fallible<Option<Temporary<Node>>> {
         self.first_child()
     }
 
-    fn LastChild(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn LastChild(self) -> Fallible<Option<Temporary<Node>>> {
         self.last_child()
     }
 
-    fn PreviousSibling(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn PreviousSibling(self) -> Fallible<Option<Temporary<Node>>> {
         self.prev_sibling()
     }
 
-    fn NextSibling(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn NextSibling(self) -> Fallible<Option<Temporary<Node>>> {
         self.next_sibling()
     }
 
-    fn PreviousNode(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn PreviousNode(self) -> Fallible<Option<Temporary<Node>>> {
         self.prev_node()
     }
 
-    fn NextNode(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn NextNode(self) -> Fallible<Option<Temporary<Node>>> {
         self.next_node()
     }
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -40,13 +40,13 @@ impl UIEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &JSRef<Window>) -> Temporary<UIEvent> {
+    pub fn new_uninitialized(window: JSRef<Window>) -> Temporary<UIEvent> {
         reflect_dom_object(box UIEvent::new_inherited(UIEventTypeId),
-                           &Window(*window),
+                           &Window(window),
                            UIEventBinding::Wrap)
     }
 
-    pub fn new(window: &JSRef<Window>,
+    pub fn new(window: JSRef<Window>,
                type_: DOMString,
                can_bubble: bool,
                cancelable: bool,
@@ -54,7 +54,7 @@ impl UIEvent {
                detail: i32) -> Temporary<UIEvent> {
         let ev = UIEvent::new_uninitialized(window).root();
         ev.deref().InitUIEvent(type_, can_bubble, cancelable, view, detail);
-        Temporary::from_rooted(&*ev)
+        Temporary::from_rooted(*ev)
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -82,7 +82,7 @@ impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
                    cancelable: bool,
                    view: Option<JSRef<Window>>,
                    detail: i32) {
-        let event: &JSRef<Event> = EventCast::from_ref(self);
+        let event: JSRef<Event> = EventCast::from_ref(*self);
         event.InitEvent(type_, can_bubble, cancelable);
         self.view.assign(view);
         self.detail.deref().set(detail);

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -68,21 +68,21 @@ impl UIEvent {
 }
 
 impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
-    fn GetView(&self) -> Option<Temporary<Window>> {
+    fn GetView(self) -> Option<Temporary<Window>> {
         self.view.get().map(|view| Temporary::new(view))
     }
 
-    fn Detail(&self) -> i32 {
+    fn Detail(self) -> i32 {
         self.detail.deref().get()
     }
 
-    fn InitUIEvent(&self,
+    fn InitUIEvent(self,
                    type_: DOMString,
                    can_bubble: bool,
                    cancelable: bool,
                    view: Option<JSRef<Window>>,
                    detail: i32) {
-        let event: JSRef<Event> = EventCast::from_ref(*self);
+        let event: JSRef<Event> = EventCast::from_ref(self);
         event.InitEvent(type_, can_bubble, cancelable);
         self.view.assign(view);
         self.detail.deref().set(detail);

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -61,26 +61,26 @@ impl URLSearchParams {
 }
 
 impl<'a> URLSearchParamsMethods for JSRef<'a, URLSearchParams> {
-    fn Append(&self, name: DOMString, value: DOMString) {
+    fn Append(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert_or_update_with(name, vec!(value.clone()),
                                                              |_k, v| v.push(value.clone()));
         self.update_steps();
     }
 
-    fn Delete(&self, name: DOMString) {
+    fn Delete(self, name: DOMString) {
         self.data.deref().borrow_mut().remove(&name);
         self.update_steps();
     }
 
-    fn Get(&self, name: DOMString) -> Option<DOMString> {
+    fn Get(self, name: DOMString) -> Option<DOMString> {
         self.data.deref().borrow().find_equiv(&name).map(|v| v[0].clone())
     }
 
-    fn Has(&self, name: DOMString) -> bool {
+    fn Has(self, name: DOMString) -> bool {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
 
-    fn Set(&self, name: DOMString, value: DOMString) {
+    fn Set(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert(name, vec!(value));
         self.update_steps();
     }

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -56,7 +56,7 @@ impl URLSearchParams {
             },
             None => {}
         }
-        Ok(Temporary::from_rooted(&*usp))
+        Ok(Temporary::from_rooted(*usp))
     }
 }
 

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -23,9 +23,9 @@ impl ValidityState {
         }
     }
 
-    pub fn new(window: &JSRef<Window>) -> Temporary<ValidityState> {
+    pub fn new(window: JSRef<Window>) -> Temporary<ValidityState> {
         reflect_dom_object(box ValidityState::new_inherited(),
-                           &Window(*window),
+                           &Window(window),
                            ValidityStateBinding::Wrap)
     }
 }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -116,7 +116,7 @@ pub trait VirtualMethods {
     }
 
     /// Called on the parent when a node is added to its child list.
-    fn child_inserted(&self, child: &JSRef<Node>) {
+    fn child_inserted(&self, child: JSRef<Node>) {
         match self.super_type() {
             Some(ref s) => s.child_inserted(child),
             _ => (),
@@ -124,7 +124,7 @@ pub trait VirtualMethods {
     }
 
     /// Called during event dispatch after the bubbling phase completes.
-    fn handle_event(&self, event: &JSRef<Event>) {
+    fn handle_event(&self, event: JSRef<Event>) {
         match self.super_type() {
             Some(s) => {
                 s.handle_event(event);
@@ -141,75 +141,75 @@ pub trait VirtualMethods {
 pub fn vtable_for<'a>(node: &'a JSRef<Node>) -> &'a VirtualMethods {
     match node.type_id() {
         ElementNodeTypeId(HTMLAnchorElementTypeId) => {
-            let element: &JSRef<HTMLAnchorElement> = HTMLAnchorElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLAnchorElement> = HTMLAnchorElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLAreaElementTypeId) => {
-            let element: &JSRef<HTMLAreaElement> = HTMLAreaElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLAreaElement> = HTMLAreaElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {
-            let element: &JSRef<HTMLBodyElement> = HTMLBodyElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLBodyElement> = HTMLBodyElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLButtonElementTypeId) => {
-            let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLButtonElement> = HTMLButtonElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLCanvasElementTypeId) => {
-            let element: &JSRef<HTMLCanvasElement> = HTMLCanvasElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLCanvasElement> = HTMLCanvasElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLFieldSetElementTypeId) => {
-            let element: &JSRef<HTMLFieldSetElement> = HTMLFieldSetElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLFieldSetElement> = HTMLFieldSetElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLImageElementTypeId) => {
-            let element: &JSRef<HTMLImageElement> = HTMLImageElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLImageElement> = HTMLImageElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLIFrameElementTypeId) => {
-            let element: &JSRef<HTMLIFrameElement> = HTMLIFrameElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLIFrameElement> = HTMLIFrameElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLInputElementTypeId) => {
-            let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLInputElement> = HTMLInputElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLLinkElementTypeId) => {
-            let element: &JSRef<HTMLLinkElement> = HTMLLinkElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLLinkElement> = HTMLLinkElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLObjectElementTypeId) => {
-            let element: &JSRef<HTMLObjectElement> = HTMLObjectElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLObjectElement> = HTMLObjectElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLOptGroupElementTypeId) => {
-            let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLOptGroupElement> = HTMLOptGroupElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLOptionElementTypeId) => {
-            let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLOptionElement> = HTMLOptionElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLSelectElementTypeId) => {
-            let element: &JSRef<HTMLSelectElement> = HTMLSelectElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLSelectElement> = HTMLSelectElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLStyleElementTypeId) => {
-            let element: &JSRef<HTMLStyleElement> = HTMLStyleElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLStyleElement> = HTMLStyleElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(HTMLTextAreaElementTypeId) => {
-            let element: &JSRef<HTMLTextAreaElement> = HTMLTextAreaElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLTextAreaElement> = HTMLTextAreaElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(ElementTypeId) => {
-            let element: &JSRef<Element> = ElementCast::to_ref(node).unwrap();
+            let element: &JSRef<Element> = ElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         ElementNodeTypeId(_) => {
-            let element: &JSRef<HTMLElement> = HTMLElementCast::to_ref(node).unwrap();
+            let element: &JSRef<HTMLElement> = HTMLElementCast::to_borrowed_ref(node).unwrap();
             element as &VirtualMethods
         }
         _ => {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -220,7 +220,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
     fn Location(&self) -> Temporary<Location> {
         if self.location.get().is_none() {
             let page = self.deref().page.clone();
-            let location = Location::new(self, page);
+            let location = Location::new(*self, page);
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
@@ -236,7 +236,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
 
     fn Navigator(&self) -> Temporary<Navigator> {
         if self.navigator.get().is_none() {
-            let navigator = Navigator::new(self);
+            let navigator = Navigator::new(*self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())
@@ -265,7 +265,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
     }
 
     fn Window(&self) -> Temporary<Window> {
-        Temporary::from_rooted(self)
+        Temporary::from_rooted(*self)
     }
 
     fn Self(&self) -> Temporary<Window> {
@@ -284,55 +284,55 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
 
     fn Performance(&self) -> Temporary<Performance> {
         if self.performance.get().is_none() {
-            let performance = Performance::new(self);
+            let performance = Performance::new(*self);
             self.performance.assign(Some(performance));
         }
         Temporary::new(self.performance.get().get_ref().clone())
     }
 
     fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("click")
     }
 
     fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
     fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("load")
     }
 
     fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
     fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("unload")
     }
 
     fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("unload", listener)
     }
 
     fn GetOnerror(&self) -> Option<OnErrorEventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("error")
     }
 
     fn SetOnerror(&self, listener: Option<OnErrorEventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
     fn Screen(&self) -> Temporary<Screen> {
         if self.screen.get().is_none() {
-            let screen = Screen::new(self);
+            let screen = Screen::new(*self);
             self.screen.assign(Some(screen));
         }
         Temporary::new(self.screen.get().get_ref().clone())
@@ -367,7 +367,7 @@ pub trait WindowHelpers {
     fn damage_and_reflow(&self, damage: DocumentDamageLevel);
     fn flush_layout(&self, goal: ReflowGoal);
     fn wait_until_safe_to_modify_dom(&self);
-    fn init_browser_context(&self, doc: &JSRef<Document>);
+    fn init_browser_context(&self, doc: JSRef<Document>);
     fn load_url(&self, href: DOMString);
     fn handle_fire_timer(&self, timer_id: TimerId, cx: *mut JSContext);
     fn evaluate_js_with_result(&self, code: &str) -> JSVal;
@@ -412,7 +412,7 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         self.page().join_layout();
     }
 
-    fn init_browser_context(&self, doc: &JSRef<Document>) {
+    fn init_browser_context(&self, doc: JSRef<Document>) {
         *self.browser_context.deref().borrow_mut() = Some(BrowserContext::new(doc));
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -202,51 +202,51 @@ pub fn base64_atob(atob: DOMString) -> Fallible<DOMString> {
 
 
 impl<'a> WindowMethods for JSRef<'a, Window> {
-    fn Alert(&self, s: DOMString) {
+    fn Alert(self, s: DOMString) {
         // Right now, just print to the console
         println!("ALERT: {:s}", s);
     }
 
-    fn Close(&self) {
+    fn Close(self) {
         let ScriptChan(ref chan) = self.script_chan;
         chan.send(ExitWindowMsg(self.page.id.clone()));
     }
 
-    fn Document(&self) -> Temporary<Document> {
+    fn Document(self) -> Temporary<Document> {
         let frame = self.page().frame();
         Temporary::new(frame.get_ref().document.clone())
     }
 
-    fn Location(&self) -> Temporary<Location> {
+    fn Location(self) -> Temporary<Location> {
         if self.location.get().is_none() {
             let page = self.deref().page.clone();
-            let location = Location::new(*self, page);
+            let location = Location::new(self, page);
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
     }
 
-    fn Console(&self) -> Temporary<Console> {
+    fn Console(self) -> Temporary<Console> {
         if self.console.get().is_none() {
-            let console = Console::new(&global::Window(*self));
+            let console = Console::new(&global::Window(self));
             self.console.assign(Some(console));
         }
         Temporary::new(self.console.get().get_ref().clone())
     }
 
-    fn Navigator(&self) -> Temporary<Navigator> {
+    fn Navigator(self) -> Temporary<Navigator> {
         if self.navigator.get().is_none() {
-            let navigator = Navigator::new(*self);
+            let navigator = Navigator::new(self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())
     }
 
-    fn SetTimeout(&self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
+    fn SetTimeout(self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
         self.set_timeout_or_interval(callback, timeout, false)
     }
 
-    fn ClearTimeout(&self, handle: i32) {
+    fn ClearTimeout(self, handle: i32) {
         let mut timers = self.active_timers.deref().borrow_mut();
         let mut timer_handle = timers.pop(&TimerId(handle));
         match timer_handle {
@@ -256,103 +256,103 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         timers.remove(&TimerId(handle));
     }
 
-    fn SetInterval(&self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
+    fn SetInterval(self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
         self.set_timeout_or_interval(callback, timeout, true)
     }
 
-    fn ClearInterval(&self, handle: i32) {
+    fn ClearInterval(self, handle: i32) {
         self.ClearTimeout(handle);
     }
 
-    fn Window(&self) -> Temporary<Window> {
-        Temporary::from_rooted(*self)
+    fn Window(self) -> Temporary<Window> {
+        Temporary::from_rooted(self)
     }
 
-    fn Self(&self) -> Temporary<Window> {
+    fn Self(self) -> Temporary<Window> {
         self.Window()
     }
 
     // http://www.whatwg.org/html/#dom-frames
-    fn Frames(&self) -> Temporary<Window> {
+    fn Frames(self) -> Temporary<Window> {
         self.Window()
     }
 
-    fn Parent(&self) -> Temporary<Window> {
+    fn Parent(self) -> Temporary<Window> {
         //TODO - Once we support iframes correctly this needs to return the parent frame
         self.Window()
     }
 
-    fn Performance(&self) -> Temporary<Performance> {
+    fn Performance(self) -> Temporary<Performance> {
         if self.performance.get().is_none() {
-            let performance = Performance::new(*self);
+            let performance = Performance::new(self);
             self.performance.assign(Some(performance));
         }
         Temporary::new(self.performance.get().get_ref().clone())
     }
 
-    fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("click")
     }
 
-    fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("load")
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
-    fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnunload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("unload")
     }
 
-    fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnunload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("unload", listener)
     }
 
-    fn GetOnerror(&self) -> Option<OnErrorEventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnerror(self) -> Option<OnErrorEventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("error")
     }
 
-    fn SetOnerror(&self, listener: Option<OnErrorEventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnerror(self, listener: Option<OnErrorEventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
-    fn Screen(&self) -> Temporary<Screen> {
+    fn Screen(self) -> Temporary<Screen> {
         if self.screen.get().is_none() {
-            let screen = Screen::new(*self);
+            let screen = Screen::new(self);
             self.screen.assign(Some(screen));
         }
         Temporary::new(self.screen.get().get_ref().clone())
     }
 
-    fn Debug(&self, message: DOMString) {
+    fn Debug(self, message: DOMString) {
         debug!("{:s}", message);
     }
 
-    fn Gc(&self) {
+    fn Gc(self) {
         unsafe {
             JS_GC(JS_GetRuntime(self.get_cx()));
         }
     }
 
-    fn Btoa(&self, btoa: DOMString) -> Fallible<DOMString> {
+    fn Btoa(self, btoa: DOMString) -> Fallible<DOMString> {
         base64_btoa(btoa)
     }
 
-    fn Atob(&self, atob: DOMString) -> Fallible<DOMString> {
+    fn Atob(self, atob: DOMString) -> Fallible<DOMString> {
         base64_atob(atob)
     }
 }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -75,7 +75,7 @@ impl Worker {
             worker_url, worker_ref, resource_task, global.script_chan().clone(),
             sender, receiver);
 
-        Ok(Temporary::from_rooted(&*worker))
+        Ok(Temporary::from_rooted(*worker))
     }
 
     pub fn handle_message(address: TrustedWorkerAddress,
@@ -92,7 +92,7 @@ impl Worker {
                 ptr::null(), ptr::mut_null()) != 0);
         }
 
-        let target: &JSRef<EventTarget> = EventTargetCast::from_ref(&*worker);
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(*worker);
         MessageEvent::dispatch_jsval(target, &global.root_ref(), message);
     }
 }
@@ -144,12 +144,12 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
     }
 
     fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("message")
     }
 
     fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -130,7 +130,7 @@ impl Worker {
 }
 
 impl<'a> WorkerMethods for JSRef<'a, Worker> {
-    fn PostMessage(&self, cx: *mut JSContext, message: JSVal) {
+    fn PostMessage(self, cx: *mut JSContext, message: JSVal) {
         let mut data = ptr::mut_null();
         let mut nbytes = 0;
         unsafe {
@@ -143,13 +143,13 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
         sender.send(DOMMessage(data, nbytes));
     }
 
-    fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnmessage(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("message")
     }
 
-    fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnmessage(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -80,12 +80,12 @@ impl WorkerGlobalScope {
 
 impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
     fn Self(&self) -> Temporary<WorkerGlobalScope> {
-        Temporary::from_rooted(self)
+        Temporary::from_rooted(*self)
     }
 
     fn Location(&self) -> Temporary<WorkerLocation> {
         if self.location.get().is_none() {
-            let location = WorkerLocation::new(self, self.worker_url.clone());
+            let location = WorkerLocation::new(*self, self.worker_url.clone());
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
@@ -125,7 +125,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
 
     fn Navigator(&self) -> Temporary<WorkerNavigator> {
         if self.navigator.get().is_none() {
-            let navigator = WorkerNavigator::new(self);
+            let navigator = WorkerNavigator::new(*self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -79,19 +79,19 @@ impl WorkerGlobalScope {
 }
 
 impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
-    fn Self(&self) -> Temporary<WorkerGlobalScope> {
-        Temporary::from_rooted(*self)
+    fn Self(self) -> Temporary<WorkerGlobalScope> {
+        Temporary::from_rooted(self)
     }
 
-    fn Location(&self) -> Temporary<WorkerLocation> {
+    fn Location(self) -> Temporary<WorkerLocation> {
         if self.location.get().is_none() {
-            let location = WorkerLocation::new(*self, self.worker_url.clone());
+            let location = WorkerLocation::new(self, self.worker_url.clone());
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
     }
 
-    fn ImportScripts(&self, url_strings: Vec<DOMString>) -> ErrorResult {
+    fn ImportScripts(self, url_strings: Vec<DOMString>) -> ErrorResult {
         let mut urls = Vec::with_capacity(url_strings.len());
         for url in url_strings.move_iter() {
             let url = UrlParser::new().base_url(&*self.worker_url)
@@ -123,27 +123,27 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         Ok(())
     }
 
-    fn Navigator(&self) -> Temporary<WorkerNavigator> {
+    fn Navigator(self) -> Temporary<WorkerNavigator> {
         if self.navigator.get().is_none() {
-            let navigator = WorkerNavigator::new(*self);
+            let navigator = WorkerNavigator::new(self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())
     }
 
-    fn Console(&self) -> Temporary<Console> {
+    fn Console(self) -> Temporary<Console> {
         if self.console.get().is_none() {
-            let console = Console::new(&global::Worker(*self));
+            let console = Console::new(&global::Worker(self));
             self.console.assign(Some(console));
         }
         Temporary::new(self.console.get().get_ref().clone())
     }
 
-    fn Btoa(&self, btoa: DOMString) -> Fallible<DOMString> {
+    fn Btoa(self, btoa: DOMString) -> Fallible<DOMString> {
         base64_btoa(btoa)
     }
 
-    fn Atob(&self, atob: DOMString) -> Fallible<DOMString> {
+    fn Atob(self, atob: DOMString) -> Fallible<DOMString> {
         base64_atob(atob)
     }
 }

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -29,9 +29,9 @@ impl WorkerLocation {
         }
     }
 
-    pub fn new(global: &JSRef<WorkerGlobalScope>, url: Url) -> Temporary<WorkerLocation> {
+    pub fn new(global: JSRef<WorkerGlobalScope>, url: Url) -> Temporary<WorkerLocation> {
         reflect_dom_object(box WorkerLocation::new_inherited(url),
-                           &Worker(*global),
+                           &Worker(global),
                            WorkerLocationBinding::Wrap)
     }
 }

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -37,11 +37,11 @@ impl WorkerLocation {
 }
 
 impl<'a> WorkerLocationMethods for JSRef<'a, WorkerLocation> {
-    fn Href(&self) -> DOMString {
+    fn Href(self) -> DOMString {
         self.url.serialize()
     }
 
-    fn Search(&self) -> DOMString {
+    fn Search(self) -> DOMString {
         match self.url.query {
             None => "".to_string(),
             Some(ref query) if query.as_slice() == "" => "".to_string(),
@@ -49,7 +49,7 @@ impl<'a> WorkerLocationMethods for JSRef<'a, WorkerLocation> {
         }
     }
 
-    fn Hash(&self) -> DOMString {
+    fn Hash(self) -> DOMString {
         match self.url.fragment {
             None => "".to_string(),
             Some(ref hash) if hash.as_slice() == "" => "".to_string(),

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -23,9 +23,9 @@ impl WorkerNavigator {
         }
     }
 
-    pub fn new(global: &JSRef<WorkerGlobalScope>) -> Temporary<WorkerNavigator> {
+    pub fn new(global: JSRef<WorkerGlobalScope>) -> Temporary<WorkerNavigator> {
         reflect_dom_object(box WorkerNavigator::new_inherited(),
-                           &Worker(*global),
+                           &Worker(global),
                            WorkerNavigatorBinding::Wrap)
     }
 }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -31,23 +31,23 @@ impl WorkerNavigator {
 }
 
 impl<'a> WorkerNavigatorMethods for JSRef<'a, WorkerNavigator> {
-    fn Product(&self) -> DOMString {
+    fn Product(self) -> DOMString {
         "Gecko".to_string()
     }
 
-    fn TaintEnabled(&self) -> bool {
+    fn TaintEnabled(self) -> bool {
         false
     }
 
-    fn AppName(&self) -> DOMString {
+    fn AppName(self) -> DOMString {
         "Netscape".to_string() // Like Gecko/Webkit
     }
 
-    fn AppCodeName(&self) -> DOMString {
+    fn AppCodeName(self) -> DOMString {
         "Mozilla".to_string()
     }
 
-    fn Platform(&self) -> DOMString {
+    fn Platform(self) -> DOMString {
         "".to_string()
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -138,7 +138,7 @@ impl XMLHttpRequest {
             ready_state: Traceable::new(Cell::new(Unsent)),
             timeout: Traceable::new(Cell::new(0u32)),
             with_credentials: Traceable::new(Cell::new(false)),
-            upload: JS::from_rooted(&XMLHttpRequestUpload::new(global)),
+            upload: JS::from_rooted(XMLHttpRequestUpload::new(global)),
             response_url: "".to_string(),
             status: Traceable::new(Cell::new(0)),
             status_text: Traceable::new(RefCell::new(ByteString::new(vec!()))),
@@ -260,12 +260,12 @@ impl XMLHttpRequest {
 
 impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
     fn GetOnreadystatechange(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("readystatechange")
     }
 
     fn SetOnreadystatechange(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("readystatechange", listener)
     }
 
@@ -467,8 +467,8 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             }
 
             // Step 8
-            let upload_target = &*self.upload.root();
-            let event_target: &JSRef<EventTarget> = EventTargetCast::from_ref(upload_target);
+            let upload_target = *self.upload.root();
+            let event_target: JSRef<EventTarget> = EventTargetCast::from_ref(upload_target);
             if event_target.has_handlers() {
                 self.upload_events.deref().set(true);
             }
@@ -741,8 +741,8 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         let event = Event::new(&global.root_ref(),
                                "readystatechange".to_string(),
                                false, true).root();
-        let target: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.dispatch_event_with_target(None, &*event).ok();
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+        target.dispatch_event_with_target(None, *event).ok();
     }
 
     fn process_partial_response(&self, progress: XHRProgress) {
@@ -859,17 +859,17 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
 
     fn dispatch_progress_event(&self, upload: bool, type_: DOMString, loaded: u64, total: Option<u64>) {
         let global = self.global.root();
-        let upload_target = &*self.upload.root();
+        let upload_target = *self.upload.root();
         let progressevent = ProgressEvent::new(&global.root_ref(),
                                                type_, false, false,
                                                total.is_some(), loaded,
                                                total.unwrap_or(0)).root();
-        let target: &JSRef<EventTarget> = if upload {
+        let target: JSRef<EventTarget> = if upload {
             EventTargetCast::from_ref(upload_target)
         } else {
-            EventTargetCast::from_ref(self)
+            EventTargetCast::from_ref(*self)
         };
-        let event: &JSRef<Event> = EventCast::from_ref(&*progressevent);
+        let event: JSRef<Event> = EventCast::from_ref(*progressevent);
         target.dispatch_event_with_target(None, event).ok();
     }
 

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -41,73 +41,73 @@ impl Reflectable for XMLHttpRequestEventTarget {
 }
 
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
-    fn GetOnloadstart(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnloadstart(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("loadstart")
     }
 
-    fn SetOnloadstart(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnloadstart(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("loadstart", listener)
     }
 
-    fn GetOnprogress(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnprogress(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("progress")
     }
 
-    fn SetOnprogress(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnprogress(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("progress", listener)
     }
 
-    fn GetOnabort(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnabort(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("abort")
     }
 
-    fn SetOnabort(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnabort(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("abort", listener)
     }
 
-    fn GetOnerror(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnerror(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("error")
     }
 
-    fn SetOnerror(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnerror(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("load")
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
-    fn GetOntimeout(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOntimeout(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("timeout")
     }
 
-    fn SetOntimeout(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOntimeout(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("timeout", listener)
     }
 
-    fn GetOnloadend(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnloadend(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("loadend")
     }
 
-    fn SetOnloadend(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnloadend(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("loadend", listener)
     }
 }

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -42,72 +42,72 @@ impl Reflectable for XMLHttpRequestEventTarget {
 
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
     fn GetOnloadstart(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("loadstart")
     }
 
     fn SetOnloadstart(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("loadstart", listener)
     }
 
     fn GetOnprogress(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("progress")
     }
 
     fn SetOnprogress(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("progress", listener)
     }
 
     fn GetOnabort(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("abort")
     }
 
     fn SetOnabort(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("abort", listener)
     }
 
     fn GetOnerror(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("error")
     }
 
     fn SetOnerror(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
     fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("load")
     }
 
     fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
     fn GetOntimeout(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("timeout")
     }
 
     fn SetOntimeout(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("timeout", listener)
     }
 
     fn GetOnloadend(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.get_event_handler_common("loadend")
     }
 
     fn SetOnloadend(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: &JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
         eventtarget.set_event_handler_common("loadend", listener)
     }
 }

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -271,7 +271,7 @@ impl Page {
         match root.root() {
             None => {},
             Some(root) => {
-                let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+                let root: JSRef<Node> = NodeCast::from_ref(*root);
                 let mut damage = *self.damage.deref().borrow_mut();
                 match damage {
                     None => {}
@@ -366,7 +366,7 @@ impl Page {
                 let last_reflow_id = self.last_reflow_id.deref();
                 last_reflow_id.set(last_reflow_id.get() + 1);
 
-                let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+                let root: JSRef<Node> = NodeCast::from_ref(*root);
                 let mut damage = self.damage.deref().borrow_mut();
                 let window_size = self.window_size.deref().get();
 
@@ -397,15 +397,15 @@ impl Page {
         match document.deref().GetElementById(fragid.to_string()) {
             Some(node) => Some(node),
             None => {
-                let doc_node: &JSRef<Node> = NodeCast::from_ref(&*document);
+                let doc_node: JSRef<Node> = NodeCast::from_ref(*document);
                 let mut anchors = doc_node.traverse_preorder()
                                           .filter(|node| node.is_anchor_element());
                 anchors.find(|node| {
-                    let elem: &JSRef<Element> = ElementCast::to_ref(node).unwrap();
+                    let elem: JSRef<Element> = ElementCast::to_ref(*node).unwrap();
                     elem.get_attribute(Null, "name").root().map_or(false, |attr| {
                         attr.deref().value().as_slice() == fragid.as_slice()
                     })
-                }).map(|node| Temporary::from_rooted(ElementCast::to_ref(&node).unwrap()))
+                }).map(|node| Temporary::from_rooted(ElementCast::to_ref(node).unwrap()))
             }
         }
     }
@@ -418,7 +418,7 @@ impl Page {
             return None;
         }
         let root = root.unwrap();
-        let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+        let root: JSRef<Node> = NodeCast::from_ref(*root);
         let address = match self.layout().hit_test(root.to_trusted_node_address(), *point) {
             Ok(HitTestResponse(node_address)) => {
                 Some(node_address)
@@ -439,7 +439,7 @@ impl Page {
             return None;
         }
         let root = root.unwrap();
-        let root: &JSRef<Node> = NodeCast::from_ref(&*root);
+        let root: JSRef<Node> = NodeCast::from_ref(*root);
         let address = match self.layout().mouse_over(root.to_trusted_node_address(), *point) {
             Ok(MouseOverResponse(node_address)) => {
                 Some(node_address)


### PR DESCRIPTION
Change all of the <Class>Methods traits to take `self` instead of
`&self`.
