### PR TITLE
Don't fail on lines starting with '#' when they also include '='

### DIFF
--- a/python/toml/toml.py
+++ b/python/toml/toml.py
@@ -104,7 +104,7 @@ def loads(s):
         raise Exception("What exactly are you trying to pull?")
     for line in s:
         line = line.strip()
-        if line == "":
+        if line == "" or line[0] == "#":
             continue
         if line[0] == '[':
             arrayoftables = False


### PR DESCRIPTION
When using a .servobuild config file base on the sample one, build fails with:

```
fabrice@fabrice-ThinkPad-X240:~/dev/servo$ ./mach build
Error running mach:

    ['build']

The error occurred in mach itself. This is likely a bug in mach itself or a
fundamental problem with a loaded module.

Please consider filing a bug against mach by going to the URL:

    https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=mach


If filing a bug, please include the full output of mach, including this error
message.

The details of the failure are as follows:

Exception: This float is missing digits after the point

  File "/home/fabrice/dev/servo/python/mach/mach/main.py", line 344, in run
    return self._run(argv)
  File "/home/fabrice/dev/servo/python/mach/mach/main.py", line 432, in _run
    instance = cls(context)
  File "./python/servo/command_base.py", line 59, in __init__
    self.config = toml.loads(open(config_path).read())
  File "/home/fabrice/dev/servo/python/toml/toml.py", line 181, in loads
    value, vtype = load_value(pair[1])
  File "/home/fabrice/dev/servo/python/toml/toml.py", line 275, in load_value
    raise Exception("This float is missing digits after the point")
fabrice@fabrice-ThinkPad-X240:~/dev/servo$ 
```

This is because of the line:

```
# Set "android = true" or use `mach build --android` to build the Android app.
```

which is not detected as a comment, but as a value because of the '='
