### PR TITLE
Silence unused_mut warnings in generated style/properties/mod.rs

### DIFF
--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1855,6 +1855,7 @@ impl<T: Send + Sync + Clone> ArcExperimental<T> for Arc<T> {
 }
 
 /// Fast path for the function below. Only computes new inherited styles.
+#[allow(unused_mut)]
 fn cascade_with_cached_declarations(applicable_declarations: &[DeclarationBlock],
                                     shareable: bool,
                                     parent_style: &ComputedValues,


### PR DESCRIPTION
I would have put the attribute on the binding itself, but that doesn't
appear to be possible yet.
