### PR TITLE
layout: Float table wrappers directly instead of generating a block

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -555,6 +555,21 @@ impl BlockFlow {
         }
     }
 
+    pub fn float_from_node_and_fragment(node: &ThreadSafeLayoutNode,
+                                        fragment: Fragment,
+                                        float_kind: FloatKind)
+                                        -> BlockFlow {
+        let base = BaseFlow::new((*node).clone());
+        BlockFlow {
+            fragment: fragment,
+            is_root: false,
+            static_b_offset: Au::new(0),
+            previous_float_inline_size: None,
+            float: Some(box FloatedBlockInfo::new(float_kind, base.writing_mode)),
+            base: base,
+        }
+    }
+
     /// Return the type of this block.
     ///
     /// This determines the algorithm used to calculate inline-size, block-size, and the
@@ -582,7 +597,9 @@ impl BlockFlow {
     }
 
     /// Compute the used value of inline-size for this Block.
-    fn compute_used_inline_size(&mut self, ctx: &LayoutContext, containing_block_inline_size: Au) {
+    pub fn compute_used_inline_size(&mut self,
+                                    ctx: &LayoutContext,
+                                    containing_block_inline_size: Au) {
         let block_type = self.block_type();
         match block_type {
             AbsoluteReplacedType => {
@@ -875,7 +892,6 @@ impl BlockFlow {
                 continue
             }
 
-
             // If we have clearance, assume there are no floats in.
             //
             // FIXME(#2008, pcwalton): This could be wrong if we have `clear: left` or `clear:
@@ -1028,7 +1044,7 @@ impl BlockFlow {
     /// This does not give any information about any float descendants because they do not affect
     /// elements outside of the subtree rooted at this float.
     ///
-    /// This function is called on a kid flow by a parent. Therefore, `assign_block-size_float` was
+    /// This function is called on a kid flow by a parent. Therefore, `assign_block_size_float` was
     /// already called on this kid flow by the traversal function. So, the values used are
     /// well-defined.
     pub fn place_float(&mut self) {
@@ -2026,9 +2042,9 @@ pub trait ISizeAndMarginsComputer {
     ///
     /// CSS Section 10.4: Minimum and Maximum inline-sizes
     fn compute_used_inline_size(&self,
-                          block: &mut BlockFlow,
-                          ctx: &LayoutContext,
-                          parent_flow_inline_size: Au) {
+                                block: &mut BlockFlow,
+                                ctx: &LayoutContext,
+                                parent_flow_inline_size: Au) {
         let mut input = self.compute_inline_size_constraint_inputs(block, parent_flow_inline_size, ctx);
 
         let containing_block_inline_size = self.containing_block_inline_size(block, parent_flow_inline_size, ctx);
@@ -2128,12 +2144,12 @@ pub trait ISizeAndMarginsComputer {
 ///
 /// They mainly differ in the way inline-size and block-sizes and margins are calculated
 /// for them.
-struct AbsoluteNonReplaced;
-struct AbsoluteReplaced;
-struct BlockNonReplaced;
-struct BlockReplaced;
-struct FloatNonReplaced;
-struct FloatReplaced;
+pub struct AbsoluteNonReplaced;
+pub struct AbsoluteReplaced;
+pub struct BlockNonReplaced;
+pub struct BlockReplaced;
+pub struct FloatNonReplaced;
+pub struct FloatReplaced;
 
 impl ISizeAndMarginsComputer for AbsoluteNonReplaced {
     /// Solve the horizontal constraint equation for absolute non-replaced elements.

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -12,7 +12,7 @@ use style::computed_values::float;
 use sync::Arc;
 
 /// The kind of float: left or right.
-#[deriving(Clone, Encodable)]
+#[deriving(Clone, Encodable, Show)]
 pub enum FloatKind {
     FloatLeft,
     FloatRight

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -228,12 +228,6 @@ pub trait Flow: fmt::Show + ToString + Sync {
         float::none
     }
 
-    /// Returns true if this float is a block formatting context and false otherwise. The default
-    /// implementation returns false.
-    fn is_block_formatting_context(&self, _only_impactable_by_floats: bool) -> bool {
-        false
-    }
-
     fn compute_collapsible_block_start_margin(&mut self,
                                       _layout_context: &mut LayoutContext,
                                       _margin_collapse_info: &mut MarginCollapseInfo) {
@@ -837,7 +831,7 @@ impl BaseFlow {
 }
 
 impl<'a> ImmutableFlowUtils for &'a Flow + 'a {
-    /// Returns true if this flow is a block or a float flow.
+    /// Returns true if this flow is a block flow.
     fn is_block_like(self) -> bool {
         match self.class() {
             BlockFlowClass => true,

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -295,6 +295,10 @@ impl Flow for TableFlow {
             _ => {}
         }
 
+        // As tables are always wrapped inside a table wrapper, they are never impacted by floats. 
+        self.block_flow.base.flags.set_impacted_by_left_floats(false);
+        self.block_flow.base.flags.set_impacted_by_right_floats(false);
+
         self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge, content_inline_size, Some(self.col_inline_sizes.clone()));
     }
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -2,25 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! CSS table formatting contexts.
+//! CSS tables.
 
 #![deny(unsafe_block)]
 
-use block::{BlockFlow, MarginsMayNotCollapse, ISizeAndMarginsComputer};
-use block::{ISizeConstraintInput, ISizeConstraintSolution};
+use block::{BlockFlow, BlockNonReplaced, FloatNonReplaced, ISizeAndMarginsComputer};
+use block::{ISizeConstraintInput, MarginsMayNotCollapse};
 use construct::FlowConstructor;
 use context::LayoutContext;
 use floats::FloatKind;
 use flow::{TableWrapperFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use fragment::Fragment;
-use layout_debug;
 use model::{Specified, Auto, specified};
 use wrapper::ThreadSafeLayoutNode;
 
 use servo_util::geometry::Au;
 use std::cmp::max;
 use std::fmt;
-use style::computed_values::table_layout;
+use style::computed_values::{float, table_layout};
 
 #[deriving(Encodable)]
 pub enum TableLayout {
@@ -75,11 +74,11 @@ impl TableWrapperFlow {
         }
     }
 
-    pub fn float_from_node(constructor: &mut FlowConstructor,
-                           node: &ThreadSafeLayoutNode,
-                           float_kind: FloatKind)
-                           -> TableWrapperFlow {
-        let mut block_flow = BlockFlow::float_from_node(constructor, node, float_kind);
+    pub fn float_from_node_and_fragment(node: &ThreadSafeLayoutNode,
+                                        fragment: Fragment,
+                                        float_kind: FloatKind)
+                                        -> TableWrapperFlow {
+        let mut block_flow = BlockFlow::float_from_node_and_fragment(node, fragment, float_kind);
         let table_layout = if block_flow.fragment().style().get_table().table_layout ==
                               table_layout::fixed {
             FixedLayout
@@ -93,23 +92,142 @@ impl TableWrapperFlow {
         }
     }
 
-    pub fn is_float(&self) -> bool {
-        self.block_flow.float.is_some()
-    }
-
-    /// Assign block-size for table-wrapper flow.
-    /// `Assign block-size` of table-wrapper flow follows a similar process to that of block flow.
-    ///
-    /// inline(always) because this is only ever called by in-order or non-in-order top-level
-    /// methods
-    #[inline(always)]
-    fn assign_block_size_table_wrapper_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
-        self.block_flow.assign_block_size_block_base(layout_context, MarginsMayNotCollapse);
-    }
-
     pub fn build_display_list_table_wrapper(&mut self, layout_context: &LayoutContext) {
         debug!("build_display_list_table_wrapper: same process as block flow");
         self.block_flow.build_display_list_block(layout_context);
+    }
+
+    fn calculate_table_column_sizes(&mut self, mut input: ISizeConstraintInput)
+                                    -> ISizeConstraintInput {
+        let style = self.block_flow.fragment.style();
+
+        // Get inline-start and inline-end paddings, borders for table.
+        // We get these values from the fragment's style since table_wrapper doesn't have its own
+        // border or padding. input.available_inline_size is same as containing_block_inline_size
+        // in table_wrapper.
+        let padding = style.logical_padding();
+        let border = style.logical_border_width();
+        let padding_and_borders =
+            specified(padding.inline_start, input.available_inline_size) +
+            specified(padding.inline_end, input.available_inline_size) +
+            border.inline_start +
+            border.inline_end;
+
+        let computed_inline_size = match self.table_layout {
+            FixedLayout => {
+                let fixed_cells_inline_size = self.col_inline_sizes
+                                                  .iter()
+                                                  .fold(Au(0), |sum, inline_size| {
+                        sum.add(inline_size)
+                    });
+
+                let mut computed_inline_size = input.computed_inline_size.specified_or_zero();
+
+                // Compare border-edge inline-sizes. Because fixed_cells_inline_size indicates
+                // content-inline-size, padding and border values are added to
+                // fixed_cells_inline_size.
+                computed_inline_size = max(
+                    fixed_cells_inline_size + padding_and_borders, computed_inline_size);
+                computed_inline_size
+            },
+            AutoLayout => {
+                // Automatic table layout is calculated according to CSS 2.1 § 17.5.2.2.
+                let mut cap_min = Au(0);
+                let mut cols_min = Au(0);
+                let mut cols_max = Au(0);
+                let mut col_min_inline_sizes = &vec!();
+                let mut col_pref_inline_sizes = &vec!();
+                for kid in self.block_flow.base.child_iter() {
+                    if kid.is_table_caption() {
+                        cap_min = kid.as_block().base.intrinsic_inline_sizes.minimum_inline_size;
+                    } else {
+                        assert!(kid.is_table());
+                        cols_min = kid.as_block().base.intrinsic_inline_sizes.minimum_inline_size;
+                        cols_max = kid.as_block()
+                                      .base
+                                      .intrinsic_inline_sizes
+                                      .preferred_inline_size;
+                        col_min_inline_sizes = kid.col_min_inline_sizes();
+                        col_pref_inline_sizes = kid.col_pref_inline_sizes();
+                    }
+                }
+                // 'extra_inline-size': difference between the calculated table inline-size and
+                // minimum inline-size required by all columns. It will be distributed over the
+                // columns.
+                let (inline_size, extra_inline_size) = match input.computed_inline_size {
+                    Auto => {
+                        if input.available_inline_size > max(cols_max, cap_min) {
+                            if cols_max > cap_min {
+                                self.col_inline_sizes = col_pref_inline_sizes.clone();
+                                (cols_max, Au(0))
+                            } else {
+                                (cap_min, cap_min - cols_min)
+                            }
+                        } else {
+                            let max = if cols_min >= input.available_inline_size &&
+                                    cols_min >= cap_min {
+                                self.col_inline_sizes = col_min_inline_sizes.clone();
+                                cols_min
+                            } else {
+                                max(input.available_inline_size, cap_min)
+                            };
+                            (max, max - cols_min)
+                        }
+                    },
+                    Specified(inline_size) => {
+                        let max = if cols_min >= inline_size && cols_min >= cap_min {
+                            self.col_inline_sizes = col_min_inline_sizes.clone();
+                            cols_min
+                        } else {
+                            max(inline_size, cap_min)
+                        };
+                        (max, max - cols_min)
+                    }
+                };
+                // The extra inline-size is distributed over the columns
+                if extra_inline_size > Au(0) {
+                    let cell_len = self.col_inline_sizes.len() as f64;
+                    self.col_inline_sizes = col_min_inline_sizes.iter()
+                                                                         .map(|inline_size| {
+                        inline_size + extra_inline_size.scale_by(1.0 / cell_len)
+                    }).collect();
+                }
+                inline_size + padding_and_borders
+            }
+        };
+        input.computed_inline_size = Specified(computed_inline_size);
+        input
+    }
+
+    fn compute_used_inline_size(&mut self,
+                                layout_context: &LayoutContext,
+                                parent_flow_inline_size: Au) {
+        // Delegate to the appropriate inline size computer to find the constraint inputs.
+        let mut input = if self.is_float() {
+            FloatNonReplaced.compute_inline_size_constraint_inputs(&mut self.block_flow,
+                                                                   parent_flow_inline_size,
+                                                                   layout_context)
+        } else {
+            BlockNonReplaced.compute_inline_size_constraint_inputs(&mut self.block_flow,
+                                                                   parent_flow_inline_size,
+                                                                   layout_context)
+        };
+
+        // Compute the inline sizes of the columns.
+        input = self.calculate_table_column_sizes(input);
+
+        // Delegate to the appropriate inline size computer to write the constraint solutions in.
+        if self.is_float() {
+            let solution = FloatNonReplaced.solve_inline_size_constraints(&mut self.block_flow,
+                                                                          &input);
+            FloatNonReplaced.set_inline_size_constraint_solutions(&mut self.block_flow, solution);
+            FloatNonReplaced.set_flow_x_coord_if_necessary(&mut self.block_flow, solution);
+        } else {
+            let solution = BlockNonReplaced.solve_inline_size_constraints(&mut self.block_flow,
+                                                                          &input);
+            BlockNonReplaced.set_inline_size_constraint_solutions(&mut self.block_flow, solution);
+            BlockNonReplaced.set_flow_x_coord_if_necessary(&mut self.block_flow, solution);
+        }
     }
 }
 
@@ -118,11 +236,11 @@ impl Flow for TableWrapperFlow {
         TableWrapperFlowClass
     }
 
-    fn as_table_wrapper<'a>(&'a mut self) -> &'a mut TableWrapperFlow {
-        self
+    fn is_float(&self) -> bool {
+        self.block_flow.is_float()
     }
 
-    fn as_immutable_table_wrapper<'a>(&'a self) -> &'a TableWrapperFlow {
+    fn as_table_wrapper<'a>(&'a mut self) -> &'a mut TableWrapperFlow {
         self
     }
 
@@ -130,16 +248,11 @@ impl Flow for TableWrapperFlow {
         &mut self.block_flow
     }
 
-    /* Recursively (bottom-up) determine the context's preferred and
-    minimum inline_sizes.  When called on this context, all child contexts
-    have had their min/pref inline_sizes set. This function must decide
-    min/pref inline_sizes based on child context inline_sizes and dimensions of
-    any fragments it is responsible for flowing.  */
+    fn float_kind(&self) -> float::T {
+        self.block_flow.float_kind()
+    }
 
     fn bubble_inline_sizes(&mut self, ctx: &LayoutContext) {
-        let _scope = layout_debug_scope!("table_wrapper::bubble_inline_sizes {:s}",
-                                            self.block_flow.base.debug_id());
-
         // get column inline-sizes info from table flow
         for kid in self.block_flow.base.child_iter() {
             assert!(kid.is_table_caption() || kid.is_table());
@@ -152,14 +265,7 @@ impl Flow for TableWrapperFlow {
         self.block_flow.bubble_inline_sizes(ctx);
     }
 
-    /// Recursively (top-down) determines the actual inline-size of child contexts and fragments. When
-    /// called on this context, the context has had its inline-size set by the parent context.
-    ///
-    /// Dual fragments consume some inline-size first, and the remainder is assigned to all child (block)
-    /// contexts.
-    fn assign_inline_sizes(&mut self, ctx: &LayoutContext) {
-        let _scope = layout_debug_scope!("table_wrapper::assign_inline_sizes {:s}",
-                                            self.block_flow.base.debug_id());
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow",
                if self.is_float() {
                    "floated table_wrapper"
@@ -167,41 +273,57 @@ impl Flow for TableWrapperFlow {
                    "table_wrapper"
                });
 
-        // The position was set to the containing block by the flow's parent.
-        let containing_block_inline_size = self.block_flow.base.position.size.inline;
+        // Table wrappers are essentially block formatting contexts and are therefore never
+        // impacted by floats.
+        self.block_flow.base.flags.set_impacted_by_left_floats(false);
+        self.block_flow.base.flags.set_impacted_by_right_floats(false);
 
-        let inline_size_computer = TableWrapper;
-        inline_size_computer.compute_used_inline_size_table_wrapper(self, ctx, containing_block_inline_size);
+        // Our inline-size was set to the inline-size of the containing block by the flow's parent.
+        // Now compute the real value.
+        let containing_block_inline_size = self.block_flow.base.position.size.inline;
+        if self.is_float() {
+            self.block_flow.float.get_mut_ref().containing_inline_size =
+                containing_block_inline_size;
+        }
+
+        self.compute_used_inline_size(layout_context, containing_block_inline_size);
 
         let inline_start_content_edge = self.block_flow.fragment.border_box.start.i;
         let content_inline_size = self.block_flow.fragment.border_box.size.inline;
-
-        match self.table_layout {
-            FixedLayout | _ if self.is_float() =>
-                self.block_flow.base.position.size.inline = content_inline_size,
-            _ => {}
-        }
 
         // In case of fixed layout, column inline-sizes are calculated in table flow.
         let assigned_col_inline_sizes = match self.table_layout {
             FixedLayout => None,
             AutoLayout => Some(self.col_inline_sizes.clone())
         };
-        self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge, content_inline_size, assigned_col_inline_sizes);
+
+        self.block_flow.propagate_assigned_inline_size_to_children(inline_start_content_edge,
+                                                                   content_inline_size,
+                                                                   assigned_col_inline_sizes);
     }
 
     fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
-        if self.is_float() {
-            debug!("assign_block_size_float: assigning block_size for floated table_wrapper");
-            self.block_flow.assign_block_size_float(ctx);
-        } else {
-            debug!("assign_block_size: assigning block_size for table_wrapper");
-            self.assign_block_size_table_wrapper_base(ctx);
-        }
+        debug!("assign_block_size: assigning block_size for table_wrapper");
+        self.block_flow.assign_block_size_block_base(ctx, MarginsMayNotCollapse);
     }
 
     fn compute_absolute_position(&mut self) {
         self.block_flow.compute_absolute_position()
+    }
+
+    fn assign_block_size_for_inorder_child_if_necessary<'a>(&mut self,
+                                                            layout_context: &'a LayoutContext<'a>)
+                                                            -> bool {
+        if self.block_flow.is_float() {
+            self.block_flow.place_float();
+            return true
+        }
+
+        let impacted = self.block_flow.base.flags.impacted_by_floats();
+        if impacted {
+            self.assign_block_size(layout_context);
+        }
+        impacted
     }
 }
 
@@ -215,125 +337,3 @@ impl fmt::Show for TableWrapperFlow {
     }
 }
 
-struct TableWrapper;
-
-impl TableWrapper {
-    fn compute_used_inline_size_table_wrapper(&self,
-                                        table_wrapper: &mut TableWrapperFlow,
-                                        ctx: &LayoutContext,
-                                        parent_flow_inline_size: Au) {
-        let input = self.compute_inline_size_constraint_inputs_table_wrapper(table_wrapper,
-                                                                       parent_flow_inline_size,
-                                                                       ctx);
-
-        let solution = self.solve_inline_size_constraints(&mut table_wrapper.block_flow, &input);
-
-        self.set_inline_size_constraint_solutions(&mut table_wrapper.block_flow, solution);
-        self.set_flow_x_coord_if_necessary(&mut table_wrapper.block_flow, solution);
-    }
-
-    fn compute_inline_size_constraint_inputs_table_wrapper(&self,
-                                                     table_wrapper: &mut TableWrapperFlow,
-                                                     parent_flow_inline_size: Au,
-                                                     ctx: &LayoutContext)
-                                                     -> ISizeConstraintInput {
-        let mut input = self.compute_inline_size_constraint_inputs(&mut table_wrapper.block_flow,
-                                                             parent_flow_inline_size,
-                                                             ctx);
-        let style = table_wrapper.block_flow.fragment.style();
-
-        // Get inline-start and inline-end paddings, borders for table.
-        // We get these values from the fragment's style since table_wrapper doesn't have it's own border or padding.
-        // input.available_inline-size is same as containing_block_inline-size in table_wrapper.
-        let padding = style.logical_padding();
-        let border = style.logical_border_width();
-        let padding_and_borders =
-            specified(padding.inline_start, input.available_inline_size) +
-            specified(padding.inline_end, input.available_inline_size) +
-            border.inline_start +
-            border.inline_end;
-
-        let computed_inline_size = match table_wrapper.table_layout {
-            FixedLayout => {
-                let fixed_cells_inline_size = table_wrapper.col_inline_sizes.iter().fold(Au(0),
-                                                                             |sum, inline_size| sum.add(inline_size));
-
-                let mut computed_inline_size = input.computed_inline_size.specified_or_zero();
-
-                // Compare border-edge inline-sizes. Because fixed_cells_inline-size indicates content-inline-size,
-                // padding and border values are added to fixed_cells_inline-size.
-                computed_inline_size = max(
-                    fixed_cells_inline_size + padding_and_borders, computed_inline_size);
-                computed_inline_size
-            },
-            AutoLayout => {
-                // Automatic table layout is calculated according to CSS 2.1 § 17.5.2.2.
-                let mut cap_min = Au(0);
-                let mut cols_min = Au(0);
-                let mut cols_max = Au(0);
-                let mut col_min_inline_sizes = &vec!();
-                let mut col_pref_inline_sizes = &vec!();
-                for kid in table_wrapper.block_flow.base.child_iter() {
-                    if kid.is_table_caption() {
-                        cap_min = kid.as_block().base.intrinsic_inline_sizes.minimum_inline_size;
-                    } else {
-                        assert!(kid.is_table());
-                        cols_min = kid.as_block().base.intrinsic_inline_sizes.minimum_inline_size;
-                        cols_max = kid.as_block().base.intrinsic_inline_sizes.preferred_inline_size;
-                        col_min_inline_sizes = kid.col_min_inline_sizes();
-                        col_pref_inline_sizes = kid.col_pref_inline_sizes();
-                    }
-                }
-                // 'extra_inline-size': difference between the calculated table inline-size and minimum inline-size
-                // required by all columns. It will be distributed over the columns.
-                let (inline_size, extra_inline_size) = match input.computed_inline_size {
-                    Auto => {
-                        if input.available_inline_size > max(cols_max, cap_min) {
-                            if cols_max > cap_min {
-                                table_wrapper.col_inline_sizes = col_pref_inline_sizes.clone();
-                                (cols_max, Au(0))
-                            } else {
-                                (cap_min, cap_min - cols_min)
-                            }
-                        } else {
-                            let max = if cols_min >= input.available_inline_size && cols_min >= cap_min {
-                                table_wrapper.col_inline_sizes = col_min_inline_sizes.clone();
-                                cols_min
-                            } else {
-                                max(input.available_inline_size, cap_min)
-                            };
-                            (max, max - cols_min)
-                        }
-                    },
-                    Specified(inline_size) => {
-                        let max = if cols_min >= inline_size && cols_min >= cap_min {
-                            table_wrapper.col_inline_sizes = col_min_inline_sizes.clone();
-                            cols_min
-                        } else {
-                            max(inline_size, cap_min)
-                        };
-                        (max, max - cols_min)
-                    }
-                };
-                // The extra inline-size is distributed over the columns
-                if extra_inline_size > Au(0) {
-                    let cell_len = table_wrapper.col_inline_sizes.len() as f64;
-                    table_wrapper.col_inline_sizes = col_min_inline_sizes.iter().map(|inline_size| {
-                        inline_size + extra_inline_size.scale_by(1.0 / cell_len)
-                    }).collect();
-                }
-                inline_size + padding_and_borders
-            }
-        };
-        input.computed_inline_size = Specified(computed_inline_size);
-        input
-    }
-}
-
-impl ISizeAndMarginsComputer for TableWrapper {
-    /// Solve the inline-size and margins constraints for this block flow.
-    fn solve_inline_size_constraints(&self, block: &mut BlockFlow, input: &ISizeConstraintInput)
-                               -> ISizeConstraintSolution {
-        self.solve_block_inline_size_constraints(block, input)
-    }
-}

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -144,3 +144,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == whitespace_nowrap_a.html whitespace_nowrap_ref.html
 == block_formatting_context_relative_a.html block_formatting_context_ref.html
 == block_formatting_context_translation_a.html block_formatting_context_translation_ref.html
+== floated_table_with_margin_a.html floated_table_with_margin_ref.html

--- a/tests/ref/floated_table_with_margin_a.html
+++ b/tests/ref/floated_table_with_margin_a.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>Rust - Wikipedia, the free encyclopedia</title>
+    <style>
+        body {
+            margin: 0;
+        }
+    </style>
+</head>
+
+<body>
+                <table style="float: right; margin: 0px 0px 0em 1em; width: 100px; background: red;">
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                </table>
+</body>
+</html>

--- a/tests/ref/floated_table_with_margin_ref.html
+++ b/tests/ref/floated_table_with_margin_ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>Rust - Wikipedia, the free encyclopedia</title>
+    <style>
+        body {
+            margin: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div style="float: right"><table style="margin: 0px 0px 0em 1em; width: 100px; background: red;">
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                    <tr><td>foo</td></tr>
+                </table></div>
+</body>
+</html>


### PR DESCRIPTION
wrapper around them.

Fixes Wikipedia tables leaking out.

Along the way, I refactored tables' width calculation significantly.
This was necessary in order to properly handle floated tables, as some
of the logic had to be ported over from block flows.

r? @glennw
