### PR TITLE
gfx: Implement most of `box-shadow` per CSS-BACKGROUNDS.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -29,7 +29,7 @@ use script_traits::UntrustedNodeAddress;
 use servo_msg::compositor_msg::LayerId;
 use servo_net::image::base::Image;
 use servo_util::dlist as servo_dlist;
-use servo_util::geometry::{mod, Au};
+use servo_util::geometry::{mod, Au, ZERO_POINT};
 use servo_util::range::Range;
 use servo_util::smallvec::{SmallVec, SmallVec8};
 use std::fmt;
@@ -171,7 +171,7 @@ impl StackingContext {
             display_list: display_list,
             layer: layer,
             bounds: bounds,
-            clip_rect: bounds,
+            clip_rect: Rect(ZERO_POINT, bounds.size),
             z_index: z_index,
             opacity: opacity,
         }
@@ -182,7 +182,7 @@ impl StackingContext {
                                           paint_context: &mut PaintContext,
                                           tile_bounds: &Rect<AzFloat>,
                                           transform: &Matrix2D<AzFloat>,
-                                          clip_rect: Option<&Rect<Au>>) {
+                                          clip_rect: Option<Rect<Au>>) {
         let temporary_draw_target =
             paint_context.get_or_create_temporary_draw_target(self.opacity);
         {
@@ -191,6 +191,7 @@ impl StackingContext {
                 font_ctx: &mut *paint_context.font_ctx,
                 page_rect: paint_context.page_rect,
                 screen_rect: paint_context.screen_rect,
+                clip_rect: clip_rect,
                 transient_clip_rect: None,
             };
 
@@ -207,12 +208,9 @@ impl StackingContext {
                                .sort_by(|this, other| this.z_index.cmp(&other.z_index));
 
             // Set up our clip rect and transform.
-            match clip_rect {
-                None => {}
-                Some(clip_rect) => paint_subcontext.draw_push_clip(clip_rect),
-            }
             let old_transform = paint_subcontext.draw_target.get_transform();
             paint_subcontext.draw_target.set_transform(transform);
+            paint_subcontext.push_clip_if_applicable();
 
             // Steps 1 and 2: Borders and background for the root.
             for display_item in display_list.background_and_borders.iter() {
@@ -240,7 +238,7 @@ impl StackingContext {
                     positioned_kid.optimize_and_draw_into_context(&mut paint_subcontext,
                                                                   &new_tile_rect,
                                                                   &new_transform,
-                                                                  Some(&positioned_kid.clip_rect))
+                                                                  Some(positioned_kid.clip_rect))
                 }
             }
 
@@ -283,21 +281,16 @@ impl StackingContext {
                     positioned_kid.optimize_and_draw_into_context(&mut paint_subcontext,
                                                                   &new_tile_rect,
                                                                   &new_transform,
-                                                                  Some(&positioned_kid.clip_rect))
+                                                                  Some(positioned_kid.clip_rect))
                 }
             }
 
             // TODO(pcwalton): Step 10: Outlines.
 
             // Undo our clipping and transform.
-            if paint_subcontext.transient_clip_rect.is_some() {
-                paint_subcontext.draw_pop_clip();
-                paint_subcontext.transient_clip_rect = None
-            }
-            paint_subcontext.draw_target.set_transform(&old_transform);
-            if clip_rect.is_some() {
-                paint_subcontext.draw_pop_clip()
-            }
+            paint_subcontext.remove_transient_clip_if_applicable();
+            paint_subcontext.pop_clip_if_applicable();
+            paint_subcontext.draw_target.set_transform(&old_transform)
         }
 
         paint_context.draw_temporary_draw_target_if_necessary(&temporary_draw_target, self.opacity)
