### PR TITLE
layout: Mark the styles of elements with pseudos as unshareable.

### DIFF
--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -16,8 +16,8 @@ use layout_task::{AssignBSizesAndStoreOverflowTraversal, AssignISizesTraversal};
 use layout_task::{BubbleISizesTraversal};
 use url::Url;
 use util::{LayoutDataAccess, LayoutDataWrapper, OpaqueNodeMethods};
-use wrapper::{layout_node_to_unsafe_layout_node, layout_node_from_unsafe_layout_node, LayoutNode, PostorderNodeMutTraversal};
-use wrapper::{ThreadSafeLayoutNode, UnsafeLayoutNode};
+use wrapper::{layout_node_to_unsafe_layout_node, layout_node_from_unsafe_layout_node, LayoutNode};
+use wrapper::{PostorderNodeMutTraversal, ThreadSafeLayoutNode, UnsafeLayoutNode};
 
 use gfx::display_list::OpaqueNode;
 use servo_util::bloom::BloomFilter;

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -633,7 +633,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
         }
     }
 
-    pub fn get_pseudo_element_type(&self) ->  PseudoElementType {
+    pub fn get_pseudo_element_type(&self) -> PseudoElementType {
         self.pseudo
     }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -167,3 +167,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == box_sizing_border_box_a.html box_sizing_border_box_ref.html
 != input_height_a.html input_height_ref.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html
+== many_brs_a.html many_brs_ref.html

--- a/tests/ref/many_brs_a.html
+++ b/tests/ref/many_brs_a.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+Cupcakes<br>are<br>supremely<br>delicious.
+</body>
+</html>

--- a/tests/ref/many_brs_ref.html
+++ b/tests/ref/many_brs_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>Cupcakes</div>
+<div>are</div>
+<div>supremely</div>
+<div>delicious.</div>
+</body>
+</html>


### PR DESCRIPTION
Makes multiple `<br>` elements work, since those are implemented via
`before` pseudos.

r? @mbrubeck
