### PR TITLE
Implement document load tracking.

### DIFF
--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -121,7 +121,6 @@ impl Pipeline {
                                   failure,
                                   script_chan.clone(),
                                   paint_chan.clone(),
-                                  resource_task,
                                   image_cache_task,
                                   font_cache_task,
                                   time_profiler_chan,

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -38,6 +38,17 @@ extern crate encoding;
 extern crate libc;
 extern crate url;
 
+#[allow(non_snake_case)]
+mod ICE_workaround {
+    use super::script::layout_interface::Msg;
+
+    #[allow(dead_code)]
+    fn ice_workaround() {
+        let (tx, _rx) = channel();
+        tx.send(Msg::SetQuirksMode);
+    }
+}
+
 // Listed first because of macro definitions
 pub mod layout_debug;
 

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -21,7 +21,6 @@ use gfx::font_cache_task::FontCacheTask;
 use gfx::paint_task::PaintChan;
 use servo_msg::constellation_msg::{ConstellationChan, Failure, PipelineId, PipelineExitType};
 use servo_net::image_cache_task::ImageCacheTask;
-use servo_net::resource_task::ResourceTask;
 use servo_util::time::TimeProfilerChan;
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel};
 use std::comm::Sender;
@@ -46,7 +45,6 @@ pub trait LayoutTaskFactory {
               failure_msg: Failure,
               script_chan: ScriptControlChan,
               paint_chan: PaintChan,
-              resource_task: ResourceTask,
               img_cache_task: ImageCacheTask,
               font_cache_task: FontCacheTask,
               time_profiler_chan: TimeProfilerChan,

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -15,6 +15,7 @@ extern crate png;
 #[phase(plugin, link)]
 extern crate log;
 extern crate serialize;
+extern crate "msg" as servo_msg;
 extern crate "util" as servo_util;
 extern crate stb_image;
 extern crate time;

--- a/components/net/local_image_cache.rs
+++ b/components/net/local_image_cache.rs
@@ -64,7 +64,7 @@ impl<NodeAddress: Send> LocalImageCache<NodeAddress> {
             state.prefetched = true;
         }
 
-        self.image_cache_task.send(Msg::Prefetch((*url).clone()));
+        self.image_cache_task.send(Msg::Prefetch((*url).clone(), None));
     }
 
     pub fn decode(&mut self, url: &Url) {

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -19,13 +19,15 @@ pub enum LoadType {
     Subframe(Url),
     Stylesheet(Url),
     PageSource(Url),
+    XHR(Url),
 }
 
 impl LoadType {
-    fn url(&self) -> &Url {
+    pub fn url(&self) -> &Url {
         match *self {
             LoadType::Image(ref url) | LoadType::Script(ref url) | LoadType::Subframe(ref url) |
-            LoadType::Stylesheet(ref url) | LoadType::PageSource(ref url) => url,
+            LoadType::Stylesheet(ref url) | LoadType::PageSource(ref url) |
+            LoadType::XHR(ref url) => url,
         }
     }
 }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Tracking of pending loads in a document.
+//! https://html.spec.whatwg.org/multipage/syntax.html#the-end
+
+use script_task::{ScriptMsg, ScriptChan};
+use servo_msg::constellation_msg::{PipelineId};
+use servo_net::resource_task::{LoadResponse, Metadata, load_whole_resource, ResourceTask};
+use servo_net::resource_task::{ControlMsg, LoadData};
+use url::Url;
+
+#[jstraceable]
+#[deriving(PartialEq, Clone)]
+pub enum LoadType {
+    Image(Url),
+    Script(Url),
+    Subframe(Url),
+    Stylesheet(Url),
+    PageSource(Url),
+}
+
+impl LoadType {
+    fn url(&self) -> &Url {
+        match *self {
+            LoadType::Image(ref url) | LoadType::Script(ref url) | LoadType::Subframe(ref url) |
+            LoadType::Stylesheet(ref url) | LoadType::PageSource(ref url) => url,
+        }
+    }
+}
+
+#[jstraceable]
+pub struct DocumentLoader {
+    pub resource_task: ResourceTask,
+    script_chan: Box<ScriptChan + Send>,
+    blocking_loads: Vec<LoadType>,
+    pipeline: PipelineId,
+    notify: bool,
+}
+
+impl DocumentLoader {
+    pub fn new(existing: &DocumentLoader) -> DocumentLoader {
+        DocumentLoader::new_with_task(existing.resource_task.clone(),
+                                      existing.script_chan.clone(),
+                                      existing.pipeline)
+    }
+
+    pub fn new_with_task(resource_task: ResourceTask, script_chan: Box<ScriptChan + Send>,
+                         pipeline: PipelineId) -> DocumentLoader {
+        DocumentLoader {
+            resource_task: resource_task,
+            script_chan: script_chan,
+            pipeline: pipeline,
+            blocking_loads: vec!(),
+            notify: true,
+        }
+    }
+
+    pub fn load_async(&mut self, load: LoadType) -> Receiver<LoadResponse> {
+        self.load_async_with(load, |_| {})
+    }
+
+    pub fn load_async_with(&mut self, load: LoadType, cb: |load_data: &mut LoadData|) -> Receiver<LoadResponse> {
+        let (tx, rx) = channel();
+        self.blocking_loads.push(load.clone());
+        let mut load_data = LoadData::new(load.url().clone(), tx);
+        cb(&mut load_data);
+        self.resource_task.send(ControlMsg::Load(load_data));
+        rx
+    }
+
+    pub fn load_sync(&mut self, load: LoadType) -> Result<(Metadata, Vec<u8>), String> {
+        self.blocking_loads.push(load.clone());
+        let result = load_whole_resource(&self.resource_task, load.url().clone());
+        self.finish_load(load);
+        result
+    }
+
+    pub fn finish_load(&mut self, load: LoadType) {
+        let idx = self.blocking_loads.iter().position(|unfinished| *unfinished == load);
+        self.blocking_loads.remove(idx.expect("unknown completed load"));
+
+        if !self.is_blocked() && self.notify {
+            self.script_chan.send(ScriptMsg::DocumentLoadsComplete(self.pipeline));
+        }
+    }
+
+    pub fn is_blocked(&self) -> bool {
+        !self.blocking_loads.is_empty()
+    }
+
+    pub fn inhibit_events(&mut self) {
+        self.notify = false;
+    }
+}

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -7,9 +7,11 @@
 //! This module contains smart pointers to global scopes, to simplify writing
 //! code that works in workers as well as window scopes.
 
+use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::conversions::FromJSValConvertible;
 use dom::bindings::js::{JS, JSRef, Root};
 use dom::bindings::utils::{Reflectable, Reflector};
+use dom::document::DocumentHelpers;
 use dom::workerglobalscope::{WorkerGlobalScope, WorkerGlobalScopeHelpers};
 use dom::window;
 use script_task::ScriptChan;
@@ -68,7 +70,10 @@ impl<'a> GlobalRef<'a> {
 
     pub fn resource_task(&self) -> ResourceTask {
         match *self {
-            GlobalRef::Window(ref window) => window.page().resource_task.clone(),
+            GlobalRef::Window(ref window) => {
+                let doc = window.Document().root();
+                doc.r().loader().resource_task.clone()
+            }
             GlobalRef::Worker(ref worker) => worker.resource_task().clone(),
         }
     }

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -7,6 +7,7 @@
 //! This module contains smart pointers to global scopes, to simplify writing
 //! code that works in workers as well as window scopes.
 
+use document_loader::LoadType;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::conversions::FromJSValConvertible;
 use dom::bindings::js::{JS, JSRef, Root};
@@ -16,7 +17,8 @@ use dom::workerglobalscope::{WorkerGlobalScope, WorkerGlobalScopeHelpers};
 use dom::window;
 use script_task::ScriptChan;
 
-use servo_net::resource_task::ResourceTask;
+use servo_msg::constellation_msg::PipelineId;
+use servo_net::resource_task::{ResourceTask, PendingAsyncLoad};
 
 use js::{JSCLASS_IS_GLOBAL, JSCLASS_IS_DOMJSCLASS};
 use js::glue::{GetGlobalForObjectCrossCompartment};
@@ -78,6 +80,28 @@ impl<'a> GlobalRef<'a> {
         }
     }
 
+    pub fn prep_async_load(&self, load: LoadType) -> PendingAsyncLoad {
+        match *self {
+            GlobalRef::Window(ref window) => {
+                let doc = window.Document().root();
+                doc.prep_async_load(load)
+            }
+            GlobalRef::Worker(ref worker) => {
+                worker.prep_async_load(load.url().clone())
+            }
+        }
+    }
+
+    pub fn finish_load(&self, load: LoadType) {
+        match *self {
+            GlobalRef::Window(ref window) => {
+                let doc = window.Document().root();
+                doc.finish_load(load)
+            }
+            GlobalRef::Worker(_) => {}
+        }
+    }
+
     pub fn get_url(&self) -> Url {
         match *self {
             GlobalRef::Window(ref window) => window.get_url(),
@@ -91,6 +115,13 @@ impl<'a> GlobalRef<'a> {
         match *self {
             GlobalRef::Window(ref window) => window.script_chan(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
+        }
+    }
+
+    pub fn pipeline(&self) -> Option<PipelineId> {
+        match *self {
+            GlobalRef::Window(ref window) => Some(window.page().id),
+            GlobalRef::Worker(_) => None,
         }
     }
 }

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -45,11 +45,11 @@ use js::rust::Cx;
 use layout_interface::{LayoutRPC, LayoutChan};
 use libc;
 use msg::constellation_msg::{PipelineId, SubpageId, WindowSizeData};
-use net::image_cache_task::ImageCacheTask;
 use script_traits::ScriptControlChan;
 use script_traits::UntrustedNodeAddress;
 use servo_msg::compositor_msg::ScriptListener;
 use servo_msg::constellation_msg::ConstellationChan;
+use servo_net::image_cache_task::ImageCacheChannel;
 use servo_util::smallvec::{SmallVec1, SmallVec};
 use servo_util::str::{LengthOrPercentageOrAuto};
 use std::cell::{Cell, RefCell};
@@ -203,7 +203,7 @@ no_jsmanaged_fields!(int, i8, i16, i32, i64)
 no_jsmanaged_fields!(Sender<T>)
 no_jsmanaged_fields!(Receiver<T>)
 no_jsmanaged_fields!(Rect<T>)
-no_jsmanaged_fields!(ImageCacheTask, ScriptControlChan)
+no_jsmanaged_fields!(ImageCacheChannel, ScriptControlChan)
 no_jsmanaged_fields!(Atom, Namespace, Timer)
 no_jsmanaged_fields!(Trusted<T>)
 no_jsmanaged_fields!(PropertyDeclarationBlock)

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -224,6 +224,9 @@ impl<'a> PrivateDedicatedWorkerGlobalScopeHelpers for JSRef<'a, DedicatedWorkerG
                 let scope: JSRef<WorkerGlobalScope> = WorkerGlobalScopeCast::from_ref(self);
                 scope.handle_fire_timer(timer_id);
             }
+            ScriptMsg::PageResourceLoaded(..) => {
+                // workers don't track loads right now
+            }
             _ => panic!("Unexpected message"),
         }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -56,7 +56,7 @@ use dom::range::Range;
 use dom::treewalker::TreeWalker;
 use dom::uievent::UIEvent;
 use dom::window::{Window, WindowHelpers};
-use servo_net::resource_task::{LoadResponse, Metadata, LoadData};
+use servo_net::resource_task::{LoadResponse, Metadata, LoadData, PendingAsyncLoad};
 use servo_util::namespace;
 use servo_util::str::{DOMString, split_html_space_chars};
 
@@ -194,6 +194,7 @@ pub trait DocumentHelpers<'a> {
     fn commit_focus_transaction(self);
     fn send_title_to_compositor(self);
     fn dirty_all_nodes(self);
+    fn prep_async_load(self, load: LoadType) -> PendingAsyncLoad;
     fn load_async(self, load: LoadType) -> Receiver<LoadResponse>;
     fn load_async_with(self, load: LoadType, cb: |&mut LoadData|) -> Receiver<LoadResponse>;
     fn load_sync(self, load: LoadType) -> Result<(Metadata, Vec<u8>), String>;
@@ -401,6 +402,10 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         for node in root.traverse_preorder() {
             node.dirty(NodeDamage::OtherNodeDamage)
         }
+    }
+
+    fn prep_async_load(self, load: LoadType) -> PendingAsyncLoad {
+        self.loader.borrow_mut().prep_async_load(load)
     }
 
     fn load_async(self, load: LoadType) -> Receiver<LoadResponse> {

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use document_loader::DocumentLoader;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::DOMImplementationBinding;
 use dom::bindings::codegen::Bindings::DOMImplementationBinding::DOMImplementationMethods;
@@ -69,10 +70,11 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
                       maybe_doctype: Option<JSRef<DocumentType>>) -> Fallible<Temporary<Document>> {
         let doc = self.document.root();
         let win = doc.r().window().root();
+        let loader = DocumentLoader::new(&*doc.r().loader());
 
         // Step 1.
         let doc = Document::new(win.r(), None, IsHTMLDocument::NonHTMLDocument,
-                                None, DocumentSource::NotFromParser).root();
+                                None, DocumentSource::NotFromParser, loader).root();
         // Step 2-3.
         let maybe_elem = if qname.is_empty() {
             None
@@ -115,10 +117,11 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     fn CreateHTMLDocument(self, title: Option<DOMString>) -> Temporary<Document> {
         let document = self.document.root();
         let win = document.r().window().root();
+        let loader = DocumentLoader::new(&*document.r().loader());
 
         // Step 1-2.
         let doc = Document::new(win.r(), None, IsHTMLDocument::HTMLDocument, None,
-                                DocumentSource::NotFromParser).root();
+                                DocumentSource::NotFromParser, loader).root();
         let doc_node: JSRef<Node> = NodeCast::from_ref(doc.r());
 
         {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use document_loader::DocumentLoader;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentReadyState;
 use dom::bindings::codegen::Bindings::DOMParserBinding;
 use dom::bindings::codegen::Bindings::DOMParserBinding::DOMParserMethods;
 use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::{Text_html, Text_xml};
+use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::error::Error::FailureUnknown;
 use dom::bindings::global::GlobalRef;
@@ -50,12 +52,15 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
         let window = self.window.root();
         let url = window.r().get_url();
         let content_type = DOMParserBinding::SupportedTypeValues::strings[ty as uint].into_string();
+        let doc = window.r().Document().root();
+        let loader = DocumentLoader::new(&*doc.r().loader());
         match ty {
             Text_html => {
                 let document = Document::new(window.r(), Some(url.clone()),
                                              IsHTMLDocument::HTMLDocument,
                                              Some(content_type),
-                                             DocumentSource::FromParser).root();
+                                             DocumentSource::FromParser,
+                                             loader).root();
                 parse_html(document.r(), HTMLInput::InputString(s), &url);
                 document.r().set_ready_state(DocumentReadyState::Complete);
                 Ok(Temporary::from_rooted(document.r()))
@@ -65,7 +70,8 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
                 Ok(Document::new(window.r(), Some(url.clone()),
                                  IsHTMLDocument::NonHTMLDocument,
                                  Some(content_type),
-                                 DocumentSource::NotFromParser))
+                                 DocumentSource::NotFromParser,
+                                 loader))
             }
             _ => {
                 Err(FailureUnknown)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -4,6 +4,7 @@
 
 //! The core DOM types. Defines the basic DOM hierarchy as well as all the HTML elements.
 
+use document_loader::DocumentLoader;
 use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
@@ -1546,9 +1547,10 @@ impl Node {
                     false => IsHTMLDocument::NonHTMLDocument,
                 };
                 let window = document.window().root();
+                let loader = DocumentLoader::new(&*document.loader());
                 let document = Document::new(window.r(), Some(document.url().clone()),
                                              is_html_doc, None,
-                                             DocumentSource::NotFromParser);
+                                             DocumentSource::NotFromParser, loader);
                 NodeCast::from_temporary(document)
             },
             NodeTypeId::Element(..) => {

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -19,7 +19,7 @@ use dom::window::{base64_atob, base64_btoa};
 use script_task::{ScriptChan, TimerSource};
 use timers::{IsInterval, TimerId, TimerManager, TimerCallback};
 
-use servo_net::resource_task::{ResourceTask, load_whole_resource};
+use servo_net::resource_task::{ResourceTask, load_whole_resource, PendingAsyncLoad};
 use servo_util::str::DOMString;
 
 use js::jsapi::JSContext;
@@ -75,7 +75,11 @@ impl WorkerGlobalScope {
     }
 
     pub fn resource_task<'a>(&'a self) -> &'a ResourceTask {
