### PR TITLE
Update behavior of Document.createElement

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -567,7 +567,11 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             debug!("Not a valid element name");
             return Err(InvalidCharacter);
         }
-        let local_name = local_name.as_slice().to_ascii_lower();
+        let local_name = if self.is_html_document {
+            local_name.as_slice().to_ascii_lower()
+        } else {
+            local_name
+        };
         let name = QualName::new(ns!(HTML), Atom::from_slice(local_name.as_slice()));
         Ok(Element::create(name, None, self, ScriptCreated))
     }

--- a/tests/wpt/metadata/dom/nodes/Document-constructor.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-constructor.html.ini
@@ -3,9 +3,6 @@
   [new Document(): interfaces]
     expected: FAIL
 
-  [new Document(): metadata]
-    expected: FAIL
-
   [new Document(): URL parsing]
     expected: FAIL
 


### PR DESCRIPTION
Fixes #4009.

Only lower-case the argument to Document#createElement if it's a HTML document.
