### PR TITLE
Don't crash on invalid utf-8 in the HTML parser.

### DIFF
--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -496,7 +496,7 @@ pub fn parse_html(page: &Page,
                         match msg {
                             Payload(data) => {
                                 // FIXME: use Vec<u8> (html5ever #34)
-                                let data = String::from_utf8(data).unwrap();
+                                let data = UTF_8.decode(data.as_slice(), DecodeReplace).unwrap();
                                 parser.tokenizer().borrow_mut().feed(data);
                             }
                             Done(Err(err)) => {

--- a/tests/wpt/metadata/XMLHttpRequest/open-url-encoding.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-encoding.htm.ini
@@ -1,3 +1,5 @@
 [open-url-encoding.htm]
   type: testharness
-  expected: CRASH
+  [XMLHttpRequest: open() - URL encoding]
+    expected: FAIL
+

--- a/tests/wpt/metadata/XMLHttpRequest/send-content-type-string.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-content-type-string.htm.ini
@@ -1,3 +1,0 @@
-[send-content-type-string.htm]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
@@ -1,3 +1,3 @@
 [send-entity-body-document.htm]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT


### PR DESCRIPTION
This was regressed by the html5ever landing.
