### PR TITLE
Support Back and forward button on mouses

### DIFF
--- a/ports/glfw/window.rs
+++ b/ports/glfw/window.rs
@@ -225,8 +225,18 @@ impl Window {
                 let hidpi = (backing_size as f32) / (window_size as f32);
                 let x = x as f32 * hidpi;
                 let y = y as f32 * hidpi;
-                if button == glfw::MouseButtonLeft || button == glfw::MouseButtonRight {
-                    self.handle_mouse(button, action, x as i32, y as i32);
+
+                match button {
+                    glfw::MouseButton5 => { // Back button (might be different per platform)
+                        self.event_queue.borrow_mut().push(NavigationWindowEvent(Back));
+                    },
+                    glfw::MouseButton6 => { // Forward
+                        self.event_queue.borrow_mut().push(NavigationWindowEvent(Forward));
+                    },
+                    glfw::MouseButtonLeft | glfw::MouseButtonRight => {
+                        self.handle_mouse(button, action, x as i32, y as i32);
+                    }
+                    _ => {}
                 }
             },
             glfw::CursorPosEvent(xpos, ypos) => {


### PR DESCRIPTION
I am not sure if this is the same key everywhere, but this works on Linux. Google didn't produce useful results for me.