@@ -672,13 +665,12 @@ impl DisplayItem {
             }
 
             BoxShadowDisplayItemClass(ref box_shadow) => {
-                render_context.draw_box_shadow(&box_shadow.base.bounds,
-                                               &box_shadow.box_bounds,
-                                               &box_shadow.offset,
-                                               box_shadow.color,
-                                               box_shadow.blur_radius,
-                                               box_shadow.spread_radius,
-                                               box_shadow.inset)
+                paint_context.draw_box_shadow(&box_shadow.box_bounds,
+                                              &box_shadow.offset,
+                                              box_shadow.color,
+                                              box_shadow.blur_radius,
+                                              box_shadow.spread_radius,
+                                              box_shadow.inset)
             }
 
             PseudoDisplayItemClass(_) => {}

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -587,6 +587,9 @@ pub struct BoxShadowDisplayItem {
 
     /// The spread radius of this shadow.
     pub spread_radius: Au,
+
+    /// True if this shadow is inset; false if it's outset.
+    pub inset: bool,
 }
 
 pub enum DisplayItemIterator<'a> {
@@ -674,7 +677,8 @@ impl DisplayItem {
                                                &box_shadow.offset,
                                                box_shadow.color,
                                                box_shadow.blur_radius,
-                                               box_shadow.spread_radius)
+                                               box_shadow.spread_radius,
+                                               box_shadow.inset)
             }
 
             PseudoDisplayItemClass(_) => {}

--- a/components/gfx/display_list/optimizer.rs
+++ b/components/gfx/display_list/optimizer.rs
@@ -58,8 +58,7 @@ impl DisplayListOptimizer {
                                              mut stacking_contexts: I)
                                              where I: Iterator<&'a Arc<StackingContext>> {
         for stacking_context in stacking_contexts {
-            if self.visible_rect.intersects(&stacking_context.bounds) &&
-                    self.visible_rect.intersects(&stacking_context.clip_rect) {
+            if self.visible_rect.intersects(&stacking_context.bounds) {
                 result_list.push_back((*stacking_context).clone())
             }
         }

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -46,7 +46,11 @@ pub struct PaintContext<'a> {
     /// rect used by the last display item. We cache the last value so that we avoid pushing and
     /// popping clip rects unnecessarily.
     pub transient_clip_rect: Option<Rect<Au>>,
-    /// The scale factor.
+    /// The factor by which this tile is zoomed in. Typically pinch zooming is the reason why this
+    /// will have a value other than 1.0.
+    ///
+    /// Unlike much of the rest of the graphics code, typed units aren't useful for this value
+    /// because it's only used in conjunction with the Azure API, which doesn't use typed units.
     pub scale: AzFloat,
 }
 

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -510,6 +510,7 @@ impl WorkerThread {
                 page_rect: tile.page_rect,
                 screen_rect: tile.screen_rect,
                 transient_clip_rect: None,
+                scale: scale,
             };
 
             // Apply the translation to paint the tile we want.

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -509,8 +509,8 @@ impl WorkerThread {
                 font_ctx: &mut self.font_context,
                 page_rect: tile.page_rect,
                 screen_rect: tile.screen_rect,
+                clip_rect: None,
                 transient_clip_rect: None,
-                scale: scale,
             };
 
             // Apply the translation to paint the tile we want.

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -24,15 +24,15 @@ use util::{OpaqueNodeMethods, ToGfxColor};
 use geom::approxeq::ApproxEq;
 use geom::{Point2D, Rect, Size2D, SideOffsets2D};
 use gfx::color;
-use gfx::display_list::{BOX_SHADOW_INFLATION_FACTOR, BackgroundAndBorderLevel, BaseDisplayItem};
-use gfx::display_list::{BorderDisplayItem, BorderDisplayItemClass, BoxShadowDisplayItem};
-use gfx::display_list::{BoxShadowDisplayItemClass, ContentStackingLevel, DisplayList};
-use gfx::display_list::{FloatStackingLevel, GradientDisplayItem, GradientDisplayItemClass};
+use gfx::display_list::{BOX_SHADOW_INFLATION_FACTOR, BaseDisplayItem, BorderDisplayItem};
+use gfx::display_list::{BorderDisplayItemClass, BorderRadii, BoxShadowDisplayItem};
+use gfx::display_list::{BoxShadowDisplayItemClass, DisplayItem, DisplayList};
+use gfx::display_list::{GradientDisplayItem, GradientDisplayItemClass};
 use gfx::display_list::{GradientStop, ImageDisplayItem, ImageDisplayItemClass, LineDisplayItem};
