### PR TITLE
Have ContentBox(es)Queries consult the flow tree

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -35,7 +35,8 @@ use floats::{ClearBoth, ClearLeft, ClearRight, FloatKind, FloatLeft, Floats, Pla
 use flow::{BaseFlow, BlockFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use flow::{MutableFlowUtils, PreorderFlowTraversal, PostorderFlowTraversal, mut_base};
 use flow;
-use fragment::{Fragment, ImageFragment, InlineBlockFragment, ScannedTextFragment};
+use fragment::{Fragment, ImageFragment, InlineBlockFragment, FragmentBoundsIterator};
+use fragment::ScannedTextFragment;
 use incremental::{Reflow, ReflowOutOfFlow};
 use layout_debug;
 use model::{Auto, IntrinsicISizes, MarginCollapseInfo, MarginsCollapse, MarginsCollapseThrough};
@@ -1815,6 +1816,14 @@ impl Flow for BlockFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.fragment.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        if iterator.should_process(&self.fragment) {
+            let fragment_origin = self.base.child_fragment_absolute_position(&self.fragment);
+            iterator.process(&self.fragment,
+                             self.fragment.abs_bounds_from_origin(&fragment_origin));
+        }
     }
 }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -322,7 +322,7 @@ impl FragmentDisplayListBuilding for Fragment {
             Rect(physical_rect.origin + flow_origin, physical_rect.size)
         };
         // Fragment position wrt to the owning flow.
-        let absolute_fragment_bounds = rect_to_absolute(self.style.writing_mode, self.border_box);
+        let absolute_fragment_bounds = self.abs_bounds_from_origin(&flow_origin);
         debug!("Fragment::build_display_list at rel={}, abs={}: {}",
                self.border_box,
                absolute_fragment_bounds,
@@ -615,18 +615,12 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
     fn build_display_list_for_block(&mut self,
                                     layout_context: &LayoutContext,
                                     background_border_level: BackgroundAndBorderLevel) {
-        let relative_offset =
-            self.fragment.relative_position(&self.base
-                                                 .absolute_position_info
-                                                 .relative_containing_block_size);
 
         // Add the box that starts the block context.
-        self.base.display_list = DisplayList::new();
-        let absolute_position =
-            self.base.abs_position.add_size(&relative_offset.to_physical(self.base.writing_mode));
+        let absolute_fragment_origin = self.base.child_fragment_absolute_position(&self.fragment);
         self.fragment.build_display_list(&mut self.base.display_list,
                                          layout_context,
-                                         absolute_position,
+                                         absolute_fragment_origin,
                                          background_border_level,
                                          &self.base.clip_rect);
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -31,7 +31,7 @@ use context::LayoutContext;
 use floats::Floats;
 use flow_list::{FlowList, FlowListIterator, MutFlowListIterator};
 use flow_ref::FlowRef;
-use fragment::{Fragment, TableRowFragment, TableCellFragment};
+use fragment::{Fragment, FragmentBoundsIterator, TableRowFragment, TableCellFragment};
 use incremental::{ReconstructFlow, Reflow, ReflowOutOfFlow, RestyleDamage};
 use inline::InlineFlow;
 use model::{CollapsibleMargins, IntrinsicISizes, MarginCollapseInfo};
@@ -213,6 +213,9 @@ pub trait Flow: fmt::Show + ToString + Sync {
 
     /// Phase 5 of reflow: builds display lists.
     fn build_display_list(&mut self, layout_context: &LayoutContext);
+
+    /// Perform an iteration of fragment bounds on this flow.
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator);
 
     fn compute_collapsible_block_start_margin(&mut self,
                                               _layout_context: &mut LayoutContext,
@@ -942,6 +945,14 @@ impl BaseFlow {
                 error!("DisplayList item {} outside of Flow overflow ({})", item, paint_bounds);
             }
         }
+    }
+
+    pub fn child_fragment_absolute_position(&self, fragment: &Fragment) -> Point2D<Au> {
+        let relative_offset =
+            fragment.relative_position(&self
+                                       .absolute_position_info
+                                       .relative_containing_block_size);
+        self.abs_position.add_size(&relative_offset.to_physical(self.writing_mode))
     }
 }
 

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -8,6 +8,7 @@ use context::{LayoutContext, SharedLayoutContext};
 use flow::{Flow, MutableFlowUtils, PreorderFlowTraversal, PostorderFlowTraversal};
 use flow;
 use flow_ref::FlowRef;
