### PR TITLE
Expose user agent option to DOM navigator interface.

### DIFF
--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -51,6 +51,10 @@ impl<'a> NavigatorMethods for JSRef<'a, Navigator> {
     fn Platform(self) -> DOMString {
         NavigatorInfo::Platform()
     }
+
+    fn UserAgent(self) -> DOMString {
+        NavigatorInfo::UserAgent()
+    }
 }
 
 impl Reflectable for Navigator {

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use servo_util::str::DOMString;
+use servo_util::opts;
 
 pub struct NavigatorInfo;
 
@@ -25,5 +26,12 @@ impl NavigatorInfo {
 
     pub fn Platform() -> DOMString {
         "".to_string()
+    }
+
+    pub fn UserAgent() -> DOMString {
+        match opts::get().user_agent {
+            Some(ref user_agent) => user_agent.clone(),
+            None => "".to_string(),
+        }
     }
 }

--- a/components/script/dom/webidls/Navigator.webidl
+++ b/components/script/dom/webidls/Navigator.webidl
@@ -23,5 +23,5 @@ interface NavigatorID {
   readonly attribute DOMString platform;
   readonly attribute DOMString product; // constant "Gecko"
   boolean taintEnabled(); // constant false
-  //readonly attribute DOMString userAgent;
+  readonly attribute DOMString userAgent;
 };

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -51,6 +51,10 @@ impl<'a> WorkerNavigatorMethods for JSRef<'a, WorkerNavigator> {
     fn Platform(self) -> DOMString {
         NavigatorInfo::Platform()
     }
+
+    fn UserAgent(self) -> DOMString {
+        NavigatorInfo::UserAgent()
+    }
 }
 
 impl Reflectable for WorkerNavigator {

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -8802,9 +8802,6 @@
   [Navigator interface: attribute appVersion]
     expected: FAIL
 
-  [Navigator interface: attribute userAgent]
-    expected: FAIL
-
   [Navigator interface: attribute language]
     expected: FAIL
 
@@ -8848,9 +8845,6 @@
     expected: FAIL
 
   [Navigator interface: window.navigator must inherit property "appVersion" with the proper type (2)]
-    expected: FAIL
-
-  [Navigator interface: window.navigator must inherit property "userAgent" with the proper type (6)]
     expected: FAIL
 
   [Navigator interface: window.navigator must inherit property "language" with the proper type (7)]
@@ -9403,9 +9397,6 @@
     expected: FAIL
 
   [WorkerNavigator interface: attribute appVersion]
-    expected: FAIL
-
-  [WorkerNavigator interface: attribute userAgent]
     expected: FAIL
 
   [WorkerNavigator interface: attribute language]


### PR DESCRIPTION
This also makes command line options available as a global. If we're happy with that change I will go through the rest of the code and update it to avoid passing and cloning the Opts structure.
