### PR TITLE
Support [*|attr], attribute selectors in any namespace (fixes #1558)

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -310,8 +310,10 @@ impl<'ln> TNode<'ln, LayoutElement<'ln>> for LayoutNode<'ln> {
                 element.get_attr(ns, name)
                         .map_or(false, |attr| test(attr))
             },
-            // FIXME: https://github.com/mozilla/servo/issues/1558
-            AnyNamespace => false,
+            AnyNamespace => {
+                let element = self.as_element();
+                element.get_attrs(name).iter().any(|attr| test(*attr))
+            }
         }
     }
 
@@ -412,6 +414,11 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     #[inline]
     fn get_attr(self, namespace: &Namespace, name: &str) -> Option<&'le str> {
         unsafe { self.element.get_attr_val_for_layout(namespace, name) }
+    }
+
+    #[inline]
+    fn get_attrs(self, name: &str) -> Vec<&'le str> {
+        unsafe { self.element.get_attr_vals_for_layout(name) }
     }
 
     fn get_link(self) -> Option<&'le str> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -5,7 +5,6 @@
 //! The core DOM types. Defines the basic DOM hierarchy as well as all the HTML elements.
 
 use dom::attr::{Attr, AttrHelpers};
-use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -2115,10 +2114,13 @@ impl<'a> style::TNode<'a, JSRef<'a, Element>> for JSRef<'a, Node> {
         match attr.namespace {
             style::SpecificNamespace(ref ns) => {
                 self.as_element().get_attribute(ns.clone(), name).root()
-                    .map_or(false, |attr| test(attr.deref().Value().as_slice()))
+                    .map_or(false, |attr| test(attr.deref().value().as_slice()))
             },
-            // FIXME: https://github.com/mozilla/servo/issues/1558
-            style::AnyNamespace => false,
+            style::AnyNamespace => {
+                self.as_element().get_attributes(name).iter()
+                    .map(|attr| attr.root())
+                    .any(|attr| test(attr.deref().value().as_slice()))
+            }
         }
     }
 

--- a/components/style/node.rs
+++ b/components/style/node.rs
@@ -23,6 +23,7 @@ pub trait TNode<'a, E: TElement<'a>> : Clone + Copy {
 
 pub trait TElement<'a> : Copy {
     fn get_attr(self, namespace: &Namespace, attr: &str) -> Option<&'a str>;
+    fn get_attrs(self, attr: &str) -> Vec<&'a str>;
     fn get_link(self) -> Option<&'a str>;
     fn get_local_name(self) -> &'a Atom;
     fn get_namespace(self) -> &'a Namespace;

--- a/tests/ref/attr_exists_selector.html
+++ b/tests/ref/attr_exists_selector.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Attribute exists selector: [foo]</title>
+    <title>Attribute exists selector: [foo] and [*|foo]</title>
     <style>
       p[data-green] { color: green }
+      p[*|data-red] { color: red }
     </style>
   </head>
   <body>
     <p data-green="">This text should be green.</p>
+    <p data-red="">This text should be red.</p>
     <p>This text should be black.</p>
   </body>
 </html>

--- a/tests/ref/attr_exists_selector_ref.html
+++ b/tests/ref/attr_exists_selector_ref.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <p style="color: green">This text should be green.</p>
+    <p style="color: red">This text should be red.</p>
     <p>This text should be black.</p>
   </body>
 </html>

--- a/tests/ref/noteq_attr_exists_selector.html
+++ b/tests/ref/noteq_attr_exists_selector.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <p>This text should be green.</p>
+    <p>This text should be red.</p>
     <p>This text should be black.</p>
   </body>
 </html>


### PR DESCRIPTION
This implements basic support for attribute selectors with namespace prefixes. I would have added a more sophisticated test covering various selectors but it seems that we don't have an XML parser yet and thus no XHTML support?

r? @SimonSapin 
