### PR TITLE
Remove the 'static lifetime parameters from TElement methods

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1077,9 +1077,9 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
 }
 
 /// Methods for interacting with HTMLObjectElement nodes
-trait ObjectElement {
+trait ObjectElement<'a> {
     /// Returns None if this node is not matching attributes.
-    fn get_type_and_data(&self) -> (Option<&'static str>, Option<&'static str>);
+    fn get_type_and_data(&self) -> (Option<&'a str>, Option<&'a str>);
 
     /// Returns true if this node has object data that is correct uri.
     fn has_object_data(&self) -> bool;
@@ -1088,8 +1088,8 @@ trait ObjectElement {
     fn get_object_data(&self) -> Option<Url>;
 }
 
-impl<'ln> ObjectElement for ThreadSafeLayoutNode<'ln> {
-    fn get_type_and_data(&self) -> (Option<&'static str>, Option<&'static str>) {
+impl<'ln> ObjectElement<'ln> for ThreadSafeLayoutNode<'ln> {
+    fn get_type_and_data(&self) -> (Option<&'ln str>, Option<&'ln str>) {
         let elem = self.as_element();
         (elem.get_attr(&namespace::Null, "type"), elem.get_attr(&namespace::Null, "data"))
     }

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -401,11 +401,11 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     }
 
     #[inline]
-    fn get_attr(&self, namespace: &Namespace, name: &str) -> Option<&'static str> {
+    fn get_attr(&self, namespace: &Namespace, name: &str) -> Option<&'le str> {
         unsafe { self.element.get_attr_val_for_layout(namespace, name) }
     }
 
-    fn get_link(&self) -> Option<&'static str> {
+    fn get_link(&self) -> Option<&'le str> {
         // FIXME: This is HTML only.
         match self.element.node.type_id_for_layout() {
             // http://www.whatwg.org/specs/web-apps/current-work/multipage/selectors.html#
@@ -791,7 +791,7 @@ pub struct ThreadSafeLayoutElement<'le> {
 
 impl<'le> ThreadSafeLayoutElement<'le> {
     #[inline]
-    pub fn get_attr(&self, namespace: &Namespace, name: &str) -> Option<&'static str> {
+    pub fn get_attr(&self, namespace: &Namespace, name: &str) -> Option<&'le str> {
         unsafe { self.element.get_attr_val_for_layout(namespace, name) }
     }
 }

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -611,7 +611,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
 
     /// If this is an element, accesses the element data. Fails if this is not an element node.
     #[inline]
-    pub fn as_element(&self) -> ThreadSafeLayoutElement {
+    pub fn as_element(&self) -> ThreadSafeLayoutElement<'ln> {
         unsafe {
             assert!(self.get_jsmanaged().is_element_for_layout());
             let elem: JS<Element> = self.get_jsmanaged().transmute_copy();

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -242,7 +242,7 @@ impl<'ln> LayoutNode<'ln> {
     }
 }
 
-impl<'ln> TNode<LayoutElement<'ln>> for LayoutNode<'ln> {
+impl<'ln> TNode<'ln, LayoutElement<'ln>> for LayoutNode<'ln> {
     fn parent_node(&self) -> Option<LayoutNode<'ln>> {
         unsafe {
             self.node.parent_node_ref().map(|node| self.new_with_this_lifetime(&node))
@@ -389,7 +389,7 @@ impl<'le> LayoutElement<'le> {
     }
 }
 
-impl<'le> TElement for LayoutElement<'le> {
+impl<'le> TElement<'le> for LayoutElement<'le> {
     #[inline]
     fn get_local_name<'a>(&'a self) -> &'a Atom {
         &self.element.local_name

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -170,7 +170,7 @@ impl Element {
 }
 
 pub trait RawLayoutElementHelpers {
-    unsafe fn get_attr_val_for_layout(&self, namespace: &Namespace, name: &str) -> Option<&'static str>;
+    unsafe fn get_attr_val_for_layout<'a>(&'a self, namespace: &Namespace, name: &str) -> Option<&'a str>;
     unsafe fn get_attr_atom_for_layout(&self, namespace: &Namespace, name: &str) -> Option<Atom>;
     unsafe fn has_class_for_layout(&self, name: &str) -> bool;
 }
@@ -178,8 +178,8 @@ pub trait RawLayoutElementHelpers {
 impl RawLayoutElementHelpers for Element {
     #[inline]
     #[allow(unrooted_must_root)]
-    unsafe fn get_attr_val_for_layout(&self, namespace: &Namespace, name: &str)
-                                      -> Option<&'static str> {
+    unsafe fn get_attr_val_for_layout<'a>(&'a self, namespace: &Namespace, name: &str)
+                                          -> Option<&'a str> {
         // cast to point to T in RefCell<T> directly
         let attrs: *const Vec<JS<Attr>> = mem::transmute(&self.attrs);
         (*attrs).iter().find(|attr: & &JS<Attr>| {
@@ -949,12 +949,12 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
 }
 
 impl<'a> style::TElement<'a> for JSRef<'a, Element> {
-    fn get_attr(&self, namespace: &Namespace, attr: &str) -> Option<&'static str> {
+    fn get_attr(&self, namespace: &Namespace, attr: &str) -> Option<&'a str> {
         self.get_attribute(namespace.clone(), attr).root().map(|attr| {
             unsafe { mem::transmute(attr.deref().value().as_slice()) }
         })
     }
-    fn get_link(&self) -> Option<&'static str> {
+    fn get_link(&self) -> Option<&'a str> {
         // FIXME: This is HTML only.
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         match node.type_id() {
@@ -966,10 +966,10 @@ impl<'a> style::TElement<'a> for JSRef<'a, Element> {
             _ => None,
          }
     }
-    fn get_local_name<'a>(&'a self) -> &'a Atom {
+    fn get_local_name<'b>(&'b self) -> &'b Atom {
         (self as &ElementHelpers).get_local_name()
     }
