### PR TITLE
Incremental Style Recalc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "msg 0.0.1",
  "net 0.0.1",
  "url 0.1.0 (git+https://github.com/servo/rust-url#29f70a47230c2aa736e263977247c786e0b2c243)",
+ "util 0.0.1",
 ]
 
 [[package]]

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -293,7 +293,7 @@ pub enum BackgroundAndBorderLevel {
 }
 
 /// A list of rendering operations to be performed.
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub struct DisplayList {
     pub list: DList<DisplayItem>,
 }
@@ -357,8 +357,9 @@ impl DisplayList {
     }
 
     /// Returns true if this list is empty and false otherwise.
+    #[inline]
     fn is_empty(&self) -> bool {
-        self.list.len() == 0
+        self.list.is_empty()
     }
 
     /// Flattens a display list into a display list with a single stacking level according to the

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -34,6 +34,7 @@ use fragment::{InlineBlockFragmentInfo, InputFragment, InputFragmentInfo, Specif
 use fragment::{TableCellFragment, TableColumnFragment, TableColumnFragmentInfo, TableFragment};
 use fragment::{TableRowFragment, TableWrapperFragment, UnscannedTextFragment};
 use fragment::{UnscannedTextFragmentInfo};
+use incremental::RestyleDamage;
 use inline::{InlineFragments, InlineFlow};
 use parallel;
 use table_wrapper::TableWrapperFlow;
@@ -88,7 +89,7 @@ pub enum ConstructionItem {
     /// Inline fragments and associated {ib} splits that have not yet found flows.
     InlineFragmentsConstructionItem(InlineFragmentsConstructionResult),
     /// Potentially ignorable whitespace.
-    WhitespaceConstructionItem(OpaqueNode, Arc<ComputedValues>),
+    WhitespaceConstructionItem(OpaqueNode, Arc<ComputedValues>, RestyleDamage),
     /// TableColumn Fragment
     TableColumnFragmentConstructionItem(Fragment),
 }
@@ -441,13 +442,15 @@ impl<'a> FlowConstructor<'a> {
                 abs_descendants.push_descendants(kid_abs_descendants);
             }
             ConstructionItemConstructionResult(WhitespaceConstructionItem(whitespace_node,
-                                                                          whitespace_style)) => {
+                                                                          whitespace_style,
+                                                                          whitespace_damage)) => {
                 // Add whitespace results. They will be stripped out later on when
                 // between block elements, and retained when between inline elements.
                 let fragment_info =
                     UnscannedTextFragment(UnscannedTextFragmentInfo::from_text(" ".to_string()));
                 let mut fragment = Fragment::from_opaque_node_and_style(whitespace_node,
                                                                         whitespace_style,
+                                                                        whitespace_damage,
                                                                         fragment_info);
                 inline_fragment_accumulator.fragments.push(&mut fragment);
             }
@@ -607,12 +610,14 @@ impl<'a> FlowConstructor<'a> {
                     abs_descendants.push_descendants(kid_abs_descendants);
                 }
                 ConstructionItemConstructionResult(WhitespaceConstructionItem(whitespace_node,
-                                                                              whitespace_style))
+                                                                              whitespace_style,
+                                                                              whitespace_damage))
                         => {
                     // Instantiate the whitespace fragment.
                     let fragment_info = UnscannedTextFragment(UnscannedTextFragmentInfo::from_text(" ".to_string()));
                     let mut fragment = Fragment::from_opaque_node_and_style(whitespace_node,
                                                                         whitespace_style,
+                                                                        whitespace_damage,
                                                                         fragment_info);
                     fragment_accumulator.fragments.push(&mut fragment)
                 }
@@ -654,7 +659,8 @@ impl<'a> FlowConstructor<'a> {
             let opaque_node = OpaqueNodeMethods::from_thread_safe_layout_node(node);
             return ConstructionItemConstructionResult(WhitespaceConstructionItem(
                 opaque_node,
-                node.style().clone()))
+                node.style().clone(),
+                node.restyle_damage()))
         }
 
         // If this is generated content, then we need to initialize the accumulator with the
