### PR TITLE
Convert a method from &JSRef to JSRef

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -238,7 +238,7 @@ impl LayoutElementHelpers for JS<Element> {
 }
 
 pub trait ElementHelpers {
-    fn html_element_in_html_document(&self) -> bool;
+    fn html_element_in_html_document(self) -> bool;
     fn get_local_name<'a>(&'a self) -> &'a Atom;
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
     fn summarize(self) -> Vec<AttrInfo>;
@@ -246,8 +246,8 @@ pub trait ElementHelpers {
 }
 
 impl<'a> ElementHelpers for JSRef<'a, Element> {
-    fn html_element_in_html_document(&self) -> bool {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
+    fn html_element_in_html_document(self) -> bool {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
         self.namespace == ns!(HTML) && node.is_in_html_doc()
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2086,8 +2086,7 @@ impl<'a> style::TNode<'a, JSRef<'a, Element>> for JSRef<'a, Node> {
     fn is_html_element_in_html_document(&self) -> bool {
         let elem: Option<JSRef<'a, Element>> = ElementCast::to_ref(*self);
         assert!(elem.is_some());
-        let elem: &ElementHelpers = &elem.unwrap() as &ElementHelpers;
-        elem.html_element_in_html_document()
+        elem.unwrap().html_element_in_html_document()
     }
 }
 


### PR DESCRIPTION
This also removes the unnecessary formation of a trait object.
