### PR TITLE
Move build_element_from_tag out of the HTML parser.

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -1,0 +1,225 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::InheritTypes::ElementCast;
+use dom::bindings::js::{JSRef, Temporary};
+use dom::document::Document;
+use dom::element::Element;
+use dom::element::ElementCreator;
+use dom::htmlanchorelement::HTMLAnchorElement;
+use dom::htmlappletelement::HTMLAppletElement;
+use dom::htmlareaelement::HTMLAreaElement;
+use dom::htmlaudioelement::HTMLAudioElement;
+use dom::htmlbaseelement::HTMLBaseElement;
+use dom::htmlbodyelement::HTMLBodyElement;
+use dom::htmlbrelement::HTMLBRElement;
+use dom::htmlbuttonelement::HTMLButtonElement;
+use dom::htmlcanvaselement::HTMLCanvasElement;
+use dom::htmldataelement::HTMLDataElement;
+use dom::htmldatalistelement::HTMLDataListElement;
+use dom::htmldirectoryelement::HTMLDirectoryElement;
+use dom::htmldivelement::HTMLDivElement;
+use dom::htmldlistelement::HTMLDListElement;
+use dom::htmlelement::HTMLElement;
+use dom::htmlembedelement::HTMLEmbedElement;
+use dom::htmlfieldsetelement::HTMLFieldSetElement;
+use dom::htmlfontelement::HTMLFontElement;
+use dom::htmlformelement::HTMLFormElement;
+use dom::htmlframeelement::HTMLFrameElement;
+use dom::htmlframesetelement::HTMLFrameSetElement;
+use dom::htmlheadelement::HTMLHeadElement;
+use dom::htmlheadingelement::{Heading1, Heading2, Heading3, Heading4, Heading5, Heading6};
+use dom::htmlheadingelement::HTMLHeadingElement;
+use dom::htmlhrelement::HTMLHRElement;
+use dom::htmlhtmlelement::HTMLHtmlElement;
+use dom::htmliframeelement::HTMLIFrameElement;
+use dom::htmlimageelement::HTMLImageElement;
+use dom::htmlinputelement::HTMLInputElement;
+use dom::htmllabelelement::HTMLLabelElement;
+use dom::htmllegendelement::HTMLLegendElement;
+use dom::htmllielement::HTMLLIElement;
+use dom::htmllinkelement::HTMLLinkElement;
+use dom::htmlmapelement::HTMLMapElement;
+use dom::htmlmetaelement::HTMLMetaElement;
+use dom::htmlmeterelement::HTMLMeterElement;
+use dom::htmlmodelement::HTMLModElement;
+use dom::htmlobjectelement::HTMLObjectElement;
+use dom::htmlolistelement::HTMLOListElement;
+use dom::htmloptgroupelement::HTMLOptGroupElement;
+use dom::htmloptionelement::HTMLOptionElement;
+use dom::htmloutputelement::HTMLOutputElement;
+use dom::htmlparagraphelement::HTMLParagraphElement;
+use dom::htmlparamelement::HTMLParamElement;
+use dom::htmlpreelement::HTMLPreElement;
+use dom::htmlprogresselement::HTMLProgressElement;
+use dom::htmlquoteelement::HTMLQuoteElement;
+use dom::htmlscriptelement::HTMLScriptElement;
+use dom::htmlselectelement::HTMLSelectElement;
+use dom::htmlsourceelement::HTMLSourceElement;
+use dom::htmlspanelement::HTMLSpanElement;
+use dom::htmlstyleelement::HTMLStyleElement;
+use dom::htmltablecaptionelement::HTMLTableCaptionElement;
+use dom::htmltablecolelement::HTMLTableColElement;
+use dom::htmltabledatacellelement::HTMLTableDataCellElement;
+use dom::htmltableelement::HTMLTableElement;
+use dom::htmltableheadercellelement::HTMLTableHeaderCellElement;
+use dom::htmltablerowelement::HTMLTableRowElement;
+use dom::htmltablesectionelement::HTMLTableSectionElement;
+use dom::htmltemplateelement::HTMLTemplateElement;
+use dom::htmltextareaelement::HTMLTextAreaElement;
+use dom::htmltimeelement::HTMLTimeElement;
+use dom::htmltitleelement::HTMLTitleElement;
+use dom::htmltrackelement::HTMLTrackElement;
+use dom::htmlulistelement::HTMLUListElement;
+use dom::htmlunknownelement::HTMLUnknownElement;
+use dom::htmlvideoelement::HTMLVideoElement;
+
+use servo_util::str::DOMString;
+
+use string_cache::QualName;
+
+pub fn create_element(name: QualName, prefix: Option<DOMString>,
+                      document: JSRef<Document>, creator: ElementCreator)
+                      -> Temporary<Element> {
+    if name.ns != ns!(HTML) {
+        return Element::new(name.local.as_slice().to_string(), name.ns, None, document);
+    }
+
+    macro_rules! make(
+        ($ctor:ident $(, $arg:expr)*) => ({
+            let obj = $ctor::new(name.local.as_slice().to_string(), prefix, document $(, $arg)*);
+            ElementCast::from_temporary(obj)
+        })
+    )
+
+    // This is a big match, and the IDs for inline-interned atoms are not very structured.
+    // Perhaps we should build a perfect hash from those IDs instead.
+    match name.local {
+        atom!("a")          => make!(HTMLAnchorElement),
+        atom!("abbr")       => make!(HTMLElement),
+        atom!("acronym")    => make!(HTMLElement),
+        atom!("address")    => make!(HTMLElement),
+        atom!("applet")     => make!(HTMLAppletElement),
+        atom!("area")       => make!(HTMLAreaElement),
+        atom!("article")    => make!(HTMLElement),
+        atom!("aside")      => make!(HTMLElement),
+        atom!("audio")      => make!(HTMLAudioElement),
+        atom!("b")          => make!(HTMLElement),
+        atom!("base")       => make!(HTMLBaseElement),
+        atom!("bdi")        => make!(HTMLElement),
+        atom!("bdo")        => make!(HTMLElement),
+        atom!("bgsound")    => make!(HTMLElement),
+        atom!("big")        => make!(HTMLElement),
+        atom!("blockquote") => make!(HTMLElement),
+        atom!("body")       => make!(HTMLBodyElement),
+        atom!("br")         => make!(HTMLBRElement),
+        atom!("button")     => make!(HTMLButtonElement),
+        atom!("canvas")     => make!(HTMLCanvasElement),
+        atom!("caption")    => make!(HTMLTableCaptionElement),
+        atom!("center")     => make!(HTMLElement),
+        atom!("cite")       => make!(HTMLElement),
+        atom!("code")       => make!(HTMLElement),
+        atom!("col")        => make!(HTMLTableColElement),
+        atom!("colgroup")   => make!(HTMLTableColElement),
+        atom!("data")       => make!(HTMLDataElement),
+        atom!("datalist")   => make!(HTMLDataListElement),
+        atom!("dd")         => make!(HTMLElement),
+        atom!("del")        => make!(HTMLModElement),
+        atom!("details")    => make!(HTMLElement),
+        atom!("dfn")        => make!(HTMLElement),
+        atom!("dir")        => make!(HTMLDirectoryElement),
+        atom!("div")        => make!(HTMLDivElement),
+        atom!("dl")         => make!(HTMLDListElement),
+        atom!("dt")         => make!(HTMLElement),
+        atom!("em")         => make!(HTMLElement),
+        atom!("embed")      => make!(HTMLEmbedElement),
+        atom!("fieldset")   => make!(HTMLFieldSetElement),
+        atom!("figcaption") => make!(HTMLElement),
+        atom!("figure")     => make!(HTMLElement),
+        atom!("font")       => make!(HTMLFontElement),
+        atom!("footer")     => make!(HTMLElement),
+        atom!("form")       => make!(HTMLFormElement),
+        atom!("frame")      => make!(HTMLFrameElement),
+        atom!("frameset")   => make!(HTMLFrameSetElement),
+        atom!("h1")         => make!(HTMLHeadingElement, Heading1),
+        atom!("h2")         => make!(HTMLHeadingElement, Heading2),
+        atom!("h3")         => make!(HTMLHeadingElement, Heading3),
+        atom!("h4")         => make!(HTMLHeadingElement, Heading4),
+        atom!("h5")         => make!(HTMLHeadingElement, Heading5),
+        atom!("h6")         => make!(HTMLHeadingElement, Heading6),
+        atom!("head")       => make!(HTMLHeadElement),
+        atom!("header")     => make!(HTMLElement),
+        atom!("hgroup")     => make!(HTMLElement),
+        atom!("hr")         => make!(HTMLHRElement),
+        atom!("html")       => make!(HTMLHtmlElement),
+        atom!("i")          => make!(HTMLElement),
+        atom!("iframe")     => make!(HTMLIFrameElement),
+        atom!("img")        => make!(HTMLImageElement),
+        atom!("input")      => make!(HTMLInputElement),
+        atom!("ins")        => make!(HTMLModElement),
+        atom!("isindex")    => make!(HTMLElement),
+        atom!("kbd")        => make!(HTMLElement),
+        atom!("label")      => make!(HTMLLabelElement),
+        atom!("legend")     => make!(HTMLLegendElement),
+        atom!("li")         => make!(HTMLLIElement),
+        atom!("link")       => make!(HTMLLinkElement),
+        atom!("main")       => make!(HTMLElement),
+        atom!("map")        => make!(HTMLMapElement),
+        atom!("mark")       => make!(HTMLElement),
+        atom!("marquee")    => make!(HTMLElement),
+        atom!("meta")       => make!(HTMLMetaElement),
+        atom!("meter")      => make!(HTMLMeterElement),
+        atom!("nav")        => make!(HTMLElement),
+        atom!("nobr")       => make!(HTMLElement),
+        atom!("noframes")   => make!(HTMLElement),
+        atom!("noscript")   => make!(HTMLElement),
+        atom!("object")     => make!(HTMLObjectElement),
+        atom!("ol")         => make!(HTMLOListElement),
+        atom!("optgroup")   => make!(HTMLOptGroupElement),
+        atom!("option")     => make!(HTMLOptionElement),
+        atom!("output")     => make!(HTMLOutputElement),
+        atom!("p")          => make!(HTMLParagraphElement),
+        atom!("param")      => make!(HTMLParamElement),
+        atom!("pre")        => make!(HTMLPreElement),
+        atom!("progress")   => make!(HTMLProgressElement),
+        atom!("q")          => make!(HTMLQuoteElement),
+        atom!("rp")         => make!(HTMLElement),
+        atom!("rt")         => make!(HTMLElement),
+        atom!("ruby")       => make!(HTMLElement),
+        atom!("s")          => make!(HTMLElement),
+        atom!("samp")       => make!(HTMLElement),
+        atom!("script")     => make!(HTMLScriptElement, creator),
+        atom!("section")    => make!(HTMLElement),
+        atom!("select")     => make!(HTMLSelectElement),
+        atom!("small")      => make!(HTMLElement),
+        atom!("source")     => make!(HTMLSourceElement),
+        atom!("spacer")     => make!(HTMLElement),
+        atom!("span")       => make!(HTMLSpanElement),
+        atom!("strike")     => make!(HTMLElement),
+        atom!("strong")     => make!(HTMLElement),
+        atom!("style")      => make!(HTMLStyleElement),
+        atom!("sub")        => make!(HTMLElement),
+        atom!("summary")    => make!(HTMLElement),
+        atom!("sup")        => make!(HTMLElement),
+        atom!("table")      => make!(HTMLTableElement),
+        atom!("tbody")      => make!(HTMLTableSectionElement),
+        atom!("td")         => make!(HTMLTableDataCellElement),
+        atom!("template")   => make!(HTMLTemplateElement),
+        atom!("textarea")   => make!(HTMLTextAreaElement),
+        atom!("th")         => make!(HTMLTableHeaderCellElement),
+        atom!("time")       => make!(HTMLTimeElement),
+        atom!("title")      => make!(HTMLTitleElement),
+        atom!("tr")         => make!(HTMLTableRowElement),
+        atom!("tt")         => make!(HTMLElement),
+        atom!("track")      => make!(HTMLTrackElement),
+        atom!("u")          => make!(HTMLElement),
+        atom!("ul")         => make!(HTMLUListElement),
+        atom!("var")        => make!(HTMLElement),
+        atom!("video")      => make!(HTMLVideoElement),
+        atom!("wbr")        => make!(HTMLElement),
+        _                   => make!(HTMLUnknownElement),
+    }
+}
+
+

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -33,7 +33,7 @@ use dom::customevent::CustomEvent;
 use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
 use dom::domimplementation::DOMImplementation;
