### PR TITLE
Implements multi line text input for TextArea

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -49,6 +49,7 @@ use script::dom::element::{HTMLObjectElementTypeId, HTMLInputElementTypeId};
 use script::dom::element::{HTMLTableColElementTypeId, HTMLTableDataCellElementTypeId};
 use script::dom::element::{HTMLTableElementTypeId, HTMLTableHeaderCellElementTypeId};
 use script::dom::element::{HTMLTableRowElementTypeId, HTMLTableSectionElementTypeId};
+use script::dom::element::HTMLTextAreaElementTypeId;
 use script::dom::node::{CommentNodeTypeId, DoctypeNodeTypeId, DocumentFragmentNodeTypeId};
 use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, ProcessingInstructionNodeTypeId};
 use script::dom::node::{TextNodeTypeId};
@@ -273,7 +274,8 @@ impl<'a> FlowConstructor<'a> {
                 TableColumnFragment(TableColumnFragmentInfo::new(node))
             }
             Some(ElementNodeTypeId(HTMLTableDataCellElementTypeId)) |
-            Some(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId)) => TableCellFragment,
+            Some(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId)) |
+            Some(ElementNodeTypeId(HTMLTextAreaElementTypeId)) => TableCellFragment,
             Some(ElementNodeTypeId(HTMLTableRowElementTypeId)) |
             Some(ElementNodeTypeId(HTMLTableSectionElementTypeId)) => TableRowFragment,
             Some(TextNodeTypeId) => UnscannedTextFragment(UnscannedTextFragmentInfo::new(node)),
@@ -487,7 +489,16 @@ impl<'a> FlowConstructor<'a> {
         // Special case: If this is generated content, then we need to initialize the accumulator
         // with the fragment corresponding to that content.
         if node.get_pseudo_element_type() != Normal ||
-           node.type_id() == Some(ElementNodeTypeId(HTMLInputElementTypeId)) {
+           node.type_id() == Some(ElementNodeTypeId(HTMLInputElementTypeId)) ||
+           node.type_id() == Some(ElementNodeTypeId(HTMLTextAreaElementTypeId)) {
+            // A TextArea's text contents are displayed through the input text
+            // box, so don't construct them.
+            // TODO Maybe this belongs somewhere else?
+            if node.type_id() == Some(ElementNodeTypeId(HTMLTextAreaElementTypeId)) {
+                for kid in node.children() {
+                    kid.set_flow_construction_result(NoConstructionResult)
+                }
+            }
             let fragment_info = UnscannedTextFragment(UnscannedTextFragmentInfo::new(node));
             let fragment = Fragment::new_from_specific_info(node, fragment_info);
             inline_fragment_accumulator.fragments.push_back(fragment);

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -274,8 +274,7 @@ impl<'a> FlowConstructor<'a> {
                 TableColumnFragment(TableColumnFragmentInfo::new(node))
             }
             Some(ElementNodeTypeId(HTMLTableDataCellElementTypeId)) |
-            Some(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId)) |
-            Some(ElementNodeTypeId(HTMLTextAreaElementTypeId)) => TableCellFragment,
+            Some(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId)) => TableCellFragment,
             Some(ElementNodeTypeId(HTMLTableRowElementTypeId)) |
             Some(ElementNodeTypeId(HTMLTableSectionElementTypeId)) => TableRowFragment,
             Some(TextNodeTypeId) => UnscannedTextFragment(UnscannedTextFragmentInfo::new(node)),

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -5,7 +5,7 @@
 #![comment = "The Servo Parallel Browser Project"]
 #![license = "MPL"]
 
-#![feature(globs, macro_rules, phase, thread_local, unsafe_destructor)]
+#![feature(globs, macro_rules, phase, thread_local, unsafe_destructor, if_let)]
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -39,13 +39,14 @@ use util::{PrivateLayoutData};
 use gfx::display_list::OpaqueNode;
 use script::dom::bindings::codegen::InheritTypes::{ElementCast, HTMLIFrameElementCast};
 use script::dom::bindings::codegen::InheritTypes::{HTMLImageElementCast, HTMLInputElementCast};
-use script::dom::bindings::codegen::InheritTypes::{NodeCast, TextCast};
+use script::dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementCast, NodeCast, TextCast};
 use script::dom::bindings::js::JS;
 use script::dom::element::{Element, HTMLAreaElementTypeId, HTMLAnchorElementTypeId};
 use script::dom::element::{HTMLLinkElementTypeId, LayoutElementHelpers, RawLayoutElementHelpers};
 use script::dom::htmliframeelement::HTMLIFrameElement;
 use script::dom::htmlimageelement::LayoutHTMLImageElementHelpers;
 use script::dom::htmlinputelement::LayoutHTMLInputElementHelpers;
