### PR TITLE
wide form buttons fixes #3972

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -2,7 +2,7 @@ input, select { display: inline-block; }
 input                   { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: nowrap; }
 input[type="button"],
 input[type="submit"],
-input[type="reset"]     { background: lightgrey; border-top: solid 1px #EEEEEE; border-left: solid 1px #CCCCCC; border-right: solid 1px #999999; border-bottom: solid 1px #999999; text-align: center; vertical-align: middle; color: black; }
+input[type="reset"]     { background: lightgrey; border-top: solid 1px #EEEEEE; border-left: solid 1px #CCCCCC; border-right: solid 1px #999999; border-bottom: solid 1px #999999; text-align: center; vertical-align: middle; color: black; width: 100%; }
 input[type="hidden"]    { display: none !important }
 input[type="checkbox"],
 input[type="radio"]     { font-family: monospace !important; border: none !important; background: transparent; }


### PR DESCRIPTION
My first pull request to servo \o/

Try to fix https://github.com/servo/servo/issues/3972. Tested with `./mach run tests/html/test-inputs.html`.
Any reasons why this CSS is formatted this way? (All properties on the same line. Looks a little bit _generated_?)