-        &   self.resource_task
+        &self.resource_task
+    }
+
+    pub fn prep_async_load(&self, url: Url) -> PendingAsyncLoad {
+        PendingAsyncLoad::new(self.resource_task.clone(), url)
     }
 
     pub fn get_url<'a>(&'a self) -> &'a Url {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use document_loader::LoadType;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::XMLHttpRequestBinding;
@@ -13,7 +14,7 @@ use dom::bindings::conversions::ToJSValConvertible;
 use dom::bindings::error::{Error, ErrorResult, Fallible};
 use dom::bindings::error::Error::{InvalidState, InvalidAccess};
 use dom::bindings::error::Error::{Network, Syntax, Security, Abort, Timeout};
-use dom::bindings::global::{GlobalField, GlobalRef, GlobalRoot};
+use dom::bindings::global::{GlobalField, GlobalRef, GlobalRoot, global_object_for_js_object};
 use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, OptionalRootedRootable};
 use dom::bindings::refcounted::Trusted;
 use dom::bindings::str::ByteString;
@@ -42,10 +43,10 @@ use js::jsapi::{JS_ParseJSON, JSContext};
 use js::jsapi::JS_ClearPendingException;
 use js::jsval::{JSVal, NullValue, UndefinedValue};
 
-use net::resource_task::{ResourceTask, ResourceCORSData, LoadData, LoadResponse};
-use net::resource_task::ControlMsg::Load;
+use net::resource_task::{PendingAsyncLoad, ResourceCORSData};
 use net::resource_task::ProgressMsg::{Payload, Done};
 use cors::{allow_cross_origin_request, CORSRequest, RequestMode};
