### PR TITLE
layout: Translate floats when clearing non-floated blocks.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -906,7 +906,7 @@ impl BlockFlow {
                 clear::right => floats.clearance(ClearRight),
                 clear::both => floats.clearance(ClearBoth),
             };
-            cur_b = cur_b + clearance;
+            translate_including_floats(&mut cur_b, clearance, &mut floats);
 
             // At this point, `cur_b` is at the border edge of the child.
             flow::mut_base(kid).position.start.b = cur_b;

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -138,3 +138,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == percentage_height_float_a.html percentage_height_float_ref.html
 == img_block_maxwidth_a.html img_block_maxwidth_ref.html
 == img_block_maxwidth_b.html img_block_maxwidth_ref.html
+== float_clearance_a.html float_clearance_ref.html

--- a/tests/ref/float_clearance_a.html
+++ b/tests/ref/float_clearance_a.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <div style="width: 256px;">
+        <div style="width: 237px; float: left;">hello</div>
+        <div style="clear: both;">darkness</div>
+        <div style="float: left;">my old friend</div>
+    </div>
+</body>
+</html>
+

--- a/tests/ref/float_clearance_ref.html
+++ b/tests/ref/float_clearance_ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <div style="width: 256px;">
+        <div style="width: 237px; float: left;">hello</div>
+        <div style="clear: both;">darkness</div>
+        <div>my old friend</div>
+    </div>
+</body>
+</html>
+


### PR DESCRIPTION
Improves CNN layout considerably.

Closes #3439.
