### PR TITLE
Wait to dump flow tree until flow is complete

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -654,9 +654,6 @@ impl LayoutTask {
         if self.opts.trace_layout {
             layout_debug::begin_trace(layout_root.clone());
         }
-        if self.opts.dump_flow_tree {
-            layout_root.dump();
-        }
 
         // Perform the primary layout passes over the flow tree to compute the locations of all
         // the boxes.
@@ -772,6 +769,10 @@ impl LayoutTask {
 
         if self.opts.trace_layout {
             layout_debug::end_trace();
+        }
+
+        if self.opts.dump_flow_tree {
+            layout_root.dump();
         }
 
         rw_data.generation += 1;


### PR DESCRIPTION
The flow tree is currently dumped for debugging purposes early on in
the flow process, so many values are still zero. If we wait to dump it
until later, the output will more accurately reflect the real flow tree.