+use fragment::FragmentBoundsIterator;
 use servo_util::opts;
 use traversal::{BubbleISizes, RecalcStyleForNode, ConstructFlows};
 use traversal::{AssignBSizesAndStoreOverflow, AssignISizes};
@@ -91,4 +92,17 @@ pub fn build_display_list_for_subtree(root: &mut FlowRef,
     let build_display_list         = BuildDisplayList         { layout_context: &layout_context };
 
     doit(root.deref_mut(), compute_absolute_positions, build_display_list);
+}
+
+pub fn iterate_through_flow_tree_fragment_bounds(root: &mut FlowRef,
+                                                 iterator: &mut FragmentBoundsIterator) {
+    fn doit(flow: &mut Flow, iterator: &mut FragmentBoundsIterator) {
+        flow.iterate_through_fragment_bounds(iterator);
+
+        for kid in flow::mut_base(flow).child_iter() {
+            doit(kid, iterator);
+        }
+    }
+
+    doit(root.deref_mut(), iterator);
 }

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -12,7 +12,7 @@ use construct::FlowConstructor;
 use context::LayoutContext;
 use floats::FloatKind;
 use flow::{TableFlowClass, FlowClass, Flow, ImmutableFlowUtils};
-use fragment::Fragment;
+use fragment::{Fragment, FragmentBoundsIterator};
 use layout_debug;
 use model::{IntrinsicISizes, IntrinsicISizesContribution};
 use table_wrapper::{TableLayout, FixedLayout, AutoLayout};
@@ -326,6 +326,10 @@ impl Flow for TableFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.block_flow.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        self.block_flow.iterate_through_fragment_bounds(iterator);
     }
 }
 

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -10,6 +10,7 @@ use block::BlockFlow;
 use construct::FlowConstructor;
 use context::LayoutContext;
 use flow::{TableCaptionFlowClass, FlowClass, Flow};
+use fragment::FragmentBoundsIterator;
 use wrapper::ThreadSafeLayoutNode;
 
 use servo_util::geometry::Au;
@@ -78,6 +79,10 @@ impl Flow for TableCaptionFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.block_flow.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        self.iterate_through_fragment_bounds(iterator);
     }
 }
 

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -9,7 +9,7 @@
 use block::{BlockFlow, MarginsMayNotCollapse, ISizeAndMarginsComputer};
 use context::LayoutContext;
 use flow::{TableCellFlowClass, FlowClass, Flow};
-use fragment::Fragment;
+use fragment::{Fragment, FragmentBoundsIterator};
 use model::{MaybeAuto};
 use layout_debug;
 use table::InternalTable;
@@ -147,6 +147,10 @@ impl Flow for TableCellFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.block_flow.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        self.block_flow.iterate_through_fragment_bounds(iterator);
     }
 }
 

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -9,7 +9,7 @@
 use context::LayoutContext;
 use css::node_style::StyledNode;
 use flow::{BaseFlow, TableColGroupFlowClass, FlowClass, Flow};
-use fragment::{Fragment, TableColumnFragment};
+use fragment::{Fragment, FragmentBoundsIterator, TableColumnFragment};
 use layout_debug;
 use wrapper::ThreadSafeLayoutNode;
 
