### PR TITLE
Format Element#tagName correctly when there's a prefix.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -656,7 +656,11 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     // http://dom.spec.whatwg.org/#dom-element-tagname
     fn TagName(self) -> DOMString {
         let qualified_name = match self.prefix {
-            Some(ref prefix) => format!("{}:{}", prefix, self.local_name).into_maybe_owned(),
+            Some(ref prefix) => {
+                (format!("{:s}:{:s}",
+                         prefix.as_slice(),
+                         self.local_name.as_slice())).into_maybe_owned()
+            },
             None => self.local_name.as_slice().into_maybe_owned()
         };
         if self.html_element_in_html_document() {

--- a/tests/wpt/metadata/dom/nodes/Document-createElementNS.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createElementNS.html.ini
@@ -9,15 +9,3 @@
   [Invalid namespace http://www.w3.org/2000/xmlns/ and QName foo:xmlns]
     expected: FAIL
 
-  [Lower-case HTML element with a prefix]
-    expected: FAIL
-
-  [Upper-case HTML element with a prefix]
-    expected: FAIL
-
-  [Lower-case non-HTML element with a prefix]
-    expected: FAIL
-
-  [Upper-case non-HTML element with a prefix]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/nodes/Element-tagName.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-tagName.html.ini
@@ -1,11 +1,5 @@
 [Element-tagName.html]
   type: testharness
-  [tagName should upper-case for HTML elements in HTML documents.]
-    expected: FAIL
-
   [tagName should be updated when changing ownerDocument]
-    expected: FAIL
-
-  [tagName should not upper-case for SVG elements in HTML documents.]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/Node-nodeName.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-nodeName.html.ini
@@ -1,5 +1,0 @@
-[Node-nodeName.html]
-  type: testharness
-  [For Element nodes, nodeName should return the same as tagName.]
-    expected: FAIL
-


### PR DESCRIPTION
format!("{}", atom) yields strings like "Atom('span' type=Inline)", which is
not intended here.
