### PR TITLE
Run a single WPT test from a relative path

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -150,6 +150,16 @@ class MachCommands(CommandBase):
     def test_wpt(self, params=None):
         if params is None:
             params = []
+        else:
+            # Allow the first argument to be a relative path from Servo's root
+            # directory, converting it to `--include some/wpt/test.html`
+            maybe_path = path.normpath(params[0])
+            wpt_path = path.join('tests', 'wpt', 'web-platform-tests')
+
+            if path.exists(maybe_path) and wpt_path in maybe_path:
+                params = ["--include",
+                          path.relpath(maybe_path, wpt_path)] + params[1:]
+
         return subprocess.call(
             ["bash", path.join("tests", "wpt", "run.sh")] + params,
             env=self.build_env())


### PR DESCRIPTION
Fixes #4055 

This PR allows `./mach test-wpt` to be run  (from /path/to/servo) with a single relative path to some wpt test.

For example:

```
./mach test-wpt tests/wpt/web-platform-tests/dom/sometest.html
```

The argument `tests/wpt/web-platform-tests/dom/sometest.html` is passed on as `--include dom/sometest.html`.
