### PR TITLE
Remove support for {return,native,concrete}Type overrides in Bindings.conf.

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -9,19 +9,11 @@
 # The configuration table maps each interface name to a |descriptor|.
 #
 # Valid fields for all descriptors:
-#   * createGlobal: True for global objects.
 #   * outerObjectHook: string to use in place of default value for outerObject and thisObject
 #                      JS class hooks
 
 DOMInterfaces = {
 
-'EventListener': {
-    'nativeType': 'EventListenerBinding::EventListener',
-},
-'NodeFilter': {
-    'nativeType': 'NodeFilterBinding::NodeFilter',
-    'returnType': 'NodeFilterBinding::NodeFilter',
-},
 'Window': {
     'outerObjectHook': 'Some(bindings::utils::outerize_global)',
 },

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -147,14 +147,19 @@ class Descriptor(DescriptorProvider):
         # built-in rooting mechanisms for them.
         if self.interface.isCallback():
             self.needsRooting = False
+            ty = "%sBinding::%s" % (ifaceName, ifaceName)
+            self.returnType = ty
+            self.argumentType = "???"
+            self.memberType = "???"
+            self.nativeType = ty
         else:
             self.needsRooting = True
+            self.returnType = "Temporary<%s>" % ifaceName
+            self.argumentType = "JSRef<%s>" % ifaceName
+            self.memberType = "Root<'a, 'b, %s>" % ifaceName
+            self.nativeType = "JS<%s>" % ifaceName
 
-        self.returnType = desc.get('returnType', "Temporary<%s>" % ifaceName)
-        self.argumentType = "JSRef<%s>" % ifaceName
-        self.memberType = "Root<'a, 'b, %s>" % ifaceName
-        self.nativeType = desc.get('nativeType', 'JS<%s>' % ifaceName)
-        self.concreteType = desc.get('concreteType', ifaceName)
+        self.concreteType = ifaceName
         self.register = desc.get('register', True)
         self.outerObjectHook = desc.get('outerObjectHook', 'None')
 


### PR DESCRIPTION
We have no reason to support non-default type names, and this commit corrects
the computations for callbacks (which needed the override until now).
