### PR TITLE
Pass the correct argument to Element::create when cloning.

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1516,7 +1516,7 @@ impl Node {
                     local: element.local_name().clone()
                 };
                 let element = Element::create(name,
-                    Some(element.prefix().as_slice().to_string()), *document, ScriptCreated);
+                    element.prefix().as_ref().map(|p| p.as_slice().to_string()), *document, ScriptCreated);
                 NodeCast::from_temporary(element)
             },
             TextNodeTypeId => {

--- a/tests/wpt/metadata/dom/nodes/Element-tagName.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-tagName.html.ini
@@ -3,9 +3,3 @@
   [tagName should be updated when changing ownerDocument]
     expected: FAIL
 
-  [tagName should be updated when changing ownerDocument (createDocument without prefix)]
-    expected: FAIL
-
-  [tagName should be updated when changing ownerDocument (createDocument with prefix)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/nodes/Node-cloneNode.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-cloneNode.html.ini
@@ -1,11 +1,5 @@
 [Node-cloneNode.html]
   type: testharness
-  [Unprefixed HTML element]
-    expected: FAIL
-
-  [Prefixed HTML element]
-    expected: FAIL
-
   [Prefixed non-HTML element]
     expected: FAIL
 


### PR DESCRIPTION
The current code calls as_slice() on the Option, yielding &[DOMString], and
then calls to_string, yielding "[prefix]".
