### PR TITLE
Fix race condition in XHR and handle other abort/open scenarios

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -19,7 +19,7 @@ use dom::workerglobalscope::DedicatedGlobalScope;
 use dom::workerglobalscope::{WorkerGlobalScope, WorkerGlobalScopeHelpers};
 use dom::xmlhttprequest::XMLHttpRequest;
 use script_task::{ScriptTask, ScriptChan};
-use script_task::{ScriptMsg, FromWorker,  DOMMessage, FireTimerMsg, XHRProgressMsg, WorkerRelease};
+use script_task::{ScriptMsg, FromWorker,  DOMMessage, FireTimerMsg, XHRProgressMsg, XHRReleaseMsg, WorkerRelease};
 use script_task::WorkerPostMessage;
 use script_task::StackRootTLS;
 
@@ -134,7 +134,10 @@ impl DedicatedWorkerGlobalScope {
                         global.delayed_release_worker();
                     },
                     Ok(XHRProgressMsg(addr, progress)) => {
-                        XMLHttpRequest::handle_xhr_progress(addr, progress)
+                        XMLHttpRequest::handle_progress(addr, progress)
+                    },
+                    Ok(XHRReleaseMsg(addr)) => {
+                        XMLHttpRequest::handle_release(addr)
                     },
                     Ok(WorkerPostMessage(addr, data, nbytes)) => {
                         Worker::handle_message(addr, data, nbytes);

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -100,6 +100,8 @@ pub enum ScriptMsg {
     ExitWindowMsg(PipelineId),
     /// Notifies the script of progress on a fetch (dispatched to all tasks).
     XHRProgressMsg(TrustedXHRAddress, XHRProgress),
+    /// Releases one reference to the XHR object (dispatched to all tasks).
+    XHRReleaseMsg(TrustedXHRAddress),
     /// Message sent through Worker.postMessage (only dispatched to
     /// DedicatedWorkerGlobalScope).
     DOMMessage(*mut u64, size_t),
@@ -530,7 +532,8 @@ impl ScriptTask {
                 FromConstellation(ExitPipelineMsg(id)) => if self.handle_exit_pipeline_msg(id) { return false },
                 FromScript(ExitWindowMsg(id)) => self.handle_exit_window_msg(id),
                 FromConstellation(ResizeMsg(..)) => fail!("should have handled ResizeMsg already"),
-                FromScript(XHRProgressMsg(addr, progress)) => XMLHttpRequest::handle_xhr_progress(addr, progress),
+                FromScript(XHRProgressMsg(addr, progress)) => XMLHttpRequest::handle_progress(addr, progress),
+                FromScript(XHRReleaseMsg(addr)) => XMLHttpRequest::handle_release(addr),
                 FromScript(DOMMessage(..)) => fail!("unexpected message"),
                 FromScript(WorkerPostMessage(addr, data, nbytes)) => Worker::handle_message(addr, data, nbytes),
                 FromScript(WorkerRelease(addr)) => Worker::handle_release(addr),

--- a/tests/wpt/metadata/XMLHttpRequest/data-uri.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/data-uri.htm.ini
@@ -1,33 +1,32 @@
 [data-uri.htm]
   type: testharness
-  expected: TIMEOUT
   [XHR method GET with charset text/plain]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method GET with charset text/plain (base64)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method GET with charset text/html]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method GET with charset image/png]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method POST with charset text/plain]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method PUT with charset text/plain]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method DELETE with charset text/plain]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method HEAD with charset text/plain]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method UNICORN with charset text/plain]
-    expected: TIMEOUT
+    expected: FAIL
 
   [XHR method GET with charset text/html;charset=UTF-8]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/send-network-error-async-events.sub.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-network-error-async-events.sub.htm.ini
@@ -1,6 +1,0 @@
-[send-network-error-async-events.sub.htm]
-  type: testharness
-  expected: TIMEOUT
-  [XmlHttpRequest: The send() method: Fire a progress event named error when Network error happens (synchronous flag is unset)]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/XMLHttpRequest/send-network-error-sync-events.sub.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-network-error-sync-events.sub.htm.ini
@@ -1,5 +1,0 @@
-[send-network-error-sync-events.sub.htm]
-  type: testharness
-  [XmlHttpRequest: The send() method: Throw a "throw an "NetworkError" exception when Network error happens (synchronous flag is set)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-abortedonmain.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-abortedonmain.html.ini
@@ -1,3 +1,3 @@
 [xmlhttprequest-timeout-abortedonmain.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overrides.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overrides.html.ini
@@ -1,3 +1,3 @@
 [xmlhttprequest-timeout-overrides.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overridesexpires.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overridesexpires.html.ini
@@ -1,3 +1,3 @@
 [xmlhttprequest-timeout-overridesexpires.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-aborted.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-aborted.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-worker-aborted.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-overrides.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-overrides.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-worker-overrides.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-overridesexpires.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-overridesexpires.html.ini
@@ -1,3 +1,6 @@
 [xmlhttprequest-timeout-worker-overridesexpires.html]
   type: testharness
-  expected: TIMEOUT
+
+  [Timeout test: timeout set to expired value before load fires, original timeout at 1000, reset at 400 to 300]
+    disabled: racy test
+

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-simple.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-simple.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-worker-simple.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-twice.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-twice.html.ini
@@ -1,4 +1,0 @@
-[xmlhttprequest-timeout-worker-twice.html]
-  type: testharness
-  disabled: xhr issue #3630
-  expected: TIMEOUT


### PR DESCRIPTION
This fixes issue #3630
A short summary of the changes:
- Use atomic generation id to cancel inflight requests
- Handles nested calls to abort, open, send inside handlers
- Adds XHRReleaseMsg to delay freeing XHR object till all
  inflight events are processed
- Handles both timeout, errors and abort/open in a symmetric fashion
  i.e All inflight events will be cancelled for timeouts, aborts,
    errors and on calling open.
- Change the ErroredMsg enum to be more symmetric with the returned
  Error enum

I noticed a few possible changes that could make the code for fetch task simpler:
- We can remove the additional timer task and let the fetch task manage 
  its own timer (or maybe the resource loader can do this.)
- The CORS related steps could also be moved into the resource loader.
- Right now upload events are not support. This requires some support 
  from resource loader. 
