### PR TITLE
Use DOMRefCell in script crate

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::attr::AttrHelpers;
+use dom::bindings::cell::{DOMRefCell, Ref};
 use dom::bindings::codegen::Bindings::DocumentBinding;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
@@ -62,7 +63,7 @@ use url::Url;
 
 use std::collections::hashmap::HashMap;
 use std::ascii::StrAsciiExt;
-use std::cell::{Cell, Ref, RefCell};
+use std::cell::Cell;
 use std::default::Default;
 use time;
 
@@ -77,11 +78,11 @@ pub enum IsHTMLDocument {
 pub struct Document {
     node: Node,
     window: JS<Window>,
-    idmap: RefCell<HashMap<Atom, Vec<JS<Element>>>>,
+    idmap: DOMRefCell<HashMap<Atom, Vec<JS<Element>>>>,
     implementation: MutNullableJS<DOMImplementation>,
     content_type: DOMString,
-    last_modified: RefCell<Option<DOMString>>,
-    encoding_name: RefCell<DOMString>,
+    last_modified: DOMRefCell<Option<DOMString>>,
+    encoding_name: DOMRefCell<DOMString>,
     is_html_document: bool,
     url: Url,
     quirks_mode: Cell<QuirksMode>,
@@ -299,7 +300,7 @@ impl Document {
         Document {
             node: Node::new_without_doc(DocumentNodeTypeId),
             window: JS::from_rooted(window),
-            idmap: RefCell::new(HashMap::new()),
+            idmap: DOMRefCell::new(HashMap::new()),
             implementation: Default::default(),
             content_type: match content_type {
                 Some(string) => string.clone(),
@@ -310,12 +311,12 @@ impl Document {
                     NonHTMLDocument => "application/xml".to_string()
                 }
             },
-            last_modified: RefCell::new(None),
+            last_modified: DOMRefCell::new(None),
             url: url,
             // http://dom.spec.whatwg.org/#concept-document-quirks
             quirks_mode: Cell::new(NoQuirks),
             // http://dom.spec.whatwg.org/#concept-document-encoding
-            encoding_name: RefCell::new("utf-8".to_string()),
+            encoding_name: DOMRefCell::new("utf-8".to_string()),
             is_html_document: is_html_document == HTMLDocument,
             images: Default::default(),
             embeds: Default::default(),

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventBinding;
 use dom::bindings::codegen::Bindings::EventBinding::{EventConstants, EventMethods};
 use dom::bindings::error::Fallible;
@@ -10,7 +11,7 @@ use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::eventtarget::EventTarget;
 use servo_util::str::DOMString;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::default::Default;
 
 use time;
@@ -53,7 +54,7 @@ pub struct Event {
     reflector_: Reflector,
     current_target: MutNullableJS<EventTarget>,
     target: MutNullableJS<EventTarget>,
-    type_: RefCell<DOMString>,
+    type_: DOMRefCell<DOMString>,
     phase: Cell<EventPhase>,
     canceled: Cell<bool>,
     stop_propagation: Cell<bool>,
@@ -74,7 +75,7 @@ impl Event {
             current_target: Default::default(),
             target: Default::default(),
             phase: Cell::new(PhaseNone),
-            type_: RefCell::new("".to_string()),
+            type_: DOMRefCell::new("".to_string()),
             canceled: Cell::new(false),
             cancelable: Cell::new(true),
             bubbles: Cell::new(false),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::callback::CallbackContainer;
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::EventListenerBinding::EventListener;
 use dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
@@ -19,7 +20,6 @@ use js::jsapi::{JS_CompileUCFunction, JS_GetFunctionObject, JS_CloneFunctionObje
 use js::jsapi::{JSContext, JSObject};
 use servo_util::str::DOMString;
 use libc::{c_char, size_t};
-use std::cell::RefCell;
 use std::ptr;
 use url::Url;
 
@@ -69,7 +69,7 @@ pub struct EventListenerEntry {
 pub struct EventTarget {
     type_id: EventTargetTypeId,
     reflector_: Reflector,
-    handlers: RefCell<HashMap<DOMString, Vec<EventListenerEntry>>>,
+    handlers: DOMRefCell<HashMap<DOMString, Vec<EventListenerEntry>>>,
 }
 
 impl EventTarget {
@@ -77,7 +77,7 @@ impl EventTarget {
         EventTarget {
             type_id: type_id,
             reflector_: Reflector::new(),
-            handlers: RefCell::new(HashMap::new()),
+            handlers: DOMRefCell::new(HashMap::new()),
         }
     }
 

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::FormDataBinding;
 use dom::bindings::codegen::Bindings::FormDataBinding::FormDataMethods;
 use dom::bindings::codegen::InheritTypes::FileCast;
@@ -14,7 +15,6 @@ use dom::blob::Blob;
 use dom::file::File;
 use dom::htmlformelement::HTMLFormElement;
 use servo_util::str::DOMString;
-use std::cell::RefCell;
 use std::collections::hashmap::HashMap;
 
 #[deriving(Clone)]
@@ -27,7 +27,7 @@ pub enum FormDatum {
 
 #[dom_struct]
 pub struct FormData {
-    data: RefCell<HashMap<DOMString, Vec<FormDatum>>>,
+    data: DOMRefCell<HashMap<DOMString, Vec<FormDatum>>>,
     reflector_: Reflector,
     global: GlobalField,
     form: Option<JS<HTMLFormElement>>
@@ -36,7 +36,7 @@ pub struct FormData {
 impl FormData {
     fn new_inherited(form: Option<JSRef<HTMLFormElement>>, global: &GlobalRef) -> FormData {
         FormData {
-            data: RefCell::new(HashMap::new()),
+            data: DOMRefCell::new(HashMap::new()),
             reflector_: Reflector::new(),
             global: GlobalField::from_rooted(global),
             form: form.map(|f| JS::from_rooted(f)),

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::attr::AttrValue;
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageElementMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLElementCast, HTMLImageElementDerived};
@@ -22,12 +23,10 @@ use string_cache::Atom;
 
 use url::{Url, UrlParser};
 
-use std::cell::RefCell;
-
 #[dom_struct]
 pub struct HTMLImageElement {
     htmlelement: HTMLElement,
-    image: RefCell<Option<Url>>,
+    image: DOMRefCell<Option<Url>>,
 }
 
 impl HTMLImageElementDerived for EventTarget {
@@ -73,7 +72,7 @@ impl HTMLImageElement {
     fn new_inherited(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> HTMLImageElement {
         HTMLImageElement {
             htmlelement: HTMLElement::new_inherited(HTMLImageElementTypeId, localName, prefix, document),
-            image: RefCell::new(None),
+            image: DOMRefCell::new(None),
         }
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -27,7 +27,7 @@ use servo_util::str::{DOMString, parse_unsigned_integer};
 use string_cache::Atom;
 
 use std::ascii::OwnedStrAsciiExt;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 
 static DEFAULT_SUBMIT_VALUE: &'static str = "Submit";
 static DEFAULT_RESET_VALUE: &'static str = "Reset";
@@ -49,7 +49,7 @@ pub struct HTMLInputElement {
     htmlelement: HTMLElement,
     input_type: Cell<InputType>,
     checked: Cell<bool>,
-    uncommitted_value: RefCell<Option<String>>,
+    uncommitted_value: DOMRefCell<Option<String>>,
     value: DOMRefCell<Option<String>>,
     size: Cell<u32>,
 }
@@ -68,7 +68,7 @@ impl HTMLInputElement {
             htmlelement: HTMLElement::new_inherited(HTMLInputElementTypeId, localName, prefix, document),
             input_type: Cell::new(InputText),
             checked: Cell::new(false),
-            uncommitted_value: RefCell::new(None),
+            uncommitted_value: DOMRefCell::new(None),
             value: DOMRefCell::new(None),
             size: Cell::new(DEFAULT_INPUT_SIZE),
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -5,6 +5,7 @@
 //! The core DOM types. Defines the basic DOM hierarchy as well as all the HTML elements.
 
 use dom::attr::{Attr, AttrHelpers};
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -110,7 +111,7 @@ pub struct Node {
     /// node is finalized.
     layout_data: LayoutDataRef,
 
-    unique_id: RefCell<String>,
+    unique_id: DOMRefCell<String>,
 }
 
 impl NodeDerived for EventTarget {
@@ -1155,7 +1156,7 @@ impl Node {
 
             layout_data: LayoutDataRef::new(),
 
-            unique_id: RefCell::new("".to_string()),
+            unique_id: DOMRefCell::new("".to_string()),
         }
     }
 

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -5,6 +5,7 @@
 //! The bulk of the HTML parser integration is in `script::parse::html`.
 //! This module is mostly about its interaction with DOM memory management.
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::ServoHTMLParserBinding;
 use dom::bindings::global;
 use dom::bindings::trace::JSTraceable;
@@ -15,7 +16,6 @@ use dom::document::Document;
 use parse::html::JSMessage;
 
 use std::default::Default;
-use std::cell::RefCell;
 use url::Url;
 use js::jsapi::JSTracer;
 use html5ever::tokenizer;
@@ -38,7 +38,7 @@ pub type Tokenizer = tokenizer::Tokenizer<TreeBuilder<TrustedNodeAddress, Sink>>
 #[privatize]
 pub struct ServoHTMLParser {
     reflector_: Reflector,
-    tokenizer: RefCell<Tokenizer>,
+    tokenizer: DOMRefCell<Tokenizer>,
 }
 
 impl ServoHTMLParser {
@@ -61,14 +61,14 @@ impl ServoHTMLParser {
 
         let parser = ServoHTMLParser {
             reflector_: Reflector::new(),
-            tokenizer: RefCell::new(tok),
+            tokenizer: DOMRefCell::new(tok),
         };
 
         reflect_dom_object(box parser, &global::Window(*window), ServoHTMLParserBinding::Wrap)
     }
 
     #[inline]
-    pub fn tokenizer<'a>(&'a self) -> &'a RefCell<Tokenizer> {
+    pub fn tokenizer<'a>(&'a self) -> &'a DOMRefCell<Tokenizer> {
         &self.tokenizer
     }
 }

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::URLSearchParamsBinding;
 use dom::bindings::codegen::Bindings::URLSearchParamsBinding::URLSearchParamsMethods;
 use dom::bindings::codegen::UnionTypes::StringOrURLSearchParams::{StringOrURLSearchParams, eURLSearchParams, eString};
@@ -15,21 +16,20 @@ use servo_util::str::DOMString;
 use encoding::all::UTF_8;
 use encoding::types::{EncodingRef, EncodeReplace};
 
-use std::cell::RefCell;
 use std::collections::hashmap::HashMap;
 use std::fmt::radix;
 use std::ascii::OwnedStrAsciiExt;
 
 #[dom_struct]
 pub struct URLSearchParams {
-    data: RefCell<HashMap<DOMString, Vec<DOMString>>>,
+    data: DOMRefCell<HashMap<DOMString, Vec<DOMString>>>,
     reflector_: Reflector,
 }
 
 impl URLSearchParams {
     fn new_inherited() -> URLSearchParams {
         URLSearchParams {
-            data: RefCell::new(HashMap::new()),
+            data: DOMRefCell::new(HashMap::new()),
             reflector_: Reflector::new(),
         }
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::{DOMRefCell, Ref};
 use dom::bindings::codegen::Bindings::EventHandlerBinding::{OnErrorEventHandlerNonNull, EventHandlerNonNull};
 use dom::bindings::codegen::Bindings::WindowBinding;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
@@ -39,7 +40,6 @@ use url::{Url, UrlParser};
 
 use libc;
 use serialize::base64::{FromBase64, ToBase64, STANDARD};
-use std::cell::{Ref, RefCell};
 use std::default::Default;
 use std::rc::Rc;
 use time;
@@ -54,7 +54,7 @@ pub struct Window {
     navigator: MutNullableJS<Navigator>,
     image_cache_task: ImageCacheTask,
     compositor: Box<ScriptListener+'static>,
-    browser_context: RefCell<Option<BrowserContext>>,
+    browser_context: DOMRefCell<Option<BrowserContext>>,
     page: Rc<Page>,
     performance: MutNullableJS<Performance>,
     navigation_start: u64,
@@ -437,7 +437,7 @@ impl Window {
             location: Default::default(),
             navigator: Default::default(),
             image_cache_task: image_cache_task,
-            browser_context: RefCell::new(None),
+            browser_context: DOMRefCell::new(None),
             performance: Default::default(),
             navigation_start: time::get_time().sec as u64,
             navigation_start_precise: time::precise_time_s(),

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::XMLHttpRequestBinding;
 use dom::bindings::codegen::Bindings::XMLHttpRequestBinding::XMLHttpRequestMethods;
@@ -50,7 +51,7 @@ use servo_util::str::DOMString;
 use servo_util::task::spawn_named;
 
 use std::ascii::StrAsciiExt;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::comm::{Sender, Receiver, channel};
 use std::default::Default;
 use std::io::{BufReader, MemWriter, Timer};
@@ -111,16 +112,16 @@ pub struct XMLHttpRequest {
     upload: JS<XMLHttpRequestUpload>,
     response_url: DOMString,
     status: Cell<u16>,
-    status_text: RefCell<ByteString>,
-    response: RefCell<ByteString>,
+    status_text: DOMRefCell<ByteString>,
+    response: DOMRefCell<ByteString>,
     response_type: Cell<XMLHttpRequestResponseType>,
     response_xml: MutNullableJS<Document>,
-    response_headers: RefCell<ResponseHeaderCollection>,
+    response_headers: DOMRefCell<ResponseHeaderCollection>,
 
     // Associated concepts
-    request_method: RefCell<Method>,
-    request_url: RefCell<Option<Url>>,
-    request_headers: RefCell<RequestHeaderCollection>,
+    request_method: DOMRefCell<Method>,
+    request_url: DOMRefCell<Option<Url>>,
+    request_headers: DOMRefCell<RequestHeaderCollection>,
     request_body_len: Cell<uint>,
     sync: Cell<bool>,
     upload_complete: Cell<bool>,
@@ -129,10 +130,10 @@ pub struct XMLHttpRequest {
 
     global: GlobalField,
     pinned_count: Cell<uint>,
-    timer: RefCell<Timer>,
+    timer: DOMRefCell<Timer>,
     fetch_time: Cell<i64>,
     timeout_pinned: Cell<bool>,
-    terminate_sender: RefCell<Option<Sender<Error>>>,
+    terminate_sender: DOMRefCell<Option<Sender<Error>>>,
 }
 
 impl XMLHttpRequest {
@@ -145,15 +146,15 @@ impl XMLHttpRequest {
             upload: JS::from_rooted(XMLHttpRequestUpload::new(global)),
             response_url: "".to_string(),
             status: Cell::new(0),
-            status_text: RefCell::new(ByteString::new(vec!())),
-            response: RefCell::new(ByteString::new(vec!())),
+            status_text: DOMRefCell::new(ByteString::new(vec!())),
+            response: DOMRefCell::new(ByteString::new(vec!())),
             response_type: Cell::new(_empty),
             response_xml: Default::default(),
-            response_headers: RefCell::new(ResponseHeaderCollection::new()),
+            response_headers: DOMRefCell::new(ResponseHeaderCollection::new()),
 
-            request_method: RefCell::new(Get),
-            request_url: RefCell::new(None),
-            request_headers: RefCell::new(RequestHeaderCollection::new()),
+            request_method: DOMRefCell::new(Get),
+            request_url: DOMRefCell::new(None),
+            request_headers: DOMRefCell::new(RequestHeaderCollection::new()),
             request_body_len: Cell::new(0),
             sync: Cell::new(false),
             send_flag: Cell::new(false),
@@ -163,10 +164,10 @@ impl XMLHttpRequest {
 
             global: GlobalField::from_rooted(global),
             pinned_count: Cell::new(0),
-            timer: RefCell::new(Timer::new().unwrap()),
+            timer: DOMRefCell::new(Timer::new().unwrap()),
             fetch_time: Cell::new(0),
             timeout_pinned: Cell::new(false),
-            terminate_sender: RefCell::new(None),
+            terminate_sender: DOMRefCell::new(None),
         }
     }
     pub fn new(global: &GlobalRef) -> Temporary<XMLHttpRequest> {

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::{DOMRefCell, Ref, RefMut};
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable};
@@ -25,7 +26,7 @@ use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_net::resource_task::ResourceTask;
 use servo_util::str::DOMString;
 use servo_util::smallvec::{SmallVec1, SmallVec};
-use std::cell::{Cell, RefCell, Ref, RefMut};
+use std::cell::Cell;
 use std::comm::{channel, Receiver, Empty, Disconnected};
 use std::mem::replace;
 use std::rc::Rc;
@@ -44,7 +45,7 @@ pub struct Page {
     pub last_reflow_id: Cell<uint>,
 
     /// The outermost frame containing the document, window, and page URL.
-    pub frame: RefCell<Option<Frame>>,
+    pub frame: DOMRefCell<Option<Frame>>,
 
     /// A handle for communicating messages to the layout task.
     pub layout_chan: LayoutChan,
@@ -53,18 +54,18 @@ pub struct Page {
     layout_rpc: Box<LayoutRPC+'static>,
 
     /// The port that we will use to join layout. If this is `None`, then layout is not running.
-    pub layout_join_port: RefCell<Option<Receiver<()>>>,
+    pub layout_join_port: DOMRefCell<Option<Receiver<()>>>,
 
     /// The current size of the window, in pixels.
     pub window_size: Cell<WindowSizeData>,
 
-    js_info: RefCell<Option<JSPageInfo>>,
+    js_info: DOMRefCell<Option<JSPageInfo>>,
 
     /// Cached copy of the most recent url loaded by the script
     /// TODO(tkuehn): this currently does not follow any particular caching policy
     /// and simply caches pages forever (!). The bool indicates if reflow is required
     /// when reloading.
-    url: RefCell<Option<(Url, bool)>>,
+    url: DOMRefCell<Option<(Url, bool)>>,
 
     next_subpage_id: Cell<SubpageId>,
 
@@ -72,10 +73,10 @@ pub struct Page {
     pub resize_event: Cell<Option<WindowSizeData>>,
 
     /// Any nodes that need to be dirtied before the next reflow.
-    pub pending_dirty_nodes: RefCell<SmallVec1<UntrustedNodeAddress>>,
+    pub pending_dirty_nodes: DOMRefCell<SmallVec1<UntrustedNodeAddress>>,
 
     /// Pending scroll to fragment event, if any
-    pub fragment_name: RefCell<Option<String>>,
+    pub fragment_name: DOMRefCell<Option<String>>,
 
     /// Associated resource task for use by DOM objects like XMLHttpRequest
     pub resource_task: ResourceTask,
@@ -84,7 +85,7 @@ pub struct Page {
     pub constellation_chan: ConstellationChan,
 
     // Child Pages.
-    pub children: RefCell<Vec<Rc<Page>>>,
+    pub children: DOMRefCell<Vec<Rc<Page>>>,
 
     /// Whether layout needs to be run at all.
     pub damaged: Cell<bool>,
@@ -142,21 +143,21 @@ impl Page {
         Page {
             id: id,
             subpage_id: subpage_id,
-            frame: RefCell::new(None),
+            frame: DOMRefCell::new(None),
             layout_chan: layout_chan,
             layout_rpc: layout_rpc,
-            layout_join_port: RefCell::new(None),
+            layout_join_port: DOMRefCell::new(None),
             window_size: Cell::new(window_size),
-            js_info: RefCell::new(Some(js_info)),
-            url: RefCell::new(None),
+            js_info: DOMRefCell::new(Some(js_info)),
+            url: DOMRefCell::new(None),
             next_subpage_id: Cell::new(SubpageId(0)),
             resize_event: Cell::new(None),
-            pending_dirty_nodes: RefCell::new(SmallVec1::new()),
-            fragment_name: RefCell::new(None),
+            pending_dirty_nodes: DOMRefCell::new(SmallVec1::new()),
+            fragment_name: DOMRefCell::new(None),
             last_reflow_id: Cell::new(0),
             resource_task: resource_task,
             constellation_chan: constellation_chan,
-            children: RefCell::new(vec!()),
+            children: DOMRefCell::new(vec!()),
             damaged: Cell::new(false),
             pending_reflows: Cell::new(0),
             avoided_reflows: Cell::new(0),

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -5,6 +5,7 @@
 //! The script task is the task that owns the DOM in memory, runs JavaScript, and spawns parsing
 //! and layout tasks.
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -64,7 +65,6 @@ use url::Url;
 
 use libc::size_t;
 use std::any::{Any, AnyRefExt};
-use std::cell::RefCell;
 use std::collections::HashSet;
 use std::comm::{channel, Sender, Receiver, Select};
 use std::mem::replace;
@@ -143,7 +143,7 @@ impl Drop for StackRootTLS {
 /// FIXME: Rename to `Page`, following WebKit?
 pub struct ScriptTask {
     /// A handle to the information pertaining to page layout
-    page: RefCell<Rc<Page>>,
+    page: DOMRefCell<Rc<Page>>,
     /// A handle to the image cache task.
     image_cache_task: ImageCacheTask,
     /// A handle to the resource task.
@@ -176,9 +176,9 @@ pub struct ScriptTask {
     /// The JavaScript runtime.
     js_runtime: js::rust::rt,
     /// The JSContext.
-    js_context: RefCell<Option<Rc<Cx>>>,
+    js_context: DOMRefCell<Option<Rc<Cx>>>,
 
-    mouse_over_targets: RefCell<Option<Vec<JS<Node>>>>
+    mouse_over_targets: DOMRefCell<Option<Vec<JS<Node>>>>
 }
 
 /// In the event of task failure, all data on the stack runs its destructor. However, there
@@ -327,7 +327,7 @@ impl ScriptTask {
         });
 
         ScriptTask {
-            page: RefCell::new(Rc::new(page)),
+            page: DOMRefCell::new(Rc::new(page)),
 
             image_cache_task: img_cache_task,
             resource_task: resource_task,
@@ -342,8 +342,8 @@ impl ScriptTask {
             devtools_port: devtools_receiver,
 
             js_runtime: js_runtime,
-            js_context: RefCell::new(Some(js_context)),
-            mouse_over_targets: RefCell::new(None)
+            js_context: DOMRefCell::new(Some(js_context)),
+            mouse_over_targets: DOMRefCell::new(None)
         }
     }
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::DOMRefCell;
+
 use script_task::{FireTimerMsg, ScriptChan};
 use script_task::{TimerSource, FromWindow, FromWorker};
 
@@ -12,7 +14,7 @@ use js::jsapi::{JSContext, JSObject};
 use js::jsval::{JSVal, NullValue};
 use js::rust::with_compartment;
 
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::cmp;
 use std::collections::hashmap::HashMap;
 use std::comm::{channel, Sender};
@@ -50,7 +52,7 @@ impl TimerHandle {
 #[jstraceable]
 #[privatize]
 pub struct TimerManager {
-    active_timers: RefCell<HashMap<TimerId, TimerHandle>>,
+    active_timers: DOMRefCell<HashMap<TimerId, TimerHandle>>,
     next_timer_handle: Cell<i32>,
 }
 
@@ -77,7 +79,7 @@ struct TimerData {
 impl TimerManager {
     pub fn new() -> TimerManager {
         TimerManager {
-            active_timers: RefCell::new(HashMap::new()),
+            active_timers: DOMRefCell::new(HashMap::new()),
             next_timer_handle: Cell::new(0)
         }
     }


### PR DESCRIPTION
#3050

Altough LayoutDataRef is touched from layout, we don't use DOMRefCell in it becasuse
it's expected to manipulate in layout task.
