### PR TITLE
Macroize event handler getters and setters

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -170,15 +170,7 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for JSRef<'a, DedicatedWorkerGlobalSc
         Ok(())
     }
 
-    fn GetOnmessage(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("message")
-    }
-
-    fn SetOnmessage(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("message", listener)
-    }
+    event_handler!(message, GetOnmessage, SetOnmessage)
 }
 
 trait PrivateDedicatedWorkerGlobalScopeHelpers {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -888,23 +888,6 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         root.query_selector_all(selectors)
     }
 
-    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("click")
-    }
-
-    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("click", listener)
-    }
-
-    fn GetOnload(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("load")
-    }
-
-    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("load", listener)
-    }
+    event_handler!(click, GetOnclick, SetOnclick)
+    event_handler!(load, GetOnload, SetOnload)
 }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -66,15 +66,7 @@ impl<'a> PrivateHTMLElementHelpers for JSRef<'a, HTMLElement> {
 }
 
 impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
-    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("click")
-    }
-
-    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("click", listener)
-    }
+    event_handler!(click, GetOnclick, SetOnclick)
 
     fn GetOnload(self) -> Option<EventHandlerNonNull> {
         if self.is_body_or_frameset() {

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -185,3 +185,29 @@ macro_rules! untraceable(
     );
 )
 
+/// These are used to generate a event handler which has no special case.
+macro_rules! define_event_handler(
+    ($handler: ident, $event_type: ident, $getter: ident, $setter: ident) => (
+        fn $getter(self) -> Option<$handler> {
+            let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
+            eventtarget.get_event_handler_common(stringify!($event_type))
+        }
+
+        fn $setter(self, listener: Option<$handler>) {
+            let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
+            eventtarget.set_event_handler_common(stringify!($event_type), listener)
+        }
+    )
+)
+
+macro_rules! event_handler(
+    ($event_type: ident, $getter: ident, $setter: ident) => (
+        define_event_handler!(EventHandlerNonNull, $event_type, $getter, $setter)
+    )
+)
+
+macro_rules! error_event_handler(
+    ($event_type: ident, $getter: ident, $setter: ident) => (
+        define_event_handler!(OnErrorEventHandlerNonNull, $event_type, $getter, $setter)
+    )
+)

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -272,45 +272,10 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         self.performance.get().unwrap()
     }
 
-    fn GetOnclick(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("click")
-    }
-
-    fn SetOnclick(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("click", listener)
-    }
-
-    fn GetOnload(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("load")
-    }
-
-    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("load", listener)
-    }
-
-    fn GetOnunload(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("unload")
-    }
-
-    fn SetOnunload(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("unload", listener)
-    }
-
-    fn GetOnerror(self) -> Option<OnErrorEventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("error")
-    }
-
-    fn SetOnerror(self, listener: Option<OnErrorEventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("error", listener)
-    }
+    event_handler!(click, GetOnclick, SetOnclick)
+    event_handler!(load, GetOnload, SetOnload)
+    event_handler!(unload, GetOnunload, SetOnunload)
+    error_event_handler!(error, GetOnerror, SetOnerror)
 
     fn Screen(self) -> Temporary<Screen> {
         if self.screen.get().is_none() {

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -149,15 +149,7 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
         Ok(())
     }
 
-    fn GetOnmessage(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("message")
-    }
-
-    fn SetOnmessage(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("message", listener)
-    }
+    event_handler!(message, GetOnmessage, SetOnmessage)
 }
 
 impl Reflectable for Worker {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -264,15 +264,7 @@ impl XMLHttpRequest {
 }
 
 impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
-    fn GetOnreadystatechange(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("readystatechange")
-    }
-
-    fn SetOnreadystatechange(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("readystatechange", listener)
-    }
+    event_handler!(readystatechange, GetOnreadystatechange, SetOnreadystatechange)
 
     fn ReadyState(self) -> u16 {
         self.ready_state.get() as u16

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -45,73 +45,11 @@ impl Reflectable for XMLHttpRequestEventTarget {
 }
 
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
-    fn GetOnloadstart(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("loadstart")
-    }
-
-    fn SetOnloadstart(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("loadstart", listener)
-    }
-
-    fn GetOnprogress(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("progress")
-    }
-
-    fn SetOnprogress(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("progress", listener)
-    }
-
-    fn GetOnabort(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("abort")
-    }
-
-    fn SetOnabort(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("abort", listener)
-    }
-
-    fn GetOnerror(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("error")
-    }
-
-    fn SetOnerror(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("error", listener)
-    }
-
-    fn GetOnload(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("load")
-    }
-
-    fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("load", listener)
-    }
-
-    fn GetOntimeout(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("timeout")
-    }
-
-    fn SetOntimeout(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("timeout", listener)
-    }
-
-    fn GetOnloadend(self) -> Option<EventHandlerNonNull> {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.get_event_handler_common("loadend")
-    }
-
-    fn SetOnloadend(self, listener: Option<EventHandlerNonNull>) {
-        let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        eventtarget.set_event_handler_common("loadend", listener)
-    }
+    event_handler!(loadstart,GetOnloadstart, SetOnloadstart)
+    event_handler!(progress, GetOnprogress, SetOnprogress)
+    event_handler!(abort, GetOnabort, SetOnabort)
+    event_handler!(error, GetOnerror, SetOnerror)
+    event_handler!(load, GetOnload, SetOnload)
+    event_handler!(timeout, GetOntimeout, SetOntimeout)
+    event_handler!(loadend, GetOnloadend, SetOnloadend)
 }


### PR DESCRIPTION
Fix #3755

This doesn't convert some specialized event handlers (e.g. `HTMLBodyElement`'s ones, `HTMLElement.GetOnload()`).
