### PR TITLE
Fixes #4123

### DIFF
--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -11,7 +11,7 @@ use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLLegendElementDer
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
-use dom::element::{AttributeHandlers, Element, HTMLFieldSetElementTypeId, HTMLButtonElementTypeId};
+use dom::element::{AttributeHandlers, Element, ElementHelpers, HTMLFieldSetElementTypeId, HTMLButtonElementTypeId};
 use dom::element::{HTMLInputElementTypeId, HTMLSelectElementTypeId, HTMLTextAreaElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlcollection::{HTMLCollection, CollectionFilter};

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -15,7 +15,7 @@ use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
-use dom::element::{AttributeHandlers, Element, HTMLOptionElementTypeId};
+use dom::element::{AttributeHandlers, Element, ElementHelpers, HTMLOptionElementTypeId};
 use dom::eventtarget::{EventTarget, NodeTargetTypeId};
 use dom::htmlelement::HTMLElement;
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, ElementNodeTypeId};

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::Bindings::NamedNodeMapBinding::NamedNodeMapMethods;
 use dom::bindings::global;
 use dom::bindings::js::{JS, JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
-use dom::element::Element;
+use dom::element::{Element, ElementHelpers};
 use dom::window::Window;
 
 #[dom_struct]

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -98,8 +98,8 @@ impl<'a> TreeSink<TrustedNodeAddress> for servohtmlparser::Sink {
         let elem: JSRef<Element> = ElementCast::to_ref(*node)
             .expect("tried to get name of non-Element in HTML parsing");
         QualName {
-            ns: elem.get_namespace().clone(),
-            local: elem.get_local_name().clone(),
+            ns: elem.namespace().clone(),
+            local: elem.local_name().clone(),
         }
     }
 


### PR DESCRIPTION
Moved all getters from Element to ElementHelpers. Existing ElementHelpers getters `get_namespace` and `get_local_name` were replaced by `namespace` and `local_name`. Callers were updated accordingly. Also the getters are no longer inlined.
3 of the getters needed to be added to RawLayoutElementHelpers as well, to accomodate existing calls directly from Element objects.
