### PR TITLE
M1455: Evaluate replacing C image & font libraries with Rust equivalents

### DIFF
--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -5,7 +5,6 @@
 use std::iter::range_step;
 use stb_image::image as stb_image;
 use png;
-
 // FIXME: Images must not be copied every frame. Instead we should atomically
 // reference count them.
 pub type Image = png::Image;


### PR DESCRIPTION
Below changes have been implemented:
Build Servo, add timing code to the image decoding implementation in the net crate, rebuild Servo, and report numbers for different kinds of images (i.e. PNG, JPEG, GIF).

Build Servo and add code that reports (via println!) the time required to decode images into displayable pixels (image-related code)
