### PR TITLE
Make sure reftests aren't passing because nothing == nothing

### DIFF
--- a/tests/ref/background_none_a.html
+++ b/tests/ref/background_none_a.html
@@ -15,7 +15,7 @@
 </style>
 </head>
 <body>
-<div id=a></div>
+<div id=a>Background: none test</div>
 </body>
 </html>
 

--- a/tests/ref/background_none_b.html
+++ b/tests/ref/background_none_b.html
@@ -10,7 +10,7 @@
 </style>
 </head>
 <body>
-<div id=a></div>
+<div id=a>Background: none test</div>
 </body>
 </html>
 

--- a/tests/ref/iframe/multiple_external.html
+++ b/tests/ref/iframe/multiple_external.html
@@ -11,6 +11,7 @@
         </style>
     </head>
     <body>
+        iframe test
         <iframe sandbox="allow-scripts" src="multiple_external_child.html"> </iframe>
         <iframe sandbox="allow-scripts" src="multiple_external_child.html"> </iframe>
     </body>

--- a/tests/ref/iframe/multiple_external_ref.html
+++ b/tests/ref/iframe/multiple_external_ref.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
     <body>
+    iframe test
     </body>
 </html>

--- a/tests/ref/img_dynamic_remove.html
+++ b/tests/ref/img_dynamic_remove.html
@@ -1,4 +1,5 @@
 <!doctype html>
+Image dynamic remove
 <img src=400x400_green.png>
 <script>
 document.getElementsByTagName("img")[0].removeAttribute("src");

--- a/tests/ref/img_dynamic_remove_ref.html
+++ b/tests/ref/img_dynamic_remove_ref.html
@@ -1,2 +1,3 @@
 <!doctype html>
+Image dynamic remove
 <img>

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -259,6 +259,13 @@ fn check_reftest(reftest: Reftest) {
     assert_eq!(left_width, right_width);
     assert_eq!(left_height, right_height);
 
+    let left_all_white = left_bytes.iter().all(|&p| p == 255);
+    let right_all_white = right_bytes.iter().all(|&p| p == 255);
+
+    if left_all_white && right_all_white {
+        fail!("Both rendering are empty")
+    }
+
     let pixels = left_bytes.iter().zip(right_bytes.iter()).map(|(&a, &b)| {
         if a as i8 - b as i8 == 0 {
             // White for correct


### PR DESCRIPTION
In the test harness, assert that the two images aren't all white.

Fixes #3481
