### PR TITLE
layout: Rewrite clipping to be per-display-item instead of having a separate `ClipDisplayItem`.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -196,92 +196,34 @@ impl StackingContext {
         };
 
         for item in list.into_iter() {
-            match item {
-                ClipDisplayItemClass(box ClipDisplayItem {
-                    base: base,
-                    children: sublist
-                }) => {
-                    let sub_stacking_context = StackingContext::new(sublist);
-                    stacking_context.merge_with_clip(sub_stacking_context, &base.bounds, base.node)
+            match item.base().level {
+                BackgroundAndBordersStackingLevel => {
+                    stacking_context.background_and_borders.push(item)
                 }
-                item => {
-                    match item.base().level {
-                        BackgroundAndBordersStackingLevel => {
-                            stacking_context.background_and_borders.push(item)
+                BlockBackgroundsAndBordersStackingLevel => {
+                    stacking_context.block_backgrounds_and_borders.push(item)
+                }
+                FloatStackingLevel => stacking_context.floats.push(item),
+                ContentStackingLevel => stacking_context.content.push(item),
+                PositionedDescendantStackingLevel(z_index) => {
+                    match stacking_context.positioned_descendants
+                                          .iter_mut()
+                                          .find(|& &(z, _)| z_index == z) {
+                        Some(&(_, ref mut my_list)) => {
+                            my_list.push(item);
+                            continue
                         }
-                        BlockBackgroundsAndBordersStackingLevel => {
-                            stacking_context.block_backgrounds_and_borders.push(item)
-                        }
-                        FloatStackingLevel => stacking_context.floats.push(item),
-                        ContentStackingLevel => stacking_context.content.push(item),
-                        PositionedDescendantStackingLevel(z_index) => {
-                            match stacking_context.positioned_descendants
-                                                  .iter_mut()
-                                                  .find(|& &(z, _)| z_index == z) {
-                                Some(&(_, ref mut my_list)) => {
-                                    my_list.push(item);
-                                    continue
-                                }
-                                None => {}
-                            }
-
-                            let mut new_list = DisplayList::new();
-                            new_list.list.push(item);
-                            stacking_context.positioned_descendants.push((z_index, new_list))
-                        }
+                        None => {}
                     }
+
+                    let mut new_list = DisplayList::new();
+                    new_list.list.push(item);
+                    stacking_context.positioned_descendants.push((z_index, new_list))
                 }
             }
         }
 
         stacking_context
-    }
-
-    /// Merges another stacking context into this one, with the given clipping rectangle and DOM
-    /// node that supplies it.
-    fn merge_with_clip(&mut self,
-                       other: StackingContext,
-                       clip_rect: &Rect<Au>,
-                       clipping_dom_node: OpaqueNode) {
-        let StackingContext {
-            background_and_borders,
-            block_backgrounds_and_borders,
-            floats,
-            content,
-            positioned_descendants: positioned_descendants
-        } = other;
-
-        let push = |destination: &mut DisplayList, source: DisplayList, level| {
-            if !source.is_empty() {
-                let base = BaseDisplayItem::new(*clip_rect, clipping_dom_node, level);
-                destination.push(ClipDisplayItemClass(box ClipDisplayItem::new(base, source)))
-            }
-        };
-
-        push(&mut self.background_and_borders,
-             background_and_borders,
-             BackgroundAndBordersStackingLevel);
-        push(&mut self.block_backgrounds_and_borders,
-             block_backgrounds_and_borders,
-             BlockBackgroundsAndBordersStackingLevel);
-        push(&mut self.floats, floats, FloatStackingLevel);
-        push(&mut self.content, content, ContentStackingLevel);
-
-        for (z_index, list) in positioned_descendants.into_iter() {
-            match self.positioned_descendants
-                      .iter_mut()
-                      .find(|& &(existing_z_index, _)| z_index == existing_z_index) {
-                Some(&(_, ref mut existing_list)) => {
-                    push(existing_list, list, PositionedDescendantStackingLevel(z_index));
-                    continue
-                }
-                None => {}
-            }
-
-            let mut new_list = DisplayList::new();
-            push(&mut new_list, list, PositionedDescendantStackingLevel(z_index));
-            self.positioned_descendants.push((z_index, new_list));
-        }
     }
 }
 
@@ -342,11 +284,13 @@ impl DisplayList {
 
     /// Draws the display list into the given render context. The display list must be flattened
     /// first for correct painting.
-    pub fn draw_into_context(&self, render_context: &mut RenderContext,
-                             current_transform: &Matrix2D<AzFloat>) {
+    pub fn draw_into_context(&self,
+                             render_context: &mut RenderContext,
+                             current_transform: &Matrix2D<AzFloat>,
+                             current_clip_rect: &Rect<Au>) {
         debug!("Beginning display list.");
         for item in self.list.iter() {
-            item.draw_into_context(render_context, current_transform)
+            item.draw_into_context(render_context, current_transform, current_clip_rect)
         }
         debug!("Ending display list.");
     }
@@ -354,12 +298,6 @@ impl DisplayList {
     /// Returns a preorder iterator over the given display list.
     pub fn iter<'a>(&'a self) -> DisplayItemIterator<'a> {
         ParentDisplayItemIterator(self.list.iter())
-    }
-
-    /// Returns true if this list is empty and false otherwise.
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.list.is_empty()
     }
 
     /// Flattens a display list into a display list with a single stacking level according to the
@@ -421,10 +359,6 @@ impl DisplayList {
     fn set_stacking_level(&mut self, new_level: StackingLevel) {
         for item in self.list.iter_mut() {
             item.mut_base().level = new_level;
-            match item.mut_sublist() {
-                None => {}
-                Some(sublist) => sublist.set_stacking_level(new_level),
-            }
         }
     }
 }
@@ -437,7 +371,6 @@ pub enum DisplayItem {
     ImageDisplayItemClass(Box<ImageDisplayItem>),
     BorderDisplayItemClass(Box<BorderDisplayItem>),
     LineDisplayItemClass(Box<LineDisplayItem>),
-    ClipDisplayItemClass(Box<ClipDisplayItem>),
 
     /// A pseudo-display item that exists only so that queries like `ContentBoxQuery` and
     /// `ContentBoxesQuery` can be answered.
@@ -450,9 +383,7 @@ pub enum DisplayItem {
 /// Information common to all display items.
 #[deriving(Clone)]
 pub struct BaseDisplayItem {
-    /// The boundaries of the display item.
-    ///
-    /// TODO: Which coordinate system should this use?
+    /// The boundaries of the display item, in layer coordinates.
     pub bounds: Rect<Au>,
 
     /// The originating DOM node.
@@ -460,14 +391,22 @@ pub struct BaseDisplayItem {
 
     /// The stacking level in which this display item lives.
     pub level: StackingLevel,
+
+    /// The rectangle to clip to.
+    ///
+    /// TODO(pcwalton): Eventually, to handle `border-radius`, this will (at least) need to grow
+    /// the ability to describe rounded rectangles.
+    pub clip_rect: Rect<Au>,
 }
 
 impl BaseDisplayItem {
-    pub fn new(bounds: Rect<Au>, node: OpaqueNode, level: StackingLevel) -> BaseDisplayItem {
+    pub fn new(bounds: Rect<Au>, node: OpaqueNode, level: StackingLevel, clip_rect: Rect<Au>)
+               -> BaseDisplayItem {
         BaseDisplayItem {
             bounds: bounds,
             node: node,
             level: level,
+            clip_rect: clip_rect,
         }
     }
 }
@@ -544,25 +483,6 @@ pub struct LineDisplayItem {
     pub style: border_style::T
 }
 
-/// Clips a list of child display items to this display item's boundaries.
-#[deriving(Clone)]
-pub struct ClipDisplayItem {
-    /// The base information.
-    pub base: BaseDisplayItem,
-
-    /// The child nodes.
-    pub children: DisplayList,
-}
-
-impl ClipDisplayItem {
-    pub fn new(base: BaseDisplayItem, children: DisplayList) -> ClipDisplayItem {
-        ClipDisplayItem {
-            base: base,
-            children: children,
-        }
-    }
-}
-
 pub enum DisplayItemIterator<'a> {
     EmptyDisplayItemIterator,
     ParentDisplayItemIterator(dlist::Items<'a,DisplayItem>),
@@ -580,22 +500,22 @@ impl<'a> Iterator<&'a DisplayItem> for DisplayItemIterator<'a> {
 
 impl DisplayItem {
     /// Renders this display item into the given render context.
-    fn draw_into_context(&self, render_context: &mut RenderContext,
-                         current_transform: &Matrix2D<AzFloat>) {
+    fn draw_into_context(&self,
+                         render_context: &mut RenderContext,
+                         current_transform: &Matrix2D<AzFloat>,
+                         current_clip_rect: &Rect<Au>) {
         // This should have been flattened to the content stacking level first.
         assert!(self.base().level == ContentStackingLevel);
+
+        let clip_rect = &self.base().clip_rect;
+        let need_to_clip = current_clip_rect != clip_rect;
+        if need_to_clip {
+            render_context.draw_push_clip(clip_rect);
+        }
 
         match *self {
             SolidColorDisplayItemClass(ref solid_color) => {
                 render_context.draw_solid_color(&solid_color.base.bounds, solid_color.color)
-            }
-
-            ClipDisplayItemClass(ref clip) => {
-                render_context.draw_push_clip(&clip.base.bounds);
-                for item in clip.children.iter() {
-                    (*item).draw_into_context(render_context, current_transform);
-                }
-                render_context.draw_pop_clip();
             }
 
             TextDisplayItemClass(ref text) => {
@@ -688,6 +608,10 @@ impl DisplayItem {
 
             PseudoDisplayItemClass(_) => {}
         }
+
+        if need_to_clip {
+            render_context.draw_pop_clip();
+        }
     }
 
     pub fn base<'a>(&'a self) -> &'a BaseDisplayItem {
@@ -697,7 +621,6 @@ impl DisplayItem {
             ImageDisplayItemClass(ref image_item) => &image_item.base,
             BorderDisplayItemClass(ref border) => &border.base,
             LineDisplayItemClass(ref line) => &line.base,
-            ClipDisplayItemClass(ref clip) => &clip.base,
             PseudoDisplayItemClass(ref base) => &**base,
         }
     }
@@ -709,7 +632,6 @@ impl DisplayItem {
             ImageDisplayItemClass(ref mut image_item) => &mut image_item.base,
             BorderDisplayItemClass(ref mut border) => &mut border.base,
             LineDisplayItemClass(ref mut line) => &mut line.base,
-            ClipDisplayItemClass(ref mut clip) => &mut clip.base,
             PseudoDisplayItemClass(ref mut base) => &mut **base,
         }
     }
@@ -718,40 +640,12 @@ impl DisplayItem {
         self.base().bounds
     }
 
-    pub fn children<'a>(&'a self) -> DisplayItemIterator<'a> {
-        match *self {
-            ClipDisplayItemClass(ref clip) => ParentDisplayItemIterator(clip.children.list.iter()),
-            SolidColorDisplayItemClass(..) |
-            TextDisplayItemClass(..) |
-            ImageDisplayItemClass(..) |
-            BorderDisplayItemClass(..) |
-            LineDisplayItemClass(..) |
-            PseudoDisplayItemClass(..) => EmptyDisplayItemIterator,
-        }
-    }
-
-    /// Returns a mutable reference to the sublist contained within this display list item, if any.
-    fn mut_sublist<'a>(&'a mut self) -> Option<&'a mut DisplayList> {
-        match *self {
-            ClipDisplayItemClass(ref mut clip) => Some(&mut clip.children),
-            SolidColorDisplayItemClass(..) |
-            TextDisplayItemClass(..) |
-            ImageDisplayItemClass(..) |
-            BorderDisplayItemClass(..) |
-            LineDisplayItemClass(..) |
-            PseudoDisplayItemClass(..) => None,
-        }
-    }
-
     pub fn debug_with_level(&self, level: uint) {
         let mut indent = String::new();
         for _ in range(0, level) {
             indent.push_str("| ")
         }
         debug!("{}+ {}", indent, self);
-        for child in self.children() {
-            child.debug_with_level(level + 1);
-        }
     }
 }
 
@@ -764,7 +658,6 @@ impl fmt::Show for DisplayItem {
                 ImageDisplayItemClass(_) => "Image",
                 BorderDisplayItemClass(_) => "Border",
                 LineDisplayItemClass(_) => "Line",
-                ClipDisplayItemClass(_) => "Clip",
                 PseudoDisplayItemClass(_) => "Pseudo",
             },
             self.base().bounds,

--- a/components/gfx/display_list/optimizer.rs
+++ b/components/gfx/display_list/optimizer.rs
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use display_list::{BorderDisplayItemClass, ClipDisplayItem, ClipDisplayItemClass, DisplayItem};
-use display_list::{DisplayList, ImageDisplayItemClass, LineDisplayItemClass};
-use display_list::{PseudoDisplayItemClass, SolidColorDisplayItemClass, TextDisplayItemClass};
+use display_list::{DisplayItem, DisplayList};
 
 use collections::dlist::DList;
 use geom::rect::Rect;
@@ -45,28 +43,11 @@ impl DisplayListOptimizer {
 
     fn process_display_item(&self, display_item: &DisplayItem) -> Option<DisplayItem> {
         // Eliminate display items outside the visible region.
-        if !self.visible_rect.intersects(&display_item.base().bounds) {
-            return None
-        }
-
-        // Recur.
-        match *display_item {
-            ClipDisplayItemClass(ref clip) => {
-                let new_children = self.process_display_list(&clip.children);
-                if new_children.is_empty() {
-                    return None
-                }
-                Some(ClipDisplayItemClass(box ClipDisplayItem {
-                    base: clip.base.clone(),
-                    children: new_children,
-                }))
-            }
-
-            BorderDisplayItemClass(_) | ImageDisplayItemClass(_) | LineDisplayItemClass(_) |
-            PseudoDisplayItemClass(_) | SolidColorDisplayItemClass(_) |
-            TextDisplayItemClass(_) => {
-                Some((*display_item).clone())
-            }
+        if !self.visible_rect.intersects(&display_item.base().bounds) ||
+                !self.visible_rect.intersects(&display_item.base().clip_rect) {
+            None
+        } else {
+            Some((*display_item).clone())
         }
     }
 }

--- a/components/gfx/render_task.rs
+++ b/components/gfx/render_task.rs
@@ -25,13 +25,14 @@ use servo_msg::compositor_msg::{LayerMetadata, RenderListener, RenderingRenderSt
 use servo_msg::constellation_msg::{ConstellationChan, Failure, FailureMsg, PipelineId};
 use servo_msg::constellation_msg::{RendererReadyMsg};
 use servo_msg::platform::surface::NativeSurfaceAzureMethods;
-use servo_util::geometry;
+use servo_util::geometry::{Au, mod};
 use servo_util::opts::Opts;
 use servo_util::smallvec::{SmallVec, SmallVec1};
 use servo_util::task::spawn_named_with_send_on_failure;
 use servo_util::time::{TimeProfilerChan, profile};
 use servo_util::time;
 use std::comm::{Receiver, Sender, channel};
+use std::i32;
 use sync::Arc;
 use font_cache_task::FontCacheTask;
 
@@ -356,8 +357,13 @@ impl<C:RenderListener + Send> RenderTask<C> {
                     ctx.clear();
 
                     // Draw the display list.
-                    profile(time::RenderingDrawingCategory, None, self.time_profiler_chan.clone(), || {
-                        display_list.draw_into_context(&mut ctx, &matrix);
+                    profile(time::RenderingDrawingCategory,
+                            None,
+                            self.time_profiler_chan.clone(),
+                            || {
+                        let clip_rect = Rect(Point2D(Au(i32::MIN), Au(i32::MIN)),
+                                             Size2D(Au(i32::MAX), Au(i32::MAX)));
+                        display_list.draw_into_context(&mut ctx, &matrix, &clip_rect);
                         ctx.draw_target.flush();
                     });
                 }

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1204,7 +1204,6 @@ impl FlowConstructionUtils for FlowRef {
 
         base.children.push_back(new_child);
         let _ = base.parallel.children_count.fetch_add(1, Relaxed);
-        let _ = base.parallel.children_and_absolute_descendant_count.fetch_add(1, Relaxed);
     }
 
     /// Finishes a flow. Once a flow is finished, no more child flows or fragments may be added to

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -9,8 +9,8 @@ use context::LayoutContext;
 use floats::{FloatLeft, Floats, PlacementInfo};
 use flow::{BaseFlow, FlowClass, Flow, InlineFlowClass, MutableFlowUtils};
 use flow;
-use fragment::{Fragment, InlineBlockFragment, ScannedTextFragment, ScannedTextFragmentInfo};
-use fragment::{SplitInfo};
+use fragment::{Fragment, InlineAbsoluteHypotheticalFragment, InlineBlockFragment};
+use fragment::{ScannedTextFragment, ScannedTextFragmentInfo, SplitInfo};
 use layout_debug;
 use model::IntrinsicISizes;
 use text;
@@ -18,7 +18,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use collections::{Deque, RingBuf};
 use geom::Rect;
-use gfx::display_list::ContentLevel;
+use gfx::display_list::{ContentLevel, DisplayList};
 use gfx::font::FontMetrics;
 use gfx::font_context::FontContext;
 use geom::Size2D;
@@ -704,19 +704,20 @@ impl InlineFlow {
             let fragment_position = self.base
                                         .abs_position
                                         .add_size(&rel_offset.to_physical(self.base.writing_mode));
-            let mut accumulator = fragment.build_display_list(&mut self.base.display_list,
-                                                              layout_context,
-                                                              fragment_position,
-                                                              ContentLevel);
+            fragment.build_display_list(&mut self.base.display_list,
+                                        layout_context,
+                                        fragment_position,
+                                        ContentLevel,
+                                        &self.base.clip_rect);
             match fragment.specific {
                 InlineBlockFragment(ref mut block_flow) => {
                     let block_flow = block_flow.flow_ref.get_mut();
-                    accumulator.push_child(&mut self.base.display_list, block_flow);
+                    self.base.display_list.push_all_move(
+                        mem::replace(&mut flow::mut_base(block_flow).display_list,
+                                     DisplayList::new()));
                 }
                 _ => {}
             }
-
-            accumulator.finish(&mut self.base.display_list);
         }
     }
 
@@ -1124,16 +1125,40 @@ impl Flow for InlineFlow {
 
     fn compute_absolute_position(&mut self) {
         for fragment in self.fragments.fragments.iter_mut() {
-            match fragment.specific {
+            let absolute_position = match fragment.specific {
                 InlineBlockFragment(ref mut info) => {
                     let block_flow = info.flow_ref.get_mut().as_block();
-
                     // FIXME(#2795): Get the real container size
                     let container_size = Size2D::zero();
                     block_flow.base.abs_position =
                         self.base.abs_position +
                         fragment.border_box.start.to_physical(self.base.writing_mode,
                                                               container_size);
+                    block_flow.base.abs_position
+                }
+                InlineAbsoluteHypotheticalFragment(ref mut info) => {
+                    let block_flow = info.flow_ref.get_mut().as_block();
+                    // FIXME(#2795): Get the real container size
+                    let container_size = Size2D::zero();
+                    block_flow.base.abs_position =
+                        self.base.abs_position +
+                        fragment.border_box.start.to_physical(self.base.writing_mode,
+                                                              container_size);
+                    block_flow.base.abs_position
+
+                }
+                _ => continue,
+            };
+
+            let clip_rect = fragment.clip_rect_for_children(self.base.clip_rect,
+                                                            absolute_position);
+
+            match fragment.specific {
+                InlineBlockFragment(ref mut info) => {
+                    flow::mut_base(info.flow_ref.get_mut()).clip_rect = clip_rect
+                }
+                InlineAbsoluteHypotheticalFragment(ref mut info) => {
+                    flow::mut_base(info.flow_ref.get_mut()).clip_rect = clip_rect
                 }
                 _ => {}
             }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -323,13 +323,7 @@ impl<'a> BuildDisplayList<'a> {
         flow.compute_absolute_position();
 
         for kid in flow::mut_base(flow).child_iter() {
-            if !kid.is_absolutely_positioned() {
-                self.process(kid)
-            }
-        }
-
-        for absolute_descendant_link in flow::mut_base(flow).abs_descendants.iter() {
-            self.process(absolute_descendant_link)
+            self.process(kid)
         }
 
         flow.build_display_list(self.layout_context)

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -73,6 +73,29 @@ impl Default for Au {
     }
 }
 
+pub static ZERO_RECT: Rect<Au> = Rect {
+    origin: Point2D {
+        x: Au(0),
+        y: Au(0),
+    },
+    size: Size2D {
+        width: Au(0),
+        height: Au(0),
+    }
+};
+
+pub static MAX_RECT: Rect<Au> = Rect {
+    origin: Point2D {
+        x: Au(i32::MIN / 2),
+        y: Au(i32::MIN / 2),
+    },
+    size: Size2D {
+        width: MAX_AU,
+        height: MAX_AU,
+    }
+};
+
+pub static MIN_AU: Au = Au(i32::MIN);
 pub static MAX_AU: Au = Au(i32::MAX);
 
 impl<E, S: Encoder<E>> Encodable<S, E> for Au {


### PR DESCRIPTION
We push down clipping areas during absolute position calculation. This
makes display items into a flat list, improving cache locality. It
dramatically simplifies the code all around.

Because we need to push down clip rects even for absolutely-positioned
children of non-absolutely-positioned flows, this patch alters the
parallel traversal to compute absolute positions for
absolutely-positioned children at the same time it computes absolute
positions for other children. This doesn't seem to break anything either
in theory (since the overall order remains correct) or in practice. It
simplifies the parallel traversal code quite a bit.

See the relevant Gecko bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=615734

r? @mrobinson 
