### PR TITLE
Close #84

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -60,9 +60,6 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
 
                 // inform the image cache to load this, but don't store a
                 // handle.
-                //
-                // TODO (Issue #84): don't prefetch if we are within a
-                // <noscript> tag.
                 image_cache.send(image_cache_task::Prefetch(img_url));
             }
         }

--- a/tests/content/test_document_images_cache.html
+++ b/tests/content/test_document_images_cache.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="harness.js"></script>
+      </head>
+      <body>
+
+        <img src="test.png">
+
+        <noscript>
+            <img src="test.jpg">
+        </noscript>
+
+        <script>
+            var images = document.images;
+            is(images, document.images);
+            is(images.length, 1);
+
+            var image = document.createElement("img");
+            image.setAttribute("src", "test.jpg");
+            document.body.appendChild(image);
+            is(images.length, 2);
+
+            document.body.removeChild(image);
+            is(images.length, 1);
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Actually `<img>` elements in `<noscript>` are not prefetched anymore.

Probably because html5ever already parses the `<noscript>` content as raw
text data if `scripting_enabled` is activated.

See https://github.com/servo/html5ever/blob/servo/src/tree_builder/rules.rs#L126

Also, added a test to the images cache.
