### PR TITLE
Usage of JSRef<Attr> in before_remove_attr & after_set_attr

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -172,22 +172,14 @@ impl<'a> AttrHelpers<'a> for JSRef<'a, Attr> {
         let namespace_is_null = self.namespace == ns!("");
 
         match set_type {
-            ReplacedAttr => {
-                if namespace_is_null {
-                    vtable_for(&node).before_remove_attr(
-                        self.local_name(),
-                        self.value().as_slice().to_string())
-                }
-            }
-            FirstSetAttr => {}
+            ReplacedAttr if namespace_is_null => vtable_for(&node).before_remove_attr(self),
+            _ => ()
         }
 
         *self.value.borrow_mut() = value;
 
         if namespace_is_null {
-            vtable_for(&node).after_set_attr(
-                self.local_name(),
-                self.value().as_slice().to_string())
+            vtable_for(&node).after_set_attr(self)
         }
     }
 

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::HTMLBodyElementBinding;
 use dom::bindings::codegen::Bindings::HTMLBodyElementBinding::HTMLBodyElementMethods;
@@ -18,7 +20,6 @@ use dom::node::{Node, ElementNodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 
 use servo_util::str::DOMString;
-use string_cache::Atom;
 
 #[dom_struct]
 pub struct HTMLBodyElement {
@@ -63,13 +64,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
         Some(element as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
-        if name.as_slice().starts_with("on") {
+        let name = attr.local_name().as_slice();
+        if name.starts_with("on") {
             static forwarded_events: &'static [&'static str] =
                 &["onfocus", "onload", "onscroll", "onafterprint", "onbeforeprint",
                   "onbeforeunload", "onhashchange", "onlanguagechange", "onmessage",
@@ -80,14 +82,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
                                         window.get_url(),
                                         window.reflector().get_jsobject());
             let evtarget: JSRef<EventTarget> =
-                if forwarded_events.iter().any(|&event| name.as_slice() == event) {
+                if forwarded_events.iter().any(|&event| name == event) {
                     EventTargetCast::from_ref(*window)
                 } else {
                     EventTargetCast::from_ref(*self)
                 };
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
-                                                  name.as_slice().slice_from(2),
-                                                  value);
+                                                  name.slice_from(2),
+                                                  attr.value().as_slice().to_string());
         }
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
@@ -78,15 +80,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
             },
@@ -94,15 +96,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 node.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLCanvasElementBinding;
 use dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::HTMLCanvasElementMethods;
 use dom::bindings::codegen::InheritTypes::HTMLCanvasElementDerived;
@@ -18,7 +20,6 @@ use dom::node::{Node, ElementNodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 
 use servo_util::str::{DOMString, parse_unsigned_integer};
-use string_cache::Atom;
 
 use geom::size::Size2D;
 
@@ -99,18 +100,18 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
         Some(element as &VirtualMethods)
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let recreate = match name.as_slice() {
-            "width" => {
+        let recreate = match attr.local_name() {
+            &atom!("width") => {
                 self.width.set(DefaultWidth);
                 true
             }
-            "height" => {
+            &atom!("height") => {
                 self.height.set(DefaultHeight);
                 true
             }
@@ -126,18 +127,19 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
         }
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let recreate = match name.as_slice() {
-            "width" => {
+        let value = attr.value();
+        let recreate = match attr.local_name() {
+            &atom!("width") => {
                 self.width.set(parse_unsigned_integer(value.as_slice().chars()).unwrap_or(DefaultWidth));
                 true
             }
-            "height" => {
+            &atom!("height") => {
                 self.height.set(parse_unsigned_integer(value.as_slice().chars()).unwrap_or(DefaultHeight));
                 true
             }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::HTMLElementBinding;
 use dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
@@ -18,7 +20,6 @@ use dom::node::{Node, ElementNodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 
 use servo_util::str::DOMString;
-use string_cache::Atom;
 
 #[dom_struct]
 pub struct HTMLElement {
@@ -99,21 +100,22 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
         Some(element as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        if name.as_slice().starts_with("on") {
+        let name = attr.local_name().as_slice();
+        if name.starts_with("on") {
             let window = window_from_node(*self).root();
             let (cx, url, reflector) = (window.get_cx(),
                                         window.get_url(),
                                         window.reflector().get_jsobject());
             let evtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
-                                                  name.as_slice().slice_from(2),
-                                                  value);
+                                                  name.slice_from(2),
+                                                  attr.value().as_slice().to_string());
         }
     }
 }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLFieldSetElementDerived, NodeCast};
@@ -83,15 +85,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
                 let maybe_legend = node.children().find(|node| node.is_htmllegendelement());
@@ -115,15 +117,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 let maybe_legend = node.children().find(|node| node.is_htmllegendelement());

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLIFrameElementBinding;
 use dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
@@ -23,7 +24,6 @@ use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_msg::constellation_msg::{IFrameSandboxed, IFrameUnsandboxed};
 use servo_msg::constellation_msg::{ConstellationChan, LoadIframeUrlMsg};
 use servo_util::str::DOMString;
-use string_cache::Atom;
 
 use std::ascii::StrAsciiExt;
 use std::cell::Cell;
@@ -188,44 +188,47 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        if "sandbox" == name.as_slice() {
-            let mut modes = AllowNothing as u8;
-            for word in value.as_slice().split(' ') {
-                modes |= match word.to_ascii_lower().as_slice() {
-                    "allow-same-origin" => AllowSameOrigin,
-                    "allow-forms" => AllowForms,
-                    "allow-pointer-lock" => AllowPointerLock,
-                    "allow-popups" => AllowPopups,
-                    "allow-scripts" => AllowScripts,
-                    "allow-top-navigation" => AllowTopNavigation,
-                    _ => AllowNothing
-                } as u8;
-            }
-            self.sandbox.set(Some(modes));
-        }
-
-        if "src" == name.as_slice() {
-            let node: JSRef<Node> = NodeCast::from_ref(*self);
-            if node.is_in_doc() {
-                self.process_the_iframe_attributes()
-            }
+        match attr.local_name() {
+            &atom!("sandbox") => {
+                let mut modes = AllowNothing as u8;
+                for word in attr.value().as_slice().split(' ') {
+                    modes |= match word.to_ascii_lower().as_slice() {
+                        "allow-same-origin" => AllowSameOrigin,
+                        "allow-forms" => AllowForms,
+                        "allow-pointer-lock" => AllowPointerLock,
+                        "allow-popups" => AllowPopups,
+                        "allow-scripts" => AllowScripts,
+                        "allow-top-navigation" => AllowTopNavigation,
+                        _ => AllowNothing
+                    } as u8;
+                }
+                self.sandbox.set(Some(modes));
+            },
+            &atom!("src") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
+                if node.is_in_doc() {
+                    self.process_the_iframe_attributes()
+                }
+            },
+            _ => ()
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        if "sandbox" == name.as_slice() {
-            self.sandbox.set(None);
+        match attr.local_name() {
+            &atom!("sandbox") => self.sandbox.set(None),
+            _ => ()
         }
     }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::AttrValue;
+use dom::attr::Attr;
+use dom::attr::{AttrHelpers, AttrValue};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageElementMethods;
@@ -166,27 +167,31 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        if "src" == name.as_slice() {
-            let window = window_from_node(*self).root();
-            let url = window.get_url();
-            self.update_image(Some((value, &url)));
+        match attr.local_name() {
+            &atom!("src") => {
+                let window = window_from_node(*self).root();
+                let url = window.get_url();
+                self.update_image(Some((attr.value().as_slice().to_string(), &url)));
+            },
+            _ => ()
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        if atom!("src") == *name {
-            self.update_image(None);
+        match attr.local_name() {
+            &atom!("src") => self.update_image(None),
+            _ => ()
         }
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -13,7 +15,6 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, HTMLFor
 use dom::bindings::codegen::InheritTypes::{HTMLInputElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable, ResultRootable};
 use dom::bindings::utils::{Reflectable, Reflector};
-use dom::attr::{AttrHelpers};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{AttributeHandlers, Element, HTMLInputElementTypeId};
 use dom::event::Event;
@@ -265,27 +266,29 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
             }
-            "checked" => {
+            &atom!("checked") => {
                 self.update_checked_state(true);
             }
-            "size" => {
+            &atom!("size") => {
+                let value = attr.value();
                 let parsed = parse_unsigned_integer(value.as_slice().chars());
                 self.size.set(parsed.unwrap_or(DEFAULT_INPUT_SIZE));
                 self.force_relayout();
             }
-            "type" => {
+            &atom!("type") => {
+                let value = attr.value();
                 self.input_type.set(match value.as_slice() {
                     "button" => InputButton(None),
                     "submit" => InputButton(Some(DEFAULT_SUBMIT_VALUE)),
@@ -303,12 +306,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                 }
                 self.force_relayout();
             }
-            "value" => {
-                *self.value.borrow_mut() = Some(value);
+            &atom!("value") => {
+                *self.value.borrow_mut() = Some(attr.value().as_slice().to_string());
                 self.force_relayout();
             }
-            "name" => {
+            &atom!("name") => {
                 if self.input_type.get() == InputRadio {
+                    let value = attr.value();
                     self.radio_group_updated(Some(value.as_slice()));
                 }
             }
@@ -316,27 +320,27 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 node.check_ancestors_disabled_state_for_form_control();
             }
-            "checked" => {
+            &atom!("checked") => {
                 self.update_checked_state(false);
             }
-            "size" => {
+            &atom!("size") => {
                 self.size.set(DEFAULT_INPUT_SIZE);
                 self.force_relayout();
             }
-            "type" => {
+            &atom!("type") => {
                 if self.input_type.get() == InputRadio {
                     broadcast_radio_checked(*self,
                                             self.get_radio_group()
@@ -346,11 +350,11 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                 self.input_type.set(InputText);
                 self.force_relayout();
             }
-            "value" => {
+            &atom!("value") => {
                 *self.value.borrow_mut() = None;
                 self.force_relayout();
             }
-            "name" => {
+            &atom!("name") => {
                 if self.input_type.get() == InputRadio {
                     self.radio_group_updated(None);
                 }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
@@ -67,19 +68,19 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
         let element: JSRef<Element> = ElementCast::from_ref(*self);
         let rel = get_attr(element, &atom!("rel"));
 
-        match (rel, name.as_slice()) {
-            (ref rel, "href") => {
+        match (rel, attr.local_name()) {
+            (ref rel, &atom!("href")) => {
                 if is_stylesheet(rel) {
-                    self.handle_stylesheet_url(value.as_slice());
+                    self.handle_stylesheet_url(attr.value().as_slice());
                 }
             }
             (_, _) => ()

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::HTMLObjectElementBinding;
 use dom::bindings::codegen::Bindings::HTMLObjectElementBinding::HTMLObjectElementMethods;
@@ -99,15 +101,18 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        if "data" == name.as_slice() {
-            let window = window_from_node(*self).root();
-            self.process_data_url(window.image_cache_task().clone());
+        match attr.local_name() {
+            &atom!("data") => {
+                let window = window_from_node(*self).root();
+                self.process_data_url(window.image_cache_task().clone());
+            },
+            _ => ()
         }
     }
 }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding::HTMLOptGroupElementMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
@@ -57,15 +59,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
                 for child in node.children().filter(|child| child.is_htmloptionelement()) {
@@ -77,15 +79,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 for child in node.children().filter(|child| child.is_htmloptionelement()) {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use dom::bindings::codegen::Bindings::HTMLOptionElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOptionElementBinding::HTMLOptionElementMethods;
@@ -97,15 +99,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
             },
@@ -113,15 +115,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 node.check_parent_disabled_state_for_option();

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding;
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElementMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
@@ -79,15 +81,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
             },
@@ -95,15 +97,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 node.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableCellElementDerived};
 use dom::bindings::js::JSRef;
 use dom::bindings::utils::{Reflectable, Reflector};
@@ -16,7 +18,6 @@ use dom::virtualmethods::VirtualMethods;
 use servo_util::str::{AutoLpa, DOMString, LengthOrPercentageOrAuto};
 use servo_util::str;
 use std::cell::Cell;
-use string_cache::Atom;
 
 #[dom_struct]
 pub struct HTMLTableCellElement {
@@ -64,27 +65,27 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => {}
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        match name.as_slice() {
-            "width" => self.width.set(str::parse_length(value.as_slice())),
-            _ => {}
+        match attr.local_name() {
+            &atom!("width") => self.width.set(str::parse_length(attr.value().as_slice())),
+            _ => ()
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => {}
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        match name.as_slice() {
-            "width" => self.width.set(AutoLpa),
-            _ => {}
+        match attr.local_name() {
+            &atom!("width") => self.width.set(AutoLpa),
+            _ => ()
         }
     }
 }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
@@ -62,15 +64,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
         Some(htmlelement as &VirtualMethods)
     }
 
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value.clone()),
-            _ => (),
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
             },
@@ -78,15 +80,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
         }
     }
 
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
-            _ => (),
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
         }
 
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        match name.as_slice() {
-            "disabled" => {
+        match attr.local_name() {
+            &atom!("disabled") => {
+                let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(false);
                 node.set_enabled_state(true);
                 node.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
 use dom::attr::{AttrValue, StringAttrValue};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
@@ -62,7 +63,6 @@ use dom::htmltextareaelement::HTMLTextAreaElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 
 use servo_util::str::DOMString;
-use string_cache::Atom;
 
 /// Trait to allow DOM nodes to opt-in to overriding (or adding to) common
 /// behaviours. Replicates the effect of C++ virtual methods.
@@ -73,18 +73,18 @@ pub trait VirtualMethods {
 
     /// Called when changing or adding attributes, after the attribute's value
     /// has been updated.
-    fn after_set_attr(&self, name: &Atom, value: DOMString) {
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.after_set_attr(name, value),
+            Some(ref s) => s.after_set_attr(attr),
             _ => (),
         }
     }
 
     /// Called when changing or removing attributes, before any modification
     /// has taken place.
-    fn before_remove_attr(&self, name: &Atom, value: DOMString) {
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
         match self.super_type() {
-            Some(ref s) => s.before_remove_attr(name, value),
+            Some(ref s) => s.before_remove_attr(attr),
             _ => (),
         }
     }


### PR DESCRIPTION
`JSRef<Attr>` does not require allocating a `DOMString` for value, which are unused in most cases. It also provides more access to `Attr` data.
