### PR TITLE
gfx: Use subpixel positioning for glyphs.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -110,8 +110,8 @@ impl ScaledFontExtensionMethods for ScaledFont {
                 let azglyph = struct__AzGlyph {
                     mIndex: glyph.id() as uint32_t,
                     mPosition: struct__AzPoint {
-                        x: (origin.x + glyph_offset.x).to_nearest_px() as AzFloat,
-                        y: (origin.y + glyph_offset.y).to_nearest_px() as AzFloat
+                        x: (origin.x + glyph_offset.x).to_subpx() as AzFloat,
+                        y: (origin.y + glyph_offset.y).to_subpx() as AzFloat
                     }
                 };
                 origin = Point2D(origin.x + glyph_advance, origin.y);

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -201,6 +201,12 @@ impl Au {
     }
 
     #[inline]
+    pub fn to_subpx(&self) -> f64 {
+        let Au(s) = *self;
+        (s as f64) / 60f64
+    }
+
+    #[inline]
     pub fn to_snapped(&self) -> Au {
         let Au(s) = *self;
         let res = s % 60i32;


### PR DESCRIPTION
Improves text rendering significantly.

r? @mbrubeck
