### PR TITLE
Remove PseudoDisplayItemClass

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -420,13 +420,6 @@ pub enum DisplayItem {
     BorderDisplayItemClass(Box<BorderDisplayItem>),
     GradientDisplayItemClass(Box<GradientDisplayItem>),
     LineDisplayItemClass(Box<LineDisplayItem>),
-
-    /// A pseudo-display item that exists only so that queries like `ContentBoxQuery` and
-    /// `ContentBoxesQuery` can be answered.
-    ///
-    /// FIXME(pcwalton): This is really bogus. Those queries should not consult the display list
-    /// but should instead consult the flow/box tree.
-    PseudoDisplayItemClass(Box<BaseDisplayItem>),
 }
 
 /// Information common to all display items.
@@ -639,8 +632,6 @@ impl DisplayItem {
                                           line.color,
                                           line.style)
             }
-
-            PseudoDisplayItemClass(_) => {}
         }
     }
 
@@ -652,7 +643,6 @@ impl DisplayItem {
             BorderDisplayItemClass(ref border) => &border.base,
             GradientDisplayItemClass(ref gradient) => &gradient.base,
             LineDisplayItemClass(ref line) => &line.base,
-            PseudoDisplayItemClass(ref base) => &**base,
         }
     }
 
@@ -664,7 +654,6 @@ impl DisplayItem {
             BorderDisplayItemClass(ref mut border) => &mut border.base,
             GradientDisplayItemClass(ref mut gradient) => &mut gradient.base,
             LineDisplayItemClass(ref mut line) => &mut line.base,
-            PseudoDisplayItemClass(ref mut base) => &mut **base,
         }
     }
 
@@ -691,7 +680,6 @@ impl fmt::Show for DisplayItem {
                 BorderDisplayItemClass(_) => "Border",
                 GradientDisplayItemClass(_) => "Gradient",
                 LineDisplayItemClass(_) => "Line",
-                PseudoDisplayItemClass(_) => "Pseudo",
             },
             self.base().bounds,
             self.base().node.id()

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -27,7 +27,7 @@ use gfx::color;
 use gfx::display_list::{BaseDisplayItem, BorderDisplayItem, BorderDisplayItemClass, DisplayItem};
 use gfx::display_list::{DisplayList, GradientDisplayItem, GradientDisplayItemClass, GradientStop};
 use gfx::display_list::{ImageDisplayItem, ImageDisplayItemClass, LineDisplayItem, BorderRadii};
-use gfx::display_list::{LineDisplayItemClass, PseudoDisplayItemClass, SidewaysLeft, SidewaysRight};
+use gfx::display_list::{LineDisplayItemClass, SidewaysLeft, SidewaysRight};
 use gfx::display_list::{SolidColorDisplayItem, SolidColorDisplayItemClass, StackingContext};
 use gfx::display_list::{TextDisplayItem, TextDisplayItemClass, Upright};
 use gfx::paint_task::PaintLayer;
@@ -549,12 +549,6 @@ impl FragmentDisplayListBuilding for Fragment {
         if self.is_primary_fragment() {
             let level =
                 StackingLevel::from_background_and_border_level(background_and_border_level);
-
-            // Add a pseudo-display item for content box queries. This is a very bogus thing to do.
-            let base_display_item = box BaseDisplayItem::new(absolute_fragment_bounds,
-                                                             self.node,
-                                                             *clip_rect);
-            display_list.push(PseudoDisplayItemClass(base_display_item), level);
 
             // Add the background to the list, if applicable.
             match self.inline_context {


### PR DESCRIPTION
Now that content box queries are made against the flow tree, we can
remove PseudoDisplayItems from the display list.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/4073)

<!-- Reviewable:end -->
