### PR TITLE
More progress in the &JSRef -> JSRef conversion

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -147,14 +147,14 @@ impl<'a> AttrMethods for JSRef<'a, Attr> {
 }
 
 pub trait AttrHelpers {
-    fn set_value(&self, set_type: AttrSettingType, value: AttrValue);
+    fn set_value(self, set_type: AttrSettingType, value: AttrValue);
     fn value<'a>(&'a self) -> Ref<'a, AttrValue>;
     fn local_name<'a>(&'a self) -> &'a Atom;
-    fn summarize(&self) -> AttrInfo;
+    fn summarize(self) -> AttrInfo;
 }
 
 impl<'a> AttrHelpers for JSRef<'a, Attr> {
-    fn set_value(&self, set_type: AttrSettingType, value: AttrValue) {
+    fn set_value(self, set_type: AttrSettingType, value: AttrValue) {
         let owner = self.owner.root();
         let node: JSRef<Node> = NodeCast::from_ref(*owner);
         let namespace_is_null = self.namespace == namespace::Null;
@@ -187,7 +187,7 @@ impl<'a> AttrHelpers for JSRef<'a, Attr> {
         &self.local_name
     }
 
-    fn summarize(&self) -> AttrInfo {
+    fn summarize(self) -> AttrInfo {
         AttrInfo {
             namespace: self.namespace.to_str().to_string(),
             name: self.Name(),

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -116,33 +116,32 @@ impl Attr {
 }
 
 impl<'a> AttrMethods for JSRef<'a, Attr> {
-    fn LocalName(&self) -> DOMString {
+    fn LocalName(self) -> DOMString {
         self.local_name().as_slice().to_string()
     }
 
-    fn Value(&self) -> DOMString {
+    fn Value(self) -> DOMString {
         self.value().as_slice().to_string()
     }
 
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(self, value: DOMString) {
         let owner = self.owner.root();
-        let value = owner.deref().parse_attribute(
-            &self.namespace, self.local_name(), value);
+        let value = owner.deref().parse_attribute(&self.namespace, self.local_name(), value);
         self.set_value(ReplacedAttr, value);
     }
 
-    fn Name(&self) -> DOMString {
+    fn Name(self) -> DOMString {
         self.name.as_slice().to_string()
     }
 
-    fn GetNamespaceURI(&self) -> Option<DOMString> {
+    fn GetNamespaceURI(self) -> Option<DOMString> {
         match self.namespace.to_str() {
             "" => None,
             url => Some(url.to_string()),
         }
     }
 
-    fn GetPrefix(&self) -> Option<DOMString> {
+    fn GetPrefix(self) -> Option<DOMString> {
         self.prefix.clone()
     }
 }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2186,7 +2186,7 @@ class CGCallGenerator(CGThing):
         if static:
             call = CGWrapper(call, pre="%s::" % descriptorProvider.interface.identifier.name)
         else: 
-            call = CGWrapper(call, pre="(*%s)." % object)
+            call = CGWrapper(call, pre="%s." % object)
         call = CGList([call, CGWrapper(args, pre="(", post=")")])
 
         self.cgRoot.append(CGList([
@@ -4064,7 +4064,7 @@ class CGInterfaceTrait(CGThing):
             return "".join(", %s: %s" % argument for argument in arguments)
 
         methods = CGList([
-            CGGeneric("fn %s(&self%s) -> %s;\n" % (name, fmt(arguments), rettype))
+            CGGeneric("fn %s(self%s) -> %s;\n" % (name, fmt(arguments), rettype))
             for name, arguments, rettype in members()
         ], "")
         self.cgRoot = CGWrapper(CGIndenter(methods),

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -46,21 +46,21 @@ impl CanvasRenderingContext2D {
 }
 
 impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D> {
-    fn Canvas(&self) -> Temporary<HTMLCanvasElement> {
+    fn Canvas(self) -> Temporary<HTMLCanvasElement> {
         Temporary::new(self.canvas)
     }
 
-    fn FillRect(&self, x: f64, y: f64, width: f64, height: f64) {
+    fn FillRect(self, x: f64, y: f64, width: f64, height: f64) {
         let rect = Rect(Point2D(x as f32, y as f32), Size2D(width as f32, height as f32));
         self.renderer.deref().send(FillRect(rect));
     }
 
-    fn ClearRect(&self, x: f64, y: f64, width: f64, height: f64) {
+    fn ClearRect(self, x: f64, y: f64, width: f64, height: f64) {
         let rect = Rect(Point2D(x as f32, y as f32), Size2D(width as f32, height as f32));
         self.renderer.deref().send(ClearRect(rect));
     }
 
-    fn StrokeRect(&self, x: f64, y: f64, width: f64, height: f64) {
+    fn StrokeRect(self, x: f64, y: f64, width: f64, height: f64) {
         let rect = Rect(Point2D(x as f32, y as f32), Size2D(width as f32, height as f32));
         self.renderer.deref().send(StrokeRect(rect));
     }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -45,37 +45,37 @@ impl CharacterData {
 }
 
 impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
-    fn Data(&self) -> DOMString {
+    fn Data(self) -> DOMString {
         self.data.deref().borrow().clone()
     }
 
-    fn SetData(&self, arg: DOMString) -> ErrorResult {
+    fn SetData(self, arg: DOMString) -> ErrorResult {
         *self.data.deref().borrow_mut() = arg;
         Ok(())
     }
 
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.data.deref().borrow().len() as u32
     }
 
-    fn SubstringData(&self, offset: u32, count: u32) -> Fallible<DOMString> {
+    fn SubstringData(self, offset: u32, count: u32) -> Fallible<DOMString> {
         Ok(self.data.deref().borrow().as_slice().slice(offset as uint, count as uint).to_string())
     }
 
-    fn AppendData(&self, arg: DOMString) -> ErrorResult {
+    fn AppendData(self, arg: DOMString) -> ErrorResult {
         self.data.deref().borrow_mut().push_str(arg.as_slice());
         Ok(())
     }
 
-    fn InsertData(&self, offset: u32, arg: DOMString) -> ErrorResult {
+    fn InsertData(self, offset: u32, arg: DOMString) -> ErrorResult {
         self.ReplaceData(offset, 0, arg)
     }
 
-    fn DeleteData(&self, offset: u32, count: u32) -> ErrorResult {
+    fn DeleteData(self, offset: u32, count: u32) -> ErrorResult {
         self.ReplaceData(offset, count, "".to_string())
     }
 
-    fn ReplaceData(&self, offset: u32, count: u32, arg: DOMString) -> ErrorResult {
+    fn ReplaceData(self, offset: u32, count: u32, arg: DOMString) -> ErrorResult {
         let length = self.data.deref().borrow().len() as u32;
         if offset > length {
             return Err(IndexSize);
@@ -94,8 +94,8 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
     }
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Remove(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.remove_self();
     }
 }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -42,7 +42,7 @@ impl Comment {
 
     pub fn Constructor(global: &GlobalRef, data: DOMString) -> Fallible<Temporary<Comment>> {
         let document = global.as_window().Document().root();
-        Ok(Comment::new(data, *&*document))
+        Ok(Comment::new(data, *document))
     }
 }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -28,27 +28,27 @@ impl Console {
 }
 
 impl<'a> ConsoleMethods for JSRef<'a, Console> {
-    fn Log(&self, message: DOMString) {
+    fn Log(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Debug(&self, message: DOMString) {
+    fn Debug(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Info(&self, message: DOMString) {
+    fn Info(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Warn(&self, message: DOMString) {
+    fn Warn(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Error(&self, message: DOMString) {
+    fn Error(self, message: DOMString) {
         println!("{:s}", message);
     }
 
-    fn Assert(&self, condition: bool, message: Option<DOMString>) {
+    fn Assert(self, condition: bool, message: Option<DOMString>) {
         if !condition {
             let message = match message {
                 Some(ref message) => message.as_slice(),

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -57,18 +57,18 @@ impl CustomEvent {
 }
 
 impl<'a> CustomEventMethods for JSRef<'a, CustomEvent> {
-    fn Detail(&self, _cx: *mut JSContext) -> JSVal {
+    fn Detail(self, _cx: *mut JSContext) -> JSVal {
         *self.detail.deref().get()
     }
 
-    fn InitCustomEvent(&self,
+    fn InitCustomEvent(self,
                        _cx: *mut JSContext,
                        type_: DOMString,
                        can_bubble: bool,
                        cancelable: bool,
                        detail: JSVal) {
         self.detail.deref().set(Traceable::new(detail));
-        let event: JSRef<Event> = EventCast::from_ref(*self);
+        let event: JSRef<Event> = EventCast::from_ref(self);
         event.InitEvent(type_, can_bubble, cancelable);
     }
 }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -151,7 +151,7 @@ impl DedicatedWorkerGlobalScope {
 }
 
 impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalScope> {
-    fn PostMessage(&self, cx: *mut JSContext, message: JSVal) {
+    fn PostMessage(self, cx: *mut JSContext, message: JSVal) {
         let mut data = ptr::mut_null();
         let mut nbytes = 0;
         unsafe {
@@ -163,13 +163,13 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalSc
         sender.send(WorkerPostMessage(*self.worker, data, nbytes));
     }
 
-    fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnmessage(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("message")
     }
 
-    fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnmessage(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -175,11 +175,11 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalSc
 }
 
 trait PrivateDedicatedWorkerGlobalScopeHelpers {
-    fn delayed_release_worker(&self);
+    fn delayed_release_worker(self);
 }
 
 impl<'a> PrivateDedicatedWorkerGlobalScopeHelpers for JSRef<'a, DedicatedWorkerGlobalScope> {
-    fn delayed_release_worker(&self) {
+    fn delayed_release_worker(self) {
         let ScriptChan(ref sender) = self.parent_sender;
         sender.send(WorkerRelease(*self.worker));
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -367,25 +367,25 @@ impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
 
 impl<'a> DocumentMethods for JSRef<'a, Document> {
     // http://dom.spec.whatwg.org/#dom-document-implementation
-    fn Implementation(&self) -> Temporary<DOMImplementation> {
+    fn Implementation(self) -> Temporary<DOMImplementation> {
         if self.implementation.get().is_none() {
-            self.implementation.assign(Some(DOMImplementation::new(*self)));
+            self.implementation.assign(Some(DOMImplementation::new(self)));
         }
         Temporary::new(self.implementation.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-document-url
-    fn URL(&self) -> DOMString {
+    fn URL(self) -> DOMString {
         self.url().serialize()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-documenturi
-    fn DocumentURI(&self) -> DOMString {
+    fn DocumentURI(self) -> DOMString {
         self.URL()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-compatmode
-    fn CompatMode(&self) -> DOMString {
+    fn CompatMode(self) -> DOMString {
         match self.quirks_mode.deref().get() {
             LimitedQuirks | NoQuirks => "CSS1Compat".to_string(),
             FullQuirks => "BackCompat".to_string()
@@ -393,18 +393,18 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-characterset
-    fn CharacterSet(&self) -> DOMString {
+    fn CharacterSet(self) -> DOMString {
         self.encoding_name.deref().borrow().as_slice().to_ascii_lower()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-content_type
-    fn ContentType(&self) -> DOMString {
+    fn ContentType(self) -> DOMString {
         self.content_type.clone()
     }
 
     // http://dom.spec.whatwg.org/#dom-document-doctype
-    fn GetDoctype(&self) -> Option<Temporary<DocumentType>> {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetDoctype(self) -> Option<Temporary<DocumentType>> {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.children().find(|child| {
             child.is_doctype()
         }).map(|node| {
@@ -414,32 +414,32 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-documentelement
-    fn GetDocumentElement(&self) -> Option<Temporary<Element>> {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetDocumentElement(self) -> Option<Temporary<Element>> {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.child_elements().next().map(|elem| Temporary::from_rooted(elem))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbytagname
-    fn GetElementsByTagName(&self, tag_name: DOMString) -> Temporary<HTMLCollection> {
+    fn GetElementsByTagName(self, tag_name: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(*self), tag_name)
+        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(self), tag_name)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbytagnamens
-    fn GetElementsByTagNameNS(&self, maybe_ns: Option<DOMString>, tag_name: DOMString) -> Temporary<HTMLCollection> {
+    fn GetElementsByTagNameNS(self, maybe_ns: Option<DOMString>, tag_name: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(*self), tag_name, maybe_ns)
+        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(self), tag_name, maybe_ns)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbyclassname
-    fn GetElementsByClassName(&self, classes: DOMString) -> Temporary<HTMLCollection> {
+    fn GetElementsByClassName(self, classes: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
 
-        HTMLCollection::by_class_name(*window, NodeCast::from_ref(*self), classes)
+        HTMLCollection::by_class_name(*window, NodeCast::from_ref(self), classes)
     }
 
     // http://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid
-    fn GetElementById(&self, id: DOMString) -> Option<Temporary<Element>> {
+    fn GetElementById(self, id: DOMString) -> Option<Temporary<Element>> {
         match self.idmap.deref().borrow().find_equiv(&id) {
             None => None,
             Some(ref elements) => Some(Temporary::new((*elements)[0].clone())),
@@ -447,17 +447,17 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createelement
-    fn CreateElement(&self, local_name: DOMString) -> Fallible<Temporary<Element>> {
+    fn CreateElement(self, local_name: DOMString) -> Fallible<Temporary<Element>> {
         if xml_name_type(local_name.as_slice()) == InvalidXMLName {
             debug!("Not a valid element name");
             return Err(InvalidCharacter);
         }
         let local_name = local_name.as_slice().to_ascii_lower();
-        Ok(build_element_from_tag(local_name, namespace::HTML, *self))
+        Ok(build_element_from_tag(local_name, namespace::HTML, self))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createelementns
-    fn CreateElementNS(&self,
+    fn CreateElementNS(self,
                        namespace: Option<DOMString>,
                        qualified_name: DOMString) -> Fallible<Temporary<Element>> {
         let ns = Namespace::from_str(null_str_as_empty_ref(&namespace));
@@ -497,31 +497,31 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         }
 
         if ns == namespace::HTML {
-            Ok(build_element_from_tag(local_name_from_qname.to_string(), ns, *self))
+            Ok(build_element_from_tag(local_name_from_qname.to_string(), ns, self))
         } else {
             Ok(Element::new(local_name_from_qname.to_string(), ns,
-                            prefix_from_qname.map(|s| s.to_string()), *self))
+                            prefix_from_qname.map(|s| s.to_string()), self))
         }
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createdocumentfragment
-    fn CreateDocumentFragment(&self) -> Temporary<DocumentFragment> {
-        DocumentFragment::new(*self)
+    fn CreateDocumentFragment(self) -> Temporary<DocumentFragment> {
+        DocumentFragment::new(self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createtextnode
-    fn CreateTextNode(&self, data: DOMString)
+    fn CreateTextNode(self, data: DOMString)
                           -> Temporary<Text> {
-        Text::new(data, *self)
+        Text::new(data, self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createcomment
-    fn CreateComment(&self, data: DOMString) -> Temporary<Comment> {
-        Comment::new(data, *self)
+    fn CreateComment(self, data: DOMString) -> Temporary<Comment> {
+        Comment::new(data, self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
-    fn CreateProcessingInstruction(&self, target: DOMString,
+    fn CreateProcessingInstruction(self, target: DOMString,
                                        data: DOMString) -> Fallible<Temporary<ProcessingInstruction>> {
         // Step 1.
         if xml_name_type(target.as_slice()) == InvalidXMLName {
@@ -534,11 +534,11 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         }
 
         // Step 3.
-        Ok(ProcessingInstruction::new(target, data, *self))
+        Ok(ProcessingInstruction::new(target, data, self))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-importnode
-    fn ImportNode(&self, node: JSRef<Node>, deep: bool) -> Fallible<Temporary<Node>> {
+    fn ImportNode(self, node: JSRef<Node>, deep: bool) -> Fallible<Temporary<Node>> {
         // Step 1.
         if node.is_document() {
             return Err(NotSupported);
@@ -550,25 +550,25 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             false => DoNotCloneChildren
         };
 
-        Ok(Node::clone(node, Some(*self), clone_children))
+        Ok(Node::clone(node, Some(self), clone_children))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-adoptnode
-    fn AdoptNode(&self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
+    fn AdoptNode(self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
         // Step 1.
         if node.is_document() {
             return Err(NotSupported);
         }
 
         // Step 2.
-        Node::adopt(node, *self);
+        Node::adopt(node, self);
 
         // Step 3.
         Ok(Temporary::from_rooted(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createevent
-    fn CreateEvent(&self, interface: DOMString) -> Fallible<Temporary<Event>> {
+    fn CreateEvent(self, interface: DOMString) -> Fallible<Temporary<Event>> {
         let window = self.window.root();
 
         match interface.as_slice().to_ascii_lower().as_slice() {
@@ -581,7 +581,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/html/#dom-document-lastmodified
-    fn LastModified(&self) -> DOMString {
+    fn LastModified(self) -> DOMString {
         match *self.last_modified.borrow() {
             Some(ref t) => t.clone(),
             None => time::now().strftime("%m/%d/%Y %H:%M:%S"),
@@ -589,18 +589,18 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createrange
-    fn CreateRange(&self) -> Temporary<Range> {
-        Range::new(*self)
+    fn CreateRange(self) -> Temporary<Range> {
+        Range::new(self)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createtreewalker
-    fn CreateTreeWalker(&self, root: JSRef<Node>, whatToShow: u32, filter: Option<NodeFilter>)
+    fn CreateTreeWalker(self, root: JSRef<Node>, whatToShow: u32, filter: Option<NodeFilter>)
                         -> Temporary<TreeWalker> {
-        TreeWalker::new(*self, root, whatToShow, filter)
+        TreeWalker::new(self, root, whatToShow, filter)
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#document.title
-    fn Title(&self) -> DOMString {
+    fn Title(self) -> DOMString {
         let mut title = String::new();
         self.GetDocumentElement().root().map(|root| {
             let root: JSRef<Node> = NodeCast::from_ref(*root);
@@ -620,7 +620,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#document.title
-    fn SetTitle(&self, title: DOMString) -> ErrorResult {
+    fn SetTitle(self, title: DOMString) -> ErrorResult {
         self.GetDocumentElement().root().map(|root| {
             let root: JSRef<Node> = NodeCast::from_ref(*root);
             let head_node = root.traverse_preorder().find(|child| {
@@ -642,7 +642,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                         }
                     },
                     None => {
-                        let new_title = HTMLTitleElement::new("title".to_string(), *self).root();
+                        let new_title = HTMLTitleElement::new("title".to_string(), self).root();
                         let new_title: JSRef<Node> = NodeCast::from_ref(*new_title);
 
                         if !title.is_empty() {
@@ -658,7 +658,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-head
-    fn GetHead(&self) -> Option<Temporary<HTMLHeadElement>> {
+    fn GetHead(self) -> Option<Temporary<HTMLHeadElement>> {
         self.get_html_element().and_then(|root| {
             let root = root.root();
             let node: JSRef<Node> = NodeCast::from_ref(*root);
@@ -671,7 +671,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-body
-    fn GetBody(&self) -> Option<Temporary<HTMLElement>> {
+    fn GetBody(self) -> Option<Temporary<HTMLElement>> {
         self.get_html_element().and_then(|root| {
             let root = root.root();
             let node: JSRef<Node> = NodeCast::from_ref(*root);
@@ -688,7 +688,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-body
-    fn SetBody(&self, new_body: Option<JSRef<HTMLElement>>) -> ErrorResult {
+    fn SetBody(self, new_body: Option<JSRef<HTMLElement>>) -> ErrorResult {
         // Step 1.
         match new_body {
             Some(ref htmlelem) => {
@@ -731,7 +731,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#dom-document-getelementsbyname
-    fn GetElementsByName(&self, name: DOMString) -> Temporary<NodeList> {
+    fn GetElementsByName(self, name: DOMString) -> Temporary<NodeList> {
         self.createNodeList(|node| {
             if !node.is_element() {
                 return false;
@@ -744,121 +744,121 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         })
     }
 
-    fn Images(&self) -> Temporary<HTMLCollection> {
+    fn Images(self) -> Temporary<HTMLCollection> {
         if self.images.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box ImagesFilter;
             self.images.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.images.get().get_ref().clone())
     }
 
-    fn Embeds(&self) -> Temporary<HTMLCollection> {
+    fn Embeds(self) -> Temporary<HTMLCollection> {
         if self.embeds.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box EmbedsFilter;
             self.embeds.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.embeds.get().get_ref().clone())
     }
 
-    fn Plugins(&self) -> Temporary<HTMLCollection> {
+    fn Plugins(self) -> Temporary<HTMLCollection> {
         self.Embeds()
     }
 
-    fn Links(&self) -> Temporary<HTMLCollection> {
+    fn Links(self) -> Temporary<HTMLCollection> {
         if self.links.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box LinksFilter;
             self.links.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.links.get().get_ref().clone())
     }
 
-    fn Forms(&self) -> Temporary<HTMLCollection> {
+    fn Forms(self) -> Temporary<HTMLCollection> {
         if self.forms.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box FormsFilter;
             self.forms.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.forms.get().get_ref().clone())
     }
 
-    fn Scripts(&self) -> Temporary<HTMLCollection> {
+    fn Scripts(self) -> Temporary<HTMLCollection> {
         if self.scripts.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box ScriptsFilter;
             self.scripts.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.scripts.get().get_ref().clone())
     }
 
-    fn Anchors(&self) -> Temporary<HTMLCollection> {
+    fn Anchors(self) -> Temporary<HTMLCollection> {
         if self.anchors.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box AnchorsFilter;
             self.anchors.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.anchors.get().get_ref().clone())
     }
 
-    fn Applets(&self) -> Temporary<HTMLCollection> {
+    fn Applets(self) -> Temporary<HTMLCollection> {
         // FIXME: This should be return OBJECT elements containing applets.
         if self.applets.get().is_none() {
             let window = self.window.root();
-            let root = NodeCast::from_ref(*self);
+            let root = NodeCast::from_ref(self);
             let filter = box AppletsFilter;
             self.applets.assign(Some(HTMLCollection::create(*window, root, filter)));
         }
         Temporary::new(self.applets.get().get_ref().clone())
     }
 
-    fn Location(&self) -> Temporary<Location> {
+    fn Location(self) -> Temporary<Location> {
         let window = self.window.root();
         window.Location()
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> Temporary<HTMLCollection> {
+    fn Children(self) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::children(*window, NodeCast::from_ref(*self))
+        HTMLCollection::children(*window, NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
-    fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelector(self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
-    fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelectorAll(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector_all(selectors)
     }
 
-    fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("click")
     }
 
-    fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("load")
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("load", listener)
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -317,8 +317,8 @@ impl Document {
                                           DocumentBinding::Wrap).root();
 
         let node: JSRef<Node> = NodeCast::from_ref(*document);
-        node.set_owner_doc(*&*document);
-        Temporary::from_rooted(*&*document)
+        node.set_owner_doc(*document);
+        Temporary::from_rooted(*document)
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -150,16 +150,16 @@ impl CollectionFilter for AppletsFilter {
 
 pub trait DocumentHelpers {
     fn url<'a>(&'a self) -> &'a Url;
-    fn quirks_mode(&self) -> QuirksMode;
-    fn set_quirks_mode(&self, mode: QuirksMode);
-    fn set_last_modified(&self, value: DOMString);
-    fn set_encoding_name(&self, name: DOMString);
-    fn content_changed(&self);
-    fn damage_and_reflow(&self, damage: DocumentDamageLevel);
-    fn wait_until_safe_to_modify_dom(&self);
-    fn unregister_named_element(&self, to_unregister: JSRef<Element>, id: DOMString);
-    fn register_named_element(&self, element: JSRef<Element>, id: DOMString);
-    fn load_anchor_href(&self, href: DOMString);
+    fn quirks_mode(self) -> QuirksMode;
+    fn set_quirks_mode(self, mode: QuirksMode);
+    fn set_last_modified(self, value: DOMString);
+    fn set_encoding_name(self, name: DOMString);
+    fn content_changed(self);
+    fn damage_and_reflow(self, damage: DocumentDamageLevel);
+    fn wait_until_safe_to_modify_dom(self);
+    fn unregister_named_element(self, to_unregister: JSRef<Element>, id: DOMString);
+    fn register_named_element(self, element: JSRef<Element>, id: DOMString);
+    fn load_anchor_href(self, href: DOMString);
 }
 
 impl<'a> DocumentHelpers for JSRef<'a, Document> {
@@ -167,37 +167,37 @@ impl<'a> DocumentHelpers for JSRef<'a, Document> {
         &*self.url
     }
 
-    fn quirks_mode(&self) -> QuirksMode {
+    fn quirks_mode(self) -> QuirksMode {
         self.quirks_mode.deref().get()
     }
 
-    fn set_quirks_mode(&self, mode: QuirksMode) {
+    fn set_quirks_mode(self, mode: QuirksMode) {
         self.quirks_mode.deref().set(mode);
     }
 
-    fn set_last_modified(&self, value: DOMString) {
+    fn set_last_modified(self, value: DOMString) {
         *self.last_modified.deref().borrow_mut() = Some(value);
     }
 
-    fn set_encoding_name(&self, name: DOMString) {
+    fn set_encoding_name(self, name: DOMString) {
         *self.encoding_name.deref().borrow_mut() = name;
     }
 
-    fn content_changed(&self) {
+    fn content_changed(self) {
         self.damage_and_reflow(ContentChangedDocumentDamage);
     }
 
-    fn damage_and_reflow(&self, damage: DocumentDamageLevel) {
+    fn damage_and_reflow(self, damage: DocumentDamageLevel) {
         self.window.root().damage_and_reflow(damage);
     }
 
-    fn wait_until_safe_to_modify_dom(&self) {
+    fn wait_until_safe_to_modify_dom(self) {
         self.window.root().wait_until_safe_to_modify_dom();
     }
 
 
     /// Remove any existing association between the provided id and any elements in this document.
-    fn unregister_named_element(&self,
+    fn unregister_named_element(self,
                                 to_unregister: JSRef<Element>,
                                 id: DOMString) {
         let mut idmap = self.idmap.deref().borrow_mut();
@@ -218,7 +218,7 @@ impl<'a> DocumentHelpers for JSRef<'a, Document> {
     }
 
     /// Associate an element present in this document with the provided id.
-    fn register_named_element(&self,
+    fn register_named_element(self,
                               element: JSRef<Element>,
                               id: DOMString) {
         assert!({
@@ -261,7 +261,7 @@ impl<'a> DocumentHelpers for JSRef<'a, Document> {
         idmap.insert(id, elements);
     }
 
-    fn load_anchor_href(&self, href: DOMString) {
+    fn load_anchor_href(self, href: DOMString) {
         let window = self.window.root();
         window.load_url(href);
     }
@@ -329,12 +329,12 @@ impl Reflectable for Document {
 }
 
 trait PrivateDocumentHelpers {
-    fn createNodeList(&self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList>;
-    fn get_html_element(&self) -> Option<Temporary<HTMLHtmlElement>>;
+    fn createNodeList(self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList>;
+    fn get_html_element(self) -> Option<Temporary<HTMLHtmlElement>>;
 }
 
 impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
-    fn createNodeList(&self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList> {
+    fn createNodeList(self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList> {
         let window = self.window.root();
 
         match self.GetDocumentElement().root() {
@@ -355,7 +355,7 @@ impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
 
     }
 
-    fn get_html_element(&self) -> Option<Temporary<HTMLHtmlElement>> {
+    fn get_html_element(self) -> Option<Temporary<HTMLHtmlElement>> {
         self.GetDocumentElement().root().filtered(|root| {
             let root: JSRef<Node> = NodeCast::from_ref(**root);
             root.type_id() == ElementNodeTypeId(HTMLHtmlElementTypeId)

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -53,23 +53,22 @@ impl DocumentFragment {
 
 impl<'a> DocumentFragmentMethods for JSRef<'a, DocumentFragment> {
     // http://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::children(*window, NodeCast::from_ref(*self))
+    fn Children(self) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::children(*window, NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
-    fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelector(self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
-    fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelectorAll(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector_all(selectors)
     }
-
 }
 
 impl Reflectable for DocumentFragment {

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -56,21 +56,21 @@ impl DocumentType {
 }
 
 impl<'a> DocumentTypeMethods for JSRef<'a, DocumentType> {
-    fn Name(&self) -> DOMString {
+    fn Name(self) -> DOMString {
         self.name.clone()
     }
 
-    fn PublicId(&self) -> DOMString {
+    fn PublicId(self) -> DOMString {
         self.public_id.clone()
     }
 
-    fn SystemId(&self) -> DOMString {
+    fn SystemId(self) -> DOMString {
         self.system_id.clone()
     }
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Remove(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.remove_self();
     }
 }

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -91,7 +91,7 @@ impl Reflectable for DOMException {
 
 impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
     // http://dom.spec.whatwg.org/#dom-domexception-code
-    fn Code(&self) -> u16 {
+    fn Code(self) -> u16 {
         match self.code {
             // http://dom.spec.whatwg.org/#concept-throw
             EncodingError => 0,
@@ -100,12 +100,12 @@ impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
     }
 
     // http://dom.spec.whatwg.org/#error-names-0
-    fn Name(&self) -> DOMString {
+    fn Name(self) -> DOMString {
         self.code.to_string()
     }
 
     // http://dom.spec.whatwg.org/#error-names-0
-    fn Message(&self) -> DOMString {
+    fn Message(self) -> DOMString {
         match self.code {
             IndexSizeError => "The index is not in the allowed range.".to_string(),
             HierarchyRequestError => "The operation would yield an incorrect node tree.".to_string(),

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -54,7 +54,7 @@ impl Reflectable for DOMImplementation {
 // http://dom.spec.whatwg.org/#domimplementation
 impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     // http://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype
-    fn CreateDocumentType(&self, qname: DOMString, pubid: DOMString, sysid: DOMString) -> Fallible<Temporary<DocumentType>> {
+    fn CreateDocumentType(self, qname: DOMString, pubid: DOMString, sysid: DOMString) -> Fallible<Temporary<DocumentType>> {
         match xml_name_type(qname.as_slice()) {
             // Step 1.
             InvalidXMLName => Err(InvalidCharacter),
@@ -69,7 +69,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     }
 
     // http://dom.spec.whatwg.org/#dom-domimplementation-createdocument
-    fn CreateDocument(&self, namespace: Option<DOMString>, qname: DOMString,
+    fn CreateDocument(self, namespace: Option<DOMString>, qname: DOMString,
                       maybe_doctype: Option<JSRef<DocumentType>>) -> Fallible<Temporary<Document>> {
         let doc = self.document.root();
         let win = doc.window.root();
@@ -115,7 +115,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     }
 
     // http://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-    fn CreateHTMLDocument(&self, title: Option<DOMString>) -> Temporary<Document> {
+    fn CreateHTMLDocument(self, title: Option<DOMString>) -> Temporary<Document> {
         let document = self.document.root();
         let win = document.window.root();
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -39,7 +39,7 @@ impl DOMParser {
 }
 
 impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
-    fn ParseFromString(&self,
+    fn ParseFromString(self,
                        _s: DOMString,
                        ty: DOMParserBinding::SupportedType)
                        -> Fallible<Temporary<Document>> {

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -41,27 +41,27 @@ impl DOMRect {
 }
 
 impl<'a> DOMRectMethods for JSRef<'a, DOMRect> {
-    fn Top(&self) -> f32 {
+    fn Top(self) -> f32 {
         self.top
     }
 
-    fn Bottom(&self) -> f32 {
+    fn Bottom(self) -> f32 {
         self.bottom
     }
 
-    fn Left(&self) -> f32 {
+    fn Left(self) -> f32 {
         self.left
     }
 
-    fn Right(&self) -> f32 {
+    fn Right(self) -> f32 {
         self.right
     }
 
-    fn Width(&self) -> f32 {
+    fn Width(self) -> f32 {
         (self.right - self.left).abs()
     }
 
-    fn Height(&self) -> f32 {
+    fn Height(self) -> f32 {
         (self.bottom - self.top).abs()
     }
 }

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -37,11 +37,11 @@ impl DOMRectList {
 }
 
 impl<'a> DOMRectListMethods for JSRef<'a, DOMRectList> {
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.rects.len() as u32
     }
 
-    fn Item(&self, index: u32) -> Option<Temporary<DOMRect>> {
+    fn Item(self, index: u32) -> Option<Temporary<DOMRect>> {
         let rects = &self.rects;
         if index < rects.len() as u32 {
             Some(Temporary::new(rects[index as uint].clone()))
@@ -50,7 +50,7 @@ impl<'a> DOMRectListMethods for JSRef<'a, DOMRectList> {
         }
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<DOMRect>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<DOMRect>> {
         *found = index < self.rects.len() as u32;
         self.Item(index)
     }

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -71,27 +71,27 @@ impl<'a> PrivateDOMTokenListHelpers for JSRef<'a, DOMTokenList> {
 // http://dom.spec.whatwg.org/#domtokenlist
 impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     // http://dom.spec.whatwg.org/#dom-domtokenlist-length
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.attribute().root().map(|attr| {
             attr.value().tokens().map(|tokens| tokens.len()).unwrap_or(0)
         }).unwrap_or(0) as u32
     }
 
     // http://dom.spec.whatwg.org/#dom-domtokenlist-item
-    fn Item(&self, index: u32) -> Option<DOMString> {
+    fn Item(self, index: u32) -> Option<DOMString> {
         self.attribute().root().and_then(|attr| attr.value().tokens().and_then(|mut tokens| {
             tokens.idx(index as uint).map(|token| token.as_slice().to_string())
         }))
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<DOMString> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<DOMString> {
         let item = self.Item(index);
         *found = item.is_some();
         item
     }
 
     // http://dom.spec.whatwg.org/#dom-domtokenlist-contains
-    fn Contains(&self, token: DOMString) -> Fallible<bool> {
+    fn Contains(self, token: DOMString) -> Fallible<bool> {
         self.check_token_exceptions(token.as_slice()).map(|slice| {
             self.attribute().root().and_then(|attr| attr.value().tokens().map(|mut tokens| {
                 let atom = Atom::from_slice(slice);

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -49,17 +49,17 @@ impl Reflectable for DOMTokenList {
 }
 
 trait PrivateDOMTokenListHelpers {
-    fn attribute(&self) -> Option<Temporary<Attr>>;
-    fn check_token_exceptions<'a>(&self, token: &'a str) -> Fallible<&'a str>;
+    fn attribute(self) -> Option<Temporary<Attr>>;
+    fn check_token_exceptions<'a>(self, token: &'a str) -> Fallible<&'a str>;
 }
 
 impl<'a> PrivateDOMTokenListHelpers for JSRef<'a, DOMTokenList> {
-    fn attribute(&self) -> Option<Temporary<Attr>> {
+    fn attribute(self) -> Option<Temporary<Attr>> {
         let element = self.element.root();
         element.deref().get_attribute(Null, self.local_name)
     }
 
-    fn check_token_exceptions<'a>(&self, token: &'a str) -> Fallible<&'a str> {
+    fn check_token_exceptions<'a>(self, token: &'a str) -> Fallible<&'a str> {
         match token {
             "" => Err(Syntax),
             token if token.find(HTML_SPACE_CHARACTERS).is_some() => Err(InvalidCharacter),

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -271,7 +271,7 @@ impl<'a> ElementHelpers for JSRef<'a, Element> {
         summarized
     }
 
-   fn is_void(&self) -> bool {
+   fn is_void(self) -> bool {
         if self.namespace != namespace::HTML {
             return false
         }
@@ -506,24 +506,24 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
 
 impl<'a> ElementMethods for JSRef<'a, Element> {
     // http://dom.spec.whatwg.org/#dom-element-namespaceuri
-    fn GetNamespaceURI(&self) -> Option<DOMString> {
+    fn GetNamespaceURI(self) -> Option<DOMString> {
         match self.namespace {
             Null => None,
             ref ns => Some(ns.to_str().to_string())
         }
     }
 
-    fn LocalName(&self) -> DOMString {
+    fn LocalName(self) -> DOMString {
         self.local_name.as_slice().to_string()
     }
 
     // http://dom.spec.whatwg.org/#dom-element-prefix
-    fn GetPrefix(&self) -> Option<DOMString> {
+    fn GetPrefix(self) -> Option<DOMString> {
         self.prefix.clone()
     }
 
     // http://dom.spec.whatwg.org/#dom-element-tagname
-    fn TagName(&self) -> DOMString {
+    fn TagName(self) -> DOMString {
         let qualified_name = match self.prefix {
             Some(ref prefix) => format!("{}:{}", prefix, self.local_name).into_maybe_owned(),
             None => self.local_name.as_slice().into_maybe_owned()
@@ -536,31 +536,31 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-id
-    fn Id(&self) -> DOMString {
+    fn Id(self) -> DOMString {
         self.get_string_attribute("id")
     }
 
     // http://dom.spec.whatwg.org/#dom-element-id
-    fn SetId(&self, id: DOMString) {
+    fn SetId(self, id: DOMString) {
         self.set_atomic_attribute("id", id);
     }
 
     // http://dom.spec.whatwg.org/#dom-element-classname
-    fn ClassName(&self) -> DOMString {
+    fn ClassName(self) -> DOMString {
         self.get_string_attribute("class")
     }
 
     // http://dom.spec.whatwg.org/#dom-element-classname
-    fn SetClassName(&self, class: DOMString) {
+    fn SetClassName(self, class: DOMString) {
         self.set_tokenlist_attribute("class", class);
     }
 
     // http://dom.spec.whatwg.org/#dom-element-classlist
-    fn ClassList(&self) -> Temporary<DOMTokenList> {
+    fn ClassList(self) -> Temporary<DOMTokenList> {
         match self.class_list.get() {
             Some(class_list) => Temporary::new(class_list),
             None => {
-                let class_list = DOMTokenList::new(*self, "class").root();
+                let class_list = DOMTokenList::new(self, "class").root();
                 self.class_list.assign(Some(class_list.deref().clone()));
                 Temporary::from_rooted(*class_list)
             }
@@ -568,24 +568,24 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-attributes
-    fn Attributes(&self) -> Temporary<NamedNodeMap> {
+    fn Attributes(self) -> Temporary<NamedNodeMap> {
         match self.attr_list.get() {
             None => (),
             Some(ref list) => return Temporary::new(list.clone()),
         }
 
         let doc = {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
+            let node: JSRef<Node> = NodeCast::from_ref(self);
             node.owner_doc().root()
         };
         let window = doc.deref().window.root();
-        let list = NamedNodeMap::new(*window, *self);
+        let list = NamedNodeMap::new(*window, self);
         self.attr_list.assign(Some(list));
         Temporary::new(self.attr_list.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-element-getattribute
-    fn GetAttribute(&self, name: DOMString) -> Option<DOMString> {
+    fn GetAttribute(self, name: DOMString) -> Option<DOMString> {
         let name = if self.html_element_in_html_document() {
             name.as_slice().to_ascii_lower()
         } else {
@@ -596,7 +596,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-getattributens
-    fn GetAttributeNS(&self,
+    fn GetAttributeNS(self,
                       namespace: Option<DOMString>,
                       local_name: DOMString) -> Option<DOMString> {
         let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
@@ -605,11 +605,11 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-setattribute
-    fn SetAttribute(&self,
+    fn SetAttribute(self,
                     name: DOMString,
                     value: DOMString) -> ErrorResult {
         {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
+            let node: JSRef<Node> = NodeCast::from_ref(self);
             node.wait_until_safe_to_modify_dom();
         }
 
@@ -636,12 +636,12 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-setattributens
-    fn SetAttributeNS(&self,
+    fn SetAttributeNS(self,
                       namespace_url: Option<DOMString>,
                       name: DOMString,
                       value: DOMString) -> ErrorResult {
         {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
+            let node: JSRef<Node> = NodeCast::from_ref(self);
             node.wait_until_safe_to_modify_dom();
         }
 
@@ -705,7 +705,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-removeattribute
-    fn RemoveAttribute(&self, name: DOMString) {
+    fn RemoveAttribute(self, name: DOMString) {
         let name = if self.html_element_in_html_document() {
             name.as_slice().to_ascii_lower()
         } else {
@@ -715,7 +715,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-removeattributens
-    fn RemoveAttributeNS(&self,
+    fn RemoveAttributeNS(self,
                          namespace: Option<DOMString>,
                          localname: DOMString) {
         let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
@@ -723,38 +723,38 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dom.spec.whatwg.org/#dom-element-hasattribute
-    fn HasAttribute(&self,
+    fn HasAttribute(self,
                     name: DOMString) -> bool {
         self.has_attribute(name.as_slice())
     }
 
     // http://dom.spec.whatwg.org/#dom-element-hasattributens
-    fn HasAttributeNS(&self,
+    fn HasAttributeNS(self,
                       namespace: Option<DOMString>,
                       local_name: DOMString) -> bool {
         self.GetAttributeNS(namespace, local_name).is_some()
     }
 
-    fn GetElementsByTagName(&self, localname: DOMString) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(*self), localname)
+    fn GetElementsByTagName(self, localname: DOMString) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(self), localname)
     }
 
-    fn GetElementsByTagNameNS(&self, maybe_ns: Option<DOMString>,
+    fn GetElementsByTagNameNS(self, maybe_ns: Option<DOMString>,
                               localname: DOMString) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(*self), localname, maybe_ns)
+        let window = window_from_node(self).root();
+        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(self), localname, maybe_ns)
     }
 
-    fn GetElementsByClassName(&self, classes: DOMString) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::by_class_name(*window, NodeCast::from_ref(*self), classes)
+    fn GetElementsByClassName(self, classes: DOMString) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::by_class_name(*window, NodeCast::from_ref(self), classes)
     }
 
     // http://dev.w3.org/csswg/cssom-view/#dom-element-getclientrects
-    fn GetClientRects(&self) -> Temporary<DOMRectList> {
-        let win = window_from_node(*self).root();
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetClientRects(self) -> Temporary<DOMRectList> {
+        let win = window_from_node(self).root();
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rects = node.get_content_boxes();
         let rects: Vec<Root<DOMRect>> = rects.iter().map(|r| {
             DOMRect::new(
@@ -769,9 +769,9 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     }
 
     // http://dev.w3.org/csswg/cssom-view/#dom-element-getboundingclientrect
-    fn GetBoundingClientRect(&self) -> Temporary<DOMRect> {
-        let win = window_from_node(*self).root();
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetBoundingClientRect(self) -> Temporary<DOMRect> {
+        let win = window_from_node(self).root();
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rect = node.get_bounding_content_box();
         DOMRect::new(
             *win,
@@ -781,45 +781,45 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
             rect.origin.x + rect.size.width)
     }
 
-    fn GetInnerHTML(&self) -> Fallible<DOMString> {
+    fn GetInnerHTML(self) -> Fallible<DOMString> {
         //XXX TODO: XML case
-        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(*self), false, false)))
+        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(self), false, false)))
     }
 
-    fn GetOuterHTML(&self) -> Fallible<DOMString> {
-        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(*self), true, false)))
+    fn GetOuterHTML(self) -> Fallible<DOMString> {
+        Ok(serialize(&mut NodeIterator::new(NodeCast::from_ref(self), true, false)))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> Temporary<HTMLCollection> {
-        let window = window_from_node(*self).root();
-        HTMLCollection::children(*window, NodeCast::from_ref(*self))
+    fn Children(self) -> Temporary<HTMLCollection> {
+        let window = window_from_node(self).root();
+        HTMLCollection::children(*window, NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
-    fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelector(self, selectors: DOMString) -> Fallible<Option<Temporary<Element>>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
-    fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
-        let root: JSRef<Node> = NodeCast::from_ref(*self);
+    fn QuerySelectorAll(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
+        let root: JSRef<Node> = NodeCast::from_ref(self);
         root.query_selector_all(selectors)
     }
 
     // http://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Remove(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.remove_self();
     }
 
     // http://dom.spec.whatwg.org/#dom-element-matches
-    fn Matches(&self, selectors: DOMString) -> Fallible<bool> {
+    fn Matches(self, selectors: DOMString) -> Fallible<bool> {
         match parse_selector_list_from_str(selectors.as_slice()) {
             Err(()) => Err(Syntax),
             Ok(ref selectors) => {
-                let root: JSRef<Node> = NodeCast::from_ref(*self);
+                let root: JSRef<Node> = NodeCast::from_ref(self);
                 Ok(matches(selectors, &root, &mut None))
             }
         }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -98,54 +98,54 @@ impl Event {
 }
 
 impl<'a> EventMethods for JSRef<'a, Event> {
-    fn EventPhase(&self) -> u16 {
+    fn EventPhase(self) -> u16 {
         self.phase.deref().get() as u16
     }
 
-    fn Type(&self) -> DOMString {
+    fn Type(self) -> DOMString {
         self.type_.deref().borrow().clone()
     }
 
-    fn GetTarget(&self) -> Option<Temporary<EventTarget>> {
+    fn GetTarget(self) -> Option<Temporary<EventTarget>> {
         self.target.get().as_ref().map(|target| Temporary::new(target.clone()))
     }
 
-    fn GetCurrentTarget(&self) -> Option<Temporary<EventTarget>> {
+    fn GetCurrentTarget(self) -> Option<Temporary<EventTarget>> {
         self.current_target.get().as_ref().map(|target| Temporary::new(target.clone()))
     }
 
-    fn DefaultPrevented(&self) -> bool {
+    fn DefaultPrevented(self) -> bool {
         self.canceled.deref().get()
     }
 
-    fn PreventDefault(&self) {
+    fn PreventDefault(self) {
         if self.cancelable.deref().get() {
             self.canceled.deref().set(true)
         }
     }
 
-    fn StopPropagation(&self) {
+    fn StopPropagation(self) {
         self.stop_propagation.deref().set(true);
     }
 
-    fn StopImmediatePropagation(&self) {
+    fn StopImmediatePropagation(self) {
         self.stop_immediate.deref().set(true);
         self.stop_propagation.deref().set(true);
     }
 
-    fn Bubbles(&self) -> bool {
+    fn Bubbles(self) -> bool {
         self.bubbles.deref().get()
     }
 
-    fn Cancelable(&self) -> bool {
+    fn Cancelable(self) -> bool {
         self.cancelable.deref().get()
     }
 
-    fn TimeStamp(&self) -> u64 {
+    fn TimeStamp(self) -> u64 {
         self.timestamp
     }
 
-    fn InitEvent(&self,
+    fn InitEvent(self,
                  type_: DOMString,
                  bubbles: bool,
                  cancelable: bool) {
@@ -163,7 +163,7 @@ impl<'a> EventMethods for JSRef<'a, Event> {
         self.cancelable.deref().set(cancelable);
     }
 
-    fn IsTrusted(&self) -> bool {
+    fn IsTrusted(self) -> bool {
         self.trusted.deref().get()
     }
 }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -94,37 +94,37 @@ impl EventTarget {
 }
 
 pub trait EventTargetHelpers {
-    fn dispatch_event_with_target<'a>(&self,
-                                      target: Option<JSRef<'a, EventTarget>>,
-                                      event: JSRef<Event>) -> Fallible<bool>;
-    fn set_inline_event_listener(&self,
+    fn dispatch_event_with_target(self,
+                                  target: Option<JSRef<EventTarget>>,
+                                  event: JSRef<Event>) -> Fallible<bool>;
+    fn set_inline_event_listener(self,
                                  ty: DOMString,
                                  listener: Option<EventListener>);
-    fn get_inline_event_listener(&self, ty: DOMString) -> Option<EventListener>;
-    fn set_event_handler_uncompiled(&self,
+    fn get_inline_event_listener(self, ty: DOMString) -> Option<EventListener>;
+    fn set_event_handler_uncompiled(self,
                                     cx: *mut JSContext,
                                     url: Url,
                                     scope: *mut JSObject,
                                     ty: &str,
                                     source: DOMString);
-    fn set_event_handler_common<T: CallbackContainer>(&self, ty: &str,
+    fn set_event_handler_common<T: CallbackContainer>(self, ty: &str,
                                                       listener: Option<T>);
-    fn get_event_handler_common<T: CallbackContainer>(&self, ty: &str) -> Option<T>;
+    fn get_event_handler_common<T: CallbackContainer>(self, ty: &str) -> Option<T>;
 
-    fn has_handlers(&self) -> bool;
+    fn has_handlers(self) -> bool;
 }
 
 impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
-    fn dispatch_event_with_target<'b>(&self,
-                                      target: Option<JSRef<'b, EventTarget>>,
-                                      event: JSRef<Event>) -> Fallible<bool> {
+    fn dispatch_event_with_target(self,
+                                  target: Option<JSRef<EventTarget>>,
+                                  event: JSRef<Event>) -> Fallible<bool> {
         if event.deref().dispatching.deref().get() || !event.deref().initialized.deref().get() {
             return Err(InvalidState);
         }
-        Ok(dispatch_event(*self, target, event))
+        Ok(dispatch_event(self, target, event))
     }
 
-    fn set_inline_event_listener(&self,
+    fn set_inline_event_listener(self,
                                  ty: DOMString,
                                  listener: Option<EventListener>) {
         let mut handlers = self.handlers.deref().borrow_mut();
@@ -156,7 +156,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
         }
     }
 
-    fn get_inline_event_listener(&self, ty: DOMString) -> Option<EventListener> {
+    fn get_inline_event_listener(self, ty: DOMString) -> Option<EventListener> {
         let handlers = self.handlers.deref().borrow();
         let entries = handlers.find(&ty);
         entries.and_then(|entries| entries.iter().find(|entry| {
@@ -167,7 +167,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
         }).map(|entry| entry.listener.get_listener()))
     }
 
-    fn set_event_handler_uncompiled(&self,
+    fn set_event_handler_uncompiled(self,
                                     cx: *mut JSContext,
                                     url: Url,
                                     scope: *mut JSObject,
@@ -207,19 +207,19 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
     }
 
     fn set_event_handler_common<T: CallbackContainer>(
-        &self, ty: &str, listener: Option<T>)
+        self, ty: &str, listener: Option<T>)
     {
         let event_listener = listener.map(|listener|
                                           EventListener::new(listener.callback()));
         self.set_inline_event_listener(ty.to_string(), event_listener);
     }
 
-    fn get_event_handler_common<T: CallbackContainer>(&self, ty: &str) -> Option<T> {
+    fn get_event_handler_common<T: CallbackContainer>(self, ty: &str) -> Option<T> {
         let listener = self.get_inline_event_listener(ty.to_string());
         listener.map(|listener| CallbackContainer::new(listener.parent.callback()))
     }
 
-    fn has_handlers(&self) -> bool {
+    fn has_handlers(self) -> bool {
         !self.handlers.deref().borrow().is_empty()
     }
 }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -225,7 +225,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
 }
 
 impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
-    fn AddEventListener(&self,
+    fn AddEventListener(self,
                         ty: DOMString,
                         listener: Option<EventListener>,
                         capture: bool) {
@@ -246,7 +246,7 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
         }
     }
 
-    fn RemoveEventListener(&self,
+    fn RemoveEventListener(self,
                            ty: DOMString,
                            listener: Option<EventListener>,
                            capture: bool) {
@@ -270,7 +270,7 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
         }
     }
 
-    fn DispatchEvent(&self, event: JSRef<Event>) -> Fallible<bool> {
+    fn DispatchEvent(self, event: JSRef<Event>) -> Fallible<bool> {
         self.dispatch_event_with_target(None, event)
     }
 }

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -36,8 +36,8 @@ impl File {
     }
 }
 
-impl FileMethods for File {
-    fn Name(&self) -> DOMString {
+impl<'a> FileMethods for JSRef<'a, File> {
+    fn Name(self) -> DOMString {
         self.name.clone()
     }
 }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -56,22 +56,22 @@ impl FormData {
 
 impl<'a> FormDataMethods for JSRef<'a, FormData> {
     #[allow(unrooted_must_root)]
-    fn Append(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+    fn Append(self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
         let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert_or_update_with(name.clone(), vec!(file.clone()),
                                         |_k, v| {v.push(file.clone());});
     }
 
-    fn Append_(&self, name: DOMString, value: DOMString) {
+    fn Append_(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert_or_update_with(name, vec!(StringData(value.clone())),
                                         |_k, v| {v.push(StringData(value.clone()));});
     }
 
-    fn Delete(&self, name: DOMString) {
+    fn Delete(self, name: DOMString) {
         self.data.deref().borrow_mut().remove(&name);
     }
 
-    fn Get(&self, name: DOMString) -> Option<FileOrString> {
+    fn Get(self, name: DOMString) -> Option<FileOrString> {
         if self.data.deref().borrow().contains_key_equiv(&name) {
             match self.data.deref().borrow().get(&name)[0].clone() {
                 StringData(ref s) => Some(eString(s.clone())),
@@ -84,16 +84,16 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
         }
     }
 
-    fn Has(&self, name: DOMString) -> bool {
+    fn Has(self, name: DOMString) -> bool {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
     #[allow(unrooted_must_root)]
-    fn Set(&self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
+    fn Set(self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {
         let file = FileData(JS::from_rooted(self.get_file_from_blob(value, filename)));
         self.data.deref().borrow_mut().insert(name, vec!(file));
     }
 
-    fn Set_(&self, name: DOMString, value: DOMString) {
+    fn Set_(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert(name, vec!(StringData(value)));
     }
 }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -50,19 +50,19 @@ impl HTMLAnchorElement {
 }
 
 trait PrivateHTMLAnchorElementHelpers {
-    fn handle_event_impl(&self, event: JSRef<Event>);
+    fn handle_event_impl(self, event: JSRef<Event>);
 }
 
 impl<'a> PrivateHTMLAnchorElementHelpers for JSRef<'a, HTMLAnchorElement> {
-    fn handle_event_impl(&self, event: JSRef<Event>) {
+    fn handle_event_impl(self, event: JSRef<Event>) {
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             let attr = element.get_attribute(Null, "href").root();
             match attr {
                 Some(ref href) => {
                     let value = href.Value();
                     debug!("clicked on link to {:s}", value);
-                    let node: JSRef<Node> = NodeCast::from_ref(*self);
+                    let node: JSRef<Node> = NodeCast::from_ref(self);
                     let doc = node.owner_doc().root();
                     doc.load_anchor_href(value);
                 }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -122,13 +122,13 @@ impl Reflectable for HTMLAnchorElement {
 }
 
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
-    fn Text(&self) -> DOMString {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Text(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.GetTextContent().unwrap()
     }
 
-    fn SetText(&self, value: DOMString) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetText(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -47,13 +47,13 @@ impl HTMLBodyElement {
 }
 
 impl<'a> HTMLBodyElementMethods for JSRef<'a, HTMLBodyElement> {
-    fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let win = window_from_node(*self).root();
+    fn GetOnunload(self) -> Option<EventHandlerNonNull> {
+        let win = window_from_node(self).root();
         win.deref().GetOnunload()
     }
 
-    fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let win = window_from_node(*self).root();
+    fn SetOnunload(self, listener: Option<EventHandlerNonNull>) {
+        let win = window_from_node(self).root();
         win.deref().SetOnunload(listener)
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -46,8 +46,8 @@ impl HTMLButtonElement {
 }
 
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 
@@ -55,8 +55,8 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -61,33 +61,33 @@ impl HTMLCanvasElement {
 }
 
 impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
-    fn Width(&self) -> u32 {
+    fn Width(self) -> u32 {
         self.width.get()
     }
 
-    fn SetWidth(&self, width: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetWidth(self, width: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("width", width)
     }
 
-    fn Height(&self) -> u32 {
+    fn Height(self) -> u32 {
         self.height.get()
     }
 
-    fn SetHeight(&self, height: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetHeight(self, height: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("height", height)
     }
 
-    fn GetContext(&self, id: DOMString) -> Option<Temporary<CanvasRenderingContext2D>> {
+    fn GetContext(self, id: DOMString) -> Option<Temporary<CanvasRenderingContext2D>> {
         if id.as_slice() != "2d" {
             return None;
         }
 
         if self.context.get().is_none() {
-            let window = window_from_node(*self).root();
+            let window = window_from_node(self).root();
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            let context = CanvasRenderingContext2D::new(&Window(*window), *self, Size2D(w, h));
+            let context = CanvasRenderingContext2D::new(&Window(*window), self, Size2D(w, h));
             self.context.assign(Some(context));
         }
         self.context.get().map(|context| Temporary::new(context))

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -172,7 +172,7 @@ impl HTMLCollection {
 
 impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     // http://dom.spec.whatwg.org/#dom-htmlcollection-length
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         match self.collection {
             Static(ref elems) => elems.len() as u32,
             Live(ref root, ref filter) => {
@@ -187,7 +187,7 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     }
 
     // http://dom.spec.whatwg.org/#dom-htmlcollection-item
-    fn Item(&self, index: u32) -> Option<Temporary<Element>> {
+    fn Item(self, index: u32) -> Option<Temporary<Element>> {
         match self.collection {
             Static(ref elems) => elems
                 .as_slice()
@@ -209,7 +209,7 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     }
 
     // http://dom.spec.whatwg.org/#dom-htmlcollection-nameditem
-    fn NamedItem(&self, key: DOMString) -> Option<Temporary<Element>> {
+    fn NamedItem(self, key: DOMString) -> Option<Temporary<Element>> {
         // Step 1.
         if key.is_empty() {
             return None;
@@ -239,13 +239,13 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
         }
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Element>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Element>> {
         let maybe_elem = self.Item(index);
         *found = maybe_elem.is_some();
         maybe_elem
     }
 
-    fn NamedGetter(&self, name: DOMString, found: &mut bool) -> Option<Temporary<Element>> {
+    fn NamedGetter(self, name: DOMString, found: &mut bool) -> Option<Temporary<Element>> {
         let maybe_elem = self.NamedItem(name);
         *found = maybe_elem.is_some();
         maybe_elem

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -43,14 +43,14 @@ impl HTMLDataListElement {
 }
 
 impl<'a> HTMLDataListElementMethods for JSRef<'a, HTMLDataListElement> {
-    fn Options(&self) -> Temporary<HTMLCollection> {
+    fn Options(self) -> Temporary<HTMLCollection> {
         struct HTMLDataListOptionsFilter;
         impl CollectionFilter for HTMLDataListOptionsFilter {
             fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 elem.is_htmloptionelement()
             }
         }
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let filter = box HTMLDataListOptionsFilter;
         let window = window_from_node(node).root();
         HTMLCollection::create(*window, node, filter)

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -52,12 +52,12 @@ impl HTMLElement {
 }
 
 trait PrivateHTMLElementHelpers {
-    fn is_body_or_frameset(&self) -> bool;
+    fn is_body_or_frameset(self) -> bool;
 }
 
 impl<'a> PrivateHTMLElementHelpers for JSRef<'a, HTMLElement> {
-    fn is_body_or_frameset(&self) -> bool {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn is_body_or_frameset(self) -> bool {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.is_htmlbodyelement() || eventtarget.is_htmlframesetelement()
     }
 }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -63,28 +63,28 @@ impl<'a> PrivateHTMLElementHelpers for JSRef<'a, HTMLElement> {
 }
 
 impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
-    fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("click")
     }
 
-    fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
         if self.is_body_or_frameset() {
-            let win = window_from_node(*self).root();
+            let win = window_from_node(self).root();
             win.deref().GetOnload()
         } else {
             None
         }
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
         if self.is_body_or_frameset() {
-            let win = window_from_node(*self).root();
+            let win = window_from_node(self).root();
             win.deref().SetOnload(listener)
         }
     }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -49,7 +49,7 @@ impl HTMLFieldSetElement {
 
 impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     // http://www.whatwg.org/html/#dom-fieldset-elements
-    fn Elements(&self) -> Temporary<HTMLCollection> {
+    fn Elements(self) -> Temporary<HTMLCollection> {
         struct ElementsFilter;
         impl CollectionFilter for ElementsFilter {
             fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
@@ -59,14 +59,14 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
                 elem != root && tag_names.iter().any(|&tag_name| tag_name == elem.deref().local_name.as_slice())
             }
         }
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let filter = box ElementsFilter;
         let window = window_from_node(node).root();
         HTMLCollection::create(*window, node, filter)
     }
 
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 
@@ -74,8 +74,8 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -131,29 +131,29 @@ impl HTMLIFrameElement {
 }
 
 impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
-    fn Src(&self) -> DOMString {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn Src(self) -> DOMString {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_string_attribute("src")
     }
 
-    fn SetSrc(&self, src: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetSrc(self, src: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_url_attribute("src", src)
     }
 
-    fn Sandbox(&self) -> DOMString {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn Sandbox(self) -> DOMString {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_string_attribute("sandbox")
     }
 
-    fn SetSandbox(&self, sandbox: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetSandbox(self, sandbox: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("sandbox", sandbox);
     }
 
-    fn GetContentWindow(&self) -> Option<Temporary<Window>> {
+    fn GetContentWindow(self) -> Option<Temporary<Window>> {
         self.size.deref().get().and_then(|size| {
-            let window = window_from_node(*self).root();
+            let window = window_from_node(self).root();
             let children = &*window.deref().page.children.deref().borrow();
             let child = children.iter().find(|child| {
                 child.subpage_id.unwrap() == size.subpage_id

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -154,7 +154,7 @@ impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
     fn GetContentWindow(self) -> Option<Temporary<Window>> {
         self.size.deref().get().and_then(|size| {
             let window = window_from_node(self).root();
-            let children = &*window.deref().page.children.deref().borrow();
+            let children = window.deref().page.children.deref().borrow();
             let child = children.iter().find(|child| {
                 child.subpage_id.unwrap() == size.subpage_id
             });

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -62,32 +62,32 @@ pub struct IFrameSize {
 }
 
 pub trait HTMLIFrameElementHelpers {
-    fn is_sandboxed(&self) -> bool;
-    fn get_url(&self) -> Option<Url>;
+    fn is_sandboxed(self) -> bool;
+    fn get_url(self) -> Option<Url>;
     /// http://www.whatwg.org/html/#process-the-iframe-attributes
-    fn process_the_iframe_attributes(&self);
+    fn process_the_iframe_attributes(self);
 }
 
 impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
-    fn is_sandboxed(&self) -> bool {
+    fn is_sandboxed(self) -> bool {
         self.sandbox.deref().get().is_some()
     }
 
-    fn get_url(&self) -> Option<Url> {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn get_url(self) -> Option<Url> {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_attribute(Null, "src").root().and_then(|src| {
             let url = src.deref().value();
             if url.as_slice().is_empty() {
                 None
             } else {
-                let window = window_from_node(*self).root();
+                let window = window_from_node(self).root();
                 UrlParser::new().base_url(&window.deref().page().get_url())
                     .parse(url.as_slice()).ok()
             }
         })
     }
 
-    fn process_the_iframe_attributes(&self) {
+    fn process_the_iframe_attributes(self) {
         let url = match self.get_url() {
             Some(url) => url.clone(),
             None => Url::parse("about:blank").unwrap(),
@@ -100,7 +100,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
         };
 
         // Subpage Id
-        let window = window_from_node(*self).root();
+        let window = window_from_node(self).root();
         let page = window.deref().page();
         let subpage_id = page.get_next_subpage_id();
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -99,93 +99,93 @@ impl LayoutHTMLImageElementHelpers for JS<HTMLImageElement> {
 impl<'a> HTMLImageElementMethods for JSRef<'a, HTMLImageElement> {
     make_getter!(Alt)
 
-    fn SetAlt(&self, alt: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetAlt(self, alt: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("alt", alt)
     }
 
     make_getter!(Src)
 
-    fn SetSrc(&self, src: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetSrc(self, src: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_url_attribute("src", src)
     }
 
     make_getter!(UseMap)
 
-    fn SetUseMap(&self, use_map: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetUseMap(self, use_map: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("usemap", use_map)
     }
 
     make_bool_getter!(IsMap)
 
-    fn SetIsMap(&self, is_map: bool) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetIsMap(self, is_map: bool) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("ismap", is_map.to_string())
     }
 
-    fn Width(&self) -> u32 {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Width(self) -> u32 {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.width) as u32
     }
 
-    fn SetWidth(&self, width: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetWidth(self, width: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("width", width)
     }
 
-    fn Height(&self) -> u32 {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Height(self) -> u32 {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let rect = node.get_bounding_content_box();
         to_px(rect.size.height) as u32
     }
 
-    fn SetHeight(&self, height: u32) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetHeight(self, height: u32) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_uint_attribute("height", height)
     }
 
     make_getter!(Name)
 
-    fn SetName(&self, name: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetName(self, name: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("name", name)
     }
 
     make_getter!(Align)
 
-    fn SetAlign(&self, align: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetAlign(self, align: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("align", align)
     }
 
     make_uint_getter!(Hspace)
 
-    fn SetHspace(&self, hspace: u32) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetHspace(self, hspace: u32) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_uint_attribute("hspace", hspace)
     }
 
     make_uint_getter!(Vspace)
 
-    fn SetVspace(&self, vspace: u32) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetVspace(self, vspace: u32) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_uint_attribute("vspace", vspace)
     }
 
     make_getter!(LongDesc)
 
-    fn SetLongDesc(&self, longdesc: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetLongDesc(self, longdesc: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("longdesc", longdesc)
     }
 
     make_getter!(Border)
 
-    fn SetBorder(&self, border: DOMString) {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetBorder(self, border: DOMString) {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.set_string_attribute("border", border)
     }
 }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -39,14 +39,14 @@ impl HTMLImageElementDerived for EventTarget {
 }
 
 trait PrivateHTMLImageElementHelpers {
-    fn update_image(&self, value: Option<(DOMString, &Url)>);
+    fn update_image(self, value: Option<(DOMString, &Url)>);
 }
 
 impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
     /// Makes the local `image` member match the status of the `src` attribute and starts
     /// prefetching the image. This method must be called after `src` is changed.
-    fn update_image(&self, value: Option<(DOMString, &Url)>) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn update_image(self, value: Option<(DOMString, &Url)>) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let document = node.owner_doc().root();
         let window = document.deref().window.root();
         let image_cache = &window.image_cache_task;

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -114,12 +114,12 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
 }
 
 trait PrivateHTMLLinkElementHelpers {
-    fn handle_stylesheet_url(&self, href: &str);
+    fn handle_stylesheet_url(self, href: &str);
 }
 
 impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
-    fn handle_stylesheet_url(&self, href: &str) {
-        let window = window_from_node(*self).root();
+    fn handle_stylesheet_url(self, href: &str) {
+        let window = window_from_node(self).root();
         match UrlParser::new().base_url(&window.deref().page().get_url()).parse(href) {
             Ok(url) => {
                 let LayoutChan(ref layout_chan) = *window.deref().page().layout_chan;

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -83,8 +83,8 @@ pub fn is_image_data(uri: &str) -> bool {
 }
 
 impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLOptGroupElementMethods for JSRef<'a, HTMLOptGroupElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html#dom-optgroup-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-option-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -42,8 +42,8 @@ impl HTMLOutputElement {
 }
 
 impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -48,7 +48,7 @@ impl HTMLScriptElement {
 pub trait HTMLScriptElementHelpers {
     /// Prepare a script (<http://www.whatwg.org/html/#prepare-a-script>),
     /// steps 6 and 7.
-    fn is_javascript(&self) -> bool;
+    fn is_javascript(self) -> bool;
 }
 
 /// Supported script types as defined by
@@ -73,8 +73,8 @@ static SCRIPT_JS_MIMES: StaticStringVec = &[
 ];
 
 impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
-    fn is_javascript(&self) -> bool {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn is_javascript(self) -> bool {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         match element.get_attribute(Null, "type").root().map(|s| s.Value()) {
             Some(ref s) if s.is_empty() => {
                 // type attr exists, but empty means js

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -107,20 +107,20 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 }
 
 impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
-    fn Src(&self) -> DOMString {
-        let element: JSRef<Element> = ElementCast::from_ref(*self);
+    fn Src(self) -> DOMString {
+        let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_url_attribute("src")
     }
 
     // http://www.whatwg.org/html/#dom-script-text
-    fn Text(&self) -> DOMString {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Text(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         Node::collect_text_contents(node.children())
     }
 
     // http://www.whatwg.org/html/#dom-script-text
-    fn SetText(&self, value: DOMString) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetText(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -48,21 +48,21 @@ impl HTMLSelectElement {
 }
 
 impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
-    fn Validity(&self) -> Temporary<ValidityState> {
-        let window = window_from_node(*self).root();
+    fn Validity(self) -> Temporary<ValidityState> {
+        let window = window_from_node(self).root();
         ValidityState::new(*window)
     }
 
     // Note: this function currently only exists for test_union.html.
-    fn Add(&self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) {
+    fn Add(self, _element: HTMLOptionElementOrHTMLOptGroupElement, _before: Option<HTMLElementOrLong>) {
     }
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -44,12 +44,12 @@ impl HTMLStyleElement {
 }
 
 pub trait StyleElementHelpers {
-    fn parse_own_css(&self);
+    fn parse_own_css(self);
 }
 
 impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
-    fn parse_own_css(&self) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn parse_own_css(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         assert!(node.is_in_doc());
 
         let win = window_from_node(node).root();

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -50,10 +50,9 @@ impl Reflectable for HTMLTableElement {
 }
 
 impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
-
     //  http://www.whatwg.org/html/#dom-table-caption
-    fn GetCaption(&self) -> Option<Temporary<HTMLTableCaptionElement>> {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn GetCaption(self) -> Option<Temporary<HTMLTableCaptionElement>> {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.children().find(|child| {
             child.type_id() == ElementNodeTypeId(HTMLTableCaptionElementTypeId)
         }).map(|node| {
@@ -62,8 +61,8 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
     }
 
     // http://www.whatwg.org/html/#dom-table-caption
-    fn SetCaption(&self, new_caption: Option<JSRef<HTMLTableCaptionElement>>) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetCaption(self, new_caption: Option<JSRef<HTMLTableCaptionElement>>) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let old_caption = self.GetCaption();
 
         match old_caption {

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -67,8 +67,8 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
 
         match old_caption {
             Some(htmlelem) => {
-                let htmlelem_jsref = &*htmlelem.root();
-                let old_caption_node: JSRef<Node> = NodeCast::from_ref(*htmlelem_jsref);
+                let htmlelem_root = htmlelem.root();
+                let old_caption_node: JSRef<Node> = NodeCast::from_ref(*htmlelem_root);
                 assert!(node.RemoveChild(old_caption_node).is_ok());
             }
             None => ()

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -49,8 +49,8 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem: JSRef<Element> = ElementCast::from_ref(*self);
+    fn SetDisabled(self, disabled: bool) {
+        let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.set_bool_attribute("disabled", disabled)
     }
 }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -44,8 +44,8 @@ impl HTMLTitleElement {
 
 impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     // http://www.whatwg.org/html/#dom-title-text
-    fn Text(&self) -> DOMString {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn Text(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         let mut content = String::new();
         for child in node.children() {
             let text: Option<JSRef<Text>> = TextCast::to_ref(child);
@@ -58,8 +58,8 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     }
 
     // http://www.whatwg.org/html/#dom-title-text
-    fn SetText(&self, value: DOMString) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn SetText(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
     }
 }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -38,15 +38,15 @@ impl Location {
 }
 
 impl<'a> LocationMethods for JSRef<'a, Location> {
-    fn Href(&self) -> DOMString {
+    fn Href(self) -> DOMString {
         UrlHelper::Href(&self.page.get_url())
     }
 
-    fn Search(&self) -> DOMString {
+    fn Search(self) -> DOMString {
         UrlHelper::Search(&self.page.get_url())
     }
 
-    fn Hash(&self) -> DOMString {
+    fn Hash(self) -> DOMString {
         UrlHelper::Hash(&self.page.get_url())
     }
 }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -7,11 +7,11 @@
 #[macro_export]
 macro_rules! make_getter(
     ( $attr:ident ) => (
-        fn $attr(&self) -> DOMString {
+        fn $attr(self) -> DOMString {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             element.get_string_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -20,11 +20,11 @@ macro_rules! make_getter(
 #[macro_export]
 macro_rules! make_bool_getter(
     ( $attr:ident ) => (
-        fn $attr(&self) -> bool {
+        fn $attr(self) -> bool {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             element.has_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );
@@ -33,11 +33,11 @@ macro_rules! make_bool_getter(
 #[macro_export]
 macro_rules! make_uint_getter(
     ( $attr:ident ) => (
-        fn $attr(&self) -> u32 {
+        fn $attr(self) -> u32 {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
             use std::ascii::StrAsciiExt;
-            let element: JSRef<Element> = ElementCast::from_ref(*self);
+            let element: JSRef<Element> = ElementCast::from_ref(self);
             element.get_uint_attribute(stringify!($attr).to_ascii_lower().as_slice())
         }
     );

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -80,15 +80,15 @@ impl MessageEvent {
 }
 
 impl<'a> MessageEventMethods for JSRef<'a, MessageEvent> {
-    fn Data(&self, _cx: *mut JSContext) -> JSVal {
+    fn Data(self, _cx: *mut JSContext) -> JSVal {
         *self.data
     }
 
-    fn Origin(&self) -> DOMString {
+    fn Origin(self) -> DOMString {
         self.origin.clone()
     }
 
-    fn LastEventId(&self) -> DOMString {
+    fn LastEventId(self) -> DOMString {
         self.lastEventId.clone()
     }
 }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -104,47 +104,47 @@ impl MouseEvent {
 }
 
 impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
-    fn ScreenX(&self) -> i32 {
+    fn ScreenX(self) -> i32 {
         self.screen_x.deref().get()
     }
 
-    fn ScreenY(&self) -> i32 {
+    fn ScreenY(self) -> i32 {
         self.screen_y.deref().get()
     }
 
-    fn ClientX(&self) -> i32 {
+    fn ClientX(self) -> i32 {
         self.client_x.deref().get()
     }
 
-    fn ClientY(&self) -> i32 {
+    fn ClientY(self) -> i32 {
         self.client_y.deref().get()
     }
 
-    fn CtrlKey(&self) -> bool {
+    fn CtrlKey(self) -> bool {
         self.ctrl_key.deref().get()
     }
 
-    fn ShiftKey(&self) -> bool {
+    fn ShiftKey(self) -> bool {
         self.shift_key.deref().get()
     }
 
-    fn AltKey(&self) -> bool {
+    fn AltKey(self) -> bool {
         self.alt_key.deref().get()
     }
 
-    fn MetaKey(&self) -> bool {
+    fn MetaKey(self) -> bool {
         self.meta_key.deref().get()
     }
 
-    fn Button(&self) -> i16 {
+    fn Button(self) -> i16 {
         self.button.deref().get()
     }
 
-    fn GetRelatedTarget(&self) -> Option<Temporary<EventTarget>> {
+    fn GetRelatedTarget(self) -> Option<Temporary<EventTarget>> {
         self.related_target.get().clone().map(|target| Temporary::new(target))
     }
 
-    fn InitMouseEvent(&self,
+    fn InitMouseEvent(self,
                       typeArg: DOMString,
                       canBubbleArg: bool,
                       cancelableArg: bool,
@@ -160,7 +160,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
                       metaKeyArg: bool,
                       buttonArg: i16,
                       relatedTargetArg: Option<JSRef<EventTarget>>) {
-        let uievent: JSRef<UIEvent> = UIEventCast::from_ref(*self);
+        let uievent: JSRef<UIEvent> = UIEventCast::from_ref(self);
         uievent.InitUIEvent(typeArg, canBubbleArg, cancelableArg, viewArg, detailArg);
         self.screen_x.deref().set(screenXArg);
         self.screen_y.deref().set(screenYArg);

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -33,15 +33,15 @@ impl NamedNodeMap {
 }
 
 impl<'a> NamedNodeMapMethods for JSRef<'a, NamedNodeMap> {
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         self.owner.root().attrs.borrow().len() as u32
     }
 
-    fn Item(&self, index: u32) -> Option<Temporary<Attr>> {
+    fn Item(self, index: u32) -> Option<Temporary<Attr>> {
         self.owner.root().attrs.borrow().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {
         let item = self.Item(index);
         *found = item.is_some();
         item

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -32,23 +32,23 @@ impl Navigator {
 }
 
 impl<'a> NavigatorMethods for JSRef<'a, Navigator> {
-    fn Product(&self) -> DOMString {
+    fn Product(self) -> DOMString {
         NavigatorInfo::Product()
     }
 
-    fn TaintEnabled(&self) -> bool {
+    fn TaintEnabled(self) -> bool {
         NavigatorInfo::TaintEnabled()
     }
 
-    fn AppName(&self) -> DOMString {
+    fn AppName(self) -> DOMString {
         NavigatorInfo::AppName()
     }
 
-    fn AppCodeName(&self) -> DOMString {
+    fn AppCodeName(self) -> DOMString {
         NavigatorInfo::AppCodeName()
     }
 
-    fn Platform(&self) -> DOMString {
+    fn Platform(self) -> DOMString {
         NavigatorInfo::Platform()
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1485,7 +1485,7 @@ impl Node {
 
 impl<'a> NodeMethods for JSRef<'a, Node> {
     // http://dom.spec.whatwg.org/#dom-node-nodetype
-    fn NodeType(&self) -> u16 {
+    fn NodeType(self) -> u16 {
         match self.type_id {
             ElementNodeTypeId(_)            => NodeConstants::ELEMENT_NODE,
             TextNodeTypeId                  => NodeConstants::TEXT_NODE,
@@ -1498,21 +1498,21 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodename
-    fn NodeName(&self) -> DOMString {
+    fn NodeName(self) -> DOMString {
         match self.type_id {
             ElementNodeTypeId(..) => {
-                let elem: JSRef<Element> = ElementCast::to_ref(*self).unwrap();
+                let elem: JSRef<Element> = ElementCast::to_ref(self).unwrap();
                 elem.TagName()
             }
             TextNodeTypeId => "#text".to_string(),
             ProcessingInstructionNodeTypeId => {
                 let processing_instruction: JSRef<ProcessingInstruction> =
-                    ProcessingInstructionCast::to_ref(*self).unwrap();
+                    ProcessingInstructionCast::to_ref(self).unwrap();
                 processing_instruction.Target()
             }
             CommentNodeTypeId => "#comment".to_string(),
             DoctypeNodeTypeId => {
-                let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(*self).unwrap();
+                let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(self).unwrap();
                 doctype.deref().name.clone()
             },
             DocumentFragmentNodeTypeId => "#document-fragment".to_string(),
@@ -1521,13 +1521,13 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-baseuri
-    fn GetBaseURI(&self) -> Option<DOMString> {
+    fn GetBaseURI(self) -> Option<DOMString> {
         // FIXME (#1824) implement.
         None
     }
 
     // http://dom.spec.whatwg.org/#dom-node-ownerdocument
-    fn GetOwnerDocument(&self) -> Option<Temporary<Document>> {
+    fn GetOwnerDocument(self) -> Option<Temporary<Document>> {
         match self.type_id {
             ElementNodeTypeId(..) |
             CommentNodeTypeId |
@@ -1540,12 +1540,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-parentnode
-    fn GetParentNode(&self) -> Option<Temporary<Node>> {
+    fn GetParentNode(self) -> Option<Temporary<Node>> {
         self.parent_node.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-parentelement
-    fn GetParentElement(&self) -> Option<Temporary<Element>> {
+    fn GetParentElement(self) -> Option<Temporary<Element>> {
         self.parent_node.get()
                         .and_then(|parent| {
                             let parent = parent.root();
@@ -1556,12 +1556,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-haschildnodes
-    fn HasChildNodes(&self) -> bool {
+    fn HasChildNodes(self) -> bool {
         self.first_child.get().is_some()
     }
 
     // http://dom.spec.whatwg.org/#dom-node-childnodes
-    fn ChildNodes(&self) -> Temporary<NodeList> {
+    fn ChildNodes(self) -> Temporary<NodeList> {
         match self.child_list.get() {
             None => (),
             Some(ref list) => return Temporary::new(list.clone()),
@@ -1569,38 +1569,38 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
         let doc = self.owner_doc().root();
         let window = doc.deref().window.root();
-        let child_list = NodeList::new_child_list(*window, *self);
+        let child_list = NodeList::new_child_list(*window, self);
         self.child_list.assign(Some(child_list));
         Temporary::new(self.child_list.get().get_ref().clone())
     }
 
     // http://dom.spec.whatwg.org/#dom-node-firstchild
-    fn GetFirstChild(&self) -> Option<Temporary<Node>> {
+    fn GetFirstChild(self) -> Option<Temporary<Node>> {
         self.first_child.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lastchild
-    fn GetLastChild(&self) -> Option<Temporary<Node>> {
+    fn GetLastChild(self) -> Option<Temporary<Node>> {
         self.last_child.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-previoussibling
-    fn GetPreviousSibling(&self) -> Option<Temporary<Node>> {
+    fn GetPreviousSibling(self) -> Option<Temporary<Node>> {
         self.prev_sibling.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nextsibling
-    fn GetNextSibling(&self) -> Option<Temporary<Node>> {
+    fn GetNextSibling(self) -> Option<Temporary<Node>> {
         self.next_sibling.get().map(|node| Temporary::new(node))
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodevalue
-    fn GetNodeValue(&self) -> Option<DOMString> {
+    fn GetNodeValue(self) -> Option<DOMString> {
         match self.type_id {
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
-                let chardata: JSRef<CharacterData> = CharacterDataCast::to_ref(*self).unwrap();
+                let chardata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
                 Some(chardata.Data())
             }
             _ => {
@@ -1610,7 +1610,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-nodevalue
-    fn SetNodeValue(&self, val: Option<DOMString>) {
+    fn SetNodeValue(self, val: Option<DOMString>) {
         match self.type_id {
             CommentNodeTypeId |
             TextNodeTypeId |
@@ -1622,7 +1622,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-textcontent
-    fn GetTextContent(&self) -> Option<DOMString> {
+    fn GetTextContent(self) -> Option<DOMString> {
         match self.type_id {
             DocumentFragmentNodeTypeId |
             ElementNodeTypeId(..) => {
@@ -1632,7 +1632,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
-                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(*self).unwrap();
+                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
                 Some(characterdata.Data())
             }
             DoctypeNodeTypeId |
@@ -1643,7 +1643,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-textcontent
-    fn SetTextContent(&self, value: Option<DOMString>) {
+    fn SetTextContent(self, value: Option<DOMString>) {
         let value = null_str_as_empty(&value);
         match self.type_id {
             DocumentFragmentNodeTypeId |
@@ -1657,14 +1657,14 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 }.root();
 
                 // Step 3.
-                Node::replace_all(node.root_ref(), *self);
+                Node::replace_all(node.root_ref(), self);
             }
             CommentNodeTypeId |
             TextNodeTypeId |
             ProcessingInstructionNodeTypeId => {
                 self.wait_until_safe_to_modify_dom();
 
-                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(*self).unwrap();
+                let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
                 *characterdata.data.deref().borrow_mut() = value;
 
                 // Notify the document that the content of this node is different
@@ -1677,17 +1677,17 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-insertbefore
-    fn InsertBefore(&self, node: JSRef<Node>, child: Option<JSRef<Node>>) -> Fallible<Temporary<Node>> {
-        Node::pre_insert(node, *self, child)
+    fn InsertBefore(self, node: JSRef<Node>, child: Option<JSRef<Node>>) -> Fallible<Temporary<Node>> {
+        Node::pre_insert(node, self, child)
     }
 
     // http://dom.spec.whatwg.org/#dom-node-appendchild
-    fn AppendChild(&self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
-        Node::pre_insert(node, *self, None)
+    fn AppendChild(self, node: JSRef<Node>) -> Fallible<Temporary<Node>> {
+        Node::pre_insert(node, self, None)
     }
 
     // http://dom.spec.whatwg.org/#concept-node-replace
-    fn ReplaceChild(&self, node: JSRef<Node>, child: JSRef<Node>) -> Fallible<Temporary<Node>> {
+    fn ReplaceChild(self, node: JSRef<Node>, child: JSRef<Node>) -> Fallible<Temporary<Node>> {
 
         // Step 1.
         match self.type_id {
@@ -1698,7 +1698,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         }
 
         // Step 2.
-        if node.is_inclusive_ancestor_of(*self) {
+        if node.is_inclusive_ancestor_of(self) {
             return Err(HierarchyRequest);
         }
 
@@ -1789,15 +1789,15 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         };
 
         // Step 9.
-        let document = document_from_node(*self).root();
+        let document = document_from_node(self).root();
         Node::adopt(node, *document);
 
         {
             // Step 10.
-            Node::remove(child, *self, Suppressed);
+            Node::remove(child, self, Suppressed);
 
             // Step 11.
-            Node::insert(node, *self, reference_child, Suppressed);
+            Node::insert(node, self, reference_child, Suppressed);
         }
 
         // Step 12-14.
@@ -1816,13 +1816,13 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-removechild
-    fn RemoveChild(&self, node: JSRef<Node>)
+    fn RemoveChild(self, node: JSRef<Node>)
                        -> Fallible<Temporary<Node>> {
-        Node::pre_remove(node, *self)
+        Node::pre_remove(node, self)
     }
 
     // http://dom.spec.whatwg.org/#dom-node-normalize
-    fn Normalize(&self) {
+    fn Normalize(self) {
         let mut prev_text = None;
         for child in self.children() {
             if child.is_text() {
@@ -1848,15 +1848,15 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-clonenode
-    fn CloneNode(&self, deep: bool) -> Temporary<Node> {
+    fn CloneNode(self, deep: bool) -> Temporary<Node> {
         match deep {
-            true => Node::clone(*self, None, CloneChildren),
-            false => Node::clone(*self, None, DoNotCloneChildren)
+            true => Node::clone(self, None, CloneChildren),
+            false => Node::clone(self, None, DoNotCloneChildren)
         }
     }
 
     // http://dom.spec.whatwg.org/#dom-node-isequalnode
-    fn IsEqualNode(&self, maybe_node: Option<JSRef<Node>>) -> bool {
+    fn IsEqualNode(self, maybe_node: Option<JSRef<Node>>) -> bool {
         fn is_equal_doctype(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
             let other_doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(other).unwrap();
@@ -1931,13 +1931,13 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             // Step 1.
             None => false,
             // Step 2-6.
-            Some(node) => is_equal_node(*self, node)
+            Some(node) => is_equal_node(self, node)
         }
     }
 
     // http://dom.spec.whatwg.org/#dom-node-comparedocumentposition
-    fn CompareDocumentPosition(&self, other: JSRef<Node>) -> u16 {
-        if *self == other {
+    fn CompareDocumentPosition(self, other: JSRef<Node>) -> u16 {
+        if self == other {
             // step 2.
             0
         } else {
@@ -1952,7 +1952,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 lastself = ancestor.clone();
             }
             for ancestor in other.ancestors() {
-                if ancestor == *self {
+                if ancestor == self {
                     // step 5.
                     return NodeConstants::DOCUMENT_POSITION_CONTAINED_BY +
                            NodeConstants::DOCUMENT_POSITION_FOLLOWING;
@@ -1961,7 +1961,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             }
 
             if lastself != lastother {
-                let abstract_uint: uintptr_t = as_uintptr(&*self);
+                let abstract_uint: uintptr_t = as_uintptr(&self);
                 let other_uint: uintptr_t = as_uintptr(&*other);
 
                 let random = if abstract_uint < other_uint {
@@ -1980,7 +1980,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                     // step 6.
                     return NodeConstants::DOCUMENT_POSITION_PRECEDING;
                 }
-                if child == *self {
+                if child == self {
                     // step 7.
                     return NodeConstants::DOCUMENT_POSITION_FOLLOWING;
                 }
@@ -1990,7 +1990,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-contains
-    fn Contains(&self, maybe_other: Option<JSRef<Node>>) -> bool {
+    fn Contains(self, maybe_other: Option<JSRef<Node>>) -> bool {
         match maybe_other {
             None => false,
             Some(other) => self.is_inclusive_ancestor_of(other)
@@ -1998,19 +1998,19 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lookupprefix
-    fn LookupPrefix(&self, _prefix: Option<DOMString>) -> Option<DOMString> {
+    fn LookupPrefix(self, _prefix: Option<DOMString>) -> Option<DOMString> {
         // FIXME (#1826) implement.
         None
     }
 
     // http://dom.spec.whatwg.org/#dom-node-lookupnamespaceuri
-    fn LookupNamespaceURI(&self, _namespace: Option<DOMString>) -> Option<DOMString> {
+    fn LookupNamespaceURI(self, _namespace: Option<DOMString>) -> Option<DOMString> {
         // FIXME (#1826) implement.
         None
     }
 
     // http://dom.spec.whatwg.org/#dom-node-isdefaultnamespace
-    fn IsDefaultNamespace(&self, _namespace: Option<DOMString>) -> bool {
+    fn IsDefaultNamespace(self, _namespace: Option<DOMString>) -> bool {
         // FIXME (#1826) implement.
         false
     }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -48,7 +48,7 @@ impl NodeList {
 }
 
 impl<'a> NodeListMethods for JSRef<'a, NodeList> {
-    fn Length(&self) -> u32 {
+    fn Length(self) -> u32 {
         match self.list_type {
             Simple(ref elems) => elems.len() as u32,
             Children(ref node) => {
@@ -58,7 +58,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
         }
     }
 
-    fn Item(&self, index: u32) -> Option<Temporary<Node>> {
+    fn Item(self, index: u32) -> Option<Temporary<Node>> {
         match self.list_type {
             _ if index >= self.Length() => None,
             Simple(ref elems) => Some(Temporary::new(elems[index as uint].clone())),
@@ -70,7 +70,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
         }
     }
 
-    fn IndexedGetter(&self, index: u32, found: &mut bool) -> Option<Temporary<Node>> {
+    fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Node>> {
         let item = self.Item(index);
         *found = item.is_some();
         item

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -36,11 +36,11 @@ impl Performance {
 }
 
 impl<'a> PerformanceMethods for JSRef<'a, Performance> {
-    fn Timing(&self) -> Temporary<PerformanceTiming> {
+    fn Timing(self) -> Temporary<PerformanceTiming> {
         Temporary::new(self.timing.clone())
     }
 
-    fn Now(&self) -> DOMHighResTimeStamp {
+    fn Now(self) -> DOMHighResTimeStamp {
         let navStart = self.timing.root().NavigationStartPrecise() as f64;
         (time::precise_time_s() - navStart) as DOMHighResTimeStamp
     }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -37,7 +37,7 @@ impl PerformanceTiming {
 }
 
 impl<'a> PerformanceTimingMethods for JSRef<'a, PerformanceTiming> {
-    fn NavigationStart(&self) -> u64 {
+    fn NavigationStart(self) -> u64 {
         self.navigationStart
     }
 }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -43,11 +43,11 @@ impl<'a> PerformanceTimingMethods for JSRef<'a, PerformanceTiming> {
 }
 
 pub trait PerformanceTimingHelpers {
-    fn NavigationStartPrecise(&self) -> f64;
+    fn NavigationStartPrecise(self) -> f64;
 }
 
 impl<'a> PerformanceTimingHelpers for JSRef<'a, PerformanceTiming> {
-    fn NavigationStartPrecise(&self) -> f64 {
+    fn NavigationStartPrecise(self) -> f64 {
         self.navigationStartPrecise
     }
 }

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -42,7 +42,7 @@ impl ProcessingInstruction {
 }
 
 impl<'a> ProcessingInstructionMethods for JSRef<'a, ProcessingInstruction> {
-    fn Target(&self) -> DOMString {
+    fn Target(self) -> DOMString {
         self.target.clone()
     }
 }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -58,13 +58,13 @@ impl ProgressEvent {
 }
 
 impl<'a> ProgressEventMethods for JSRef<'a, ProgressEvent> {
-    fn LengthComputable(&self) -> bool {
+    fn LengthComputable(self) -> bool {
         self.length_computable
     }
-    fn Loaded(&self) -> u64{
+    fn Loaded(self) -> u64{
         self.loaded
     }
-    fn Total(&self) -> u64 {
+    fn Total(self) -> u64 {
         self.total
     }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -39,7 +39,7 @@ impl Range {
 
 impl<'a> RangeMethods for JSRef<'a, Range> {
     /// http://dom.spec.whatwg.org/#dom-range-detach
-    fn Detach(&self) {
+    fn Detach(self) {
         // This method intentionally left blank.
     }
 }

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -30,11 +30,11 @@ impl Screen {
 }
 
 impl<'a> ScreenMethods for JSRef<'a, Screen> {
-    fn ColorDepth(&self) -> u32 {
+    fn ColorDepth(self) -> u32 {
         24
     }
 
-    fn PixelDepth(&self) -> u32 {
+    fn PixelDepth(self) -> u32 {
         24
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -26,265 +26,265 @@ pub struct TestBinding {
 }
 
 impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
-    fn BooleanAttribute(&self) -> bool { false }
-    fn SetBooleanAttribute(&self, _: bool) {}
-    fn ByteAttribute(&self) -> i8 { 0 }
-    fn SetByteAttribute(&self, _: i8) {}
-    fn OctetAttribute(&self) -> u8 { 0 }
-    fn SetOctetAttribute(&self, _: u8) {}
-    fn ShortAttribute(&self) -> i16 { 0 }
-    fn SetShortAttribute(&self, _: i16) {}
-    fn UnsignedShortAttribute(&self) -> u16 { 0 }
-    fn SetUnsignedShortAttribute(&self, _: u16) {}
-    fn LongAttribute(&self) -> i32 { 0 }
-    fn SetLongAttribute(&self, _: i32) {}
-    fn UnsignedLongAttribute(&self) -> u32 { 0 }
-    fn SetUnsignedLongAttribute(&self, _: u32) {}
-    fn LongLongAttribute(&self) -> i64 { 0 }
-    fn SetLongLongAttribute(&self, _: i64) {}
-    fn UnsignedLongLongAttribute(&self) -> u64 { 0 }
-    fn SetUnsignedLongLongAttribute(&self, _: u64) {}
-    fn FloatAttribute(&self) -> f32 { 0. }
-    fn SetFloatAttribute(&self, _: f32) {}
-    fn DoubleAttribute(&self) -> f64 { 0. }
-    fn SetDoubleAttribute(&self, _: f64) {}
-    fn StringAttribute(&self) -> DOMString { "".to_string() }
-    fn SetStringAttribute(&self, _: DOMString) {}
-    fn ByteStringAttribute(&self) -> ByteString { ByteString::new(vec!()) }
-    fn SetByteStringAttribute(&self, _: ByteString) {}
-    fn EnumAttribute(&self) -> TestEnum { _empty }
-    fn SetEnumAttribute(&self, _: TestEnum) {}
-    fn InterfaceAttribute(&self) -> Temporary<Blob> {
+    fn BooleanAttribute(self) -> bool { false }
+    fn SetBooleanAttribute(self, _: bool) {}
+    fn ByteAttribute(self) -> i8 { 0 }
+    fn SetByteAttribute(self, _: i8) {}
+    fn OctetAttribute(self) -> u8 { 0 }
+    fn SetOctetAttribute(self, _: u8) {}
+    fn ShortAttribute(self) -> i16 { 0 }
+    fn SetShortAttribute(self, _: i16) {}
+    fn UnsignedShortAttribute(self) -> u16 { 0 }
+    fn SetUnsignedShortAttribute(self, _: u16) {}
+    fn LongAttribute(self) -> i32 { 0 }
+    fn SetLongAttribute(self, _: i32) {}
+    fn UnsignedLongAttribute(self) -> u32 { 0 }
+    fn SetUnsignedLongAttribute(self, _: u32) {}
+    fn LongLongAttribute(self) -> i64 { 0 }
+    fn SetLongLongAttribute(self, _: i64) {}
+    fn UnsignedLongLongAttribute(self) -> u64 { 0 }
+    fn SetUnsignedLongLongAttribute(self, _: u64) {}
+    fn FloatAttribute(self) -> f32 { 0. }
+    fn SetFloatAttribute(self, _: f32) {}
+    fn DoubleAttribute(self) -> f64 { 0. }
+    fn SetDoubleAttribute(self, _: f64) {}
+    fn StringAttribute(self) -> DOMString { "".to_string() }
+    fn SetStringAttribute(self, _: DOMString) {}
+    fn ByteStringAttribute(self) -> ByteString { ByteString::new(vec!()) }
+    fn SetByteStringAttribute(self, _: ByteString) {}
+    fn EnumAttribute(self) -> TestEnum { _empty }
+    fn SetEnumAttribute(self, _: TestEnum) {}
+    fn InterfaceAttribute(self) -> Temporary<Blob> {
         let global = self.global.root();
         Blob::new(&global.root_ref())
     }
-    fn SetInterfaceAttribute(&self, _: JSRef<Blob>) {}
-    fn UnionAttribute(&self) -> HTMLElementOrLong { eLong(0) }
-    fn SetUnionAttribute(&self, _: HTMLElementOrLong) {}
-    fn Union2Attribute(&self) -> EventOrString { eString("".to_string()) }
-    fn SetUnion2Attribute(&self, _: EventOrString) {}
-    fn AnyAttribute(&self, _: *mut JSContext) -> JSVal { NullValue() }
-    fn SetAnyAttribute(&self, _: *mut JSContext, _: JSVal) {}
+    fn SetInterfaceAttribute(self, _: JSRef<Blob>) {}
+    fn UnionAttribute(self) -> HTMLElementOrLong { eLong(0) }
+    fn SetUnionAttribute(self, _: HTMLElementOrLong) {}
+    fn Union2Attribute(self) -> EventOrString { eString("".to_string()) }
+    fn SetUnion2Attribute(self, _: EventOrString) {}
+    fn AnyAttribute(self, _: *mut JSContext) -> JSVal { NullValue() }
+    fn SetAnyAttribute(self, _: *mut JSContext, _: JSVal) {}
 
-    fn GetBooleanAttributeNullable(&self) -> Option<bool> { Some(false) }
-    fn SetBooleanAttributeNullable(&self, _: Option<bool>) {}
-    fn GetByteAttributeNullable(&self) -> Option<i8> { Some(0) }
-    fn SetByteAttributeNullable(&self, _: Option<i8>) {}
-    fn GetOctetAttributeNullable(&self) -> Option<u8> { Some(0) }
-    fn SetOctetAttributeNullable(&self, _: Option<u8>) {}
-    fn GetShortAttributeNullable(&self) -> Option<i16> { Some(0) }
-    fn SetShortAttributeNullable(&self, _: Option<i16>) {}
-    fn GetUnsignedShortAttributeNullable(&self) -> Option<u16> { Some(0) }
-    fn SetUnsignedShortAttributeNullable(&self, _: Option<u16>) {}
-    fn GetLongAttributeNullable(&self) -> Option<i32> { Some(0) }
-    fn SetLongAttributeNullable(&self, _: Option<i32>) {}
-    fn GetUnsignedLongAttributeNullable(&self) -> Option<u32> { Some(0) }
-    fn SetUnsignedLongAttributeNullable(&self, _: Option<u32>) {}
-    fn GetLongLongAttributeNullable(&self) -> Option<i64> { Some(0) }
-    fn SetLongLongAttributeNullable(&self, _: Option<i64>) {}
-    fn GetUnsignedLongLongAttributeNullable(&self) -> Option<u64> { Some(0) }
-    fn SetUnsignedLongLongAttributeNullable(&self, _: Option<u64>) {}
-    fn GetFloatAttributeNullable(&self) -> Option<f32> { Some(0.) }
-    fn SetFloatAttributeNullable(&self, _: Option<f32>) {}
-    fn GetDoubleAttributeNullable(&self) -> Option<f64> { Some(0.) }
-    fn SetDoubleAttributeNullable(&self, _: Option<f64>) {}
-    fn GetByteStringAttributeNullable(&self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
-    fn SetByteStringAttributeNullable(&self, _: Option<ByteString>) {}
-    fn GetStringAttributeNullable(&self) -> Option<DOMString> { Some("".to_string()) }
-    fn SetStringAttributeNullable(&self, _: Option<DOMString>) {}
-    fn GetEnumAttributeNullable(&self) -> Option<TestEnum> { Some(_empty) }
-    fn GetInterfaceAttributeNullable(&self) -> Option<Temporary<Blob>> {
+    fn GetBooleanAttributeNullable(self) -> Option<bool> { Some(false) }
+    fn SetBooleanAttributeNullable(self, _: Option<bool>) {}
+    fn GetByteAttributeNullable(self) -> Option<i8> { Some(0) }
+    fn SetByteAttributeNullable(self, _: Option<i8>) {}
+    fn GetOctetAttributeNullable(self) -> Option<u8> { Some(0) }
+    fn SetOctetAttributeNullable(self, _: Option<u8>) {}
+    fn GetShortAttributeNullable(self) -> Option<i16> { Some(0) }
+    fn SetShortAttributeNullable(self, _: Option<i16>) {}
+    fn GetUnsignedShortAttributeNullable(self) -> Option<u16> { Some(0) }
+    fn SetUnsignedShortAttributeNullable(self, _: Option<u16>) {}
+    fn GetLongAttributeNullable(self) -> Option<i32> { Some(0) }
+    fn SetLongAttributeNullable(self, _: Option<i32>) {}
+    fn GetUnsignedLongAttributeNullable(self) -> Option<u32> { Some(0) }
+    fn SetUnsignedLongAttributeNullable(self, _: Option<u32>) {}
+    fn GetLongLongAttributeNullable(self) -> Option<i64> { Some(0) }
+    fn SetLongLongAttributeNullable(self, _: Option<i64>) {}
+    fn GetUnsignedLongLongAttributeNullable(self) -> Option<u64> { Some(0) }
+    fn SetUnsignedLongLongAttributeNullable(self, _: Option<u64>) {}
+    fn GetFloatAttributeNullable(self) -> Option<f32> { Some(0.) }
+    fn SetFloatAttributeNullable(self, _: Option<f32>) {}
+    fn GetDoubleAttributeNullable(self) -> Option<f64> { Some(0.) }
+    fn SetDoubleAttributeNullable(self, _: Option<f64>) {}
+    fn GetByteStringAttributeNullable(self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
+    fn SetByteStringAttributeNullable(self, _: Option<ByteString>) {}
+    fn GetStringAttributeNullable(self) -> Option<DOMString> { Some("".to_string()) }
+    fn SetStringAttributeNullable(self, _: Option<DOMString>) {}
+    fn GetEnumAttributeNullable(self) -> Option<TestEnum> { Some(_empty) }
+    fn GetInterfaceAttributeNullable(self) -> Option<Temporary<Blob>> {
         let global = self.global.root();
         Some(Blob::new(&global.root_ref()))
     }
-    fn SetInterfaceAttributeNullable(&self, _: Option<JSRef<Blob>>) {}
-    fn GetUnionAttributeNullable(&self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
-    fn SetUnionAttributeNullable(&self, _: Option<HTMLElementOrLong>) {}
-    fn GetUnion2AttributeNullable(&self) -> Option<EventOrString> { Some(eString("".to_string())) }
-    fn SetUnion2AttributeNullable(&self, _: Option<EventOrString>) {}
-    fn ReceiveVoid(&self) -> () {}
-    fn ReceiveBoolean(&self) -> bool { false }
-    fn ReceiveByte(&self) -> i8 { 0 }
-    fn ReceiveOctet(&self) -> u8 { 0 }
-    fn ReceiveShort(&self) -> i16 { 0 }
-    fn ReceiveUnsignedShort(&self) -> u16 { 0 }
-    fn ReceiveLong(&self) -> i32 { 0 }
-    fn ReceiveUnsignedLong(&self) -> u32 { 0 }
-    fn ReceiveLongLong(&self) -> i64 { 0 }
-    fn ReceiveUnsignedLongLong(&self) -> u64 { 0 }
-    fn ReceiveFloat(&self) -> f32 { 0. }
-    fn ReceiveDouble(&self) -> f64 { 0. }
-    fn ReceiveString(&self) -> DOMString { "".to_string() }
-    fn ReceiveByteString(&self) -> ByteString { ByteString::new(vec!()) }
-    fn ReceiveEnum(&self) -> TestEnum { _empty }
-    fn ReceiveInterface(&self) -> Temporary<Blob> {
+    fn SetInterfaceAttributeNullable(self, _: Option<JSRef<Blob>>) {}
+    fn GetUnionAttributeNullable(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
+    fn SetUnionAttributeNullable(self, _: Option<HTMLElementOrLong>) {}
+    fn GetUnion2AttributeNullable(self) -> Option<EventOrString> { Some(eString("".to_string())) }
+    fn SetUnion2AttributeNullable(self, _: Option<EventOrString>) {}
+    fn ReceiveVoid(self) -> () {}
+    fn ReceiveBoolean(self) -> bool { false }
+    fn ReceiveByte(self) -> i8 { 0 }
+    fn ReceiveOctet(self) -> u8 { 0 }
+    fn ReceiveShort(self) -> i16 { 0 }
+    fn ReceiveUnsignedShort(self) -> u16 { 0 }
+    fn ReceiveLong(self) -> i32 { 0 }
+    fn ReceiveUnsignedLong(self) -> u32 { 0 }
+    fn ReceiveLongLong(self) -> i64 { 0 }
+    fn ReceiveUnsignedLongLong(self) -> u64 { 0 }
+    fn ReceiveFloat(self) -> f32 { 0. }
+    fn ReceiveDouble(self) -> f64 { 0. }
+    fn ReceiveString(self) -> DOMString { "".to_string() }
+    fn ReceiveByteString(self) -> ByteString { ByteString::new(vec!()) }
+    fn ReceiveEnum(self) -> TestEnum { _empty }
+    fn ReceiveInterface(self) -> Temporary<Blob> {
         let global = self.global.root();
         Blob::new(&global.root_ref())
     }
-    fn ReceiveAny(&self, _: *mut JSContext) -> JSVal { NullValue() }
-    fn ReceiveUnion(&self) -> HTMLElementOrLong { eLong(0) }
-    fn ReceiveUnion2(&self) -> EventOrString { eString("".to_string()) }
+    fn ReceiveAny(self, _: *mut JSContext) -> JSVal { NullValue() }
+    fn ReceiveUnion(self) -> HTMLElementOrLong { eLong(0) }
+    fn ReceiveUnion2(self) -> EventOrString { eString("".to_string()) }
 
-    fn ReceiveNullableBoolean(&self) -> Option<bool> { Some(false) }
-    fn ReceiveNullableByte(&self) -> Option<i8> { Some(0) }
-    fn ReceiveNullableOctet(&self) -> Option<u8> { Some(0) }
-    fn ReceiveNullableShort(&self) -> Option<i16> { Some(0) }
-    fn ReceiveNullableUnsignedShort(&self) -> Option<u16> { Some(0) }
-    fn ReceiveNullableLong(&self) -> Option<i32> { Some(0) }
-    fn ReceiveNullableUnsignedLong(&self) -> Option<u32> { Some(0) }
-    fn ReceiveNullableLongLong(&self) -> Option<i64> { Some(0) }
-    fn ReceiveNullableUnsignedLongLong(&self) -> Option<u64> { Some(0) }
-    fn ReceiveNullableFloat(&self) -> Option<f32> { Some(0.) }
-    fn ReceiveNullableDouble(&self) -> Option<f64> { Some(0.) }
-    fn ReceiveNullableString(&self) -> Option<DOMString> { Some("".to_string()) }
-    fn ReceiveNullableByteString(&self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
-    fn ReceiveNullableEnum(&self) -> Option<TestEnum> { Some(_empty) }
-    fn ReceiveNullableInterface(&self) -> Option<Temporary<Blob>> {
+    fn ReceiveNullableBoolean(self) -> Option<bool> { Some(false) }
+    fn ReceiveNullableByte(self) -> Option<i8> { Some(0) }
+    fn ReceiveNullableOctet(self) -> Option<u8> { Some(0) }
+    fn ReceiveNullableShort(self) -> Option<i16> { Some(0) }
+    fn ReceiveNullableUnsignedShort(self) -> Option<u16> { Some(0) }
+    fn ReceiveNullableLong(self) -> Option<i32> { Some(0) }
+    fn ReceiveNullableUnsignedLong(self) -> Option<u32> { Some(0) }
+    fn ReceiveNullableLongLong(self) -> Option<i64> { Some(0) }
+    fn ReceiveNullableUnsignedLongLong(self) -> Option<u64> { Some(0) }
+    fn ReceiveNullableFloat(self) -> Option<f32> { Some(0.) }
+    fn ReceiveNullableDouble(self) -> Option<f64> { Some(0.) }
+    fn ReceiveNullableString(self) -> Option<DOMString> { Some("".to_string()) }
+    fn ReceiveNullableByteString(self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
+    fn ReceiveNullableEnum(self) -> Option<TestEnum> { Some(_empty) }
+    fn ReceiveNullableInterface(self) -> Option<Temporary<Blob>> {
         let global = self.global.root();
         Some(Blob::new(&global.root_ref()))
     }
-    fn ReceiveNullableUnion(&self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
-    fn ReceiveNullableUnion2(&self) -> Option<EventOrString> { Some(eString("".to_string())) }
+    fn ReceiveNullableUnion(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
+    fn ReceiveNullableUnion2(self) -> Option<EventOrString> { Some(eString("".to_string())) }
 
-    fn PassBoolean(&self, _: bool) {}
-    fn PassByte(&self, _: i8) {}
-    fn PassOctet(&self, _: u8) {}
-    fn PassShort(&self, _: i16) {}
-    fn PassUnsignedShort(&self, _: u16) {}
-    fn PassLong(&self, _: i32) {}
-    fn PassUnsignedLong(&self, _: u32) {}
-    fn PassLongLong(&self, _: i64) {}
-    fn PassUnsignedLongLong(&self, _: u64) {}
-    fn PassFloat(&self, _: f32) {}
-    fn PassDouble(&self, _: f64) {}
-    fn PassString(&self, _: DOMString) {}
-    fn PassByteString(&self, _: ByteString) {}
-    fn PassEnum(&self, _: TestEnum) {}
-    fn PassInterface(&self, _: JSRef<Blob>) {}
-    fn PassUnion(&self, _: HTMLElementOrLong) {}
-    fn PassUnion2(&self, _: EventOrString) {}
-    fn PassUnion3(&self, _: BlobOrString) {}
-    fn PassAny(&self, _: *mut JSContext, _: JSVal) {}
+    fn PassBoolean(self, _: bool) {}
+    fn PassByte(self, _: i8) {}
+    fn PassOctet(self, _: u8) {}
+    fn PassShort(self, _: i16) {}
+    fn PassUnsignedShort(self, _: u16) {}
+    fn PassLong(self, _: i32) {}
+    fn PassUnsignedLong(self, _: u32) {}
+    fn PassLongLong(self, _: i64) {}
+    fn PassUnsignedLongLong(self, _: u64) {}
+    fn PassFloat(self, _: f32) {}
+    fn PassDouble(self, _: f64) {}
+    fn PassString(self, _: DOMString) {}
+    fn PassByteString(self, _: ByteString) {}
+    fn PassEnum(self, _: TestEnum) {}
+    fn PassInterface(self, _: JSRef<Blob>) {}
+    fn PassUnion(self, _: HTMLElementOrLong) {}
+    fn PassUnion2(self, _: EventOrString) {}
+    fn PassUnion3(self, _: BlobOrString) {}
+    fn PassAny(self, _: *mut JSContext, _: JSVal) {}
 
-    fn PassNullableBoolean(&self, _: Option<bool>) {}
-    fn PassNullableByte(&self, _: Option<i8>) {}
-    fn PassNullableOctet(&self, _: Option<u8>) {}
-    fn PassNullableShort(&self, _: Option<i16>) {}
-    fn PassNullableUnsignedShort(&self, _: Option<u16>) {}
-    fn PassNullableLong(&self, _: Option<i32>) {}
-    fn PassNullableUnsignedLong(&self, _: Option<u32>) {}
-    fn PassNullableLongLong(&self, _: Option<i64>) {}
-    fn PassNullableUnsignedLongLong(&self, _: Option<u64>) {}
-    fn PassNullableFloat(&self, _: Option<f32>) {}
-    fn PassNullableDouble(&self, _: Option<f64>) {}
-    fn PassNullableString(&self, _: Option<DOMString>) {}
-    fn PassNullableByteString(&self, _: Option<ByteString>) {}
-    // fn PassNullableEnum(&self, _: Option<TestEnum>) {}
-    fn PassNullableInterface(&self, _: Option<JSRef<Blob>>) {}
-    fn PassNullableUnion(&self, _: Option<HTMLElementOrLong>) {}
-    fn PassNullableUnion2(&self, _: Option<EventOrString>) {}
+    fn PassNullableBoolean(self, _: Option<bool>) {}
+    fn PassNullableByte(self, _: Option<i8>) {}
+    fn PassNullableOctet(self, _: Option<u8>) {}
+    fn PassNullableShort(self, _: Option<i16>) {}
+    fn PassNullableUnsignedShort(self, _: Option<u16>) {}
+    fn PassNullableLong(self, _: Option<i32>) {}
+    fn PassNullableUnsignedLong(self, _: Option<u32>) {}
+    fn PassNullableLongLong(self, _: Option<i64>) {}
+    fn PassNullableUnsignedLongLong(self, _: Option<u64>) {}
+    fn PassNullableFloat(self, _: Option<f32>) {}
+    fn PassNullableDouble(self, _: Option<f64>) {}
+    fn PassNullableString(self, _: Option<DOMString>) {}
+    fn PassNullableByteString(self, _: Option<ByteString>) {}
+    // fn PassNullableEnum(self, _: Option<TestEnum>) {}
+    fn PassNullableInterface(self, _: Option<JSRef<Blob>>) {}
+    fn PassNullableUnion(self, _: Option<HTMLElementOrLong>) {}
+    fn PassNullableUnion2(self, _: Option<EventOrString>) {}
 
-    fn PassOptionalBoolean(&self, _: Option<bool>) {}
-    fn PassOptionalByte(&self, _: Option<i8>) {}
-    fn PassOptionalOctet(&self, _: Option<u8>) {}
-    fn PassOptionalShort(&self, _: Option<i16>) {}
-    fn PassOptionalUnsignedShort(&self, _: Option<u16>) {}
-    fn PassOptionalLong(&self, _: Option<i32>) {}
-    fn PassOptionalUnsignedLong(&self, _: Option<u32>) {}
-    fn PassOptionalLongLong(&self, _: Option<i64>) {}
-    fn PassOptionalUnsignedLongLong(&self, _: Option<u64>) {}
-    fn PassOptionalFloat(&self, _: Option<f32>) {}
-    fn PassOptionalDouble(&self, _: Option<f64>) {}
-    fn PassOptionalString(&self, _: Option<DOMString>) {}
-    fn PassOptionalByteString(&self, _: Option<ByteString>) {}
-    fn PassOptionalEnum(&self, _: Option<TestEnum>) {}
-    fn PassOptionalInterface(&self, _: Option<JSRef<Blob>>) {}
-    fn PassOptionalUnion(&self, _: Option<HTMLElementOrLong>) {}
-    fn PassOptionalUnion2(&self, _: Option<EventOrString>) {}
-    fn PassOptionalAny(&self, _: *mut JSContext, _: JSVal) {}
+    fn PassOptionalBoolean(self, _: Option<bool>) {}
+    fn PassOptionalByte(self, _: Option<i8>) {}
+    fn PassOptionalOctet(self, _: Option<u8>) {}
+    fn PassOptionalShort(self, _: Option<i16>) {}
+    fn PassOptionalUnsignedShort(self, _: Option<u16>) {}
+    fn PassOptionalLong(self, _: Option<i32>) {}
+    fn PassOptionalUnsignedLong(self, _: Option<u32>) {}
+    fn PassOptionalLongLong(self, _: Option<i64>) {}
+    fn PassOptionalUnsignedLongLong(self, _: Option<u64>) {}
+    fn PassOptionalFloat(self, _: Option<f32>) {}
+    fn PassOptionalDouble(self, _: Option<f64>) {}
+    fn PassOptionalString(self, _: Option<DOMString>) {}
+    fn PassOptionalByteString(self, _: Option<ByteString>) {}
+    fn PassOptionalEnum(self, _: Option<TestEnum>) {}
+    fn PassOptionalInterface(self, _: Option<JSRef<Blob>>) {}
+    fn PassOptionalUnion(self, _: Option<HTMLElementOrLong>) {}
+    fn PassOptionalUnion2(self, _: Option<EventOrString>) {}
+    fn PassOptionalAny(self, _: *mut JSContext, _: JSVal) {}
 
-    fn PassOptionalNullableBoolean(&self, _: Option<Option<bool>>) {}
-    fn PassOptionalNullableByte(&self, _: Option<Option<i8>>) {}
-    fn PassOptionalNullableOctet(&self, _: Option<Option<u8>>) {}
-    fn PassOptionalNullableShort(&self, _: Option<Option<i16>>) {}
-    fn PassOptionalNullableUnsignedShort(&self, _: Option<Option<u16>>) {}
-    fn PassOptionalNullableLong(&self, _: Option<Option<i32>>) {}
-    fn PassOptionalNullableUnsignedLong(&self, _: Option<Option<u32>>) {}
-    fn PassOptionalNullableLongLong(&self, _: Option<Option<i64>>) {}
-    fn PassOptionalNullableUnsignedLongLong(&self, _: Option<Option<u64>>) {}
-    fn PassOptionalNullableFloat(&self, _: Option<Option<f32>>) {}
-    fn PassOptionalNullableDouble(&self, _: Option<Option<f64>>) {}
-    fn PassOptionalNullableString(&self, _: Option<Option<DOMString>>) {}
-    fn PassOptionalNullableByteString(&self, _: Option<Option<ByteString>>) {}
-    // fn PassOptionalNullableEnum(&self, _: Option<Option<TestEnum>>) {}
-    fn PassOptionalNullableInterface(&self, _: Option<Option<JSRef<Blob>>>) {}
-    fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
-    fn PassOptionalNullableUnion2(&self, _: Option<Option<EventOrString>>) {}
+    fn PassOptionalNullableBoolean(self, _: Option<Option<bool>>) {}
+    fn PassOptionalNullableByte(self, _: Option<Option<i8>>) {}
+    fn PassOptionalNullableOctet(self, _: Option<Option<u8>>) {}
+    fn PassOptionalNullableShort(self, _: Option<Option<i16>>) {}
+    fn PassOptionalNullableUnsignedShort(self, _: Option<Option<u16>>) {}
+    fn PassOptionalNullableLong(self, _: Option<Option<i32>>) {}
+    fn PassOptionalNullableUnsignedLong(self, _: Option<Option<u32>>) {}
+    fn PassOptionalNullableLongLong(self, _: Option<Option<i64>>) {}
+    fn PassOptionalNullableUnsignedLongLong(self, _: Option<Option<u64>>) {}
+    fn PassOptionalNullableFloat(self, _: Option<Option<f32>>) {}
+    fn PassOptionalNullableDouble(self, _: Option<Option<f64>>) {}
+    fn PassOptionalNullableString(self, _: Option<Option<DOMString>>) {}
+    fn PassOptionalNullableByteString(self, _: Option<Option<ByteString>>) {}
+    // fn PassOptionalNullableEnum(self, _: Option<Option<TestEnum>>) {}
+    fn PassOptionalNullableInterface(self, _: Option<Option<JSRef<Blob>>>) {}
+    fn PassOptionalNullableUnion(self, _: Option<Option<HTMLElementOrLong>>) {}
+    fn PassOptionalNullableUnion2(self, _: Option<Option<EventOrString>>) {}
 
-    fn PassOptionalBooleanWithDefault(&self, _: bool) {}
-    fn PassOptionalByteWithDefault(&self, _: i8) {}
-    fn PassOptionalOctetWithDefault(&self, _: u8) {}
-    fn PassOptionalShortWithDefault(&self, _: i16) {}
-    fn PassOptionalUnsignedShortWithDefault(&self, _: u16) {}
-    fn PassOptionalLongWithDefault(&self, _: i32) {}
-    fn PassOptionalUnsignedLongWithDefault(&self, _: u32) {}
-    fn PassOptionalLongLongWithDefault(&self, _: i64) {}
-    fn PassOptionalUnsignedLongLongWithDefault(&self, _: u64) {}
-    fn PassOptionalStringWithDefault(&self, _: DOMString) {}
-    fn PassOptionalEnumWithDefault(&self, _: TestEnum) {}
+    fn PassOptionalBooleanWithDefault(self, _: bool) {}
+    fn PassOptionalByteWithDefault(self, _: i8) {}
+    fn PassOptionalOctetWithDefault(self, _: u8) {}
+    fn PassOptionalShortWithDefault(self, _: i16) {}
+    fn PassOptionalUnsignedShortWithDefault(self, _: u16) {}
+    fn PassOptionalLongWithDefault(self, _: i32) {}
+    fn PassOptionalUnsignedLongWithDefault(self, _: u32) {}
+    fn PassOptionalLongLongWithDefault(self, _: i64) {}
+    fn PassOptionalUnsignedLongLongWithDefault(self, _: u64) {}
+    fn PassOptionalStringWithDefault(self, _: DOMString) {}
+    fn PassOptionalEnumWithDefault(self, _: TestEnum) {}
 
-    fn PassOptionalNullableBooleanWithDefault(&self, _: Option<bool>) {}
-    fn PassOptionalNullableByteWithDefault(&self, _: Option<i8>) {}
-    fn PassOptionalNullableOctetWithDefault(&self, _: Option<u8>) {}
-    fn PassOptionalNullableShortWithDefault(&self, _: Option<i16>) {}
-    fn PassOptionalNullableUnsignedShortWithDefault(&self, _: Option<u16>) {}
-    fn PassOptionalNullableLongWithDefault(&self, _: Option<i32>) {}
-    fn PassOptionalNullableUnsignedLongWithDefault(&self, _: Option<u32>) {}
-    fn PassOptionalNullableLongLongWithDefault(&self, _: Option<i64>) {}
-    fn PassOptionalNullableUnsignedLongLongWithDefault(&self, _: Option<u64>) {}
-    // fn PassOptionalNullableFloatWithDefault(&self, _: Option<f32>) {}
-    // fn PassOptionalNullableDoubleWithDefault(&self, _: Option<f64>) {}
-    fn PassOptionalNullableStringWithDefault(&self, _: Option<DOMString>) {}
-    fn PassOptionalNullableByteStringWithDefault(&self, _: Option<ByteString>) {}
-    // fn PassOptionalNullableEnumWithDefault(&self, _: Option<TestEnum>) {}
-    fn PassOptionalNullableInterfaceWithDefault(&self, _: Option<JSRef<Blob>>) {}
-    fn PassOptionalNullableUnionWithDefault(&self, _: Option<HTMLElementOrLong>) {}
-    fn PassOptionalNullableUnion2WithDefault(&self, _: Option<EventOrString>) {}
-    fn PassOptionalAnyWithDefault(&self, _: *mut JSContext, _: JSVal) {}
+    fn PassOptionalNullableBooleanWithDefault(self, _: Option<bool>) {}
+    fn PassOptionalNullableByteWithDefault(self, _: Option<i8>) {}
+    fn PassOptionalNullableOctetWithDefault(self, _: Option<u8>) {}
+    fn PassOptionalNullableShortWithDefault(self, _: Option<i16>) {}
+    fn PassOptionalNullableUnsignedShortWithDefault(self, _: Option<u16>) {}
+    fn PassOptionalNullableLongWithDefault(self, _: Option<i32>) {}
+    fn PassOptionalNullableUnsignedLongWithDefault(self, _: Option<u32>) {}
+    fn PassOptionalNullableLongLongWithDefault(self, _: Option<i64>) {}
+    fn PassOptionalNullableUnsignedLongLongWithDefault(self, _: Option<u64>) {}
+    // fn PassOptionalNullableFloatWithDefault(self, _: Option<f32>) {}
+    // fn PassOptionalNullableDoubleWithDefault(self, _: Option<f64>) {}
+    fn PassOptionalNullableStringWithDefault(self, _: Option<DOMString>) {}
+    fn PassOptionalNullableByteStringWithDefault(self, _: Option<ByteString>) {}
+    // fn PassOptionalNullableEnumWithDefault(self, _: Option<TestEnum>) {}
+    fn PassOptionalNullableInterfaceWithDefault(self, _: Option<JSRef<Blob>>) {}
+    fn PassOptionalNullableUnionWithDefault(self, _: Option<HTMLElementOrLong>) {}
+    fn PassOptionalNullableUnion2WithDefault(self, _: Option<EventOrString>) {}
+    fn PassOptionalAnyWithDefault(self, _: *mut JSContext, _: JSVal) {}
 
-    fn PassOptionalNullableBooleanWithNonNullDefault(&self, _: Option<bool>) {}
-    fn PassOptionalNullableByteWithNonNullDefault(&self, _: Option<i8>) {}
-    fn PassOptionalNullableOctetWithNonNullDefault(&self, _: Option<u8>) {}
-    fn PassOptionalNullableShortWithNonNullDefault(&self, _: Option<i16>) {}
-    fn PassOptionalNullableUnsignedShortWithNonNullDefault(&self, _: Option<u16>) {}
-    fn PassOptionalNullableLongWithNonNullDefault(&self, _: Option<i32>) {}
-    fn PassOptionalNullableUnsignedLongWithNonNullDefault(&self, _: Option<u32>) {}
-    fn PassOptionalNullableLongLongWithNonNullDefault(&self, _: Option<i64>) {}
-    fn PassOptionalNullableUnsignedLongLongWithNonNullDefault(&self, _: Option<u64>) {}
-    // fn PassOptionalNullableFloatWithNonNullDefault(&self, _: Option<f32>) {}
-    // fn PassOptionalNullableDoubleWithNonNullDefault(&self, _: Option<f64>) {}
-    fn PassOptionalNullableStringWithNonNullDefault(&self, _: Option<DOMString>) {}
-    // fn PassOptionalNullableEnumWithNonNullDefault(&self, _: Option<TestEnum>) {}
+    fn PassOptionalNullableBooleanWithNonNullDefault(self, _: Option<bool>) {}
+    fn PassOptionalNullableByteWithNonNullDefault(self, _: Option<i8>) {}
+    fn PassOptionalNullableOctetWithNonNullDefault(self, _: Option<u8>) {}
+    fn PassOptionalNullableShortWithNonNullDefault(self, _: Option<i16>) {}
+    fn PassOptionalNullableUnsignedShortWithNonNullDefault(self, _: Option<u16>) {}
+    fn PassOptionalNullableLongWithNonNullDefault(self, _: Option<i32>) {}
+    fn PassOptionalNullableUnsignedLongWithNonNullDefault(self, _: Option<u32>) {}
+    fn PassOptionalNullableLongLongWithNonNullDefault(self, _: Option<i64>) {}
+    fn PassOptionalNullableUnsignedLongLongWithNonNullDefault(self, _: Option<u64>) {}
+    // fn PassOptionalNullableFloatWithNonNullDefault(self, _: Option<f32>) {}
+    // fn PassOptionalNullableDoubleWithNonNullDefault(self, _: Option<f64>) {}
+    fn PassOptionalNullableStringWithNonNullDefault(self, _: Option<DOMString>) {}
+    // fn PassOptionalNullableEnumWithNonNullDefault(self, _: Option<TestEnum>) {}
 
-    fn PassVariadicBoolean(&self, _: Vec<bool>) {}
-    fn PassVariadicByte(&self, _: Vec<i8>) {}
-    fn PassVariadicOctet(&self, _: Vec<u8>) {}
-    fn PassVariadicShort(&self, _: Vec<i16>) {}
-    fn PassVariadicUnsignedShort(&self, _: Vec<u16>) {}
-    fn PassVariadicLong(&self, _: Vec<i32>) {}
-    fn PassVariadicUnsignedLong(&self, _: Vec<u32>) {}
-    fn PassVariadicLongLong(&self, _: Vec<i64>) {}
-    fn PassVariadicUnsignedLongLong(&self, _: Vec<u64>) {}
-    fn PassVariadicFloat(&self, _: Vec<f32>) {}
-    fn PassVariadicDouble(&self, _: Vec<f64>) {}
-    fn PassVariadicString(&self, _: Vec<DOMString>) {}
-    fn PassVariadicByteString(&self, _: Vec<ByteString>) {}
-    fn PassVariadicEnum(&self, _: Vec<TestEnum>) {}
-    // fn PassVariadicInterface(&self, _: Vec<JSRef<Blob>>) {}
-    fn PassVariadicUnion(&self, _: Vec<HTMLElementOrLong>) {}
-    fn PassVariadicUnion2(&self, _: Vec<EventOrString>) {}
-    fn PassVariadicUnion3(&self, _: Vec<BlobOrString>) {}
-    fn PassVariadicAny(&self, _: *mut JSContext, _: Vec<JSVal>) {}
+    fn PassVariadicBoolean(self, _: Vec<bool>) {}
+    fn PassVariadicByte(self, _: Vec<i8>) {}
+    fn PassVariadicOctet(self, _: Vec<u8>) {}
+    fn PassVariadicShort(self, _: Vec<i16>) {}
+    fn PassVariadicUnsignedShort(self, _: Vec<u16>) {}
+    fn PassVariadicLong(self, _: Vec<i32>) {}
+    fn PassVariadicUnsignedLong(self, _: Vec<u32>) {}
+    fn PassVariadicLongLong(self, _: Vec<i64>) {}
+    fn PassVariadicUnsignedLongLong(self, _: Vec<u64>) {}
+    fn PassVariadicFloat(self, _: Vec<f32>) {}
+    fn PassVariadicDouble(self, _: Vec<f64>) {}
+    fn PassVariadicString(self, _: Vec<DOMString>) {}
+    fn PassVariadicByteString(self, _: Vec<ByteString>) {}
+    fn PassVariadicEnum(self, _: Vec<TestEnum>) {}
+    // fn PassVariadicInterface(self, _: Vec<JSRef<Blob>>) {}
+    fn PassVariadicUnion(self, _: Vec<HTMLElementOrLong>) {}
+    fn PassVariadicUnion2(self, _: Vec<EventOrString>) {}
+    fn PassVariadicUnion3(self, _: Vec<BlobOrString>) {}
+    fn PassVariadicAny(self, _: *mut JSContext, _: Vec<JSVal>) {}
 }
 
 impl TestBinding {

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -133,24 +133,24 @@ impl Reflectable for TreeWalker {
 type NodeAdvancer<'a, 'b> = |node: JSRef<'a, Node>|: 'b -> Option<Temporary<Node>>;
 
 trait PrivateTreeWalkerHelpers<'a, 'b> {
-    fn traverse_children(&self,
+    fn traverse_children(self,
                          next_child: NodeAdvancer<'a, 'b>,
                          next_sibling: NodeAdvancer<'a, 'b>)
                          -> Fallible<Option<Temporary<Node>>>;
-    fn traverse_siblings(&self,
+    fn traverse_siblings(self,
                          next_child: NodeAdvancer<'a, 'b>,
                          next_sibling: NodeAdvancer<'a, 'b>)
                          -> Fallible<Option<Temporary<Node>>>;
-    fn is_root_node(&self, node: JSRef<'a, Node>) -> bool;
-    fn is_current_node(&self, node: JSRef<'a, Node>) -> bool;
-    fn first_following_node_not_following_root(&self, node: JSRef<'a, Node>)
+    fn is_root_node(self, node: JSRef<'a, Node>) -> bool;
+    fn is_current_node(self, node: JSRef<'a, Node>) -> bool;
+    fn first_following_node_not_following_root(self, node: JSRef<'a, Node>)
                                                -> Option<Temporary<Node>>;
-    fn accept_node(&self, node: JSRef<'a, Node>) -> Fallible<u16>;
+    fn accept_node(self, node: JSRef<'a, Node>) -> Fallible<u16>;
 }
 
 impl<'a, 'b> PrivateTreeWalkerHelpers<'a, 'b> for JSRef<'a, TreeWalker> {
     // http://dom.spec.whatwg.org/#concept-traverse-children
-    fn traverse_children(&self,
+    fn traverse_children(self,
                          next_child: NodeAdvancer<'a, 'b>,
                          next_sibling: NodeAdvancer<'a, 'b>)
                          -> Fallible<Option<Temporary<Node>>> {
@@ -229,7 +229,7 @@ impl<'a, 'b> PrivateTreeWalkerHelpers<'a, 'b> for JSRef<'a, TreeWalker> {
     }
 
     // http://dom.spec.whatwg.org/#concept-traverse-siblings
-    fn traverse_siblings(&self,
+    fn traverse_siblings(self,
                          next_child: NodeAdvancer<'a, 'b>,
                          next_sibling: NodeAdvancer<'a, 'b>)
                          -> Fallible<Option<Temporary<Node>>> {
@@ -293,7 +293,7 @@ impl<'a, 'b> PrivateTreeWalkerHelpers<'a, 'b> for JSRef<'a, TreeWalker> {
     }
 
     // http://dom.spec.whatwg.org/#concept-tree-following
-    fn first_following_node_not_following_root(&self, node: JSRef<'a, Node>)
+    fn first_following_node_not_following_root(self, node: JSRef<'a, Node>)
                                                -> Option<Temporary<Node>> {
         // "An object A is following an object B if A and B are in the same tree
         //  and A comes after B in tree order."
@@ -320,7 +320,7 @@ impl<'a, 'b> PrivateTreeWalkerHelpers<'a, 'b> for JSRef<'a, TreeWalker> {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-filter
-    fn accept_node(&self, node: JSRef<'a, Node>) -> Fallible<u16> {
+    fn accept_node(self, node: JSRef<'a, Node>) -> Fallible<u16> {
         // "To filter node run these steps:"
         // "1. Let n be node's nodeType attribute value minus 1."
         let n: uint = node.NodeType() as uint - 1;
@@ -336,32 +336,32 @@ impl<'a, 'b> PrivateTreeWalkerHelpers<'a, 'b> for JSRef<'a, TreeWalker> {
         match self.filter {
             FilterNone => Ok(NodeFilterConstants::FILTER_ACCEPT),
             FilterNative(f) => Ok((*f)(node)),
-            FilterJS(callback) => callback.AcceptNode_(*self, node, RethrowExceptions)
+            FilterJS(callback) => callback.AcceptNode_(self, node, RethrowExceptions)
         }
     }
 
-    fn is_root_node(&self, node: JSRef<'a, Node>) -> bool {
+    fn is_root_node(self, node: JSRef<'a, Node>) -> bool {
         JS::from_rooted(node) == self.root_node
     }
 
-    fn is_current_node(&self, node: JSRef<'a, Node>) -> bool {
+    fn is_current_node(self, node: JSRef<'a, Node>) -> bool {
         JS::from_rooted(node) == self.current_node.get()
     }
 }
 
 pub trait TreeWalkerHelpers<'a> {
-    fn parent_node(&self) -> Fallible<Option<Temporary<Node>>>;
-    fn first_child(&self) -> Fallible<Option<Temporary<Node>>>;
-    fn last_child(&self) -> Fallible<Option<Temporary<Node>>>;
-    fn next_sibling(&self) -> Fallible<Option<Temporary<Node>>>;
-    fn prev_sibling(&self) -> Fallible<Option<Temporary<Node>>>;
-    fn next_node(&self) -> Fallible<Option<Temporary<Node>>>;
-    fn prev_node(&self) -> Fallible<Option<Temporary<Node>>>;
+    fn parent_node(self) -> Fallible<Option<Temporary<Node>>>;
+    fn first_child(self) -> Fallible<Option<Temporary<Node>>>;
+    fn last_child(self) -> Fallible<Option<Temporary<Node>>>;
+    fn next_sibling(self) -> Fallible<Option<Temporary<Node>>>;
+    fn prev_sibling(self) -> Fallible<Option<Temporary<Node>>>;
+    fn next_node(self) -> Fallible<Option<Temporary<Node>>>;
+    fn prev_node(self) -> Fallible<Option<Temporary<Node>>>;
 }
 
 impl<'a> TreeWalkerHelpers<'a> for JSRef<'a, TreeWalker> {
     // http://dom.spec.whatwg.org/#dom-treewalker-parentnode
-    fn parent_node(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn parent_node(self) -> Fallible<Option<Temporary<Node>>> {
         // "1. Let node be the value of the currentNode attribute."
         let mut node = self.current_node.get().root().clone();
         // "2. While node is not null and is not root, run these substeps:"
@@ -389,35 +389,35 @@ impl<'a> TreeWalkerHelpers<'a> for JSRef<'a, TreeWalker> {
     }
 
     // http://dom.spec.whatwg.org/#dom-treewalker-firstchild
-    fn first_child(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn first_child(self) -> Fallible<Option<Temporary<Node>>> {
         // "The firstChild() method must traverse children of type first."
         self.traverse_children(|node| node.first_child(),
                                |node| node.next_sibling())
     }
 
     // http://dom.spec.whatwg.org/#dom-treewalker-lastchild
-    fn last_child(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn last_child(self) -> Fallible<Option<Temporary<Node>>> {
         // "The lastChild() method must traverse children of type last."
         self.traverse_children(|node| node.last_child(),
                                |node| node.prev_sibling())
     }
 
     // http://dom.spec.whatwg.org/#dom-treewalker-nextsibling
-    fn next_sibling(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn next_sibling(self) -> Fallible<Option<Temporary<Node>>> {
         // "The nextSibling() method must traverse siblings of type next."
         self.traverse_siblings(|node| node.first_child(),
                                |node| node.next_sibling())
     }
 
     // http://dom.spec.whatwg.org/#dom-treewalker-previoussibling
-    fn prev_sibling(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn prev_sibling(self) -> Fallible<Option<Temporary<Node>>> {
         // "The previousSibling() method must traverse siblings of type previous."
         self.traverse_siblings(|node| node.last_child(),
                                |node| node.prev_sibling())
     }
 
     // http://dom.spec.whatwg.org/#dom-treewalker-previousnode
-    fn prev_node(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn prev_node(self) -> Fallible<Option<Temporary<Node>>> {
         // "1. Let node be the value of the currentNode attribute."
         let mut node = self.current_node.get().root().clone();
         // "2. While node is not root, run these substeps:"
@@ -478,7 +478,7 @@ impl<'a> TreeWalkerHelpers<'a> for JSRef<'a, TreeWalker> {
     }
 
     // http://dom.spec.whatwg.org/#dom-treewalker-nextnode
-    fn next_node(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn next_node(self) -> Fallible<Option<Temporary<Node>>> {
         // "1. Let node be the value of the currentNode attribute."
         let mut node = self.current_node.get().root().clone();
         // "2. Let result be FILTER_ACCEPT."

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -69,15 +69,15 @@ impl TreeWalker {
 }
 
 impl<'a> TreeWalkerMethods for JSRef<'a, TreeWalker> {
-    fn Root(&self) -> Temporary<Node> {
+    fn Root(self) -> Temporary<Node> {
         Temporary::new(self.root_node)
     }
 
-    fn WhatToShow(&self) -> u32 {
+    fn WhatToShow(self) -> u32 {
         self.what_to_show
     }
 
-    fn GetFilter(&self) -> Option<NodeFilter> {
+    fn GetFilter(self) -> Option<NodeFilter> {
         match self.filter {
             FilterNone => None,
             FilterJS(nf) => Some(nf),
@@ -85,41 +85,41 @@ impl<'a> TreeWalkerMethods for JSRef<'a, TreeWalker> {
         }
     }
 
-    fn CurrentNode(&self) -> Temporary<Node> {
+    fn CurrentNode(self) -> Temporary<Node> {
         Temporary::new(self.current_node.get())
     }
 
-    fn SetCurrentNode(&self, node: JSRef<Node>) -> ErrorResult {
+    fn SetCurrentNode(self, node: JSRef<Node>) -> ErrorResult {
         // XXX Future: check_same_origin(root_node, node) (throws)
         self.current_node.set(JS::from_rooted(node));
         Ok(())
     }
 
-    fn ParentNode(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn ParentNode(self) -> Fallible<Option<Temporary<Node>>> {
         self.parent_node()
     }
 
-    fn FirstChild(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn FirstChild(self) -> Fallible<Option<Temporary<Node>>> {
         self.first_child()
     }
 
-    fn LastChild(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn LastChild(self) -> Fallible<Option<Temporary<Node>>> {
         self.last_child()
     }
 
-    fn PreviousSibling(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn PreviousSibling(self) -> Fallible<Option<Temporary<Node>>> {
         self.prev_sibling()
     }
 
-    fn NextSibling(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn NextSibling(self) -> Fallible<Option<Temporary<Node>>> {
         self.next_sibling()
     }
 
-    fn PreviousNode(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn PreviousNode(self) -> Fallible<Option<Temporary<Node>>> {
         self.prev_node()
     }
 
-    fn NextNode(&self) -> Fallible<Option<Temporary<Node>>> {
+    fn NextNode(self) -> Fallible<Option<Temporary<Node>>> {
         self.next_node()
     }
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -68,21 +68,21 @@ impl UIEvent {
 }
 
 impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
-    fn GetView(&self) -> Option<Temporary<Window>> {
+    fn GetView(self) -> Option<Temporary<Window>> {
         self.view.get().map(|view| Temporary::new(view))
     }
 
-    fn Detail(&self) -> i32 {
+    fn Detail(self) -> i32 {
         self.detail.deref().get()
     }
 
-    fn InitUIEvent(&self,
+    fn InitUIEvent(self,
                    type_: DOMString,
                    can_bubble: bool,
                    cancelable: bool,
                    view: Option<JSRef<Window>>,
                    detail: i32) {
-        let event: JSRef<Event> = EventCast::from_ref(*self);
+        let event: JSRef<Event> = EventCast::from_ref(self);
         event.InitEvent(type_, can_bubble, cancelable);
         self.view.assign(view);
         self.detail.deref().set(detail);

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -61,26 +61,26 @@ impl URLSearchParams {
 }
 
 impl<'a> URLSearchParamsMethods for JSRef<'a, URLSearchParams> {
-    fn Append(&self, name: DOMString, value: DOMString) {
+    fn Append(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert_or_update_with(name, vec!(value.clone()),
                                                              |_k, v| v.push(value.clone()));
         self.update_steps();
     }
 
-    fn Delete(&self, name: DOMString) {
+    fn Delete(self, name: DOMString) {
         self.data.deref().borrow_mut().remove(&name);
         self.update_steps();
     }
 
-    fn Get(&self, name: DOMString) -> Option<DOMString> {
+    fn Get(self, name: DOMString) -> Option<DOMString> {
         self.data.deref().borrow().find_equiv(&name).map(|v| v[0].clone())
     }
 
-    fn Has(&self, name: DOMString) -> bool {
+    fn Has(self, name: DOMString) -> bool {
         self.data.deref().borrow().contains_key_equiv(&name)
     }
 
-    fn Set(&self, name: DOMString, value: DOMString) {
+    fn Set(self, name: DOMString, value: DOMString) {
         self.data.deref().borrow_mut().insert(name, vec!(value));
         self.update_steps();
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -364,21 +364,21 @@ impl Reflectable for Window {
 }
 
 pub trait WindowHelpers {
-    fn damage_and_reflow(&self, damage: DocumentDamageLevel);
-    fn flush_layout(&self, goal: ReflowGoal);
-    fn wait_until_safe_to_modify_dom(&self);
-    fn init_browser_context(&self, doc: JSRef<Document>);
-    fn load_url(&self, href: DOMString);
-    fn handle_fire_timer(&self, timer_id: TimerId, cx: *mut JSContext);
-    fn evaluate_js_with_result(&self, code: &str) -> JSVal;
+    fn damage_and_reflow(self, damage: DocumentDamageLevel);
+    fn flush_layout(self, goal: ReflowGoal);
+    fn wait_until_safe_to_modify_dom(self);
+    fn init_browser_context(self, doc: JSRef<Document>);
+    fn load_url(self, href: DOMString);
+    fn handle_fire_timer(self, timer_id: TimerId, cx: *mut JSContext);
+    fn evaluate_js_with_result(self, code: &str) -> JSVal;
 }
 
 trait PrivateWindowHelpers {
-    fn set_timeout_or_interval(&self, callback: JSVal, timeout: i32, is_interval: bool) -> i32;
+    fn set_timeout_or_interval(self, callback: JSVal, timeout: i32, is_interval: bool) -> i32;
 }
 
 impl<'a> WindowHelpers for JSRef<'a, Window> {
-    fn evaluate_js_with_result(&self, code: &str) -> JSVal {
+    fn evaluate_js_with_result(self, code: &str) -> JSVal {
         let global = self.reflector().get_jsobject();
         let code: Vec<u16> = code.as_slice().utf16_units().collect();
         let mut rval = UndefinedValue();
@@ -397,27 +397,27 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         })
     }
 
-    fn damage_and_reflow(&self, damage: DocumentDamageLevel) {
+    fn damage_and_reflow(self, damage: DocumentDamageLevel) {
         self.page().damage(damage);
         self.page().avoided_reflows.set(self.page().avoided_reflows.get() + 1);
     }
 
-    fn flush_layout(&self, goal: ReflowGoal) {
+    fn flush_layout(self, goal: ReflowGoal) {
         self.page().flush_layout(goal);
     }
 
-    fn wait_until_safe_to_modify_dom(&self) {
+    fn wait_until_safe_to_modify_dom(self) {
         // FIXME: This disables concurrent layout while we are modifying the DOM, since
         //        our current architecture is entirely unsafe in the presence of races.
         self.page().join_layout();
     }
 
-    fn init_browser_context(&self, doc: JSRef<Document>) {
+    fn init_browser_context(self, doc: JSRef<Document>) {
         *self.browser_context.deref().borrow_mut() = Some(BrowserContext::new(doc));
     }
 
     /// Commence a new URL load which will either replace this window or scroll to a fragment.
-    fn load_url(&self, href: DOMString) {
+    fn load_url(self, href: DOMString) {
         let base_url = self.page().get_url();
         debug!("current page url is {:?}", base_url);
         let url = UrlParser::new().base_url(&base_url).parse(href.as_slice());
@@ -431,7 +431,7 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         }
     }
 
-    fn handle_fire_timer(&self, timer_id: TimerId, cx: *mut JSContext) {
+    fn handle_fire_timer(self, timer_id: TimerId, cx: *mut JSContext) {
         let this_value = self.reflector().get_jsobject();
 
         let data = match self.active_timers.deref().borrow().find(&timer_id) {
@@ -455,7 +455,7 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
 }
 
 impl<'a> PrivateWindowHelpers for JSRef<'a, Window> {
-    fn set_timeout_or_interval(&self, callback: JSVal, timeout: i32, is_interval: bool) -> i32 {
+    fn set_timeout_or_interval(self, callback: JSVal, timeout: i32, is_interval: bool) -> i32 {
         let timeout = cmp::max(0, timeout) as u64;
         let handle = self.next_timer_handle.deref().get();
         self.next_timer_handle.deref().set(handle + 1);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -202,51 +202,51 @@ pub fn base64_atob(atob: DOMString) -> Fallible<DOMString> {
 
 
 impl<'a> WindowMethods for JSRef<'a, Window> {
-    fn Alert(&self, s: DOMString) {
+    fn Alert(self, s: DOMString) {
         // Right now, just print to the console
         println!("ALERT: {:s}", s);
     }
 
-    fn Close(&self) {
+    fn Close(self) {
         let ScriptChan(ref chan) = self.script_chan;
         chan.send(ExitWindowMsg(self.page.id.clone()));
     }
 
-    fn Document(&self) -> Temporary<Document> {
+    fn Document(self) -> Temporary<Document> {
         let frame = self.page().frame();
         Temporary::new(frame.get_ref().document.clone())
     }
 
-    fn Location(&self) -> Temporary<Location> {
+    fn Location(self) -> Temporary<Location> {
         if self.location.get().is_none() {
             let page = self.deref().page.clone();
-            let location = Location::new(*self, page);
+            let location = Location::new(self, page);
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
     }
 
-    fn Console(&self) -> Temporary<Console> {
+    fn Console(self) -> Temporary<Console> {
         if self.console.get().is_none() {
-            let console = Console::new(&global::Window(*self));
+            let console = Console::new(&global::Window(self));
             self.console.assign(Some(console));
         }
         Temporary::new(self.console.get().get_ref().clone())
     }
 
-    fn Navigator(&self) -> Temporary<Navigator> {
+    fn Navigator(self) -> Temporary<Navigator> {
         if self.navigator.get().is_none() {
-            let navigator = Navigator::new(*self);
+            let navigator = Navigator::new(self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())
     }
 
-    fn SetTimeout(&self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
+    fn SetTimeout(self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
         self.set_timeout_or_interval(callback, timeout, false)
     }
 
-    fn ClearTimeout(&self, handle: i32) {
+    fn ClearTimeout(self, handle: i32) {
         let mut timers = self.active_timers.deref().borrow_mut();
         let mut timer_handle = timers.pop(&TimerId(handle));
         match timer_handle {
@@ -256,103 +256,103 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         timers.remove(&TimerId(handle));
     }
 
-    fn SetInterval(&self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
+    fn SetInterval(self, _cx: *mut JSContext, callback: JSVal, timeout: i32) -> i32 {
         self.set_timeout_or_interval(callback, timeout, true)
     }
 
-    fn ClearInterval(&self, handle: i32) {
+    fn ClearInterval(self, handle: i32) {
         self.ClearTimeout(handle);
     }
 
-    fn Window(&self) -> Temporary<Window> {
-        Temporary::from_rooted(*self)
+    fn Window(self) -> Temporary<Window> {
+        Temporary::from_rooted(self)
     }
 
-    fn Self(&self) -> Temporary<Window> {
+    fn Self(self) -> Temporary<Window> {
         self.Window()
     }
 
     // http://www.whatwg.org/html/#dom-frames
-    fn Frames(&self) -> Temporary<Window> {
+    fn Frames(self) -> Temporary<Window> {
         self.Window()
     }
 
-    fn Parent(&self) -> Temporary<Window> {
+    fn Parent(self) -> Temporary<Window> {
         //TODO - Once we support iframes correctly this needs to return the parent frame
         self.Window()
     }
 
-    fn Performance(&self) -> Temporary<Performance> {
+    fn Performance(self) -> Temporary<Performance> {
         if self.performance.get().is_none() {
-            let performance = Performance::new(*self);
+            let performance = Performance::new(self);
             self.performance.assign(Some(performance));
         }
         Temporary::new(self.performance.get().get_ref().clone())
     }
 
-    fn GetOnclick(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("click")
     }
 
-    fn SetOnclick(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("click", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("load")
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
-    fn GetOnunload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnunload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("unload")
     }
 
-    fn SetOnunload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnunload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("unload", listener)
     }
 
-    fn GetOnerror(&self) -> Option<OnErrorEventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnerror(self) -> Option<OnErrorEventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("error")
     }
 
-    fn SetOnerror(&self, listener: Option<OnErrorEventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnerror(self, listener: Option<OnErrorEventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
-    fn Screen(&self) -> Temporary<Screen> {
+    fn Screen(self) -> Temporary<Screen> {
         if self.screen.get().is_none() {
-            let screen = Screen::new(*self);
+            let screen = Screen::new(self);
             self.screen.assign(Some(screen));
         }
         Temporary::new(self.screen.get().get_ref().clone())
     }
 
-    fn Debug(&self, message: DOMString) {
+    fn Debug(self, message: DOMString) {
         debug!("{:s}", message);
     }
 
-    fn Gc(&self) {
+    fn Gc(self) {
         unsafe {
             JS_GC(JS_GetRuntime(self.get_cx()));
         }
     }
 
-    fn Btoa(&self, btoa: DOMString) -> Fallible<DOMString> {
+    fn Btoa(self, btoa: DOMString) -> Fallible<DOMString> {
         base64_btoa(btoa)
     }
 
-    fn Atob(&self, atob: DOMString) -> Fallible<DOMString> {
+    fn Atob(self, atob: DOMString) -> Fallible<DOMString> {
         base64_atob(atob)
     }
 }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -130,7 +130,7 @@ impl Worker {
 }
 
 impl<'a> WorkerMethods for JSRef<'a, Worker> {
-    fn PostMessage(&self, cx: *mut JSContext, message: JSVal) {
+    fn PostMessage(self, cx: *mut JSContext, message: JSVal) {
         let mut data = ptr::mut_null();
         let mut nbytes = 0;
         unsafe {
@@ -143,13 +143,13 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
         sender.send(DOMMessage(data, nbytes));
     }
 
-    fn GetOnmessage(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnmessage(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("message")
     }
 
-    fn SetOnmessage(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnmessage(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("message", listener)
     }
 }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -79,19 +79,19 @@ impl WorkerGlobalScope {
 }
 
 impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
-    fn Self(&self) -> Temporary<WorkerGlobalScope> {
-        Temporary::from_rooted(*self)
+    fn Self(self) -> Temporary<WorkerGlobalScope> {
+        Temporary::from_rooted(self)
     }
 
-    fn Location(&self) -> Temporary<WorkerLocation> {
+    fn Location(self) -> Temporary<WorkerLocation> {
         if self.location.get().is_none() {
-            let location = WorkerLocation::new(*self, self.worker_url.deref().clone());
+            let location = WorkerLocation::new(self, self.worker_url.deref().clone());
             self.location.assign(Some(location));
         }
         Temporary::new(self.location.get().get_ref().clone())
     }
 
-    fn ImportScripts(&self, url_strings: Vec<DOMString>) -> ErrorResult {
+    fn ImportScripts(self, url_strings: Vec<DOMString>) -> ErrorResult {
         let mut urls = Vec::with_capacity(url_strings.len());
         for url in url_strings.move_iter() {
             let url = UrlParser::new().base_url(&*self.worker_url)
@@ -123,27 +123,27 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         Ok(())
     }
 
-    fn Navigator(&self) -> Temporary<WorkerNavigator> {
+    fn Navigator(self) -> Temporary<WorkerNavigator> {
         if self.navigator.get().is_none() {
-            let navigator = WorkerNavigator::new(*self);
+            let navigator = WorkerNavigator::new(self);
             self.navigator.assign(Some(navigator));
         }
         Temporary::new(self.navigator.get().get_ref().clone())
     }
 
-    fn Console(&self) -> Temporary<Console> {
+    fn Console(self) -> Temporary<Console> {
         if self.console.get().is_none() {
-            let console = Console::new(&global::Worker(*self));
+            let console = Console::new(&global::Worker(self));
             self.console.assign(Some(console));
         }
         Temporary::new(self.console.get().get_ref().clone())
     }
 
-    fn Btoa(&self, btoa: DOMString) -> Fallible<DOMString> {
+    fn Btoa(self, btoa: DOMString) -> Fallible<DOMString> {
         base64_btoa(btoa)
     }
 
-    fn Atob(&self, atob: DOMString) -> Fallible<DOMString> {
+    fn Atob(self, atob: DOMString) -> Fallible<DOMString> {
         base64_atob(atob)
     }
 }

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -38,15 +38,15 @@ impl WorkerLocation {
 }
 
 impl<'a> WorkerLocationMethods for JSRef<'a, WorkerLocation> {
-    fn Href(&self) -> DOMString {
+    fn Href(self) -> DOMString {
         UrlHelper::Href(self.url.deref())
     }
 
-    fn Search(&self) -> DOMString {
+    fn Search(self) -> DOMString {
         UrlHelper::Search(self.url.deref())
     }
 
-    fn Hash(&self) -> DOMString {
+    fn Hash(self) -> DOMString {
         UrlHelper::Hash(self.url.deref())
     }
 }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -32,23 +32,23 @@ impl WorkerNavigator {
 }
 
 impl<'a> WorkerNavigatorMethods for JSRef<'a, WorkerNavigator> {
-    fn Product(&self) -> DOMString {
+    fn Product(self) -> DOMString {
         NavigatorInfo::Product()
     }
 
-    fn TaintEnabled(&self) -> bool {
+    fn TaintEnabled(self) -> bool {
         NavigatorInfo::TaintEnabled()
     }
 
-    fn AppName(&self) -> DOMString {
+    fn AppName(self) -> DOMString {
         NavigatorInfo::AppName()
     }
 
-    fn AppCodeName(&self) -> DOMString {
+    fn AppCodeName(self) -> DOMString {
         NavigatorInfo::AppCodeName()
     }
 
-    fn Platform(&self) -> DOMString {
+    fn Platform(self) -> DOMString {
         NavigatorInfo::Platform()
     }
 }

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -41,73 +41,73 @@ impl Reflectable for XMLHttpRequestEventTarget {
 }
 
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
-    fn GetOnloadstart(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnloadstart(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("loadstart")
     }
 
-    fn SetOnloadstart(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnloadstart(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("loadstart", listener)
     }
 
-    fn GetOnprogress(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnprogress(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("progress")
     }
 
-    fn SetOnprogress(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnprogress(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("progress", listener)
     }
 
-    fn GetOnabort(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnabort(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("abort")
     }
 
-    fn SetOnabort(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnabort(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("abort", listener)
     }
 
-    fn GetOnerror(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnerror(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("error")
     }
 
-    fn SetOnerror(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnerror(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("error", listener)
     }
 
-    fn GetOnload(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnload(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("load")
     }
 
-    fn SetOnload(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("load", listener)
     }
 
-    fn GetOntimeout(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOntimeout(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("timeout")
     }
 
-    fn SetOntimeout(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOntimeout(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("timeout", listener)
     }
 
-    fn GetOnloadend(&self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn GetOnloadend(self) -> Option<EventHandlerNonNull> {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.get_event_handler_common("loadend")
     }
 
-    fn SetOnloadend(&self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
+    fn SetOnloadend(self, listener: Option<EventHandlerNonNull>) {
+        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
         eventtarget.set_event_handler_common("loadend", listener)
     }
 }


### PR DESCRIPTION
Change all of the <Class>Methods traits to take `self` instead of
`&self`.

Convert various helper traits from &JSRef to JSRef. I converted them all with a few exceptions:
- Methods that were used by trait objects, since trait objects don't
  work with `self` methods.
- Methods that take an &'b JSRef<'a, T> and return an &'b. In reality,
  many (all?) could return an &'a instead, but this isn't allowed by the
  Deref trait.
- Methods that internally rely on the same issue with Deref.
- I left out the traits involved in layout entirely, even though not all
  of their methods suffer from one of the above problems.

There will probably be solutions to all of these problems in the future.
