### PR TITLE
Implement HTML{Anchor,Area,Link}Element.relList.

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrValue;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLAnchorElementBinding;
@@ -21,6 +22,7 @@ use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 use dom::virtualmethods::VirtualMethods;
 
 use std::default::Default;
+use string_cache::Atom;
 use servo_util::str::DOMString;
 
 #[dom_struct]
@@ -87,6 +89,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
             None => {}
         }
         self.handle_event_impl(event);
+    }
+
+    fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
+        match name {
+            &atom!("id") => AttrValue::from_atomic(value),
+            &atom!("rel") => AttrValue::from_tokenlist(value),
+            _ => self.super_type().unwrap().parse_plain_attribute(name, value),
+        }
     }
 }
 

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -3,22 +3,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
+use dom::bindings::codegen::Bindings::HTMLAreaElementBinding::HTMLAreaElementMethods;
 use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
-use dom::bindings::js::{JSRef, Temporary};
+use dom::bindings::codegen::InheritTypes::ElementCast;
+use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
+use dom::domtokenlist::DOMTokenList;
+use dom::element::Element;
 use dom::element::HTMLAreaElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
 
+use std::default::Default;
 use servo_util::str::DOMString;
 
 #[jstraceable]
 #[must_root]
 #[privatize]
 pub struct HTMLAreaElement {
-    htmlelement: HTMLElement
+    htmlelement: HTMLElement,
+    rel_list: MutNullableJS<DOMTokenList>,
 }
 
 impl HTMLAreaElementDerived for EventTarget {
@@ -30,7 +36,8 @@ impl HTMLAreaElementDerived for EventTarget {
 impl HTMLAreaElement {
     fn new_inherited(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> HTMLAreaElement {
         HTMLAreaElement {
-            htmlelement: HTMLElement::new_inherited(HTMLAreaElementTypeId, localName, prefix, document)
+            htmlelement: HTMLElement::new_inherited(HTMLAreaElementTypeId, localName, prefix, document),
+            rel_list: Default::default(),
         }
     }
 
@@ -44,5 +51,16 @@ impl HTMLAreaElement {
 impl Reflectable for HTMLAreaElement {
     fn reflector<'a>(&'a self) -> &'a Reflector {
         self.htmlelement.reflector()
+    }
+}
+
+impl<'a> HTMLAreaElementMethods for JSRef<'a, HTMLAreaElement> {
+    fn RelList(self) -> Temporary<DOMTokenList> {
+        if self.rel_list.get().is_none() {
+            let element: JSRef<Element> = ElementCast::from_ref(self);
+            let rel_list = DOMTokenList::new(element, &atom!("rel"));
+            self.rel_list.assign(Some(rel_list));
+        }
+        self.rel_list.get().unwrap()
     }
 }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrValue;
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding::HTMLAreaElementMethods;
-use dom::bindings::codegen::InheritTypes::HTMLAreaElementDerived;
+use dom::bindings::codegen::InheritTypes::{HTMLAreaElementDerived, HTMLElementCast};
 use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
@@ -15,8 +16,10 @@ use dom::element::HTMLAreaElementTypeId;
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, ElementNodeTypeId};
+use dom::virtualmethods::VirtualMethods;
 
 use std::default::Default;
+use string_cache::Atom;
 use servo_util::str::DOMString;
 
 #[jstraceable]
@@ -45,6 +48,21 @@ impl HTMLAreaElement {
     pub fn new(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> Temporary<HTMLAreaElement> {
         let element = HTMLAreaElement::new_inherited(localName, prefix, document);
         Node::reflect_node(box element, document, HTMLAreaElementBinding::Wrap)
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLAreaElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
+        match name {
+            &atom!("id") => AttrValue::from_atomic(value),
+            &atom!("rel") => AttrValue::from_tokenlist(value),
+            _ => self.super_type().unwrap().parse_plain_attribute(name, value),
+        }
     }
 }
 

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::Attr;
+use dom::attr::{Attr, AttrValue};
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding::HTMLLinkElementMethods;
@@ -90,6 +90,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
                 }
             }
             (_, _) => ()
+        }
+    }
+
+    fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
+        match name {
+            &atom!("id") => AttrValue::from_atomic(value),
+            &atom!("rel") => AttrValue::from_tokenlist(value),
+            _ => self.super_type().unwrap().parse_plain_attribute(name, value),
         }
     }
 

