### PR TITLE
Remove the glob import from the HTML parser.

### DIFF
--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -6,13 +6,16 @@ use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLScriptElementCast};
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable, Root};
+use dom::comment::Comment;
 use dom::document::{Document, DocumentHelpers};
+use dom::documenttype::DocumentType;
 use dom::element::{Element, AttributeHandlers, ElementHelpers, ParserCreated};
+use dom::htmlscriptelement::HTMLScriptElement;
 use dom::htmlscriptelement::HTMLScriptElementHelpers;
 use dom::node::{Node, NodeHelpers, TrustedNodeAddress};
 use dom::servohtmlparser;
 use dom::servohtmlparser::ServoHTMLParser;
-use dom::types::*;
+use dom::text::Text;
 use page::Page;
 use parse::Parser;
 


### PR DESCRIPTION
Glob imports are frowned upon, and after the removal of
build_element_for_tag, only a few types are actually used.
