### PR TITLE
layout: Make content of `display: inline-block; overflow: hidden` visible.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1098,7 +1098,8 @@ impl BlockFlow {
                                              DList::new()));
         }
 
-        accumulator.finish(&mut *self, display_list);
+        accumulator.finish(&mut display_list);
+        self.base.display_list = display_list;
         self.base.layers = child_layers
     }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1833,8 +1833,11 @@ pub struct ChildDisplayListAccumulator {
 
 impl ChildDisplayListAccumulator {
     /// Creates a `ChildDisplayListAccumulator` from the `overflow` property in the given style.
-    fn new(style: &ComputedValues, bounds: Rect<Au>, node: OpaqueNode,
-            level: StackingLevel, may_need_clip: bool)
+    fn new(style: &ComputedValues,
+           bounds: Rect<Au>,
+           node: OpaqueNode,
+           level: StackingLevel,
+           may_need_clip: bool)
            -> ChildDisplayListAccumulator {
         ChildDisplayListAccumulator {
             clip_display_item: match (may_need_clip, style.get_box().overflow) {
@@ -1869,9 +1872,9 @@ impl ChildDisplayListAccumulator {
         }
     }
 
-    /// Consumes this accumulator and pushes the clipping item, if any, onto the display list
-    /// associated with the given flow, along with the items in the given display list.
-    pub fn finish(self, parent: &mut Flow, mut display_list: DisplayList) {
+    /// Consumes this accumulator and pushes the clipping item, if any, onto the given display
+    /// list.
+    pub fn finish(self, display_list: &mut DisplayList) {
         let ChildDisplayListAccumulator {
             clip_display_item
         } = self;
@@ -1879,6 +1882,5 @@ impl ChildDisplayListAccumulator {
             None => {}
             Some(clip_display_item) => display_list.push(ClipDisplayItemClass(clip_display_item)),
         }
-        flow::mut_base(parent).display_list = display_list
     }
 }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -786,11 +786,13 @@ impl InlineFlow {
             let rel_offset = fragment.relative_position(&self.base
                                                              .absolute_position_info
                                                              .relative_containing_block_size);
+            let fragment_position = self.base
+                                        .abs_position
+                                        .add_size(&rel_offset.to_physical(self.base.writing_mode));
             let mut accumulator = fragment.build_display_list(&mut self.base.display_list,
-                                             layout_context,
-                                             self.base.abs_position.add_size(
-                                                &rel_offset.to_physical(self.base.writing_mode)),
-                                             ContentLevel);
+                                                              layout_context,
+                                                              fragment_position,
+                                                              ContentLevel);
             match fragment.specific {
                 InlineBlockFragment(ref mut block_flow) => {
                     let block_flow = block_flow.flow_ref.get_mut();
@@ -798,10 +800,9 @@ impl InlineFlow {
                 }
                 _ => {}
             }
-        }
 
-        // TODO(#225): Should `inline-block` elements have flows as children of the inline flow or
-        // should the flow be nested inside the fragment somehow?
+            accumulator.finish(&mut self.base.display_list);
+        }
 
         // For now, don't traverse the subtree rooted here.
     }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -170,3 +170,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html
 == many_brs_a.html many_brs_ref.html
 == box_sizing_sanity_check_a.html box_sizing_sanity_check_ref.html
+== inline_block_overflow_hidden_a.html inline_block_overflow_hidden_ref.html

--- a/tests/ref/inline_block_overflow_hidden_a.html
+++ b/tests/ref/inline_block_overflow_hidden_a.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="display: inline-block; overflow: hidden">This should be visible</div>
+</body>
+</html>
+

--- a/tests/ref/inline_block_overflow_hidden_ref.html
+++ b/tests/ref/inline_block_overflow_hidden_ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="display: inline-block">This should be visible</div>
+</body>
+</html>
+
+


### PR DESCRIPTION
Makes lots of GitHub appear.

r? @glennw
