### PR TITLE
[gfx/style] Implement border-radius.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -474,16 +474,33 @@ pub struct GradientDisplayItem {
 /// Renders a border.
 #[deriving(Clone)]
 pub struct BorderDisplayItem {
+    /// Fields common to all display items.
     pub base: BaseDisplayItem,
 
-    /// The border widths
-    pub border: SideOffsets2D<Au>,
+    /// Border widths.
+    pub border_widths: SideOffsets2D<Au>,
 
-    /// The border colors.
+    /// Border colors.
     pub color: SideOffsets2D<Color>,
 
-    /// The border styles.
-    pub style: SideOffsets2D<border_style::T>
+    /// Border styles.
+    pub style: SideOffsets2D<border_style::T>,
+
+    /// Border radii.
+    ///
+    /// TODO(pcwalton): Elliptical radii.
+    pub radius: BorderRadii<Au>,
+}
+
+/// Information about the border radii.
+///
+/// TODO(pcwalton): Elliptical radii.
+#[deriving(Clone, Default, Show)]
+pub struct BorderRadii<T> {
+    pub top_left:     T,
+    pub top_right:    T,
+    pub bottom_right: T,
+    pub bottom_left:  T,
 }
 
 /// Renders a line segment.
@@ -565,7 +582,8 @@ impl DisplayItem {
 
             BorderDisplayItemClass(ref border) => {
                 render_context.draw_border(&border.base.bounds,
-                                           border.border,
+                                           border.border_widths,
+                                           &border.radius,
                                            border.color,
                                            border.style)
             }
@@ -658,4 +676,3 @@ impl OpaqueNodeMethods for OpaqueNode {
         }
     }
 }
-

--- a/components/style/properties/common_types.rs
+++ b/components/style/properties/common_types.rs
@@ -20,7 +20,7 @@ pub mod specified {
     use super::{Au, CSSFloat};
     pub use cssparser::Color as CSSColor;
 
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum Length {
         Au_(Au),  // application units
         Em(CSSFloat),
@@ -82,11 +82,12 @@ pub mod specified {
         }
     }
 
-    #[deriving(Clone)]
+    #[deriving(Clone, Show)]
     pub enum LengthOrPercentage {
         LP_Length(Length),
         LP_Percentage(CSSFloat),  // [0 .. 100%] maps to [0.0 .. 1.0]
     }
+
     impl LengthOrPercentage {
         fn parse_internal(input: &ComponentValue, negative_ok: bool)
                               -> Result<LengthOrPercentage, ()> {
@@ -502,11 +503,12 @@ pub mod computed {
         }
     }
 
-    #[deriving(PartialEq, Clone)]
+    #[deriving(PartialEq, Clone, Show)]
     pub enum LengthOrPercentage {
         LP_Length(Au),
         LP_Percentage(CSSFloat),
     }
+
     #[allow(non_snake_case)]
     pub fn compute_LengthOrPercentage(value: specified::LengthOrPercentage, context: &Context)
                                    -> LengthOrPercentage {
@@ -516,7 +518,7 @@ pub mod computed {
         }
     }
 
-    #[deriving(PartialEq, Clone)]
+    #[deriving(PartialEq, Clone, Show)]
     pub enum LengthOrPercentageOrAuto {
         LPA_Length(Au),
         LPA_Percentage(CSSFloat),
@@ -532,7 +534,7 @@ pub mod computed {
         }
     }
 
-    #[deriving(PartialEq, Clone)]
+    #[deriving(PartialEq, Clone, Show)]
     pub enum LengthOrPercentageOrNone {
         LPN_Length(Au),
         LPN_Percentage(CSSFloat),
@@ -602,5 +604,3 @@ pub fn parse_url(input: &str, base_url: &Url) -> Url {
     UrlParser::new().base_url(base_url).parse(input)
         .unwrap_or_else(|_| Url::parse("about:invalid").unwrap())
 }
-
-


### PR DESCRIPTION
This patch is a first stab at implementing border-radius. It looks fine as long as
the border isn't an ellipse (that might not even parse yet), and the border-widths
around a border-radius are the same.

Here's a cool screenshot!

![](https://www.dropbox.com/s/gdtmgjrlnf82gzz/Screenshot%202014-11-12%2018.03.29.png?dl=0)

r? @pcwalton @SimonSapin
