### PR TITLE
Mask root layer rectangles to their boundaries

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -456,6 +456,7 @@ impl IOCompositor {
 
         match frame_rect {
             Some(ref frame_rect) => {
+                *root_layer.masks_to_bounds.borrow_mut() = true;
                 *root_layer.bounds.borrow_mut() = frame_rect * self.device_pixels_per_page_px();
             }
             None => {}

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -122,6 +122,8 @@ flaky_linux == acid2_noscroll.html acid2_ref_broken.html
 
 == iframe/simple.html iframe/simple_ref.html
 == iframe/multiple_external.html iframe/multiple_external_ref.html
+== iframe/overflow.html iframe/overflow_ref.html
+
 == floated_generated_content_a.html floated_generated_content_b.html
 == inline_block_margin_a.html inline_block_margin_ref.html
 == inline_block_img_a.html inline_block_img_ref.html

--- a/tests/ref/iframe/overflow.html
+++ b/tests/ref/iframe/overflow.html
@@ -1,0 +1,8 @@
+<html>
+ <body>
+   <iframe src="data:text/html,%3Cdiv%20style%3D%22background%3Agreen%3B%20width%3A%20200px%3B%20height%3A%20200px%3B%22%3E%3C%2Fdiv%3E"
+           style="display: block; width: 108px; height: 108px;">
+  </iframe>
+ </div>
+</body>
+</html>

--- a/tests/ref/iframe/overflow_ref.html
+++ b/tests/ref/iframe/overflow_ref.html
@@ -1,0 +1,6 @@
+<html>
+ <body style="margin: 16px;">
+   <div style="background: green; width: 100px; height: 100px;"></div>
+ </div>
+</body>
+</html>


### PR DESCRIPTION
This prevents iframes contents from overflowing their root layers.
