### PR TITLE
Implements case insensitive font family names.

### DIFF
--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -21,6 +21,7 @@ extern crate rustrt;
 extern crate stb_image;
 extern crate png;
 extern crate serialize;
+extern crate unicode;
 #[phase(plugin)]
 extern crate "plugins" as servo_plugins;
 extern crate "net" as servo_net;
@@ -71,4 +72,3 @@ pub mod platform;
 // Text
 #[path = "text/mod.rs"]
 pub mod text;
-

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -26,6 +26,7 @@ extern crate sync;
 extern crate task_info;
 extern crate "time" as std_time;
 extern crate string_cache;
+extern crate unicode;
 extern crate url;
 
 #[phase(plugin)]

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -7,6 +7,7 @@ use geometry::Au;
 use std::from_str::FromStr;
 use std::iter::Filter;
 use std::str::{CharEq, CharSplits};
+use unicode::char::to_lowercase;
 
 pub type DOMString = String;
 pub type StaticCharVec = &'static [char];
@@ -184,3 +185,22 @@ pub fn parse_length(mut value: &str) -> LengthOrPercentageOrAuto {
 }
 
 
+#[deriving(Clone, Eq, PartialEq, Hash, Show)]
+pub struct LowercaseString {
+    inner: String,
+}
+
+impl LowercaseString {
+    pub fn new(s: &str) -> LowercaseString {
+        LowercaseString {
+            inner: s.chars().map(to_lowercase).collect(),
+        }
+    }
+}
+
+impl Str for LowercaseString {
+    #[inline]
+    fn as_slice(&self) -> &str {
+        self.inner.as_slice()
+    }
+}

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -1,3 +1,4 @@
+== case-insensitive-font-family.html case-insensitive-font-family-ref.html
 != img_simple.html img_simple_ref.html
 == basic_width_px.html basic_width_em.html
 == br.html br-ref.html

--- a/tests/ref/case-insensitive-font-family-ref.html
+++ b/tests/ref/case-insensitive-font-family-ref.html
@@ -1,0 +1,1 @@
+<div style="font-family: Arial">Hello, world!</div>

--- a/tests/ref/case-insensitive-font-family.html
+++ b/tests/ref/case-insensitive-font-family.html
@@ -1,0 +1,1 @@
+<div style="font-family: arial">Hello, world!</div>


### PR DESCRIPTION
One part (of 8!) of css font family disambiguation is that font families should
be matched case-insensitively.

This patch implements that. Once it lands, a bug needs to be filed to do lowercasing
properly (as a string, instead of char-by-char -- it's a unicode thing).

r? @glennw 
