### PR TITLE
Defer to GetAttribute in HasAttribute.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -854,16 +854,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
 
     // http://dom.spec.whatwg.org/#dom-element-hasattribute
     fn HasAttribute(self, name: DOMString) -> bool {
-        // Step 1.
-        if self.html_element_in_html_document() {
-            // TODO(pcwalton): Small string optimization here.
-            return self.has_attribute(&Atom::from_slice(name.as_slice()
-                                                            .to_ascii_lower()
-                                                            .as_slice()))
-        }
-
-        // Step 2.
-        self.has_attribute(&Atom::from_slice(name.as_slice()))
+        self.GetAttribute(name).is_some()
     }
 
     // http://dom.spec.whatwg.org/#dom-element-hasattributens

--- a/tests/wpt/metadata/dom/nodes/attributes.html.ini
+++ b/tests/wpt/metadata/dom/nodes/attributes.html.ini
@@ -1,3 +1,53 @@
 [attributes.html]
   type: testharness
-  expected: CRASH
+  [setAttribute should not change the order of previously set attributes.]
+    expected: FAIL
+
+  [setAttribute should set the first attribute with the given name]
+    expected: FAIL
+
+  [setAttribute should set the attribute with the given qualified name]
+    expected: FAIL
+
+  [When qualifiedName does not match the QName production, an NAMESPACE_ERR exception is to be thrown.]
+    expected: FAIL
+
+  [null and the empty string should result in a null namespace.]
+    expected: FAIL
+
+  [XML-namespaced attributes don\'t need an xml prefix]
+    expected: FAIL
+
+  [xmlns should be allowed as local name]
+    expected: FAIL
+
+  [xmlns should be allowed as prefix in the XMLNS namespace]
+    expected: FAIL
+
+  [xmlns should be allowed as qualified name in the XMLNS namespace]
+    expected: FAIL
+
+  [Setting the same attribute with another prefix should not change the prefix]
+    expected: FAIL
+
+  [Attributes should work in document fragments.]
+    expected: FAIL
+
+  [Attribute values should not be parsed.]
+    expected: FAIL
+
+  [Specified attributes should be accessible.]
+    expected: FAIL
+
+  [Entities in attributes should have been expanded while parsing.]
+    expected: FAIL
+
+  [First set attribute is returned by getAttribute]
+    expected: FAIL
+
+  [First set attribute is returned with mapped attribute set later]
+    expected: FAIL
+
+  [Attribute with prefix in local name]
+    expected: FAIL
+


### PR DESCRIPTION
The semantics of has_attribute aren't anywhere close to the ones expected for
Element#hasAttribute, and it fails an assertion when passed non-lower-case
names.
