### PR TITLE
CSS selector :enabled no longer matches Anchor, Area & Link elements

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -19,7 +19,6 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::namespace::Null;
 use servo_util::str::DOMString;
 
@@ -76,32 +75,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
         let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(htmlelement as &VirtualMethods)
-    }
-
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
-        }
-
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "href" => node.set_enabled_state(true),
-            _ => ()
-        }
-    }
-
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
-            _ => (),
-        }
-
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "href" => node.set_enabled_state(false),
-            _ => ()
-        }
     }
 
     fn handle_event(&self, event: JSRef<Event>) {

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -4,7 +4,6 @@
 
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
-use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
@@ -12,9 +11,7 @@ use dom::element::HTMLAreaElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
-use dom::virtualmethods::VirtualMethods;
 
-use servo_util::atom::Atom;
 use servo_util::str::DOMString;
 
 #[jstraceable]
@@ -40,39 +37,6 @@ impl HTMLAreaElement {
     pub fn new(localName: DOMString, document: JSRef<Document>) -> Temporary<HTMLAreaElement> {
         let element = HTMLAreaElement::new_inherited(localName, document);
         Node::reflect_node(box element, document, HTMLAreaElementBinding::Wrap)
-    }
-}
-
-impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
-    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
-        Some(htmlelement as &VirtualMethods)
-    }
-
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
-        }
-
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "href" => node.set_enabled_state(true),
-            _ => ()
-        }
-    }
-
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
-            _ => (),
-        }
-
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "href" => node.set_enabled_state(false),
-            _ => ()
-        }
     }
 }
 

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -5,7 +5,7 @@
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
-use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
@@ -83,24 +83,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
                 if is_stylesheet(rel) {
                     self.handle_stylesheet_url(value.as_slice());
                 }
-
-                let node: JSRef<Node> = NodeCast::from_ref(*self);
-                node.set_enabled_state(true)
             }
             (_, _) => ()
-        }
-    }
-
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
-            _ => (),
-        }
-
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "href" => node.set_enabled_state(false),
-            _ => ()
         }
     }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -5,7 +5,6 @@
 use dom::attr::{AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
-use dom::bindings::codegen::InheritTypes::HTMLAreaElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLBodyElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementCast;
@@ -25,7 +24,6 @@ use dom::bindings::js::JSRef;
 use dom::element::Element;
 use dom::element::ElementTypeId_;
 use dom::element::HTMLAnchorElementTypeId;
-use dom::element::HTMLAreaElementTypeId;
 use dom::element::HTMLBodyElementTypeId;
 use dom::element::HTMLButtonElementTypeId;
 use dom::element::HTMLCanvasElementTypeId;
@@ -42,7 +40,6 @@ use dom::element::HTMLStyleElementTypeId;
 use dom::element::HTMLTextAreaElementTypeId;
 use dom::event::Event;
 use dom::htmlanchorelement::HTMLAnchorElement;
-use dom::htmlareaelement::HTMLAreaElement;
 use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlbuttonelement::HTMLButtonElement;
 use dom::htmlcanvaselement::HTMLCanvasElement;
@@ -142,10 +139,6 @@ pub fn vtable_for<'a>(node: &'a JSRef<'a, Node>) -> &'a VirtualMethods + 'a {
     match node.type_id() {
         ElementNodeTypeId(HTMLAnchorElementTypeId) => {
             let element: &'a JSRef<'a, HTMLAnchorElement> = HTMLAnchorElementCast::to_borrowed_ref(node).unwrap();
-            element as &'a VirtualMethods + 'a
-        }
-        ElementNodeTypeId(HTMLAreaElementTypeId) => {
-            let element: &'a JSRef<'a, HTMLAreaElement> = HTMLAreaElementCast::to_borrowed_ref(node).unwrap();
             element as &'a VirtualMethods + 'a
         }
         ElementNodeTypeId(HTMLBodyElementTypeId) => {

--- a/tests/content/test_enabled_disabled_selectors.html
+++ b/tests/content/test_enabled_disabled_selectors.html
@@ -15,14 +15,12 @@
                     check_selector(elem, ":disabled", false);
                 }
 
-                // Anchor, Area and Link are :enabled with an href, but never :disabled.
+                // Anchor, Area and Link elements are no longer :enabled with an href.
                 list = ["a", "area", "link"];
                 for(i = 0; i < list.length; i++) {
                     elem = document.createElement(list[i]);
-                    check_selector(elem, ":enabled", false);
-                    check_selector(elem, ":disabled", false);
                     elem.setAttribute("href", "");
-                    check_selector(elem, ":enabled", true);
+                    check_selector(elem, ":enabled", false);
                     check_selector(elem, ":disabled", false);
                 }
 


### PR DESCRIPTION
HTML spec has been modified [1] to disable support for :enabled CSS
selector on Anchor, Area & Link elements, after discussion on W3C
Bugzilla [2].

[1] https://html5.org/r/8818
[2] https://www.w3.org/Bugs/Public/show_bug.cgi?id=26622

Next step: Move :enabled CSS selector content test to web-platform-tests.
