### PR TITLE
Position layers using their absolute position

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1251,8 +1251,9 @@ impl BlockFlow {
         let layer_rect = self.base.position.union(&self.base.overflow);
         let size = Size2D(layer_rect.size.inline.to_nearest_px() as uint,
                           layer_rect.size.block.to_nearest_px() as uint);
-        let origin = Point2D(layer_rect.start.i.to_nearest_px() as uint,
-                             layer_rect.start.b.to_nearest_px() as uint);
+        let origin = Point2D(self.base.abs_position.x.to_nearest_px() as uint,
+                             self.base.abs_position.y.to_nearest_px() as uint);
+
         let scroll_policy = if self.is_fixed() {
             FixedPosition
         } else {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -61,6 +61,7 @@
 == position_fixed_background_color_a.html position_fixed_background_color_b.html
 == position_fixed_overflow_a.html position_fixed_overflow_b.html
 == position_fixed_tile_edge.html position_fixed_tile_edge_ref.html
+== position_fixed_tile_edge_2.html position_fixed_tile_edge_ref.html
 == position_relative_a.html position_relative_b.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
 == background_none_a.html background_none_b.html

--- a/tests/ref/position_fixed_tile_edge_2.html
+++ b/tests/ref/position_fixed_tile_edge_2.html
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <div style="position: absolute; top: 0px; left: 512px;">
+        <div style="position: absolute; background: green; width: 20px; height: 20px;"></div>
+
+        <!-- This position:fixed sibling should force its sibling to be layerized. -->
+        <div style="position: fixed;"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Layers are currently all children of the root layer, so instead of
using coordinates relative to the parent flow we should use coordinates
relative to the page.

Fixes #2061.
