### PR TITLE
Fix deprecation in selector matching test

### DIFF
--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -1260,9 +1260,9 @@ mod tests {
         let rules_list = get_mock_rules([".intro.foo", "#top"]);
         let mut selector_map = SelectorMap::new();
         selector_map.insert(rules_list[1][0].clone());
-        assert_eq!(1, selector_map.id_hash.find(&atom!("top")).unwrap()[0].declarations.source_order);
+        assert_eq!(1, selector_map.id_hash.get(&atom!("top")).unwrap()[0].declarations.source_order);
         selector_map.insert(rules_list[0][0].clone());
-        assert_eq!(0, selector_map.class_hash.find(&Atom::from_slice("intro")).unwrap()[0].declarations.source_order);
-        assert!(selector_map.class_hash.find(&Atom::from_slice("foo")).is_none());
+        assert_eq!(0, selector_map.class_hash.get(&Atom::from_slice("intro")).unwrap()[0].declarations.source_order);
+        assert!(selector_map.class_hash.get(&Atom::from_slice("foo")).is_none());
     }
 }


### PR DESCRIPTION
```
selector_matching.rs:1263:44: 1263:63 warning: use of deprecated item: Renamed to `get`, #[warn(deprecated)] on by default
selector_matching.rs:1263         assert_eq!(1, selector_map.id_hash.find(&atom!("top")).unwrap()[0].declarations.source_order);
                                                                     ^~~~~~~~~~~~~~~~~~~
selector_matching.rs:1265:47: 1265:79 warning: use of deprecated item: Renamed to `get`, #[warn(deprecated)] on by default
selector_matching.rs:1265         assert_eq!(0, selector_map.class_hash.find(&Atom::from_slice("intro")).unwrap()[0].declarations.source_order);
                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
selector_matching.rs:1266:41: 1266:71 warning: use of deprecated item: Renamed to `get`, #[warn(deprecated)] on by default
selector_matching.rs:1266         assert!(selector_map.class_hash.find(&Atom::from_slice("foo")).is_none());
                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The 'find' function was changed to 'get'. Updated to remove this warning given when running the tests.
