### PR TITLE
layout: Make `box-sizing` only affect explicitly-specified or percentage sizes, not automatically computed ones.

### DIFF
--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -307,6 +307,14 @@ impl MaybeAuto {
     pub fn specified_or_zero(&self) -> Au {
         self.specified_or_default(Au::new(0))
     }
+
+    #[inline]
+    pub fn map(&self, mapper: |Au| -> Au) -> MaybeAuto {
+        match *self {
+            Auto => Auto,
+            Specified(value) => Specified(mapper(value)),
+        }
+    }
 }
 
 pub fn specified_or_none(length: computed::LengthOrPercentageOrNone, containing_length: Au) -> Option<Au> {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -168,3 +168,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 != input_height_a.html input_height_ref.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html
 == many_brs_a.html many_brs_ref.html
+== box_sizing_sanity_check_a.html box_sizing_sanity_check_ref.html

--- a/tests/ref/box_sizing_sanity_check_a.html
+++ b/tests/ref/box_sizing_sanity_check_a.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="box-sizing: border-box; float: left; background: yellow;">Heeheehee</div>
+</body>
+</html>
+

--- a/tests/ref/box_sizing_sanity_check_ref.html
+++ b/tests/ref/box_sizing_sanity_check_ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="float: left; background: yellow;">Heeheehee</div>
+</body>
+</html>
+


### PR DESCRIPTION
Improves GitHub significantly.

r? @glennw
