### PR TITLE
More work on iframes updated via script

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -104,6 +104,10 @@ impl FrameTree {
         }
     }
 
+    fn add_child(&self, new_child: ChildFrameTree) {
+        self.children.borrow_mut().push(new_child);
+    }
+
     fn update_child_pipeline(frame_tree: Rc<FrameTree>,
                              new_pipeline: Rc<Pipeline>,
                              old_subpage_id: SubpageId) {
@@ -128,8 +132,7 @@ impl FrameTree {
                 let new_frame_tree =
                      Rc::new(FrameTree::new(new_pipeline,
                                             Some(frame_tree.pipeline.borrow().clone())));
-                frame_tree.children.borrow_mut().push(ChildFrameTree::new(new_frame_tree,
-                                                                          new_rect));
+                frame_tree.add_child(ChildFrameTree::new(new_frame_tree, new_rect));
             }
         }
     }
@@ -901,8 +904,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                             let parent = next_frame_tree.find(parent.id).expect(
                                 "Constellation: pending frame has a parent frame that is not
                                 active. This is a bug.");
-                            parent.children.borrow_mut().push(ChildFrameTree::new(to_add.clone(),
-                                                              rect));
+                            parent.add_child(ChildFrameTree::new(to_add.clone(), rect));
                         }
                     }
                 }

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -581,9 +581,10 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                     match children.iter_mut().find(|child| subpage_eq(child)) {
                         None => {}
                         Some(child) => {
+                            let has_compositor_layer = child.frame_tree.has_compositor_layer.get();
                             update_child_rect(child,
                                               rect,
-                                              true,
+                                              has_compositor_layer,
                                               &mut already_sent,
                                               &mut self.compositor_proxy,
                                               self.window_size.device_pixel_ratio)

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -88,7 +88,7 @@ pub struct Constellation<LTF, STF> {
 
 /// Stores the Id of the outermost frame's pipeline, along with a vector of children frames
 struct FrameTree {
-    pub pipeline: Rc<Pipeline>,
+    pub pipeline: RefCell<Rc<Pipeline>>,
     pub parent: RefCell<Option<Rc<Pipeline>>>,
     pub children: RefCell<Vec<ChildFrameTree>>,
     pub has_compositor_layer: Cell<bool>,
@@ -97,12 +97,43 @@ struct FrameTree {
 impl FrameTree {
     fn new(pipeline: Rc<Pipeline>, parent_pipeline: Option<Rc<Pipeline>>) -> FrameTree {
         FrameTree {
-            pipeline: pipeline,
+            pipeline: RefCell::new(pipeline.clone()),
             parent: RefCell::new(parent_pipeline),
             children: RefCell::new(vec!()),
             has_compositor_layer: Cell::new(false),
         }
     }
+
+    fn update_child_pipeline(frame_tree: Rc<FrameTree>,
+                             new_pipeline: Rc<Pipeline>,
+                             old_subpage_id: SubpageId) {
+        let existing_tree = match frame_tree.find_with_subpage_id(Some(old_subpage_id)) {
+            Some(existing_tree) => existing_tree.clone(),
+            None => panic!("Tried to update non-existing frame tree with pipeline={} subpage={}",
+                           new_pipeline.id,
+                           old_subpage_id),
+        };
+
+        *existing_tree.pipeline.borrow_mut() = new_pipeline;
+    }
+
+    fn create_or_update_child_pipeline(frame_tree: Rc<FrameTree>,
+                                       new_pipeline: Rc<Pipeline>,
+                                       new_rect: Option<TypedRect<PagePx, f32>>,
+                                       old_subpage_id: Option<SubpageId>) {
+        match old_subpage_id {
+            Some(old_subpage_id) =>
+                FrameTree::update_child_pipeline(frame_tree.clone(), new_pipeline, old_subpage_id),
+            None => {
+                let new_frame_tree =
+                     Rc::new(FrameTree::new(new_pipeline,
+                                            Some(frame_tree.pipeline.borrow().clone())));
+                frame_tree.children.borrow_mut().push(ChildFrameTree::new(new_frame_tree,
+                                                                          new_rect));
+            }
+        }
+    }
+
 }
 
 #[deriving(Clone)]
@@ -150,7 +181,7 @@ pub struct FrameTreeDiff {
 impl FrameTree {
     fn to_sendable(&self) -> SendableFrameTree {
         SendableFrameTree {
-            pipeline: self.pipeline.to_sendable(),
+            pipeline: self.pipeline.borrow().to_sendable(),
             children: self.children
                           .borrow()
                           .iter()
@@ -163,18 +194,24 @@ impl FrameTree {
 trait FrameTreeTraversal {
     fn contains(&self, id: PipelineId) -> bool;
     fn find(&self, id: PipelineId) -> Option<Self>;
+    fn find_with_subpage_id(&self, id: Option<SubpageId>) -> Option<Rc<FrameTree>>;
     fn replace_child(&self, id: PipelineId, new_child: Self) -> ReplaceResult;
     fn iter(&self) -> FrameTreeIterator;
 }
 
 impl FrameTreeTraversal for Rc<FrameTree> {
     fn contains(&self, id: PipelineId) -> bool {
-        self.iter().any(|frame_tree| id == frame_tree.pipeline.id)
+        self.iter().any(|frame_tree| id == frame_tree.pipeline.borrow().id)
     }
 
     /// Returns the frame tree whose key is id
     fn find(&self, id: PipelineId) -> Option<Rc<FrameTree>> {
-        self.iter().find(|frame_tree| id == frame_tree.pipeline.id)
+        self.iter().find(|frame_tree| id == frame_tree.pipeline.borrow().id)
+    }
+
+    /// Returns the frame tree whose subpage is id
+    fn find_with_subpage_id(&self, id: Option<SubpageId>) -> Option<Rc<FrameTree>> {
+        self.iter().find(|frame_tree| id == frame_tree.pipeline.borrow().subpage_id)
     }
 
     /// Replaces a node of the frame tree in place. Returns the node that was removed or the
@@ -183,7 +220,7 @@ impl FrameTreeTraversal for Rc<FrameTree> {
         for frame_tree in self.iter() {
             let mut children = frame_tree.children.borrow_mut();
             let child = children.iter_mut()
-                .find(|child| child.frame_tree.pipeline.id == id);
+                .find(|child| child.frame_tree.pipeline.borrow().id == id);
             match child {
                 Some(child) => {
                     *new_child.parent.borrow_mut() = child.frame_tree.parent.borrow().clone();
@@ -274,7 +311,7 @@ impl NavigationContext {
 
     /// Loads a new set of page frames, returning all evicted frame trees
     fn load(&mut self, frame_tree: Rc<FrameTree>) -> Vec<Rc<FrameTree>> {
-        debug!("navigating to {}", frame_tree.pipeline.id);
+        debug!("navigating to {}", frame_tree.pipeline.borrow().id);
         let evicted = replace(&mut self.next, vec!());
         match self.current.take() {
             Some(current) => self.previous.push(current),
@@ -427,11 +464,12 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 debug!("constellation got frame rect message");
                 self.handle_frame_rect_msg(pipeline_id, subpage_id, Rect::from_untyped(&rect));
             }
-            ScriptLoadedURLInIFrameMsg(url, source_pipeline_id, subpage_id, sandbox) => {
+            ScriptLoadedURLInIFrameMsg(url, source_pipeline_id, new_subpage_id, old_subpage_id, sandbox) => {
                 debug!("constellation got iframe URL load message");
                 self.handle_script_loaded_url_in_iframe_msg(url,
                                                             source_pipeline_id,
-                                                            subpage_id,
+                                                            new_subpage_id,
+                                                            old_subpage_id,
                                                             sandbox);
             }
             // Load a new page, usually -- but not always -- from a mouse click or typed url
@@ -515,12 +553,12 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
 
         loop {
             let idx = self.pending_frames.iter().position(|pending| {
-                pending.after.pipeline.id == pipeline_id
+                pending.after.pipeline.borrow().id == pipeline_id
             });
             match idx {
                 Some(idx) => {
                     debug!("removing pending frame change for failed pipeline");
-                    force_pipeline_exit(&self.pending_frames[idx].after.pipeline);
+                    force_pipeline_exit(&self.pending_frames[idx].after.pipeline.borrow());
                     self.pending_frames.remove(idx);
                 },
                 None => break,
@@ -560,7 +598,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
 
         // Returns true if a child frame tree's subpage id matches the given subpage id
         let subpage_eq = |child_frame_tree: & &mut ChildFrameTree| {
-            child_frame_tree.frame_tree.pipeline.
+            child_frame_tree.frame_tree.pipeline.borrow().
                 subpage_id.expect("Constellation:
                 child frame does not have a subpage id. This should not be possible.")
                 == subpage_id
@@ -621,7 +659,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                              device_pixel_ratio: ScaleFactor<ViewportPx,DevicePixel,f32>) {
             child_frame_tree.rect = Some(rect);
             // NOTE: work around borrowchk issues
-            let pipeline = &child_frame_tree.frame_tree.pipeline;
+            let pipeline = &*child_frame_tree.frame_tree.pipeline.borrow();
             if !already_sent.contains(&pipeline.id) {
                 if is_active {
                     let ScriptControlChan(ref script_chan) = pipeline.script_chan;
@@ -647,23 +685,22 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
     // navigation.
     fn handle_script_loaded_url_in_iframe_msg(&mut self,
                                               url: Url,
-                                              source_pipeline_id: PipelineId,
-                                              subpage_id: SubpageId,
+                                              containing_page_pipeline_id: PipelineId,
+                                              new_subpage_id: SubpageId,
+                                              old_subpage_id: Option<SubpageId>,
                                               sandbox: IFrameSandboxState) {
         // Start by finding the frame trees matching the pipeline id,
         // and add the new pipeline to their sub frames.
-        let frame_trees = self.find_all(source_pipeline_id);
+        let frame_trees = self.find_all(containing_page_pipeline_id);
         if frame_trees.is_empty() {
             panic!("Constellation: source pipeline id of ScriptLoadedURLInIFrameMsg is not in
                     navigation context, nor is it in a pending frame. This should be
                     impossible.");
         }
 
-        let next_pipeline_id = self.get_next_pipeline_id();
-
         // Compare the pipeline's url to the new url. If the origin is the same,
         // then reuse the script task in creating the new pipeline
-        let source_pipeline = self.pipelines.get(&source_pipeline_id).expect("Constellation:
+        let source_pipeline = self.pipelines.get(&containing_page_pipeline_id).expect("Constellation:
             source Id of ScriptLoadedURLInIFrameMsg does have an associated pipeline in
             constellation. This should be impossible.").clone();
 
@@ -681,18 +718,20 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
             None
         };
 
+        let new_frame_pipeline_id = self.get_next_pipeline_id();
         let pipeline = self.new_pipeline(
-            next_pipeline_id,
-            Some(subpage_id),
+            new_frame_pipeline_id,
+            Some(new_subpage_id),
             script_pipeline,
             LoadData::new(url)
         );
 
-        let rect = self.pending_sizes.remove(&(source_pipeline_id, subpage_id));
+        let rect = self.pending_sizes.remove(&(containing_page_pipeline_id, new_subpage_id));
         for frame_tree in frame_trees.iter() {
-            frame_tree.children.borrow_mut().push(ChildFrameTree::new(
-                Rc::new(FrameTree::new(pipeline.clone(), Some(source_pipeline.clone()))),
-                rect));
+            FrameTree::create_or_update_child_pipeline(frame_tree.clone(),
+                                                       pipeline.clone(),
+                                                       rect,
+                                                       old_subpage_id);
         }
         self.pipelines.insert(pipeline.id, pipeline);
     }
@@ -721,7 +760,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         // changes would be overriden by changing the subframe associated with source_id.
 
         let parent = source_frame.parent.clone();
-        let subpage_id = source_frame.pipeline.subpage_id;
+        let subpage_id = source_frame.pipeline.borrow().subpage_id;
         let next_pipeline_id = self.get_next_pipeline_id();
 
         let pipeline = self.new_pipeline(next_pipeline_id, subpage_id, None, load_data);
@@ -749,7 +788,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 } else {
                     let old = self.current_frame().as_ref().unwrap();
                     for frame in old.iter() {
-                        frame.pipeline.revoke_paint_permission();
+                        frame.pipeline.borrow().revoke_paint_permission();
                     }
                 }
                 self.navigation_context.forward()
@@ -761,7 +800,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 } else {
                     let old = self.current_frame().as_ref().unwrap();
                     for frame in old.iter() {
-                        frame.pipeline.revoke_paint_permission();
+                        frame.pipeline.borrow().revoke_paint_permission();
                     }
                 }
                 self.navigation_context.back()
@@ -769,7 +808,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         };
 
         for frame in destination_frame.iter() {
-            frame.pipeline.load();
+            frame.pipeline.borrow().load();
         }
         self.grant_paint_permission(destination_frame, constellation_msg::Navigate);
 
@@ -782,8 +821,9 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
 
     fn handle_key_msg(&self, key: Key, state: KeyState, mods: KeyModifiers) {
         self.current_frame().as_ref().map(|frame| {
-            let ScriptControlChan(ref chan) = frame.pipeline.script_chan;
-            chan.send(SendEventMsg(frame.pipeline.id, script_traits::KeyEvent(key, state, mods)));
+            let ScriptControlChan(ref chan) = frame.pipeline.borrow().script_chan;
+            chan.send(SendEventMsg(frame.pipeline.borrow().id,
+                                   script_traits::KeyEvent(key, state, mods)));
         });
     }
 
@@ -804,7 +844,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         // If it is not found, it simply means that this pipeline will not receive
         // permission to paint.
         let pending_index = self.pending_frames.iter().rposition(|frame_change| {
-            frame_change.after.pipeline.id == pipeline_id
+            frame_change.after.pipeline.borrow().id == pipeline_id
         });
         match pending_index {
             Some(pending_index) => {
@@ -830,7 +870,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                             frame not contained in the current frame. This is a bug");
 
                         for frame in to_revoke.iter() {
-                            frame.pipeline.revoke_paint_permission();
+                            frame.pipeline.borrow().revoke_paint_permission();
                         }
 
                         // If to_add is not the root frame, then replace revoked_frame with it.
@@ -840,8 +880,8 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                         {
                             if to_add.parent.borrow().is_some() {
                                 debug!("Constellation: replacing {} with {} in {}",
-                                       revoke_id, to_add.pipeline.id,
-                                       next_frame_tree.pipeline.id);
+                                       revoke_id, to_add.pipeline.borrow().id,
+                                       next_frame_tree.pipeline.borrow().id);
                                 flag = true;
                             }
                         }
@@ -854,7 +894,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                         // Add to_add to parent's children, if it is not the root
                         let parent = &to_add.parent;
                         for parent in parent.borrow().iter() {
-                            let subpage_id = to_add.pipeline.subpage_id
+                            let subpage_id = to_add.pipeline.borrow().subpage_id
                                 .expect("Constellation:
                                 Child frame's subpage id is None. This should be impossible.");
                             let rect = self.pending_sizes.remove(&(parent.id, subpage_id));
@@ -878,14 +918,14 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         let mut already_seen = HashSet::new();
         for frame_tree in self.current_frame().iter() {
             debug!("constellation sending resize message to active frame");
-            let pipeline = &frame_tree.pipeline;
+            let pipeline = &*frame_tree.pipeline.borrow();;
             let ScriptControlChan(ref chan) = pipeline.script_chan;
             let _ = chan.send_opt(ResizeMsg(pipeline.id, new_size));
             already_seen.insert(pipeline.id);
         }
         for frame_tree in self.navigation_context.previous.iter()
             .chain(self.navigation_context.next.iter()) {
-            let pipeline = &frame_tree.pipeline;
+            let pipeline = &*frame_tree.pipeline.borrow();
             if !already_seen.contains(&pipeline.id) {
                 debug!("constellation sending resize message to inactive frame");
                 let ScriptControlChan(ref chan) = pipeline.script_chan;
@@ -900,9 +940,9 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
             let frame_tree = &change.after;
             if frame_tree.parent.borrow().is_none() {
                 debug!("constellation sending resize message to pending outer frame ({})",
-                       frame_tree.pipeline.id);
-                let ScriptControlChan(ref chan) = frame_tree.pipeline.script_chan;
-                let _ = chan.send_opt(ResizeMsg(frame_tree.pipeline.id, new_size));
+                       frame_tree.pipeline.borrow().id);
+                let ScriptControlChan(ref chan) = frame_tree.pipeline.borrow().script_chan;
+                let _ = chan.send_opt(ResizeMsg(frame_tree.pipeline.borrow().id, new_size));
             }
         }
 
@@ -914,14 +954,14 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         // TODO(tkuehn): should only exit once per unique script task,
         // and then that script task will handle sub-exits
         for frame_tree in frame_tree.iter() {
-            frame_tree.pipeline.exit();
-            self.pipelines.remove(&frame_tree.pipeline.id);
+            frame_tree.pipeline.borrow().exit();
+            self.pipelines.remove(&frame_tree.pipeline.borrow().id);
         }
     }
 
     fn handle_evicted_frames(&mut self, evicted: Vec<Rc<FrameTree>>) {
         for frame_tree in evicted.into_iter() {
-            if !self.navigation_context.contains(frame_tree.pipeline.id) {
+            if !self.navigation_context.contains(frame_tree.pipeline.borrow().id) {
                 self.close_pipelines(frame_tree);
             } else {
                 let frames = frame_tree.children.borrow().iter()
@@ -959,7 +999,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 let mut iter = frame_tree.iter();
                 for frame in iter {
                     frame.has_compositor_layer.set(true);
-                    frame.pipeline.grant_paint_permission();
+                    frame.pipeline.borrow().grant_paint_permission();
                 }
             }
             Err(()) => {} // message has been discarded, probably shutting down
@@ -972,7 +1012,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                                             -> Option<(ChildFrameTree, Rc<FrameTree>)> {
         for child in frame_tree.children.borrow().iter() {
             let child_frame_tree = child.frame_tree.clone();
-            if child.frame_tree.pipeline.id == child_pipeline_id {
+            if child.frame_tree.pipeline.borrow().id == child_pipeline_id {
                 return Some((ChildFrameTree::new(child_frame_tree, child.rect),
                             frame_tree.clone()));
             }
@@ -999,13 +1039,13 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         };
 
         if child.frame_tree.has_compositor_layer.get() {
-            child.frame_tree.pipeline.grant_paint_permission();
+            child.frame_tree.pipeline.borrow().grant_paint_permission();
             return;
         }
 
         let sendable_frame_tree_diff = FrameTreeDiff {
-            parent_pipeline: parent.pipeline.to_sendable(),
-            pipeline: child.frame_tree.pipeline.to_sendable(),
+            parent_pipeline: parent.pipeline.borrow().to_sendable(),
+            pipeline: child.frame_tree.pipeline.borrow().to_sendable(),
             rect: child.rect,
         };
 
@@ -1014,7 +1054,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         match port.recv_opt() {
             Ok(()) => {
                 child.frame_tree.has_compositor_layer.set(true);
-                child.frame_tree.pipeline.grant_paint_permission();
+                child.frame_tree.pipeline.borrow().grant_paint_permission();
             }
             Err(()) => {} // The message has been discarded, we are probably shutting down.
         }

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use compositor_task::{GetGraphicsMetadata, CreateOrUpdateRootLayer, CreateOrUpdateDescendantLayer};
-use compositor_task::{Exit, ChangeReadyState, LoadComplete, Paint, ScrollFragmentPoint, SetIds};
-use compositor_task::{SetLayerOrigin, ShutdownComplete, ChangePaintState, PaintMsgDiscarded};
-use compositor_task::{CompositorEventListener, CompositorReceiver, ScrollTimeout, FrameTreeUpdateMsg};
+use compositor_task::{GetGraphicsMetadata, ChangeLayerPipelineAndRemoveChildren};
+use compositor_task::{CreateOrUpdateRootLayer, CreateOrUpdateDescendantLayer};
+use compositor_task::{CreateRootLayerForPipeline, Exit, ChangeReadyState, LoadComplete, Paint};
+use compositor_task::{ScrollFragmentPoint, SetIds, SetLayerOrigin, ShutdownComplete};
+use compositor_task::{ChangePaintState, PaintMsgDiscarded, CompositorEventListener};
+use compositor_task::{CompositorReceiver, ScrollTimeout};
 use windowing::WindowEvent;
 
 use geom::scale_factor::ScaleFactor;
@@ -92,7 +94,11 @@ impl CompositorEventListener for NullCompositor {
                 response_chan.send(());
             }
 
-            FrameTreeUpdateMsg(_, response_channel) => {
+            ChangeLayerPipelineAndRemoveChildren(_, _, response_channel) => {
+                response_channel.send(());
+            }
+
+            CreateRootLayerForPipeline(_, _, _, response_channel) => {
                 response_channel.send(());
             }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -118,8 +118,8 @@ pub trait TLayoutNode {
                     Some(elem) => elem,
                     None => panic!("not an iframe element!")
                 };
-            let size = (*iframe_element.unsafe_get()).size().unwrap();
-            (*size.pipeline_id(), *size.subpage_id())
+            ((*iframe_element.unsafe_get()).containing_page_pipeline_id().unwrap(),
+             (*iframe_element.unsafe_get()).subpage_id().unwrap())
         }
     }
 

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -200,7 +200,7 @@ pub enum Msg {
     LoadCompleteMsg,
     FrameRectMsg(PipelineId, SubpageId, Rect<f32>),
     LoadUrlMsg(PipelineId, LoadData),
-    ScriptLoadedURLInIFrameMsg(Url, PipelineId, SubpageId, IFrameSandboxState),
+    ScriptLoadedURLInIFrameMsg(Url, PipelineId, SubpageId, Option<SubpageId>, IFrameSandboxState),
     NavigateMsg(NavigationDirection),
     PainterReadyMsg(PipelineId),
     ResizedWindowMsg(WindowSizeData),

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -20,7 +20,7 @@ use dom::node::{Node, NodeHelpers, ElementNodeTypeId, window_from_node};
 use dom::urlhelper::UrlHelper;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::Window;
-use page::IterablePage;
+use page::{IterablePage, Page};
 
 use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_msg::constellation_msg::{IFrameSandboxed, IFrameUnsandboxed};
@@ -44,7 +44,8 @@ enum SandboxAllowance {
 #[dom_struct]
 pub struct HTMLIFrameElement {
     htmlelement: HTMLElement,
-    size: Cell<Option<IFrameSize>>,
+    subpage_id: Cell<Option<SubpageId>>,
+    containing_page_pipeline_id: Cell<Option<PipelineId>>,
     sandbox: Cell<Option<u8>>,
 }
 
@@ -54,30 +55,12 @@ impl HTMLIFrameElementDerived for EventTarget {
     }
 }
 
-#[jstraceable]
-#[privatize]
-pub struct IFrameSize {
-    pipeline_id: PipelineId,
-    subpage_id: SubpageId,
-}
-
-impl IFrameSize {
-    #[inline]
-    pub fn pipeline_id<'a>(&'a self) -> &'a PipelineId {
-        &self.pipeline_id
-    }
-
-    #[inline]
-    pub fn subpage_id<'a>(&'a self) -> &'a SubpageId {
-        &self.subpage_id
-    }
-}
-
 pub trait HTMLIFrameElementHelpers {
     fn is_sandboxed(self) -> bool;
     fn get_url(self) -> Option<Url>;
     /// http://www.whatwg.org/html/#process-the-iframe-attributes
     fn process_the_iframe_attributes(self);
+    fn generate_new_subpage_id(self, page: &Page) -> (SubpageId, Option<SubpageId>);
 }
 
 impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
@@ -99,6 +82,13 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
         })
     }
 
+    fn generate_new_subpage_id(self, page: &Page) -> (SubpageId, Option<SubpageId>) {
+        let old_subpage_id = self.subpage_id.get();
+        let subpage_id = page.get_next_subpage_id();
+        self.subpage_id.set(Some(subpage_id));
+        (subpage_id, old_subpage_id)
+    }
+
     fn process_the_iframe_attributes(self) {
         let url = match self.get_url() {
             Some(url) => url.clone(),
@@ -111,18 +101,18 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
             IFrameUnsandboxed
         };
 
-        // Subpage Id
         let window = window_from_node(self).root();
         let page = window.page();
-        let subpage_id = page.get_next_subpage_id();
+        let (new_subpage_id, old_subpage_id) = self.generate_new_subpage_id(page);
 
-        self.size.set(Some(IFrameSize {
-            pipeline_id: page.id,
-            subpage_id: subpage_id,
-        }));
+        self.containing_page_pipeline_id.set(Some(page.id));
 
         let ConstellationChan(ref chan) = page.constellation_chan;
-        chan.send(ScriptLoadedURLInIFrameMsg(url, page.id, subpage_id, sandboxed));
+        chan.send(ScriptLoadedURLInIFrameMsg(url,
+                                             page.id,
+                                             new_subpage_id,
+                                             old_subpage_id,
+                                             sandboxed));
     }
 }
 
@@ -130,7 +120,8 @@ impl HTMLIFrameElement {
     fn new_inherited(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> HTMLIFrameElement {
         HTMLIFrameElement {
             htmlelement: HTMLElement::new_inherited(HTMLIFrameElementTypeId, localName, prefix, document),
-            size: Cell::new(None),
+            subpage_id: Cell::new(None),
+            containing_page_pipeline_id: Cell::new(None),
             sandbox: Cell::new(None),
         }
     }
@@ -142,8 +133,13 @@ impl HTMLIFrameElement {
     }
 
     #[inline]
-    pub fn size(&self) -> Option<IFrameSize> {
-        self.size.get()
+    pub fn containing_page_pipeline_id(&self) -> Option<PipelineId> {
+        self.containing_page_pipeline_id.get()
+    }
+
+    #[inline]
+    pub fn subpage_id(&self) -> Option<SubpageId> {
+        self.subpage_id.get()
     }
 }
 
@@ -169,11 +165,11 @@ impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn GetContentWindow(self) -> Option<Temporary<Window>> {
-        self.size.get().and_then(|size| {
+        self.subpage_id.get().and_then(|subpage_id| {
             let window = window_from_node(self).root();
             let children = window.page().children.borrow();
             let child = children.iter().find(|child| {
-                child.subpage_id.unwrap() == size.subpage_id
+                child.subpage_id.unwrap() == subpage_id
             });
             child.and_then(|page| {
                 page.frame.borrow().as_ref().map(|frame| {


### PR DESCRIPTION
iframes added or loaded via script are not reflected visibly in the content of a page. The next step in making this happen is to have compositor layers accurately reflect newly recreated or loaded iframes. This change allows iframes to appear, but there are still some further changes necessary to make the output correct and reliable.
