### PR TITLE
Remove unused exit after load option.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -14,7 +14,7 @@ use constellation::{SendableFrameTree, FrameTreeDiff};
 use pipeline::CompositionPipeline;
 use scrolling::ScrollingTimerProxy;
 use windowing;
-use windowing::{FinishedWindowEvent, IdleWindowEvent, LoadUrlWindowEvent, MouseWindowClickEvent};
+use windowing::{IdleWindowEvent, LoadUrlWindowEvent, MouseWindowClickEvent};
 use windowing::{MouseWindowEvent, MouseWindowEventClass, MouseWindowMouseDownEvent};
 use windowing::{MouseWindowMouseUpEvent, MouseWindowMoveEventClass, NavigationWindowEvent};
 use windowing::{QuitWindowEvent, RefreshWindowEvent, ResizeWindowEvent, ScrollWindowEvent};
@@ -668,16 +668,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.on_key_event(key, state, modifiers);
             }
 
-            FinishedWindowEvent => {
-                let exit = opts::get().exit_after_load;
-                if exit {
-                    debug!("shutting down the constellation for FinishedWindowEvent");
-                    let ConstellationChan(ref chan) = self.constellation_chan;
-                    chan.send(ExitMsg);
-                    self.shutdown_state = ShuttingDown;
-                }
-            }
-
             QuitWindowEvent => {
                 debug!("shutting down the constellation for QuitWindowEvent");
                 let ConstellationChan(ref chan) = self.constellation_chan;
@@ -1052,13 +1042,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         self.window.present();
 
         self.last_composite_time = precise_time_ns();
-
-        let exit = opts::get().exit_after_load;
-        if exit {
-            debug!("shutting down the constellation for exit_after_load");
-            let ConstellationChan(ref chan) = self.constellation_chan;
-            chan.send(ExitMsg);
-        }
 
         self.composition_request = NoCompositingNecessary;
         self.process_pending_scroll_events();

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -55,8 +55,6 @@ pub enum WindowEvent {
     PinchZoomWindowEvent(f32),
     /// Sent when the user uses chrome navigation (i.e. backspace or shift-backspace).
     NavigationWindowEvent(WindowNavigateMsg),
-    /// Sent when rendering is finished.
-    FinishedWindowEvent,
     /// Sent when the user quits the application
     QuitWindowEvent,
     /// Sent when a key input state changes
@@ -77,7 +75,6 @@ impl Show for WindowEvent {
             ZoomWindowEvent(..) => write!(f, "Zoom"),
             PinchZoomWindowEvent(..) => write!(f, "PinchZoom"),
             NavigationWindowEvent(..) => write!(f, "Navigation"),
-            FinishedWindowEvent => write!(f, "Finished"),
             QuitWindowEvent => write!(f, "Quit"),
         }
     }

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -64,9 +64,6 @@ pub struct Opts {
 
     pub nonincremental_layout: bool,
 
-    /// True to exit after the page load (`-x`).
-    pub exit_after_load: bool,
-
     pub output_file: Option<String>,
     pub headless: bool,
     pub hard_fail: bool,
@@ -168,7 +165,6 @@ fn default_opts() -> Opts {
         enable_experimental: false,
         layout_threads: 1,
         nonincremental_layout: false,
-        exit_after_load: false,
         output_file: None,
         headless: true,
         hard_fail: true,
@@ -321,7 +317,6 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         enable_experimental: opt_match.opt_present("e"),
         layout_threads: layout_threads,
         nonincremental_layout: nonincremental_layout,
-        exit_after_load: opt_match.opt_present("x"),
         output_file: opt_match.opt_str("o"),
         headless: opt_match.opt_present("z"),
         hard_fail: opt_match.opt_present("f"),

--- a/ports/android/glut_app/window.rs
+++ b/ports/android/glut_app/window.rs
@@ -7,7 +7,7 @@
 use compositing::compositor_task::{mod, CompositorProxy, CompositorReceiver};
 use compositing::windowing::{WindowEvent, WindowMethods};
 use compositing::windowing::{IdleWindowEvent, ResizeWindowEvent, MouseWindowEventClass};
-use compositing::windowing::{ScrollWindowEvent, ZoomWindowEvent, NavigationWindowEvent, FinishedWindowEvent};
+use compositing::windowing::{ScrollWindowEvent, ZoomWindowEvent, NavigationWindowEvent};
 use compositing::windowing::{MouseWindowClickEvent, MouseWindowMouseDownEvent, MouseWindowMouseUpEvent};
 use compositing::windowing::{Forward, Back};
 
@@ -19,8 +19,8 @@ use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeGraphicsMetadata;
-use msg::compositor_msg::{IdleRenderState, RenderState, RenderingRenderState};
-use msg::compositor_msg::{FinishedLoading, Blank, ReadyState};
+use msg::compositor_msg::{IdleRenderState, RenderState};
+use msg::compositor_msg::{Blank, ReadyState};
 use util::geometry::ScreenPx;
 
 use glut::glut::{ACTIVE_SHIFT, WindowHeight};
@@ -182,13 +182,6 @@ impl WindowMethods for Window {
 
     /// Sets the render state.
     fn set_render_state(&self, render_state: RenderState) {
-        if self.ready_state.get() == FinishedLoading &&
-            self.render_state.get() == RenderingRenderState &&
-            render_state == IdleRenderState {
-            // page loaded
-            self.event_queue.borrow_mut().push(FinishedWindowEvent);
-        }
-
         self.render_state.set(render_state);
         //FIXME: set_window_title causes crash with Android version of freeGLUT. Temporarily blocked.
         //self.update_window_title()

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -57,7 +57,6 @@ pub extern "C" fn cef_run_message_loop() {
         layout_threads: 1,
         nonincremental_layout: false,
         //layout_threads: cmp::max(rt::default_sched_threads() * 3 / 4, 1),
-        exit_after_load: false,
         output_file: None,
         headless: false,
         hard_fail: false,

--- a/ports/glfw/window.rs
+++ b/ports/glfw/window.rs
@@ -14,7 +14,7 @@ use compositing::windowing::{MouseWindowEventClass,  MouseWindowMoveEventClass};
 use compositing::windowing::{MouseWindowMouseUpEvent, RefreshWindowEvent};
 use compositing::windowing::{NavigationWindowEvent, ScrollWindowEvent, ZoomWindowEvent};
 use compositing::windowing::{PinchZoomWindowEvent, QuitWindowEvent};
-use compositing::windowing::{WindowEvent, WindowMethods, FinishedWindowEvent};
+use compositing::windowing::{WindowEvent, WindowMethods};
 use geom::point::{Point2D, TypedPoint2D};
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
@@ -161,13 +161,6 @@ impl WindowMethods for Window {
 
     /// Sets the render state.
     fn set_render_state(&self, render_state: RenderState) {
-        if self.ready_state.get() == FinishedLoading &&
-            self.render_state.get() == RenderingRenderState &&
-            render_state == IdleRenderState {
-            // page loaded
-            self.event_queue.borrow_mut().push(FinishedWindowEvent);
-        }
-
         self.render_state.set(render_state);
         self.update_window_title()
     }

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -9,7 +9,7 @@ use compositing::windowing::{WindowEvent, WindowMethods};
 use compositing::windowing::{IdleWindowEvent, ResizeWindowEvent};
 use compositing::windowing::{MouseWindowEventClass,  MouseWindowMoveEventClass, ScrollWindowEvent};
 use compositing::windowing::{ZoomWindowEvent, PinchZoomWindowEvent, NavigationWindowEvent};
-use compositing::windowing::{FinishedWindowEvent, QuitWindowEvent, MouseWindowClickEvent};
+use compositing::windowing::{QuitWindowEvent, MouseWindowClickEvent};
 use compositing::windowing::{MouseWindowMouseDownEvent, MouseWindowMouseUpEvent};
 use compositing::windowing::{Forward, Back};
 use geom::point::{Point2D, TypedPoint2D};
@@ -175,13 +175,6 @@ impl WindowMethods for Window {
 
     /// Sets the render state.
     fn set_render_state(&self, render_state: RenderState) {
-        if self.ready_state.get() == FinishedLoading &&
-            self.render_state.get() == RenderingRenderState &&
-            render_state == IdleRenderState {
-            // page loaded
-            self.event_queue.borrow_mut().push(FinishedWindowEvent);
-        }
-
         self.render_state.set(render_state);
         self.update_window_title()
     }


### PR DESCRIPTION
This simplifies some upcoming changes to how event handling works.
