### PR TITLE
Redirect android resource folder (user-agent.css and friends) to /sdcard/servo.

### DIFF
--- a/components/util/resource_files.rs
+++ b/components/util/resource_files.rs
@@ -3,11 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::io::{File, IoResult};
-use std::io::fs::PathExtensions;
-use std::os;
 use std::path::Path;
 
+#[cfg(not(target_os = "android"))]
+use std::io::fs::PathExtensions;
+#[cfg(not(target_os = "android"))]
+use std::os;
 
+#[cfg(target_os = "android")]
+pub fn resources_dir_path() -> Path {
+    Path::new("/sdcard/servo/")
+}
+
+#[cfg(not(target_os = "android"))]
 pub fn resources_dir_path() -> Path {
     // FIXME: Find a way to not rely on the executable being under `<servo source>/target`.
     let mut path = os::self_exe_path().expect("can't get exe path");


### PR DESCRIPTION
This is a temporary solution, until they are packaged properly.
