### PR TITLE
Enables incremental reflow for inline-size assignment.

### DIFF
--- a/components/gfx/render_task.rs
+++ b/components/gfx/render_task.rs
@@ -33,6 +33,7 @@ use servo_util::task::spawn_named_with_send_on_failure;
 use servo_util::time::{TimeProfilerChan, profile};
 use servo_util::time;
 use std::comm::{Receiver, Sender, channel};
+use std::fmt;
 use std::mem;
 use std::task::TaskBuilder;
 use sync::Arc;
@@ -51,6 +52,12 @@ pub struct RenderLayer {
     pub background_color: Color,
     /// The scrolling policy of this layer.
     pub scroll_policy: ScrollPolicy,
+}
+
+impl fmt::Show for RenderLayer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} @ {} [{}]", self.id, self.position, self.scroll_policy)
+    }
 }
 
 pub struct RenderRequest {
@@ -566,4 +573,3 @@ enum MsgToWorkerThread {
 enum MsgFromWorkerThread {
     PaintedTileMsgFromWorkerThread(Box<LayerBuffer>),
 }
-

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -707,4 +707,3 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                                               DisplayList::new()).flatten(FloatStackingLevel)
     }
 }
-

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -645,11 +645,11 @@ impl LayoutTask {
             match rw_data.parallel_traversal {
                 None => {
                     // Sequential mode.
-                    self.solve_constraints(&mut layout_root, &shared_layout_ctx)
+                    self.solve_constraints(&mut layout_root, &shared_layout_ctx);
                 }
                 Some(_) => {
                     // Parallel mode.
-                    self.solve_constraints_parallel(data, rw_data, &mut layout_root, &mut shared_layout_ctx)
+                    self.solve_constraints_parallel(data, rw_data, &mut layout_root, &mut shared_layout_ctx);
                 }
             }
         });
@@ -740,6 +740,8 @@ impl LayoutTask {
                                           DList::new()).into_iter() {
                     layers.push(layer)
                 }
+
+                debug!("Layers: {}", layers);
 
                 debug!("Layout done!");
 

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -61,7 +61,7 @@ impl LayerId {
 }
 
 /// The scrolling policy of a layer.
-#[deriving(Clone, PartialEq)]
+#[deriving(Clone, PartialEq, Show)]
 pub enum ScrollPolicy {
     /// These layers scroll when the parent receives a scrolling message.
     Scrollable,

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -95,8 +95,9 @@ pub static MAX_RECT: Rect<Au> = Rect {
     }
 };
 
-pub static MIN_AU: Au = Au(i32::MIN);
-pub static MAX_AU: Au = Au(i32::MAX);
+pub static ZERO_AU: Au = Au(0);
+pub static MIN_AU:  Au = Au(i32::MIN);
+pub static MAX_AU:  Au = Au(i32::MAX);
 
 impl<E, S: Encoder<E>> Encodable<S, E> for Au {
     fn encode(&self, e: &mut S) -> Result<(), E> {
@@ -319,4 +320,3 @@ pub fn f32_rect_to_au_rect(rect: Rect<f32>) -> Rect<Au> {
     Rect(Point2D(Au::from_frac32_px(rect.origin.x), Au::from_frac32_px(rect.origin.y)),
          Size2D(Au::from_frac32_px(rect.size.width), Au::from_frac32_px(rect.size.height)))
 }
-

--- a/components/util/smallvec.rs
+++ b/components/util/smallvec.rs
@@ -7,6 +7,7 @@
 
 use std::mem::init as i;
 use std::cmp;
+use std::fmt;
 use std::intrinsics;
 use std::kinds::marker::ContravariantLifetime;
 use std::mem;
@@ -405,6 +406,12 @@ macro_rules! def_small_vector(
             }
         }
 
+        impl<T: fmt::Show + 'static> fmt::Show for $name<T> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", self.as_slice())
+            }
+        }
+
         impl<T: 'static> $name<T> {
             #[inline]
             pub fn new() -> $name<T> {
@@ -527,4 +534,3 @@ pub mod tests {
         ].as_slice());
     }
 }
-


### PR DESCRIPTION
This used to be run unconditionally. Now, it's sensitive to reflow flags.

I will be making block size assignment incremental, next.

EDIT: Nevermind. Incremental block size "just works". I included that too. Please don't r+ until I add a reftest.

r? @pcwalton
