### PR TITLE
Remove suggestion to use #[must_root] for functions

### DIFF
--- a/components/plugins/lints.rs
+++ b/components/plugins/lints.rs
@@ -112,7 +112,7 @@ impl LintPass for UnrootedPass {
             ast::DefaultBlock => {
                 for arg in decl.inputs.iter() {
                     lint_unrooted_ty(cx, &*arg.ty,
-                                     "Type must be rooted, use #[must_root] on the fn definition to propagate")
+                                     "Type must be rooted")
                 }
             }
             _ => () // fn is `unsafe`


### PR DESCRIPTION
The correct thing to do here is to use `#[allow(unrooted_must_root)]` (the warning already mentions this). `#[must_root]` on functions does nothing.