+use script::dom::htmltextareaelement::LayoutHTMLTextAreaElementHelpers;
 use script::dom::node::{DocumentNodeTypeId, ElementNodeTypeId, Node, NodeTypeId};
 use script::dom::node::{LayoutNodeHelpers, RawLayoutNodeHelpers, SharedLayoutData};
 use script::dom::node::{HAS_CHANGED, IS_DIRTY, HAS_DIRTY_SIBLINGS, HAS_DIRTY_DESCENDANTS};
@@ -188,7 +189,10 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
                 Some(text) => (*text.unsafe_get()).characterdata().data_for_layout().to_string(),
                 None => match HTMLInputElementCast::to_js(self.get_jsmanaged()) {
                     Some(input) => input.get_value_for_layout(),
-                    None => panic!("not text!")
+                    None => match HTMLTextAreaElementCast::to_js(self.get_jsmanaged()) {
+                        Some(area) => area.get_value_for_layout(),
+                        None => panic!("not text!")
+                    }
                 }
             }
         }

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -184,16 +184,14 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
 
     fn text(&self) -> String {
         unsafe {
-            let text_opt: Option<JS<Text>> = TextCast::to_js(self.get_jsmanaged());
-            match text_opt {
-                Some(text) => (*text.unsafe_get()).characterdata().data_for_layout().to_string(),
-                None => match HTMLInputElementCast::to_js(self.get_jsmanaged()) {
-                    Some(input) => input.get_value_for_layout(),
-                    None => match HTMLTextAreaElementCast::to_js(self.get_jsmanaged()) {
-                        Some(area) => area.get_value_for_layout(),
-                        None => panic!("not text!")
-                    }
-                }
+            if let Some(text) = TextCast::to_js(self.get_jsmanaged()) {
+                (*text.unsafe_get()).characterdata().data_for_layout().to_string()
+            } else if let Some(input) = HTMLInputElementCast::to_js(self.get_jsmanaged()) {
+                input.get_value_for_layout()
+            } else if let Some(area) = HTMLTextAreaElementCast::to_js(self.get_jsmanaged()) {
+                area.get_value_for_layout()
+            } else {
+                panic!("not text!")
             }
         }
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -7,6 +7,7 @@ use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
+use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::utils::{Reflectable, Reflector};
@@ -46,15 +47,66 @@ impl HTMLTextAreaElement {
 }
 
 impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
+    // TODO A few of these attributes have default values and additional
+    // constraints
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-cols
+    make_uint_getter!(Cols)
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-cols
+    make_uint_setter!(SetCols, "cols")
+
     // http://www.whatwg.org/html/#dom-fe-disabled
     make_bool_getter!(Disabled)
 
     // http://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled")
 
+    // https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name
+    make_getter!(Name)
+
+    // https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name
+    make_setter!(SetName, "name")
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-placeholder
+    make_getter!(Placeholder)
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-placeholder
+    make_setter!(SetPlaceholder, "placeholder")
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-required
+    make_bool_getter!(Required)
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-required
+    make_bool_setter!(SetRequired, "required")
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-rows
+    make_uint_getter!(Rows)
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-rows
+    make_uint_setter!(SetRows, "rows")
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-wrap
+    make_getter!(Wrap)
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-wrap
+    make_setter!(SetWrap, "wrap")
+
     // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-type
     fn Type(self) -> DOMString {
         "textarea".to_string()
+    }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-defaultvalue
+    fn DefaultValue(self) -> DOMString {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
+        node.GetTextContent().unwrap()
+    }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-defaultvalue
+    fn SetDefaultValue(self, value: DOMString) {
+        let node: JSRef<Node> = NodeCast::from_ref(self);
+        node.SetTextContent(Some(value))
     }
 }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -139,11 +139,11 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 }
 
