### PR TITLE
Make set_timeout_or_interval's is_interval an enumerated value instead of a boolean

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -25,7 +25,7 @@ use page::Page;
 use script_task::{ExitWindowMsg, ScriptChan, TriggerLoadMsg, TriggerFragmentMsg};
 use script_task::FromWindow;
 use script_traits::ScriptControlChan;
-use timers::{TimerId, TimerManager};
+use timers::{Interval, NonInterval, TimerId, TimerManager};
 
 use servo_msg::compositor_msg::ScriptListener;
 use servo_msg::constellation_msg::LoadData;
@@ -228,7 +228,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            false, // is_interval
+                                            NonInterval, // is_interval
                                             FromWindow(self.page.id.clone()),
                                             self.script_chan.clone())
     }
@@ -241,7 +241,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            true, // is_interval
+                                            Interval, // is_interval
                                             FromWindow(self.page.id.clone()),
                                             self.script_chan.clone())
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -228,7 +228,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            NonInterval, // is_interval
+                                            NonInterval,
                                             FromWindow(self.page.id.clone()),
                                             self.script_chan.clone())
     }
@@ -241,7 +241,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            Interval, // is_interval
+                                            Interval,
                                             FromWindow(self.page.id.clone()),
                                             self.script_chan.clone())
     }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -160,7 +160,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            NonInterval, // is_interval
+                                            NonInterval,
                                             FromWorker,
                                             self.script_chan.clone())
     }
@@ -173,7 +173,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            Interval, // is_interval
+                                            Interval,
                                             FromWorker,
                                             self.script_chan.clone())
     }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -14,7 +14,7 @@ use dom::workerlocation::WorkerLocation;
 use dom::workernavigator::WorkerNavigator;
 use dom::window::{base64_atob, base64_btoa};
 use script_task::{ScriptChan, FromWorker};
-use timers::{TimerId, TimerManager};
+use timers::{Interval, NonInterval, TimerId, TimerManager};
 
 use servo_net::resource_task::{ResourceTask, load_whole_resource};
 use servo_util::str::DOMString;
@@ -160,7 +160,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            false, // is_interval
+                                            NonInterval, // is_interval
                                             FromWorker,
                                             self.script_chan.clone())
     }
@@ -173,7 +173,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         self.timers.set_timeout_or_interval(callback,
                                             args,
                                             timeout,
-                                            true, // is_interval
+                                            Interval, // is_interval
                                             FromWorker,
                                             self.script_chan.clone())
     }


### PR DESCRIPTION
Created an `IsInterval` enum to improve readability and remove the need for `true // is_interval`

I'm still fairly new to rust. I briefly looked for a way to implement boolean comparisons of the enum but didn't figure out a way. 

Also I'm not attached to any of the names. Let me know what I can fix :)
