### PR TITLE
layout: Block formatting contexts should contain all their floats.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -978,13 +978,15 @@ impl BlockFlow {
         // root element as having `overflow: scroll` and use the layers-based scrolling
         // infrastructure to make it scrollable.
         let mut block_size = cur_b - block_start_offset;
-        if self.is_root() {
+        let is_root = self.is_root();
+        if is_root {
             let screen_size = LogicalSize::from_physical(
                 self.fragment.style.writing_mode, layout_context.shared.screen_size);
             block_size = Au::max(screen_size.block, block_size)
         }
 
-        if self.is_float() || self.is_absolutely_positioned() {
+        if is_root || self.formatting_context_type() != NonformattingContext ||
+                self.is_absolutely_positioned() {
             // The content block-size includes all the floats per CSS 2.1 § 10.6.7. The easiest way
             // to handle this is to just treat this as clearance.
             block_size = block_size + floats.clearance(ClearBoth);

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -147,3 +147,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == floated_table_with_margin_a.html floated_table_with_margin_ref.html
 == margins_inside_floats_a.html margins_inside_floats_ref.html
 == block_formatting_context_complex_a.html block_formatting_context_complex_ref.html
+== block_formatting_context_containing_floats_a.html block_formatting_context_containing_floats_ref.html

--- a/tests/ref/block_formatting_context_containing_floats_a.html
+++ b/tests/ref/block_formatting_context_containing_floats_a.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="overflow: hidden; background: green;">
+    <div style="width: 250px; height: 250px; float: left; background: blue;"></div>
+</div>
+</body>
+</html>
+

--- a/tests/ref/block_formatting_context_containing_floats_ref.html
+++ b/tests/ref/block_formatting_context_containing_floats_ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="background: green;">
+    <div style="width: 250px; height: 250px; float: left; background: blue;"></div>
+    <div style="clear: left;">
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
Improves Pinterest considerably.

r? @glennw
