### PR TITLE
Privatize DOM (fixes #3644)

### DIFF
--- a/components/layout/util.rs
+++ b/components/layout/util.rs
@@ -78,20 +78,20 @@ pub trait LayoutDataAccess {
 impl<'ln> LayoutDataAccess for LayoutNode<'ln> {
     #[inline(always)]
     unsafe fn borrow_layout_data_unchecked(&self) -> *const Option<LayoutDataWrapper> {
-        mem::transmute(self.get().layout_data.borrow_unchecked())
+        mem::transmute(self.get().layout_data_unchecked())
     }
 
     #[inline(always)]
     fn borrow_layout_data<'a>(&'a self) -> Ref<'a,Option<LayoutDataWrapper>> {
         unsafe {
-            mem::transmute(self.get().layout_data.borrow())
+            mem::transmute(self.get().layout_data())
         }
     }
 
     #[inline(always)]
     fn mutate_layout_data<'a>(&'a self) -> RefMut<'a,Option<LayoutDataWrapper>> {
         unsafe {
-            mem::transmute(self.get().layout_data.borrow_mut())
+            mem::transmute(self.get().layout_data_mut())
         }
     }
 }

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -721,7 +721,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
     #[inline(always)]
     pub fn borrow_layout_data<'a>(&'a self) -> Ref<'a,Option<LayoutDataWrapper>> {
         unsafe {
-            mem::transmute(self.get().layout_data.borrow())
+            mem::transmute(self.get().layout_data())
         }
     }
 
@@ -729,7 +729,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
     #[inline(always)]
     pub fn mutate_layout_data<'a>(&'a self) -> RefMut<'a,Option<LayoutDataWrapper>> {
         unsafe {
-            mem::transmute(self.get().layout_data.borrow_mut())
+            mem::transmute(self.get().layout_data_mut())
         }
     }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -116,8 +116,8 @@ pub trait TLayoutNode {
                 fail!("not an iframe element!")
             }
             let iframe_element: JS<HTMLIFrameElement> = self.get_jsmanaged().transmute_copy();
-            let size = (*iframe_element.unsafe_get()).size.get().unwrap();
-            (size.pipeline_id, size.subpage_id)
+            let size = (*iframe_element.unsafe_get()).size().unwrap();
+            (*size.pipeline_id(), *size.subpage_id())
         }
     }
 
@@ -189,7 +189,7 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
         unsafe {
             if self.get().is_text() {
                 let text: JS<Text> = self.get_jsmanaged().transmute_copy();
-                (*text.unsafe_get()).characterdata.data.borrow().clone()
+                (*text.unsafe_get()).characterdata().data().clone()
             } else if self.get().is_htmlinputelement() {
                 let input: JS<HTMLInputElement> = self.get_jsmanaged().transmute_copy();
                 input.get_value_for_layout()
@@ -765,7 +765,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
             Some(TextNodeTypeId) => {
                 unsafe {
                     let text: JS<Text> = self.get_jsmanaged().transmute_copy();
-                    if !is_whitespace((*text.unsafe_get()).characterdata.data.borrow().as_slice()) {
+                    if !is_whitespace((*text.unsafe_get()).characterdata().data().as_slice()) {
                         return false
                     }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -425,7 +425,7 @@ pub struct LayoutElement<'le> {
 impl<'le> LayoutElement<'le> {
     pub fn style_attribute(&self) -> &'le Option<PropertyDeclarationBlock> {
         let style: &Option<PropertyDeclarationBlock> = unsafe {
-            let style: &RefCell<Option<PropertyDeclarationBlock>> = &self.element.style_attribute;
+            let style: &RefCell<Option<PropertyDeclarationBlock>> = self.element.style_attribute();
             // cast to the direct reference to T placed on the head of RefCell<T>
             mem::transmute(style)
         };
@@ -436,12 +436,12 @@ impl<'le> LayoutElement<'le> {
 impl<'le> TElement<'le> for LayoutElement<'le> {
     #[inline]
     fn get_local_name(self) -> &'le Atom {
-        &self.element.local_name
+        self.element.local_name()
     }
 
     #[inline]
     fn get_namespace(self) -> &'le Namespace {
-        &self.element.namespace
+        self.element.namespace()
     }
 
     #[inline]
@@ -456,7 +456,7 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
 
     fn get_link(self) -> Option<&'le str> {
         // FIXME: This is HTML only.
-        match self.element.node.type_id_for_layout() {
+        match self.element.node().type_id_for_layout() {
             // http://www.whatwg.org/specs/web-apps/current-work/multipage/selectors.html#
             // selector-link
             ElementNodeTypeId(HTMLAnchorElementTypeId) |
@@ -470,7 +470,7 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
 
     fn get_hover_state(self) -> bool {
         unsafe {
-            self.element.node.get_hover_state_for_layout()
+            self.element.node().get_hover_state_for_layout()
         }
     }
 
@@ -481,13 +481,13 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
 
     fn get_disabled_state(self) -> bool {
         unsafe {
-            self.element.node.get_disabled_state_for_layout()
+            self.element.node().get_disabled_state_for_layout()
         }
     }
 
     fn get_enabled_state(self) -> bool {
         unsafe {
-            self.element.node.get_enabled_state_for_layout()
+            self.element.node().get_enabled_state_for_layout()
         }
     }
 

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -27,6 +27,7 @@ mod jstraceable;
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box lints::TransmutePass as LintPassObject);
     reg.register_lint_pass(box lints::UnrootedPass as LintPassObject);
+    reg.register_lint_pass(box lints::PrivatizePass as LintPassObject);
     reg.register_syntax_extension(intern("jstraceable"), Decorator(box jstraceable::expand_jstraceable))
 }
 

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -72,13 +72,14 @@ impl Str for AttrValue {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Attr {
     reflector_: Reflector,
     local_name: Atom,
     value: RefCell<AttrValue>,
-    pub name: Atom,
-    pub namespace: Namespace,
-    pub prefix: Option<DOMString>,
+    name: Atom,
+    namespace: Namespace,
+    prefix: Option<DOMString>,
 
     /// the element that owns this attribute.
     owner: JS<Element>,
@@ -110,6 +111,21 @@ impl Attr {
                prefix: Option<DOMString>, owner: JSRef<Element>) -> Temporary<Attr> {
         reflect_dom_object(box Attr::new_inherited(local_name, value, name, namespace, prefix, owner),
                            &global::Window(window), AttrBinding::Wrap)
+    }
+
+    #[inline]
+    pub fn name<'a>(&'a self) -> &'a Atom {
+        &self.name
+    }
+
+    #[inline]
+    pub fn namespace<'a>(&'a self) -> &'a Namespace {
+        &self.namespace
+    }
+
+    #[inline]
+    pub fn prefix<'a>(&'a self) -> &'a Option<DOMString> {
+        &self.prefix
     }
 }
 

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5452,7 +5452,7 @@ class GlobalGenRoots():
                 protoDescriptor = config.getDescriptor(protoName)
                 delegate = string.Template('''impl ${selfName} for ${baseName} {
   fn ${fname}(&self) -> bool {
-    self.${parentName}.${fname}()
+    self.${parentName}().${fname}()
   }
 }
 ''').substitute({'fname': 'is_' + name.lower(),

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -83,7 +83,7 @@ impl<'a> GlobalRef<'a> {
     /// thread.
     pub fn script_chan<'b>(&'b self) -> &'b ScriptChan {
         match *self {
-            Window(ref window) => &window.script_chan,
+            Window(ref window) => window.script_chan(),
             Worker(ref worker) => worker.script_chan(),
         }
     }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -660,7 +660,7 @@ pub extern fn outerize_global(_cx: *mut JSContext, obj: JSHandleObject) -> *mut 
                              IDLInterface::get_prototype_depth(None::<window::Window>))
             .unwrap()
             .root();
