### PR TITLE
Add serve-docs command to mach

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -1,7 +1,11 @@
 from __future__ import print_function, unicode_literals
 
 import os.path as path
+from os import chdir
 import subprocess
+import SimpleHTTPServer
+import SocketServer
+from shutil import copytree, rmtree, ignore_patterns
 
 from mach.decorators import (
     CommandArgument,
@@ -36,3 +40,29 @@ class MachCommands(CommandBase):
         self.ensure_bootstrapped()
         return subprocess.call(["cargo", "doc"] + params,
                                env=self.build_env())
+
+    @Command('serve-docs',
+             description='Locally serve Servo and Rust documentation',
+             category='post-build',
+             allow_all_args=True)
+    @CommandArgument(
+        'port', default=8888, nargs='?', type=int, metavar='PORT',
+        help="Port to serve documentation at (default is 8888)")
+    def serve_docs(self, port):
+        self.doc([])
+        servedir = path.join("target", "serve-docs")
+        docdir = path.join("target", "doc")
+
+        rmtree(servedir, True)
+        copytree(docdir, servedir, ignore=ignore_patterns('.*'))
+
+        rustdocs = path.join("rust", self.rust_snapshot_path(), "doc")
+        copytree(rustdocs, path.join(servedir, "rust"), ignore=ignore_patterns('.*'))
+
+        chdir(servedir)
+        Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+
+        httpd = SocketServer.TCPServer(("", port), Handler)
+
+        print("serving at port", port)
+        httpd.serve_forever()


### PR DESCRIPTION
This enables the user to run `./mach serve-docs` (with an optional port
number), starting a local web server that hosts the documentation for
Servo and Rust.

This closes #3807
