### PR TITLE
Move code related to json packet reading to JsonPacketSender trait

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -7,7 +7,7 @@
 /// inspection, JS evaluation, autocompletion) in Servo.
 
 use actor::{Actor, ActorRegistry};
-use protocol::JsonPacketSender;
+use protocol::JsonPacketStream;
 
 use devtools_traits::{EvaluateJS, NullValue, VoidValue, NumberValue, StringValue, BooleanValue};
 use devtools_traits::{ActorValue, DevtoolScriptControlMsg};

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -8,7 +8,7 @@ use devtools_traits::{GetRootNode, GetDocumentElement, GetChildren, DevtoolScrip
 use devtools_traits::{GetLayout, NodeInfo};
 
 use actor::{Actor, ActorRegistry};
-use protocol::JsonPacketSender;
+use protocol::JsonPacketStream;
 
 use collections::TreeMap;
 use servo_msg::constellation_msg::PipelineId;

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -8,7 +8,7 @@
 
 use actor::{Actor, ActorRegistry};
 use actors::tab::{TabActor, TabActorMsg};
-use protocol::JsonPacketSender;
+use protocol::JsonPacketStream;
 
 use serialize::json;
 use std::io::TcpStream;

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -7,7 +7,7 @@
 /// Supports dynamic attaching and detaching which control notifications of navigation, etc.
 
 use actor::{Actor, ActorRegistry};
-use protocol::JsonPacketSender;
+use protocol::JsonPacketStream;
 
 use serialize::json;
 use std::io::TcpStream;


### PR DESCRIPTION
I was messing around devtools code and saw some TODOs, is anyone working on it? I took one of them:

`// TODO: this really belongs in the protocol module.`

I would be glad to help with this if no one is on it already, just let me know.