-        win.browser_context.borrow().as_ref().unwrap().window_proxy()
+        win.browser_context().as_ref().unwrap().window_proxy()
     }
 }
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -17,6 +17,7 @@ pub enum BlobType {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Blob {
     reflector_: Reflector,
     type_: BlobType

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -39,7 +39,7 @@ impl BrowserContext {
 
     pub fn active_window(&self) -> Temporary<Window> {
         let doc = self.active_document().root();
-        Temporary::new(doc.window.clone())
+        Temporary::new(doc.window().clone())
     }
 
     pub fn window_proxy(&self) -> *mut JSObject {

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -15,6 +15,7 @@ use std::ptr;
 
 #[allow(raw_pointer_deriving)]
 #[jstraceable]
+#[privatize]
 pub struct BrowserContext {
     history: Vec<SessionHistoryEntry>,
     active_index: uint,
@@ -66,6 +67,7 @@ impl BrowserContext {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct SessionHistoryEntry {
     document: JS<Document>,
     children: Vec<BrowserContext>

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -17,6 +17,7 @@ use canvas::canvas_render_task::{CanvasMsg, CanvasRenderTask, ClearRect, Close, 
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct CanvasRenderingContext2D {
     reflector_: Reflector,
     global: GlobalField,

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -26,7 +26,7 @@ pub struct CharacterData {
 
 impl CharacterDataDerived for EventTarget {
     fn is_characterdata(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             NodeTargetTypeId(TextNodeTypeId) |
             NodeTargetTypeId(CommentNodeTypeId) |
             NodeTargetTypeId(ProcessingInstructionNodeTypeId) => true,

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -14,13 +14,14 @@ use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::node::{CommentNodeTypeId, Node, NodeTypeId, TextNodeTypeId, ProcessingInstructionNodeTypeId, NodeHelpers};
 use servo_util::str::DOMString;
 
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct CharacterData {
-    pub node: Node,
-    pub data: RefCell<DOMString>,
+    node: Node,
+    data: RefCell<DOMString>,
 }
 
 impl CharacterDataDerived for EventTarget {
@@ -40,6 +41,21 @@ impl CharacterData {
             node: Node::new_inherited(id, document),
             data: RefCell::new(data),
         }
+    }
+
+    #[inline]
+    pub fn node<'a>(&'a self) -> &'a Node {
+        &self.node
+    }
+
+    #[inline]
+    pub fn data(&self) -> Ref<DOMString> {
+        self.data.borrow()
+    }
+
+    #[inline]
+    pub fn set_data(&self, data: DOMString) {
+        *self.data.borrow_mut() = data;
     }
 }
 

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -25,7 +25,7 @@ pub struct Comment {
 
 impl CommentDerived for EventTarget {
     fn is_comment(&self) -> bool {
-        self.type_id == NodeTargetTypeId(CommentNodeTypeId)
+        *self.type_id() == NodeTargetTypeId(CommentNodeTypeId)
     }
 }
 

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -18,8 +18,9 @@ use servo_util::str::DOMString;
 /// An HTML comment.
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Comment {
-    pub characterdata: CharacterData,
+    characterdata: CharacterData,
 }
 
 impl CommentDerived for EventTarget {
@@ -43,6 +44,11 @@ impl Comment {
     pub fn Constructor(global: &GlobalRef, data: DOMString) -> Fallible<Temporary<Comment>> {
         let document = global.as_window().Document().root();
         Ok(Comment::new(data, *document))
+    }
+
+    #[inline]
+    pub fn characterdata<'a>(&'a self) -> &'a CharacterData {
+        &self.characterdata
     }
 }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -11,8 +11,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Console {
-    pub reflector_: Reflector
+    reflector_: Reflector
 }
 
 impl Console {

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -19,6 +19,7 @@ use std::cell::Cell;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct CustomEvent {
     event: Event,
     detail: Cell<JSVal>,

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -27,7 +27,7 @@ pub struct CustomEvent {
 
 impl CustomEventDerived for Event {
     fn is_customevent(&self) -> bool {
-        self.type_id == CustomEventTypeId
+        *self.type_id() == CustomEventTypeId
     }
 }
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -193,7 +193,7 @@ impl Reflectable for DedicatedWorkerGlobalScope {
 
 impl DedicatedWorkerGlobalScopeDerived for EventTarget {
     fn is_dedicatedworkerglobalscope(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             WorkerGlobalScopeTypeId(DedicatedGlobalScope) => true,
             _ => false
         }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -37,6 +37,7 @@ use url::Url;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DedicatedWorkerGlobalScope {
     workerglobalscope: WorkerGlobalScope,
     receiver: Receiver<ScriptMsg>,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -62,7 +62,7 @@ use url::Url;
 
 use std::collections::hashmap::HashMap;
 use std::ascii::StrAsciiExt;
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::default::Default;
 use time;
 
@@ -75,16 +75,17 @@ pub enum IsHTMLDocument {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Document {
-    pub node: Node,
+    node: Node,
     reflector_: Reflector,
-    pub window: JS<Window>,
+    window: JS<Window>,
     idmap: RefCell<HashMap<Atom, Vec<JS<Element>>>>,
     implementation: MutNullableJS<DOMImplementation>,
     content_type: DOMString,
     last_modified: RefCell<Option<DOMString>>,
-    pub encoding_name: RefCell<DOMString>,
-    pub is_html_document: bool,
+    encoding_name: RefCell<DOMString>,
+    is_html_document: bool,
     url: Url,
     quirks_mode: Cell<QuirksMode>,
     images: MutNullableJS<HTMLCollection>,
@@ -342,6 +343,21 @@ impl Document {
         let node: JSRef<Node> = NodeCast::from_ref(*document);
         node.set_owner_doc(*document);
         Temporary::from_rooted(*document)
+    }
+
+    #[inline]
+    pub fn window<'a>(&'a self) -> &'a JS<Window> {
+        &self.window
+    }
+
+    #[inline]
+    pub fn encoding_name(&self) -> Ref<DOMString> {
+        self.encoding_name.borrow()
+    }
+
+    #[inline]
+    pub fn is_html_document(&self) -> bool {
+        self.is_html_document
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -641,7 +641,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                     for child in title_elem.children() {
                         if child.is_text() {
                             let text: JSRef<Text> = TextCast::to_ref(child).unwrap();
-                            title.push_str(text.characterdata.data.borrow().as_slice());
+                            title.push_str(text.characterdata().data().as_slice());
                         }
                     }
                 });

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -98,7 +98,7 @@ pub struct Document {
 
 impl DocumentDerived for EventTarget {
     fn is_document(&self) -> bool {
-        self.type_id == NodeTargetTypeId(DocumentNodeTypeId)
+        *self.type_id() == NodeTargetTypeId(DocumentNodeTypeId)
     }
 }
 

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -27,7 +27,7 @@ pub struct DocumentFragment {
 
 impl DocumentFragmentDerived for EventTarget {
     fn is_documentfragment(&self) -> bool {
-        self.type_id == NodeTargetTypeId(DocumentFragmentNodeTypeId)
+        *self.type_id() == NodeTargetTypeId(DocumentFragmentNodeTypeId)
     }
 }
 

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -20,8 +20,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DocumentFragment {
-    pub node: Node,
+    node: Node,
 }
 
 impl DocumentFragmentDerived for EventTarget {

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -25,7 +25,7 @@ pub struct DocumentType {
 
 impl DocumentTypeDerived for EventTarget {
     fn is_documenttype(&self) -> bool {
-        self.type_id == NodeTargetTypeId(DoctypeNodeTypeId)
+        *self.type_id() == NodeTargetTypeId(DoctypeNodeTypeId)
     }
 }
 

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -15,11 +15,12 @@ use servo_util::str::DOMString;
 /// The `DOCTYPE` tag.
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DocumentType {
-    pub node: Node,
-    pub name: DOMString,
-    pub public_id: DOMString,
-    pub system_id: DOMString,
+    node: Node,
+    name: DOMString,
+    public_id: DOMString,
+    system_id: DOMString,
 }
 
 impl DocumentTypeDerived for EventTarget {
@@ -52,6 +53,21 @@ impl DocumentType {
                                                        system_id,
                                                        document);
         Node::reflect_node(box documenttype, document, DocumentTypeBinding::Wrap)
+    }
+
+    #[inline]
+    pub fn name<'a>(&'a self) -> &'a DOMString {
+        &self.name
+    }
+
+    #[inline]
+    pub fn public_id<'a>(&'a self) -> &'a DOMString {
+        &self.public_id
+    }
+
+    #[inline]
+    pub fn system_id<'a>(&'a self) -> &'a DOMString {
+        &self.system_id
     }
 }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -62,9 +62,10 @@ impl DOMErrorName {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DOMException {
-    pub code: DOMErrorName,
-    pub reflector_: Reflector
+    code: DOMErrorName,
+    reflector_: Reflector
 }
 
 impl DOMException {

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -39,7 +39,7 @@ impl DOMImplementation {
     }
 
     pub fn new(document: JSRef<Document>) -> Temporary<DOMImplementation> {
-        let window = document.window.root();
+        let window = document.window().root();
         reflect_dom_object(box DOMImplementation::new_inherited(document),
                            &Window(*window),
                            DOMImplementationBinding::Wrap)
@@ -73,7 +73,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     fn CreateDocument(self, namespace: Option<DOMString>, qname: DOMString,
                       maybe_doctype: Option<JSRef<DocumentType>>) -> Fallible<Temporary<Document>> {
         let doc = self.document.root();
-        let win = doc.window.root();
+        let win = doc.window().root();
 
         // Step 1.
         let doc = Document::new(*win, None, NonHTMLDocument, None).root();
@@ -118,7 +118,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     // http://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
     fn CreateHTMLDocument(self, title: Option<DOMString>) -> Temporary<Document> {
         let document = self.document.root();
-        let win = document.window.root();
+        let win = document.window().root();
 
         // Step 1-2.
         let doc = Document::new(*win, None, HTMLDocument, None).root();

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -24,6 +24,7 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DOMImplementation {
     document: JS<Document>,
     reflector_: Reflector,

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -16,6 +16,7 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DOMParser {
     window: JS<Window>, //XXXjdm Document instead?
     reflector_: Reflector

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -12,6 +12,7 @@ use servo_util::geometry::Au;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DOMRect {
     reflector_: Reflector,
     top: f32,

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -12,6 +12,7 @@ use dom::window::Window;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DOMRectList {
     reflector_: Reflector,
     rects: Vec<JS<DOMRect>>,

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -17,6 +17,7 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct DOMTokenList {
     reflector_: Reflector,
     element: JS<Element>,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -35,7 +35,7 @@ use servo_util::namespace;
 use servo_util::str::DOMString;
 
 use std::ascii::StrAsciiExt;
-use std::cell::RefCell;
+use std::cell::{Ref, RefMut, RefCell};
 use std::default::Default;
 use std::mem;
 use std::slice::Items;
@@ -44,14 +44,15 @@ use url::UrlParser;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Element {
-    pub node: Node,
-    pub local_name: Atom,
-    pub namespace: Namespace,
-    pub prefix: Option<DOMString>,
-    pub attrs: RefCell<Vec<JS<Attr>>>,
-    pub style_attribute: RefCell<Option<style::PropertyDeclarationBlock>>,
-    pub attr_list: MutNullableJS<NamedNodeMap>,
+    node: Node,
+    local_name: Atom,
+    namespace: Namespace,
+    prefix: Option<DOMString>,
+    attrs: RefCell<Vec<JS<Attr>>>,
+    style_attribute: RefCell<Option<style::PropertyDeclarationBlock>>,
+    attr_list: MutNullableJS<NamedNodeMap>,
     class_list: MutNullableJS<DOMTokenList>,
 }
 
@@ -170,6 +171,36 @@ impl Element {
     #[inline]
     pub fn node<'a>(&'a self) -> &'a Node {
         &self.node
+    }
+
+    #[inline]
+    pub fn local_name<'a>(&'a self) -> &'a Atom {
+        &self.local_name
+    }
+
+    #[inline]
+    pub fn namespace<'a>(&'a self) -> &'a Namespace {
+        &self.namespace
+    }
+
+    #[inline]
+    pub fn prefix<'a>(&'a self) -> &'a Option<DOMString> {
+        &self.prefix
+    }
+
+    #[inline]
+    pub fn attrs(&self) -> Ref<Vec<JS<Attr>>> {
+        self.attrs.borrow()
+    }
+
+    #[inline]
+    pub fn attrs_mut(&self) -> RefMut<Vec<JS<Attr>>> {
+        self.attrs.borrow_mut()
+    }
+
+    #[inline]
+    pub fn style_attribute<'a>(&'a self) -> &'a RefCell<Option<style::PropertyDeclarationBlock>> {
+        &self.style_attribute
     }
 }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -268,7 +268,7 @@ impl LayoutElementHelpers for JS<Element> {
         }
         let node: JS<Node> = self.transmute_copy();
         let owner_doc = node.owner_doc_for_layout().unsafe_get();
-        (*owner_doc).is_html_document
+        (*owner_doc).is_html_document()
     }
 }
 
@@ -631,7 +631,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
                 let node: JSRef<Node> = NodeCast::from_ref(self);
                 node.owner_doc().root()
             };
-            let window = doc.window.root();
+            let window = doc.window().root();
             let list = NamedNodeMap::new(*window, self);
             self.attr_list.assign(Some(list));
         }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -57,7 +57,7 @@ pub struct Element {
 
 impl ElementDerived for EventTarget {
     fn is_element(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             NodeTargetTypeId(ElementNodeTypeId(_)) => true,
             _ => false
         }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -166,6 +166,11 @@ impl Element {
         Node::reflect_node(box Element::new_inherited(ElementTypeId_, local_name, namespace, prefix, document),
                            document, ElementBinding::Wrap)
     }
+
+    #[inline]
+    pub fn node<'a>(&'a self) -> &'a Node {
+        &self.node
+    }
 }
 
 pub trait RawLayoutElementHelpers {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -191,7 +191,7 @@ impl RawLayoutElementHelpers for Element {
         (*attrs).iter().find(|attr: & &JS<Attr>| {
             let attr = attr.unsafe_get();
             name == (*attr).local_name_atom_forever().as_slice() &&
-            (*attr).namespace == *namespace
+            *(*attr).namespace() == *namespace
         }).map(|attr| {
             let attr = attr.unsafe_get();
             (*attr).value_ref_forever()
@@ -222,7 +222,7 @@ impl RawLayoutElementHelpers for Element {
         (*attrs).iter().find(|attr: & &JS<Attr>| {
             let attr = attr.unsafe_get();
             name == (*attr).local_name_atom_forever().as_slice() &&
-            (*attr).namespace == *namespace
+            *(*attr).namespace() == *namespace
         }).and_then(|attr| {
             let attr = attr.unsafe_get();
             (*attr).value_atom_forever()
@@ -360,7 +360,7 @@ pub trait AttributeHandlers {
 impl<'a> AttributeHandlers for JSRef<'a, Element> {
     fn get_attribute(self, namespace: Namespace, local_name: &str) -> Option<Temporary<Attr>> {
         self.get_attributes(local_name).iter().map(|attr| attr.root())
-            .find(|attr| attr.namespace == namespace)
+            .find(|attr| *attr.namespace() == namespace)
             .map(|x| Temporary::from_rooted(*x))
     }
 
@@ -496,7 +496,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
             false => Atom::from_slice(name)
         };
         self.attrs.borrow().iter().map(|attr| attr.root()).any(|attr| {
-            *attr.local_name() == name && attr.namespace == ns!("")
+            *attr.local_name() == name && *attr.namespace() == ns!("")
         })
     }
 
@@ -684,7 +684,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         let name = Atom::from_slice(name.as_slice());
         let value = self.parse_attribute(&ns!(""), &name, value);
         self.do_set_attribute(name.clone(), value, name.clone(), ns!(""), None, |attr| {
-            attr.name.as_slice() == name.as_slice()
+            attr.name().as_slice() == name.as_slice()
         });
         Ok(())
     }
@@ -753,7 +753,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
                               namespace.clone(), prefix.map(|s| s.to_string()),
                               |attr| {
             *attr.local_name() == local_name &&
-            attr.namespace == namespace
+            *attr.namespace() == namespace
         });
         Ok(())
     }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -37,21 +37,22 @@ pub enum EventTypeId {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Event {
-    pub type_id: EventTypeId,
+    type_id: EventTypeId,
     reflector_: Reflector,
-    pub current_target: MutNullableJS<EventTarget>,
-    pub target: MutNullableJS<EventTarget>,
+    current_target: MutNullableJS<EventTarget>,
+    target: MutNullableJS<EventTarget>,
     type_: RefCell<DOMString>,
-    pub phase: Cell<EventPhase>,
-    pub canceled: Cell<bool>,
-    pub stop_propagation: Cell<bool>,
-    pub stop_immediate: Cell<bool>,
-    pub cancelable: Cell<bool>,
-    pub bubbles: Cell<bool>,
-    pub trusted: Cell<bool>,
-    pub dispatching: Cell<bool>,
-    pub initialized: Cell<bool>,
+    phase: Cell<EventPhase>,
+    canceled: Cell<bool>,
+    stop_propagation: Cell<bool>,
+    stop_immediate: Cell<bool>,
+    cancelable: Cell<bool>,
+    bubbles: Cell<bool>,
+    trusted: Cell<bool>,
+    dispatching: Cell<bool>,
+    initialized: Cell<bool>,
     timestamp: u64,
 }
 
@@ -95,6 +96,61 @@ impl Event {
                        type_: DOMString,
                        init: &EventBinding::EventInit) -> Fallible<Temporary<Event>> {
         Ok(Event::new(global, type_, init.bubbles, init.cancelable))
+    }
+
+    #[inline]
+    pub fn type_id<'a>(&'a self) -> &'a EventTypeId {
+        &self.type_id
+    }
+
+    #[inline]
+    pub fn clear_current_target(&self) {
+        self.current_target.clear();
+    }
+
+    #[inline]
+    pub fn set_current_target(&self, val: JSRef<EventTarget>) {
+        self.current_target.assign(Some(val));
+    }
+
+    #[inline]
+    pub fn set_target(&self, val: JSRef<EventTarget>) {
+        self.target.assign(Some(val));
+    }
+
+    #[inline]
+    pub fn set_phase(&self, val: EventPhase) {
+        self.phase.set(val)
+    }
+
+    #[inline]
+    pub fn stop_propagation(&self) -> bool {
+        self.stop_propagation.get()
+    }
+
+    #[inline]
+    pub fn stop_immediate(&self) -> bool {
+        self.stop_immediate.get()
+    }
+
+    #[inline]
+    pub fn bubbles(&self) -> bool {
+        self.bubbles.get()
+    }
+
+    #[inline]
+    pub fn dispatching(&self) -> bool {
+        self.dispatching.get()
+    }
+
+    #[inline]
+    pub fn set_dispatching(&self, val: bool) {
+        self.dispatching.set(val)
+    }
+
+    #[inline]
+    pub fn initialized(&self) -> bool {
+        self.initialized.get()
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -59,15 +59,17 @@ impl EventListenerType {
 
 #[deriving(PartialEq)]
 #[jstraceable]
+#[privatize]
 pub struct EventListenerEntry {
-    pub phase: ListenerPhase,
-    pub listener: EventListenerType
+    phase: ListenerPhase,
+    listener: EventListenerType
 }
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct EventTarget {
-    pub type_id: EventTargetTypeId,
+    type_id: EventTargetTypeId,
     reflector_: Reflector,
     handlers: RefCell<HashMap<DOMString, Vec<EventListenerEntry>>>,
 }
@@ -93,6 +95,11 @@ impl EventTarget {
             let filtered = listeners.iter().filter(|entry| entry.phase == desired_phase);
             filtered.map(|entry| entry.listener.get_listener()).collect()
         })
+    }
+
+    #[inline]
+    pub fn type_id<'a>(&'a self) -> &'a EventTargetTypeId {
+        &self.type_id
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -128,7 +128,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
     fn dispatch_event_with_target(self,
                                   target: Option<JSRef<EventTarget>>,
                                   event: JSRef<Event>) -> Fallible<bool> {
-        if event.dispatching.get() || !event.initialized.get() {
+        if event.dispatching() || !event.initialized() {
             return Err(InvalidState);
         }
         Ok(dispatch_event(self, target, event))

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -12,10 +12,11 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct File {
-    pub blob: Blob,
-    pub name: DOMString,
-    pub type_: BlobType
+    blob: Blob,
+    name: DOMString,
+    type_: BlobType
 }
 
 impl File {
@@ -33,6 +34,10 @@ impl File {
         reflect_dom_object(box File::new_inherited(file_bits, name),
                            global,
                            FileBinding::Wrap)
+    }
+
+    pub fn name<'a>(&'a self) -> &'a DOMString {
+        &self.name
     }
 }
 

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -113,7 +113,7 @@ impl PrivateFormDataHelpers for FormData {
     fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File> {
         let global = self.global.root();
         let f: Option<JSRef<File>> = FileCast::to_ref(value);
-        let name = filename.unwrap_or(f.map(|inner| inner.name.clone()).unwrap_or("blob".to_string()));
+        let name = filename.unwrap_or(f.map(|inner| inner.name().clone()).unwrap_or("blob".to_string()));
         File::new(&global.root_ref(), value, name)
     }
 }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -27,6 +27,7 @@ pub enum FormDatum {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct FormData {
     data: RefCell<HashMap<DOMString, Vec<FormDatum>>>,
     reflector_: Reflector,

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -23,8 +23,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLAnchorElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLAnchorElementDerived for EventTarget {

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -30,7 +30,7 @@ pub struct HTMLAnchorElement {
 
 impl HTMLAnchorElementDerived for EventTarget {
     fn is_htmlanchorelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLAnchorElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLAnchorElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLAppletElement {
 
 impl HTMLAppletElementDerived for EventTarget {
     fn is_htmlappletelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLAppletElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLAppletElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLAppletElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLAppletElementDerived for EventTarget {

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -23,7 +23,7 @@ pub struct HTMLAreaElement {
 
 impl HTMLAreaElementDerived for EventTarget {
     fn is_htmlareaelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLAreaElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLAreaElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -16,8 +16,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLAreaElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLAreaElementDerived for EventTarget {

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLAudioElement {
-    pub htmlmediaelement: HTMLMediaElement
+    htmlmediaelement: HTMLMediaElement
 }
 
 impl HTMLAudioElementDerived for EventTarget {

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLAudioElement {
 
 impl HTMLAudioElementDerived for EventTarget {
     fn is_htmlaudioelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLAudioElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLAudioElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLBaseElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLBaseElementDerived for EventTarget {

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLBaseElement {
 
 impl HTMLBaseElementDerived for EventTarget {
     fn is_htmlbaseelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLBaseElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLBaseElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -22,8 +22,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLBodyElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLBodyElementDerived for EventTarget {

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -29,7 +29,7 @@ pub struct HTMLBodyElement {
 
 impl HTMLBodyElementDerived for EventTarget {
     fn is_htmlbodyelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLBodyElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLBodyElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLBRElement {
 
 impl HTMLBRElementDerived for EventTarget {
     fn is_htmlbrelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLBRElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLBRElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLBRElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLBRElementDerived for EventTarget {

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -22,8 +22,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLButtonElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLButtonElementDerived for EventTarget {

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -29,7 +29,7 @@ pub struct HTMLButtonElement {
 
 impl HTMLButtonElementDerived for EventTarget {
     fn is_htmlbuttonelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLButtonElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLButtonElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -30,8 +30,9 @@ static DefaultHeight: u32 = 150;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLCanvasElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
     context: MutNullableJS<CanvasRenderingContext2D>,
     width: Cell<u32>,
     height: Cell<u32>,

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -40,7 +40,7 @@ pub struct HTMLCanvasElement {
 
 impl HTMLCanvasElementDerived for EventTarget {
     fn is_htmlcanvaselement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLCanvasElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLCanvasElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -31,6 +31,7 @@ pub enum CollectionTypeId {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLCollection {
     collection: CollectionTypeId,
     reflector_: Reflector,

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -67,7 +67,7 @@ impl HTMLCollection {
             fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 match self.namespace_filter {
                     None => true,
-                    Some(ref namespace) => elem.namespace == *namespace
+                    Some(ref namespace) => *elem.namespace() == *namespace
                 }
             }
         }
@@ -89,9 +89,9 @@ impl HTMLCollection {
         impl CollectionFilter for TagNameFilter {
             fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 if elem.html_element_in_html_document() {
-                    elem.local_name == self.ascii_lower_tag
+                    *elem.local_name() == self.ascii_lower_tag
                 } else {
-                    elem.local_name == self.tag
+                    *elem.local_name() == self.tag
                 }
             }
         }
@@ -121,11 +121,11 @@ impl HTMLCollection {
             fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
                 let ns_match = match self.namespace_filter {
                     Some(ref namespace) => {
-                        elem.namespace == *namespace
+                        *elem.namespace() == *namespace
                     },
                     None => true
                 };
-                ns_match && elem.local_name == self.tag
+                ns_match && *elem.local_name() == self.tag
             }
         }
         let filter = TagNameNSFilter {

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLDataElement {
 
 impl HTMLDataElementDerived for EventTarget {
     fn is_htmldataelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLDataElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLDataElementTypeId))
     }
 }
 

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLDataElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLDataElementDerived for EventTarget {

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -25,7 +25,7 @@ pub struct HTMLDataListElement {
 
 impl HTMLDataListElementDerived for EventTarget {
     fn is_htmldatalistelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLDataListElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLDataListElementTypeId))
     }
 }
 

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -18,8 +18,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLDataListElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLDataListElementDerived for EventTarget {

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLDirectoryElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLDirectoryElementDerived for EventTarget {

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLDirectoryElement {
 
 impl HTMLDirectoryElementDerived for EventTarget {
     fn is_htmldirectoryelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLDirectoryElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLDirectoryElementTypeId))
     }
 }
 

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLDivElement {
 
 impl HTMLDivElementDerived for EventTarget {
     fn is_htmldivelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLDivElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLDivElementTypeId))
     }
 }
 

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLDivElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLDivElementDerived for EventTarget {

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLDListElement {
 
 impl HTMLDListElementDerived for EventTarget {
     fn is_htmldlistelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLDListElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLDListElementTypeId))
     }
 }
 

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLDListElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLDListElementDerived for EventTarget {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -29,7 +29,7 @@ pub struct HTMLElement {
 
 impl HTMLElementDerived for EventTarget {
     fn is_htmlelement(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             NodeTargetTypeId(ElementNodeTypeId(ElementTypeId_)) => false,
             NodeTargetTypeId(ElementNodeTypeId(_)) => true,
             _ => false

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -22,8 +22,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLElement {
-    pub element: Element
+    element: Element
 }
 
 impl HTMLElementDerived for EventTarget {
@@ -47,6 +48,11 @@ impl HTMLElement {
     pub fn new(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> Temporary<HTMLElement> {
         let element = HTMLElement::new_inherited(HTMLElementTypeId, localName, prefix, document);
         Node::reflect_node(box element, document, HTMLElementBinding::Wrap)
+    }
+
+    #[inline]
+    pub fn element<'a>(&'a self) -> &'a Element {
+        &self.element
     }
 }
 

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLEmbedElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLEmbedElementDerived for EventTarget {

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLEmbedElement {
 
 impl HTMLEmbedElementDerived for EventTarget {
     fn is_htmlembedelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLEmbedElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLEmbedElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -30,7 +30,7 @@ pub struct HTMLFieldSetElement {
 
 impl HTMLFieldSetElementDerived for EventTarget {
     fn is_htmlfieldsetelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLFieldSetElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLFieldSetElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -58,7 +58,7 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
                 static tag_names: StaticStringVec = &["button", "fieldset", "input",
                     "keygen", "object", "output", "select", "textarea"];
                 let root: JSRef<Element> = ElementCast::to_ref(root).unwrap();
-                elem != root && tag_names.iter().any(|&tag_name| tag_name == elem.local_name.as_slice())
+                elem != root && tag_names.iter().any(|&tag_name| tag_name == elem.local_name().as_slice())
             }
         }
         let node: JSRef<Node> = NodeCast::from_ref(self);

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -23,8 +23,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLFieldSetElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLFieldSetElementDerived for EventTarget {

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLFontElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLFontElementDerived for EventTarget {

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLFontElement {
 
 impl HTMLFontElementDerived for EventTarget {
     fn is_htmlfontelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLFontElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLFontElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -31,8 +31,9 @@ use url::form_urlencoded::serialize;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLFormElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLFormElementDerived for EventTarget {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -218,8 +218,8 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         }
 
         // This is wrong. https://html.spec.whatwg.org/multipage/forms.html#planned-navigation
-        let ScriptChan(ref script_chan) = win.script_chan;
-        script_chan.send(TriggerLoadMsg(win.page.id, load_data));
+        let ScriptChan(ref script_chan) = *win.script_chan();
+        script_chan.send(TriggerLoadMsg(win.page().id, load_data));
     }
 
     fn get_form_dataset(self, _submitter: Option<FormSubmitter>) -> Vec<FormDatum> {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -38,7 +38,7 @@ pub struct HTMLFormElement {
 
 impl HTMLFormElementDerived for EventTarget {
     fn is_htmlformelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLFormElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLFormElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLFrameElement {
 
 impl HTMLFrameElementDerived for EventTarget {
     fn is_htmlframeelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLFrameElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLFrameElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLFrameElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLFrameElementDerived for EventTarget {

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLFrameSetElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLFrameSetElementDerived for EventTarget {

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLFrameSetElement {
 
 impl HTMLFrameSetElementDerived for EventTarget {
     fn is_htmlframesetelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLFrameSetElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLFrameSetElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLHeadElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLHeadElementDerived for EventTarget {

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLHeadElement {
 
 impl HTMLHeadElementDerived for EventTarget {
     fn is_htmlheadelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLHeadElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLHeadElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -33,7 +33,7 @@ pub struct HTMLHeadingElement {
 
 impl HTMLHeadingElementDerived for EventTarget {
     fn is_htmlheadingelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLHeadingElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLHeadingElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -25,9 +25,10 @@ pub enum HeadingLevel {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLHeadingElement {
-    pub htmlelement: HTMLElement,
-    pub level: HeadingLevel,
+    htmlelement: HTMLElement,
+    level: HeadingLevel,
 }
 
 impl HTMLHeadingElementDerived for EventTarget {

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLHRElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLHRElementDerived for EventTarget {

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLHRElement {
 
 impl HTMLHRElementDerived for EventTarget {
     fn is_htmlhrelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLHRElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLHRElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLHtmlElement {
 
 impl HTMLHtmlElementDerived for EventTarget {
     fn is_htmlhtmlelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLHtmlElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLHtmlElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLHtmlElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLHtmlElementDerived for EventTarget {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -41,10 +41,11 @@ enum SandboxAllowance {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLIFrameElement {
-    pub htmlelement: HTMLElement,
-    pub size: Cell<Option<IFrameSize>>,
-    pub sandbox: Cell<Option<u8>>,
+    htmlelement: HTMLElement,
+    size: Cell<Option<IFrameSize>>,
+    sandbox: Cell<Option<u8>>,
 }
 
 impl HTMLIFrameElementDerived for EventTarget {
@@ -54,9 +55,22 @@ impl HTMLIFrameElementDerived for EventTarget {
 }
 
 #[jstraceable]
+#[privatize]
 pub struct IFrameSize {
-    pub pipeline_id: PipelineId,
-    pub subpage_id: SubpageId,
+    pipeline_id: PipelineId,
+    subpage_id: SubpageId,
+}
+
+impl IFrameSize {
+    #[inline]
+    pub fn pipeline_id<'a>(&'a self) -> &'a PipelineId {
+        &self.pipeline_id
+    }
+
+    #[inline]
+    pub fn subpage_id<'a>(&'a self) -> &'a SubpageId {
+        &self.subpage_id
+    }
 }
 
 pub trait HTMLIFrameElementHelpers {
@@ -125,6 +139,11 @@ impl HTMLIFrameElement {
     pub fn new(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> Temporary<HTMLIFrameElement> {
         let element = HTMLIFrameElement::new_inherited(localName, prefix, document);
         Node::reflect_node(box element, document, HTMLIFrameElementBinding::Wrap)
+    }
+
+    #[inline]
+    pub fn size(&self) -> Option<IFrameSize> {
+        self.size.get()
     }
 }
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -171,7 +171,7 @@ impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
     fn GetContentWindow(self) -> Option<Temporary<Window>> {
         self.size.get().and_then(|size| {
             let window = window_from_node(self).root();
-            let children = window.page.children.borrow();
+            let children = window.page().children.borrow();
             let child = children.iter().find(|child| {
                 child.subpage_id.unwrap() == size.subpage_id
             });

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -50,7 +50,7 @@ pub struct HTMLIFrameElement {
 
 impl HTMLIFrameElementDerived for EventTarget {
     fn is_htmliframeelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLIFrameElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLIFrameElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -49,7 +49,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         let document = node.owner_doc().root();
         let window = document.window().root();
-        let image_cache = &window.image_cache_task;
+        let image_cache = window.image_cache_task();
         match value {
             None => {
                 *self.image.borrow_mut() = None;

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -34,7 +34,7 @@ pub struct HTMLImageElement {
 
 impl HTMLImageElementDerived for EventTarget {
     fn is_htmlimageelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLImageElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLImageElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -48,7 +48,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
     fn update_image(self, value: Option<(DOMString, &Url)>) {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         let document = node.owner_doc().root();
-        let window = document.window.root();
+        let window = document.window().root();
         let image_cache = &window.image_cache_task;
         match value {
             None => {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -26,8 +26,9 @@ use std::cell::RefCell;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLImageElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
     image: RefCell<Option<Url>>,
 }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -45,8 +45,9 @@ enum InputType {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLInputElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
     input_type: Cell<InputType>,
     checked: Cell<bool>,
     uncommitted_value: RefCell<Option<String>>,

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -57,7 +57,7 @@ pub struct HTMLInputElement {
 
 impl HTMLInputElementDerived for EventTarget {
     fn is_htmlinputelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLInputElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLInputElementTypeId))
     }
 }
 

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLLabelElement {
 
 impl HTMLLabelElementDerived for EventTarget {
     fn is_htmllabelelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLLabelElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLLabelElementTypeId))
     }
 }
 

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLLabelElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLLabelElementDerived for EventTarget {

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLLegendElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLLegendElementDerived for EventTarget {

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLLegendElement {
 
 impl HTMLLegendElementDerived for EventTarget {
     fn is_htmllegendelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLLegendElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLLegendElementTypeId))
     }
 }
 

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLLIElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLLIElementDerived for EventTarget {

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -22,7 +22,7 @@ pub struct HTMLLIElement {
 
 impl HTMLLIElementDerived for EventTarget {
     fn is_htmllielement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLLIElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLLIElementTypeId))
     }
 }
 

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -23,8 +23,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLLinkElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLLinkElementDerived for EventTarget {

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -30,7 +30,7 @@ pub struct HTMLLinkElement {
 
 impl HTMLLinkElementDerived for EventTarget {
     fn is_htmllinkelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLLinkElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLLinkElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLMapElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLMapElementDerived for EventTarget {

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLMapElement {
 
 impl HTMLMapElementDerived for EventTarget {
     fn is_htmlmapelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLMapElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLMapElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -14,8 +14,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLMediaElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLMediaElementDerived for EventTarget {
@@ -33,6 +34,11 @@ impl HTMLMediaElement {
         HTMLMediaElement {
             htmlelement: HTMLElement::new_inherited(type_id, tag_name, prefix, document)
         }
+    }
+
+    #[inline]
+    pub fn htmlelement<'a>(&'a self) -> &'a HTMLElement {
+        &self.htmlelement
     }
 }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -21,7 +21,7 @@ pub struct HTMLMediaElement {
 
 impl HTMLMediaElementDerived for EventTarget {
     fn is_htmlmediaelement(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             NodeTargetTypeId(ElementNodeTypeId(HTMLVideoElementTypeId)) |
             NodeTargetTypeId(ElementNodeTypeId(HTMLAudioElementTypeId)) => true,
             _ => false

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLMetaElement {
 
 impl HTMLMetaElementDerived for EventTarget {
     fn is_htmlmetaelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLMetaElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLMetaElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLMetaElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLMetaElementDerived for EventTarget {

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLMeterElement {
 
 impl HTMLMeterElementDerived for EventTarget {
     fn is_htmlmeterelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLMeterElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLMeterElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLMeterElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLMeterElementDerived for EventTarget {

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLModElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLModElementDerived for EventTarget {

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLModElement {
 
 impl HTMLModElementDerived for EventTarget {
     fn is_htmlmodelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLModElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLModElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -27,8 +27,9 @@ use url::Url;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLObjectElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLObjectElementDerived for EventTarget {

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -109,7 +109,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
 
         if "data" == name.as_slice() {
             let window = window_from_node(*self).root();
-            self.process_data_url(window.image_cache_task.clone());
+            self.process_data_url(window.image_cache_task().clone());
         }
     }
 }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -34,7 +34,7 @@ pub struct HTMLObjectElement {
 
 impl HTMLObjectElementDerived for EventTarget {
     fn is_htmlobjectelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLObjectElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLObjectElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLOListElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLOListElementDerived for EventTarget {

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLOListElement {
 
 impl HTMLOListElementDerived for EventTarget {
     fn is_htmlolistelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLOListElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLOListElementTypeId))
     }
 }
 

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -27,7 +27,7 @@ pub struct HTMLOptGroupElement {
 
 impl HTMLOptGroupElementDerived for EventTarget {
     fn is_htmloptgroupelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLOptGroupElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLOptGroupElementTypeId))
     }
 }
 

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -20,8 +20,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLOptGroupElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLOptGroupElementDerived for EventTarget {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -31,7 +31,7 @@ pub struct HTMLOptionElement {
 
 impl HTMLOptionElementDerived for EventTarget {
     fn is_htmloptionelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLOptionElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLOptionElementTypeId))
     }
 }
 

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -24,8 +24,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLOptionElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLOptionElementDerived for EventTarget {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -51,7 +51,7 @@ impl HTMLOptionElement {
 
 fn collect_text(node: &JSRef<Node>, value: &mut DOMString) {
     let elem: JSRef<Element> = ElementCast::to_ref(*node).unwrap();
-    let svg_script = elem.namespace == ns!(SVG) && elem.local_name.as_slice() == "script";
+    let svg_script = *elem.namespace() == ns!(SVG) && elem.local_name().as_slice() == "script";
     let html_script = node.is_htmlscriptelement();
     if svg_script || html_script {
         return;

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -24,7 +24,7 @@ pub struct HTMLOutputElement {
 
 impl HTMLOutputElementDerived for EventTarget {
     fn is_htmloutputelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLOutputElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLOutputElementTypeId))
     }
 }
 

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -17,8 +17,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLOutputElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLOutputElementDerived for EventTarget {

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLParagraphElement {
 
 impl HTMLParagraphElementDerived for EventTarget {
     fn is_htmlparagraphelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLParagraphElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLParagraphElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLParagraphElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLParagraphElementDerived for EventTarget {

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLParamElement {
 
 impl HTMLParamElementDerived for EventTarget {
     fn is_htmlparamelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLParamElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLParamElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLParamElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLParamElementDerived for EventTarget {

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLPreElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLPreElementDerived for EventTarget {

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLPreElement {
 
 impl HTMLPreElementDerived for EventTarget {
     fn is_htmlpreelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLPreElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLPreElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLProgressElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLProgressElementDerived for EventTarget {

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -22,7 +22,7 @@ pub struct HTMLProgressElement {
 
 impl HTMLProgressElementDerived for EventTarget {
     fn is_htmlprogresselement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLProgressElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLProgressElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLQuoteElement {
 
 impl HTMLQuoteElementDerived for EventTarget {
     fn is_htmlquoteelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLQuoteElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLQuoteElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLQuoteElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLQuoteElementDerived for EventTarget {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -27,7 +27,7 @@ pub struct HTMLScriptElement {
 
 impl HTMLScriptElementDerived for EventTarget {
     fn is_htmlscriptelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLScriptElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLScriptElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -20,8 +20,9 @@ use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLScriptElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLScriptElementDerived for EventTarget {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -30,7 +30,7 @@ pub struct HTMLSelectElement {
 
 impl HTMLSelectElementDerived for EventTarget {
     fn is_htmlselectelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLSelectElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLSelectElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -23,8 +23,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLSelectElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLSelectElementDerived for EventTarget {

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -101,7 +101,7 @@ fn serialize_processing_instruction(processing_instruction: JSRef<ProcessingInst
 
 fn serialize_doctype(doctype: JSRef<DocumentType>, html: &mut String) {
     html.push_str("<!DOCTYPE");
-    html.push_str(doctype.name.as_slice());
+    html.push_str(doctype.name().as_slice());
     html.push_char('>');
 }
 

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -78,10 +78,10 @@ fn serialize_text(text: JSRef<Text>, html: &mut String) {
     match text_node.parent_node().map(|node| node.root()) {
         Some(ref parent) if parent.is_element() => {
             let elem: JSRef<Element> = ElementCast::to_ref(**parent).unwrap();
-            match elem.local_name.as_slice() {
+            match elem.local_name().as_slice() {
                 "style" | "script" | "xmp" | "iframe" |
                 "noembed" | "noframes" | "plaintext" |
-                "noscript" if elem.namespace == ns!(HTML)
+                "noscript" if *elem.namespace() == ns!(HTML)
                 => html.push_str(text.characterdata().data().as_slice()),
                 _ => escape(text.characterdata().data().as_slice(), false, html)
             }
@@ -107,15 +107,15 @@ fn serialize_doctype(doctype: JSRef<DocumentType>, html: &mut String) {
 
 fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &mut String) {
     html.push_char('<');
-    html.push_str(elem.local_name.as_slice());
-    for attr in elem.attrs.borrow().iter() {
+    html.push_str(elem.local_name().as_slice());
+    for attr in elem.attrs().iter() {
         let attr = attr.root();
         serialize_attr(*attr, html);
     };
     html.push_char('>');
 
-    match elem.local_name.as_slice() {
-        "pre" | "listing" | "textarea" if elem.namespace == ns!(HTML) => {
+    match elem.local_name().as_slice() {
+        "pre" | "listing" | "textarea" if *elem.namespace() == ns!(HTML) => {
             let node: JSRef<Node> = NodeCast::from_ref(elem);
             match node.first_child().map(|child| child.root()) {
                 Some(ref child) if child.is_text() => {
@@ -131,7 +131,7 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
     }
 
     if !(elem.is_void()) {
-        open_elements.push(elem.local_name.as_slice().to_string());
+        open_elements.push(elem.local_name().as_slice().to_string());
     }
 }
 

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -93,9 +93,9 @@ fn serialize_text(text: JSRef<Text>, html: &mut String) {
 fn serialize_processing_instruction(processing_instruction: JSRef<ProcessingInstruction>,
                                     html: &mut String) {
     html.push_str("<?");
-    html.push_str(processing_instruction.target.as_slice());
+    html.push_str(processing_instruction.target().as_slice());
     html.push_char(' ');
-    html.push_str(processing_instruction.characterdata.data().as_slice());
+    html.push_str(processing_instruction.characterdata().data().as_slice());
     html.push_str("?>");
 }
 

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -69,7 +69,7 @@ pub fn serialize(iterator: &mut NodeIterator) -> String {
 
 fn serialize_comment(comment: JSRef<Comment>, html: &mut String) {
     html.push_str("<!--");
-    html.push_str(comment.characterdata.data.borrow().as_slice());
+    html.push_str(comment.characterdata.data().as_slice());
     html.push_str("-->");
 }
 
@@ -82,11 +82,11 @@ fn serialize_text(text: JSRef<Text>, html: &mut String) {
                 "style" | "script" | "xmp" | "iframe" |
                 "noembed" | "noframes" | "plaintext" |
                 "noscript" if elem.namespace == ns!(HTML)
-                => html.push_str(text.characterdata.data.borrow().as_slice()),
-                _ => escape(text.characterdata.data.borrow().as_slice(), false, html)
+                => html.push_str(text.characterdata().data().as_slice()),
+                _ => escape(text.characterdata().data().as_slice(), false, html)
             }
         }
-        _ => escape(text.characterdata.data.borrow().as_slice(), false, html)
+        _ => escape(text.characterdata().data().as_slice(), false, html)
     }
 }
 
@@ -95,7 +95,7 @@ fn serialize_processing_instruction(processing_instruction: JSRef<ProcessingInst
     html.push_str("<?");
     html.push_str(processing_instruction.target.as_slice());
     html.push_char(' ');
-    html.push_str(processing_instruction.characterdata.data.borrow().as_slice());
+    html.push_str(processing_instruction.characterdata.data().as_slice());
     html.push_str("?>");
 }
 
@@ -120,7 +120,7 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
             match node.first_child().map(|child| child.root()) {
                 Some(ref child) if child.is_text() => {
                     let text: JSRef<CharacterData> = CharacterDataCast::to_ref(**child).unwrap();
-                    if text.data.borrow().len() > 0 && text.data.borrow().as_slice().char_at(0) == '\n' {
+                    if text.data().len() > 0 && text.data().as_slice().char_at(0) == '\n' {
                         html.push_char('\x0A');
                     }
                 },

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -69,7 +69,7 @@ pub fn serialize(iterator: &mut NodeIterator) -> String {
 
 fn serialize_comment(comment: JSRef<Comment>, html: &mut String) {
     html.push_str("<!--");
-    html.push_str(comment.characterdata.data().as_slice());
+    html.push_str(comment.characterdata().data().as_slice());
     html.push_str("-->");
 }
 

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -137,20 +137,20 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
 
 fn serialize_attr(attr: JSRef<Attr>, html: &mut String) {
     html.push_char(' ');
-    if attr.namespace == ns!(XML) {
+    if *attr.namespace() == ns!(XML) {
         html.push_str("xml:");
         html.push_str(attr.local_name().as_slice());
-    } else if attr.namespace == ns!(XMLNS) &&
+    } else if *attr.namespace() == ns!(XMLNS) &&
         *attr.local_name() == Atom::from_slice("xmlns") {
         html.push_str("xmlns");
-    } else if attr.namespace == ns!(XMLNS) {
+    } else if *attr.namespace() == ns!(XMLNS) {
         html.push_str("xmlns:");
         html.push_str(attr.local_name().as_slice());
-    } else if attr.namespace == ns!(XLink) {
+    } else if *attr.namespace() == ns!(XLink) {
         html.push_str("xlink:");
         html.push_str(attr.local_name().as_slice());
     } else {
-        html.push_str(attr.name.as_slice());
+        html.push_str(attr.name().as_slice());
     };
     html.push_str("=\"");
     escape(attr.value().as_slice(), true, html);

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLSourceElement {
 
 impl HTMLSourceElementDerived for EventTarget {
     fn is_htmlsourceelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLSourceElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLSourceElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLSourceElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLSourceElementDerived for EventTarget {

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLSpanElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLSpanElementDerived for EventTarget {

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLSpanElement {
 
 impl HTMLSpanElementDerived for EventTarget {
     fn is_htmlspanelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLSpanElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLSpanElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -19,8 +19,9 @@ use style::Stylesheet;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLStyleElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLStyleElementDerived for EventTarget {

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -26,7 +26,7 @@ pub struct HTMLStyleElement {
 
 impl HTMLStyleElementDerived for EventTarget {
     fn is_htmlstyleelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLStyleElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLStyleElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTableCaptionElement {
 
 impl HTMLTableCaptionElementDerived for EventTarget {
     fn is_htmltablecaptionelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableCaptionElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableCaptionElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableCaptionElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLTableCaptionElementDerived for EventTarget {

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -14,8 +14,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableCellElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTableCellElementDerived for EventTarget {
@@ -33,6 +34,11 @@ impl HTMLTableCellElement {
         HTMLTableCellElement {
             htmlelement: HTMLElement::new_inherited(type_id, tag_name, prefix, document)
         }
+    }
+
+    #[inline]
+    pub fn htmlelement<'a>(&'a self) -> &'a HTMLElement {
+        &self.htmlelement
     }
 }
 

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -21,7 +21,7 @@ pub struct HTMLTableCellElement {
 
 impl HTMLTableCellElementDerived for EventTarget {
     fn is_htmltablecellelement(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             NodeTargetTypeId(ElementNodeTypeId(HTMLTableDataCellElementTypeId)) |
             NodeTargetTypeId(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId)) => true,
             _ => false

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTableColElement {
 
 impl HTMLTableColElementDerived for EventTarget {
     fn is_htmltablecolelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableColElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableColElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableColElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTableColElementDerived for EventTarget {

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableDataCellElement {
-    pub htmltablecellelement: HTMLTableCellElement,
+    htmltablecellelement: HTMLTableCellElement,
 }
 
 impl HTMLTableDataCellElementDerived for EventTarget {

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTableDataCellElement {
 
 impl HTMLTableDataCellElementDerived for EventTarget {
     fn is_htmltabledatacellelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableDataCellElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableDataCellElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -19,8 +19,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTableElementDerived for EventTarget {

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -26,7 +26,7 @@ pub struct HTMLTableElement {
 
 impl HTMLTableElementDerived for EventTarget {
     fn is_htmltableelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTableHeaderCellElement {
 
 impl HTMLTableHeaderCellElementDerived for EventTarget {
     fn is_htmltableheadercellelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableHeaderCellElement {
-    pub htmltablecellelement: HTMLTableCellElement,
+    htmltablecellelement: HTMLTableCellElement,
 }
 
 impl HTMLTableHeaderCellElementDerived for EventTarget {

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTableRowElement {
 
 impl HTMLTableRowElementDerived for EventTarget {
     fn is_htmltablerowelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableRowElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableRowElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableRowElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTableRowElementDerived for EventTarget {

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTableSectionElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTableSectionElementDerived for EventTarget {

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTableSectionElement {
 
 impl HTMLTableSectionElementDerived for EventTarget {
     fn is_htmltablesectionelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTableSectionElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTableSectionElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTemplateElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTemplateElementDerived for EventTarget {

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTemplateElement {
 
 impl HTMLTemplateElementDerived for EventTarget {
     fn is_htmltemplateelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTemplateElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTemplateElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -20,8 +20,9 @@ use string_cache::Atom;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTextAreaElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTextAreaElementDerived for EventTarget {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -27,7 +27,7 @@ pub struct HTMLTextAreaElement {
 
 impl HTMLTextAreaElementDerived for EventTarget {
     fn is_htmltextareaelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTextAreaElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTextAreaElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTimeElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLTimeElementDerived for EventTarget {

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTimeElement {
 
 impl HTMLTimeElementDerived for EventTarget {
     fn is_htmltimeelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTimeElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTimeElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -25,7 +25,7 @@ pub struct HTMLTitleElement {
 
 impl HTMLTitleElementDerived for EventTarget {
     fn is_htmltitleelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTitleElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTitleElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -18,8 +18,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTitleElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTitleElementDerived for EventTarget {
@@ -50,7 +51,7 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
         for child in node.children() {
             let text: Option<JSRef<Text>> = TextCast::to_ref(child);
             match text {
-                Some(text) => content.push_str(text.characterdata.data.borrow().as_slice()),
+                Some(text) => content.push_str(text.characterdata().data().as_slice()),
                 None => (),
             }
         }

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLTrackElement {
 
 impl HTMLTrackElementDerived for EventTarget {
     fn is_htmltrackelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLTrackElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLTrackElementTypeId))
     }
 }
 

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLTrackElement {
-    pub htmlelement: HTMLElement,
+    htmlelement: HTMLElement,
 }
 
 impl HTMLTrackElementDerived for EventTarget {

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLUListElement {
 
 impl HTMLUListElementDerived for EventTarget {
     fn is_htmlulistelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLUListElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLUListElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLUListElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLUListElementDerived for EventTarget {

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLUnknownElement {
 
 impl HTMLUnknownElementDerived for EventTarget {
     fn is_htmlunknownelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLUnknownElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLUnknownElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLUnknownElement {
-    pub htmlelement: HTMLElement
+    htmlelement: HTMLElement
 }
 
 impl HTMLUnknownElementDerived for EventTarget {

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -22,7 +22,7 @@ pub struct HTMLVideoElement {
 
 impl HTMLVideoElementDerived for EventTarget {
     fn is_htmlvideoelement(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ElementNodeTypeId(HTMLVideoElementTypeId))
+        *self.type_id() == NodeTargetTypeId(ElementNodeTypeId(HTMLVideoElementTypeId))
     }
 }
 

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -15,8 +15,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct HTMLVideoElement {
-    pub htmlmediaelement: HTMLMediaElement
+    htmlmediaelement: HTMLMediaElement
 }
 
 impl HTMLVideoElementDerived for EventTarget {

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -17,6 +17,7 @@ use std::rc::Rc;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Location {
     reflector_: Reflector, //XXXjdm cycle: window->Location->window
     page: Rc<Page>,

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -20,6 +20,7 @@ use js::jsval::JSVal;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct MessageEvent {
     event: Event,
     data: JSVal,

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -30,7 +30,7 @@ pub struct MessageEvent {
 
 impl MessageEventDerived for Event {
     fn is_messageevent(&self) -> bool {
-        self.type_id == MessageEventTypeId
+        *self.type_id() == MessageEventTypeId
     }
 }
 

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -21,18 +21,19 @@ use std::default::Default;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct MouseEvent {
-    pub mouseevent: UIEvent,
-    pub screen_x: Cell<i32>,
-    pub screen_y: Cell<i32>,
-    pub client_x: Cell<i32>,
-    pub client_y: Cell<i32>,
-    pub ctrl_key: Cell<bool>,
-    pub shift_key: Cell<bool>,
-    pub alt_key: Cell<bool>,
-    pub meta_key: Cell<bool>,
-    pub button: Cell<i16>,
-    pub related_target: MutNullableJS<EventTarget>
+    mouseevent: UIEvent,
+    screen_x: Cell<i32>,
+    screen_y: Cell<i32>,
+    client_x: Cell<i32>,
+    client_y: Cell<i32>,
+    ctrl_key: Cell<bool>,
+    shift_key: Cell<bool>,
+    alt_key: Cell<bool>,
+    meta_key: Cell<bool>,
+    button: Cell<i16>,
+    related_target: MutNullableJS<EventTarget>
 }
 
 impl MouseEventDerived for Event {

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -38,7 +38,7 @@ pub struct MouseEvent {
 
 impl MouseEventDerived for Event {
     fn is_mouseevent(&self) -> bool {
-        self.type_id == MouseEventTypeId
+        *self.type_id() == MouseEventTypeId
     }
 }
 

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -13,6 +13,7 @@ use dom::window::Window;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct NamedNodeMap {
     reflector_: Reflector,
     owner: JS<Element>,

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -35,11 +35,11 @@ impl NamedNodeMap {
 
 impl<'a> NamedNodeMapMethods for JSRef<'a, NamedNodeMap> {
     fn Length(self) -> u32 {
-        self.owner.root().attrs.borrow().len() as u32
+        self.owner.root().attrs().len() as u32
     }
 
     fn Item(self, index: u32) -> Option<Temporary<Attr>> {
-        self.owner.root().attrs.borrow().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
+        self.owner.root().attrs().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
     }
 
     fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -13,8 +13,9 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Navigator {
-    pub reflector_: Reflector //XXXjdm cycle: window->navigator->window
+    reflector_: Reflector //XXXjdm cycle: window->navigator->window
 }
 
 impl Navigator {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1529,8 +1529,8 @@ impl Node {
                     copy_elem.attrs.borrow_mut().push_unrooted(
                         &Attr::new(*window,
                                    attr.local_name().clone(), attr.value().clone(),
-                                   attr.name.clone(), attr.namespace.clone(),
-                                   attr.prefix.clone(), copy_elem));
+                                   attr.name().clone(), attr.namespace().clone(),
+                                   attr.prefix().clone(), copy_elem));
                 }
             },
             _ => ()
@@ -1988,7 +1988,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             assert!(element.attrs.borrow().len() == other_element.attrs.borrow().len());
             element.attrs.borrow().iter().map(|attr| attr.root()).all(|attr| {
                 other_element.attrs.borrow().iter().map(|attr| attr.root()).any(|other_attr| {
-                    (attr.namespace == other_attr.namespace) &&
+                    (*attr.namespace() == *other_attr.namespace()) &&
                     (attr.local_name() == other_attr.local_name()) &&
                     (attr.value().as_slice() == other_attr.value().as_slice())
                 })

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -73,9 +73,10 @@ use uuid;
 /// An HTML node.
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Node {
     /// The JavaScript reflector for this node.
-    pub eventtarget: EventTarget,
+    eventtarget: EventTarget,
 
     /// The type of node that this is.
     type_id: NodeTypeId,
@@ -108,7 +109,7 @@ pub struct Node {
     ///
     /// Must be sent back to the layout task to be destroyed when this
     /// node is finalized.
-    pub layout_data: LayoutDataRef,
+    layout_data: LayoutDataRef,
 
     unique_id: RefCell<String>,
 }
@@ -1147,6 +1148,21 @@ impl Node {
     #[inline]
     pub fn eventtarget<'a>(&'a self) -> &'a EventTarget {
         &self.eventtarget
+    }
+
+    #[inline]
+    pub fn layout_data(&self) -> Ref<Option<LayoutData>> {
+        self.layout_data.borrow()
+    }
+
+    #[inline]
+    pub fn layout_data_mut(&self) -> RefMut<Option<LayoutData>> {
+        self.layout_data.borrow_mut()
+    }
+
+    #[inline]
+    pub unsafe fn layout_data_unchecked(&self) -> *const Option<LayoutData> {
+        self.layout_data.borrow_unchecked()
     }
 
     // http://dom.spec.whatwg.org/#concept-node-adopt

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1458,9 +1458,9 @@ impl Node {
         let copy: Root<Node> = match node.type_id() {
             DoctypeNodeTypeId => {
                 let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
-                let doctype = DocumentType::new(doctype.name.clone(),
-                                                Some(doctype.public_id.clone()),
-                                                Some(doctype.system_id.clone()), *document);
+                let doctype = DocumentType::new(doctype.name().clone(),
+                                                Some(doctype.public_id().clone()),
+                                                Some(doctype.system_id().clone()), *document);
                 NodeCast::from_temporary(doctype)
             },
             DocumentFragmentNodeTypeId => {
@@ -1612,7 +1612,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             CommentNodeTypeId => "#comment".to_string(),
             DoctypeNodeTypeId => {
                 let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(self).unwrap();
-                doctype.name.clone()
+                doctype.name().clone()
             },
             DocumentFragmentNodeTypeId => "#document-fragment".to_string(),
             DocumentNodeTypeId => "#document".to_string()
@@ -1959,9 +1959,9 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         fn is_equal_doctype(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
             let other_doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(other).unwrap();
-            (doctype.name == other_doctype.name) &&
-            (doctype.public_id == other_doctype.public_id) &&
-            (doctype.system_id == other_doctype.system_id)
+            (*doctype.name() == *other_doctype.name()) &&
+            (*doctype.public_id() == *other_doctype.public_id()) &&
+            (*doctype.system_id() == *other_doctype.system_id())
         }
         fn is_equal_element(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let element: JSRef<Element> = ElementCast::to_ref(node).unwrap();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -741,7 +741,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     fn is_in_html_doc(self) -> bool {
-        self.owner_doc().root().is_html_document
+        self.owner_doc().root().is_html_document()
     }
 
     fn children(self) -> AbstractNodeChildrenIterator<'a> {
@@ -1112,7 +1112,7 @@ impl Node {
              document:  JSRef<Document>,
              wrap_fn:   extern "Rust" fn(*mut JSContext, &GlobalRef, Box<N>) -> Temporary<N>)
              -> Temporary<N> {
-        let window = document.window.root();
+        let window = document.window().root();
         reflect_dom_object(node, &global::Window(*window), wrap_fn)
     }
 
@@ -1474,11 +1474,11 @@ impl Node {
             },
             DocumentNodeTypeId => {
                 let document: JSRef<Document> = DocumentCast::to_ref(node).unwrap();
-                let is_html_doc = match document.is_html_document {
+                let is_html_doc = match document.is_html_document() {
                     true => HTMLDocument,
                     false => NonHTMLDocument
                 };
-                let window = document.window.root();
+                let window = document.window().root();
                 let document = Document::new(*window, Some(document.url().clone()),
                                              is_html_doc, None);
                 NodeCast::from_temporary(document)
@@ -1516,7 +1516,7 @@ impl Node {
             DocumentNodeTypeId => {
                 let node_doc: JSRef<Document> = DocumentCast::to_ref(node).unwrap();
                 let copy_doc: JSRef<Document> = DocumentCast::to_ref(*copy).unwrap();
-                copy_doc.set_encoding_name(node_doc.encoding_name.borrow().clone());
+                copy_doc.set_encoding_name(node_doc.encoding_name().clone());
                 copy_doc.set_quirks_mode(node_doc.quirks_mode());
             },
             ElementNodeTypeId(..) => {
@@ -1524,7 +1524,7 @@ impl Node {
                 let copy_elem: JSRef<Element> = ElementCast::to_ref(*copy).unwrap();
 
                 // FIXME: https://github.com/mozilla/servo/issues/1737
-                let window = document.window.root();
+                let window = document.window().root();
                 for attr in node_elem.attrs.borrow().iter().map(|attr| attr.root()) {
                     copy_elem.attrs.borrow_mut().push_unrooted(
                         &Attr::new(*window,
@@ -1667,7 +1667,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         }
 
         let doc = self.owner_doc().root();
-        let window = doc.window.root();
+        let window = doc.window().root();
         let child_list = NodeList::new_child_list(*window, self);
         self.child_list.assign(Some(child_list));
         self.child_list.get().unwrap()
@@ -2125,7 +2125,7 @@ pub fn document_from_node<T: NodeBase+Reflectable>(derived: JSRef<T>) -> Tempora
 
 pub fn window_from_node<T: NodeBase+Reflectable>(derived: JSRef<T>) -> Temporary<Window> {
     let document = document_from_node(derived).root();
-    Temporary::new(document.window.clone())
+    Temporary::new(document.window().clone())
 }
 
 impl<'a> VirtualMethods for JSRef<'a, Node> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -115,7 +115,7 @@ pub struct Node {
 
 impl NodeDerived for EventTarget {
     fn is_node(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             NodeTargetTypeId(_) => true,
             _ => false
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1496,8 +1496,8 @@ impl Node {
             },
             ProcessingInstructionNodeTypeId => {
                 let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
-                let pi = ProcessingInstruction::new(pi.target.clone(),
-                                                    pi.characterdata.data().clone(), *document);
+                let pi = ProcessingInstruction::new(pi.target().clone(),
+                                                    pi.characterdata().data().clone(), *document);
                 NodeCast::from_temporary(pi)
             },
         }.root();
@@ -1974,8 +1974,8 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         fn is_equal_processinginstruction(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
             let other_pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(other).unwrap();
-            (pi.target == other_pi.target) &&
-            (*pi.characterdata.data() == *other_pi.characterdata.data())
+            (*pi.target() == *other_pi.target()) &&
+            (*pi.characterdata().data() == *other_pi.characterdata().data())
         }
         fn is_equal_characterdata(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(node).unwrap();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1501,8 +1501,8 @@ impl Node {
             },
             ElementNodeTypeId(..) => {
                 let element: JSRef<Element> = ElementCast::to_ref(node).unwrap();
-                let element = build_element_from_tag(element.local_name.as_slice().to_string(),
-                    element.namespace.clone(), Some(element.prefix.as_slice().to_string()), *document);
+                let element = build_element_from_tag(element.local_name().as_slice().to_string(),
+                    element.namespace().clone(), Some(element.prefix().as_slice().to_string()), *document);
                 NodeCast::from_temporary(element)
             },
             TextNodeTypeId => {
@@ -1541,8 +1541,8 @@ impl Node {
 
                 // FIXME: https://github.com/mozilla/servo/issues/1737
                 let window = document.window().root();
-                for attr in node_elem.attrs.borrow().iter().map(|attr| attr.root()) {
-                    copy_elem.attrs.borrow_mut().push_unrooted(
+                for attr in node_elem.attrs().iter().map(|attr| attr.root()) {
+                    copy_elem.attrs_mut().push_unrooted(
                         &Attr::new(*window,
                                    attr.local_name().clone(), attr.value().clone(),
                                    attr.name().clone(), attr.namespace().clone(),
@@ -1983,9 +1983,9 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             let element: JSRef<Element> = ElementCast::to_ref(node).unwrap();
             let other_element: JSRef<Element> = ElementCast::to_ref(other).unwrap();
             // FIXME: namespace prefix
-            (element.namespace == other_element.namespace) &&
-            (element.local_name == other_element.local_name) &&
-            (element.attrs.borrow().len() == other_element.attrs.borrow().len())
+            (*element.namespace() == *other_element.namespace()) &&
+            (*element.local_name() == *other_element.local_name()) &&
+            (element.attrs().len() == other_element.attrs().len())
         }
         fn is_equal_processinginstruction(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
@@ -2001,9 +2001,9 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         fn is_equal_element_attrs(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let element: JSRef<Element> = ElementCast::to_ref(node).unwrap();
             let other_element: JSRef<Element> = ElementCast::to_ref(other).unwrap();
-            assert!(element.attrs.borrow().len() == other_element.attrs.borrow().len());
-            element.attrs.borrow().iter().map(|attr| attr.root()).all(|attr| {
-                other_element.attrs.borrow().iter().map(|attr| attr.root()).any(|other_attr| {
+            assert!(element.attrs().len() == other_element.attrs().len());
+            element.attrs().iter().map(|attr| attr.root()).all(|attr| {
+                other_element.attrs().iter().map(|attr| attr.root()).any(|other_attr| {
                     (*attr.namespace() == *other_attr.namespace()) &&
                     (attr.local_name() == other_attr.local_name()) &&
                     (attr.value().as_slice() == other_attr.value().as_slice())

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1144,6 +1144,11 @@ impl Node {
         }
     }
 
+    #[inline]
+    pub fn eventtarget<'a>(&'a self) -> &'a EventTarget {
+        &self.eventtarget
+    }
+
     // http://dom.spec.whatwg.org/#concept-node-adopt
     pub fn adopt(node: JSRef<Node>, document: JSRef<Document>) {
         // Step 1.
@@ -1464,7 +1469,7 @@ impl Node {
             },
             CommentNodeTypeId => {
                 let comment: JSRef<Comment> = CommentCast::to_ref(node).unwrap();
-                let comment = Comment::new(comment.characterdata.data.borrow().clone(), *document);
+                let comment = Comment::new(comment.characterdata.data().clone(), *document);
                 NodeCast::from_temporary(comment)
             },
             DocumentNodeTypeId => {
@@ -1486,13 +1491,13 @@ impl Node {
             },
             TextNodeTypeId => {
                 let text: JSRef<Text> = TextCast::to_ref(node).unwrap();
-                let text = Text::new(text.characterdata.data.borrow().clone(), *document);
+                let text = Text::new(text.characterdata().data().clone(), *document);
                 NodeCast::from_temporary(text)
             },
             ProcessingInstructionNodeTypeId => {
                 let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
                 let pi = ProcessingInstruction::new(pi.target.clone(),
-                                                    pi.characterdata.data.borrow().clone(), *document);
+                                                    pi.characterdata.data().clone(), *document);
                 NodeCast::from_temporary(pi)
             },
         }.root();
@@ -1569,7 +1574,7 @@ impl Node {
         for node in iterator {
             let text: Option<JSRef<Text>> = TextCast::to_ref(node);
             match text {
-                Some(text) => content.push_str(text.characterdata.data.borrow().as_slice()),
+                Some(text) => content.push_str(text.characterdata().data().as_slice()),
                 None => (),
             }
         }
@@ -1759,7 +1764,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 self.wait_until_safe_to_modify_dom();
 
                 let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(self).unwrap();
-                *characterdata.data.borrow_mut() = value;
+                characterdata.set_data(value);
 
                 // Notify the document that the content of this node is different
                 let document = self.owner_doc().root();
@@ -1970,12 +1975,12 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
             let other_pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(other).unwrap();
             (pi.target == other_pi.target) &&
-            (*pi.characterdata.data.borrow() == *other_pi.characterdata.data.borrow())
+            (*pi.characterdata.data() == *other_pi.characterdata.data())
         }
         fn is_equal_characterdata(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(node).unwrap();
             let other_characterdata: JSRef<CharacterData> = CharacterDataCast::to_ref(other).unwrap();
-            *characterdata.data.borrow() == *other_characterdata.data.borrow()
+            *characterdata.data() == *other_characterdata.data()
         }
         fn is_equal_element_attrs(node: JSRef<Node>, other: JSRef<Node>) -> bool {
             let element: JSRef<Element> = ElementCast::to_ref(node).unwrap();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1469,7 +1469,7 @@ impl Node {
             },
             CommentNodeTypeId => {
                 let comment: JSRef<Comment> = CommentCast::to_ref(node).unwrap();
-                let comment = Comment::new(comment.characterdata.data().clone(), *document);
+                let comment = Comment::new(comment.characterdata().data().clone(), *document);
                 NodeCast::from_temporary(comment)
             },
             DocumentNodeTypeId => {

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -10,8 +10,9 @@ use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct NodeIterator {
-    pub reflector_: Reflector
+    reflector_: Reflector
 }
 
 impl NodeIterator {

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -19,6 +19,7 @@ pub enum NodeListType {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct NodeList {
     list_type: NodeListType,
     reflector_: Reflector,

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -15,6 +15,7 @@ pub type DOMHighResTimeStamp = f64;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Performance {
     reflector_: Reflector,
     timing: JS<PerformanceTiming>,

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -30,8 +30,8 @@ impl PerformanceTiming {
 
     #[allow(unrooted_must_root)]
     pub fn new(window: JSRef<Window>) -> Temporary<PerformanceTiming> {
-        let timing = PerformanceTiming::new_inherited(window.navigationStart,
-                                                      window.navigationStartPrecise);
+        let timing = PerformanceTiming::new_inherited(window.navigation_start(),
+                                                      window.navigation_start_precise());
         reflect_dom_object(box timing, &global::Window(window),
                            PerformanceTimingBinding::Wrap)
     }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -11,6 +11,7 @@ use dom::window::Window;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct PerformanceTiming {
     reflector_: Reflector,
     navigationStart: u64,

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -23,7 +23,7 @@ pub struct ProcessingInstruction {
 
 impl ProcessingInstructionDerived for EventTarget {
     fn is_processinginstruction(&self) -> bool {
-        self.type_id == NodeTargetTypeId(ProcessingInstructionNodeTypeId)
+        *self.type_id() == NodeTargetTypeId(ProcessingInstructionNodeTypeId)
     }
 }
 

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -16,9 +16,10 @@ use servo_util::str::DOMString;
 /// An HTML processing instruction node.
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct ProcessingInstruction {
-    pub characterdata: CharacterData,
-    pub target: DOMString,
+    characterdata: CharacterData,
+    target: DOMString,
 }
 
 impl ProcessingInstructionDerived for EventTarget {
@@ -38,6 +39,14 @@ impl ProcessingInstruction {
     pub fn new(target: DOMString, data: DOMString, document: JSRef<Document>) -> Temporary<ProcessingInstruction> {
         Node::reflect_node(box ProcessingInstruction::new_inherited(target, data, document),
                            document, ProcessingInstructionBinding::Wrap)
+    }
+
+    pub fn characterdata<'a>(&'a self) -> &'a CharacterData {
+        &self.characterdata
+    }
+
+    pub fn target<'a>(&'a self) -> &'a DOMString {
+        &self.target
     }
 }
 

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -25,7 +25,7 @@ pub struct ProgressEvent {
 
 impl ProgressEventDerived for Event {
     fn is_progressevent(&self) -> bool {
-        self.type_id == ProgressEventTypeId
+        *self.type_id() == ProgressEventTypeId
     }
 }
 

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -15,6 +15,7 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct ProgressEvent {
     event: Event,
     length_computable: bool,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -26,7 +26,7 @@ impl Range {
     }
 
     pub fn new(document: JSRef<Document>) -> Temporary<Range> {
-        let window = document.window.root();
+        let window = document.window().root();
         reflect_dom_object(box Range::new_inherited(),
                            &Window(*window),
                            RangeBinding::Wrap)

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -13,6 +13,7 @@ use dom::document::Document;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Range {
     reflector_: Reflector
 }

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -11,6 +11,7 @@ use dom::window::Window;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Screen {
     reflector_: Reflector,
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -20,6 +20,7 @@ use js::jsval::{JSVal, NullValue};
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct TestBinding {
     reflector: Reflector,
     global: GlobalField,

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -25,7 +25,7 @@ pub struct Text {
 
 impl TextDerived for EventTarget {
     fn is_text(&self) -> bool {
-        self.type_id == NodeTargetTypeId(TextNodeTypeId)
+        *self.type_id() == NodeTargetTypeId(TextNodeTypeId)
     }
 }
 

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -18,8 +18,9 @@ use servo_util::str::DOMString;
 /// An HTML text node.
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Text {
-    pub characterdata: CharacterData,
+    characterdata: CharacterData,
 }
 
 impl TextDerived for EventTarget {
@@ -43,6 +44,11 @@ impl Text {
     pub fn Constructor(global: &GlobalRef, text: DOMString) -> Fallible<Temporary<Text>> {
         let document = global.as_window().Document().root();
         Ok(Text::new(text, *document))
+    }
+
+    #[inline]
+    pub fn characterdata<'a>(&'a self) -> &'a CharacterData {
+        &self.characterdata
     }
 }
 

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -49,7 +49,7 @@ impl TreeWalker {
                            root_node: JSRef<Node>,
                            what_to_show: u32,
                            filter: Filter) -> Temporary<TreeWalker> {
-        let window = document.window.root();
+        let window = document.window().root();
         reflect_dom_object(box TreeWalker::new_inherited(root_node, what_to_show, filter),
                            &Window(*window),
                            TreeWalkerBinding::Wrap)

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -23,12 +23,13 @@ use std::cell::Cell;
 // http://dom.spec.whatwg.org/#interface-treewalker
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct TreeWalker {
-    pub reflector_: Reflector,
-    pub root_node: JS<Node>,
-    pub current_node: Cell<JS<Node>>,
-    pub what_to_show: u32,
-    pub filter: Filter
+    reflector_: Reflector,
+    root_node: JS<Node>,
+    current_node: Cell<JS<Node>>,
+    what_to_show: u32,
+    filter: Filter
 }
 
 impl TreeWalker {

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -21,8 +21,9 @@ use std::default::Default;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct UIEvent {
-    pub event: Event,
+    event: Event,
     view: MutNullableJS<Window>,
     detail: Cell<i32>
 }
@@ -66,6 +67,11 @@ impl UIEvent {
                                  init.parent.bubbles, init.parent.cancelable,
                                  init.view.root_ref(), init.detail);
         Ok(event)
+    }
+
+    #[inline]
+    pub fn event<'a>(&'a self) -> &'a Event {
+        &self.event
     }
 }
 

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -30,7 +30,7 @@ pub struct UIEvent {
 
 impl UIEventDerived for Event {
     fn is_uievent(&self) -> bool {
-        self.type_id == UIEventTypeId
+        *self.type_id() == UIEventTypeId
     }
 }
 

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -22,6 +22,7 @@ use std::ascii::OwnedStrAsciiExt;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct URLSearchParams {
     data: RefCell<HashMap<DOMString, Vec<DOMString>>>,
     reflector_: Reflector,

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -10,6 +10,7 @@ use dom::window::Window;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct ValidityState {
     reflector_: Reflector,
     state: u8,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -33,6 +33,7 @@ untraceable!(TrustedWorkerAddress)
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct Worker {
     eventtarget: EventTarget,
     refcount: Cell<uint>,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -32,8 +32,9 @@ pub enum WorkerGlobalScopeId {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct WorkerGlobalScope {
-    pub eventtarget: EventTarget,
+    eventtarget: EventTarget,
     worker_url: Url,
     js_context: Rc<Cx>,
     resource_task: ResourceTask,
@@ -59,6 +60,11 @@ impl WorkerGlobalScope {
             navigator: Default::default(),
             console: Default::default(),
         }
+    }
+
+    #[inline]
+    pub fn eventtarget<'a>(&'a self) -> &'a EventTarget {
+        &self.eventtarget
     }
 
     pub fn get_cx(&self) -> *mut JSContext {

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -16,6 +16,7 @@ use url::Url;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct WorkerLocation {
     reflector_: Reflector,
     url: Url,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -13,6 +13,7 @@ use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct WorkerNavigator {
     reflector_: Reflector,
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -680,7 +680,7 @@ impl Reflectable for XMLHttpRequest {
 
 impl XMLHttpRequestDerived for EventTarget {
     fn is_xmlhttprequest(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             XMLHttpRequestTargetTypeId(XMLHttpRequestTypeId) => true,
             _ => false
         }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -104,6 +104,7 @@ enum SyncOrAsync<'a> {
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct XMLHttpRequest {
     eventtarget: XMLHttpRequestEventTarget,
     ready_state: Cell<XMLHttpRequestState>,

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -13,8 +13,9 @@ use dom::xmlhttprequest::XMLHttpRequestId;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct XMLHttpRequestEventTarget {
-    pub eventtarget: EventTarget,
+    eventtarget: EventTarget,
 }
 
 impl XMLHttpRequestEventTarget {
@@ -22,6 +23,11 @@ impl XMLHttpRequestEventTarget {
         XMLHttpRequestEventTarget {
             eventtarget: EventTarget::new_inherited(XMLHttpRequestTargetTypeId(type_id))
         }
+    }
+
+    #[inline]
+    pub fn eventtarget<'a>(&'a self) -> &'a EventTarget {
+        &self.eventtarget
     }
 }
 impl XMLHttpRequestEventTargetDerived for EventTarget {

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -32,7 +32,7 @@ impl XMLHttpRequestEventTarget {
 }
 impl XMLHttpRequestEventTargetDerived for EventTarget {
     fn is_xmlhttprequesteventtarget(&self) -> bool {
-        match self.type_id {
+        match *self.type_id() {
             XMLHttpRequestTargetTypeId(_) => true,
             _ => false
         }

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -13,6 +13,7 @@ use dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
 
 #[jstraceable]
 #[must_root]
+#[privatize]
 pub struct XMLHttpRequestUpload {
     eventtarget: XMLHttpRequestEventTarget
 }

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -38,6 +38,6 @@ impl Reflectable for XMLHttpRequestUpload {
 
 impl XMLHttpRequestUploadDerived for EventTarget {
     fn is_xmlhttprequestupload(&self) -> bool {
-        self.type_id == XMLHttpRequestTargetTypeId(XMLHttpRequestUploadTypeId)
+        *self.type_id() == XMLHttpRequestTargetTypeId(XMLHttpRequestUploadTypeId)
     }
 }

--- a/components/script/html/hubbub_html_parser.rs
+++ b/components/script/html/hubbub_html_parser.rs
@@ -503,7 +503,7 @@ pub fn parse_html(page: &Page,
                         for child in scriptnode.children() {
                             debug!("child = {:?}", child);
                             let text: JSRef<Text> = TextCast::to_ref(child).unwrap();
-                            data.push_str(text.characterdata.data.borrow().as_slice());
+                            data.push_str(text.characterdata().data().as_slice());
                         }
 
                         debug!("script data = {:?}", data);

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -167,7 +167,7 @@ impl Page {
         if self.damaged.get() {
             let frame = self.frame();
             let window = frame.as_ref().unwrap().window.root();
-            self.reflow(goal, window.control_chan.clone(), &*window.compositor);
+            self.reflow(goal, window.control_chan().clone(), window.compositor());
         } else {
             self.avoided_reflows.set(self.avoided_reflows.get() + 1);
         }


### PR DESCRIPTION
This PR removes public fields from all (hope I didn't miss any) DOM structs. Should |Page| be privatized as well? This PR additionally introduces a #[privatize] lint to ensure nobody accidentally re-introduces a public field.

All changesets compile separately if applied in the same order. Hope that helps reviewing but I can of course squash them before merging.
