### PR TITLE
Fixed test filter

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -105,7 +105,7 @@ class MachCommands(CommandBase):
 
         def cargo_test(component):
             return 0 != subprocess.call(
-                ["cargo", "test", "-p", component], env=self.build_env())
+                ["cargo", "test", "-p", component] + test_name, env=self.build_env())
 
         for component in os.listdir("components"):
             ret = ret or cargo_test(component)


### PR DESCRIPTION
Minor change, added unit test filter to components so that ./mach test-unit [test-filter] works in line with documentation.

I'd personally like to also make filters on the components as well as the tests. This would change the interface (probably to ./mach test-unit [component-filter] [test-filter]), but change is NOT in this pull request.
