### PR TITLE
Don't move the data when extracting the bytes in XMLHttpRequest::Send.

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -450,7 +450,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             Get | Head => None, // Step 3
             _ => data
         };
-        let extracted = data.map(|d| d.extract());
+        let extracted = data.as_ref().map(|d| d.extract());
         self.request_body_len.set(extracted.as_ref().map(|e| e.len()).unwrap_or(0));
 
         // Step 6

--- a/tests/wpt/metadata/XMLHttpRequest/formdata.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/formdata.htm.ini
@@ -1,8 +1,5 @@
 [formdata.htm]
   type: testharness
-  [empty formdata]
-    expected: FAIL
-
   [formdata with string]
     expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/send-content-type-charset.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-content-type-charset.htm.ini
@@ -15,6 +15,3 @@
   [XMLHttpRequest: send() - charset parameter of Content-Type 6]
     expected: FAIL
 
-  [XMLHttpRequest: send() - charset parameter of Content-Type 7]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/send-content-type-string.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-content-type-string.htm.ini
@@ -1,5 +1,0 @@
-[send-content-type-string.htm]
-  type: testharness
-  [XMLHttpRequest: send() - Content-Type]
-    expected: FAIL
-


### PR DESCRIPTION
The data is used later to set the Content-Type header. Current rustc
(4d2af3861) does not detect this use-after-move, but treats the later use as
if the data was None. It will, however, detect the bug in d2b30f7d3, which we
are upgrading to.
