### PR TITLE
gfx: Rewrite display list construction to make stacking-contexts more first-class.

### DIFF
--- a/components/gfx/display_list/optimizer.rs
+++ b/components/gfx/display_list/optimizer.rs
@@ -2,52 +2,66 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use display_list::{DisplayItem, DisplayList};
+//! Transforms a display list to produce a visually-equivalent, but cheaper-to-render, one.
+
+use display_list::{DisplayItem, DisplayList, StackingContext};
 
 use collections::dlist::DList;
 use geom::rect::Rect;
-use servo_util::geometry::Au;
+use servo_util::geometry::{mod, Au};
 use sync::Arc;
 
+/// Transforms a display list to produce a visually-equivalent, but cheaper-to-render, one.
 pub struct DisplayListOptimizer {
-    display_list: Arc<DisplayList>,
     /// The visible rect in page coordinates.
     visible_rect: Rect<Au>,
 }
 
 impl DisplayListOptimizer {
-    /// `visible_rect` specifies the visible rect in page coordinates.
-    pub fn new(display_list: Arc<DisplayList>, visible_rect: Rect<Au>) -> DisplayListOptimizer {
+    /// Creates a new display list optimizer object. `visible_rect` specifies the visible rect in
+    /// page coordinates.
+    pub fn new(visible_rect: &Rect<f32>) -> DisplayListOptimizer {
         DisplayListOptimizer {
-            display_list: display_list,
-            visible_rect: visible_rect,
+            visible_rect: geometry::f32_rect_to_au_rect(*visible_rect),
         }
     }
 
-    pub fn optimize(self) -> DisplayList {
-        self.process_display_list(&*self.display_list)
+    /// Optimizes the given display list, returning an equivalent, but cheaper-to-paint, one.
+    pub fn optimize(self, display_list: &DisplayList) -> DisplayList {
+        let mut result = DisplayList::new();
+        self.add_in_bounds_display_items(&mut result.background_and_borders,
+                                         display_list.background_and_borders.iter());
+        self.add_in_bounds_display_items(&mut result.block_backgrounds_and_borders,
+                                         display_list.block_backgrounds_and_borders.iter());
+        self.add_in_bounds_display_items(&mut result.floats, display_list.floats.iter());
+        self.add_in_bounds_display_items(&mut result.content, display_list.content.iter());
+        self.add_in_bounds_stacking_contexts(&mut result.children, display_list.children.iter());
+        result
     }
 
-    fn process_display_list(&self, display_list: &DisplayList) -> DisplayList {
-        let mut result = DList::new();
-        for item in display_list.iter() {
-            match self.process_display_item(item) {
-                None => {}
-                Some(display_item) => result.push_back(display_item),
+    /// Adds display items that intersect the visible rect to `result_list`.
+    fn add_in_bounds_display_items<'a,I>(&self,
+                                         result_list: &mut DList<DisplayItem>,
+                                         mut display_items: I)
+                                         where I: Iterator<&'a DisplayItem> {
+        for display_item in display_items {
+            if self.visible_rect.intersects(&display_item.base().bounds) &&
+                    self.visible_rect.intersects(&display_item.base().clip_rect) {
+                result_list.push_back((*display_item).clone())
             }
         }
-        DisplayList {
-            list: result,
-        }
     }
 
-    fn process_display_item(&self, display_item: &DisplayItem) -> Option<DisplayItem> {
-        // Eliminate display items outside the visible region.
-        if !self.visible_rect.intersects(&display_item.base().bounds) ||
-                !self.visible_rect.intersects(&display_item.base().clip_rect) {
-            None
-        } else {
-            Some((*display_item).clone())
+    /// Adds child stacking contexts whose boundaries intersect the visible rect to `result_list`.
+    fn add_in_bounds_stacking_contexts<'a,I>(&self,
+                                             result_list: &mut DList<Arc<StackingContext>>,
+                                             mut stacking_contexts: I)
+                                             where I: Iterator<&'a Arc<StackingContext>> {
+        for stacking_context in stacking_contexts {
+            if self.visible_rect.intersects(&stacking_context.bounds) &&
+                    self.visible_rect.intersects(&stacking_context.clip_rect) {
+                result_list.push_back((*stacking_context).clone())
+            }
         }
     }
 }

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -20,6 +20,7 @@ extern crate native;
 extern crate rustrt;
 extern crate stb_image;
 extern crate png;
+extern crate script_traits;
 extern crate serialize;
 extern crate unicode;
 #[phase(plugin)]

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -467,7 +467,7 @@ impl<'a> RenderContext<'a>  {
     }
 }
 
-trait ToAzurePoint {
+pub trait ToAzurePoint {
     fn to_azure_point(&self) -> Point2D<AzFloat>;
 }
 
@@ -477,7 +477,7 @@ impl ToAzurePoint for Point2D<Au> {
     }
 }
 
-trait ToAzureRect {
+pub trait ToAzureRect {
     fn to_azure_rect(&self) -> Rect<AzFloat>;
 }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1481,11 +1481,31 @@ impl Fragment {
         self.style = (*new_style).clone()
     }
 
-    pub fn abs_bounds_from_origin(&self, fragment_origin: &Point2D<Au>) -> Rect<Au> {
+    /// Given the stacking-context-relative position of the containing flow, returns the boundaries
+    /// of this fragment relative to the parent stacking context.
+    pub fn stacking_relative_bounds(&self, stacking_relative_flow_origin: &Point2D<Au>)
+                                    -> Rect<Au> {
         // FIXME(#2795): Get the real container size
         let container_size = Size2D::zero();
-        self.border_box.to_physical(self.style.writing_mode, container_size)
-                        .translate(fragment_origin)
+        self.border_box
+            .to_physical(self.style.writing_mode, container_size)
+            .translate(stacking_relative_flow_origin)
+    }
+
+    /// Returns true if this fragment establishes a new stacking context and false otherwise.
+    pub fn establishes_stacking_context(&self) -> bool {
+        match self.style().get_box().position {
+            position::absolute | position::fixed => {
+                // FIXME(pcwalton): This should only establish a new stacking context when
+                // `z-index` is not `auto`. But this matches what we did before.
+                true
+            }
+            position::relative | position::static_ => {
+                // FIXME(pcwalton): `position: relative` establishes a new stacking context if
+                // `z-index` is not `auto`. But this matches what we did before.
+                false
+            }
+        }
     }
 }
 

--- a/components/util/dlist.rs
+++ b/components/util/dlist.rs
@@ -96,3 +96,30 @@ pub fn append_from<T>(this: &mut DList<T>, other: &mut DList<T>) {
         other.length = 0;
     }
 }
+
+/// Prepends the items in the other list to this one, leaving the other list empty.
+#[inline]
+pub fn prepend_from<T>(this: &mut DList<T>, other: &mut DList<T>) {
+    unsafe {
+        let this = mem::transmute::<&mut DList<T>,&mut RawDList<T>>(this);
+        let other = mem::transmute::<&mut DList<T>,&mut RawDList<T>>(other);
+        if this.length == 0 {
+            this.head = mem::replace(&mut other.head, ptr::null_mut());
+            this.tail = mem::replace(&mut other.tail, ptr::null_mut());
+            this.length = mem::replace(&mut other.length, 0);
+            return
+        }
+
+        let old_other_tail = mem::replace(&mut other.tail, ptr::null_mut());
+        if old_other_tail.is_null() {
+            return
+        }
+        (*old_other_tail).next = this.head;
+        (*this.head).prev = old_other_tail;
+
+        this.head = mem::replace(&mut other.head, ptr::null_mut());
+        this.length += other.length;
+        other.length = 0;
+    }
+}
+

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -74,6 +74,11 @@ impl Default for Au {
     }
 }
 
+pub static ZERO_POINT: Point2D<Au> = Point2D {
+    x: Au(0),
+    y: Au(0),
+};
+
 pub static ZERO_RECT: Rect<Au> = Rect {
     origin: Point2D {
         x: Au(0),


### PR DESCRIPTION
This implements the scheme described here:

```
https://groups.google.com/forum/#!topic/mozilla.dev.servo/sZVPSfPVfkg
```

This commit changes Servo to generate one display list per stacking
context instead of one display list per layer. This is purely a
refactoring; there are no functional changes. Performance is essentially
the same as before. However, there should be numerous future benefits
that this is intended to allow for:
- It makes the code simpler to understand because the "new layer needed"
  vs. "no new layer needed" code paths are more consolidated.
- It makes it easy to support CSS properties that did not fit into our
  previous flat display list model (without unconditionally layerizing
  them):
  
  o `opacity` should be easy to support because the stacking context
    provides the higher-level grouping of display items to which opacity
    is to be applied.
  
  o `transform` can be easily supported because the stacking context
    provides a place to stash the transformation matrix. This has the side
    benefit of nicely separating the transformation matrix from the
    clipping regions.
- The `flatten` logic is now O(1) instead of O(n) and now only needs to
  be invoked for pseudo-stacking contexts (right now: just floats),
  instead of for every stacking context.
- Layers are now a proper tree instead of a flat list as far as layout
  is concerned, bringing us closer to a production-quality
  compositing/layers framework.
- This commit opens the door to incremental display list construction at
  the level of stacking contexts.

Future performance improvements could come from optimizing allocation of
display list items, and, of course, incremental display list
construction.

r? @glennw
f? @mrobinson @cgaebel
