### PR TITLE
layout: Support any `display` property in generated content, and allow

### DIFF
--- a/components/layout/css/node_util.rs
+++ b/components/layout/css/node_util.rs
@@ -5,7 +5,7 @@
 use incremental::RestyleDamage;
 use util::LayoutDataAccess;
 use wrapper::{TLayoutNode, ThreadSafeLayoutNode};
-use wrapper::{After, AfterBlock, Before, BeforeBlock, Normal};
+use wrapper::{After, Before, Normal};
 use std::mem;
 use style::ComputedValues;
 use sync::Arc;
@@ -26,7 +26,7 @@ impl<'ln> NodeUtil for ThreadSafeLayoutNode<'ln> {
         unsafe {
             let layout_data_ref = self.borrow_layout_data();
             match self.get_pseudo_element_type() {
-                Before | BeforeBlock => {
+                Before(_) => {
                      mem::transmute(layout_data_ref.as_ref()
                                                    .unwrap()
                                                    .data
@@ -34,7 +34,7 @@ impl<'ln> NodeUtil for ThreadSafeLayoutNode<'ln> {
                                                    .as_ref()
                                                    .unwrap())
                 }
-                After | AfterBlock => {
+                After(_) => {
                     mem::transmute(layout_data_ref.as_ref()
                                                   .unwrap()
                                                   .data

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -19,7 +19,7 @@ use wrapper::ThreadSafeLayoutNode;
 use servo_util::geometry::Au;
 use std::cmp::max;
 use std::fmt;
-use style::computed_values::{float, table_layout};
+use style::computed_values::{clear, float, table_layout};
 
 #[deriving(Encodable)]
 pub enum TableLayout {
@@ -246,6 +246,10 @@ impl Flow for TableWrapperFlow {
 
     fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
         &mut self.block_flow
+    }
+
+    fn float_clearance(&self) -> clear::T {
+        self.block_flow.float_clearance()
     }
 
     fn float_kind(&self) -> float::T {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -148,3 +148,4 @@ flaky_gpu,flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 == margins_inside_floats_a.html margins_inside_floats_ref.html
 == block_formatting_context_complex_a.html block_formatting_context_complex_ref.html
 == block_formatting_context_containing_floats_a.html block_formatting_context_containing_floats_ref.html
+== clear_generated_content_table_a.html clear_generated_content_table_ref.html

--- a/tests/ref/clear_generated_content_table_a.html
+++ b/tests/ref/clear_generated_content_table_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.clearit:after {
+    content: "";
+    clear: both;
+    display: table;
+}
+</style>
+</head>
+<body>
+<div class=clearit>
+    <div style="float: left;">x</div>
+</div>
+<div style="float: left;">y</div>
+</body>
+</html>
+

--- a/tests/ref/clear_generated_content_table_ref.html
+++ b/tests/ref/clear_generated_content_table_ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class=clearit>
+    <div style="float: left;">x</div>
+</div>
+<div style="display: table; clear: both;"></div>
+<div style="float: left;">y</div>
+</body>
+</html>
+
+


### PR DESCRIPTION
tables to clear floats.

Improves the GitHub header.

r? @glennw