-use dom::element::{Element, AttributeHandlers, get_attribute_parts};
+use dom::element::{Element, ScriptCreated, AttributeHandlers, get_attribute_parts};
 use dom::element::{HTMLHeadElementTypeId, HTMLTitleElementTypeId};
 use dom::element::{HTMLBodyElementTypeId, HTMLFrameSetElementTypeId};
 use dom::event::{Event, DoesNotBubble, NotCancelable};
@@ -55,7 +55,6 @@ use dom::range::Range;
 use dom::treewalker::TreeWalker;
 use dom::uievent::UIEvent;
 use dom::window::{Window, WindowHelpers};
-use parse::html::{build_element_from_tag, ScriptCreated};
 use servo_util::namespace;
 use servo_util::str::{DOMString, split_html_space_chars};
 
@@ -529,7 +528,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         }
         let local_name = local_name.as_slice().to_ascii_lower();
         let name = QualName::new(ns!(HTML), Atom::from_slice(local_name.as_slice()));
-        Ok(build_element_from_tag(name, None, self, ScriptCreated))
+        Ok(Element::create(name, None, self, ScriptCreated))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createelementns
@@ -574,8 +573,8 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
         if ns == ns!(HTML) {
             let name = QualName::new(ns!(HTML), Atom::from_slice(local_name_from_qname));
-            Ok(build_element_from_tag(name, prefix_from_qname.map(|s| s.to_string()), self,
-                                      ScriptCreated))
+            Ok(Element::create(name, prefix_from_qname.map(|s| s.to_string()), self,
+                               ScriptCreated))
         } else {
             Ok(Element::new(local_name_from_qname.to_string(), ns,
                             prefix_from_qname.map(|s| s.to_string()), self))

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -19,6 +19,7 @@ use dom::bindings::js::{OptionalSettable, OptionalRootable, Root};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::bindings::error::{ErrorResult, Fallible, NamespaceError, InvalidCharacter, Syntax};
 use dom::bindings::utils::{QName, Name, InvalidXMLName, xml_name_type};
+use dom::create::create_element;
 use dom::domrect::DOMRect;
 use dom::domrectlist::DOMRectList;
 use dom::document::{Document, DocumentHelpers, LayoutDocumentHelpers};
@@ -147,11 +148,22 @@ pub enum ElementTypeId {
     ElementTypeId_,
 }
 
+#[deriving(PartialEq)]
+pub enum ElementCreator {
+    ParserCreated,
+    ScriptCreated,
+}
+
 //
 // Element methods
 //
-
 impl Element {
+    pub fn create(name: QualName, prefix: Option<DOMString>,
+                  document: JSRef<Document>, creator: ElementCreator)
+                  -> Temporary<Element> {
+        create_element(name, prefix, document, creator)
+    }
+
     pub fn new_inherited(type_id: ElementTypeId, local_name: DOMString, namespace: Namespace, prefix: Option<DOMString>, document: JSRef<Document>) -> Element {
         Element {
             node: Node::new_inherited(ElementNodeTypeId(type_id), document),

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -14,6 +14,7 @@ use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{HTMLScriptElementTypeId, Element, AttributeHandlers};
+use dom::element::{ElementCreator, ParserCreated};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId, window_from_node, CloneChildrenFlag};
@@ -22,7 +23,6 @@ use dom::window::WindowHelpers;
 
 use encoding::all::UTF_8;
 use encoding::types::{Encoding, DecodeReplace};
-use parse::html::{ElementCreator, ParserCreated};
 use servo_net::resource_task::load_whole_resource;
 use servo_util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
 use std::cell::Cell;

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -33,7 +33,7 @@ use dom::comment::Comment;
 use dom::document::{Document, DocumentHelpers, HTMLDocument, NonHTMLDocument, NotFromParser};
 use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
-use dom::element::{AttributeHandlers, Element, ElementTypeId};
+use dom::element::{AttributeHandlers, Element, ScriptCreated, ElementTypeId};
 use dom::element::{HTMLAnchorElementTypeId, HTMLButtonElementTypeId, ElementHelpers};
 use dom::element::{HTMLInputElementTypeId, HTMLSelectElementTypeId};
 use dom::element::{HTMLTextAreaElementTypeId, HTMLOptGroupElementTypeId};
@@ -45,7 +45,6 @@ use dom::text::Text;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
 use dom::window::Window;
 use geom::rect::Rect;
-use parse::html::{build_element_from_tag, ScriptCreated};
 use layout_interface::{ContentBoxResponse, ContentBoxesResponse, LayoutRPC,
                        LayoutChan, ReapLayoutDataMsg};
 use devtools_traits::NodeInfo;
@@ -1520,7 +1519,7 @@ impl Node {
                     ns: element.namespace().clone(),
                     local: element.local_name().clone()
                 };
-                let element = build_element_from_tag(name,
+                let element = Element::create(name,
                     Some(element.prefix().as_slice().to_string()), *document, ScriptCreated);
                 NodeCast::from_temporary(element)
             },

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -91,6 +91,7 @@ pub mod dom {
     pub mod domrectlist;
     pub mod comment;
     pub mod console;
+    mod create;
     pub mod customevent;
     pub mod dedicatedworkerglobalscope;
     pub mod document;


### PR DESCRIPTION
This function is not particular to the parser, so should live in the DOM.
