### PR TITLE
Add Android build config to mach/servobuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,19 @@ cd servo
 ``` sh
 git clone https://github.com/servo/servo
 cd servo
-ANDROID_TOOLCHAIN=/path/to/toolchain ANDROID_NDK=/path/to/ndk PATH=$PATH:/path/to/toolchain/bin ./mach build --target arm-linux-androideabi
+ANDROID_TOOLCHAIN=/path/to/toolchain ANDROID_NDK=/path/to/ndk PATH=$PATH:/path/to/toolchain/bin ./mach build --android
 cd ports/android
 ANDROID_NDK=/path/to/ndk ANDROID_SDK=/path/to/sdk make
 ANDROID_SDK=/path/to/sdk make install
+```
+
+Rather than setting the `ANDROID_*` environment variables every time, you can
+also create a `.servobuild` file and then edit it to contain the correct paths
+to the Android SDK/NDK tools:
+
+```
+cp servobuild.example .servobuild
+# edit .servobuild
 ```
 
 ## Running

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -73,6 +73,14 @@ class CommandBase(object):
             self.config["tools"]["cargo-root"] = path.join(
                 context.topdir, "cargo")
 
+        self.config.setdefault("build", {})
+        self.config["build"].setdefault("android", False)
+
+        self.config.setdefault("android", {})
+        self.config["android"].setdefault("sdk", "")
+        self.config["android"].setdefault("ndk", "")
+        self.config["android"].setdefault("toolchain", "")
+
     _rust_snapshot_path = None
 
     def rust_snapshot_path(self):
@@ -110,6 +118,14 @@ class CommandBase(object):
                                          (os.pathsep.join(extra_lib),
                                           os.pathsep,
                                           env.get("LD_LIBRARY_PATH", ""))
+
+        # Paths to Android build tools:
+        if self.config["android"]["sdk"]:
+            env["ANDROID_SDK"] = self.config["android"]["sdk"]
+        if self.config["android"]["ndk"]:
+            env["ANDROID_NDK"] = self.config["android"]["ndk"]
+        if self.config["android"]["toolchain"]:
+            env["ANDROID_TOOLCHAIN"] = self.config["android"]["toolchain"]
 
         return env
 

--- a/servobuild.example
+++ b/servobuild.example
@@ -9,6 +9,10 @@ rust-root = "/path/to/rust"
 system-cargo = false
 cargo-root = "/path/to/cargo"
 
+[build]
+# Set "android = true" or use `mach build --android` to build the Android app.
+android = false
+
 # Android information
 [android]
 sdk = "/opt/android-sdk"


### PR DESCRIPTION
This allows setting Android toolchain paths in `.servobuild`, and also adds a `--android` option that sets the correct default target and causes `mach build` to also build the APK.
