### PR TITLE
layout: Use the new `append_from` method to get rid of a bunch of moves in display list construction.

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -19,7 +19,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use collections::{Deque, RingBuf};
 use geom::{Rect, Size2D};
-use gfx::display_list::{ContentLevel, DisplayList};
+use gfx::display_list::ContentLevel;
 use gfx::font::FontMetrics;
 use gfx::font_context::FontContext;
 use gfx::text::glyph::CharIndex;
@@ -1199,9 +1199,9 @@ impl Flow for InlineFlow {
             match fragment.specific {
                 InlineBlockFragment(ref mut block_flow) => {
                     let block_flow = block_flow.flow_ref.deref_mut();
-                    self.base.display_list.push_all_move(
-                        mem::replace(&mut flow::mut_base(block_flow).display_list,
-                                     DisplayList::new()));
+                    self.base
+                        .display_list
+                        .append_from(&mut flow::mut_base(block_flow).display_list)
                 }
                 _ => {}
             }

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -710,11 +710,10 @@ impl LayoutTask {
                 debug!("Done building display list. Display List = {}",
                        flow::base(layout_root.deref()).display_list);
 
-                let root_display_list =
-                    mem::replace(&mut flow::mut_base(layout_root.deref_mut()).display_list,
-                                 DisplayList::new());
-                root_display_list.debug();
-                let display_list = Arc::new(root_display_list.flatten(ContentStackingLevel));
+                flow::mut_base(&mut *layout_root).display_list.flatten(ContentStackingLevel);
+                let display_list =
+                    Arc::new(mem::replace(&mut flow::mut_base(&mut *layout_root).display_list,
+                                          DisplayList::new()));
 
                 // FIXME(pcwalton): This is really ugly and can't handle overflow: scroll. Refactor
                 // it with extreme prejudice.
@@ -754,7 +753,7 @@ impl LayoutTask {
                     scroll_policy: Scrollable,
                 };
 
-                rw_data.display_list = Some(display_list.clone());
+                rw_data.display_list = Some(display_list);
 
                 // TODO(pcwalton): Eventually, when we have incremental reflow, this will have to
                 // be smarter in order to handle retained layer contents properly from reflow to


### PR DESCRIPTION
These were showing up in the profile.

r? @glennw