@@ -95,6 +95,9 @@ impl Flow for TableColGroupFlow {
     fn build_display_list(&mut self, _: &LayoutContext) {}
 
     fn repair_style(&mut self, _: &Arc<ComputedValues>) {}
+
+    fn iterate_through_fragment_bounds(&self, _: &mut FragmentBoundsIterator) {
+    }
 }
 
 impl fmt::Show for TableColGroupFlow {

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -12,7 +12,7 @@ use construct::FlowConstructor;
 use context::LayoutContext;
 use flow::{TableRowFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use flow;
-use fragment::Fragment;
+use fragment::{Fragment, FragmentBoundsIterator};
 use layout_debug;
 use table::{ColumnInlineSize, InternalTable};
 use model::{MaybeAuto, Specified, Auto};
@@ -250,6 +250,10 @@ impl Flow for TableRowFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.block_flow.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        self.block_flow.iterate_through_fragment_bounds(iterator);
     }
 }
 

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -12,7 +12,7 @@ use construct::FlowConstructor;
 use context::LayoutContext;
 use flow::{TableRowGroupFlowClass, FlowClass, Flow, ImmutableFlowUtils};
 use flow;
-use fragment::Fragment;
+use fragment::{Fragment, FragmentBoundsIterator};
 use layout_debug;
 use model::IntrinsicISizesContribution;
 use table::{ColumnInlineSize, InternalTable, TableFlow};
@@ -210,6 +210,10 @@ impl Flow for TableRowGroupFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.block_flow.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        self.block_flow.iterate_through_fragment_bounds(iterator);
     }
 }
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -19,7 +19,7 @@ use construct::FlowConstructor;
 use context::LayoutContext;
 use floats::FloatKind;
 use flow::{TableWrapperFlowClass, FlowClass, Flow, ImmutableFlowUtils};
-use fragment::Fragment;
+use fragment::{Fragment, FragmentBoundsIterator};
 use table::ColumnInlineSize;
 use wrapper::ThreadSafeLayoutNode;
 