-use gfx::display_list::{LineDisplayItemClass, PositionedDescendantStackingLevel};
-use gfx::display_list::{PseudoDisplayItemClass, RootOfStackingContextLevel, SidewaysLeft};
+use gfx::display_list::{LineDisplayItemClass};
+use gfx::display_list::{PseudoDisplayItemClass, SidewaysLeft};
 use gfx::display_list::{SidewaysRight, SolidColorDisplayItem, SolidColorDisplayItemClass};
-use gfx::display_list::{StackingLevel, TextDisplayItem, TextDisplayItemClass, Upright};
+use gfx::display_list::{StackingContext, TextDisplayItem, TextDisplayItemClass, Upright};
 use gfx::paint_task::PaintLayer;
 use servo_msg::compositor_msg::{FixedPosition, Scrollable};
 use servo_msg::constellation_msg::{ConstellationChan, FrameRectMsg};
@@ -435,14 +435,14 @@ impl FragmentDisplayListBuilding for Fragment {
                 absolute_bounds.translate(&Point2D(box_shadow.offset_x, box_shadow.offset_y))
                                .inflate(inflation, inflation);
             list.push(BoxShadowDisplayItemClass(box BoxShadowDisplayItem {
-                base: BaseDisplayItem::new(bounds, self.node, level, *clip_rect),
+                base: BaseDisplayItem::new(bounds, self.node, *clip_rect),
                 box_bounds: *absolute_bounds,
                 color: style.resolve_color(box_shadow.color).to_gfx_color(),
                 offset: Point2D(box_shadow.offset_x, box_shadow.offset_y),
                 blur_radius: box_shadow.blur_radius,
                 spread_radius: box_shadow.spread_radius,
                 inset: box_shadow.inset,
-            }));
+            }), level);
         }
     }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -441,6 +441,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 offset: Point2D(box_shadow.offset_x, box_shadow.offset_y),
                 blur_radius: box_shadow.blur_radius,
                 spread_radius: box_shadow.spread_radius,
+                inset: box_shadow.inset,
             }));
         }
     }

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -24,12 +24,15 @@ use util::{OpaqueNodeMethods, ToGfxColor};
 use geom::approxeq::ApproxEq;
 use geom::{Point2D, Rect, Size2D, SideOffsets2D};
 use gfx::color;
-use gfx::display_list::{BaseDisplayItem, BorderDisplayItem, BorderDisplayItemClass, DisplayItem};
-use gfx::display_list::{DisplayList, GradientDisplayItem, GradientDisplayItemClass, GradientStop};
-use gfx::display_list::{ImageDisplayItem, ImageDisplayItemClass, LineDisplayItem, BorderRadii};
-use gfx::display_list::{LineDisplayItemClass, PseudoDisplayItemClass, SidewaysLeft, SidewaysRight};
-use gfx::display_list::{SolidColorDisplayItem, SolidColorDisplayItemClass, StackingContext};
-use gfx::display_list::{TextDisplayItem, TextDisplayItemClass, Upright};
+use gfx::display_list::{BOX_SHADOW_INFLATION_FACTOR, BackgroundAndBorderLevel, BaseDisplayItem};
+use gfx::display_list::{BorderDisplayItem, BorderDisplayItemClass, BoxShadowDisplayItem};
+use gfx::display_list::{BoxShadowDisplayItemClass, ContentStackingLevel, DisplayList};
+use gfx::display_list::{FloatStackingLevel, GradientDisplayItem, GradientDisplayItemClass};
+use gfx::display_list::{GradientStop, ImageDisplayItem, ImageDisplayItemClass, LineDisplayItem};
+use gfx::display_list::{LineDisplayItemClass, PositionedDescendantStackingLevel};
+use gfx::display_list::{PseudoDisplayItemClass, RootOfStackingContextLevel, SidewaysLeft};
+use gfx::display_list::{SidewaysRight, SolidColorDisplayItem, SolidColorDisplayItemClass};
+use gfx::display_list::{StackingLevel, TextDisplayItem, TextDisplayItemClass, Upright};
 use gfx::paint_task::PaintLayer;
 use servo_msg::compositor_msg::{FixedPosition, Scrollable};
 use servo_msg::constellation_msg::{ConstellationChan, FrameRectMsg};
