### PR TITLE
Update README for Homebrew.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,10 @@ Servo welcomes contribution from everyone.  See
 
 ## Prerequisites
 
-Note, on systems without glfw3 packages, you can compile from source. An
-example can be found in [the TravisCI install
-script](etc/ci/travis.install.sh).
-
 On OS X (homebrew):
 
 ``` sh
-brew install automake pkg-config python glfw3 cmake
+brew install automake pkg-config python cmake
 pip install virtualenv
 ```
 
@@ -32,7 +28,7 @@ On Debian-based Linuxes:
 sudo apt-get install curl freeglut3-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     msttcorefonts gperf g++ cmake python-virtualenv \
-    libssl-dev libglfw-dev libbz2-dev
+    libssl-dev
 ```
 
 On Fedora:
@@ -41,7 +37,7 @@ On Fedora:
 sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
-    rpm-build openssl-devel glfw-devel cmake bzip2
+    rpm-build openssl-devel cmake
 pushd .
 cd /tmp
 wget http://corefonts.sourceforge.net/msttcorefonts-2.5-1.spec
@@ -53,7 +49,7 @@ popd
 On Arch Linux:
 
 ``` sh
-sudo pacman -S base-devel git python2 python2-virtualenv mesa glfw ttf-font cmake bzip2
+sudo pacman -S base-devel git python2 python2-virtualenv mesa ttf-font cmake
 ```
 
 Cross-compilation for Android:


### PR DESCRIPTION
glfw3 is in the `homebrew/versions` keg.

``` bash
➜  ~  brew install glfw3
Error: No available formula for glfw3
Searching formulae...
Searching taps...
homebrew/versions/glfw3
```

Simplest fix:

``` bash
﻿➜  ~  brew install homebrew/versions/glfw3
Cloning into '/usr/local/Library/Taps/homebrew/homebrew-versions'...
remote: Counting objects: 2495, done.
remote: Total 2495 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (2495/2495), 820.05 KiB | 462.00 KiB/s, done.
Resolving deltas: 100% (1433/1433), done.
Checking connectivity... done.
Tapped 161 formulae
==> Installing glfw3 from homebrew/homebrew-versions
==> Downloading https://downloads.sourceforge.net/project/glfw/glfw/3.0.4/glfw-3.0.4.tar.bz2
Already downloaded: /Library/Caches/Homebrew/glfw3-3.0.4.tar.bz2
==> Patching
patching file CMakeLists.txt
Hunk #1 succeeded at 370 with fuzz 1 (offset 13 lines).
==> cmake -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/glfw3/3.0.4 -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev -DGLFW_USE_CHDIR=TRUE -DGLFW_USE_MENUBAR=TRUE -DBUIL
==> make install
🍺  /usr/local/Cellar/glfw3/3.0.4: 11 files, 220K, built in 9 seconds
```

Users who have `homebrew/versions` already tapped won't notice this, since after tapping `homebrew/versions` keg shouldn't notice, since after tapping, the library is available using just `brew install glfw3`.

``` bash
➜  ~  brew tap
homebrew/versions
➜  ~  brew install glfw3
==> Installing glfw3 from homebrew/homebrew-versions
==> Downloading https://downloads.sourceforge.net/project/glfw/glfw/3.0.4/glfw-3.0.4.tar.bz2
Already downloaded: /Library/Caches/Homebrew/glfw3-3.0.4.tar.bz2
==> Patching
patching file CMakeLists.txt
Hunk #1 succeeded at 370 with fuzz 1 (offset 13 lines).
==> cmake -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/glfw3/3.0.4 -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev -DGLFW_USE_CHDIR=TRUE -DGLFW_USE_MENUBAR=TRUE -DBUIL
==> make install
🍺  /usr/local/Cellar/glfw3/3.0.4: 11 files, 220K, built in 9 seconds
```
