### PR TITLE
Handle null strings in Namespace::new.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -57,7 +57,7 @@ use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage};
 use servo_util::atom::Atom;
 use servo_util::namespace;
 use servo_util::namespace::{Namespace, Null};
-use servo_util::str::{DOMString, null_str_as_empty_ref, split_html_space_chars};
+use servo_util::str::{DOMString, split_html_space_chars};
 
 use std::collections::hashmap::HashMap;
 use std::ascii::StrAsciiExt;
@@ -464,7 +464,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     fn CreateElementNS(self,
                        namespace: Option<DOMString>,
                        qualified_name: DOMString) -> Fallible<Temporary<Element>> {
-        let ns = Namespace::from_str(null_str_as_empty_ref(&namespace));
+        let ns = Namespace::from_str(namespace);
         match xml_name_type(qualified_name.as_slice()) {
             InvalidXMLName => {
                 debug!("Not a valid element name");

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -37,7 +37,7 @@ use style;
 use servo_util::atom::Atom;
 use servo_util::namespace;
 use servo_util::namespace::{Namespace, Null};
-use servo_util::str::{DOMString, null_str_as_empty_ref};
+use servo_util::str::DOMString;
 
 use std::ascii::StrAsciiExt;
 use std::cell::{Cell, RefCell};
@@ -599,7 +599,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     fn GetAttributeNS(self,
                       namespace: Option<DOMString>,
                       local_name: DOMString) -> Option<DOMString> {
-        let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
+        let namespace = Namespace::from_str(namespace);
         self.get_attribute(namespace, local_name.as_slice()).root()
                      .map(|attr| attr.deref().Value())
     }
@@ -646,7 +646,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         }
 
         // Step 1.
-        let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace_url));
+        let namespace = Namespace::from_str(namespace_url);
 
         let name_type = xml_name_type(name.as_slice());
         match name_type {
@@ -718,7 +718,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     fn RemoveAttributeNS(self,
                          namespace: Option<DOMString>,
                          localname: DOMString) {
-        let namespace = Namespace::from_str(null_str_as_empty_ref(&namespace));
+        let namespace = Namespace::from_str(namespace);
         self.remove_attribute(namespace, localname.as_slice())
     }
 

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -12,7 +12,6 @@ use dom::element::{Element, AttributeHandlers, ElementHelpers};
 use dom::node::{Node, NodeHelpers};
 use dom::window::Window;
 use servo_util::atom::Atom;
-use servo_util::namespace;
 use servo_util::namespace::Namespace;
 use servo_util::str::{DOMString, split_html_space_chars};
 
@@ -109,13 +108,8 @@ impl HTMLCollection {
     pub fn by_tag_name_ns(window: JSRef<Window>, root: JSRef<Node>, tag: DOMString,
                           maybe_ns: Option<DOMString>) -> Temporary<HTMLCollection> {
         let namespace_filter = match maybe_ns {
-            Some(namespace) => {
-                match namespace.as_slice() {
-                    "*" => None,
-                    ns => Some(Namespace::from_str(ns)),
-                }
-            },
-            None => Some(namespace::Null),
+            Some(ref namespace) if namespace.as_slice() == "*" => None,
+            ns => Some(Namespace::from_str(ns)),
         };
 
         if tag.as_slice() == "*" {

--- a/components/style/namespaces.rs
+++ b/components/style/namespaces.rs
@@ -40,7 +40,7 @@ pub fn parse_namespace_rule(rule: AtRule, namespaces: &mut NamespaceMap) {
             },
             URL(value) | String(value) => {
                 if ns.is_some() { syntax_error!() }
-                ns = Some(Namespace::from_str(value.as_slice()));
+                ns = Some(Namespace::from_str(Some(value)));
                 break
             },
             _ => syntax_error!(),

--- a/components/util/namespace.rs
+++ b/components/util/namespace.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use str::DOMString;
+
 #[deriving(Eq, PartialEq, Clone, Encodable, Hash, Show)]
 pub enum Namespace {
     Null,
@@ -16,16 +18,17 @@ pub enum Namespace {
 
 impl Namespace {
     /// Empty string for "no namespace"
-    pub fn from_str(url: &str) -> Namespace {
+    pub fn from_str(url: Option<DOMString>) -> Namespace {
         match url {
-            "http://www.w3.org/1999/xhtml" => HTML,
-            "http://www.w3.org/XML/1998/namespace" => XML,
-            "http://www.w3.org/2000/xmlns/" => XMLNS,
-            "http://www.w3.org/1999/xlink" => XLink,
-            "http://www.w3.org/2000/svg" => SVG,
-            "http://www.w3.org/1998/Math/MathML" => MathML,
-            "" => Null,
-            ns => Other(ns.to_string())
+            None => Null,
+            Some(ref ns) if ns.as_slice() == "" => Null,
+            Some(ref ns) if ns.as_slice() == "http://www.w3.org/1999/xhtml" => HTML,
+            Some(ref ns) if ns.as_slice() == "http://www.w3.org/XML/1998/namespace" => XML,
+            Some(ref ns) if ns.as_slice() == "http://www.w3.org/2000/xmlns/" => XMLNS,
+            Some(ref ns) if ns.as_slice() == "http://www.w3.org/1999/xlink" => XLink,
+            Some(ref ns) if ns.as_slice() == "http://www.w3.org/2000/svg" => SVG,
+            Some(ref ns) if ns.as_slice() == "http://www.w3.org/1998/Math/MathML" => MathML,
+            Some(ns) => Other(ns)
         }
     }
     pub fn to_str<'a>(&'a self) -> &'a str {


### PR DESCRIPTION
This also avoids a string copy in the rare case of an unrecognized namespace.