-    fn get_namespace<'a>(&'a self) -> &'a Namespace {
+    fn get_namespace<'b>(&'b self) -> &'b Namespace {
         (self as &ElementHelpers).get_namespace()
     }
     fn get_hover_state(&self) -> bool {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -948,7 +948,7 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 }
 
-impl<'a> style::TElement for JSRef<'a, Element> {
+impl<'a> style::TElement<'a> for JSRef<'a, Element> {
     fn get_attr(&self, namespace: &Namespace, attr: &str) -> Option<&'static str> {
         self.get_attribute(namespace.clone(), attr).root().map(|attr| {
             unsafe { mem::transmute(attr.deref().value().as_slice()) }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2033,7 +2033,7 @@ impl<'a> VirtualMethods for JSRef<'a, Node> {
     }
 }
 
-impl<'a> style::TNode<JSRef<'a, Element>> for JSRef<'a, Node> {
+impl<'a> style::TNode<'a, JSRef<'a, Element>> for JSRef<'a, Node> {
     fn parent_node(&self) -> Option<JSRef<'a, Node>> {
         (self as &NodeHelpers).parent_node().map(|node| *node.root())
     }

--- a/components/style/node.rs
+++ b/components/style/node.rs
@@ -10,7 +10,7 @@ use servo_util::atom::Atom;
 use servo_util::namespace::Namespace;
 
 
-pub trait TNode<E:TElement> : Clone {
+pub trait TNode<'a, E: TElement<'a>> : Clone {
     fn parent_node(&self) -> Option<Self>;
     /// Name is prefixed to avoid a conflict with TLayoutNode.
     fn tnode_first_child(&self) -> Option<Self>;
@@ -23,7 +23,7 @@ pub trait TNode<E:TElement> : Clone {
     fn is_html_element_in_html_document(&self) -> bool;
 }
 
-pub trait TElement {
+pub trait TElement<'a> {
     fn get_attr(&self, namespace: &Namespace, attr: &str) -> Option<&'static str>;
     fn get_link(&self) -> Option<&'static str>;
     fn get_local_name<'a>(&'a self) -> &'a Atom;

--- a/components/style/node.rs
+++ b/components/style/node.rs
@@ -24,10 +24,10 @@ pub trait TNode<'a, E: TElement<'a>> : Clone {
 }
 
 pub trait TElement<'a> {
-    fn get_attr(&self, namespace: &Namespace, attr: &str) -> Option<&'static str>;
-    fn get_link(&self) -> Option<&'static str>;
-    fn get_local_name<'a>(&'a self) -> &'a Atom;
-    fn get_namespace<'a>(&'a self) -> &'a Namespace;
+    fn get_attr(&self, namespace: &Namespace, attr: &str) -> Option<&'a str>;
+    fn get_link(&self) -> Option<&'a str>;
+    fn get_local_name<'b>(&'b self) -> &'b Atom;
+    fn get_namespace<'b>(&'b self) -> &'b Namespace;
     fn get_hover_state(&self) -> bool;
     fn get_id(&self) -> Option<Atom>;
     fn get_disabled_state(&self) -> bool;

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -79,8 +79,9 @@ impl SelectorMap {
     ///
     /// Extract matching rules as per node's ID, classes, tag name, etc..
     /// Sort the Rules at the end to maintain cascading order.
-    fn get_all_matching_rules<E:TElement,
-                              N:TNode<E>,
+    fn get_all_matching_rules<'a,
+                              E:TElement<'a>,
+                              N:TNode<'a, E>,
                               V:VecLike<DeclarationBlock>>(
                               &self,
                               node: &N,
@@ -147,8 +148,9 @@ impl SelectorMap {
         }
     }
 
-    fn get_matching_rules_from_hash<E:TElement,
-                                    N:TNode<E>,
+    fn get_matching_rules_from_hash<'a,
+                                    E:TElement<'a>,
+                                    N:TNode<'a, E>,
                                     V:VecLike<DeclarationBlock>>(
                                     node: &N,
                                     parent_bf: &Option<BloomFilter>,
@@ -165,8 +167,9 @@ impl SelectorMap {
     }
 
     /// Adds rules in `rules` that match `node` to the `matching_rules` list.
-    fn get_matching_rules<E:TElement,
-                          N:TNode<E>,
+    fn get_matching_rules<'a,
+                          E:TElement<'a>,
+                          N:TNode<'a, E>,
                           V:VecLike<DeclarationBlock>>(
                           node: &N,
                           parent_bf: &Option<BloomFilter>,
@@ -344,8 +347,9 @@ impl Stylist {
     /// The returned boolean indicates whether the style is *shareable*; that is, whether the
     /// matched selectors are simple enough to allow the matching logic to be reduced to the logic
     /// in `css::matching::PrivateMatchMethods::candidate_element_allows_for_style_sharing`.
-    pub fn push_applicable_declarations<E:TElement,
-                                        N:TNode<E>,
+    pub fn push_applicable_declarations<'a,
+                                        E:TElement<'a>,
+                                        N:TNode<'a, E>,
                                         V:VecLike<DeclarationBlock>>(
                                         &self,
                                         element: &N,
@@ -467,7 +471,7 @@ impl DeclarationBlock {
     }
 }
 
-pub fn matches<E:TElement, N:TNode<E>>(selector_list: &SelectorList, element: &N, parent_bf: &Option<BloomFilter>) -> bool {
+pub fn matches<'a, E:TElement<'a>, N:TNode<'a, E>>(selector_list: &SelectorList, element: &N, parent_bf: &Option<BloomFilter>) -> bool {
     get_selector_list_selectors(selector_list).iter().any(|selector|
         selector.pseudo_element.is_none() &&
         matches_compound_selector(&*selector.compound_selectors, element, parent_bf, &mut false))
@@ -479,8 +483,9 @@ pub fn matches<E:TElement, N:TNode<E>>(selector_list: &SelectorList, element: &N
 /// `shareable` to false unless you are willing to update the style sharing logic. Otherwise things
 /// will almost certainly break as nodes will start mistakenly sharing styles. (See the code in
 /// `main/css/matching.rs`.)
-fn matches_compound_selector<E:TElement,
-                             N:TNode<E>>(
+fn matches_compound_selector<'a,
+                             E:TElement<'a>,
+                             N:TNode<'a, E>>(
                              selector: &CompoundSelector,
                              element: &N,
                              parent_bf: &Option<BloomFilter>,
@@ -544,7 +549,7 @@ enum SelectorMatchingResult {
 /// Quickly figures out whether or not the compound selector is worth doing more
 /// work on. If the simple selectors don't match, or there's a child selector
 /// that does not appear in the bloom parent bloom filter, we can exit early.
-fn can_fast_reject<E: TElement, N: TNode<E>>(
+fn can_fast_reject<'a, E: TElement<'a>, N: TNode<'a, E>>(
   mut selector: &CompoundSelector,
   element: &N,
   parent_bf: &Option<BloomFilter>,
@@ -605,8 +610,9 @@ fn can_fast_reject<E: TElement, N: TNode<E>>(
     return None;
 }
 
-fn matches_compound_selector_internal<E:TElement,
-                                      N:TNode<E>>(
+fn matches_compound_selector_internal<'a,
+                                      E:TElement<'a>,
+                                      N:TNode<'a, E>>(
                                       selector: &CompoundSelector,
                                       element: &N,
                                       parent_bf: &Option<BloomFilter>,
@@ -680,8 +686,8 @@ fn matches_compound_selector_internal<E:TElement,
 /// will almost certainly break as nodes will start mistakenly sharing styles. (See the code in
 /// `main/css/matching.rs`.)
 #[inline]
-pub fn matches_simple_selector<E:TElement,
-                           N:TNode<E>>(
+pub fn matches_simple_selector<'a, E:TElement<'a>,
+                           N:TNode<'a, E>>(
                            selector: &SimpleSelector,
                            element: &N,
                            shareable: &mut bool)
@@ -863,8 +869,8 @@ fn url_is_visited(_url: &str) -> bool {
 
 #[inline]
 fn matches_generic_nth_child<'a,
-                             E:TElement,
-                             N:TNode<E>>(
+                             E:TElement<'a>,
+                             N:TNode<'a, E>>(
                              element: &N,
                              a: i32,
                              b: i32,
@@ -919,7 +925,7 @@ fn matches_generic_nth_child<'a,
 }
 
 #[inline]
-fn matches_root<E:TElement,N:TNode<E>>(element: &N) -> bool {
+fn matches_root<'a, E:TElement<'a>,N:TNode<'a, E>>(element: &N) -> bool {
     match element.parent_node() {
         Some(parent) => parent.is_document(),
         None => false
@@ -927,7 +933,7 @@ fn matches_root<E:TElement,N:TNode<E>>(element: &N) -> bool {
 }
 
 #[inline]
-fn matches_first_child<E:TElement,N:TNode<E>>(element: &N) -> bool {
+fn matches_first_child<'a, E:TElement<'a>,N:TNode<'a, E>>(element: &N) -> bool {
     let mut node = element.clone();
     loop {
         match node.prev_sibling() {
@@ -949,7 +955,7 @@ fn matches_first_child<E:TElement,N:TNode<E>>(element: &N) -> bool {
 }
 
 #[inline]
-fn matches_last_child<E:TElement,N:TNode<E>>(element: &N) -> bool {
+fn matches_last_child<'a, E:TElement<'a>,N:TNode<'a, E>>(element: &N) -> bool {
     let mut node = element.clone();
     loop {
         match node.next_sibling() {


### PR DESCRIPTION
This improves the static correctness of layout's use of DOM nodes.

Fixes #2595.
