### PR TITLE
Remove VoidVal.

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4539,7 +4539,6 @@ class CGBindingRoot(CGThing):
             'dom::bindings::utils::{Reflectable}',
             'dom::bindings::utils::{squirrel_away_unique}',
             'dom::bindings::utils::{ThrowingConstructor,  unwrap, unwrap_jsmanaged}',
-            'dom::bindings::utils::VoidVal',
             'dom::bindings::utils::get_dictionary_property',
             'dom::bindings::utils::{NativeProperties, NativePropertyHooks}',
             'dom::bindings::trace::JSTraceable',

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -198,8 +198,6 @@ pub enum ConstantVal {
     BoolVal(bool),
     /// `null` constant.
     NullVal,
-    /// `undefined` constant.
-    VoidVal
 }
 
 /// Representation of an IDL constant.
@@ -220,7 +218,6 @@ impl ConstantSpec {
             UintVal(u) => UInt32Value(u),
             DoubleVal(d) => DoubleValue(d),
             BoolVal(b) => BooleanValue(b),
-            VoidVal => UndefinedValue(),
         }
     }
 }


### PR DESCRIPTION
There are no undefined constants in IDL.