-pub trait HTMLTextAreaElementHelpers {
+trait PrivateHTMLTextAreaElementHelpers {
     fn force_relayout(self);
 }
 
-impl<'a> HTMLTextAreaElementHelpers for JSRef<'a, HTMLTextAreaElement> {
+impl<'a> PrivateHTMLTextAreaElementHelpers for JSRef<'a, HTMLTextAreaElement> {
     fn force_relayout(self) {
         let doc = document_from_node(self).root();
         let node: JSRef<Node> = NodeCast::from_ref(self);
@@ -223,7 +223,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
         }
 
         if child.is_text() {
-            self.SetValue(child.GetTextContent().unwrap());
+            self.SetValue(self.DefaultValue());
         }
     }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::Attr;
+use dom::attr::{Attr, AttrValue};
 use dom::attr::AttrHelpers;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -54,6 +54,9 @@ impl LayoutHTMLTextAreaElementHelpers for JS<HTMLTextAreaElement> {
         (*self.unsafe_get()).textinput.borrow_for_layout().get_content()
     }
 }
+
+static DEFAULT_COLS: u32 = 20;
+static DEFAULT_ROWS: u32 = 2;
 
 impl HTMLTextAreaElement {
     fn new_inherited(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> HTMLTextAreaElement {
@@ -211,6 +214,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
+    }
+
+    fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
+        match name {
+            &atom!("cols") => AttrValue::from_u32(value, DEFAULT_COLS),
+            &atom!("rows") => AttrValue::from_u32(value, DEFAULT_ROWS),
+            _ => self.super_type().unwrap().parse_plain_attribute(name, value),
+        }
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {

--- a/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -7,22 +7,22 @@
 interface HTMLTextAreaElement : HTMLElement {
   //         attribute DOMString autocomplete;
   //         attribute boolean autofocus;
-  //         attribute unsigned long cols;
+           attribute unsigned long cols;
   //         attribute DOMString dirName;
            attribute boolean disabled;
   //readonly attribute HTMLFormElement? form;
   //         attribute DOMString inputMode;
   //         attribute long maxLength;
   //         attribute long minLength;
-  //         attribute DOMString name;
-  //         attribute DOMString placeholder;
+           attribute DOMString name;
+           attribute DOMString placeholder;
   //         attribute boolean readOnly;
-  //         attribute boolean required;
-  //         attribute unsigned long rows;
-  //         attribute DOMString wrap;
+           attribute boolean required;
+           attribute unsigned long rows;
+           attribute DOMString wrap;
 
   readonly attribute DOMString type;
-  //         attribute DOMString defaultValue;
+           attribute DOMString defaultValue;
   //[TreatNullAs=EmptyString] attribute DOMString value;
   //readonly attribute unsigned long textLength;
 

--- a/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -23,7 +23,7 @@ interface HTMLTextAreaElement : HTMLElement {
 
   readonly attribute DOMString type;
            attribute DOMString defaultValue;
-  //[TreatNullAs=EmptyString] attribute DOMString value;
+  [TreatNullAs=EmptyString] attribute DOMString value;
   //readonly attribute unsigned long textLength;
 
   //readonly attribute boolean willValidate;

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -1,5 +1,6 @@
-input, select { display: inline-block; }
+input, textarea, select { display: inline-block; }
 input                   { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: nowrap; }
+textarea                { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: pre; }
 input[type="button"],
 input[type="submit"],
 input[type="reset"]     { background: lightgrey; border-top: solid 1px #EEEEEE; border-left: solid 1px #CCCCCC; border-right: solid 1px #999999; border-bottom: solid 1px #999999; text-align: center; vertical-align: middle; color: black; width: 100%; }

--- a/tests/html/textarea.html
+++ b/tests/html/textarea.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+<textarea name="textarea">Write something here
+and maybe here</textarea>
+</body>

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -5370,9 +5370,6 @@
   [HTMLTextAreaElement interface: attribute autofocus]
     expected: FAIL
 
-  [HTMLTextAreaElement interface: attribute cols]
-    expected: FAIL
-
   [HTMLTextAreaElement interface: attribute dirName]
     expected: FAIL
 
@@ -5388,28 +5385,7 @@
   [HTMLTextAreaElement interface: attribute minLength]
     expected: FAIL
 
-  [HTMLTextAreaElement interface: attribute name]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: attribute placeholder]
-    expected: FAIL
-
   [HTMLTextAreaElement interface: attribute readOnly]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: attribute required]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: attribute rows]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: attribute wrap]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: attribute defaultValue]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: attribute value]
     expected: FAIL
 
   [HTMLTextAreaElement interface: attribute textLength]
@@ -5463,9 +5439,6 @@
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "autofocus" with the proper type (1)]
     expected: FAIL
 
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "cols" with the proper type (2)]
-    expected: FAIL
-
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "dirName" with the proper type (3)]
     expected: FAIL
 
