### PR TITLE
Rebuild after ./mach test-unit

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -74,6 +74,16 @@ class MachCommands(CommandBase):
         for component in os.listdir("components"):
             ret = ret or cargo_test(component)
 
+        # XXX This is a workaround for issue #3928. For some reason, when
+        # cargo test is run, ./target/servo is deleted- breaking all subsequent
+        # tests if run with ./mach test (not to mention breaking ./mach run
+        # until you rebuild again). I would hope that there's a better solution
+        # to this (backing up the file before and moving it back after? some
+        # sort of cargo configuration?) but this is quick and easy for now.
+        print("Rebuilding servo...")
+        self.context.built_tests = False
+        self.ensure_built_tests()
+
         return ret
 
     @Command('test-ref',

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -47,7 +47,7 @@ class MachCommands(CommandBase):
              category='testing')
     def test(self):
         test_start = time()
-        for t in ["tidy", "unit", "ref", "content", "wpt"]:
+        for t in ["tidy", "ref", "content", "wpt", "unit"]:
             Registrar.dispatch("test-%s" % t, context=self.context)
         elapsed = time() - test_start
 
@@ -74,16 +74,9 @@ class MachCommands(CommandBase):
         for component in os.listdir("components"):
             ret = ret or cargo_test(component)
 
-        # XXX This is a workaround for issue #3928. For some reason, when
-        # cargo test is run, ./target/servo is deleted- breaking all subsequent
-        # tests if run with ./mach test (not to mention breaking ./mach run
-        # until you rebuild again). I would hope that there's a better solution
-        # to this (backing up the file before and moving it back after? some
-        # sort of cargo configuration?) but this is quick and easy for now.
-        print("Rebuilding servo...")
-        self.context.built_tests = False
-        self.ensure_built_tests()
-
+        print("WARNING: test-unit has probably destroyed your servo binary "
+              " (see https://github.com/rust-lang/cargo/issues/961 ). You "
+              " may want to rebuild now.")
         return ret
 
     @Command('test-ref',


### PR DESCRIPTION
This is a quick and dirty workaround for issue #3928. Basically, `cargo test` is deleting `./target/servo`, which is clearly not ideal if we want to do anything with servo after running the unit tests. This PR makes sure to rebuild after running `./mach test-unit`.

I'm not familiar enough with cargo yet to know why it's doing this or what better alternatives there are to fixing this. Having to rebuild afterwards feels pretty ugly to me, but my rationalization right now is that the time it takes to build is negligible in comparison to the time it takes to run the tests. Ideally, this should be something we could take care of in Cargo.toml, but again, I'm new to this (and the documentation seems less than helpful from what I can tell so far).

I won't be available for the rest of the day, so if anyone has suggestions, or wants to wait for a better solution, I'll get back to it tomorrow probably. Otherwise, this PR at least makes `./mach test` work properly, so there's that.
