### PR TITLE
Fix #3753

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -380,19 +380,19 @@ pub struct ScannedTextFragmentInfo {
     /// fragments, it will have to be restored.
     pub original_new_line_pos: Option<Vec<CharIndex>>,
 
-    /// The inline-size of the text fragment.
-    pub content_inline_size: Au,
+    /// The intrinsic size of the text fragment.
+    pub content_size: LogicalSize<Au>,
 }
 
 impl ScannedTextFragmentInfo {
     /// Creates the information specific to a scanned text fragment from a range and a text run.
-    pub fn new(run: Arc<Box<TextRun>>, range: Range<CharIndex>, content_inline_size: Au)
+    pub fn new(run: Arc<Box<TextRun>>, range: Range<CharIndex>, content_size: LogicalSize<Au>)
                -> ScannedTextFragmentInfo {
         ScannedTextFragmentInfo {
             run: run,
             range: range,
             original_new_line_pos: None,
-            content_inline_size: content_inline_size,
+            content_size: content_size,
         }
     }
 }
@@ -603,7 +603,7 @@ impl Fragment {
         let new_border_box =
             LogicalRect::from_point_size(self.style.writing_mode, self.border_box.start, size);
 
-        info.content_inline_size = size.inline;
+        info.content_size = size.clone();
 
         Fragment {
             node: self.node,
@@ -821,7 +821,7 @@ impl Fragment {
             }
         };
 
-        self.border_padding = border + padding
+        self.border_padding = border + padding;
     }
 
     // Return offset from original position because of `position: relative`.
@@ -1705,7 +1705,7 @@ impl Fragment {
             ScannedTextFragment(ref info) => {
                 // Scanned text fragments will have already had their content inline-sizes assigned
                 // by this point.
-                self.border_box.size.inline = info.content_inline_size + noncontent_inline_size
+                self.border_box.size.inline = info.content_size.inline + noncontent_inline_size
             }
             ImageFragment(ref mut image_fragment_info) => {
                 // TODO(ksh8281): compute border,margin
@@ -1805,10 +1805,10 @@ impl Fragment {
                 image_fragment_info.computed_block_size = Some(block_size);
                 self.border_box.size.block = block_size + noncontent_block_size
             }
-            ScannedTextFragment(_) => {
+            ScannedTextFragment(ref info) => {
                 // Scanned text fragments' content block-sizes are calculated by the text run
                 // scanner during flow construction.
-                self.border_box.size.block = self.border_box.size.block + noncontent_block_size
+                self.border_box.size.block = info.content_size.block + noncontent_block_size
             }
             InlineBlockFragment(ref mut info) => {
                 // Not the primary fragment, so we do not take the noncontent size into account.

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -408,7 +408,7 @@ impl LineBreaker {
                 ScannedTextFragmentInfo::new(
                     run.clone(),
                     split.range,
-                    in_fragment.border_box.size.inline);
+                    in_fragment.border_box.size);
             let size = LogicalSize::new(
                 writing_mode, split.inline_size, in_fragment.border_box.size.block);
             in_fragment.transform(size, info)
@@ -499,7 +499,7 @@ impl LineBreaker {
                     ScannedTextFragmentInfo::new(
                         run.clone(),
                         split.range,
-                        in_fragment.border_box.size.inline);
+                        in_fragment.border_box.size);
                 let size = LogicalSize::new(self.floats.writing_mode,
                                             split.inline_size,
                                             in_fragment.border_box.size.block);

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -159,9 +159,9 @@ impl TextRunScanner {
                 continue
             }
 
-            let text_inline_size = old_fragment.border_box.size.inline;
+            let text_size = old_fragment.border_box.size;
             let new_text_fragment_info =
-                ScannedTextFragmentInfo::new(run.clone(), range, text_inline_size);
+                ScannedTextFragmentInfo::new(run.clone(), range, text_size);
             let new_metrics = new_text_fragment_info.run.metrics_for_range(&range);
             let bounding_box_size = bounding_box_for_run_metrics(&new_metrics,
                                                                  old_fragment.style.writing_mode);
@@ -223,5 +223,3 @@ pub fn line_height_from_style(style: &ComputedValues, metrics: &FontMetrics) -> 
         line_height::Length(l) => l
     }
 }
-
-


### PR DESCRIPTION
r? @pcwalton

Looks like I forgot to save `ScannedTextFragment`s block sizes with their
inline sizes. This patch fixes that.

Fixes #3753 
