### PR TITLE
layout: Stop having text alignment stomp on layerization flags.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1737,7 +1737,9 @@ impl Flow for BlockFlow {
                         .stacking_relative_position_of_absolute_containing_block
                 },
             relative_containing_block_size: self.fragment.content_box().size,
-            layers_needed_for_positioned_flows: self.base.flags.contains(LAYERS_NEEDED_FOR_DESCENDANTS),
+            layers_needed_for_positioned_flows: self.base
+                                                    .flags
+                                                    .contains(LAYERS_NEEDED_FOR_DESCENDANTS),
         };
 
         // Compute the origin and clipping rectangle for children.

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -497,8 +497,10 @@ bitflags! {
         #[doc = "Whether this flow is right-floated. This is checked all over layout, so a"]
         #[doc = "virtual call is too expensive."]
         const FLOATS_RIGHT = 0b0000_0100_0000_0000,
-        #[doc = "Text alignment."]
-        const TEXT_ALIGN = 0b0000_1000_0000_0000,
+        #[doc = "Text alignment. \
+
+                 NB: If you update this, update `TEXT_ALIGN_SHIFT` below."]
+        const TEXT_ALIGN = 0b0111_1000_0000_0000,
     }
 }
 
@@ -508,12 +510,10 @@ bitflags! {
 
 static HAS_FLOATED_DESCENDANTS_BITMASK: FlowFlags = FlowFlags { bits: 0b0000_0011 };
 
-// NB: If you update this field, you must update the the text align flags.
-/// The bitmask of flags that represent the text alignment field.
-static TEXT_ALIGN_BITMASK: FlowFlags = FlowFlags { bits: 0b0011_0000 };
-
 /// The number of bits we must shift off to handle the text alignment field.
-static TEXT_ALIGN_SHIFT: uint = 4;
+///
+/// NB: If you update this, update `TEXT_ALIGN` above.
+static TEXT_ALIGN_SHIFT: uint = 11;
 
 impl FlowFlags {
     /// Propagates text alignment flags from an appropriate parent flow per CSS 2.1.
@@ -526,17 +526,18 @@ impl FlowFlags {
 
     #[inline]
     pub fn text_align(self) -> text_align::T {
-        FromPrimitive::from_u16((self & TEXT_ALIGN_BITMASK).bits() >> TEXT_ALIGN_SHIFT).unwrap()
+        FromPrimitive::from_u16((self & TEXT_ALIGN).bits() >> TEXT_ALIGN_SHIFT).unwrap()
     }
 
     #[inline]
     pub fn set_text_align(&mut self, value: text_align::T) {
-        *self = (*self & !TEXT_ALIGN_BITMASK) | FlowFlags::from_bits(value as u16 << TEXT_ALIGN_SHIFT).unwrap();
+        *self = (*self & !TEXT_ALIGN) |
+            FlowFlags::from_bits(value as u16 << TEXT_ALIGN_SHIFT).unwrap();
     }
 
     #[inline]
     pub fn set_text_align_override(&mut self, parent: FlowFlags) {
-        self.insert(parent & TEXT_ALIGN_BITMASK);
+        self.insert(parent & TEXT_ALIGN);
     }
 
     #[inline]


### PR DESCRIPTION
Fixes the blank spaces showing up in Wikipedia.

r? @kmcallister 
