### PR TITLE
Add support for very basic mouse-drag scrolling

### DIFF
--- a/ports/glfw/window.rs
+++ b/ports/glfw/window.rs
@@ -194,7 +194,9 @@ impl Window {
                 let hidpi = (backing_size as f32) / (window_size as f32);
                 let x = x as f32 * hidpi;
                 let y = y as f32 * hidpi;
-                if button == glfw::MouseButtonLeft || button == glfw::MouseButtonRight {
+                if button == glfw::MouseButtonLeft ||
+                   button == glfw::MouseButtonRight ||
+                   button == glfw::MouseButtonMiddle {
                     self.handle_mouse(button, action, x as i32, y as i32);
                 }
             },


### PR DESCRIPTION
Mouse-drag scrolling simulates touch scrolling for devices without
touchscreens. It will be useful for performance work on a variety of
devices and a stopgap for interaction until scrollbars exist.  The
implementation is very basic now, with support for rudimentary
rate-limiting, but will need deeper integration into the compositor for
proper iframe/overflow:scroll support.
