### PR TITLE
Fix whitespace_pre with incremental reflow turned on.

### DIFF
--- a/components/layout/css/matching.rs
+++ b/components/layout/css/matching.rs
@@ -13,6 +13,7 @@ use script::dom::node::{TextNodeTypeId};
 use servo_util::bloom::BloomFilter;
 use servo_util::cache::{Cache, LRUCache, SimpleHashCache};
 use servo_util::smallvec::{SmallVec, SmallVec16};
+use servo_util::arc_ptr_eq;
 use std::mem;
 use std::hash::{Hash, sip};
 use std::slice::Items;
@@ -88,16 +89,6 @@ impl<'a> ApplicableDeclarationsCacheQuery<'a> {
         ApplicableDeclarationsCacheQuery {
             declarations: declarations,
         }
-    }
-}
-
-// Workaround for lack of `ptr_eq` on Arcs...
-#[inline]
-fn arc_ptr_eq<T>(a: &Arc<T>, b: &Arc<T>) -> bool {
-    unsafe {
-        let a: uint = mem::transmute_copy(a);
-        let b: uint = mem::transmute_copy(b);
-        a == b
     }
 }
 

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -199,7 +199,10 @@ impl TextRunScanner {
                 // Next, concatenate all of the transformed strings together, saving the new
                 // character indices.
                 let mut run_str = String::new();
-                let mut new_ranges: Vec<Range<CharIndex>> = vec![];
+
+                let mut new_ranges: Vec<Range<CharIndex>> =
+                    Vec::with_capacity(transformed_strs.len());
+
                 let mut char_total = CharIndex(0);
                 for i in range(0, transformed_strs.len() as int) {
                     let added_chars = CharIndex(transformed_strs[i as uint].as_slice().char_len() as int);
@@ -323,4 +326,3 @@ pub fn line_height_from_style(style: &ComputedValues, metrics: &FontMetrics) -> 
         line_height::Length(l) => l
     }
 }
-

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -32,6 +32,8 @@ extern crate url;
 #[phase(plugin)]
 extern crate string_cache_macros;
 
+use std::sync::Arc;
+
 pub mod bloom;
 pub mod cache;
 pub mod debug_utils;
@@ -54,4 +56,12 @@ pub mod workqueue;
 
 pub fn breakpoint() {
     unsafe { ::std::intrinsics::breakpoint() };
+}
+
+// Workaround for lack of `ptr_eq` on Arcs...
+#[inline]
+pub fn arc_ptr_eq<T: 'static + Send + Sync>(a: &Arc<T>, b: &Arc<T>) -> bool {
+    let a: &T = a.deref();
+    let b: &T = b.deref();
+    (a as *const T) == (b as *const T)
 }


### PR DESCRIPTION
This implements fragment merging, in order to incrementally reflow linebroken
text. This makes the `whitespace_pre.html` reftest pass with incremental reflow
turned on with `-i`.
