### PR TITLE
Add an optional --debug-mozjs argument to `mach build` that enables a no...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479"
+source = "git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd"
 dependencies = [
- "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs#47cd6a4e60c75642ba182f0df9a42b71ec7c2c88)",
+ "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs#0dd618fcc78fe7aa64e4e2a3b0f7f0d8a2f0f08a)",
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ source = "git+https://github.com/Kimundi/lazy-static.rs#e62a65372f1dd9019e37eb93
 [[package]]
 name = "mozjs-sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#47cd6a4e60c75642ba182f0df9a42b71ec7c2c88"
+source = "git+https://github.com/servo/mozjs#0dd618fcc78fe7aa64e4e2a3b0f7f0d8a2f0f08a"
 
 [[package]]
 name = "msg"
@@ -396,7 +396,7 @@ dependencies = [
  "gfx 0.0.1",
  "html5ever 0.0.0 (git+https://github.com/servo/html5ever?ref=servo#0bdd6087dc8df6a92c96e1859bbb4ebbb0be7c1f)",
  "http 0.1.0-pre (git+https://github.com/servo/rust-http?ref=servo#5e9b063b36028a5b40a417c661ee5c628b594be9)",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479)",
+ "js 0.1.0 (git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd)",
  "msg 0.0.1",
  "net 0.0.1",
  "plugins 0.0.1",

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -13,17 +13,17 @@
 //! "CSS 2.1" or "CSS 2.2" refers to the editor's draft of the W3C "Cascading Style Sheets Level 2
 //! Revision 2 (CSS 2.2) Specification" available here:
 //!
-//!     http://dev.w3.org/csswg/css2/
+//!   http://dev.w3.org/csswg/css2/
 //!
 //! "INTRINSIC" refers to L. David Baron's "More Precise Definitions of Inline Layout and Table
 //! Layout" available here:
 //!
-//!     http://dbaron.org/css/intrinsic/
+//!   http://dbaron.org/css/intrinsic/
 //!
 //! "CSS-SIZING" refers to the W3C "CSS Intrinsic & Extrinsic Sizing Module Level 3" document
 //! available here:
 //!
-//!     http://dev.w3.org/csswg/css-sizing/
+//!   http://dev.w3.org/csswg/css-sizing/
 
 #![deny(unsafe_block)]
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -7,7 +7,7 @@
 //! This follows the "More Precise Definitions of Inline Layout and Table Layout" proposal written
 //! by L. David Baron (Mozilla) here:
 //!
-//!     http://dbaron.org/css/intrinsic/
+//!   http://dbaron.org/css/intrinsic/
 //!
 //! Hereafter this document is referred to as INTRINSIC.
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -9,6 +9,9 @@ build = "make -f makefile.cargo"
 name = "script"
 path = "lib.rs"
 
+[features]
+debugmozjs = ['js/debugmozjs']
+
 [dependencies.plugins]
 path = "../plugins"
 

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -583,29 +583,29 @@ fn matches_compound_selector<'a,E,N>(selector: &CompoundSelector,
 
 /// A result of selector matching, includes 3 failure types,
 ///
-///     NotMatchedAndRestartFromClosestLaterSibling
-///     NotMatchedAndRestartFromClosestDescendant
-///     NotMatchedGlobally
+///   NotMatchedAndRestartFromClosestLaterSibling
+///   NotMatchedAndRestartFromClosestDescendant
+///   NotMatchedGlobally
 ///
 /// When NotMatchedGlobally appears, stop selector matching completely since
 /// the succeeding selectors never matches.
 /// It is raised when
-///     Child combinator cannot find the candidate element.
-///     Descendant combinator cannot find the candidate element.
+///   Child combinator cannot find the candidate element.
+///   Descendant combinator cannot find the candidate element.
 ///
 /// When NotMatchedAndRestartFromClosestDescendant appears, the selector
 /// matching does backtracking and restarts from the closest Descendant
 /// combinator.
 /// It is raised when
-///     NextSibling combinator cannot find the candidate element.
-///     LaterSibling combinator cannot find the candidate element.
-///     Child combinator doesn't match on the found element.
+///   NextSibling combinator cannot find the candidate element.
+///   LaterSibling combinator cannot find the candidate element.
+///   Child combinator doesn't match on the found element.
 ///
 /// When NotMatchedAndRestartFromClosestLaterSibling appears, the selector
 /// matching does backtracking and restarts from the closest LaterSibling
 /// combinator.
 /// It is raised when
-///     NextSibling combinator doesn't match on the found element.
+///   NextSibling combinator doesn't match on the found element.
 ///
 /// For example, when the selector "d1 d2 a" is provided and we cannot *find*
 /// an appropriate ancestor node for "d1", this selector matching raises

--- a/ports/android/glut_app/Cargo.lock
+++ b/ports/android/glut_app/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479"
+source = "git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd"
 dependencies = [
  "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs#47cd6a4e60c75642ba182f0df9a42b71ec7c2c88)",
 ]
@@ -390,7 +390,7 @@ dependencies = [
  "gfx 0.0.1",
  "html5ever 0.0.0 (git+https://github.com/servo/html5ever?ref=servo#0bdd6087dc8df6a92c96e1859bbb4ebbb0be7c1f)",
  "http 0.1.0-pre (git+https://github.com/servo/rust-http?ref=servo#5e9b063b36028a5b40a417c661ee5c628b594be9)",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479)",
+ "js 0.1.0 (git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd)",
  "msg 0.0.1",
  "net 0.0.1",
  "plugins 0.0.1",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "gfx 0.0.1",
  "glfw 0.0.1 (git+https://github.com/servo/glfw-rs?ref=servo#a15c2d04b8969aea653841d1d79e5fdf68de664b)",
  "glfw_app 0.0.1",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479)",
