### PR TITLE
Fix a script -> layout race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure#e151fa23f5cb3c1ef62b4d41bad9abdd1f4f3471)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom#b001a76e907befaae1d0d6dd259418a22092da86)",
+ "util 0.0.1",
 ]
 
 [[package]]
@@ -112,6 +113,7 @@ version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
  "msg 0.0.1",
+ "util 0.0.1",
 ]
 
 [[package]]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -12,3 +12,6 @@ git = "https://github.com/servo/rust-azure"
 
 [dependencies.geom]
 git = "https://github.com/servo/rust-geom"
+
+[dependencies.util]
+path = "../util"

--- a/components/canvas/canvas_render_task.rs
+++ b/components/canvas/canvas_render_task.rs
@@ -6,9 +6,9 @@ use azure::azure_hl::{DrawTarget, Color, B8G8R8A8, SkiaBackend, StrokeOptions, D
 use azure::azure_hl::{ColorPattern, ColorPatternRef};
 use geom::rect::Rect;
 use geom::size::Size2D;
+use servo_util::task::spawn_named;
 
 use std::comm;
-use std::task::TaskBuilder;
 
 pub enum CanvasMsg {
     FillRect(Rect<f32>),
@@ -37,8 +37,7 @@ impl CanvasRenderTask {
 
     pub fn start(size: Size2D<i32>) -> Sender<CanvasMsg> {
         let (chan, port) = comm::channel::<CanvasMsg>();
-        let builder = TaskBuilder::new().named("CanvasTask");
-        builder.spawn(proc() {
+        spawn_named("CanvasTask", proc() {
             let mut renderer = CanvasRenderTask::new(size);
 
             loop {

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -6,5 +6,6 @@
 
 extern crate azure;
 extern crate geom;
+extern crate "util" as servo_util;
 
 pub mod canvas_render_task;

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -12,3 +12,6 @@ path = "../devtools_traits"
 
 [dependencies.msg]
 path = "../msg"
+
+[dependencies.util]
+path = "../util"

--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -13,6 +13,7 @@ use sync::Arc;
 use font_template::{FontTemplate, FontTemplateDescriptor};
 use platform::font_template::FontTemplateData;
 use servo_net::resource_task::{ResourceTask, load_whole_resource};
+use servo_util::task::spawn_named;
 use style::{Source, LocalSource, UrlSource_};
 
 /// A list of font templates that make up a given font family.
@@ -245,7 +246,7 @@ impl FontCacheTask {
     pub fn new(resource_task: ResourceTask) -> FontCacheTask {
         let (chan, port) = channel();
 
-        spawn(proc() {
+        spawn_named("FontCacheTask", proc() {
             // TODO: Allow users to specify these.
             let mut generic_fonts = HashMap::with_capacity(5);
             add_generic_font(&mut generic_fonts, "serif", "Times New Roman");

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -266,7 +266,7 @@ impl PreorderFlow for FlowTreeVerification {
     fn process(&mut self, flow: &mut Flow) {
         let base = flow::base(flow);
         if !base.flags.is_leaf() && !base.flags.is_nonleaf() {
-            println("flow tree verification failed: flow wasn't a leaf or a nonleaf!");
+            println!("flow tree verification failed: flow wasn't a leaf or a nonleaf!");
             flow.dump();
             fail!("flow tree verification failed")
         }

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -128,7 +128,7 @@ pub trait TLayoutNode {
     fn first_child(&self) -> Option<Self>;
 
     /// Dumps this node tree, for debugging.
-    fn dump(&self) {
+    fn dump(self) {
         // TODO(pcwalton): Reimplement this in a way that's safe for layout to call.
     }
 }
@@ -165,6 +165,11 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
             node: node.transmute_copy(),
             chain: self.chain,
         }
+    }
+
+    /// Dumps the subtree rooted at this node, for debugging.
+    fn dump(self) {
+        self.dump_indent(0);
     }
 
     fn type_id(&self) -> Option<NodeTypeId> {
@@ -204,6 +209,28 @@ impl<'ln> LayoutNode<'ln> {
             node: node,
             chain: ContravariantLifetime,
         })
+    }
+
+
+    /// Dumps the node tree, for debugging, with indentation.
+    fn dump_indent(self, indent: uint) {
+        let mut s = String::new();
+        for _ in range(0, indent) {
+            s.push_str("    ");
+        }
+
+        s.push_str(self.debug_str().as_slice());
+        error!("{:s}", s);
+
+        // FIXME: this should have a pure version?
+        for kid in self.children() {
+            kid.dump_indent(indent + 1u)
+        }
+    }
+
+    /// Returns a string that describes this node.
+    fn debug_str(self) -> String {
+        format!("{}: dirty={}", self.type_id(), self.is_dirty())
     }
 
     pub fn flow_debug_id(self) -> uint {

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -6,11 +6,11 @@ use image::base::{Image, load_from_memory};
 use resource_task;
 use resource_task::{LoadData, ResourceTask};
 
+use servo_util::task::spawn_named;
 use servo_util::taskpool::TaskPool;
 use std::comm::{channel, Receiver, Sender};
 use std::collections::hashmap::HashMap;
 use std::mem::replace;
-use std::task::spawn;
 use std::result;
 use sync::{Arc, Mutex};
 use serialize::{Encoder, Encodable};
@@ -84,7 +84,7 @@ impl ImageCacheTask {
         let (chan, port) = channel();
         let chan_clone = chan.clone();
 
-        spawn(proc() {
+        spawn_named("ImageCacheTask", proc() {
             let mut cache = ImageCache {
                 resource_task: resource_task,
                 port: port,
@@ -105,7 +105,7 @@ impl ImageCacheTask {
     pub fn new_sync(resource_task: ResourceTask, task_pool: TaskPool) -> ImageCacheTask {
         let (chan, port) = channel();
 
-        spawn(proc() {
+        spawn_named("ImageCacheTaskWaiter", proc() {
             let inner_cache = ImageCacheTask::new(resource_task, task_pool);
 
             loop {
@@ -248,7 +248,7 @@ impl ImageCache {
                 let resource_task = self.resource_task.clone();
                 let url_clone = url.clone();
 
-                spawn(proc() {
+                spawn_named("ImageCacheTaskPrefetch", proc() {
                     let url = url_clone;
                     debug!("image_cache_task: started fetch for {:s}", url.serialize());
 
@@ -463,7 +463,7 @@ fn load_image_data(url: Url, resource_task: ResourceTask) -> Result<Vec<u8>, ()>
 pub fn spawn_listener<A: Send>(f: proc(Receiver<A>):Send) -> Sender<A> {
     let (setup_chan, setup_port) = channel();
 
-    spawn(proc() {
+    spawn_named("ImageCacheListener", proc() {
         let (chan, port) = channel();
         setup_chan.send(chan);
         f(port);

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -10,7 +10,6 @@ use file_loader;
 use http_loader;
 
 use std::comm::{channel, Receiver, Sender};
-use std::task::TaskBuilder;
 use http::headers::content_type::MediaType;
 use http::headers::response::HeaderCollection as ResponseHeaderCollection;
 use http::headers::request::HeaderCollection as RequestHeaderCollection;
@@ -20,6 +19,7 @@ use url::Url;
 use http::status::Ok as StatusOk;
 use http::status::Status;
 
+use servo_util::task::spawn_named;
 
 pub enum ControlMsg {
     /// Request the data associated with a particular URL
@@ -166,8 +166,7 @@ pub type ResourceTask = Sender<ControlMsg>;
 /// Create a ResourceTask
 pub fn new_resource_task(user_agent: Option<String>) -> ResourceTask {
     let (setup_chan, setup_port) = channel();
-    let builder = TaskBuilder::new().named("ResourceManager");
-    builder.spawn(proc() {
+    spawn_named("ResourceManager", proc() {
         ResourceManager::new(setup_port, user_agent).start();
     });
     setup_chan

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -26,6 +26,7 @@ use script_task::StackRootTLS;
 use servo_net::resource_task::{ResourceTask, load_whole_resource};
 use servo_util::task_state;
 use servo_util::task_state::{Script, InWorker};
+use servo_util::task::spawn_named;
 
 use js::glue::JS_STRUCTURED_CLONE_VERSION;
 use js::jsapi::{JSContext, JS_ReadStructuredClone, JS_WriteStructuredClone, JS_ClearPendingException};
@@ -34,8 +35,6 @@ use js::rust::Cx;
 
 use std::rc::Rc;
 use std::ptr;
-use std::task::TaskBuilder;
-use native::task::NativeTaskBuilder;
 use url::Url;
 
 #[dom_struct]
@@ -88,11 +87,7 @@ impl DedicatedWorkerGlobalScope {
                             parent_sender: ScriptChan,
                             own_sender: ScriptChan,
                             receiver: Receiver<ScriptMsg>) {
-        TaskBuilder::new()
-            .native()
-            .named(format!("Web Worker at {}", worker_url.serialize()))
-            .spawn(proc() {
-
+        spawn_named(format!("Web Worker at {}", worker_url.serialize()), proc() {
             task_state::initialize(Script | InWorker);
 
             let roots = RootCollection::new();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -73,7 +73,7 @@ impl Reflectable for Element {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Show)]
 #[jstraceable]
 pub enum ElementTypeId {
     HTMLElementTypeId,
@@ -534,6 +534,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
     fn notify_attribute_changed(self, _local_name: &Atom) {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         if node.is_in_doc() {
+            debug!("Attribute changed. Dispatching content_changed.");
             let document = node.owner_doc().root();
             document.content_changed(node);
         }
@@ -1172,4 +1173,3 @@ impl<'a> style::TElement<'a> for JSRef<'a, Element> {
         }
     }
 }
-

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -57,7 +57,6 @@ use std::default::Default;
 use std::io::{BufReader, MemWriter, Timer};
 use std::from_str::FromStr;
 use std::path::BytesContainer;
-use std::task::TaskBuilder;
 use std::time::duration::Duration;
 use std::num::Zero;
 use time;
@@ -549,10 +548,9 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             return XMLHttpRequest::fetch(&mut Sync(self), resource_task, load_data,
                                          terminate_receiver, cors_request);
         } else {
-            let builder = TaskBuilder::new().named("XHRTask");
             self.fetch_time.set(time::now().to_timespec().sec);
             let script_chan = global.root_ref().script_chan().clone();
-            builder.spawn(proc() {
+            spawn_named("XHRTask", proc() {
                 let _ = XMLHttpRequest::fetch(&mut Async(addr.unwrap(), script_chan),
                                               resource_task, load_data, terminate_receiver, cors_request);
             });

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -31,18 +31,19 @@ pub fn iter_font_face_rules_inner(rules: &[CSSRule], device: &Device,
     }
 }
 
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub enum Source {
     UrlSource_(UrlSource),
     LocalSource(String),
 }
 
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub struct UrlSource {
     pub url: Url,
     pub format_hints: Vec<String>,
 }
 
+#[deriving(Show)]
 pub struct FontFaceRule {
     pub family: String,
     pub sources: Vec<Source>,

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -16,15 +16,18 @@ use properties::longhands;
 use servo_util::geometry::ScreenPx;
 use url::Url;
 
+#[deriving(Show)]
 pub struct MediaRule {
     pub media_queries: MediaQueryList,
     pub rules: Vec<CSSRule>,
 }
 
+#[deriving(Show)]
 pub struct MediaQueryList {
     media_queries: Vec<MediaQuery>
 }
 
+#[deriving(Show)]
 pub enum Range<T> {
     Min(T),
     Max(T),
@@ -41,16 +44,18 @@ impl<T: Ord> Range<T> {
     }
 }
 
+#[deriving(Show)]
 pub enum Expression {
     Width(Range<Au>),
 }
 
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Show)]
 pub enum Qualifier {
     Only,
     Not,
 }
 
+#[deriving(Show)]
 pub struct MediaQuery {
     qualifier: Option<Qualifier>,
     media_type: MediaQueryType,
@@ -68,19 +73,20 @@ impl MediaQuery {
     }
 }
 
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Show)]
 pub enum MediaQueryType {
     All,  // Always true
     MediaType_(MediaType),
 }
 
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Show)]
 pub enum MediaType {
     Screen,
     Print,
     Unknown,
 }
 
+#[deriving(Show)]
 pub struct Device {
     pub media_type: MediaType,
     pub viewport_size: TypedSize2D<ScreenPx, f32>,

--- a/components/style/properties/common_types.rs
+++ b/components/style/properties/common_types.rs
@@ -19,7 +19,7 @@ pub mod specified {
     use super::{Au, CSSFloat};
     pub use cssparser::Color as CSSColor;
 
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum Length {
         Au_(Au),  // application units
         Em(CSSFloat),
@@ -81,7 +81,7 @@ pub mod specified {
         }
     }
 
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum LengthOrPercentage {
         LP_Length(Length),
         LP_Percentage(CSSFloat),  // [0 .. 100%] maps to [0.0 .. 1.0]
@@ -109,7 +109,7 @@ pub mod specified {
         }
     }
 
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum LengthOrPercentageOrAuto {
         LPA_Length(Length),
         LPA_Percentage(CSSFloat),  // [0 .. 100%] maps to [0.0 .. 1.0]
@@ -138,7 +138,7 @@ pub mod specified {
         }
     }
 
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum LengthOrPercentageOrNone {
         LPN_Length(Length),
         LPN_Percentage(CSSFloat),  // [0 .. 100%] maps to [0.0 .. 1.0]
@@ -169,7 +169,7 @@ pub mod specified {
     }
 
     // http://dev.w3.org/csswg/css2/colors.html#propdef-background-position
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum PositionComponent {
         Pos_Length(Length),
         Pos_Percentage(CSSFloat),  // [0 .. 100%] maps to [0.0 .. 1.0]
@@ -264,7 +264,7 @@ pub mod computed {
         }
     }
 
-    #[deriving(PartialEq, Clone)]
+    #[deriving(PartialEq, Clone, Show)]
     pub enum LengthOrPercentage {
         LP_Length(Au),
         LP_Percentage(CSSFloat),
@@ -278,7 +278,7 @@ pub mod computed {
         }
     }
 
-    #[deriving(PartialEq, Clone)]
+    #[deriving(PartialEq, Clone, Show)]
     pub enum LengthOrPercentageOrAuto {
         LPA_Length(Au),
         LPA_Percentage(CSSFloat),
@@ -294,7 +294,7 @@ pub mod computed {
         }
     }
 
-    #[deriving(PartialEq, Clone)]
+    #[deriving(PartialEq, Clone, Show)]
     pub enum LengthOrPercentageOrNone {
         LPN_Length(Au),
         LPN_Percentage(CSSFloat),

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -5,6 +5,7 @@
 // This file is a Mako template: http://www.makotemplates.org/
 
 pub use std::ascii::StrAsciiExt;
+use std::fmt;
 
 use servo_util::logical_geometry::{WritingMode, LogicalMargin};
 use sync::Arc;
@@ -158,7 +159,7 @@ pub mod longhands {
             ${caller.body()}
             pub mod computed_value {
                 #[allow(non_camel_case_types)]
-                #[deriving(PartialEq, Clone, FromPrimitive)]
+                #[deriving(PartialEq, Clone, FromPrimitive, Show)]
                 pub enum T {
                     % for value in values.split():
                         ${to_rust_ident(value)},
@@ -349,7 +350,7 @@ pub mod longhands {
         pub use super::computed_as_specified as to_computed_value;
         pub type SpecifiedValue = computed_value::T;
         pub mod computed_value {
-            #[deriving(PartialEq, Clone)]
+            #[deriving(PartialEq, Clone, Show)]
             pub enum T {
                 Auto,
                 Number(i32),
@@ -432,7 +433,7 @@ pub mod longhands {
     ${switch_to_style_struct("InheritedBox")}
 
     <%self:single_component_value name="line-height">
-        #[deriving(Clone)]
+        #[deriving(Clone, Show)]
         pub enum SpecifiedValue {
             SpecifiedNormal,
             SpecifiedLength(specified::Length),
@@ -457,7 +458,7 @@ pub mod longhands {
         }
         pub mod computed_value {
             use super::super::{Au, CSSFloat};
-            #[deriving(PartialEq, Clone)]
+            #[deriving(PartialEq, Clone, Show)]
             pub enum T {
                 Normal,
                 Length(Au),
@@ -483,7 +484,7 @@ pub mod longhands {
         <% vertical_align_keywords = (
             "baseline sub super top text-top middle bottom text-bottom".split()) %>
         #[allow(non_camel_case_types)]
-        #[deriving(Clone)]
+        #[deriving(Clone, Show)]
         pub enum SpecifiedValue {
             % for keyword in vertical_align_keywords:
                 Specified_${to_rust_ident(keyword)},
@@ -510,7 +511,7 @@ pub mod longhands {
         pub mod computed_value {
             use super::super::{Au, CSSFloat};
             #[allow(non_camel_case_types)]
-            #[deriving(PartialEq, Clone)]
+            #[deriving(PartialEq, Clone, Show)]
             pub enum T {
                 % for keyword in vertical_align_keywords:
                     ${to_rust_ident(keyword)},
@@ -554,12 +555,12 @@ pub mod longhands {
     <%self:longhand name="content">
             pub use super::computed_as_specified as to_computed_value;
             pub mod computed_value {
-                #[deriving(PartialEq, Clone)]
+                #[deriving(PartialEq, Clone, Show)]
                 pub enum ContentItem {
                     StringContent(String),
                 }
                 #[allow(non_camel_case_types)]
-                #[deriving(PartialEq, Clone)]
+                #[deriving(PartialEq, Clone, Show)]
                 pub enum T {
                     normal,
                     none,
@@ -630,14 +631,14 @@ pub mod longhands {
             pub mod computed_value {
                 use super::super::super::common_types::computed::LengthOrPercentage;
 
-                #[deriving(PartialEq, Clone)]
+                #[deriving(PartialEq, Clone, Show)]
                 pub struct T {
                     pub horizontal: LengthOrPercentage,
                     pub vertical: LengthOrPercentage,
                 }
             }
 
-            #[deriving(Clone)]
+            #[deriving(Clone, Show)]
             pub struct SpecifiedValue {
                 pub horizontal: specified::LengthOrPercentage,
                 pub vertical: specified::LengthOrPercentage,
@@ -764,7 +765,7 @@ pub mod longhands {
     <%self:longhand name="font-family">
         pub use super::computed_as_specified as to_computed_value;
         pub mod computed_value {
-            #[deriving(PartialEq, Clone)]
+            #[deriving(PartialEq, Clone, Show)]
             pub enum FontFamily {
                 FamilyName(String),
                 // Generic
@@ -835,7 +836,7 @@ pub mod longhands {
     ${single_keyword("font-variant", "normal small-caps")}
 
     <%self:single_component_value name="font-weight">
-        #[deriving(Clone)]
+        #[deriving(Clone, Show)]
         pub enum SpecifiedValue {
             Bolder,
             Lighter,
@@ -872,7 +873,7 @@ pub mod longhands {
             }
         }
         pub mod computed_value {
-            #[deriving(PartialEq, Clone)]
+            #[deriving(PartialEq, Clone, Show)]
             pub enum T {
                 % for weight in range(100, 901, 100):
                     Weight${weight},
@@ -975,7 +976,7 @@ pub mod longhands {
 
     <%self:longhand name="text-decoration">
         pub use super::computed_as_specified as to_computed_value;
-        #[deriving(PartialEq, Clone)]
+        #[deriving(PartialEq, Clone, Show)]
         pub struct SpecifiedValue {
             pub underline: bool,
             pub overline: bool,
@@ -1028,7 +1029,7 @@ pub mod longhands {
                     derived_from="display text-decoration">
         pub use super::computed_as_specified as to_computed_value;
 
-        #[deriving(Clone, PartialEq)]
+        #[deriving(Clone, PartialEq, Show)]
         pub struct SpecifiedValue {
             pub underline: Option<RGBA>,
             pub overline: Option<RGBA>,
@@ -1504,6 +1505,12 @@ pub struct PropertyDeclarationBlock {
     pub normal: Arc<Vec<PropertyDeclaration>>,
 }
 
+impl fmt::Show for PropertyDeclarationBlock {
+     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PropertyDeclarationBlock {{ important: {}, normal: {} }}",
+               self.important.deref(), self.normal.deref())
+     }
+}
 
 pub fn parse_style_attribute(input: &str, base_url: &Url) -> PropertyDeclarationBlock {
     parse_property_declaration_list(tokenize(input), base_url)
@@ -1548,7 +1555,7 @@ pub fn parse_property_declaration_list<I: Iterator<Node>>(input: I, base_url: &U
     }
 }
 
-
+#[deriving(Show)]
 pub enum CSSWideKeyword {
     InitialKeyword,
     InheritKeyword,
@@ -1569,7 +1576,7 @@ impl CSSWideKeyword {
 }
 
 
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub enum DeclaredValue<T> {
     SpecifiedValue(T),
     Initial,
@@ -1579,7 +1586,7 @@ pub enum DeclaredValue<T> {
     // depending on whether the property is inherited.
 }
 
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub enum PropertyDeclaration {
     % for property in LONGHANDS:
         ${property.camel_case}Declaration(DeclaredValue<longhands::${property.ident}::SpecifiedValue>),
@@ -1587,6 +1594,7 @@ pub enum PropertyDeclaration {
 }
 
 
+#[deriving(Show)]
 pub enum PropertyDeclarationParseResult {
     UnknownProperty,
     ExperimentalProperty,
@@ -1695,7 +1703,7 @@ pub mod style_structs {
     use super::longhands;
 
     % for style_struct in STYLE_STRUCTS:
-        #[deriving(PartialEq, Clone)]
+        #[deriving(PartialEq, Clone, Show)]
         pub struct ${style_struct.name} {
             % for longhand in style_struct.longhands:
                 pub ${longhand.ident}: longhands::${longhand.ident}::computed_value::T,

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -4,6 +4,7 @@
 
 use std::ascii::AsciiExt;
 use std::collections::hashmap::HashMap;
+use std::fmt;
 use std::hash::Hash;
 use std::num::div_rem;
 use sync::Arc;
@@ -54,6 +55,7 @@ pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C
 /// Hence, the union of the rules keyed on each of node's classes, ID,
 /// element name, etc. will contain the Rules that actually match that
 /// node.
+#[deriving(Show)]
 struct SelectorMap {
     // TODO: Tune the initial capacity of the HashMap
     id_hash: HashMap<Atom, Vec<Rule>>,
@@ -263,6 +265,7 @@ impl SelectorMap {
 // rapidly increase.
 pub static RECOMMENDED_SELECTOR_BLOOM_FILTER_SIZE: uint = 4096;
 
+#[deriving(Show)]
 pub struct Stylist {
     element_map: PerPseudoElementSelectorMap,
     before_map: PerPseudoElementSelectorMap,
@@ -485,6 +488,7 @@ impl Stylist {
     }
 }
 
+#[deriving(Show)]
 struct PerOriginSelectorMap {
     normal: SelectorMap,
     important: SelectorMap,
@@ -500,6 +504,7 @@ impl PerOriginSelectorMap {
     }
 }
 
+#[deriving(Show)]
 struct PerPseudoElementSelectorMap {
     user_agent: PerOriginSelectorMap,
     author: PerOriginSelectorMap,
@@ -526,6 +531,13 @@ struct Rule {
     declarations: DeclarationBlock,
 }
 
+impl fmt::Show for Rule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Rule {{ selector: {}, declarations: {} }}",
+               self.selector.deref(), self.declarations)
+    }
+}
+
 /// A property declaration together with its precedence among rules of equal specificity so that
 /// we can sort them.
 #[deriving(Clone)]
@@ -533,6 +545,13 @@ pub struct DeclarationBlock {
     pub declarations: Arc<Vec<PropertyDeclaration>>,
     source_order: uint,
     specificity: u32,
+}
+
+impl fmt::Show for DeclarationBlock {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DeclarationBlock {{ declarations: {}, source_order: {}, specificity: {} }}",
+               self.declarations.deref(), self.source_order, self.specificity)
+    }
 }
 
 impl DeclarationBlock {
@@ -1154,4 +1173,3 @@ mod tests {
         assert!(selector_map.class_hash.find(&Atom::from_slice("foo")).is_none());
     }
 }
-

--- a/components/style/selectors.rs
+++ b/components/style/selectors.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{cmp, iter};
+use std::{cmp, fmt, iter};
 use std::ascii::{StrAsciiExt, OwnedStrAsciiExt};
 use sync::Arc;
 
@@ -29,7 +29,14 @@ pub struct Selector {
     pub specificity: u32,
 }
 
-#[deriving(Eq, PartialEq, Clone, Hash)]
+impl fmt::Show for Selector {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Selector {{ compound_selectors: {}, pseudo_element: {}, specificity: {} }}",
+               self.compound_selectors.deref(), self.pseudo_element, self.specificity)
+    }
+}
+
+#[deriving(Eq, PartialEq, Clone, Hash, Show)]
 pub enum PseudoElement {
     Before,
     After,
@@ -38,13 +45,13 @@ pub enum PseudoElement {
 }
 
 
-#[deriving(PartialEq, Clone)]
+#[deriving(PartialEq, Clone, Show)]
 pub struct CompoundSelector {
     pub simple_selectors: Vec<SimpleSelector>,
     pub next: Option<(Box<CompoundSelector>, Combinator)>,  // c.next is left of c
 }
 
-#[deriving(PartialEq, Clone)]
+#[deriving(PartialEq, Clone, Show)]
 pub enum Combinator {
     Child,  //  >
     Descendant,  // space
@@ -52,7 +59,7 @@ pub enum Combinator {
     LaterSibling,  // ~
 }
 
-#[deriving(Eq, PartialEq, Clone, Hash)]
+#[deriving(Eq, PartialEq, Clone, Hash, Show)]
 pub enum SimpleSelector {
     IDSelector(Atom),
     ClassSelector(Atom),
@@ -91,27 +98,27 @@ pub enum SimpleSelector {
 }
 
 
-#[deriving(Eq, PartialEq, Clone, Hash)]
+#[deriving(Eq, PartialEq, Clone, Hash, Show)]
 pub enum CaseSensitivity {
     CaseSensitive,  // Selectors spec says language-defined, but HTML says sensitive.
     CaseInsensitive,
 }
 
 
-#[deriving(Eq, PartialEq, Clone, Hash)]
+#[deriving(Eq, PartialEq, Clone, Hash, Show)]
 pub struct LocalName {
     pub name: Atom,
     pub lower_name: Atom,
 }
 
-#[deriving(Eq, PartialEq, Clone, Hash)]
+#[deriving(Eq, PartialEq, Clone, Hash, Show)]
 pub struct AttrSelector {
     pub name: Atom,
     pub lower_name: Atom,
     pub namespace: NamespaceConstraint,
 }
 
-#[deriving(Eq, PartialEq, Clone, Hash)]
+#[deriving(Eq, PartialEq, Clone, Hash, Show)]
 pub enum NamespaceConstraint {
     AnyNamespace,
     SpecificNamespace(Namespace),
@@ -125,6 +132,7 @@ pub fn parse_selector_list_from_str(input: &str) -> Result<SelectorList, ()> {
 }
 
 /// Re-exported to script, but opaque.
+#[deriving(Show)]
 pub struct SelectorList {
     selectors: Vec<Selector>
 }

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -18,21 +18,21 @@ use media_queries::{Device, MediaRule, parse_media_rule};
 use media_queries;
 use font_face::{FontFaceRule, Source, parse_font_face_rule, iter_font_face_rules_inner};
 
-
+#[deriving(Show)]
 pub struct Stylesheet {
     /// List of rules in the order they were found (important for
     /// cascading order)
     rules: Vec<CSSRule>,
 }
 
-
+#[deriving(Show)]
 pub enum CSSRule {
     CSSStyleRule(StyleRule),
     CSSMediaRule(MediaRule),
     CSSFontFaceRule(FontFaceRule),
 }
 
-
+#[deriving(Show)]
 pub struct StyleRule {
     pub selectors: Vec<selectors::Selector>,
     pub declarations: properties::PropertyDeclarationBlock,

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -28,6 +28,7 @@ use std::fmt;
 ///
 /// The ratio between ScreenPx and DevicePixel for a given display be found by calling
 /// `servo::windowing::WindowMethods::hidpi_factor`.
+#[deriving(Show)]
 pub enum ScreenPx {}
 
 /// One CSS "px" in the coordinate system of the "initial viewport":
@@ -39,7 +40,7 @@ pub enum ScreenPx {}
 ///
 /// At the default zoom level of 100%, one PagePx is equal to one ScreenPx.  However, if the
 /// document is zoomed in or out then this scale may be larger or smaller.
-#[deriving(Encodable)]
+#[deriving(Encodable, Show)]
 pub enum ViewportPx {}
 
 /// One CSS "px" in the root coordinate system for the content document.
@@ -48,7 +49,7 @@ pub enum ViewportPx {}
 /// This is the mobile-style "pinch zoom" that enlarges content without reflowing it.  When the
 /// viewport zoom is not equal to 1.0, then the layout viewport is no longer the same physical size
 /// as the viewable area.
-#[deriving(Encodable)]
+#[deriving(Encodable, Show)]
 pub enum PagePx {}
 
 // In summary, the hierarchy of pixel units and the factors to convert from one to the next:

--- a/components/util/smallvec.rs
+++ b/components/util/smallvec.rs
@@ -12,7 +12,6 @@ use std::kinds::marker::ContravariantLifetime;
 use std::mem;
 use std::ptr;
 use std::raw::Slice;
-use rustrt::local_heap;
 use alloc::heap;
 
 // Generic code for all small vectors
@@ -60,6 +59,7 @@ pub trait SmallVecPrivate<T> {
 pub trait SmallVec<T> : SmallVecPrivate<T> where T: 'static {
     fn inline_size(&self) -> uint;
     fn len(&self) -> uint;
+    fn is_empty(&self) -> bool;
     fn cap(&self) -> uint;
 
     fn spilled(&self) -> bool {
@@ -110,12 +110,13 @@ pub trait SmallVec<T> : SmallVecPrivate<T> where T: 'static {
             } else {
                 None
             };
+            let cap = self.cap();
             let inline_size = self.inline_size();
             self.set_cap(inline_size);
             self.set_len(0);
             SmallVecMoveIterator {
                 allocation: ptr_opt,
-                cap: inline_size,
+                cap: cap,
                 iter: iter,
                 lifetime: ContravariantLifetime::<'a>,
             }
@@ -169,13 +170,9 @@ pub trait SmallVec<T> : SmallVecPrivate<T> where T: 'static {
             ptr::copy_nonoverlapping_memory(new_alloc, self.begin(), self.len());
 
             if self.spilled() {
-                if intrinsics::owns_managed::<T>() {
-                    local_heap::local_free(self.ptr() as *mut u8)
-                } else {
-                    heap::deallocate(self.mut_ptr() as *mut u8,
-                                     mem::size_of::<T>() * self.cap(),
-                                     mem::min_align_of::<T>())
-                }
+                heap::deallocate(self.mut_ptr() as *mut u8,
+                                 mem::size_of::<T>() * self.cap(),
+                                 mem::min_align_of::<T>())
             } else {
                 let mut_begin: *mut T = mem::transmute(self.begin());
                 intrinsics::set_memory(mut_begin, 0, self.len())
@@ -326,13 +323,10 @@ impl<'a, T: 'static> Drop for SmallVecMoveIterator<'a,T> {
             None => {}
             Some(allocation) => {
                 unsafe {
-                    if intrinsics::owns_managed::<T>() {
-                        local_heap::local_free(allocation as *mut u8)
-                    } else {
-                        heap::deallocate(allocation as *mut u8,
-                                         mem::size_of::<T>() * self.cap,
-                                         mem::min_align_of::<T>())
-                    }
+                    heap::deallocate(allocation,
+                                     mem::size_of::<T>() * self.cap,
+                                     mem::min_align_of::<T>())
+
                 }
             }
         }
@@ -383,6 +377,9 @@ macro_rules! def_small_vector(
             fn len(&self) -> uint {
                 self.len
             }
+            fn is_empty(&self) -> bool {
+                self.len == 0
+            }
             fn cap(&self) -> uint {
                 self.cap
             }
@@ -402,6 +399,26 @@ macro_rules! def_small_vector(
             #[inline]
             fn vec_slice_mut<'a>(&'a mut self, start: uint, end: uint) -> &'a mut [T] {
                 self.slice_mut(start, end)
+            }
+        }
+
+        impl<T: 'static> FromIterator<T> for $name<T> {
+            fn from_iter<I: Iterator<T>>(mut iter: I) -> $name<T> {
+                let mut v = $name::new();
+
+                for elem in iter {
+                    v.push(elem);
+                }
+
+                v
+            }
+        }
+
+        impl<T: 'static> Extendable<T> for $name<T> {
+            fn extend<I: Iterator<T>>(&mut self, mut iter: I) {
+                for elem in iter {
+                    self.push(elem);
+                }
             }
         }
 
@@ -444,13 +461,9 @@ macro_rules! def_small_vector_drop_impl(
                         *ptr.offset(i as int) = mem::uninitialized();
                     }
 
-                    if intrinsics::owns_managed::<T>() {
-                        local_heap::local_free(self.ptr() as *mut u8)
-                    } else {
-                        heap::deallocate(self.mut_ptr() as *mut u8,
-                                         mem::size_of::<T>() * self.cap(),
-                                         mem::min_align_of::<T>())
-                    }
+                    heap::deallocate(self.mut_ptr() as *mut u8,
+                                     mem::size_of::<T>() * self.cap(),
+                                     mem::min_align_of::<T>())
                 }
             }
         }
@@ -527,4 +540,3 @@ pub mod tests {
         ].as_slice());
     }
 }
-

--- a/components/util/task.rs
+++ b/components/util/task.rs
@@ -15,6 +15,11 @@ pub fn spawn_named<S: IntoMaybeOwned<'static>>(name: S, f: proc():Send) {
     builder.spawn(f);
 }
 
+pub fn spawn_named_native<S: IntoMaybeOwned<'static>>(name: S, f: proc():Send) {
+    let builder = task::TaskBuilder::new().native().named(name);
+    builder.spawn(f);
+}
+
 /// Arrange to send a particular message to a channel if the task fails.
 pub fn spawn_named_with_send_on_failure<T: Send>(name: &'static str,
                                                  state: task_state::TaskState,

--- a/components/util/taskpool.rs
+++ b/components/util/taskpool.rs
@@ -15,6 +15,7 @@
 // The only difference is that a normal channel is used instead of a sync_channel.
 //
 
+use task::spawn_named;
 use std::sync::{Arc, Mutex};
 
 pub struct TaskPool {
@@ -28,9 +29,9 @@ impl TaskPool {
 
         let state = Arc::new(Mutex::new(rx));
 
-        for _ in range(0, tasks) {
+        for i in range(0, tasks) {
             let state = state.clone();
-            spawn(proc() worker(&*state));
+            spawn_named(format!("TaskPoolWorker {}", i), proc() worker(&*state));
         }
 
         return TaskPool { tx: tx };
@@ -50,4 +51,3 @@ impl TaskPool {
         self.tx.send(job);
     }
 }
-

--- a/components/util/workqueue.rs
+++ b/components/util/workqueue.rs
@@ -9,14 +9,13 @@
 
 use task_state;
 
-use native::task::NativeTaskBuilder;
+use libc::funcs::posix88::unistd::usleep;
 use rand::{Rng, XorShiftRng};
 use std::mem;
 use std::rand::weak_rng;
 use std::sync::atomics::{AtomicUint, SeqCst};
 use std::sync::deque::{Abort, BufferPool, Data, Empty, Stealer, Worker};
-use std::task::TaskBuilder;
-use libc::funcs::posix88::unistd::usleep;
+use task::spawn_named_native;
 
 /// A unit of work.
 ///
@@ -247,8 +246,8 @@ impl<QueueData: Send, WorkData: Send> WorkQueue<QueueData, WorkData> {
         }
 
         // Spawn threads.
-        for thread in threads.into_iter() {
-            TaskBuilder::new().named(task_name).native().spawn(proc() {
+        for (i, thread) in threads.into_iter().enumerate() {
+            spawn_named_native(format!("{}: {}", task_name, i), proc() {
                 task_state::initialize(state | task_state::InWorker);
                 let mut thread = thread;
                 thread.start()

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -1,3 +1,4 @@
+== restyle_bg.html restyle_bg_ref.html
 != img_simple.html img_simple_ref.html
 == basic_width_px.html basic_width_em.html
 == br.html br-ref.html
@@ -39,7 +40,7 @@
 == block_image.html 500x300_green.html
 != block_image.html noteq_500x300_white.html
 == object_element_a.html object_element_b.html
-flaky_cpu == append_style_a.html append_style_b.html
+== append_style_a.html append_style_b.html
 == height_compute_reset.html height_compute.html
 == width_nonreplaced_block_simple_a.html width_nonreplaced_block_simple_b.html
 == max_width_float_simple_a.html max_width_float_simple_b.html

--- a/tests/ref/restyle_bg.html
+++ b/tests/ref/restyle_bg.html
@@ -1,0 +1,7 @@
+<body>
+<div id="X" style="background-color: blue">XXX</div>
+  <script>
+    document.getElementById("X")
+      .setAttribute("style", "background-color: red");
+  </script>
+</body>

--- a/tests/ref/restyle_bg_ref.html
+++ b/tests/ref/restyle_bg_ref.html
@@ -1,0 +1,3 @@
+<body>
+<div id="X" style="background-color: red">XXX</div>
+</body>


### PR DESCRIPTION
When content changed, script used to immediately dirty the changed
nodes regardless of what layout was doing at the same time. The
correct thing to do in that situation is to queue the nodes, then
dirty them after layout is finished and re-run layout.

This patch makes that change.

There's also some extra debugging goodness in this patch that I found
useful when tracking down the bug.

r? @jdm @pcwalton