+use servo_msg::constellation_msg::PipelineId;
 use servo_util::str::DOMString;
 use servo_util::task::spawn_named;
 
@@ -119,7 +120,7 @@ impl XHRProgress {
 
 enum SyncOrAsync<'a> {
     Sync(JSRef<'a, XMLHttpRequest>),
-    Async(TrustedXHRAddress, Box<ScriptChan+Send>)
+    Async(TrustedXHRAddress, Box<ScriptChan+Send>, Option<PipelineId>)
 }
 
 enum TerminateReason {
@@ -207,21 +208,49 @@ impl XMLHttpRequest {
     }
 
     #[allow(unsafe_blocks)]
-    fn fetch(fetch_type: &SyncOrAsync, resource_task: ResourceTask,
-             mut load_data: LoadData, terminate_receiver: Receiver<TerminateReason>,
-             cors_request: Result<Option<CORSRequest>,()>, gen_id: GenerationId,
-             start_port: Receiver<LoadResponse>) -> ErrorResult {
+    fn fetch(fetch_type: &SyncOrAsync, mut pending: PendingAsyncLoad,
+             terminate_receiver: Receiver<TerminateReason>,
+             cors_request: Result<Option<CORSRequest>,()>, gen_id: GenerationId)
+             -> ErrorResult {
 
         fn notify_partial_progress(fetch_type: &SyncOrAsync, msg: XHRProgress) {
             match *fetch_type {
                 SyncOrAsync::Sync(xhr) => {
                     xhr.process_partial_response(msg);
                 },
-                SyncOrAsync::Async(ref addr, ref script_chan) => {
+                SyncOrAsync::Async(ref addr, ref script_chan, _) => {
                     script_chan.send(ScriptMsg::RunnableMsg(box XHRProgressHandler::new(addr.clone(), msg)));
                 }
             }
         }
+
+        enum AutoFinishLoad<'a> {
+            AsyncFinish(LoadType, Option<PipelineId>, Box<ScriptChan+Send>),
+            SyncFinish(JSRef<'a, XMLHttpRequest>, Url)
+        }
+        #[unsafe_destructor]
+        impl<'a> Drop for AutoFinishLoad<'a> {
+            fn drop(&mut self) {
+                match *self {
+                    AutoFinishLoad::SyncFinish(ref xhr, ref url) => {
+                        let reflector = xhr.reflector().get_jsobject();
+                        global_object_for_js_object(reflector)
+                            .root()
+                            .r()
+                            .finish_load(LoadType::XHR(url.clone()));
+                    }
+                    AutoFinishLoad::AsyncFinish(ref load, ref pipeline, ref chan) => {
+                        chan.send(ScriptMsg::PageResourceLoaded(pipeline.clone(), load.clone()));
+                    }
+                }
+            }
+        }
+        let _auto_finish = match fetch_type {
+            &SyncOrAsync::Sync(xhr) => AutoFinishLoad::SyncFinish(xhr, pending.url().clone()),
+            &SyncOrAsync::Async(_, ref script_chan, ref pipeline) =>
+                AutoFinishLoad::AsyncFinish(LoadType::XHR(pending.url().clone()),
+                                            pipeline.clone(), (*script_chan).clone())
+        };
 
         macro_rules! notify_error_and_return(
             ($err:expr) => ({
@@ -242,7 +271,6 @@ impl XMLHttpRequest {
                 }
             );
         )
-
 
         match cors_request {
             Err(_) => {
@@ -265,7 +293,7 @@ impl XMLHttpRequest {
                         if response.network_error {
                             notify_error_and_return!(Network);
                         } else {
-                            load_data.cors = Some(ResourceCORSData {
+                            pending.load_data.cors = Some(ResourceCORSData {
                                 preflight: req.preflight_flag,
                                 origin: req.origin.clone()
                             });
@@ -278,8 +306,7 @@ impl XMLHttpRequest {
         }
 
         // Step 10, 13
-        resource_task.send(Load(load_data));
-
+        let start_port = pending.load();
 
         let progress_port;
         select! (
@@ -538,10 +565,6 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
         }
 
         let global = self.global.root();
-        let resource_task = global.r().resource_task();
-        let (start_chan, start_port) = channel();
-        let mut load_data = LoadData::new(self.request_url.borrow().clone().unwrap(), start_chan);
-        load_data.data = extracted;
 
         // Default headers
         {
@@ -576,20 +599,27 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             }
         } // drops the borrow_mut
 
-        load_data.headers = (*self.request_headers.borrow()).clone();
-        load_data.method = (*self.request_method.borrow()).clone();
+        let url = self.request_url.borrow().as_ref().unwrap().clone();
+        let mut pending = global.r().prep_async_load(LoadType::XHR(url));
+        pending.load_data.data = extracted;
+        pending.load_data.headers = (*self.request_headers.borrow()).clone();
+        pending.load_data.method = (*self.request_method.borrow()).clone();
+
         let (terminate_sender, terminate_receiver) = channel();
         *self.terminate_sender.borrow_mut() = Some(terminate_sender);
 
         // CORS stuff
-        let referer_url = self.global.root().r().get_url();
+        let referer_url = global.r().get_url();
         let mode = if self.upload_events.get() {
             RequestMode::ForcedPreflight
         } else {
             RequestMode::CORS
         };
-        let cors_request = CORSRequest::maybe_new(referer_url.clone(), load_data.url.clone(), mode,
-                                                  load_data.method.clone(), load_data.headers.clone());
+        let cors_request = CORSRequest::maybe_new(referer_url.clone(),
+                                                  pending.load_data.url.clone(),
+                                                  mode,
+                                                  pending.load_data.method.clone(),
+                                                  pending.load_data.headers.clone());
         match cors_request {
             Ok(None) => {
                 let mut buf = String::new();
@@ -612,24 +642,22 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
 
         let gen_id = self.generation_id.get();
         if self.sync.get() {
-            return XMLHttpRequest::fetch(&mut SyncOrAsync::Sync(self), resource_task, load_data,
-                                         terminate_receiver, cors_request, gen_id, start_port);
+            return XMLHttpRequest::fetch(&mut SyncOrAsync::Sync(self), pending,
+                                         terminate_receiver, cors_request, gen_id);
         } else {
             self.fetch_time.set(time::now().to_timespec().sec);
             let script_chan = global.r().script_chan();
             // Pin the object before launching the fetch task. This is to ensure that
             // the object will stay alive as long as there are (possibly cancelled)
             // inflight events queued up in the script task's port.
-            let addr = Trusted::new(self.global.root().r().get_cx(), self,
-                                    script_chan.clone());
+            let addr = Trusted::new(global.r().get_cx(), self, script_chan.clone());
+            let pipeline = global.r().pipeline();
             spawn_named("XHRTask", proc() {
-                let _ = XMLHttpRequest::fetch(&mut SyncOrAsync::Async(addr, script_chan),
-                                              resource_task,
-                                              load_data,
+                let _ = XMLHttpRequest::fetch(&mut SyncOrAsync::Async(addr, script_chan, pipeline),
+                                              pending,
                                               terminate_receiver,
                                               cors_request,
-                                              gen_id,
-                                              start_port);
+                                              gen_id);
             });
             let timeout = self.timeout.get();
             if timeout > 0 {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -12,6 +12,7 @@ use geom::point::Point2D;
 use geom::rect::Rect;
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel, UntrustedNodeAddress};
 use servo_msg::constellation_msg::{PipelineExitType, WindowSizeData};
+use servo_net::resource_task::PendingAsyncLoad;
 use servo_util::geometry::Au;
 use std::any::{Any, AnyRefExt};
 use std::comm::{channel, Receiver, Sender};
@@ -27,7 +28,7 @@ pub enum Msg {
     AddStylesheet(Stylesheet),
 
     /// Adds the given stylesheet to the document.
-    LoadStylesheet(Url),
+    LoadStylesheet(Url, PendingAsyncLoad),
 
     /// Puts a document into quirks mode, causing the quirks mode stylesheet to be loaded.
     SetQuirksMode,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -43,6 +43,8 @@ extern crate string_cache;
 #[phase(plugin)]
 extern crate string_cache_macros;
 
+pub mod layout_interface;
+
 pub mod cors;
 pub mod document_loader;
 
@@ -221,7 +223,6 @@ pub mod dom {
 
 pub mod parse;
 
-pub mod layout_interface;
 pub mod page;
 pub mod script_task;
 mod timers;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -44,6 +44,7 @@ extern crate string_cache;
 extern crate string_cache_macros;
 
 pub mod cors;
+pub mod document_loader;
 
 /// The implementation of the DOM.
 #[macro_escape]

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -24,7 +24,6 @@ use js::rust::Cx;
 use servo_msg::compositor_msg::ScriptListener;
 use servo_msg::constellation_msg::{ConstellationChan, WindowSizeData};
 use servo_msg::constellation_msg::{PipelineId, SubpageId};
-use servo_net::resource_task::ResourceTask;
 use servo_net::storage_task::StorageTask;
 use servo_util::geometry::{Au, MAX_RECT};
 use servo_util::geometry;
@@ -80,9 +79,6 @@ pub struct Page {
     /// Pending scroll to fragment event, if any
     pub fragment_name: DOMRefCell<Option<String>>,
 
-    /// Associated resource task for use by DOM objects like XMLHttpRequest
-    pub resource_task: ResourceTask,
-
     /// A handle for communicating messages to the storage task.
     pub storage_task: StorageTask,
 
@@ -127,7 +123,6 @@ impl Page {
     pub fn new(id: PipelineId, subpage_id: Option<SubpageId>,
            layout_chan: LayoutChan,
            window_size: WindowSizeData,
-           resource_task: ResourceTask,
            storage_task: StorageTask,
            constellation_chan: ConstellationChan,
            js_context: Rc<Cx>) -> Page {
@@ -155,7 +150,6 @@ impl Page {
             resize_event: Cell::new(None),
             fragment_name: DOMRefCell::new(None),
             last_reflow_id: Cell::new(0),
-            resource_task: resource_task,
             storage_task: storage_task,
             constellation_chan: constellation_chan,
             children: DOMRefCell::new(vec!()),

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -4,6 +4,7 @@
 
 #![allow(unsafe_blocks)]
 
+use document_loader::LoadType;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLScriptElementCast};
@@ -196,7 +197,10 @@ pub fn parse_html(document: JSRef<Document>,
                             ProgressMsg::Done(Err(err)) => {
                                 panic!("Failed to load page URL {}, error: {}", url.serialize(), err);
                             }
-                            ProgressMsg::Done(Ok(())) => break,
+                            ProgressMsg::Done(Ok(())) => {
+                                document.finish_load(LoadType::PageSource(url.clone()));
+                                break;
+                            }
                         }
                     }
                 }

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -587,6 +587,8 @@ impl ScriptTask {
                 panic!("should have handled ExitPipeline already"),
             ConstellationControlMsg::GetTitle(pipeline_id) =>
                 self.handle_get_title_msg(pipeline_id),
+            ConstellationControlMsg::StylesheetLoadComplete(id, url) =>
+                self.handle_resource_loaded(id, LoadType::Stylesheet(url)),
         }
     }
 
@@ -630,6 +632,13 @@ impl ScriptTask {
             ModifyAttribute(id, node_id, modifications) =>
                 devtools::handle_modify_attribute(&*self.page.borrow(), id, node_id, modifications),
         }
+    }
+
+    fn handle_resource_loaded(&self, pipeline: PipelineId, load: LoadType) {
+        let page = get_page(&*self.page.borrow(), pipeline);
+        let frame = page.frame();
+        let doc = frame.as_ref().unwrap().document.root();
+        doc.finish_load(load);
     }
 
     fn handle_new_layout(&self, new_layout_info: NewLayoutInfo) {

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -127,6 +127,8 @@ pub enum ScriptMsg {
     RefcountCleanup(*const libc::c_void),
     /// Notify a document that all pending loads are complete.
     DocumentLoadsComplete(PipelineId),
+    /// Notify a document that a pending load is complete.
+    PageResourceLoaded(Option<PipelineId>, LoadType),
 }
 
 /// A cloneable interface for communicating with an event loop.
@@ -614,6 +616,8 @@ impl ScriptTask {
                 LiveDOMReferences::cleanup(self.get_cx(), addr),
             ScriptMsg::DocumentLoadsComplete(id) =>
                 self.handle_loads_complete(id),
+            ScriptMsg::PageResourceLoaded(id, load) =>
+                self.handle_resource_loaded(id.unwrap(), load),
         }
     }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -31,6 +31,7 @@ use servo_net::resource_task::ResourceTask;
 use servo_net::storage_task::StorageTask;
 use servo_util::smallvec::SmallVec1;
 use std::any::Any;
+use url::Url;
 
 use geom::point::Point2D;
 use geom::rect::Rect;
@@ -68,6 +69,8 @@ pub enum ConstellationControlMsg {
     Viewport(PipelineId, Rect<f32>),
     /// Requests that the script task immediately send the constellation the title of a pipeline.
     GetTitle(PipelineId),
+    /// Notifies script that a stylesheet has finished loading.
+    StylesheetLoadComplete(PipelineId, Url),
 }
 
 /// Events from the compositor that the script task needs to know about


### PR DESCRIPTION
Improves on the state of the art for #1416. Images, XHR, stylesheets, and scripts now block the document load event from firing, and DOMContentLoaded is dispatched after parsing is complete.