+ "js 0.1.0 (git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers#eac91e00db9af155f3004b408a18cb6d9f462a25)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479"
+source = "git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd"
 dependencies = [
  "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs#47cd6a4e60c75642ba182f0df9a42b71ec7c2c88)",
 ]
@@ -407,7 +407,7 @@ dependencies = [
  "gfx 0.0.1",
  "html5ever 0.0.0 (git+https://github.com/servo/html5ever?ref=servo#0bdd6087dc8df6a92c96e1859bbb4ebbb0be7c1f)",
  "http 0.1.0-pre (git+https://github.com/servo/rust-http?ref=servo#5e9b063b36028a5b40a417c661ee5c628b594be9)",
- "js 0.1.0 (git+https://github.com/servo/rust-mozjs#0d1700b4bb5981f75a4c75b7df75d8f28e499479)",
+ "js 0.1.0 (git+https://github.com/servo/rust-mozjs#1ec216a2577c03738fa11a78958bb2a0fd3f7fbd)",
  "msg 0.0.1",
  "net 0.0.1",
  "plugins 0.0.1",

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -108,7 +108,7 @@ class MachCommands(CommandBase):
 
         tgz_file = "cargo-nightly-%s.tar.gz" % host_triple()
         # FIXME(#3582): use https.
-        nightly_url = "http://static.rust-lang.org/cargo-dist/2014-10-02/%s" % tgz_file
+        nightly_url = "http://static.rust-lang.org/cargo-dist/2014-10-21/%s" % tgz_file
 
         download("Cargo nightly", nightly_url, tgz_file)
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -31,11 +31,15 @@ class MachCommands(CommandBase):
                      default=None,
                      action='store_true',
                      help='Build for Android')
+    @CommandArgument('--debug-mozjs',
+                     default=None,
+                     action='store_true',
+                     help='Enable debug assertions in mozjs')
     @CommandArgument('--verbose', '-v',
                      action='store_true',
                      help='Print verbose output')
     def build(self, target=None, release=False, jobs=None, android=None,
-              verbose=False):
+              verbose=False, debug_mozjs=False):
         self.ensure_bootstrapped()
 
         if android is None:
@@ -50,6 +54,13 @@ class MachCommands(CommandBase):
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
+
+        features = []
+        if debug_mozjs:
+            features += ["script/debugmozjs"]
+
+        if features:
+            opts += ["--features", "%s" % ' '.join(features)]
 
         build_start = time()
         if android:


### PR DESCRIPTION
...n-optimized, debug build of mozjs and rust-mozjs. Update the Cargo snapshot to enable new feature support.
