### PR TITLE
gfx: Switch the default to CPU painting.

### DIFF
--- a/components/gfx/render_task.rs
+++ b/components/gfx/render_task.rs
@@ -162,7 +162,7 @@ impl<C:RenderListener + Send> RenderTask<C> {
             { // Ensures RenderTask and graphics context are destroyed before shutdown msg
                 let native_graphics_context = compositor.get_graphics_metadata().map(
                     |md| NativePaintingGraphicsContext::from_metadata(&md));
-                let cpu_painting = opts::get().cpu_painting;
+                let gpu_painting = opts::get().gpu_painting;
 
                 // FIXME: rust/#5967
                 let mut render_task = RenderTask {
@@ -173,10 +173,10 @@ impl<C:RenderListener + Send> RenderTask<C> {
                     font_ctx: box FontContext::new(fc.clone()),
                     time_profiler_chan: time_profiler_chan,
 
-                    graphics_context: if cpu_painting {
-                        CpuGraphicsContext
-                    } else {
+                    graphics_context: if gpu_painting {
                         GpuGraphicsContext
+                    } else {
+                        CpuGraphicsContext
                     },
 
                     native_graphics_context: native_graphics_context,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -29,9 +29,9 @@ pub struct Opts {
     /// FIXME(pcwalton): This is not currently used. All rendering is sequential.
     pub n_render_threads: uint,
 
-    /// True to use CPU painting, false to use GPU painting via Skia-GL (`-c`). Note that
+    /// True to use GPU painting via Skia-GL, false to use CPU painting via Skia (`-g`). Note that
     /// compositing is always done on the GPU.
-    pub cpu_painting: bool,
+    pub gpu_painting: bool,
 
     /// The maximum size of each tile in pixels (`-s`).
     pub tile_size: uint,
@@ -121,7 +121,8 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
     let args = args.tail();
 
     let opts = vec!(
-        getopts::optflag("c", "cpu", "CPU rendering"),
+        getopts::optflag("c", "cpu", "CPU painting (default)"),
+        getopts::optflag("g", "gpu", "GPU painting"),
         getopts::optopt("o", "output", "Output file", "output.png"),
         getopts::optopt("r", "rendering", "Rendering backend", "direct2d|core-graphics|core-graphics-accelerated|cairo|skia."),
         getopts::optopt("s", "size", "Size of tiles", "512"),
@@ -189,7 +190,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         from_str(period.as_slice()).unwrap()
     });
 
-    let cpu_painting = FORCE_CPU_PAINTING || opt_match.opt_present("c");
+    let gpu_painting = !FORCE_CPU_PAINTING && opt_match.opt_present("g");
 
     let mut layout_threads: uint = match opt_match.opt_str("y") {
         Some(layout_threads_str) => from_str(layout_threads_str.as_slice()).unwrap(),
@@ -224,7 +225,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
     let opts = Opts {
         urls: urls,
         n_render_threads: n_render_threads,
-        cpu_painting: cpu_painting,
+        gpu_painting: gpu_painting,
         tile_size: tile_size,
         device_pixels_per_px: device_pixels_per_px,
         time_profiler_period: time_profiler_period,

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -52,7 +52,7 @@ pub extern "C" fn cef_run_message_loop() {
     let opts = opts::Opts {
         urls: urls,
         n_render_threads: 1,
-        cpu_painting: false,
+        gpu_painting: false,
         tile_size: 512,
         device_pixels_per_px: None,
         time_profiler_period: None,

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -231,9 +231,12 @@ fn capture(reftest: &Reftest, side: uint) -> (u32, u32, Vec<u8>) {
             url.fragment = reftest.fragment_identifier.clone();
             url.to_string()
         });
-    // GPU rendering is the default
+    // CPU rendering is the default
     if reftest.render_mode.contains(CpuRendering) {
         command.arg("-c");
+    }
+    if reftest.render_mode.contains(GpuRendering) {
+        command.arg("-g");
     }
     if reftest.experimental {
         command.arg("--experimental");


### PR DESCRIPTION
We've discussed this some and I think there's consensus to do it as a
pragmatic decision for now. CPU painting is more stable, especially with
buggy drivers, and faster (because we aren't caching the necessary
OpenGL objects yet and possibly for other reasons), so it provides a
better "out of the box" experience for newcomers to Servo who don't know
to pass the `-c` option. This patch continues to reftest both Skia and
Skia-GL out of a desire to keep options open. Skia-GL remains a
first-class citizen.

r? @metajack
