### PR TITLE
layout: Implement `opacity` per CSS-COLOR § 3.2.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -146,6 +146,8 @@ pub struct StackingContext {
     pub clip_rect: Rect<Au>,
     /// The `z-index` for this stacking context.
     pub z_index: i32,
+    /// The opacity of this stacking context.
+    pub opacity: AzFloat,
 }
 
 impl StackingContext {
@@ -157,6 +159,7 @@ impl StackingContext {
     pub fn new(display_list: Box<DisplayList>,
                bounds: Rect<Au>,
                z_index: i32,
+               opacity: AzFloat,
                layer: Option<Arc<RenderLayer>>)
                -> StackingContext {
         StackingContext {
@@ -165,6 +168,7 @@ impl StackingContext {
             bounds: bounds,
             clip_rect: bounds,
             z_index: z_index,
+            opacity: opacity,
         }
     }
 
@@ -174,82 +178,107 @@ impl StackingContext {
                                           tile_bounds: &Rect<AzFloat>,
                                           current_transform: &Matrix2D<AzFloat>,
                                           current_clip_stack: &mut Vec<Rect<Au>>) {
-        // Optimize the display list to throw out out-of-bounds display items and so forth.
-        let display_list = DisplayListOptimizer::new(tile_bounds).optimize(&*self.display_list);
+        let temporary_draw_target =
+            render_context.get_or_create_temporary_draw_target(self.opacity);
+        {
+            let mut render_subcontext = RenderContext {
+                draw_target: temporary_draw_target.clone(),
+                font_ctx: &mut *render_context.font_ctx,
+                page_rect: render_context.page_rect,
+                screen_rect: render_context.screen_rect,
+                ..*render_context
+            };
 
-        // Sort positioned children according to z-index.
-        let mut positioned_children = SmallVec8::new();
-        for kid in display_list.children.iter() {
-            positioned_children.push((*kid).clone());
-        }
-        positioned_children.as_slice_mut().sort_by(|this, other| this.z_index.cmp(&other.z_index));
+            // Optimize the display list to throw out out-of-bounds display items and so forth.
+            let display_list =
+                DisplayListOptimizer::new(tile_bounds).optimize(&*self.display_list);
 
-        // Steps 1 and 2: Borders and background for the root.
-        for display_item in display_list.background_and_borders.iter() {
-            display_item.draw_into_context(render_context, current_transform, current_clip_stack)
-        }
-
-        // Step 3: Positioned descendants with negative z-indices.
-        for positioned_kid in positioned_children.iter() {
-            if positioned_kid.z_index >= 0 {
-                break
+            // Sort positioned children according to z-index.
+            let mut positioned_children = SmallVec8::new();
+            for kid in display_list.children.iter() {
+                positioned_children.push((*kid).clone());
             }
-            if positioned_kid.layer.is_none() {
-                let new_transform =
-                    current_transform.translate(positioned_kid.bounds.origin.x.to_nearest_px()
-                                                    as AzFloat,
-                                                positioned_kid.bounds.origin.y.to_nearest_px()
-                                                    as AzFloat);
-                let new_tile_rect =
-                    self.compute_tile_rect_for_child_stacking_context(tile_bounds,
-                                                                      &**positioned_kid);
-                positioned_kid.optimize_and_draw_into_context(render_context,
-                                                              &new_tile_rect,
-                                                              &new_transform,
-                                                              current_clip_stack);
-            }
-        }
+            positioned_children.as_slice_mut()
+                               .sort_by(|this, other| this.z_index.cmp(&other.z_index));
 
-        // Step 4: Block backgrounds and borders.
-        for display_item in display_list.block_backgrounds_and_borders.iter() {
-            display_item.draw_into_context(render_context, current_transform, current_clip_stack)
-        }
-
-        // Step 5: Floats.
-        for display_item in display_list.floats.iter() {
-            display_item.draw_into_context(render_context, current_transform, current_clip_stack)
-        }
-
-        // TODO(pcwalton): Step 6: Inlines that generate stacking contexts.
-
-        // Step 7: Content.
-        for display_item in display_list.content.iter() {
-            display_item.draw_into_context(render_context, current_transform, current_clip_stack)
-        }
-
-        // Steps 8 and 9: Positioned descendants with nonnegative z-indices.
-        for positioned_kid in positioned_children.iter() {
-            if positioned_kid.z_index < 0 {
-                continue
+            // Steps 1 and 2: Borders and background for the root.
+            for display_item in display_list.background_and_borders.iter() {
+                display_item.draw_into_context(&mut render_subcontext,
+                                               current_transform,
+                                               current_clip_stack)
             }
 
-            if positioned_kid.layer.is_none() {
-                let new_transform =
-                    current_transform.translate(positioned_kid.bounds.origin.x.to_nearest_px()
-                                                    as AzFloat,
-                                                positioned_kid.bounds.origin.y.to_nearest_px()
-                                                    as AzFloat);
-                let new_tile_rect =
-                    self.compute_tile_rect_for_child_stacking_context(tile_bounds,
-                                                                      &**positioned_kid);
-                positioned_kid.optimize_and_draw_into_context(render_context,
-                                                              &new_tile_rect,
-                                                              &new_transform,
-                                                              current_clip_stack);
+            // Step 3: Positioned descendants with negative z-indices.
+            for positioned_kid in positioned_children.iter() {
+                if positioned_kid.z_index >= 0 {
+                    break
+                }
+                if positioned_kid.layer.is_none() {
+                    let new_transform =
+                        current_transform.translate(positioned_kid.bounds.origin.x.to_nearest_px()
+                                                        as AzFloat,
+                                                    positioned_kid.bounds.origin.y.to_nearest_px()
+                                                        as AzFloat);
+                    let new_tile_rect =
+                        self.compute_tile_rect_for_child_stacking_context(tile_bounds,
+                                                                          &**positioned_kid);
+                    positioned_kid.optimize_and_draw_into_context(&mut render_subcontext,
+                                                                  &new_tile_rect,
+                                                                  &new_transform,
+                                                                  current_clip_stack);
+                }
             }
+
+            // Step 4: Block backgrounds and borders.
+            for display_item in display_list.block_backgrounds_and_borders.iter() {
+                display_item.draw_into_context(&mut render_subcontext,
+                                               current_transform,
+                                               current_clip_stack)
+            }
+
+            // Step 5: Floats.
+            for display_item in display_list.floats.iter() {
+                display_item.draw_into_context(&mut render_subcontext,
+                                               current_transform,
+                                               current_clip_stack)
+            }
+
+            // TODO(pcwalton): Step 6: Inlines that generate stacking contexts.
+
+            // Step 7: Content.
+            for display_item in display_list.content.iter() {
+                display_item.draw_into_context(&mut render_subcontext,
+                                               current_transform,
+                                               current_clip_stack)
+            }
+
+            // Steps 8 and 9: Positioned descendants with nonnegative z-indices.
+            for positioned_kid in positioned_children.iter() {
+                if positioned_kid.z_index < 0 {
+                    continue
+                }
+
+                if positioned_kid.layer.is_none() {
+                    let new_transform =
+                        current_transform.translate(positioned_kid.bounds.origin.x.to_nearest_px()
+                                                        as AzFloat,
+                                                    positioned_kid.bounds.origin.y.to_nearest_px()
+                                                        as AzFloat);
+                    let new_tile_rect =
+                        self.compute_tile_rect_for_child_stacking_context(tile_bounds,
+                                                                          &**positioned_kid);
+                    positioned_kid.optimize_and_draw_into_context(&mut render_subcontext,
+                                                                  &new_tile_rect,
+                                                                  &new_transform,
+                                                                  current_clip_stack);
+                }
+            }
+
+            // TODO(pcwalton): Step 10: Outlines.
         }
 
-        // TODO(pcwalton): Step 10: Outlines.
+        render_context.draw_temporary_draw_target_if_necessary(&temporary_draw_target,
+                                                               self.opacity)
     }
 
     /// Translate the given tile rect into the coordinate system of a child stacking context.

--- a/components/gfx/render_task.rs
+++ b/components/gfx/render_task.rs
@@ -505,7 +505,7 @@ impl WorkerThread {
         {
             // Build the render context.
             let mut render_context = RenderContext {
-                draw_target: &draw_target,
+                draw_target: draw_target.clone(),
                 font_ctx: &mut self.font_context,
                 page_rect: tile.page_rect,
                 screen_rect: tile.screen_rect,

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1494,6 +1494,9 @@ impl Fragment {
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.
     pub fn establishes_stacking_context(&self) -> bool {
+        if self.style().get_effects().opacity != 1.0 {
+            return true
+        }
         match self.style().get_box().position {
             position::absolute | position::fixed => {
                 // FIXME(pcwalton): This should only establish a new stacking context when

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -25,27 +25,27 @@ use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
 use geom::scale_factor::ScaleFactor;
+use gfx::color;
 use gfx::display_list::{DisplayList, OpaqueNode, StackingContext};
-use gfx::render_task::{RenderInitMsg, RenderChan, RenderLayer};
-use gfx::{render_task, color};
+use gfx::font_cache_task::FontCacheTask;
+use gfx::render_task::{mod, RenderInitMsg, RenderChan, RenderLayer};
 use layout_traits;
 use layout_traits::{LayoutControlMsg, LayoutTaskFactory};
 use log;
 use script::dom::bindings::js::JS;
 use script::dom::node::{ElementNodeTypeId, LayoutDataRef, Node};
 use script::dom::element::{HTMLBodyElementTypeId, HTMLHtmlElementTypeId};
-use script::layout_interface::{
-    AddStylesheetMsg, ContentBoxResponse, ContentBoxesResponse, ContentBoxesQuery,
-    ContentBoxQuery, ExitNowMsg, GetRPCMsg, HitTestResponse, LayoutChan, LayoutRPC,
-    LoadStylesheetMsg, MouseOverResponse, Msg, NoQuery, PrepareToExitMsg, ReapLayoutDataMsg,
-    Reflow, ReflowForDisplay, ReflowMsg, ScriptLayoutChan, TrustedNodeAddress,
-};
+use script::layout_interface::{AddStylesheetMsg, ContentBoxResponse, ContentBoxesResponse};
+use script::layout_interface::{ContentBoxesQuery, ContentBoxQuery, ExitNowMsg, GetRPCMsg};
+use script::layout_interface::{HitTestResponse, LayoutChan, LayoutRPC, LoadStylesheetMsg};
+use script::layout_interface::{MouseOverResponse, Msg, NoQuery, PrepareToExitMsg};
+use script::layout_interface::{ReapLayoutDataMsg, Reflow, ReflowForDisplay, ReflowMsg};
+use script::layout_interface::{ScriptLayoutChan, TrustedNodeAddress};
 use script_traits::{SendEventMsg, ReflowEvent, ReflowCompleteMsg, OpaqueScriptLayoutChannel};
 use script_traits::{ScriptControlChan, UntrustedNodeAddress};
 use servo_msg::compositor_msg::Scrollable;
 use servo_msg::constellation_msg::{ConstellationChan, PipelineId, Failure, FailureMsg};
 use servo_net::image_cache_task::{ImageCacheTask, ImageResponseMsg};
-use gfx::font_cache_task::{FontCacheTask};
 use servo_net::local_image_cache::{ImageResponder, LocalImageCache};
 use servo_net::resource_task::{ResourceTask, load_bytes_iter};
 use servo_util::geometry::Au;
@@ -679,6 +679,7 @@ impl LayoutTask {
             let stacking_context = Arc::new(StackingContext::new(display_list,
                                                                  origin,
                                                                  0,
+                                                                 1.0,
                                                                  Some(render_layer)));
 
             rw_data.stacking_context = Some(stacking_context.clone());

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#64853170e435d9320f3fd828b9e7d16bc4c260a3"
+source = "git+https://github.com/servo/rust-azure#d323c3c7c248d3d5a2d46a6a5ee61c6e92aec0b0"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -212,7 +212,7 @@ source = "git+https://github.com/servo/libfreetype2#f5c49c0da1d5bc6b206c41763440
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#e5e74911ac6d3201009879b72499d6c681302611"
+source = "git+https://github.com/servo/rust-geom#95e746133b4a35b53eb259304668b63ee8de42b8"
 
 [[package]]
 name = "gfx"

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1208,6 +1208,37 @@ pub mod longhands {
     ${switch_to_style_struct("Box")}
 
     ${single_keyword("box-sizing", "content-box border-box")}
+
+    ${new_style_struct("Effects", is_inherited=False)}
+
+    <%self:single_component_value name="opacity">
+        pub type SpecifiedValue = CSSFloat;
+        pub mod computed_value {
+            use super::super::CSSFloat;
+            pub type T = CSSFloat;
+        }
+        #[inline]
+        pub fn get_initial_value() -> computed_value::T {
+            1.0
+        }
+        #[inline]
+        pub fn to_computed_value(value: SpecifiedValue, _: &computed::Context)
+                                 -> computed_value::T {
+            if value < 0.0 {
+                0.0
+            } else if value > 1.0 {
+                1.0
+            } else {
+                value
+            }
+        }
+        fn from_component_value(input: &ComponentValue, _: &Url) -> Result<SpecifiedValue,()> {
+            match *input {
+                Number(ref value) => Ok(value.value),
+                _ => Err(())
+            }
+        }
+    </%self:single_component_value>
 }
 
 

--- a/ports/android/glut_app/Cargo.lock
+++ b/ports/android/glut_app/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#612ffc4fbf80c1bd5faae4b86dfc539dda06fb0c"
+source = "git+https://github.com/servo/rust-azure#d323c3c7c248d3d5a2d46a6a5ee61c6e92aec0b0"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#612ffc4fbf80c1bd5faae4b86dfc539dda06fb0c"
+source = "git+https://github.com/servo/rust-azure#d323c3c7c248d3d5a2d46a6a5ee61c6e92aec0b0"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -185,4 +185,5 @@ fragment=top != ../html/acid2.html acid2_ref.html
 != linear_gradients_corners_a.html linear_gradients_corners_ref.html
 == linear_gradients_lengths_a.html linear_gradients_lengths_ref.html
 == incremental_float_a.html incremental_float_ref.html
-== table_specified_width_a.html table_specified_width_ref.html
+== opacity_simple_a.html opacity_simple_ref.html
+== opacity_stacking_context_a.html opacity_stacking_context_ref.html

--- a/tests/ref/opacity_simple_a.html
+++ b/tests/ref/opacity_simple_a.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that opacity works. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 50px;
+    left: 50px;
+}
+#a {
+    background: #800000;
+}
+#b {
+    background: #000080;
+    opacity: 0.75;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+</body>
+</html>
+

--- a/tests/ref/opacity_simple_ref.html
+++ b/tests/ref/opacity_simple_ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that opacity works. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 50px;
+    left: 50px;
+    background: #200060;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+</html>
+

--- a/tests/ref/opacity_stacking_context_a.html
+++ b/tests/ref/opacity_stacking_context_a.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `opacity` causes a new stacking context to be formed. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+
+#a {
+    background: red;
+    top: 0;
+    left: 0;
+    z-index: 1;
+}
+
+#b {
+    background: #00ff00;
+    top: 25px;
+    left: 25px;
+    z-index: 2;
+}
+
+#c {
+    background: blue;
+    top: 50px;
+    left: 50px;
+    z-index: 3;
+}
+
+#container {
+    opacity: 0.5;
+    width: 200px;
+    height: 200px;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=c></section>
+<div id=container>
+    <section id=b></section>
+</div>
+</body>
+</html>
+

--- a/tests/ref/opacity_stacking_context_ref.html
+++ b/tests/ref/opacity_stacking_context_ref.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `opacity` causes a new stacking context to be formed. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+
+#a {
+    background: red;
+    top: 0;
+    left: 0;
+    z-index: 2;
+}
+
+#b {
+    background: #00ff00;
+    top: 25px;
+    left: 25px;
+    z-index: 1;
+    opacity: 0.5;
+}
+
+#c {
+    background: blue;
+    top: 50px;
+    left: 50px;
+    z-index: 3;
+}
+
+#container {
+    width: 200px;
+    height: 200px;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=c></section>
+<div id=container>
+    <section id=b></section>
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
This adds the infrastructure necessary to support stacking contexts that
are not containing blocks for absolutely-positioned elements. Our
infrastructure did not support that before. This minor revamp actually
ended up simplifying the logic around display list building and
stacking-relative position computation for absolutely-positioned flows,
which was nice.

This will need this PR: https://github.com/servo/rust-azure/pull/112 I have not updated the Cargo.lock file yet because I want the merge commit.

r? @glennw
f? @SimonSapin 
