### PR TITLE
Add an option to validate display list items

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -96,6 +96,9 @@ pub struct Opts {
 
     /// Dumps the flow tree after a layout.
     pub dump_flow_tree: bool,
+
+    /// Whether to show an error when display list geometry escapes flow overflow regions.
+    pub validate_display_list_geometry: bool,
 }
 
 fn print_usage(app: &str, opts: &[getopts::OptGroup]) {
@@ -143,6 +146,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         getopts::optopt("", "resolution", "Set window resolution.", "800x600"),
         getopts::optopt("u", "user-agent", "Set custom user agent string", "NCSA Mosaic/1.0 (X11;SunOS 4.1.4 sun4m)"),
         getopts::optflag("", "dump-flow-tree", "Dump the flow (render) tree during each layout."),
+        getopts::optflag("", "validate-display-list-geometry", "Display an error when display list geometry escapes overflow region."),
         getopts::optflag("h", "help", "Print this message")
     );
 
@@ -244,6 +248,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         initial_window_size: initial_window_size,
         user_agent: opt_match.opt_str("u"),
         dump_flow_tree: opt_match.opt_present("dump-flow-tree"),
+        validate_display_list_geometry: opt_match.opt_present("validate-display-list-geometry"),
     };
 
     set_opts(opts);

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -73,6 +73,7 @@ pub extern "C" fn cef_run_message_loop() {
         initial_window_size: TypedSize2D(800, 600),
         user_agent: None,
         dump_flow_tree: false,
+        validate_display_list_geometry: false,
     };
     native::start(0, 0 as *const *const u8, proc() {
        let window = Some(glfw_app::create_window());


### PR DESCRIPTION
When this option is enabled, the layout task will print an error when
display list items draw outside their owning Flow's position rect. This
will make it easier to detect layout errors before they break rendering.

This is a command-line option for the moment, because we violate this
rule quite a bit still. Once all bugs causing this are fixed, we can be
more aggressive about enabling the option.
