### PR TITLE
*Do not merge yet* Symlink /ports/cef/target to /target, to reduce compile time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /target
 /rust
 /cargo
-/ports/cef/target
 /ports/android/bin
 /ports/android/libs
 /ports/android/local.properties

--- a/ports/cef/target
+++ b/ports/cef/target
@@ -1,0 +1,1 @@
+/home/simon/tmp/cargo-targets/servo


### PR DESCRIPTION
**Do not merge yet.** @alexcrichton advised against doing this, so let’s see if something might go horribly wrong that I haven’t anticipated, before merging.

Currently, `mach build-cef` uses a completely separate target directory than `mach build`, so everything gets built twice.

Now that we’ve upgraded Rust to a version that fixes https://github.com/rust-lang/rust/issues/16496, we can make this symlink to share target directories.

"git" dependencies builds are shared as expected, but "path" dependencies still get rebuilt for some reason that might be related to https://github.com/rust-lang/cargo/issues/497

@alexcrichton says this is unsupported behavior and we shouldn’t do it, but it still is strictly better than what we have now as far as I can tell.
