### PR TITLE
gfx: Fix imprecision in `float_to_fixed`.

### DIFF
--- a/components/gfx/text/util.rs
+++ b/components/gfx/text/util.rs
@@ -110,7 +110,7 @@ pub fn transform_text(text: &str, mode: CompressionMode,
 }
 
 pub fn float_to_fixed(before: int, f: f64) -> i32 {
-    (1i32 << before as uint) * (f as i32)
+    ((1i32 << before as uint) as f64 * f) as i32
 }
 
 pub fn fixed_to_float(before: int, f: i32) -> f64 {


### PR DESCRIPTION
Improves text rendering a lot.

r? @zwarich
