### PR TITLE
Added libbz2-dev to Debian based prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On Debian-based Linuxes:
 sudo apt-get install curl freeglut3-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     msttcorefonts gperf g++ cmake python-virtualenv \
-    libssl-dev
+    libssl-dev libbz2-dev
 ```
 
 On Fedora:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On Fedora:
 sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
-    rpm-build openssl-devel cmake
+    rpm-build openssl-devel cmake bzip2
 pushd .
 cd /tmp
 wget http://corefonts.sourceforge.net/msttcorefonts-2.5-1.spec
@@ -49,7 +49,7 @@ popd
 On Arch Linux:
 
 ``` sh
-sudo pacman -S base-devel git python2 python2-virtualenv mesa ttf-font cmake
+sudo pacman -S base-devel git python2 python2-virtualenv mesa ttf-font cmake bzip2
 ```
 
 Cross-compilation for Android:


### PR DESCRIPTION
Encountered this when building for the first time today:

```
note: /usr/bin/ld: cannot find -lbz2
collect2: error: ld returned 1 exit status

error: aborting due to previous error
Could not compile `servo`.
```

Installing the libbz2-dev packaged fixed it. Added to the list of packages to install on Debian based linuxes in README.md
