### PR TITLE
Use freetype-sys on Linux.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#612ffc4fbf80c1bd5faae4b86dfc539dda06fb0c"
+source = "git+https://github.com/servo/rust-azure#64853170e435d9320f3fd828b9e7d16bc4c260a3"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -203,7 +203,7 @@ source = "git+https://github.com/servo/rust-freetype#e55b06110fb2d74a2db68ead740
 [[package]]
 name = "freetype-sys"
 version = "2.4.11"
-source = "git+https://github.com/servo/libfreetype2#5b6499164106f094937565595c7b96d07de55521"
+source = "git+https://github.com/servo/libfreetype2#03522d7401669f220ad3fca5aa887577b0cf314e"
 
 [[package]]
 name = "geom"
@@ -532,7 +532,7 @@ source = "git+https://github.com/rust-lang/semver#7dca047a9cd40e929a4545b37a1917
 [[package]]
 name = "skia-sys"
 version = "0.0.20130412"
-source = "git+https://github.com/servo/skia#d92603043a9b7dd0b25c0b3b562099a0cc32ac6c"
+source = "git+https://github.com/servo/skia#63e40419e2570646a8d83fefb8914d6e1b786cfb"
 dependencies = [
  "expat-sys 2.1.0 (git+https://github.com/servo/libexpat)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ On Debian-based Linuxes:
 sudo apt-get install curl freeglut3-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     msttcorefonts gperf g++ cmake python-virtualenv \
-    libssl-dev libglfw-dev
+    libssl-dev libglfw-dev libbz2-dev
 ```
 
 On Fedora:
@@ -41,7 +41,7 @@ On Fedora:
 sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
-    rpm-build openssl-devel glfw-devel cmake
+    rpm-build openssl-devel glfw-devel cmake bzip2
 pushd .
 cd /tmp
 wget http://corefonts.sourceforge.net/msttcorefonts-2.5-1.spec
@@ -53,7 +53,7 @@ popd
 On Arch Linux:
 
 ``` sh
-sudo pacman -S base-devel git python2 python2-virtualenv mesa glfw ttf-font cmake
+sudo pacman -S base-devel git python2 python2-virtualenv mesa glfw ttf-font cmake bzip2
 ```
 
 Cross-compilation for Android:


### PR DESCRIPTION
See:
https://github.com/servo/libfreetype2/pull/2
https://github.com/servo/skia/pull/38
https://github.com/servo/rust-azure/pull/114

Let’s close #3867, even though this only works around and doesn’t fix the underlying issue.

r? @larsbergstrom 
