### PR TITLE
style: Remove `max-height` from the `input` style.

### DIFF
--- a/components/style/user-agent.css
+++ b/components/style/user-agent.css
@@ -116,7 +116,7 @@ area:link,
 link:link               { color: blue }
 script                  { display: none }
 style                   { display: none }
-input                   { background: white; min-height: 1.0em; max-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: nowrap; }
+input                   { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: nowrap; }
 input[type="button"],
 input[type="submit"],
 input[type="reset"]     { background: lightgrey; border-top: solid 1px #EEEEEE; border-left: solid 1px #CCCCCC; border-right: solid 1px #999999; border-bottom: solid 1px #999999; text-align: center; vertical-align: middle; color: black; }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -164,3 +164,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == vertical_align_text_bottom_a.html vertical_align_text_bottom_ref.html
 == inline_hypothetical_box_a.html inline_hypothetical_box_ref.html
 == box_sizing_border_box_a.html box_sizing_border_box_ref.html
+!= input_height_a.html input_height_ref.html

--- a/tests/ref/input_height_a.html
+++ b/tests/ref/input_height_a.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<!-- We assume that inputs are not 100px high on any platform, since that would be absurd -->
+<input type=text style="height: 100px;"></input>
+</body>
+</html>
+

--- a/tests/ref/input_height_ref.html
+++ b/tests/ref/input_height_ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input type=text></input>
+</body>
+</html>
+
+


### PR DESCRIPTION
Some pages, like Google, want to set height explicitly.

r? @jdm