--- a/components/script/dom/webidls/HTMLAnchorElement.webidl
+++ b/components/script/dom/webidls/HTMLAnchorElement.webidl
@@ -17,7 +17,7 @@ interface HTMLAnchorElement : HTMLElement {
   //         attribute DOMString download;
   //[PutForwards=value] attribute DOMSettableTokenList ping;
   //         attribute DOMString rel;
-  //readonly attribute DOMTokenList relList;
+  readonly attribute DOMTokenList relList;
   //         attribute DOMString hreflang;
   //         attribute DOMString type;
 

--- a/components/script/dom/webidls/HTMLAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLAreaElement.webidl
@@ -12,7 +12,7 @@ interface HTMLAreaElement : HTMLElement {
   //         attribute DOMString download;
   //[PutForwards=value] attribute DOMSettableTokenList ping;
   //         attribute DOMString rel;
-  //readonly attribute DOMTokenList relList;
+  readonly attribute DOMTokenList relList;
   //         attribute DOMString hreflang;
   //         attribute DOMString type;
 

--- a/components/script/dom/webidls/HTMLLinkElement.webidl
+++ b/components/script/dom/webidls/HTMLLinkElement.webidl
@@ -8,7 +8,7 @@ interface HTMLLinkElement : HTMLElement {
   //         attribute DOMString href;
   //         attribute DOMString crossOrigin;
   //         attribute DOMString rel;
-  //readonly attribute DOMTokenList relList;
+  readonly attribute DOMTokenList relList;
   //         attribute DOMString media;
   //         attribute DOMString hreflang;
   //         attribute DOMString type;

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -2418,9 +2418,6 @@
   [HTMLLinkElement interface: attribute rel]
     expected: FAIL
 
-  [HTMLLinkElement interface: attribute relList]
-    expected: FAIL
-
   [HTMLLinkElement interface: attribute media]
     expected: FAIL
 
@@ -2449,9 +2446,6 @@
     expected: FAIL
 
   [HTMLLinkElement interface: document.createElement("link") must inherit property "rel" with the proper type (2)]
-    expected: FAIL
-
-  [HTMLLinkElement interface: document.createElement("link") must inherit property "relList" with the proper type (3)]
     expected: FAIL
 
   [HTMLLinkElement interface: document.createElement("link") must inherit property "media" with the proper type (4)]
@@ -2829,9 +2823,6 @@
   [HTMLAnchorElement interface: attribute rel]
     expected: FAIL
 
-  [HTMLAnchorElement interface: attribute relList]
-    expected: FAIL
-
   [HTMLAnchorElement interface: attribute hreflang]
     expected: FAIL
 
@@ -2863,9 +2854,6 @@
     expected: FAIL
 
   [HTMLAnchorElement interface: document.createElement("a") must inherit property "rel" with the proper type (3)]
-    expected: FAIL
-
-  [HTMLAnchorElement interface: document.createElement("a") must inherit property "relList" with the proper type (4)]
     expected: FAIL
 
   [HTMLAnchorElement interface: document.createElement("a") must inherit property "hreflang" with the proper type (5)]
@@ -4884,9 +4872,6 @@
   [HTMLAreaElement interface: attribute rel]
     expected: FAIL
 
-  [HTMLAreaElement interface: attribute relList]
-    expected: FAIL
-
   [HTMLAreaElement interface: attribute hreflang]
     expected: FAIL
 
@@ -4915,9 +4900,6 @@
     expected: FAIL
 
   [HTMLAreaElement interface: document.createElement("area") must inherit property "rel" with the proper type (6)]
-    expected: FAIL
-
-  [HTMLAreaElement interface: document.createElement("area") must inherit property "relList" with the proper type (7)]
     expected: FAIL
 
   [HTMLAreaElement interface: document.createElement("area") must inherit property "hreflang" with the proper type (8)]

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-link-element/link-rellist.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-link-element/link-rellist.html.ini
@@ -1,5 +1,0 @@
-[link-rellist.html]
-  type: testharness
-  [link.relList: non-string contains]
-    expected: FAIL
-


### PR DESCRIPTION
This addresses: https://github.com/servo/servo/issues/3994

However I wasn't able to get the _html/semantics/document-metadata/the-link-element/link-rellist.html_ to run as needed, but I'm fairly certain the code change does the right thing. Could you let me know if there something missing from the .Contains() implementation for non-string literals, or if something is wrong with my commit?
