### PR TITLE
Panic if DOMTokenList#contains is called for an unparsed attribute.

### DIFF
--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -90,10 +90,13 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     // http://dom.spec.whatwg.org/#dom-domtokenlist-contains
     fn Contains(self, token: DOMString) -> Fallible<bool> {
         self.check_token_exceptions(token.as_slice()).map(|slice| {
-            self.attribute().root().and_then(|attr| attr.value().tokens().map(|tokens| {
+            self.attribute().root().map(|attr| {
+                let value = attr.value();
+                let tokens = value.tokens()
+                                  .expect("Should have parsed this attribute");
                 let atom = Atom::from_slice(slice);
                 tokens.iter().any(|token| *token == atom)
-            })).unwrap_or(false)
+            }).unwrap_or(false)
         })
     }
 }


### PR DESCRIPTION
Previously, if the attribute was not parsed into a token list, and the
tokens() method returned None, DOMTokenList#contains would silently return
false. This issue was encountered in
https://github.com/servo/servo/pull/4076 and took quite some time to
figure out.
