### PR TITLE
Include leading margin in inline block size

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -62,6 +62,7 @@
 == position_fixed_overflow_a.html position_fixed_overflow_b.html
 == position_fixed_tile_edge.html position_fixed_tile_edge_ref.html
 == position_fixed_tile_edge_2.html position_fixed_tile_edge_ref.html
+== position_fixed_tile_edge_3.html position_fixed_tile_edge_ref.html
 == position_relative_a.html position_relative_b.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
 == background_none_a.html background_none_b.html

--- a/tests/ref/position_fixed_tile_edge_3.html
+++ b/tests/ref/position_fixed_tile_edge_3.html
@@ -1,0 +1,11 @@
+<html>
+  <body>
+    <div style="position: absolute; top: 0px; left: 0px;">
+        <div style="position: absolute; background: green; margin-left: 512px; width: 20px; height: 20px;"></div>
+
+        <!-- This position:fixed sibling should force its sibling to be layerized. -->
+        <div style="position: fixed;"></div>
+    </div>
+  </body>
+</html>
+


### PR DESCRIPTION
Extra size from margins should be included in block size, so that
layers are large enough to include the entire block. This is typically
hidden by large tile sizes (512x512), but fitted tiles makes the issue
a lot more common.