@@ -1196,12 +1202,16 @@ impl FlowConstructionUtils for FlowRef {
     ///
     /// This must not be public because only the layout constructor can do this.
     fn add_new_child(&mut self, mut new_child: FlowRef) {
+        let base = flow::mut_base(self.get_mut());
+
         {
             let kid_base = flow::mut_base(new_child.get_mut());
+
+            base.restyle_damage.insert(kid_base.restyle_damage.propagate_up());
+
             kid_base.parallel.parent = parallel::mut_owned_flow_to_unsafe_flow(self);
         }
 
-        let base = flow::mut_base(self.get_mut());
         base.children.push_back(new_child);
         let _ = base.parallel.children_count.fetch_add(1, Relaxed);
         let _ = base.parallel.children_and_absolute_descendant_count.fetch_add(1, Relaxed);

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -11,6 +11,7 @@ use gfx::display_list::OpaqueNode;
 use gfx::font_context::FontContext;
 use gfx::font_cache_task::FontCacheTask;
 use script::layout_interface::LayoutChan;
+use script_traits::UntrustedNodeAddress;
 use servo_msg::constellation_msg::ConstellationChan;
 use servo_net::local_image_cache::LocalImageCache;
 use servo_util::geometry::Au;
@@ -49,7 +50,7 @@ fn create_or_get_local_context(shared_layout_context: &SharedLayoutContext) -> *
 
 pub struct SharedLayoutContext {
     /// The local image cache.
-    pub image_cache: Arc<Mutex<LocalImageCache>>,
+    pub image_cache: Arc<Mutex<LocalImageCache<UntrustedNodeAddress>>>,
 
     /// The current screen size.
     pub screen_size: Size2D<Au>,

--- a/components/layout/css/matching.rs
+++ b/components/layout/css/matching.rs
@@ -7,8 +7,6 @@
 use css::node_style::StyledNode;
 use construct::FlowConstructor;
 use context::LayoutContext;
-use incremental;
-use incremental::RestyleDamage;
 use util::{LayoutDataAccess, LayoutDataWrapper};
 use wrapper::{LayoutElement, LayoutNode, PostorderNodeMutTraversal, ThreadSafeLayoutNode};
 use wrapper::{TLayoutNode};
@@ -333,7 +331,7 @@ trait PrivateMatchMethods {
                                    style: &mut Option<Arc<ComputedValues>>,
                                    applicable_declarations_cache: &mut
                                    ApplicableDeclarationsCache,
-                                   shareable: bool) -> RestyleDamage;
+                                   shareable: bool);
 
     fn share_style_with_candidate_if_possible(&self,
                                               parent_node: Option<LayoutNode>,
@@ -348,7 +346,7 @@ impl<'ln> PrivateMatchMethods for LayoutNode<'ln> {
                                    style: &mut Option<Arc<ComputedValues>>,
                                    applicable_declarations_cache: &mut
                                    ApplicableDeclarationsCache,
-                                   shareable: bool) -> RestyleDamage {
+                                   shareable: bool) {
         let this_style;
         let cacheable;
         match parent_style {
@@ -380,9 +378,7 @@ impl<'ln> PrivateMatchMethods for LayoutNode<'ln> {
             applicable_declarations_cache.insert(applicable_declarations, this_style.clone());
         }
 
-        let damage = incremental::compute_damage(style, &*this_style);
         *style = Some(this_style);
-        damage
     }
 
 
@@ -472,15 +468,10 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
             match self.share_style_with_candidate_if_possible(parent.clone(), candidate) {
                 Some(shared_style) => {
                     // Yay, cache hit. Share the style.
-                    let damage = {
-                        let mut layout_data_ref = self.mutate_layout_data();
-                        let shared_data = &mut layout_data_ref.as_mut().unwrap().shared_data;
-                        let style = &mut shared_data.style;
-                        let damage = incremental::compute_damage(style, &*shared_style);
-                        *style = Some(shared_style);
-                        damage
-                    };
-                    ThreadSafeLayoutNode::new(self).set_restyle_damage(damage);
+                    let mut layout_data_ref = self.mutate_layout_data();
+                    let shared_data = &mut layout_data_ref.as_mut().unwrap().shared_data;
+                    let style = &mut shared_data.style;
+                    *style = Some(shared_style);
                     return StyleWasShared(i)
                 }
                 None => {}
@@ -613,71 +604,61 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
         //
         // FIXME(pcwalton): Isolate this unsafety into the `wrapper` module to allow
         // enforced safe, race-free access to the parent style.
-        let (down_restyle_damage, parent_style) = match parent {
-            None => (RestyleDamage::empty(), None),
+        let parent_style = match parent {
+            None => None,
             Some(parent_node) => {
                 let parent_layout_data = parent_node.borrow_layout_data_unchecked();
                 match *parent_layout_data {
                     None => fail!("no parent data?!"),
                     Some(ref parent_layout_data) => {
-                        let down_restyle_damage =
-                            parent_layout_data.data.restyle_damage.propagate_down();
                         match parent_layout_data.shared_data.style {
                             None => fail!("parent hasn't been styled yet?!"),
-                            Some(ref style) => (down_restyle_damage, Some(style)),
+                            Some(ref style) => Some(style),
                         }
                     }
                 }
             }
         };
 
-        let mut damage = down_restyle_damage;
-
-        {
-            let mut layout_data_ref = self.mutate_layout_data();
-            match &mut *layout_data_ref {
-                &None => fail!("no layout data"),
-                &Some(ref mut layout_data) => {
-                    match self.type_id() {
-                        Some(TextNodeTypeId) => {
-                            // Text nodes get a copy of the parent style. This ensures
-                            // that during fragment construction any non-inherited
-                            // CSS properties (such as vertical-align) are correctly
-                            // set on the fragment(s).
-                            let cloned_parent_style = parent_style.unwrap().clone();
-                            layout_data.shared_data.style = Some(cloned_parent_style);
+        let mut layout_data_ref = self.mutate_layout_data();
+        match &mut *layout_data_ref {
+            &None => fail!("no layout data"),
+            &Some(ref mut layout_data) => {
+                match self.type_id() {
+                    Some(TextNodeTypeId) => {
+                        // Text nodes get a copy of the parent style. This ensures
+                        // that during fragment construction any non-inherited
+                        // CSS properties (such as vertical-align) are correctly
+                        // set on the fragment(s).
+                        let cloned_parent_style = parent_style.unwrap().clone();
+                        layout_data.shared_data.style = Some(cloned_parent_style);
+                    }
+                    _ => {
+                        self.cascade_node_pseudo_element(
+                            parent_style,
+                            applicable_declarations.normal.as_slice(),
+                            &mut layout_data.shared_data.style,
+                            applicable_declarations_cache,
+                            applicable_declarations.normal_shareable);
+                        if applicable_declarations.before.len() > 0 {
+                               self.cascade_node_pseudo_element(
+                                   Some(layout_data.shared_data.style.as_ref().unwrap()),
+                                   applicable_declarations.before.as_slice(),
+                                   &mut layout_data.data.before_style,
+                                   applicable_declarations_cache,
+                                   false);
                         }
-                        _ => {
-                            damage = damage
-                                   | self.cascade_node_pseudo_element(
-                                          parent_style,
-                                          applicable_declarations.normal.as_slice(),
-                                          &mut layout_data.shared_data.style,
-                                          applicable_declarations_cache,
-                                          applicable_declarations.normal_shareable);
-                            if applicable_declarations.before.len() > 0 {
-                                damage = damage
-                                       | self.cascade_node_pseudo_element(
-                                           Some(layout_data.shared_data.style.as_ref().unwrap()),
-                                           applicable_declarations.before.as_slice(),
-                                           &mut layout_data.data.before_style,
-                                           applicable_declarations_cache,
-                                           false);
-                            }
-                            if applicable_declarations.after.len() > 0 {
-                                damage = damage
-                                       | self.cascade_node_pseudo_element(Some(layout_data.shared_data.style.as_ref().unwrap()),
-                                           applicable_declarations.after.as_slice(),
-                                           &mut layout_data.data.after_style,
-                                           applicable_declarations_cache,
-                                           false);
-                            }
+                        if applicable_declarations.after.len() > 0 {
+                               self.cascade_node_pseudo_element(
+                                   Some(layout_data.shared_data.style.as_ref().unwrap()),
+                                   applicable_declarations.after.as_slice(),
+                                   &mut layout_data.data.after_style,
+                                   applicable_declarations_cache,
+                                   false);
                         }
                     }
                 }
             }
         }
-
-        ThreadSafeLayoutNode::new(self).set_restyle_damage(damage);
     }
 }

--- a/components/layout/css/node_style.rs
+++ b/components/layout/css/node_style.rs
@@ -14,7 +14,8 @@ use sync::Arc;
 /// Node mixin providing `style` method that returns a `NodeStyle`
 pub trait StyledNode {
     fn style<'a>(&'a self) -> &'a Arc<ComputedValues>;
-    fn restyle_damage(&self) -> RestyleDamage;
+    fn restyle_damage(self) -> RestyleDamage;
+    fn set_restyle_damage(self, damage: RestyleDamage);
 }
 
 impl<'ln> StyledNode for ThreadSafeLayoutNode<'ln> {
@@ -23,8 +24,14 @@ impl<'ln> StyledNode for ThreadSafeLayoutNode<'ln> {
         self.get_css_select_results()
     }
 
-    fn restyle_damage(&self) -> RestyleDamage {
+    fn restyle_damage(self) -> RestyleDamage {
         self.get_restyle_damage()
     }
-}
 
+    fn set_restyle_damage(self, damage: RestyleDamage) {
+        fn doit<N: NodeUtil>(n: N, damage: RestyleDamage) {
+            n.set_restyle_damage(damage);
+        }
+        doit(self, damage);
+    }
+}

--- a/components/layout/css/node_util.rs
+++ b/components/layout/css/node_util.rs
@@ -4,7 +4,7 @@
 
 use incremental::RestyleDamage;
 use util::LayoutDataAccess;
-use wrapper::{TLayoutNode, ThreadSafeLayoutNode};
+use wrapper::ThreadSafeLayoutNode;
 use wrapper::{After, Before, Normal};
 use std::mem;
 use style::ComputedValues;
@@ -14,8 +14,8 @@ pub trait NodeUtil {
     fn get_css_select_results<'a>(&'a self) -> &'a Arc<ComputedValues>;
     fn have_css_select_results(&self) -> bool;
 
-    fn get_restyle_damage(&self) -> RestyleDamage;
-    fn set_restyle_damage(&self, damage: RestyleDamage);
+    fn get_restyle_damage(self) -> RestyleDamage;
+    fn set_restyle_damage(self, damage: RestyleDamage);
 }
 
 impl<'ln> NodeUtil for ThreadSafeLayoutNode<'ln> {
@@ -62,28 +62,19 @@ impl<'ln> NodeUtil for ThreadSafeLayoutNode<'ln> {
 
     /// Get the description of how to account for recent style changes.
     /// This is a simple bitfield and fine to copy by value.
-    fn get_restyle_damage(&self) -> RestyleDamage {
-        // For DOM elements, if we haven't computed damage yet, assume the worst.
-        // Other nodes don't have styles.
-        let default = if self.node_is_element() {
-            RestyleDamage::all()
-        } else {
-            RestyleDamage::empty()
-        };
-
+    fn get_restyle_damage(self) -> RestyleDamage {
         let layout_data_ref = self.borrow_layout_data();
         layout_data_ref
             .as_ref().unwrap()
             .data
             .restyle_damage
-            .unwrap_or(default)
     }
 
     /// Set the restyle damage field.
-    fn set_restyle_damage(&self, damage: RestyleDamage) {
+    fn set_restyle_damage(self, damage: RestyleDamage) {
         let mut layout_data_ref = self.mutate_layout_data();
         match &mut *layout_data_ref {
-            &Some(ref mut layout_data) => layout_data.data.restyle_damage = Some(damage),
+            &Some(ref mut layout_data) => layout_data.data.restyle_damage = damage,
             _ => fail!("no layout data for this node"),
         }
     }

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -190,6 +190,10 @@ impl Floats {
         }
     }
 
+    pub fn len(&self) -> uint {
+        self.list.list.as_ref().map(|list| list.floats.len()).unwrap_or(0)
+    }
+
     /// Returns a rectangle that encloses the region from block-start to block-start + block-size, with inline-size small
     /// enough that it doesn't collide with any floats. max_x is the x-coordinate beyond which
     /// floats have no effect. (Generally this is the containing block inline-size.)
@@ -437,4 +441,3 @@ impl Floats {
         clearance
     }
 }
-

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -471,6 +471,13 @@ pub trait PreorderFlowTraversal {
     /// The operation to perform. Return true to continue or false to stop.
     fn process(&mut self, flow: &mut Flow) -> bool;
 
+    /// Returns true if this node must be processed in-order. If this returns false,
+    /// we skip the operation for this node, but continue processing the descendants.
+    /// This is called *after* parent nodes are visited.
+    fn should_process(&mut self, _flow: &mut Flow) -> bool {
+        true
+    }
+
     /// Returns true if this node should be pruned. If this returns true, we skip the operation
     /// entirely and do not process any descendant nodes. This is called *before* child nodes are
     /// visited. The default implementation never prunes any nodes.
@@ -1031,6 +1038,10 @@ impl<'a> MutableFlowUtils for &'a mut Flow + 'a {
             return true
         }
 
+        if !traversal.should_process(self) {
+            return true
+        }
+
         if !traversal.process(self) {
             return false
         }
@@ -1240,4 +1251,3 @@ impl ContainingBlockLink {
         }
     }
 }
-

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -13,7 +13,6 @@ use floats::{ClearBoth, ClearLeft, ClearRight, ClearType};
 use flow::Flow;
 use flow;
 use flow_ref::FlowRef;
-use incremental::RestyleDamage;
 use inline::{InlineFragmentContext, InlineMetrics};
 use layout_debug;
 use model::{Auto, IntrinsicISizes, MaybeAuto, Specified, specified};
@@ -88,9 +87,6 @@ pub struct Fragment {
 
     /// The CSS style of this fragment.
     pub style: Arc<ComputedValues>,
-
-    /// The incremental damage done to this fragment during the current layout round.
-    pub restyle_damage: RestyleDamage,
 
     /// The position of this fragment relative to its owning flow.
     /// The size includes padding and border, but not margin.
@@ -444,7 +440,6 @@ impl Fragment {
         Fragment {
             node: OpaqueNodeMethods::from_thread_safe_layout_node(node),
             style: style,
-            restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -463,7 +458,6 @@ impl Fragment {
         Fragment {
             node: OpaqueNodeMethods::from_thread_safe_layout_node(node),
             style: style,
-            restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -490,7 +484,6 @@ impl Fragment {
         Fragment {
             node: OpaqueNodeMethods::from_thread_safe_layout_node(node),
             style: Arc::new(node_style),
-            restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -504,14 +497,12 @@ impl Fragment {
     /// Constructs a new `Fragment` instance from an opaque node.
     pub fn from_opaque_node_and_style(node: OpaqueNode,
                                       style: Arc<ComputedValues>,
-                                      restyle_damage: RestyleDamage,
                                       specific: SpecificFragmentInfo)
                                       -> Fragment {
         let writing_mode = style.writing_mode;
         Fragment {
             node: node,
             style: style,
-            restyle_damage: restyle_damage,
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -534,7 +525,6 @@ impl Fragment {
         Fragment {
             node: self.node,
             style: self.style.clone(),
-            restyle_damage: self.restyle_damage,
             border_box: LogicalRect::from_point_size(
                 self.style.writing_mode, self.border_box.start, size),
             border_padding: self.border_padding,

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -13,6 +13,7 @@ use floats::{ClearBoth, ClearLeft, ClearRight, ClearType};
 use flow::Flow;
 use flow;
 use flow_ref::FlowRef;
+use incremental::RestyleDamage;
 use inline::{InlineFragmentContext, InlineMetrics};
 use layout_debug;
 use model::{Auto, IntrinsicISizes, MaybeAuto, Specified, specified};
@@ -35,13 +36,14 @@ use gfx::display_list::{Upright, SidewaysLeft, SidewaysRight};
 use gfx::font::FontStyle;
 use gfx::text::glyph::CharIndex;
 use gfx::text::text_run::TextRun;
+use script_traits::UntrustedNodeAddress;
 use serialize::{Encodable, Encoder};
 use servo_msg::constellation_msg::{ConstellationChan, FrameRectMsg, PipelineId, SubpageId};
 use servo_net::image::holder::ImageHolder;
 use servo_net::local_image_cache::LocalImageCache;
 use servo_util::geometry::Au;
 use servo_util::geometry;
-use servo_util::logical_geometry::{LogicalRect, LogicalSize, LogicalMargin};
+use servo_util::logical_geometry::{LogicalRect, LogicalSize, LogicalMargin, WritingMode};
 use servo_util::range::*;
 use servo_util::smallvec::SmallVec;
 use servo_util::str::is_whitespace;
@@ -86,6 +88,9 @@ pub struct Fragment {
 
     /// The CSS style of this fragment.
     pub style: Arc<ComputedValues>,
+
+    /// The incremental damage done to this fragment during the current layout round.
+    pub restyle_damage: RestyleDamage,
 
     /// The position of this fragment relative to its owning flow.
     /// The size includes padding and border, but not margin.
@@ -202,7 +207,8 @@ impl InputFragmentInfo {
 #[deriving(Clone)]
 pub struct ImageFragmentInfo {
     /// The image held within this fragment.
-    pub image: ImageHolder,
+    pub image: ImageHolder<UntrustedNodeAddress>,
+    pub for_node: UntrustedNodeAddress,
     pub computed_inline_size: Option<Au>,
     pub computed_block_size: Option<Au>,
     pub dom_inline_size: Option<Au>,
@@ -217,7 +223,7 @@ impl ImageFragmentInfo {
     /// me.
     pub fn new(node: &ThreadSafeLayoutNode,
                image_url: Url,
-               local_image_cache: Arc<Mutex<LocalImageCache>>)
+               local_image_cache: Arc<Mutex<LocalImageCache<UntrustedNodeAddress>>>)
                -> ImageFragmentInfo {
         fn convert_length(node: &ThreadSafeLayoutNode, name: &str) -> Option<Au> {
             let element = node.as_element();
@@ -230,8 +236,13 @@ impl ImageFragmentInfo {
         let is_vertical = node.style().writing_mode.is_vertical();
         let dom_width = convert_length(node, "width");
         let dom_height = convert_length(node, "height");
+
+        let opaque_node: OpaqueNode = OpaqueNodeMethods::from_thread_safe_layout_node(node);
+        let untrusted_node: UntrustedNodeAddress = opaque_node.to_untrusted_node_address();
+
         ImageFragmentInfo {
             image: ImageHolder::new(image_url, local_image_cache),
+            for_node: untrusted_node,
             computed_inline_size: None,
             computed_block_size: None,
             dom_inline_size: if is_vertical { dom_height } else { dom_width },
@@ -252,13 +263,13 @@ impl ImageFragmentInfo {
 
     /// Returns the original inline-size of the image.
     pub fn image_inline_size(&mut self) -> Au {
-        let size = self.image.get_size().unwrap_or(Size2D::zero());
+        let size = self.image.get_size(self.for_node).unwrap_or(Size2D::zero());
         Au::from_px(if self.writing_mode_is_vertical { size.height } else { size.width })
     }
 
     /// Returns the original block-size of the image.
     pub fn image_block_size(&mut self) -> Au {
-        let size = self.image.get_size().unwrap_or(Size2D::zero());
+        let size = self.image.get_size(self.for_node).unwrap_or(Size2D::zero());
         Au::from_px(if self.writing_mode_is_vertical { size.width } else { size.height })
     }
 
@@ -433,6 +444,7 @@ impl Fragment {
         Fragment {
             node: OpaqueNodeMethods::from_thread_safe_layout_node(node),
             style: style,
+            restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -451,6 +463,7 @@ impl Fragment {
         Fragment {
             node: OpaqueNodeMethods::from_thread_safe_layout_node(node),
             style: style,
+            restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -477,6 +490,7 @@ impl Fragment {
         Fragment {
             node: OpaqueNodeMethods::from_thread_safe_layout_node(node),
             style: Arc::new(node_style),
+            restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -490,12 +504,14 @@ impl Fragment {
     /// Constructs a new `Fragment` instance from an opaque node.
     pub fn from_opaque_node_and_style(node: OpaqueNode,
                                       style: Arc<ComputedValues>,
+                                      restyle_damage: RestyleDamage,
                                       specific: SpecificFragmentInfo)
                                       -> Fragment {
         let writing_mode = style.writing_mode;
         Fragment {
             node: node,
             style: style,
+            restyle_damage: restyle_damage,
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
@@ -518,6 +534,7 @@ impl Fragment {
         Fragment {
             node: self.node,
             style: self.style.clone(),
+            restyle_damage: self.restyle_damage,
             border_box: LogicalRect::from_point_size(
                 self.style.writing_mode, self.border_box.start, size),
             border_padding: self.border_padding,
@@ -805,7 +822,7 @@ impl Fragment {
         };
 
         let mut holder = ImageHolder::new(image_url.clone(), layout_context.shared.image_cache.clone());
-        let image = match holder.get_image() {
+        let image = match holder.get_image(self.node.to_untrusted_node_address()) {
             None => {
                 // No image data at all? Do nothing.
                 //
@@ -987,7 +1004,7 @@ impl Fragment {
     /// * `layout_context`: The layout context.
     /// * `dirty`: The dirty rectangle in the coordinate system of the owning flow.
     /// * `flow_origin`: Position of the origin of the owning flow wrt the display list root flow.
-    pub fn build_display_list(&self,
+    pub fn build_display_list(&mut self,
                               display_list: &mut DisplayList,
                               layout_context: &LayoutContext,
                               flow_origin: Point2D<Au>,
@@ -995,12 +1012,12 @@ impl Fragment {
                               -> ChildDisplayListAccumulator {
         // FIXME(#2795): Get the real container size
         let container_size = Size2D::zero();
-        let rect_to_absolute = |logical_rect: LogicalRect<Au>| {
-            let physical_rect = logical_rect.to_physical(self.style.writing_mode, container_size);
+        let rect_to_absolute = |writing_mode: WritingMode, logical_rect: LogicalRect<Au>| {
+            let physical_rect = logical_rect.to_physical(writing_mode, container_size);
             Rect(physical_rect.origin + flow_origin, physical_rect.size)
         };
         // Fragment position wrt to the owning flow.
-        let absolute_fragment_bounds = rect_to_absolute(self.border_box);
+        let absolute_fragment_bounds = rect_to_absolute(self.style.writing_mode, self.border_box);
         debug!("Fragment::build_display_list at rel={}, abs={}: {}",
                self.border_box,
                absolute_fragment_bounds,
@@ -1088,7 +1105,7 @@ impl Fragment {
         }
 
         let content_box = self.content_box();
-        let absolute_content_box = rect_to_absolute(content_box);
+        let absolute_content_box = rect_to_absolute(self.style.writing_mode, content_box);
 
         // Create special per-fragment-type display items.
         match self.specific {
@@ -1133,7 +1150,7 @@ impl Fragment {
                                 accumulator.push(display_list, SolidColorDisplayItemClass(
                                     box SolidColorDisplayItem {
                                         base: BaseDisplayItem::new(
-                                            rect_to_absolute(rect()),
+                                            rect_to_absolute(self.style.writing_mode, rect()),
                                             self.node, ContentStackingLevel),
                                         color: color.to_gfx_color(),
                                     }
@@ -1182,9 +1199,9 @@ impl Fragment {
             }
             ImageFragment(_) => {
                 match self.specific {
-                    ImageFragment(ref image_fragment) => {
-                        let image_ref = &image_fragment.image;
-                        match image_ref.get_image_if_present() {
+                    ImageFragment(ref mut image_fragment) => {
+                        let image_ref = &mut image_fragment.image;
+                        match image_ref.get_image(self.node.to_untrusted_node_address()) {
                             Some(image) => {
                                 debug!("(building display list) building image fragment");
 
@@ -1437,7 +1454,7 @@ impl Fragment {
                     let advance = metrics.advance_width;
 
                     let should_continue;
-                    if advance <= remaining_inline_size {
+                    if advance <= remaining_inline_size || glyphs.is_whitespace() {
                         should_continue = true;
 
                         if starts_line && pieces_processed_count == 0 && glyphs.is_whitespace() {
@@ -1452,21 +1469,8 @@ impl Fragment {
                         // The advance is more than the remaining inline-size.
                         should_continue = false;
                         let slice_begin = offset + slice_range.begin();
-                        let slice_end = offset + slice_range.end();
 
-                        if glyphs.is_whitespace() {
-                            // If there are still things after the trimmable whitespace, create the
-                            // inline-end chunk.
-                            if slice_end < text_fragment_info.range.end() {
-                                debug!("split_to_inline_size: case=skipping trimmable trailing \
-                                        whitespace, then split remainder");
-                                let inline_end_range_end = text_fragment_info.range.end() - slice_end;
-                                inline_end_range = Some(Range::new(slice_end, inline_end_range_end));
-                            } else {
-                                debug!("split_to_inline_size: case=skipping trimmable trailing \
-                                        whitespace");
-                            }
-                        } else if slice_begin < text_fragment_info.range.end() {
+                        if slice_begin < text_fragment_info.range.end() {
                             // There are still some things inline-start over at the end of the line. Create
                             // the inline-end chunk.
                             let inline_end_range_end = text_fragment_info.range.end() - slice_begin;

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -11,7 +11,6 @@ use flow::{BaseFlow, FlowClass, Flow, InlineFlowClass, MutableFlowUtils};
 use flow;
 use fragment::{Fragment, InlineBlockFragment, ScannedTextFragment, ScannedTextFragmentInfo};
 use fragment::{SplitInfo};
-use incremental;
 use layout_debug;
 use model::IntrinsicISizes;
 use text;
@@ -764,22 +763,13 @@ pub struct InlineFlow {
 
 impl InlineFlow {
     pub fn from_fragments(node: ThreadSafeLayoutNode, fragments: InlineFragments) -> InlineFlow {
-        let fragment_damage =
-            fragments.fragments.iter().fold(
-                incremental::RestyleDamage::empty(),
-                |dmg, frag| dmg | frag.restyle_damage);
-
-        let mut ret = InlineFlow {
+        InlineFlow {
             base: BaseFlow::new(node),
             fragments: fragments,
             lines: Vec::new(),
             minimum_block_size_above_baseline: Au(0),
             minimum_depth_below_baseline: Au(0),
-        };
-
-        ret.base.restyle_damage.insert(fragment_damage);
-
-        ret
+        }
     }
 
     pub fn build_display_list_inline(&mut self, layout_context: &LayoutContext) {

--- a/components/layout/util.rs
+++ b/components/layout/util.rs
@@ -13,7 +13,8 @@ use libc::uintptr_t;
 use script::dom::bindings::js::JS;
 use script::dom::bindings::utils::Reflectable;
 use script::dom::node::{Node, SharedLayoutData};
-use script::layout_interface::{LayoutChan, UntrustedNodeAddress, TrustedNodeAddress};
+use script::layout_interface::{LayoutChan, TrustedNodeAddress};
+use script_traits::UntrustedNodeAddress;
 use std::mem;
 use std::cell::{Ref, RefMut};
 use style::ComputedValues;
@@ -29,7 +30,7 @@ pub struct PrivateLayoutData {
     pub after_style: Option<Arc<ComputedValues>>,
 
     /// Description of how to account for recent style changes.
-    pub restyle_damage: Option<RestyleDamage>,
+    pub restyle_damage: RestyleDamage,
 
     /// The current results of flow construction for this node. This is either a flow or a
     /// `ConstructionItem`. See comments in `construct.rs` for more details.
@@ -49,7 +50,7 @@ impl PrivateLayoutData {
         PrivateLayoutData {
             before_style: None,
             after_style: None,
-            restyle_damage: None,
+            restyle_damage: RestyleDamage::empty(),
             flow_construction_result: NoConstructionResult,
             before_flow_construction_result: NoConstructionResult,
             after_flow_construction_result: NoConstructionResult,
@@ -161,4 +162,3 @@ impl ToGfxColor for style::computed_values::RGBA {
         gfx::color::rgba(self.red, self.green, self.blue, self.alpha)
     }
 }
-

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -227,8 +227,8 @@ impl ImageCache {
         }
     }
 
-    fn get_state(&self, url: Url) -> ImageState {
-        match self.state_map.find(&url) {
+    fn get_state(&self, url: &Url) -> ImageState {
+        match self.state_map.find(url) {
             Some(state) => state.clone(),
             None => Init
         }
@@ -239,7 +239,7 @@ impl ImageCache {
     }
 
     fn prefetch(&mut self, url: Url) {
-        match self.get_state(url.clone()) {
+        match self.get_state(&url) {
             Init => {
                 let to_cache = self.chan.clone();
                 let resource_task = self.resource_task.clone();
@@ -270,7 +270,7 @@ impl ImageCache {
     }
 
     fn store_prefetched_image_data(&mut self, url: Url, data: Result<Vec<u8>, ()>) {
-        match self.get_state(url.clone()) {
+        match self.get_state(&url) {
           Prefetching(next_step) => {
             match data {
               Ok(data) => {
@@ -298,7 +298,7 @@ impl ImageCache {
     }
 
     fn decode(&mut self, url: Url) {
-        match self.get_state(url.clone()) {
+        match self.get_state(&url) {
             Init => fail!("decoding image before prefetch"),
 
             Prefetching(DoNotDecode) => {
@@ -338,7 +338,7 @@ impl ImageCache {
 
     fn store_image(&mut self, url: Url, image: Option<Arc<Box<Image>>>) {
 
-        match self.get_state(url.clone()) {
+        match self.get_state(&url) {
           Decoding => {
             match image {
               Some(image) => {
@@ -376,7 +376,7 @@ impl ImageCache {
     }
 
     fn get_image(&self, url: Url, response: Sender<ImageResponseMsg>) {
-        match self.get_state(url.clone()) {
+        match self.get_state(&url) {
             Init => fail!("request for image before prefetch"),
             Prefetching(DoDecode) => response.send(ImageNotReady),
             Prefetching(DoNotDecode) | Prefetched(..) => fail!("request for image before decode"),
@@ -387,7 +387,7 @@ impl ImageCache {
     }
 
     fn wait_for_image(&mut self, url: Url, response: Sender<ImageResponseMsg>) {
-        match self.get_state(url.clone()) {
+        match self.get_state(&url) {
             Init => fail!("request for image before prefetch"),
 
             Prefetching(DoNotDecode) | Prefetched(..) => fail!("request for image before decode"),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -49,8 +49,10 @@ use http::headers::response::HeaderCollection as ResponseHeaderCollection;
 use http::headers::request::HeaderCollection as RequestHeaderCollection;
 use http::method::Method;
 use std::io::timer::Timer;
+use script_traits::UntrustedNodeAddress;
 use servo_msg::compositor_msg::ScriptListener;
 use servo_msg::constellation_msg::ConstellationChan;
+use servo_util::smallvec::{SmallVec1, SmallVec};
 use layout_interface::{LayoutRPC, LayoutChan};
 use dom::bindings::utils::WindowProxyHandler;
 
@@ -148,6 +150,17 @@ impl<T: JSTraceable> JSTraceable for Vec<T> {
     }
 }
 
+// XXXManishearth Check if the following three are optimized to no-ops
+// if e.trace() is a no-op (e.g it is an untraceable type)
+impl<T: JSTraceable + 'static> JSTraceable for SmallVec1<T> {
+    #[inline]
+    fn trace(&self, trc: *mut JSTracer) {
+        for e in self.iter() {
+            e.trace(trc);
+        }
+    }
+}
+
 impl<T: JSTraceable> JSTraceable for Option<T> {
     #[inline]
     fn trace(&self, trc: *mut JSTracer) {
@@ -192,6 +205,7 @@ untraceable!(ResponseHeaderCollection, RequestHeaderCollection, Method)
 untraceable!(ConstellationChan)
 untraceable!(LayoutChan)
 untraceable!(WindowProxyHandler)
+untraceable!(UntrustedNodeAddress)
 
 impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -54,7 +54,6 @@ use dom::uievent::UIEvent;
 use dom::window::{Window, WindowHelpers};
 use html::hubbub_html_parser::build_element_from_tag;
 use hubbub::hubbub::{QuirksMode, NoQuirks, LimitedQuirks, FullQuirks};
-use layout_interface::{DocumentDamageLevel, ContentChangedDocumentDamage};
 use servo_util::namespace;
 use servo_util::str::{DOMString, split_html_space_chars};
 
@@ -165,8 +164,8 @@ pub trait DocumentHelpers<'a> {
     fn set_quirks_mode(self, mode: QuirksMode);
     fn set_last_modified(self, value: DOMString);
     fn set_encoding_name(self, name: DOMString);
-    fn content_changed(self);
-    fn damage_and_reflow(self, damage: DocumentDamageLevel);
+    fn content_changed(self, node: JSRef<Node>);
+    fn reflow(self);
     fn wait_until_safe_to_modify_dom(self);
     fn unregister_named_element(self, to_unregister: JSRef<Element>, id: Atom);
     fn register_named_element(self, element: JSRef<Element>, id: Atom);
@@ -195,18 +194,18 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         *self.encoding_name.borrow_mut() = name;
     }
 
-    fn content_changed(self) {
-        self.damage_and_reflow(ContentChangedDocumentDamage);
+    fn content_changed(self, node: JSRef<Node>) {
+        node.dirty();
+        self.reflow();
     }
 
-    fn damage_and_reflow(self, damage: DocumentDamageLevel) {
-        self.window.root().damage_and_reflow(damage);
+    fn reflow(self) {
+        self.window.root().reflow();
     }
 
     fn wait_until_safe_to_modify_dom(self) {
         self.window.root().wait_until_safe_to_modify_dom();
     }
-
 
     /// Remove any existing association between the provided id and any elements in this document.
     fn unregister_named_element(self,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -28,8 +28,6 @@ use dom::node::{ElementNodeTypeId, Node, NodeHelpers, NodeIterator, document_fro
 use dom::node::{window_from_node, LayoutNodeHelpers};
 use dom::nodelist::NodeList;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
-use layout_interface::ContentChangedDocumentDamage;
-use layout_interface::MatchSelectorsDocumentDamage;
 use devtools_traits::AttrInfo;
 use style::{matches, parse_selector_list_from_str};
 use style;
@@ -323,6 +321,7 @@ pub trait AttributeHandlers {
     fn remove_attribute(self, namespace: Namespace, name: &str);
     fn notify_attribute_changed(self, local_name: &Atom);
     fn has_class(&self, name: &str) -> bool;
+    fn notify_attribute_removed(self);
 
     fn set_atomic_attribute(self, name: &str, value: DOMString);
 
@@ -436,19 +435,24 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
                 }
 
                 self.attrs.borrow_mut().remove(idx);
+                self.notify_attribute_removed();
             }
         };
     }
 
-    fn notify_attribute_changed(self, local_name: &Atom) {
+    fn notify_attribute_changed(self, _local_name: &Atom) {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         if node.is_in_doc() {
-            let damage = match local_name.as_slice() {
-                "style" | "id" | "class" => MatchSelectorsDocumentDamage,
-                _ => ContentChangedDocumentDamage
-            };
             let document = node.owner_doc().root();
-            document.damage_and_reflow(damage);
+            document.content_changed(node);
+        }
+    }
+
+    fn notify_attribute_removed(self) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
+        if node.is_in_doc() {
+            let document = node.owner_doc().root();
+            document.content_changed(node);
         }
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -175,7 +175,8 @@ fn broadcast_radio_checked(broadcaster: JSRef<HTMLInputElement>, group: Option<&
 impl<'a> HTMLInputElementHelpers for JSRef<'a, HTMLInputElement> {
     fn force_relayout(self) {
         let doc = document_from_node(self).root();
-        doc.content_changed()
+        let node: JSRef<Node> = NodeCast::from_ref(self);
+        doc.content_changed(node)
     }
 
     fn radio_group_updated(self, group: Option<&str>) {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -14,11 +14,10 @@ use geom::point::Point2D;
 use geom::rect::Rect;
 use js::jsapi::JSTracer;
 use libc::c_void;
-use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel};
+use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel, UntrustedNodeAddress};
 use servo_msg::constellation_msg::WindowSizeData;
 use servo_util::geometry::Au;
 use std::any::{Any, AnyRefExt};
-use std::cmp;
 use std::comm::{channel, Receiver, Sender};
 use std::owned::BoxAny;
 use style::Stylesheet;
@@ -85,47 +84,13 @@ impl JSTraceable for TrustedNodeAddress {
     }
 }
 
-/// The address of a node. Layout sends these back. They must be validated via
-/// `from_untrusted_node_address` before they can be used, because we do not trust layout.
-pub type UntrustedNodeAddress = *const c_void;
-
 pub struct ContentBoxResponse(pub Rect<Au>);
 pub struct ContentBoxesResponse(pub Vec<Rect<Au>>);
 pub struct HitTestResponse(pub UntrustedNodeAddress);
 pub struct MouseOverResponse(pub Vec<UntrustedNodeAddress>);
 
-/// Determines which part of the
-#[deriving(PartialEq, PartialOrd, Eq, Ord)]
-#[jstraceable]
-pub enum DocumentDamageLevel {
-    /// Reflow, but do not perform CSS selector matching.
-    ReflowDocumentDamage,
-    /// Perform CSS selector matching and reflow.
-    MatchSelectorsDocumentDamage,
-    /// Content changed; set full style damage and do the above.
-    ContentChangedDocumentDamage,
-}
-
-impl DocumentDamageLevel {
-    /// Sets this damage to the maximum of this damage and the given damage.
-    pub fn add(&mut self, new_damage: DocumentDamageLevel) {
-        *self = cmp::max(*self, new_damage);
-    }
-}
-
-/// What parts of the document have changed, as far as the script task can tell.
-///
-/// Note that this is fairly coarse-grained and is separate from layout's notion of the document
-#[jstraceable]
-pub struct DocumentDamage {
-    /// The topmost node in the tree that has changed.
-    pub root: TrustedNodeAddress,
-    /// The amount of damage that occurred.
-    pub level: DocumentDamageLevel,
-}
-
 /// Why we're doing reflow.
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Show)]
 pub enum ReflowGoal {
     /// We're reflowing in order to send a display list to the screen.
     ReflowForDisplay,
@@ -137,8 +102,6 @@ pub enum ReflowGoal {
 pub struct Reflow {
     /// The document node.
     pub document_root: TrustedNodeAddress,
-    /// The style changes that need to be done.
-    pub damage: DocumentDamage,
     /// The goal of reflow: either to render to the screen or to flush layout info for script.
     pub goal: ReflowGoal,
     /// The URL of the page.
@@ -189,22 +152,4 @@ impl ScriptLayoutChan for OpaqueScriptLayoutChannel {
         let OpaqueScriptLayoutChannel((_, receiver)) = self;
         *receiver.downcast::<Receiver<Msg>>().unwrap()
     }
-}
-
-#[test]
-fn test_add_damage() {
-    fn assert_add(mut a: DocumentDamageLevel, b: DocumentDamageLevel,
-                  result: DocumentDamageLevel) {
-        a.add(b);
-        assert!(a == result);
-    }
-
-    assert_add(ReflowDocumentDamage, ReflowDocumentDamage, ReflowDocumentDamage);
-    assert_add(ContentChangedDocumentDamage, ContentChangedDocumentDamage, ContentChangedDocumentDamage);
-    assert_add(ReflowDocumentDamage, MatchSelectorsDocumentDamage, MatchSelectorsDocumentDamage);
-    assert_add(MatchSelectorsDocumentDamage, ReflowDocumentDamage, MatchSelectorsDocumentDamage);
-    assert_add(ReflowDocumentDamage, ContentChangedDocumentDamage, ContentChangedDocumentDamage);
-    assert_add(ContentChangedDocumentDamage, ReflowDocumentDamage, ContentChangedDocumentDamage);
-    assert_add(MatchSelectorsDocumentDamage, ContentChangedDocumentDamage, ContentChangedDocumentDamage);
-    assert_add(ContentChangedDocumentDamage, MatchSelectorsDocumentDamage, ContentChangedDocumentDamage);
 }

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -13,6 +13,9 @@ path = "../msg"
 [dependencies.net]
 path = "../net"
 
+[dependencies.util]
+path = "../util"
+
 [dependencies.devtools_traits]
 path = "../devtools_traits"
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -9,8 +9,10 @@
 
 extern crate devtools_traits;
 extern crate geom;
+extern crate libc;
 extern crate "msg" as servo_msg;
 extern crate "net" as servo_net;
+extern crate "util" as servo_util;
 extern crate url;
 extern crate serialize;
 
@@ -20,17 +22,23 @@ extern crate serialize;
 //   that these modules won't have to depend on script.
 
 use devtools_traits::DevtoolsControlChan;
+use libc::c_void;
 use servo_msg::constellation_msg::{ConstellationChan, PipelineId, Failure, WindowSizeData};
 use servo_msg::constellation_msg::SubpageId;
 use servo_msg::compositor_msg::ScriptListener;
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
+use servo_util::smallvec::SmallVec1;
 use std::any::Any;
 use url::Url;
 
 use geom::point::Point2D;
 
 use serialize::{Encodable, Encoder};
+
+/// The address of a node. Layout sends these back. They must be validated via
+/// `from_untrusted_node_address` before they can be used, because we do not trust layout.
+pub type UntrustedNodeAddress = *const c_void;
 
 pub struct NewLayoutInfo {
     pub old_pipeline_id: PipelineId,
@@ -60,7 +68,7 @@ pub enum ConstellationControlMsg {
 /// Events from the compositor that the script task needs to know about
 pub enum CompositorEvent {
     ResizeEvent(WindowSizeData),
-    ReflowEvent,
+    ReflowEvent(SmallVec1<UntrustedNodeAddress>),
     ClickEvent(uint, Point2D<f32>),
     MouseDownEvent(uint, Point2D<f32>),
     MouseUpEvent(uint, Point2D<f32>),

--- a/components/style/node.rs
+++ b/components/style/node.rs
@@ -19,6 +19,12 @@ pub trait TNode<'a, E: TElement<'a>> : Clone + Copy {
     fn as_element(self) -> E;
     fn match_attr(self, attr: &AttrSelector, test: |&str| -> bool) -> bool;
     fn is_html_element_in_html_document(self) -> bool;
+
+    fn is_dirty(self) -> bool;
+    unsafe fn set_dirty(self, value: bool);
+
+    fn has_dirty_descendants(self) -> bool;
+    unsafe fn set_dirty_descendants(self, value: bool);
 }
 
 pub trait TElement<'a> : Copy {


### PR DESCRIPTION
This patch puts in the initial framework for incremental reflow. Nodes' styles
are no longer recalculated unless the node has changed.

I've been hacking on the general problem of incremental reflow for the past
couple weeks, and I've yet to get a full implementation that actually passes all
the reftests + wikipedia + cnn. Therefore, I'm going to try to land the different
parts of it one by one.

This patch only does incremental style recalc, without incremental flow
construction, inline-size bubbling, reflow, or display lists. Those will be coming
in that order as I finish them.

At least with this strategy, I can land a working version of incremental reflow,
even if not yet complete.

r? @pcwalton
