### PR TITLE
layout: Unify the block-size computation for blocks and floats.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -685,9 +685,7 @@ pub struct BaseFlow {
     /// The children of this flow.
     pub children: FlowList,
 
-    /* layout computations */
-    // TODO: min/pref and position are used during disjoint phases of
-    // layout; maybe combine into a single enum to save space.
+    /// Intrinsic inline sizes for this flow.
     pub intrinsic_inline_sizes: IntrinsicISizes,
 
     /// The upper left corner of the box representing this flow, relative to the box representing

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -282,7 +282,7 @@ impl Flow for TableWrapperFlow {
         // Now compute the real value.
         let containing_block_inline_size = self.block_flow.base.position.size.inline;
         if self.is_float() {
-            self.block_flow.float.get_mut_ref().containing_inline_size =
+            self.block_flow.float.as_mut().unwrap().containing_inline_size =
                 containing_block_inline_size;
         }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -145,3 +145,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == block_formatting_context_relative_a.html block_formatting_context_ref.html
 == block_formatting_context_translation_a.html block_formatting_context_translation_ref.html
 == floated_table_with_margin_a.html floated_table_with_margin_ref.html
+== margins_inside_floats_a.html margins_inside_floats_ref.html

--- a/tests/ref/margins_inside_floats_a.html
+++ b/tests/ref/margins_inside_floats_a.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="float: left;">
+    <div style="margin-bottom: 64px;">Must be this tall</div>
+    <div style="margin-top: 64px;">to write multi-threaded code.</div>
+</div>
+</body>
+</html>
+

--- a/tests/ref/margins_inside_floats_ref.html
+++ b/tests/ref/margins_inside_floats_ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>
+    <div style="margin-bottom: 64px;">Must be this tall</div>
+    <div style="margin-top: 64px;">to write multi-threaded code.</div>
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
The float code was old and did not support most of CSS 2.1. So unifying
the two paths both simplifies code and improves functionality.

Improves the Reddit sidebar.

r? @glennw
