### PR TITLE
layout: Shrink fragments down from 448 bytes to 128 bytes.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -238,12 +238,12 @@ impl<'a> FlowConstructor<'a> {
             Some(url) => {
                 // FIXME(pcwalton): The fact that image fragments store the cache within them makes
                 // little sense to me.
-                ImageFragment(ImageFragmentInfo::new(node,
-                                                     url,
-                                                     self.layout_context
-                                                         .shared
-                                                         .image_cache
-                                                         .clone()))
+                ImageFragment(box ImageFragmentInfo::new(node,
+                                                         url,
+                                                         self.layout_context
+                                                             .shared
+                                                             .image_cache
+                                                             .clone()))
             }
         }
     }
@@ -258,7 +258,7 @@ impl<'a> FlowConstructor<'a> {
                                                  -> SpecificFragmentInfo {
         match node.type_id() {
             Some(ElementNodeTypeId(HTMLIFrameElementTypeId)) => {
-                IframeFragment(IframeFragmentInfo::new(node))
+                IframeFragment(box IframeFragmentInfo::new(node))
             }
             Some(ElementNodeTypeId(HTMLImageElementTypeId)) => {
                 self.build_fragment_info_for_image(node, node.image_url())

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -502,7 +502,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 if opts::get().show_debug_fragment_borders {
                     self.build_debug_borders_around_text_fragments(display_list,
                                                                    flow_origin,
-                                                                   text_fragment,
+                                                                   &**text_fragment,
                                                                    clip_rect);
                 }
             }
@@ -559,7 +559,7 @@ impl FragmentDisplayListBuilding for Fragment {
         // the iframe is actually going to be displayed.
         match self.specific {
             IframeFragment(ref iframe_fragment) => {
-                self.finalize_position_and_size_of_iframe(iframe_fragment,
+                self.finalize_position_and_size_of_iframe(&**iframe_fragment,
                                                           absolute_fragment_bounds.origin,
                                                           layout_context)
             }

--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -8,7 +8,7 @@ use style::ComputedValues;
 
 bitflags! {
     #[doc = "Individual layout actions that may be necessary after restyling."]
-    flags RestyleDamage: int {
+    flags RestyleDamage: u8 {
         #[doc = "Repaint the node itself."]
         #[doc = "Currently unused; need to decide how this propagates."]
         static Repaint = 0x01,

--- a/components/layout/layout_debug.rs
+++ b/components/layout/layout_debug.rs
@@ -92,8 +92,8 @@ impl Drop for Scope {
 /// Generate a unique ID. This is used for items such as Fragment
 /// which are often reallocated but represent essentially the
 /// same data.
-pub fn generate_unique_debug_id() -> uint {
-    unsafe { DEBUG_ID_COUNTER.fetch_add(1, SeqCst) }
+pub fn generate_unique_debug_id() -> u16 {
+    unsafe { DEBUG_ID_COUNTER.fetch_add(1, SeqCst) as u16 }
 }
 
 /// Begin a layout debug trace. If this has not been called,

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -13,6 +13,7 @@ use layout_debug;
 use wrapper::ThreadSafeLayoutNode;
 
 use servo_util::geometry::Au;
+use std::cmp::max;
 use std::fmt;
 use style::computed_values::LengthOrPercentageOrAuto;
 
@@ -64,7 +65,7 @@ impl Flow for TableColGroupFlow {
             // Retrieve the specified value from the appropriate CSS property.
             let inline_size = fragment.style().content_inline_size();
             let span: int = match fragment.specific {
-                TableColumnFragment(col_fragment) => col_fragment.span.unwrap_or(1),
+                TableColumnFragment(col_fragment) => max(col_fragment.span, 1),
                 _ => fail!("non-table-column fragment inside table column?!"),
             };
             for _ in range(0, span) {

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -160,16 +160,17 @@ impl TextRunScanner {
             }
 
             let text_size = old_fragment.border_box.size;
+            let &NewLinePositions(ref mut new_line_positions) =
+                new_line_positions.get_mut(logical_offset);
             let new_text_fragment_info =
-                ScannedTextFragmentInfo::new(run.clone(), range, text_size);
+                box ScannedTextFragmentInfo::new(run.clone(),
+                                                 range,
+                                                 mem::replace(new_line_positions, Vec::new()),
+                                                 text_size);
             let new_metrics = new_text_fragment_info.run.metrics_for_range(&range);
             let bounding_box_size = bounding_box_for_run_metrics(&new_metrics,
                                                                  old_fragment.style.writing_mode);
-            let mut new_fragment = old_fragment.transform(bounding_box_size,
-                                                          new_text_fragment_info);
-            let &NewLinePositions(ref mut new_line_positions) =
-                new_line_positions.get_mut(logical_offset);
-            new_fragment.new_line_pos = mem::replace(new_line_positions, Vec::new());
+            let new_fragment = old_fragment.transform(bounding_box_size, new_text_fragment_info);
             out_fragments.push(new_fragment)
         }
 


### PR DESCRIPTION
16% performance improvement in layout (!)

r? @metajack (or whoever)