@@ -333,6 +333,10 @@ impl Flow for TableWrapperFlow {
 
     fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.block_flow.repair_style(new_style)
+    }
+
+    fn iterate_through_fragment_bounds(&self, iterator: &mut FragmentBoundsIterator) {
+        self.block_flow.iterate_through_fragment_bounds(iterator);
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -45,8 +45,7 @@ use dom::text::Text;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
 use dom::window::Window;
 use geom::rect::Rect;
-use layout_interface::{ContentBoxResponse, ContentBoxesResponse, LayoutRPC,
-                       LayoutChan, ReapLayoutDataMsg};
+use layout_interface::{LayoutChan, ReapLayoutDataMsg};
 use devtools_traits::NodeInfo;
 use script_traits::UntrustedNodeAddress;
 use servo_util::geometry::Au;
@@ -689,20 +688,11 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     fn get_bounding_content_box(self) -> Rect<Au> {
-        let window = window_from_node(self).root();
-        let page = window.page();
-        let addr = self.to_trusted_node_address();
-
-        let ContentBoxResponse(rect) = page.layout().content_box(addr);
-        rect
+        window_from_node(self).root().page().content_box_query(self.to_trusted_node_address())
     }
 
     fn get_content_boxes(self) -> Vec<Rect<Au>> {
-        let window = window_from_node(self).root();
-        let page = window.page();
-        let addr = self.to_trusted_node_address();
-        let ContentBoxesResponse(rects) = page.layout().content_boxes(addr);
-        rects
+        window_from_node(self).root().page().content_boxes_query(self.to_trusted_node_address())
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -19,7 +19,7 @@ use dom::location::Location;
 use dom::navigator::Navigator;
 use dom::performance::Performance;
 use dom::screen::Screen;
-use layout_interface::ReflowGoal;
+use layout_interface::NoQuery;
 use page::Page;
 use script_task::{ExitWindowMsg, ScriptChan, TriggerLoadMsg, TriggerFragmentMsg};
 use script_task::FromWindow;
@@ -312,7 +312,7 @@ impl Reflectable for Window {
 
 pub trait WindowHelpers {
     fn reflow(self);
-    fn flush_layout(self, goal: ReflowGoal);
+    fn flush_layout(self);
     fn wait_until_safe_to_modify_dom(self);
     fn init_browser_context(self, doc: JSRef<Document>);
     fn load_url(self, href: DOMString);
@@ -350,8 +350,8 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         self.page().damage();
     }
 
-    fn flush_layout(self, goal: ReflowGoal) {
-        self.page().flush_layout(goal);
+    fn flush_layout(self) {
+        self.page().flush_layout(NoQuery);
     }
 
     fn wait_until_safe_to_modify_dom(self) {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -60,9 +60,9 @@ pub enum Msg {
 //    3) and really needs to be fast.
 pub trait LayoutRPC {
     /// Requests the dimensions of the content box, as in the `getBoundingClientRect()` call.
-    fn content_box(&self, node: TrustedNodeAddress) -> ContentBoxResponse;
+    fn content_box(&self) -> ContentBoxResponse;
     /// Requests the dimensions of all the content boxes, as in the `getClientRects()` call.
-    fn content_boxes(&self, node: TrustedNodeAddress) -> ContentBoxesResponse;
+    fn content_boxes(&self) -> ContentBoxesResponse;
     /// Requests the node containing the point of interest
     fn hit_test(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<HitTestResponse, ()>;
     fn mouse_over(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<MouseOverResponse, ()>;
@@ -82,6 +82,13 @@ pub enum ReflowGoal {
     ReflowForScriptQuery,
 }
 
+/// Any query to perform with this reflow.
+pub enum ReflowQueryType {
+    NoQuery,
+    ContentBoxQuery(TrustedNodeAddress),
+    ContentBoxesQuery(TrustedNodeAddress),
+}
+
 /// Information needed for a reflow.
 pub struct Reflow {
     /// The document node.
@@ -99,7 +106,9 @@ pub struct Reflow {
     /// The channel that we send a notification to.
     pub script_join_chan: Sender<()>,
     /// Unique identifier
-    pub id: uint
+    pub id: uint,
+    /// The type of query if any to perform during this reflow.
+    pub query_type: ReflowQueryType,
 }
 
 /// Encapsulates a channel to the layout task.

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -29,7 +29,7 @@ use dom::window::{Window, WindowHelpers};
 use dom::worker::{Worker, TrustedWorkerAddress};
 use dom::xmlhttprequest::{TrustedXHRAddress, XMLHttpRequest, XHRProgress};
 use parse::html::{InputString, InputUrl, parse_html};
-use layout_interface::{ScriptLayoutChan, LayoutChan, ReflowForDisplay};
+use layout_interface::{ScriptLayoutChan, LayoutChan, NoQuery, ReflowForDisplay};
 use layout_interface;
 use page::{Page, IterablePage, Frame};
 use timers::TimerId;
@@ -815,7 +815,7 @@ impl ScriptTask {
             let document_as_node = NodeCast::from_ref(document_js_ref);
             document.content_changed(document_as_node);
         }
-        window.flush_layout(ReflowForDisplay);
+        window.flush_layout();
 
         {
             // No more reflow required
@@ -870,7 +870,7 @@ impl ScriptTask {
         }
 
         page.damage();
-        page.reflow(ReflowForDisplay, self.control_chan.clone(), &*self.compositor);
+        page.reflow(ReflowForDisplay, self.control_chan.clone(), &*self.compositor, NoQuery);
     }
 
     /// This is the main entry point for receiving and dispatching DOM events.
@@ -969,7 +969,7 @@ impl ScriptTask {
                                         let eventtarget: JSRef<EventTarget> = EventTargetCast::from_ref(node);
                                         let _ = eventtarget.dispatch_event_with_target(None, *event);
 
-                                        window.flush_layout(ReflowForDisplay);
+                                        window.flush_layout();
                                     }
                                     None => {}
                                 }


### PR DESCRIPTION
Instead of looking at the display tree, have ContentBox(es)Query consult
the flow tree. This allow optimizing away parts of the display tree
later. To do this we need to be more careful about how we send reflow
requests, only querying the flow tree when possible.

Fixes #3790.