@@ -5481,28 +5454,7 @@
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "minLength" with the proper type (8)]
     expected: FAIL
 
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "name" with the proper type (9)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "placeholder" with the proper type (10)]
-    expected: FAIL
-
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "readOnly" with the proper type (11)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "required" with the proper type (12)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "rows" with the proper type (13)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "wrap" with the proper type (14)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "defaultValue" with the proper type (16)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "value" with the proper type (17)]
     expected: FAIL
 
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "textLength" with the proper type (18)]

--- a/tests/wpt/metadata/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-forms.html.ini
@@ -13401,31 +13401,10 @@
   [textarea.autofocus: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
-  [textarea.cols: typeof IDL attribute]
-    expected: FAIL
-
   [textarea.cols: IDL get with DOM attribute unset]
     expected: FAIL
 
-  [textarea.cols: setAttribute() to -2147483649 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to -2147483648 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to -36 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to -1 followed by IDL get]
-    expected: FAIL
-
   [textarea.cols: setAttribute() to 0 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to 1 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to 2147483647 followed by IDL get]
     expected: FAIL
 
   [textarea.cols: setAttribute() to 2147483648 followed by IDL get]
@@ -13434,28 +13413,10 @@
   [textarea.cols: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
-  [textarea.cols: setAttribute() to 4294967296 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "-1" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "-0" followed by IDL get]
-    expected: FAIL
-
   [textarea.cols: setAttribute() to "0" followed by IDL get]
     expected: FAIL
 
-  [textarea.cols: setAttribute() to "1" followed by IDL get]
-    expected: FAIL
-
   [textarea.cols: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\\v7" followed by IDL get]
     expected: FAIL
 
   [textarea.cols: setAttribute() to "\\f7" followed by IDL get]
@@ -13464,100 +13425,13 @@
   [textarea.cols: setAttribute() to " 7" followed by IDL get]
     expected: FAIL
 
-  [textarea.cols: setAttribute() to "\xc2\xa07" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xef\xbb\xbf7" followed by IDL get]
-    expected: FAIL
-
   [textarea.cols: setAttribute() to "\\n7" followed by IDL get]
     expected: FAIL
 
   [textarea.cols: setAttribute() to "\\r7" followed by IDL get]
     expected: FAIL
 
-  [textarea.cols: setAttribute() to "\xe2\x80\xa87" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\xa97" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe1\x9a\x807" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe1\xa0\x8e7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x807" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x817" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x827" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x837" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x847" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x857" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x867" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x877" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x887" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x897" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\x8a7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe2\x80\xaf7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\xe3\x80\x807" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
   [textarea.cols: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to object "2" followed by IDL get]
     expected: FAIL
 
   [textarea.cols: setAttribute() to object "3" followed by getAttribute()]
@@ -13567,12 +13441,6 @@
     expected: FAIL
 
   [textarea.cols: IDL set to 0 must throw INDEX_SIZE_ERR]
-    expected: FAIL
-
-  [textarea.cols: IDL set to 1 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.cols: IDL set to 2147483647 followed by getAttribute()]
     expected: FAIL
 
   [textarea.dirName: typeof IDL attribute]
@@ -14484,264 +14352,6 @@
   [textarea.maxLength: IDL set to 2147483647 followed by getAttribute()]
     expected: FAIL
 
-  [textarea.name: typeof IDL attribute]
-    expected: FAIL
-
-  [textarea.name: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to "" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to undefined followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to 7 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to 1.5 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to true followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to false followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to object "[object Object\]" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to NaN followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to -Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to "\\0" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to null followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to object "test-toString" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.name: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.name: IDL set to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: typeof IDL attribute]
-    expected: FAIL
-
-  [textarea.placeholder: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to "" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to undefined followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to 7 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to 1.5 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to true followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to false followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to object "[object Object\]" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to NaN followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to -Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to "\\0" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to null followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to object "test-toString" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.placeholder: IDL set to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
   [textarea.readOnly: typeof IDL attribute]
     expected: FAIL
 
@@ -14850,139 +14460,10 @@
   [textarea.readOnly: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
-  [textarea.required: typeof IDL attribute]
-    expected: FAIL
-
-  [textarea.required: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to " foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: setAttribute() to "required" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to "" followed by hasAttribute()]
-    expected: FAIL
-
-  [textarea.required: IDL set to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to " foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to undefined followed by hasAttribute()]
-    expected: FAIL
-
-  [textarea.required: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to null followed by hasAttribute()]
-    expected: FAIL
-
-  [textarea.required: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to false followed by hasAttribute()]
-    expected: FAIL
-
-  [textarea.required: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to NaN followed by hasAttribute()]
-    expected: FAIL
-
-  [textarea.required: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.required: IDL set to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: typeof IDL attribute]
-    expected: FAIL
-
   [textarea.rows: IDL get with DOM attribute unset]
     expected: FAIL
 
-  [textarea.rows: setAttribute() to -2147483649 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to -2147483648 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to -36 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to -1 followed by IDL get]
-    expected: FAIL
-
   [textarea.rows: setAttribute() to 0 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to 1 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to 2147483647 followed by IDL get]
     expected: FAIL
 
   [textarea.rows: setAttribute() to 2147483648 followed by IDL get]
@@ -14991,28 +14472,10 @@
   [textarea.rows: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
-  [textarea.rows: setAttribute() to 4294967296 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "-1" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "-0" followed by IDL get]
-    expected: FAIL
-
   [textarea.rows: setAttribute() to "0" followed by IDL get]
     expected: FAIL
 
-  [textarea.rows: setAttribute() to "1" followed by IDL get]
-    expected: FAIL
-
   [textarea.rows: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\\v7" followed by IDL get]
     expected: FAIL
 
   [textarea.rows: setAttribute() to "\\f7" followed by IDL get]
@@ -15021,100 +14484,13 @@
   [textarea.rows: setAttribute() to " 7" followed by IDL get]
     expected: FAIL
 
-  [textarea.rows: setAttribute() to "\xc2\xa07" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xef\xbb\xbf7" followed by IDL get]
-    expected: FAIL
-
   [textarea.rows: setAttribute() to "\\n7" followed by IDL get]
     expected: FAIL
 
   [textarea.rows: setAttribute() to "\\r7" followed by IDL get]
     expected: FAIL
 
-  [textarea.rows: setAttribute() to "\xe2\x80\xa87" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\xa97" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe1\x9a\x807" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe1\xa0\x8e7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x807" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x817" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x827" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x837" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x847" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x857" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x867" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x877" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x887" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x897" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\x8a7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe2\x80\xaf7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\xe3\x80\x807" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
   [textarea.rows: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to object "2" followed by IDL get]
     expected: FAIL
 
   [textarea.rows: setAttribute() to object "3" followed by getAttribute()]
@@ -15124,141 +14500,6 @@
     expected: FAIL
 
   [textarea.rows: IDL set to 0 must throw INDEX_SIZE_ERR]
-    expected: FAIL
-
-  [textarea.rows: IDL set to 1 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.rows: IDL set to 2147483647 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: typeof IDL attribute]
-    expected: FAIL
-
-  [textarea.wrap: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to "" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to undefined followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to 7 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to 1.5 followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to true followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to true followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to false followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to false followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to object "[object Object\]" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to NaN followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to -Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to "\\0" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to null followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to object "test-toString" followed by getAttribute()]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [textarea.wrap: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
   [textarea.itemScope: typeof IDL attribute]


### PR DESCRIPTION
Fixes #3918 

Can be tested in `tests/html/textarea.html`. Also implemented some content reflecting IDL attributes for HTMLTextAreaElement while I was in there.

There are some major problems with TextInput when Multiple is enabled that I haven't addressed here, but I'm prepared to open up a follow-up issue.
