### PR TITLE
Move windowing code out of compositor, take 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "compositing 0.0.1",
  "gfx 0.0.1",
+ "glfw_app 0.0.1",
  "layout 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
@@ -32,7 +33,7 @@ dependencies = [
  "egl 0.1.0 (git+https://github.com/servo/rust-egl#88f2a13812ddbce2bf2317221663a61c31b3e220)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype#0b03da276e4bdeae2300596dabc4ccb16733ad70)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom#90add8d65273c8a46aa16d73959e29a51d0c282d)",
- "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#7ccfaca315a43d97914e1601c90ad348ef190edf)",
+ "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#180d3ff2f28d239e32d01982c76be5c97d5763a8)",
  "opengles 0.1.0 (git+https://github.com/servo/rust-opengles#6776e9c07feb149d34b087039ecf6b2c143e3afc)",
  "skia-sys 0.0.20130412 (git+https://github.com/servo/skia#6d696712962fd0d41120b7a414a48417da8e6a92)",
@@ -64,8 +65,6 @@ dependencies = [
  "devtools_traits 0.0.1",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom#90add8d65273c8a46aa16d73959e29a51d0c282d)",
  "gfx 0.0.1",
- "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#7ccfaca315a43d97914e1601c90ad348ef190edf)",
- "glut 0.0.1 (git+https://github.com/servo/rust-glut#01af0162ea0322ad1a40d6adb023a39813605949)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#180d3ff2f28d239e32d01982c76be5c97d5763a8)",
  "layout_traits 0.0.1",
  "msg 0.0.1",
@@ -195,7 +194,7 @@ dependencies = [
 [[package]]
 name = "glfw"
 version = "0.0.1"
-source = "git+https://github.com/servo/glfw-rs?ref=servo#7ccfaca315a43d97914e1601c90ad348ef190edf"
+source = "git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b"
 dependencies = [
  "glfw-sys 3.0.4 (git+https://github.com/servo/glfw?ref=cargo-3.0.4#65a2b4721276589d9de24f6a9999a2db37286cae)",
  "semver 0.0.1 (git+https://github.com/rust-lang/semver#d04583a173395b76c1eaa15cc630a5f6f8f0ae10)",
@@ -207,11 +206,16 @@ version = "3.0.4"
 source = "git+https://github.com/servo/glfw?ref=cargo-3.0.4#65a2b4721276589d9de24f6a9999a2db37286cae"
 
 [[package]]
-name = "glut"
+name = "glfw_app"
 version = "0.0.1"
-source = "git+https://github.com/servo/rust-glut#01af0162ea0322ad1a40d6adb023a39813605949"
 dependencies = [
- "opengles 0.1.0 (git+https://github.com/servo/rust-opengles#6776e9c07feb149d34b087039ecf6b2c143e3afc)",
+ "alert 0.1.0 (git+https://github.com/servo/rust-alert#fdc24f13be8d8a2d15214ec228d166b3221b809e)",
+ "compositing 0.0.1",
+ "geom 0.1.0 (git+https://github.com/servo/rust-geom#90add8d65273c8a46aa16d73959e29a51d0c282d)",
+ "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
+ "layers 0.1.0 (git+https://github.com/servo/rust-layers#180d3ff2f28d239e32d01982c76be5c97d5763a8)",
+ "msg 0.0.1",
+ "util 0.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The Servo Project Developers"]
 
 [lib]
 name = "servo"
-crate-type = ["rlib", "dylib"]
+crate-type = ["rlib"]
 
 [[bin]]
 name = "servo"
@@ -24,6 +24,8 @@ name = "contenttest"
 path = "tests/contenttest.rs"
 harness = false
 
+[features]
+default = ["glfw_app"]
 
 [dependencies.compositing]
 path = "components/compositing"
@@ -45,6 +47,10 @@ path = "components/layout"
 
 [dependencies.gfx]
 path = "components/gfx"
+
+[dependencies.glfw_app]
+path = "ports/glfw"
+optional = true
 
 [dependencies.url]
 git = "https://github.com/servo/rust-url"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ git clone https://github.com/servo/servo
 cd servo
 ANDROID_TOOLCHAIN=/path/to/toolchain ANDROID_NDK=/path/to/ndk PATH=$PATH:/path/to/toolchain/bin ./mach build --android
 cd ports/android
-ANDROID_NDK=/path/to/ndk ANDROID_SDK=/path/to/sdk make
 ANDROID_SDK=/path/to/sdk make install
 ```
 

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -40,10 +40,6 @@ git = "https://github.com/servo/rust-azure"
 [dependencies.geom]
 git = "https://github.com/servo/rust-geom"
 
-[dependencies.glfw]
-git = "https://github.com/servo/glfw-rs"
-branch = "servo"
-
 [dependencies.layers]
 git = "https://github.com/servo/rust-layers"
 
@@ -61,7 +57,3 @@ git = "https://github.com/servo/rust-core-graphics"
 
 [dependencies.core_text]
 git = "https://github.com/servo/rust-core-text"
-
-[dependencies.glut]
-git = "https://github.com/servo/rust-glut"
-

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -19,10 +19,6 @@ extern crate azure;
 extern crate devtools_traits;
 extern crate geom;
 extern crate gfx;
-#[cfg(not(target_os="android"))]
-extern crate glfw;
-#[cfg(target_os="android")]
-extern crate glut;
 extern crate layers;
 extern crate layout_traits;
 extern crate opengles;
@@ -56,7 +52,4 @@ mod headless;
 pub mod pipeline;
 pub mod constellation;
 
-mod windowing;
-
-#[path="platform/mod.rs"]
-pub mod platform;
+pub mod windowing;

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -10,7 +10,6 @@ use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
 use servo_msg::compositor_msg::{ReadyState, RenderState};
 use servo_util::geometry::ScreenPx;
-use std::rc::Rc;
 
 pub enum MouseWindowEvent {
     MouseWindowClickEvent(uint, TypedPoint2D<DevicePixel, f32>),
@@ -54,14 +53,7 @@ pub enum WindowEvent {
     QuitWindowEvent,
 }
 
-/// Methods for an abstract Application.
-pub trait ApplicationMethods {
-    fn new() -> Self;
-}
-
-pub trait WindowMethods<A> {
-    /// Creates a new window.
-    fn new(app: &A, is_foreground: bool, size: TypedSize2D<DevicePixel, uint>) -> Rc<Self>;
+pub trait WindowMethods {
     /// Returns the size of the window in hardware pixels.
     fn framebuffer_size(&self) -> TypedSize2D<DevicePixel, uint>;
     /// Returns the size of the window in density-independent "px" units.

--- a/ports/android/Makefile
+++ b/ports/android/Makefile
@@ -1,9 +1,11 @@
+CARGO_OPTS ?=
+
 .PHONY: all
-all:
+all: glut_app
 	NDK_DEBUG=1 $(ANDROID_NDK)/ndk-build -B
-	find ../../target ! \( -type d -name dist -prune \) -name libmozjs.so | \
+	find glut_app/target ! \( -type d -name dist -prune \) -name libmozjs.so | \
 		xargs -I {} cp -f {} libs/armeabi
-	find ../../target ! \( -type d -name dist -prune \) -name 'libservo-*.so' | \
+	find glut_app/target ! \( -type d -name dist -prune \) -name 'libglut_app-*.so' | \
 		xargs -I {} cp -f {} libs/armeabi/libservo.so
 	find ../../rust/lib/rustlib/arm-linux-androideabi/lib \
 		-name '*.so' -type f -size +1c | \
@@ -13,6 +15,11 @@ all:
 		--target "android-18" \
 		--path .
 	ant debug
+
+.PHONY: glut_app
+glut_app:
+	cd glut_app; \
+	../../../mach cargo build --target=arm-linux-androideabi $(CARGO_OPTS)
 
 .PHONY: install
 install:

--- a/ports/android/glut_app/Cargo.lock
+++ b/ports/android/glut_app/Cargo.lock
@@ -1,26 +1,14 @@
 [root]
-name = "embedding"
+name = "glut_app"
 version = "0.0.1"
 dependencies = [
- "azure 0.1.0 (git+https://github.com/servo/rust-azure#b357751c04a89a87e6ef1f0cebe5f20957dd112d)",
- "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics#6a9919f8a912cc67571b891ba198d5325964a104)",
- "core_text 0.1.0 (git+https://github.com/servo/rust-core-text#1ad11072b31657eeccaf4879c6e98723d488bd3d)",
- "devtools 0.0.1",
+ "alert 0.1.0 (git+https://github.com/servo/rust-alert#fdc24f13be8d8a2d15214ec228d166b3221b809e)",
+ "compositing 0.0.1",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom#90add8d65273c8a46aa16d73959e29a51d0c282d)",
- "gfx 0.0.1",
- "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
- "glfw_app 0.0.1",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs#41fb0d80a5ed5614ca13a120cdb3281e599d4e04)",
+ "glut 0.0.1 (git+https://github.com/servo/rust-glut#01af0162ea0322ad1a40d6adb023a39813605949)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#180d3ff2f28d239e32d01982c76be5c97d5763a8)",
  "msg 0.0.1",
- "net 0.0.1",
- "opengles 0.1.0 (git+https://github.com/servo/rust-opengles#6776e9c07feb149d34b087039ecf6b2c143e3afc)",
- "plugins 0.0.1",
- "png 0.1.0 (git+https://github.com/servo/rust-png#74418ffbf20e94b0d3bed4a9d004062a13342c79)",
- "script 0.0.1",
  "servo 0.0.1",
- "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image#f5022de4ad6bb474a03493d1f274dde9b0f1af0c)",
- "style 0.0.1",
  "util 0.0.1",
 ]
 
@@ -217,16 +205,11 @@ version = "3.0.4"
 source = "git+https://github.com/servo/glfw?ref=cargo-3.0.4#65a2b4721276589d9de24f6a9999a2db37286cae"
 
 [[package]]
-name = "glfw_app"
+name = "glut"
 version = "0.0.1"
+source = "git+https://github.com/servo/rust-glut#01af0162ea0322ad1a40d6adb023a39813605949"
 dependencies = [
- "alert 0.1.0 (git+https://github.com/servo/rust-alert#fdc24f13be8d8a2d15214ec228d166b3221b809e)",
- "compositing 0.0.1",
- "geom 0.1.0 (git+https://github.com/servo/rust-geom#90add8d65273c8a46aa16d73959e29a51d0c282d)",
- "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
- "layers 0.1.0 (git+https://github.com/servo/rust-layers#180d3ff2f28d239e32d01982c76be5c97d5763a8)",
- "msg 0.0.1",
- "util 0.0.1",
+ "opengles 0.1.0 (git+https://github.com/servo/rust-opengles#6776e9c07feb149d34b087039ecf6b2c143e3afc)",
 ]
 
 [[package]]
@@ -445,7 +428,6 @@ version = "0.0.1"
 dependencies = [
  "compositing 0.0.1",
  "gfx 0.0.1",
- "glfw_app 0.0.1",
  "layout 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",

--- a/ports/android/glut_app/Cargo.toml
+++ b/ports/android/glut_app/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "glut_app"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "glut_app"
+path = "lib.rs"
+crate-type = ["dylib"]
+
+[dependencies.alert]
+git = "https://github.com/servo/rust-alert"
+
+[dependencies.compositing]
+path = "../../../components/compositing"
+
+[dependencies.geom]
+git = "https://github.com/servo/rust-geom"
+
+[dependencies.glut]
+git = "https://github.com/servo/rust-glut"
+
+[dependencies.layers]
+git = "https://github.com/servo/rust-layers"
+
+[dependencies.msg]
+path = "../../../components/msg"
+
+[dependencies.servo]
+path = "../../.."
+default-features = false
+
+[dependencies.util]
+path = "../../../components/util"

--- a/ports/android/glut_app/lib.rs
+++ b/ports/android/glut_app/lib.rs
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A simple application that uses GLUT to open a window for Servo to display in.
+
+#![license = "MPL"]
+#![feature(macro_rules, phase)]
+#![deny(unused_imports, unused_variable)]
+
+extern crate alert;
+extern crate compositing;
+extern crate geom;
+extern crate glut;
+extern crate layers;
+extern crate libc;
+#[phase(plugin, link)] extern crate log;
+extern crate msg;
+extern crate native;
+extern crate servo;
+#[phase(plugin, link)] extern crate util;
+
+use geom::scale_factor::ScaleFactor;
+use std::rc::Rc;
+use std::string;
+use util::opts;
+use window::Window;
+
+use glut::glut::{init, init_display_mode, DOUBLE};
+
+mod window;
+
+pub fn create_window(opts: &opts::Opts) -> Rc<Window> {
+    // Initialize GLUT.
+    init();
+    init_display_mode(DOUBLE);
+
+    // Read command-line options.
+    let scale_factor = opts.device_pixels_per_px.unwrap_or(ScaleFactor(1.0));
+    let size = opts.initial_window_size.as_f32() * scale_factor;
+
+    // Open a window.
+    Window::new(size.as_uint())
+}
+
+#[no_mangle]
+#[allow(dead_code)]
+pub extern "C" fn android_start(argc: int, argv: *const *const u8) -> int {
+    native::start(argc, argv, proc() {
+        let mut args: Vec<String> = vec!();
+        for i in range(0u, argc as uint) {
+            unsafe {
+                args.push(string::raw::from_buf(*argv.offset(i as int) as *const u8));
+            }
+        }
+
+        opts::from_cmdline_args(args.as_slice()).map(|mut opts| {
+            // Always use CPU rendering on android.
+            opts.cpu_painting = true;
+            let window = Some(create_window(&opts));
+            servo::run(opts, window);
+        });
+    })
+}

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["dylib"]
 [dependencies.servo]
 path = "../.."
 
+[dependencies.glfw_app]
+path = "../glfw"
+
 [dependencies.plugins]
 path = "../../components/plugins"
 
@@ -44,9 +47,6 @@ git = "https://github.com/servo/rust-geom"
 [dependencies.glfw]
 git = "https://github.com/servo/glfw-rs"
 branch = "servo"
-
-[dependencies.glut]
-git = "https://github.com/servo/rust-glut"
 
 [dependencies.js]
 git = "https://github.com/servo/rust-mozjs"

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -7,6 +7,7 @@ use azure;
 use command_line::command_line_init;
 use eutil::fptr_is_null;
 use geom::size::TypedSize2D;
+use glfw_app;
 use libc::{c_int, c_void};
 use native;
 use servo;
@@ -74,7 +75,8 @@ pub extern "C" fn cef_run_message_loop() {
         dump_flow_tree: false,
     };
     native::start(0, 0 as *const *const u8, proc() {
-       servo::run(opts);
+       let window = Some(glfw_app::create_window(&opts));
+       servo::run(opts, window);
     });
 }
 

--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -18,10 +18,8 @@ extern crate servo;
 extern crate azure;
 extern crate geom;
 extern crate gfx;
-#[cfg(not(target_os="android"))]
 extern crate glfw;
-#[cfg(target_os="android")]
-extern crate glut;
+extern crate glfw_app;
 extern crate js;
 extern crate layers;
 extern crate opengles;

--- a/ports/glfw/Cargo.toml
+++ b/ports/glfw/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "glfw_app"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "glfw_app"
+path = "lib.rs"
+
+[dependencies.alert]
+git = "https://github.com/servo/rust-alert"
+
+[dependencies.compositing]
+path = "../../components/compositing"
+
+[dependencies.geom]
+git = "https://github.com/servo/rust-geom"
+
+[dependencies.glfw]
+git = "https://github.com/servo/glfw-rs"
+branch = "servo"
+
+[dependencies.layers]
+git = "https://github.com/servo/rust-layers"
+
+[dependencies.msg]
+path = "../../components/msg"
+
+[dependencies.util]
+path = "../../components/util"

--- a/ports/glfw/lib.rs
+++ b/ports/glfw/lib.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A simple application that uses GLFW to open a window for Servo to display in.
+
+#![license = "MPL"]
+#![feature(macro_rules)]
+#![deny(unused_imports, unused_variable)]
+
+extern crate alert;
+extern crate compositing;
+extern crate geom;
+extern crate glfw;
+extern crate layers;
+extern crate libc;
+extern crate msg;
+extern crate time;
+extern crate util;
+
+use geom::scale_factor::ScaleFactor;
+use std::rc::Rc;
+use window::Window;
+
+mod window;
+
+pub fn create_window(opts: &util::opts::Opts) -> Rc<Window> {
+    // Initialize GLFW.
+    let glfw = glfw::init(glfw::LOG_ERRORS).unwrap_or_else(|_| {
+        // handles things like inability to connect to X
+        // cannot simply fail, since the runtime isn't up yet (causes a nasty abort)
+        println!("GLFW initialization failed");
+        unsafe { libc::exit(1); }
+    });
+
+    // Read command-line options.
+    let foreground = opts.output_file.is_none();
+    let scale_factor = opts.device_pixels_per_px.unwrap_or(ScaleFactor(1.0));
+    let size = opts.initial_window_size.as_f32() * scale_factor;
+
+    // Open a window.
+    Window::new(glfw, foreground, size.as_uint())
+}

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -46,20 +46,22 @@ class MachCommands(CommandBase):
             opts += ["--release"]
         if target:
             opts += ["--target", target]
-        elif android:
-            opts += ["--target", "arm-linux-androideabi"]
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
 
         build_start = time()
-        status = subprocess.call(
-            ["cargo", "build"] + opts,
-            env=self.build_env())
         if android:
-            status = status or subprocess.call(
-                ["make", "-C", "ports/android"],
+            make_opts = []
+            if opts:
+                make_opts += ["CARGO_OPTS=" + " ".join(opts)]
+            status = subprocess.call(
+                ["make", "-C", "ports/android"] + make_opts,
+                env=self.build_env())
+        else:
+            status = subprocess.call(
+                ["cargo", "build"] + opts,
                 env=self.build_env())
         elapsed = time() - build_start
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ extern crate native;
 extern crate "util" as servo_util;
 
 #[cfg(not(test),not(target_os="android"))]
+extern crate glfw_app;
+
+#[cfg(not(test),not(target_os="android"))]
 use servo_util::opts;
 
 #[cfg(not(test),not(target_os="android"))]
@@ -20,13 +23,19 @@ use servo::run;
 #[cfg(not(test),not(target_os="android"))]
 use std::os;
 
-#[cfg(not(test), target_os="linux")]
-#[cfg(not(test), target_os="macos")]
+#[cfg(not(test), not(target_os="android"))]
 #[start]
 #[allow(dead_code)]
 fn start(argc: int, argv: *const *const u8) -> int {
     native::start(argc, argv, proc() {
-        opts::from_cmdline_args(os::args().as_slice()).map(run);
+        opts::from_cmdline_args(os::args().as_slice()).map(|opts| {
+            let window = if opts.headless {
+                None
+            } else {
+                Some(glfw_app::create_window(&opts))
+            };
+            run(opts, window);
+        });
     })
 }
 


### PR DESCRIPTION
This includes the previously-reviewed commits from #3533, plus additional fixes for test failures, and a workaround for CEF link errors on Mac (related to rust-lang/rust#14344).  Opening a new PR because this required a fairly invasive rebase, and the original was polluted by a bunch of test commits. r? @larsbergstrom 