@@ -111,6 +114,16 @@ pub trait FragmentDisplayListBuilding {
                                                     abs_bounds: &Rect<Au>,
                                                     level: StackingLevel,
                                                     clip_rect: &Rect<Au>);
+
+    /// Adds the display items necessary to paint the box shadow of this fragment to the display
+    /// list if necessary.
+    fn build_display_list_for_box_shadow_if_applicable(&self,
+                                                       style: &ComputedValues,
+                                                       list: &mut DisplayList,
+                                                       layout_context: &LayoutContext,
+                                                       level: StackingLevel,
+                                                       absolute_bounds: &Rect<Au>,
+                                                       clip_rect: &Rect<Au>);
 
     fn build_debug_borders_around_text_fragments(&self,
                                                  display_list: &mut DisplayList,
@@ -407,6 +420,31 @@ impl FragmentDisplayListBuilding for Fragment {
         display_list.push(gradient_display_item, level)
     }
 
+    fn build_display_list_for_box_shadow_if_applicable(&self,
+                                                       style: &ComputedValues,
+                                                       list: &mut DisplayList,
+                                                       _layout_context: &LayoutContext,
+                                                       level: StackingLevel,
+                                                       absolute_bounds: &Rect<Au>,
+                                                       clip_rect: &Rect<Au>) {
+        // NB: According to CSS-BACKGROUNDS, box shadows render in *reverse* order (front to back).
+        for box_shadow in style.get_effects().box_shadow.iter().rev() {
+            let inflation = (box_shadow.spread_radius + box_shadow.blur_radius) *
+                BOX_SHADOW_INFLATION_FACTOR;
+            let bounds =
+                absolute_bounds.translate(&Point2D(box_shadow.offset_x, box_shadow.offset_y))
+                               .inflate(inflation, inflation);
+            list.push(BoxShadowDisplayItemClass(box BoxShadowDisplayItem {
+                base: BaseDisplayItem::new(bounds, self.node, level, *clip_rect),
+                box_bounds: *absolute_bounds,
+                color: style.resolve_color(box_shadow.color).to_gfx_color(),
+                offset: Point2D(box_shadow.offset_x, box_shadow.offset_y),
+                blur_radius: box_shadow.blur_radius,
+                spread_radius: box_shadow.spread_radius,
+            }));
+        }
+    }
+
     fn build_display_list_for_borders_if_applicable(&self,
                                                     style: &ComputedValues,
                                                     display_list: &mut DisplayList,
@@ -555,6 +593,34 @@ impl FragmentDisplayListBuilding for Fragment {
                                                              self.node,
                                                              *clip_rect);
             display_list.push(PseudoDisplayItemClass(base_display_item), level);
+
+            // Add a shadow to the list, if applicable.
+            match self.inline_context {
+                Some(ref inline_context) => {
+                    for style in inline_context.styles.iter().rev() {
+                        self.build_display_list_for_box_shadow_if_applicable(
+                            &**style,
+                            display_list,
+                            layout_context,
+                            level,
+                            &absolute_fragment_bounds,
+                            clip_rect);
+                    }
+                }
+                None => {}
+            }
+            match self.specific {
+                ScannedTextFragment(_) => {},
+                _ => {
+                    self.build_display_list_for_box_shadow_if_applicable(
+                        &*self.style,
+                        display_list,
+                        layout_context,
+                        level,
+                        &absolute_fragment_bounds,
+                        clip_rect);
+                }
+            }
 
             // Add the background to the list, if applicable.
             match self.inline_context {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -193,3 +193,5 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == box_shadow_default_color_a.html box_shadow_default_color_ref.html
 == box_shadow_paint_order_a.html box_shadow_paint_order_ref.html
 == box_shadow_spread_a.html box_shadow_spread_ref.html
+== box_shadow_inset_a.html box_shadow_inset_ref.html
+== box_shadow_inset_parsing_a.html box_shadow_inset_parsing_ref.html

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -187,3 +187,9 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == incremental_float_a.html incremental_float_ref.html
 == opacity_simple_a.html opacity_simple_ref.html
 == opacity_stacking_context_a.html opacity_stacking_context_ref.html
+== table_specified_width_a.html table_specified_width_ref.html
+!= box_shadow_blur_a.html box_shadow_blur_ref.html
+== box_shadow_border_box_a.html box_shadow_border_box_ref.html
+== box_shadow_default_color_a.html box_shadow_default_color_ref.html
+== box_shadow_paint_order_a.html box_shadow_paint_order_ref.html
+== box_shadow_spread_a.html box_shadow_spread_ref.html

--- a/tests/ref/box_shadow_blur_a.html
+++ b/tests/ref/box_shadow_blur_a.html
@@ -8,7 +8,7 @@ section {
     top: 100px;
     left: 100px;
     border: solid black 1px;
-    box-shadow: 10px 10px 5px;
+    box-shadow: 10px 10px 5px 0px;
 }
 </style>
 </head>

--- a/tests/ref/box_shadow_blur_a.html
+++ b/tests/ref/box_shadow_blur_a.html
@@ -1,0 +1,18 @@
+<head>
+<!-- Tests that box-shadow blur does something. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border: solid black 1px;
+    box-shadow: 10px 10px 5px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_blur_ref.html
+++ b/tests/ref/box_shadow_blur_ref.html
@@ -1,0 +1,18 @@
+<head>
+<!-- Tests that box-shadow blur does something. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border: solid black 1px;
+    box-shadow: 10px 10px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_border_box_a.html
+++ b/tests/ref/box_shadow_border_box_a.html
@@ -9,7 +9,7 @@ section {
     left: 100px;
     border-left: solid green 10px;
     border-right: solid green 10px;
-    box-shadow: 10px 10px;
+    box-shadow: 20px 10px;
 }
 </style>
 </head>

--- a/tests/ref/box_shadow_border_box_a.html
+++ b/tests/ref/box_shadow_border_box_a.html
@@ -1,0 +1,19 @@
+<head>
+<!-- Tests that the entire border-box is shadowed, not just the content box. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border-left: solid green 10px;
+    border-right: solid green 10px;
+    box-shadow: 10px 10px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_border_box_ref.html
+++ b/tests/ref/box_shadow_border_box_ref.html
@@ -1,0 +1,30 @@
+<head>
+<!-- Tests that the entire border-box is shadowed, not just the content box. -->
+<style>
+section {
+    position: absolute;
+}
+#a {
+    width: 120px;
+    height: 100px;
+    top: 110px;
+    left: 110px;
+    background: black;
+}
+#b {
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border-left: solid green 10px;
+    border-right: solid green 10px;
+    background: white;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+</body>
+
+

--- a/tests/ref/box_shadow_border_box_ref.html
+++ b/tests/ref/box_shadow_border_box_ref.html
@@ -8,7 +8,7 @@ section {
     width: 120px;
     height: 100px;
     top: 110px;
-    left: 110px;
+    left: 120px;
     background: black;
 }
 #b {

--- a/tests/ref/box_shadow_default_color_a.html
+++ b/tests/ref/box_shadow_default_color_a.html
@@ -1,0 +1,19 @@
+<head>
+<!-- Tests that box-shadow blur does something. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border: solid black 1px;
+    color: blue;
+    box-shadow: 10px 10px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_default_color_a.html
+++ b/tests/ref/box_shadow_default_color_a.html
@@ -1,5 +1,5 @@
 <head>
-<!-- Tests that box-shadow blur does something. -->
+<!-- Tests that the box-shadow color is correct if unspecified. -->
 <style>
 section {
     position: absolute;
@@ -9,7 +9,7 @@ section {
     left: 100px;
     border: solid black 1px;
     color: blue;
-    box-shadow: 10px 10px;
+    box-shadow: 30px 10px;
 }
 </style>
 </head>

--- a/tests/ref/box_shadow_default_color_ref.html
+++ b/tests/ref/box_shadow_default_color_ref.html
@@ -1,5 +1,5 @@
 <head>
-<!-- Tests that box-shadow blur does something. -->
+<!-- Tests that the box-shadow color is correct if unspecified. -->
 <style>
 section {
     position: absolute;
@@ -8,7 +8,7 @@ section {
     top: 100px;
     left: 100px;
     border: solid black 1px;
-    box-shadow: 10px 10px blue;
+    box-shadow: 30px 10px blue;
 }
 </style>
 </head>

--- a/tests/ref/box_shadow_default_color_ref.html
+++ b/tests/ref/box_shadow_default_color_ref.html
@@ -1,0 +1,18 @@
+<head>
+<!-- Tests that box-shadow blur does something. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border: solid black 1px;
+    box-shadow: 10px 10px blue;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_inset_a.html
+++ b/tests/ref/box_shadow_inset_a.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<!-- Tests that box-shadow inset works. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    box-shadow: inset 50px 10px gold;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_inset_parsing_a.html
+++ b/tests/ref/box_shadow_inset_parsing_a.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<head>
+<!-- Tests that box-shadow inset parsing quirks work properly. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border: solid black 1px;
+    box-shadow: inset 0 0 1em gold;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+
+

--- a/tests/ref/box_shadow_inset_parsing_ref.html
+++ b/tests/ref/box_shadow_inset_parsing_ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<head>
+<!-- Tests that box-shadow inset parsing quirks work properly. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    border: solid black 1px;
+    box-shadow: 0 0 1em gold inset;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+
+
+

--- a/tests/ref/box_shadow_inset_ref.html
+++ b/tests/ref/box_shadow_inset_ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<head>
+<!-- Tests that box-shadow inset works. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    background: gold;
+}
+nav {
+    display: block;
+    position: absolute;
+    width: 50px;
+    height: 90px;
+    background: white;
+    left: 50px;
+    top: 10px;
+}
+</style>
+</head>
+<body>
+<section><nav></nav></section>
+</body>
+
+

--- a/tests/ref/box_shadow_paint_order_a.html
+++ b/tests/ref/box_shadow_paint_order_a.html
@@ -1,0 +1,16 @@
+<head>
+<!-- Tests paint order of multiple box shadows. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    box-shadow: -25px -25px purple, -50px -50px turquoise;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>

--- a/tests/ref/box_shadow_paint_order_ref.html
+++ b/tests/ref/box_shadow_paint_order_ref.html
@@ -1,0 +1,30 @@
+<head>
+<!-- Tests paint order of multiple box shadows. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+#a {
+    top: 50px;
+    left: 50px;
+    background: turquoise;
+}
+#b {
+    top: 75px;
+    left: 75px;
+    background: purple;
+}
+#c {
+    top: 100px;
+    left: 100px;
+    background: white;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+<section id=c></section>
+</body>

--- a/tests/ref/box_shadow_spread_a.html
+++ b/tests/ref/box_shadow_spread_a.html
@@ -1,0 +1,17 @@
+<head>
+<!-- Tests that spread works. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 100px;
+    left: 100px;
+    box-shadow: 0 0 0 25px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+

--- a/tests/ref/box_shadow_spread_ref.html
+++ b/tests/ref/box_shadow_spread_ref.html
@@ -1,0 +1,18 @@
+<head>
+<!-- Tests that spread works. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 75px;
+    left: 75px;
+    border: solid black 25px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+
+


### PR DESCRIPTION
All features of the `box-shadow` property are supported, including
spread and multiple shadows, with the exception of `inset`. However,
spread currently looks ugly when combined with blur. This is the result
of a present limitation in the Azure API that will necessitate
modifications to Azure. Because that will involve modifying all Azure
backends, I have left that work to a followup.

Note that this needs this PR in `rust-azure` to land first: https://github.com/servo/rust-azure/pull/112

r? @SimonSapin 
