### PR TITLE
Add an option to show debug fragment borders

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -42,6 +42,7 @@ use servo_net::local_image_cache::LocalImageCache;
 use servo_util::geometry::{Au, ZERO_RECT};
 use servo_util::geometry;
 use servo_util::logical_geometry::{LogicalRect, LogicalSize, LogicalMargin, WritingMode};
+use servo_util::opts;
 use servo_util::range::*;
 use servo_util::smallvec::SmallVec;
 use servo_util::str::is_whitespace;
@@ -1335,24 +1336,21 @@ impl Fragment {
                     });
                 }
 
-                // Draw debug frames for text bounds.
-                //
-                // FIXME(#2263, pcwalton): This is a bit of an abuse of the logging infrastructure.
-                // We should have a real `SERVO_DEBUG` system.
-                debug!("{:?}", self.build_debug_borders_around_text_fragments(display_list,
-                                                                              flow_origin,
-                                                                              text_fragment,
-                                                                              clip_rect))
+                if opts::get().show_debug_fragment_borders {
+                    self.build_debug_borders_around_text_fragments(display_list,
+                                                                   flow_origin,
+                                                                   text_fragment,
+                                                                   clip_rect);
+                }
             }
             GenericFragment | IframeFragment(..) | TableFragment | TableCellFragment |
             TableRowFragment | TableWrapperFragment | InlineBlockFragment(_) | InputFragment |
             InlineAbsoluteHypotheticalFragment(_) => {
-                // FIXME(pcwalton): This is a bit of an abuse of the logging infrastructure. We
-                // should have a real `SERVO_DEBUG` system.
-                debug!("{:?}",
-                       self.build_debug_borders_around_fragment(display_list,
-                                                                flow_origin,
-                                                                clip_rect))
+                if opts::get().show_debug_fragment_borders {
+                    self.build_debug_borders_around_fragment(display_list,
+                                                             flow_origin,
+                                                             clip_rect);
+                }
             }
             ImageFragment(ref mut image_fragment) => {
                 let image_ref = &mut image_fragment.image;

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -74,6 +74,9 @@ pub struct Opts {
     /// debugging purposes (`--show-debug-borders`).
     pub show_debug_borders: bool,
 
+    /// True if we should show borders on all fragments for debugging purposes (`--show-debug-fragment-borders`).
+    pub show_debug_fragment_borders: bool,
+
     /// If set with --disable-text-aa, disable antialiasing on fonts. This is primarily useful for reftests
     /// where pixel perfect results are required when using fonts such as the Ahem
     /// font for layout tests.
@@ -137,6 +140,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         getopts::optflag("f", "hard-fail", "Exit on task failure instead of displaying about:failure"),
         getopts::optflag("b", "bubble-widths", "Bubble intrinsic widths separately like other engines"),
         getopts::optflag("", "show-debug-borders", "Show debugging borders on layers and tiles."),
+        getopts::optflag("", "show-debug-fragment-borders", "Show debugging borders on fragments."),
         getopts::optflag("", "disable-text-aa", "Disable antialiasing for text rendering."),
         getopts::optflag("", "trace-layout", "Write layout trace to external file for debugging."),
         getopts::optflagopt("", "devtools", "Start remote devtools server on port", "6000"),
@@ -238,6 +242,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         hard_fail: opt_match.opt_present("f"),
         bubble_inline_sizes_separately: bubble_inline_sizes_separately,
         show_debug_borders: opt_match.opt_present("show-debug-borders"),
+        show_debug_fragment_borders: opt_match.opt_present("show-debug-fragment-borders"),
         enable_text_antialiasing: !opt_match.opt_present("disable-text-aa"),
         trace_layout: trace_layout,
         devtools_port: devtools_port,

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -67,6 +67,7 @@ pub extern "C" fn cef_run_message_loop() {
         hard_fail: false,
         bubble_inline_sizes_separately: false,
         show_debug_borders: false,
+        show_debug_fragment_borders: false,
         enable_text_antialiasing: true,
         trace_layout: false,
         devtools_port: None,


### PR DESCRIPTION
This is quite a bit cleaner than abusing the rust debug functionality.
If we start collecting too many debugging options in the servo
executable we could opt to organize them into a single option.

Fixes #2263.
