### PR TITLE
Make callers of `${Derived}::${base}()` use casts instead.

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -39,7 +39,7 @@ use util::{PrivateLayoutData};
 use gfx::display_list::OpaqueNode;
 use script::dom::bindings::codegen::InheritTypes::{ElementCast, HTMLIFrameElementCast};
 use script::dom::bindings::codegen::InheritTypes::{HTMLImageElementCast, HTMLInputElementCast};
-use script::dom::bindings::codegen::InheritTypes::{TextCast};
+use script::dom::bindings::codegen::InheritTypes::{NodeCast, TextCast};
 use script::dom::bindings::js::JS;
 use script::dom::element::{Element, HTMLAreaElementTypeId, HTMLAnchorElementTypeId};
 use script::dom::element::{HTMLLinkElementTypeId, LayoutElementHelpers, RawLayoutElementHelpers};
@@ -508,7 +508,7 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
 
     fn get_link(self) -> Option<&'le str> {
         // FIXME: This is HTML only.
-        match self.element.node().type_id_for_layout() {
+        match NodeCast::from_actual(self.element).type_id_for_layout() {
             // http://www.whatwg.org/specs/web-apps/current-work/multipage/selectors.html#
             // selector-link
             ElementNodeTypeId(HTMLAnchorElementTypeId) |
@@ -525,7 +525,7 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     #[inline]
     fn get_hover_state(self) -> bool {
         unsafe {
-            self.element.node().get_hover_state_for_layout()
+            NodeCast::from_actual(self.element).get_hover_state_for_layout()
         }
     }
 
@@ -539,14 +539,14 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     #[inline]
     fn get_disabled_state(self) -> bool {
         unsafe {
-            self.element.node().get_disabled_state_for_layout()
+            NodeCast::from_actual(self.element).get_disabled_state_for_layout()
         }
     }
 
     #[inline]
     fn get_enabled_state(self) -> bool {
         unsafe {
-            self.element.node().get_enabled_state_for_layout()
+            NodeCast::from_actual(self.element).get_enabled_state_for_layout()
         }
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -184,11 +184,6 @@ impl Element {
     }
 
     #[inline]
-    pub fn node<'a>(&'a self) -> &'a Node {
-        &self.node
-    }
-
-    #[inline]
     pub fn local_name<'a>(&'a self) -> &'a Atom {
         &self.local_name
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -50,11 +50,6 @@ impl HTMLElement {
         let element = HTMLElement::new_inherited(HTMLElementTypeId, localName, prefix, document);
         Node::reflect_node(box element, document, HTMLElementBinding::Wrap)
     }
-
-    #[inline]
-    pub fn element<'a>(&'a self) -> &'a Element {
-        &self.element
-    }
 }
 
 trait PrivateHTMLElementHelpers {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1150,11 +1150,6 @@ impl Node {
     }
 
     #[inline]
-    pub fn eventtarget<'a>(&'a self) -> &'a EventTarget {
-        &self.eventtarget
-    }
-
-    #[inline]
     pub fn layout_data(&self) -> Ref<Option<LayoutData>> {
         self.layout_data.borrow()
     }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -66,11 +66,6 @@ impl UIEvent {
                                  init.view.root_ref(), init.detail);
         Ok(event)
     }
-
-    #[inline]
-    pub fn event<'a>(&'a self) -> &'a Event {
-        &self.event
-    }
 }
 
 impl<'a> UIEventMethods for JSRef<'a, UIEvent> {


### PR DESCRIPTION
Fix #4124

This also introduce `BarCast::from_actual()` which is used for up-cast for dom's actual data types (non JS pointer values).
