### PR TITLE
No longer consider window size when scrolling

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -564,13 +564,11 @@ impl IOCompositor {
                       layer_id: LayerId,
                       origin: TypedPoint2D<LayerPixel, f32>)
                       -> bool {
-        let window_size = self.window_size.as_f32() / self.scene.scale;
         match self.find_layer_with_pipeline_and_layer_id(pipeline_id, layer_id) {
             Some(ref layer) => {
                 if layer.extra_data.borrow().wants_scroll_events == WantsScrollEvents {
                     events::clamp_scroll_offset_and_scroll_layer(layer.clone(),
-                                                                 TypedPoint2D(0f32, 0f32) - origin,
-                                                                 window_size);
+                                                                 TypedPoint2D(0f32, 0f32) - origin);
                 }
                 true
             }
@@ -757,15 +755,13 @@ impl IOCompositor {
                               cursor: TypedPoint2D<DevicePixel, i32>) {
         let delta = delta / self.scene.scale;
         let cursor = cursor.as_f32() / self.scene.scale;
-        let window_size = self.window_size.as_f32() / self.scene.scale;
 
         let mut scroll = false;
         match self.scene.root {
             Some(ref mut layer) => {
                 scroll = events::handle_scroll_event(layer.clone(),
                                                      delta,
-                                                     cursor,
-                                                     window_size) == ScrollPositionChanged;
+                                                     cursor) == ScrollPositionChanged;
             }
             None => { }
         }
@@ -819,13 +815,11 @@ impl IOCompositor {
             window_size.height.get() * (viewport_zoom.inv() - old_viewport_zoom.inv()).get() * 0.5);
 
         let cursor = TypedPoint2D(-1f32, -1f32);  // Make sure this hits the base layer.
-        let window_size = self.window_size.as_f32() / self.scene.scale;
         match self.scene.root {
             Some(ref mut layer) => {
                 events::handle_scroll_event(layer.clone(),
                                             page_delta,
-                                            cursor,
-                                            window_size);
+                                            cursor);
             }
             None => { }
         }

--- a/components/compositing/compositor_data.rs
+++ b/components/compositing/compositor_data.rs
@@ -8,7 +8,7 @@ use pipeline::CompositionPipeline;
 
 use azure::azure_hl::Color;
 use geom::point::TypedPoint2D;
-use geom::size::{Size2D, TypedSize2D};
+use geom::size::Size2D;
 use geom::rect::Rect;
 use gfx::render_task::UnusedBufferMsg;
 use layers::geometry::LayerPixel;
@@ -79,15 +79,13 @@ impl CompositorData {
     }
 
     pub fn update_layer(layer: Rc<Layer<CompositorData>>, layer_properties: LayerProperties) {
-        let size: TypedSize2D<LayerPixel, f32> = Size2D::from_untyped(&layer_properties.rect.size);
-        layer.resize(size);
+        layer.resize(Size2D::from_untyped(&layer_properties.rect.size));
 
         // Call scroll for bounds checking if the page shrunk. Use (-1, -1) as the
         // cursor position to make sure the scroll isn't propagated downwards.
         events::handle_scroll_event(layer.clone(),
                                     TypedPoint2D(0f32, 0f32),
-                                    TypedPoint2D(-1f32, -1f32),
-                                    size);
+                                    TypedPoint2D(-1f32, -1f32));
         CompositorData::update_layer_except_size(layer, layer_properties);
     }
 

--- a/components/compositing/events.rs
+++ b/components/compositing/events.rs
@@ -51,8 +51,7 @@ pub enum ScrollEventResult {
 /// returns false, so a parent layer can scroll instead.
 pub fn handle_scroll_event(layer: Rc<Layer<CompositorData>>,
                            delta: TypedPoint2D<LayerPixel, f32>,
-                           cursor: TypedPoint2D<LayerPixel, f32>,
-                           window_size: TypedSize2D<LayerPixel, f32>)
+                           cursor: TypedPoint2D<LayerPixel, f32>)
                            -> ScrollEventResult {
     // If this layer doesn't want scroll events, neither it nor its children can handle scroll
     // events.
@@ -68,15 +67,14 @@ pub fn handle_scroll_event(layer: Rc<Layer<CompositorData>>,
         if child_bounds.contains(&new_cursor) {
             let result = handle_scroll_event(child.clone(),
                                              delta,
-                                             new_cursor - child_bounds.origin,
-                                             child_bounds.size);
+                                             new_cursor - child_bounds.origin);
             if result != ScrollEventUnhandled {
                 return result;
             }
         }
     }
 
-    clamp_scroll_offset_and_scroll_layer(layer, scroll_offset + delta, window_size)
+    clamp_scroll_offset_and_scroll_layer(layer, scroll_offset + delta)
 }
 
 pub fn calculate_content_size_for_layer(layer: Rc<Layer<CompositorData>>)
@@ -88,12 +86,12 @@ pub fn calculate_content_size_for_layer(layer: Rc<Layer<CompositorData>>)
 }
 
 pub fn clamp_scroll_offset_and_scroll_layer(layer: Rc<Layer<CompositorData>>,
-                                            new_offset: TypedPoint2D<LayerPixel, f32>,
-                                            window_size: TypedSize2D<LayerPixel, f32>)
+                                            new_offset: TypedPoint2D<LayerPixel, f32>)
                                             -> ScrollEventResult {
-    let layer_size = calculate_content_size_for_layer(layer.clone());
-    let min_x = (window_size.width - layer_size.width).get().min(0.0);
-    let min_y = (window_size.height - layer_size.height).get().min(0.0);
+    let layer_size = layer.bounds.borrow().size;
+    let content_size = calculate_content_size_for_layer(layer.clone());
+    let min_x = (layer_size.width - content_size.width).get().min(0.0);
+    let min_y = (layer_size.height - content_size.height).get().min(0.0);
     let new_offset : TypedPoint2D<LayerPixel, f32> =
         Point2D(Length(new_offset.x.get().clamp(&min_x, &0.0)),
                 Length(new_offset.y.get().clamp(&min_y, &0.0)));


### PR DESCRIPTION
Now that scrolling roots are properly sized, we can simply look at the
scrolling root layer size when deciding the extents of layer scrolling.
This simplifies things a bit and further codifies the current model of
scrolling root + mask_to_bounds.
