### PR TITLE
M1456, Implement MIME sniffing initial Step

### DIFF
--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -37,6 +37,7 @@ pub mod data_loader;
 pub mod image_cache_task;
 pub mod local_image_cache;
 pub mod resource_task;
+mod sniffer_task;
 
 /// An implementation of the [Fetch spec](http://fetch.spec.whatwg.org/)
 pub mod fetch {

--- a/components/net/sniffer_task.rs
+++ b/components/net/sniffer_task.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A task that sniffs data
+use std::comm::{channel, Receiver, Sender, Disconnected};
+use std::task::TaskBuilder;
+use resource_task::{LoadResponse};
+
+pub type SnifferTask = Sender<LoadResponse>;
+
+pub fn new_sniffer_task(next_rx: Sender<LoadResponse>) -> SnifferTask {
+  let(sen, rec) = channel();
+  let builder = TaskBuilder::new().named("SnifferManager");
+  builder.spawn(proc(){
+    SnifferManager::new(rec).start(next_rx);
+  });
+  sen
+}
+
+struct SnifferManager {
+  data_receiver: Receiver<LoadResponse>,
+}
+
+impl SnifferManager {
+  fn new(data_receiver: Receiver <LoadResponse>) -> SnifferManager {
+    SnifferManager {
+      data_receiver: data_receiver,
+    }
+  }
+}
+
+impl SnifferManager {
+  fn start(&self, next_rx: Sender<LoadResponse>) {
+    loop {
+      match self.data_receiver.try_recv() {
+        Ok(snif_data) => next_rx.send(snif_data),
+        Err(e) => {
+          if e == Disconnected {
+            break
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Issue: #3144 

We created a sniffer task in components/net/, added a call in resource_task load function to create a new sniffer task (sending all the data), and sniffer_task currently sends all the data back to resource_task.

The purpose of this request is to get feedback from @jdm on our progress before moving forward and writing tests.
