### PR TITLE
Use WindowMethods to get native graphics metadata instead of relying on azure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#eac91e00db9af155f3004b408a18cb6d9f462a25)",
  "msg 0.0.1",
+ "opengles 0.1.0 (git+https://github.com/servo/rust-opengles#6776e9c07feb149d34b087039ecf6b2c143e3afc)",
  "util 0.0.1",
 ]
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -145,13 +145,13 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         // display list. This is only here because we don't have that logic in the renderer yet.
         let window_size = window.framebuffer_size();
         let hidpi_factor = window.hidpi_factor();
+        let context = CompositorTask::create_graphics_context(&window.native_metadata());
 
         let show_debug_borders = opts::get().show_debug_borders;
         IOCompositor {
             window: window,
             port: port,
-            context: rendergl::RenderContext::new(CompositorTask::create_graphics_context(),
-                                                  show_debug_borders),
+            context: rendergl::RenderContext::new(context, show_debug_borders),
             root_pipeline: None,
             scene: Scene::new(Rect {
                 origin: Zero::zero(),
@@ -294,7 +294,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 }
 
                 (Ok(GetGraphicsMetadata(chan)), NotShuttingDown) => {
-                    chan.send(Some(azure_hl::current_graphics_metadata()));
+                    chan.send(Some(self.window.native_metadata()));
                 }
 
                 (Ok(CreateOrUpdateRootLayer(layer_properties)), NotShuttingDown) => {

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -25,9 +25,6 @@ use std::rc::Rc;
 
 use url::Url;
 
-#[cfg(target_os="linux")]
-use azure::azure_hl;
-
 /// The implementation of the layers-based compositor.
 #[deriving(Clone)]
 pub struct CompositorChan {
@@ -189,11 +186,13 @@ impl CompositorTask {
     ///
     /// FIXME(pcwalton): Probably could be less platform-specific, using the metadata abstraction.
     #[cfg(target_os="linux")]
-    pub fn create_graphics_context() -> NativeCompositingGraphicsContext {
-        NativeCompositingGraphicsContext::from_display(azure_hl::current_display())
+    pub fn create_graphics_context(native_metadata: &NativeGraphicsMetadata)
+                                    -> NativeCompositingGraphicsContext {
+        NativeCompositingGraphicsContext::from_display(native_metadata.display)
     }
     #[cfg(not(target_os="linux"))]
-    pub fn create_graphics_context() -> NativeCompositingGraphicsContext {
+    pub fn create_graphics_context(_: &NativeGraphicsMetadata)
+                                    -> NativeCompositingGraphicsContext {
         NativeCompositingGraphicsContext::new()
     }
 

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -8,6 +8,7 @@ use geom::point::TypedPoint2D;
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
+use layers::platform::surface::NativeGraphicsMetadata;
 use servo_msg::compositor_msg::{ReadyState, RenderState};
 use servo_util::geometry::ScreenPx;
 
@@ -71,5 +72,8 @@ pub trait WindowMethods {
 
     /// Returns the hidpi factor of the monitor.
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32>;
+
+    /// Gets the OS native graphics information for this window.
+    fn native_metadata(&self) -> NativeGraphicsMetadata;
 }
 

--- a/ports/android/glut_app/Cargo.lock
+++ b/ports/android/glut_app/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "alert 0.1.0 (git+https://github.com/servo/rust-alert#fdc24f13be8d8a2d15214ec228d166b3221b809e)",
  "compositing 0.0.1",
+ "egl 0.1.0 (git+https://github.com/servo/rust-egl#88f2a13812ddbce2bf2317221663a61c31b3e220)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom#b001a76e907befaae1d0d6dd259418a22092da86)",
  "glut 0.0.1 (git+https://github.com/servo/rust-glut#01af0162ea0322ad1a40d6adb023a39813605949)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#eac91e00db9af155f3004b408a18cb6d9f462a25)",

--- a/ports/android/glut_app/Cargo.toml
+++ b/ports/android/glut_app/Cargo.toml
@@ -32,3 +32,6 @@ default-features = false
 
 [dependencies.util]
 path = "../../../components/util"
+
+[dependencies.egl]
+git = "https://github.com/servo/rust-egl"

--- a/ports/android/glut_app/lib.rs
+++ b/ports/android/glut_app/lib.rs
@@ -10,6 +10,7 @@
 
 extern crate alert;
 extern crate compositing;
+extern crate egl;
 extern crate geom;
 extern crate glut;
 extern crate layers;

--- a/ports/android/glut_app/window.rs
+++ b/ports/android/glut_app/window.rs
@@ -18,6 +18,7 @@ use geom::point::{Point2D, TypedPoint2D};
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
+use layers::platform::surface::NativeGraphicsMetadata;
 use msg::compositor_msg::{IdleRenderState, RenderState, RenderingRenderState};
 use msg::compositor_msg::{FinishedLoading, Blank, ReadyState};
 use util::geometry::ScreenPx;
@@ -186,6 +187,13 @@ impl WindowMethods for Window {
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32> {
         //FIXME: Do nothing in GLUT now.
         ScaleFactor(1.0)
+    }
+
+    fn native_metadata(&self) -> NativeGraphicsMetadata {
+        use egl::egl::GetCurrentDisplay;
+        NativeGraphicsMetadata {
+            display: GetCurrentDisplay(),
+        }
     }
 }
 

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#eac91e00db9af155f3004b408a18cb6d9f462a25)",
  "msg 0.0.1",
+ "opengles 0.1.0 (git+https://github.com/servo/rust-opengles#6776e9c07feb149d34b087039ecf6b2c143e3afc)",
  "util 0.0.1",
 ]
 

--- a/ports/glfw/Cargo.toml
+++ b/ports/glfw/Cargo.toml
@@ -28,3 +28,6 @@ path = "../../components/msg"
 
 [dependencies.util]
 path = "../../components/util"
+
+[dependencies.opengles]
+git = "https://github.com/servo/rust-opengles"

--- a/ports/glfw/lib.rs
+++ b/ports/glfw/lib.rs
@@ -17,6 +17,7 @@ extern crate libc;
 extern crate msg;
 extern crate time;
 extern crate util;
+extern crate opengles;
 
 use geom::scale_factor::ScaleFactor;
 use std::rc::Rc;

--- a/ports/glfw/window.rs
+++ b/ports/glfw/window.rs
@@ -17,6 +17,7 @@ use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use glfw::{mod, Context};
 use layers::geometry::DevicePixel;
+use layers::platform::surface::NativeGraphicsMetadata;
 use libc::c_int;
 use msg::compositor_msg::{IdleRenderState, RenderState, RenderingRenderState};
 use msg::compositor_msg::{FinishedLoading, Blank, Loading, PerformingLayout, ReadyState};
@@ -150,6 +151,23 @@ impl WindowMethods for Window {
         let backing_size = self.framebuffer_size().width.get();
         let window_size = self.size().width.get();
         ScaleFactor((backing_size as f32) / window_size)
+    }
+
+    #[cfg(target_os="linux")]
+    fn native_metadata(&self) -> NativeGraphicsMetadata {
+        NativeGraphicsMetadata {
+            display: unsafe { glfw::ffi::glfwGetX11Display() },
+        }
+    }
+
+    #[cfg(target_os="macos")]
+    fn native_metadata(&self) -> NativeGraphicsMetadata {
+        use opengles::cgl::{CGLGetCurrentContext, CGLGetPixelFormat};
+        unsafe {
+            NativeGraphicsMetadata {
+                pixel_format: CGLGetPixelFormat(CGLGetCurrentContext()),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This is a prerequisite for glutin support.

Tested on Linux, mac. Tested that android + cef build.
