### PR TITLE
Build fixes for Android windowing code

### DIFF
--- a/ports/android/glut_app/lib.rs
+++ b/ports/android/glut_app/lib.rs
@@ -56,8 +56,10 @@ pub extern "C" fn android_start(argc: int, argv: *const *const u8) -> int {
         }
 
         if opts::from_cmdline_args(args.as_slice()) {
-            let window = Some(create_window());
-            servo::run(window);
+            let window = create_window();
+            let mut browser = servo::Browser::new(Some(window.clone()));
+            while browser.handle_event(window.wait_events()) {}
+            browser.shutdown();
         }
     })
 }


### PR DESCRIPTION
This begins porting the Android event loop to work with the inverted flow control from #3761.  Unfortunately, GLUT does not give us enough control over the event loop to really make this work, so this will build but it may not run properly.  Our current plan is to get rid of GLUT and switch to Glutin in the near future.

r? @pcwalton
