### PR TITLE
Handle dynamic addition of attributes

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -129,6 +129,7 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == float_table_a.html float_table_ref.html
 == table_containing_block_a.html table_containing_block_ref.html
 == link_style_order.html link_style_order_ref.html
+== link_style_dynamic_addition.html link_style_dynamic_addition_ref.html
 == percent_height.html percent_height_ref.html
 == inline_block_with_margin_a.html inline_block_with_margin_ref.html
 == table_padding_a.html table_padding_ref.html

--- a/tests/ref/link_style_dynamic_addition.html
+++ b/tests/ref/link_style_dynamic_addition.html
@@ -1,0 +1,11 @@
+<html>
+    <head></head>
+    <body>
+        <script>
+            var link = document.createElement("link");
+            document.head.appendChild(link);
+            link.setAttribute("rel", "stylesheet");
+            link.setAttribute("href", "data:text/css,body{background:green}");
+        </script>
+    </body>
+</html>

--- a/tests/ref/link_style_dynamic_addition_ref.html
+++ b/tests/ref/link_style_dynamic_addition_ref.html
@@ -1,0 +1,7 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="data:text/css,body{background:green}">
+    </head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
Handles dynamic addition of attributes to `<link rel=stylesheet>`
elements.

Fixes #3361
