### PR TITLE
Add the MPL back to components/plugs/lints.rs

### DIFF
--- a/components/plugins/lints.rs
+++ b/components/plugins/lints.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use syntax::{ast, codemap, visit};
 use syntax::attr::AttrMetaMethods;
 use rustc::lint::{Context, LintPass, LintArray};


### PR DESCRIPTION
This license was accidentally removed in 5b866e9e.
