### PR TITLE
Add an extended_deref method to JSRef

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -147,14 +147,14 @@ impl<'a> AttrMethods for JSRef<'a, Attr> {
     }
 }
 
-pub trait AttrHelpers {
+pub trait AttrHelpers<'a> {
     fn set_value(self, set_type: AttrSettingType, value: AttrValue);
-    fn value<'a>(&'a self) -> Ref<'a, AttrValue>;
-    fn local_name<'a>(&'a self) -> &'a Atom;
+    fn value(self) -> Ref<'a, AttrValue>;
+    fn local_name(self) -> &'a Atom;
     fn summarize(self) -> AttrInfo;
 }
 
-impl<'a> AttrHelpers for JSRef<'a, Attr> {
+impl<'a> AttrHelpers<'a> for JSRef<'a, Attr> {
     fn set_value(self, set_type: AttrSettingType, value: AttrValue) {
         let owner = self.owner.root();
         let node: JSRef<Node> = NodeCast::from_ref(*owner);
@@ -180,12 +180,12 @@ impl<'a> AttrHelpers for JSRef<'a, Attr> {
         }
     }
 
-    fn value<'a>(&'a self) -> Ref<'a, AttrValue> {
-        self.value.deref().borrow()
+    fn value(self) -> Ref<'a, AttrValue> {
+        self.extended_deref().value.borrow()
     }
 
-    fn local_name<'a>(&'a self) -> &'a Atom {
-        &self.local_name
+    fn local_name(self) -> &'a Atom {
+        &self.extended_deref().local_name
     }
 
     fn summarize(self) -> AttrInfo {

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -493,6 +493,14 @@ impl<'a,T> JSRef<'a,T> {
     }
 }
 
+impl<'a, T: Reflectable> JSRef<'a, T> {
+    pub fn extended_deref(self) -> &'a T {
+        unsafe {
+            &*self.ptr
+        }
+    }
+}
+
 impl<'a, T: Reflectable> Reflectable for JSRef<'a, T> {
     fn reflector<'a>(&'a self) -> &'a Reflector {
         self.deref().reflector()

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -157,8 +157,8 @@ impl CollectionFilter for AppletsFilter {
     }
 }
 
-pub trait DocumentHelpers {
-    fn url<'a>(&'a self) -> &'a Url;
+pub trait DocumentHelpers<'a> {
+    fn url(self) -> &'a Url;
     fn quirks_mode(self) -> QuirksMode;
     fn set_quirks_mode(self, mode: QuirksMode);
     fn set_last_modified(self, value: DOMString);
@@ -171,9 +171,9 @@ pub trait DocumentHelpers {
     fn load_anchor_href(self, href: DOMString);
 }
 
-impl<'a> DocumentHelpers for JSRef<'a, Document> {
-    fn url<'a>(&'a self) -> &'a Url {
-        &*self.url
+impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
+    fn url(self) -> &'a Url {
+        &*self.extended_deref().url
     }
 
     fn quirks_mode(self) -> QuirksMode {


### PR DESCRIPTION
The extended_deref method will take a JSRef<'a, T> and produce an &'a T,
in contrast to the standard deref method that takes an &'b JSRef<'a, T>
and produces an &'b T. This is useful when avoiding passing a JSRef by
reference.
