### PR TITLE
plugins: Autogeneration of Reflectable; Inheritance lint

### DIFF
--- a/components/plugins/jstraceable.rs
+++ b/components/plugins/jstraceable.rs
@@ -37,7 +37,9 @@ pub fn expand_jstraceable(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, item: 
                 explicit_self: ty::borrowed_explicit_self(),
                 args: vec!(ty::Ptr(box ty::Literal(ty::Path::new(vec!("js","jsapi","JSTracer"))), ty::Raw(ast::MutMutable))),
                 ret_ty: ty::nil_ty(),
-                attributes: vec!(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("inline")))),
+                attributes: vec!(attr::mk_attr_outer(attr::mk_attr_id(),
+                                                     attr::mk_name_value_item_str(InternedString::new("inline"),
+                                                                                  InternedString::new("always")))),
                 combine_substructure: combine_substructure(|a, b, c| {
                     jstraceable_substructure(a, b, c)
                 })

--- a/components/plugins/jstraceable.rs
+++ b/components/plugins/jstraceable.rs
@@ -17,6 +17,9 @@ pub fn expand_dom_struct(_: &mut ExtCtxt, _: Span, _: &MetaItem, item: P<Item>) 
     item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("must_root"))));
     item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("privatize"))));
     item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("jstraceable"))));
+
+    // The following attribute is only for internal usage
+    item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("_generate_reflector"))));
     P(item2)
 }
 

--- a/components/plugins/jstraceable.rs
+++ b/components/plugins/jstraceable.rs
@@ -14,12 +14,20 @@ use syntax::parse::token::InternedString;
 
 pub fn expand_dom_struct(_: &mut ExtCtxt, _: Span, _: &MetaItem, item: P<Item>) -> P<Item> {
     let mut item2 = (*item).clone();
-    item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("must_root"))));
-    item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("privatize"))));
-    item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("jstraceable"))));
+    {
+        let add_attr = |s| {
+            item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new(s))));
+        };
+        add_attr("must_root");
+        add_attr("privatize");
+        add_attr("jstraceable");
 
-    // The following attribute is only for internal usage
-    item2.attrs.push(attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_word_item(InternedString::new("_generate_reflector"))));
+        // The following attributes are only for internal usage
+        add_attr("_generate_reflector");
+        // #[dom_struct] gets consumed, so this lets us keep around a residue
+        // Do NOT register a modifier/decorator on this attribute
+        add_attr("_dom_struct_marker");
+    }
     P(item2)
 }
 

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -47,5 +47,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box lints::TransmutePass as LintPassObject);
     reg.register_lint_pass(box lints::UnrootedPass as LintPassObject);
     reg.register_lint_pass(box lints::PrivatizePass as LintPassObject);
+    reg.register_lint_pass(box lints::InheritancePass as LintPassObject);
 }
 

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -12,7 +12,7 @@
 //!  - `#[dom_struct]` : Implies `#[privatize]`,`#[jstraceable]`, and `#[must_root]`.
 //!     Use this for structs that correspond to a DOM type
 
-#![feature(macro_rules, plugin_registrar, quote, phase)]
+#![feature(macro_rules, plugin_registrar, quote, phase, if_let)]
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
@@ -33,12 +33,17 @@ use syntax::parse::token::intern;
 // Public for documentation to show up
 /// Handles the auto-deriving for `#[jstraceable]`
 pub mod jstraceable;
+/// Autogenerates implementations of Reflectable on DOM structs
+pub mod reflector;
 pub mod lints;
+/// Utilities for writing plugins
+pub mod utils;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(intern("dom_struct"), Modifier(box jstraceable::expand_dom_struct));
     reg.register_syntax_extension(intern("jstraceable"), Decorator(box jstraceable::expand_jstraceable));
+    reg.register_syntax_extension(intern("_generate_reflector"), Decorator(box reflector::expand_reflector));
     reg.register_lint_pass(box lints::TransmutePass as LintPassObject);
     reg.register_lint_pass(box lints::UnrootedPass as LintPassObject);
     reg.register_lint_pass(box lints::PrivatizePass as LintPassObject);

--- a/components/plugins/lints.rs
+++ b/components/plugins/lints.rs
@@ -277,7 +277,7 @@ impl LintPass for InheritancePass {
                                         if match_lang_ty(cx, &*f.node.ty, "reflector") {
                                             if ctr > 0 {
                                                 cx.span_lint(INHERITANCE_INTEGRITY, f.span,
-                                                             "The Reflector should be the first field of the DOM struct");                                            
+                                                             "The Reflector should be the first field of the DOM struct");
                                             }
                                             return true;
                                         }
@@ -287,7 +287,7 @@ impl LintPass for InheritancePass {
             // Find all #[dom_struct] fields
             let dom_spans: Vec<_> = def.fields.iter().enumerate().filter_map(|(ctr, f)| {
                 if let ast::TyPath(_, _, ty_id) = f.node.ty.node {
-                    if let Some(def::DefTy(def_id, _)) = cx.tcx.def_map.borrow().find_copy(&ty_id) {
+                    if let Some(def::DefTy(def_id, _)) = cx.tcx.def_map.borrow().get(&ty_id).cloned() {
                         if ty::has_attr(cx.tcx, def_id, "_dom_struct_marker") {
                             // If the field is not the first, it's probably
                             // being misused (a)
@@ -327,7 +327,7 @@ impl LintPass for InheritancePass {
                 }
             } else if dom_spans.len() == 0 {
                 cx.span_lint(INHERITANCE_INTEGRITY, cx.tcx.map.expect_item(id).span,
-                             "This DOM struct has no reflector or parent DOM struct");                
+                             "This DOM struct has no reflector or parent DOM struct");
             }
         }
     }

--- a/components/plugins/lints.rs
+++ b/components/plugins/lints.rs
@@ -5,11 +5,13 @@
 use syntax::{ast, ast_map, ast_util, codemap, visit};
 use syntax::ast::Public;
 use syntax::attr::AttrMetaMethods;
-use rustc::lint::{Context, LintPass, LintArray};
+use rustc::lint::{Context, LintPass, LintArray, Level};
 use rustc::middle::ty::expr_ty;
 use rustc::middle::{ty, def};
 use rustc::middle::typeck::astconv::AstConv;
 use rustc::util::ppaux::Repr;
+
+use utils::match_lang_ty;
 
 declare_lint!(TRANSMUTE_TYPE_LINT, Allow,
               "Warn and report types being transmuted")
@@ -17,6 +19,8 @@ declare_lint!(UNROOTED_MUST_ROOT, Deny,
               "Warn and report usage of unrooted jsmanaged objects")
 declare_lint!(PRIVATIZE, Deny,
               "Allows to enforce private fields for struct definitions")
+declare_lint!(INHERITANCE_INTEGRITY, Deny,
+              "Ensures that struct fields are properly laid out for inheritance to work")
 
 /// Lint for auditing transmutes
 ///
@@ -40,6 +44,12 @@ pub struct UnrootedPass;
 ///
 /// This lint (disable with `-A privatize`/`#[allow(privatize)]`) ensures all types marked with `#[privatize]` have no private fields
 pub struct PrivatizePass;
+
+/// Lint for ensuring proper layout of DOM structs
+///
+/// A DOM struct must have one Reflector field or one field
+/// which itself is a DOM struct (in which case it must be the first field).
+pub struct InheritancePass;
 
 impl LintPass for TransmutePass {
     fn get_lints(&self) -> LintArray {
@@ -247,6 +257,68 @@ impl LintPass for PrivatizePass {
                     }
                     _ => {}
                 }
+            }
+        }
+    }
+}
+
+impl LintPass for InheritancePass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(INHERITANCE_INTEGRITY)
+    }
+
+    fn check_struct_def(&mut self, cx: &Context, def: &ast::StructDef, _i: ast::Ident, _gen: &ast::Generics, id: ast::NodeId) {
+        // Lints are run post expansion, so it's fine to use
+        // #[_dom_struct_marker] here without also checking for #[dom_struct]
+        if ty::has_attr(cx.tcx, ast_util::local_def(id), "_dom_struct_marker") {
+            // Find the reflector, if any
+            let reflector_span = def.fields.iter()
+                                    .find(|f| match_lang_ty(cx, &*f.node.ty, "reflector"))
+                                    .map(|f| f.span);
+            // Find all #[dom_struct] fields
+            let dom_spans: Vec<_> = def.fields.iter().enumerate().filter_map(|(ctr, f)| {
+                if let ast::TyPath(_, _, ty_id) = f.node.ty.node {
+                    if let Some(def::DefTy(def_id, _)) = cx.tcx.def_map.borrow().find_copy(&ty_id) {
+                        if ty::has_attr(cx.tcx, def_id, "_dom_struct_marker") {
+                            // If the field is not the first, it's probably
+                            // being misused (a)
+                            if ctr > 0 {
+                                cx.span_lint(INHERITANCE_INTEGRITY, f.span,
+                                             "Bare DOM structs should only be used as the first field of a \
+                                              DOM struct. Consider using JS<T> instead.");
+                            }
+                            return Some(f.span)
+                        }
+                    }
+                }
+                None
+            }).collect();
+
+            // We should not have both a reflector and a dom struct field
+            if let Some(sp) = reflector_span {
+                if dom_spans.len() > 0 {
+                    cx.span_lint(INHERITANCE_INTEGRITY, cx.tcx.map.expect_item(id).span,
+                                 "This DOM struct has both Reflector and bare DOM struct members");
+                    if cx.current_level(INHERITANCE_INTEGRITY) != Level::Allow {
+                        let sess = cx.sess();
+                        sess.span_note(sp, "Reflector found here");
+                        for span in dom_spans.iter() {
+                            sess.span_note(*span, "Bare DOM struct found here");
+                        }
+                    }
+                }
+            // Nor should we have more than one dom struct field
+            } else if dom_spans.len() > 1 {
+                cx.span_lint(INHERITANCE_INTEGRITY, cx.tcx.map.expect_item(id).span,
+                             "This DOM struct has multiple DOM struct members, only one is allowed");
+                if cx.current_level(INHERITANCE_INTEGRITY) != Level::Allow {
+                    for span in dom_spans.iter() {
+                        cx.sess().span_note(*span, "Bare DOM struct found here");
+                    }
+                }
+            } else if dom_spans.len() == 0 {
+                cx.span_lint(INHERITANCE_INTEGRITY, cx.tcx.map.expect_item(id).span,
+                             "This DOM struct has no reflector or parent DOM struct");                
             }
         }
     }

--- a/components/plugins/reflector.rs
+++ b/components/plugins/reflector.rs
@@ -11,9 +11,9 @@ use utils::match_ty_unwrap;
 
 
 pub fn expand_reflector(cx: &mut ExtCtxt, span: Span, _: &MetaItem, item: &Item, push: |P<Item>|) {
-
     if let ast::ItemStruct(ref def, _) = item.node {
         let struct_name = item.ident;
+        // This path has to be hardcoded, unfortunately, since we can't resolve paths at expansion time
         match def.fields.iter().find(|f| match_ty_unwrap(&*f.node.ty, &["dom", "bindings", "utils", "Reflector"]).is_some()) {
             // If it has a field that is a Reflector, use that
             Some(f) => {
@@ -28,10 +28,6 @@ pub fn expand_reflector(cx: &mut ExtCtxt, span: Span, _: &MetaItem, item: &Item,
                 impl_item.map(|it| push(it))
             },
             // Or just call it on the first field (supertype).
-            // TODO: Write a lint to ensure that this first field is indeed a #[dom_struct],
-            // and the only such field in the struct definition (including reflectors)
-            // Unfortunately we can't do it here itself because a def_map (from middle) is not available
-            // at expansion time
             None => {
                 let field_name = def.fields[0].node.ident();
                 let impl_item = quote_item!(cx,
@@ -45,6 +41,6 @@ pub fn expand_reflector(cx: &mut ExtCtxt, span: Span, _: &MetaItem, item: &Item,
             }
         };
     } else {
-        cx.span_bug(span, "#[dom_struct] seems to have been applied to a non-struct");
+        cx.span_err(span, "#[dom_struct] seems to have been applied to a non-struct");
     }
 }

--- a/components/plugins/reflector.rs
+++ b/components/plugins/reflector.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use syntax::ext::base::ExtCtxt;
+use syntax::codemap::Span;
+use syntax::ptr::P;
+use syntax::ast::{Item, MetaItem};
+use syntax::ast;
+use utils::match_ty_unwrap;
+
+
+pub fn expand_reflector(cx: &mut ExtCtxt, span: Span, _: &MetaItem, item: &Item, push: |P<Item>|) {
+
+    if let ast::ItemStruct(ref def, _) = item.node {
+        let struct_name = item.ident;
+        match def.fields.iter().find(|f| match_ty_unwrap(&*f.node.ty, &["dom", "bindings", "utils", "Reflector"]).is_some()) {
+            // If it has a field that is a Reflector, use that
+            Some(f) => {
+                let field_name = f.node.ident();
+                let impl_item = quote_item!(cx,
+                    impl ::dom::bindings::utils::Reflectable for $struct_name {
+                        fn reflector<'a>(&'a self) -> &'a ::dom::bindings::utils::Reflector {
+                            &self.$field_name
+                        }
+                    }
+                );
+                impl_item.map(|it| push(it))
+            },
+            // Or just call it on the first field (supertype).
+            // TODO: Write a lint to ensure that this first field is indeed a #[dom_struct],
+            // and the only such field in the struct definition (including reflectors)
+            // Unfortunately we can't do it here itself because a def_map (from middle) is not available
+            // at expansion time
+            None => {
+                let field_name = def.fields[0].node.ident();
+                let impl_item = quote_item!(cx,
+                    impl ::dom::bindings::utils::Reflectable for $struct_name {
+                        fn reflector<'a>(&'a self) -> &'a ::dom::bindings::utils::Reflector {
+                            self.$field_name.reflector()
+                        }
+                    }
+                );
+                impl_item.map(|it| push(it))
+            }
+        };
+    } else {
+        cx.span_bug(span, "#[dom_struct] seems to have been applied to a non-struct");
+    }
+}

--- a/components/plugins/utils.rs
+++ b/components/plugins/utils.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use syntax::ptr::P;
+use syntax::ast::{TyPath, Path, AngleBracketedParameters, PathSegment, Ty};
+
+/// Matches a type with a provided string, and returns its type parameters if successful
+pub fn match_ty_unwrap<'a>(ty: &'a Ty, segments: &[&str]) -> Option<&'a [P<Ty>]> {
+    match ty.node {
+        TyPath(Path {segments: ref seg, ..}, _, _) => {
+            // So ast::Path isn't the full path, just the tokens that were provided.
+            // I could muck around with the maps and find the full path
+            // however the more efficient way is to simply reverse the iterators and zip them
+            // which will compare them in reverse until one of them runs out of segments
+            if seg.iter().rev().zip(segments.iter().rev()).all(|(a,b)| a.identifier.as_str() == *b) {
+                match seg.as_slice().last() {
+                    Some(&PathSegment {parameters: AngleBracketedParameters(ref a), ..}) => {
+                        Some(a.types.as_slice())
+                    }
+                    _ => None
+                }
+            } else {
+                None
+            }
+        },
+        _ => None
+    }
+}

--- a/components/plugins/utils.rs
+++ b/components/plugins/utils.rs
@@ -39,7 +39,7 @@ pub fn match_ty_unwrap<'a>(ty: &'a Ty, segments: &[&str]) -> Option<&'a [P<Ty>]>
 pub fn match_lang_ty(cx: &Context, ty: &Ty, value: &str) -> bool {
     let mut found = false;
     if let TyPath(_, _, ty_id) = ty.node {
-        if let Some(def::DefTy(def_id, _)) = cx.tcx.def_map.borrow().find_copy(&ty_id) {
+        if let Some(def::DefTy(def_id, _)) = cx.tcx.def_map.borrow().get(&ty_id).cloned() {
             // Iterating through attributes is hard because of cross-crate defs
             ty::each_attr(cx.tcx, def_id, |attr| {
                 if let ast::MetaNameValue(ref name, ref val) = attr.node.value.node {

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::element::{Element, AttributeHandlers};
 use dom::node::Node;
 use dom::window::Window;
@@ -85,11 +85,6 @@ pub struct Attr {
     owner: Option<JS<Element>>,
 }
 
-impl Reflectable for Attr {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 impl Attr {
     fn new_inherited(local_name: Atom, value: AttrValue,

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -85,7 +85,6 @@ pub struct Attr {
     owner: Option<JS<Element>>,
 }
 
-
 impl Attr {
     fn new_inherited(local_name: Atom, value: AttrValue,
                      name: Atom, namespace: Namespace,

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -346,9 +346,12 @@ pub fn reflect_dom_object<T: Reflectable>
 }
 
 /// A struct to store a reference to the reflector of a DOM object.
-#[allow(raw_pointer_deriving, unrooted_must_root)]
+// Allowing unused_attribute because the lint sometimes doesn't run in order
+#[allow(raw_pointer_deriving, unrooted_must_root, unused_attributes)]
 #[deriving(PartialEq)]
 #[must_root]
+#[servo_lang = "reflector"]
+// If you're renaming or moving this field, update the path in plugins::reflector as well
 pub struct Reflector {
     object: Cell<*mut JSObject>,
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -5,7 +5,7 @@
 use dom::bindings::codegen::InheritTypes::FileDerived;
 use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::error::Fallible;
 use dom::bindings::codegen::Bindings::BlobBinding;
 use dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
@@ -123,11 +123,6 @@ impl<'a> BlobMethods for JSRef<'a, Blob> {
     //fn Close(self) {
     //    TODO
     //}
-}
-impl Reflectable for Blob {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
 }
 
 impl FileDerived for Blob {

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -65,6 +65,8 @@ impl BrowserContext {
     }
 }
 
+// This isn't a DOM struct, just a convenience struct
+// without a reflector, so we don't mark this as #[dom_struct]
 #[must_root]
 #[privatize]
 #[jstraceable]

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -65,7 +65,9 @@ impl BrowserContext {
     }
 }
 
-#[dom_struct]
+#[must_root]
+#[privatize]
+#[jstraceable]
 pub struct SessionHistoryEntry {
     document: JS<Document>,
     children: Vec<BrowserContext>

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -64,7 +64,6 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
     }
 }
 
-
 #[unsafe_destructor]
 impl Drop for CanvasRenderingContext2D {
     fn drop(&mut self) {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding;
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasRenderingContext2DMethods;
 use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::htmlcanvaselement::HTMLCanvasElement;
 
 use geom::point::Point2D;
@@ -64,11 +64,6 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
     }
 }
 
-impl Reflectable for CanvasRenderingContext2D {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 #[unsafe_destructor]
 impl Drop for CanvasRenderingContext2D {

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -10,7 +10,6 @@ use dom::bindings::codegen::InheritTypes::{CharacterDataDerived, NodeCast};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::error::Error::IndexSize;
 use dom::bindings::js::JSRef;
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::node::{Node, NodeHelpers, NodeTypeId};
@@ -122,8 +121,3 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
     }
 }
 
-impl Reflectable for CharacterData {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.node.reflector()
-    }
-}

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -8,7 +8,6 @@ use dom::bindings::codegen::InheritTypes::CommentDerived;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -50,8 +49,3 @@ impl Comment {
     }
 }
 
-impl Reflectable for Comment {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.characterdata.reflector()
-    }
-}

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::ConsoleBinding;
 use dom::bindings::codegen::Bindings::ConsoleBinding::ConsoleMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use servo_util::str::DOMString;
 
 #[dom_struct]
@@ -58,8 +58,3 @@ impl<'a> ConsoleMethods for JSRef<'a, Console> {
     }
 }
 
-impl Reflectable for Console {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -222,4 +222,3 @@ pub fn create_element(name: QualName, prefix: Option<DOMString>,
     }
 }
 
-

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast};
 use dom::bindings::error::ErrorResult;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, OptionalRootedRootable, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::document::DocumentHelpers;
 use dom::element::{Element, ElementHelpers, StylePriority};
 use dom::htmlelement::HTMLElement;
@@ -411,10 +411,4 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         [Top, SetTop, "top"],
         [ZIndex, SetZIndex, "z-index"]
     )
-}
-
-impl Reflectable for CSSStyleDeclaration {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
 }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::InheritTypes::{EventCast, CustomEventDerived};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary, MutHeap};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId};
 use js::jsapi::JSContext;
 use js::jsval::{JSVal, NullValue};
@@ -73,8 +73,3 @@ impl<'a> CustomEventMethods for JSRef<'a, CustomEvent> {
     }
 }
 
-impl Reflectable for CustomEvent {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.event.reflector()
-    }
-}

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -11,7 +11,7 @@ use dom::bindings::error::ErrorResult;
 use dom::bindings::error::Error::DataClone;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary, RootCollection};
-use dom::bindings::utils::{Reflectable, Reflector};
+use dom::bindings::utils::Reflectable;
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 use dom::messageevent::MessageEvent;
 use dom::worker::{Worker, TrustedWorkerAddress};
@@ -182,11 +182,6 @@ impl<'a> PrivateDedicatedWorkerGlobalScopeHelpers for JSRef<'a, DedicatedWorkerG
     }
 }
 
-impl Reflectable for DedicatedWorkerGlobalScope {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.workerglobalscope.reflector()
-    }
-}
 
 impl DedicatedWorkerGlobalScopeDerived for EventTarget {
     fn is_dedicatedworkerglobalscope(&self) -> bool {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -182,7 +182,6 @@ impl<'a> PrivateDedicatedWorkerGlobalScopeHelpers for JSRef<'a, DedicatedWorkerG
     }
 }
 
-
 impl DedicatedWorkerGlobalScopeDerived for EventTarget {
     fn is_dedicatedworkerglobalscope(&self) -> bool {
         match *self.type_id() {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -25,7 +25,7 @@ use dom::bindings::error::Error::{HierarchyRequest, NamespaceError};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, OptionalSettable, TemporaryPushable};
 use dom::bindings::js::OptionalRootable;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::bindings::utils::xml_name_type;
 use dom::bindings::utils::XMLName::{QName, Name, InvalidXMLName};
 use dom::comment::Comment;
@@ -472,11 +472,6 @@ impl Document {
     }
 }
 
-impl Reflectable for Document {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.node.reflector()
-    }
-}
 
 trait PrivateDocumentHelpers {
     fn createNodeList(self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList>;

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -472,7 +472,6 @@ impl Document {
     }
 }
 
-
 trait PrivateDocumentHelpers {
     fn createNodeList(self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList>;
     fn get_html_element(self) -> Option<Temporary<HTMLHtmlElement>>;

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::InheritTypes::{DocumentFragmentDerived, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::Element;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -70,8 +69,3 @@ impl<'a> DocumentFragmentMethods for JSRef<'a, DocumentFragment> {
     }
 }
 
-impl Reflectable for DocumentFragment {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.node.reflector()
-    }
-}

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -6,7 +6,6 @@ use dom::bindings::codegen::Bindings::DocumentTypeBinding;
 use dom::bindings::codegen::Bindings::DocumentTypeBinding::DocumentTypeMethods;
 use dom::bindings::codegen::InheritTypes::{DocumentTypeDerived, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::node::{Node, NodeHelpers, NodeTypeId};
@@ -89,8 +88,3 @@ impl<'a> DocumentTypeMethods for JSRef<'a, DocumentType> {
     }
 }
 
-impl Reflectable for DocumentType {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.node.reflector()
-    }
-}

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -62,15 +62,15 @@ impl DOMErrorName {
 
 #[dom_struct]
 pub struct DOMException {
+    reflector_: Reflector,
     code: DOMErrorName,
-    reflector_: Reflector
 }
 
 impl DOMException {
     fn new_inherited(code: DOMErrorName) -> DOMException {
         DOMException {
+            reflector_: Reflector::new(),
             code: code,
-            reflector_: Reflector::new()
         }
     }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::Bindings::DOMExceptionBinding::DOMExceptionMethods;
 use dom::bindings::error::Error;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use servo_util::str::DOMString;
 
 #[repr(uint)]
@@ -83,11 +83,6 @@ impl DOMException {
     }
 }
 
-impl Reflectable for DOMException {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
     // http://dom.spec.whatwg.org/#dom-domexception-code

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -83,7 +83,6 @@ impl DOMException {
     }
 }
 
-
 impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
     // http://dom.spec.whatwg.org/#dom-domexception-code
     fn Code(self) -> u16 {

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -11,7 +11,7 @@ use dom::bindings::error::Fallible;
 use dom::bindings::error::Error::{InvalidCharacter, NamespaceError};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Root, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::utils::xml_name_type;
 use dom::bindings::utils::XMLName::{QName, Name, InvalidXMLName};
 use dom::document::{Document, DocumentHelpers, IsHTMLDocument};
@@ -47,11 +47,6 @@ impl DOMImplementation {
     }
 }
 
-impl Reflectable for DOMImplementation {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 // http://dom.spec.whatwg.org/#domimplementation
 impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -27,15 +27,15 @@ use servo_util::str::DOMString;
 
 #[dom_struct]
 pub struct DOMImplementation {
-    document: JS<Document>,
     reflector_: Reflector,
+    document: JS<Document>,
 }
 
 impl DOMImplementation {
     fn new_inherited(document: JSRef<Document>) -> DOMImplementation {
         DOMImplementation {
-            document: JS::from_rooted(document),
             reflector_: Reflector::new(),
+            document: JS::from_rooted(document),
         }
     }
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -47,7 +47,6 @@ impl DOMImplementation {
     }
 }
 
-
 // http://dom.spec.whatwg.org/#domimplementation
 impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     // http://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -19,15 +19,15 @@ use servo_util::str::DOMString;
 
 #[dom_struct]
 pub struct DOMParser {
+    reflector_: Reflector,
     window: JS<Window>, //XXXjdm Document instead?
-    reflector_: Reflector
 }
 
 impl DOMParser {
     fn new_inherited(window: JSRef<Window>) -> DOMParser {
         DOMParser {
+            reflector_: Reflector::new(),
             window: JS::from_rooted(window),
-            reflector_: Reflector::new()
         }
     }
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -10,7 +10,7 @@ use dom::bindings::error::Fallible;
 use dom::bindings::error::Error::FailureUnknown;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::document::{Document, DocumentHelpers, IsHTMLDocument};
 use dom::document::DocumentSource;
 use dom::window::Window;
@@ -74,8 +74,3 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
     }
 }
 
-impl Reflectable for DOMParser {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::DOMRectBinding;
 use dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::window::Window;
 use servo_util::geometry::Au;
 use std::num::Float;
@@ -66,8 +66,3 @@ impl<'a> DOMRectMethods for JSRef<'a, DOMRect> {
     }
 }
 
-impl Reflectable for DOMRect {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/domrectlist.rs
+++ b/components/script/dom/domrectlist.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::DOMRectListBinding;
 use dom::bindings::codegen::Bindings::DOMRectListBinding::DOMRectListMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::domrect::DOMRect;
 use dom::window::Window;
 
@@ -55,8 +55,3 @@ impl<'a> DOMRectListMethods for JSRef<'a, DOMRectList> {
     }
 }
 
-impl Reflectable for DOMRectList {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::Bindings::DOMStringMapBinding::DOMStringMapMethods;
 use dom::bindings::error::ErrorResult;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::node::window_from_node;
 use dom::htmlelement::{HTMLElement, HTMLElementCustomAttributeHelpers};
 use servo_util::str::DOMString;
@@ -64,8 +64,3 @@ impl<'a> DOMStringMapMethods for JSRef<'a, DOMStringMap> {
     }
 }
 
-impl Reflectable for DOMStringMap {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -9,7 +9,7 @@ use dom::bindings::error::Fallible;
 use dom::bindings::error::Error::{InvalidCharacter, Syntax};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflector, Reflectable, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::element::{Element, AttributeHandlers};
 use dom::node::window_from_node;
 
@@ -40,11 +40,6 @@ impl DOMTokenList {
     }
 }
 
-impl Reflectable for DOMTokenList {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 trait PrivateDOMTokenListHelpers {
     fn attribute(self) -> Option<Temporary<Attr>>;

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -40,7 +40,6 @@ impl DOMTokenList {
     }
 }
 
-
 trait PrivateDOMTokenListHelpers {
     fn attribute(self) -> Option<Temporary<Attr>>;
     fn check_token_exceptions<'a>(self, token: &'a str) -> Fallible<&'a str>;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -25,7 +25,6 @@ use dom::bindings::error::{ErrorResult, Fallible};
 use dom::bindings::error::Error::{NamespaceError, InvalidCharacter, Syntax};
 use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, TemporaryPushable};
 use dom::bindings::js::{OptionalRootable, Root};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::bindings::utils::xml_name_type;
 use dom::bindings::utils::XMLName::{QName, Name, InvalidXMLName};
 use dom::create::create_element;
@@ -86,11 +85,6 @@ impl ElementDerived for EventTarget {
     }
 }
 
-impl Reflectable for Element {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.node.reflector()
-    }
-}
 
 #[deriving(PartialEq, Show)]
 #[jstraceable]

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -85,7 +85,6 @@ impl ElementDerived for EventTarget {
     }
 }
 
-
 #[deriving(PartialEq, Show)]
 #[jstraceable]
 pub enum ElementTypeId {

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -12,7 +12,7 @@ use dom::bindings::js::{JSRef, Temporary, MutHeap};
 use js::jsapi::JSContext;
 use dom::bindings::trace::JSTraceable;
 
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId, EventBubbles, EventCancelable};
 use servo_util::str::DOMString;
 
@@ -126,10 +126,4 @@ impl<'a> ErrorEventMethods for JSRef<'a, ErrorEvent> {
         self.error.get()
     }
 
-}
-
-impl Reflectable for ErrorEvent {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.event.reflector()
-    }
 }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::Bindings::EventBinding::{EventConstants, EventMethod
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::eventtarget::EventTarget;
 use servo_util::str::DOMString;
 use std::cell::Cell;
@@ -240,18 +240,3 @@ impl<'a> EventMethods for JSRef<'a, Event> {
     }
 }
 
-impl Reflectable for Event {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
-
-pub trait EventHelpers {
-    fn set_trusted(self, trusted: bool);
-}
-
-impl<'a> EventHelpers for JSRef<'a, Event> {
-    fn set_trusted(self, trusted: bool) {
-        self.trusted.set(trusted);
-    }
-}

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -240,3 +240,12 @@ impl<'a> EventMethods for JSRef<'a, Event> {
     }
 }
 
+pub trait EventHelpers {
+    fn set_trusted(self, trusted: bool);
+}
+
+impl<'a> EventHelpers for JSRef<'a, Event> {
+    fn set_trusted(self, trusted: bool) {
+        self.trusted.set(trusted);
+    }
+}

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -51,8 +51,8 @@ pub enum EventCancelable {
 
 #[dom_struct]
 pub struct Event {
-    type_id: EventTypeId,
     reflector_: Reflector,
+    type_id: EventTypeId,
     current_target: MutNullableJS<EventTarget>,
     target: MutNullableJS<EventTarget>,
     type_: DOMRefCell<DOMString>,
@@ -71,8 +71,8 @@ pub struct Event {
 impl Event {
     pub fn new_inherited(type_id: EventTypeId) -> Event {
         Event {
-            type_id: type_id,
             reflector_: Reflector::new(),
+            type_id: type_id,
             current_target: Default::default(),
             target: Default::default(),
             phase: Cell::new(EventPhase::None),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -301,7 +301,6 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
     }
 }
 
-
 impl<'a> VirtualMethods for JSRef<'a, EventTarget> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
         None

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -72,16 +72,16 @@ pub struct EventListenerEntry {
 
 #[dom_struct]
 pub struct EventTarget {
-    type_id: EventTargetTypeId,
     reflector_: Reflector,
+    type_id: EventTargetTypeId,
     handlers: DOMRefCell<HashMap<DOMString, Vec<EventListenerEntry>, FnvHasher>>,
 }
 
 impl EventTarget {
     pub fn new_inherited(type_id: EventTargetTypeId) -> EventTarget {
         EventTarget {
-            type_id: type_id,
             reflector_: Reflector::new(),
+            type_id: type_id,
             handlers: DOMRefCell::new(HashMap::with_hasher(FnvHasher)),
         }
     }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -301,11 +301,6 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
     }
 }
 
-impl Reflectable for EventTarget {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 impl<'a> VirtualMethods for JSRef<'a, EventTarget> {
     fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::FileBinding;
 use dom::bindings::codegen::Bindings::FileBinding::FileMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::blob::{Blob, BlobTypeId};
 use servo_util::str::DOMString;
 
@@ -44,8 +44,3 @@ impl<'a> FileMethods for JSRef<'a, File> {
     }
 }
 
-impl Reflectable for File {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.blob.reflector()
-    }
-}

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -11,7 +11,7 @@ use dom::bindings::codegen::UnionTypes::FileOrString::{eFile, eString};
 use dom::bindings::error::{Fallible};
 use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::blob::Blob;
 use dom::file::File;
 use dom::htmlformelement::HTMLFormElement;
@@ -107,11 +107,6 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
     }
 }
 
-impl Reflectable for FormData {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 trait PrivateFormDataHelpers{
   fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File>;

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -29,8 +29,8 @@ pub enum FormDatum {
 
 #[dom_struct]
 pub struct FormData {
-    data: DOMRefCell<HashMap<DOMString, Vec<FormDatum>>>,
     reflector_: Reflector,
+    data: DOMRefCell<HashMap<DOMString, Vec<FormDatum>>>,
     global: GlobalField,
     form: Option<JS<HTMLFormElement>>
 }
@@ -38,8 +38,8 @@ pub struct FormData {
 impl FormData {
     fn new_inherited(form: Option<JSRef<HTMLFormElement>>, global: &GlobalRef) -> FormData {
         FormData {
-            data: DOMRefCell::new(HashMap::new()),
             reflector_: Reflector::new(),
+            data: DOMRefCell::new(HashMap::new()),
             global: GlobalField::from_rooted(global),
             form: form.map(|f| JS::from_rooted(f)),
         }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -107,7 +107,6 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
     }
 }
 
-
 trait PrivateFormDataHelpers{
   fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File>;
 }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -98,7 +98,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
     }
 }
 
-
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
     fn Text(self) -> DOMString {
         let node: JSRef<Node> = NodeCast::from_ref(self);

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -11,7 +11,6 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::{Document, DocumentHelpers};
 use dom::domtokenlist::DOMTokenList;
 use dom::element::{Element, AttributeHandlers, ElementTypeId};
@@ -99,11 +98,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLAnchorElement> {
     }
 }
 
-impl Reflectable for HTMLAnchorElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
 
 impl<'a> HTMLAnchorElementMethods for JSRef<'a, HTMLAnchorElement> {
     fn Text(self) -> DOMString {

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLAppletElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAppletElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLAppletElement {
     }
 }
 
-impl Reflectable for HTMLAppletElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLAudioElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLAudioElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLAudioElement {
     }
 }
 
-impl Reflectable for HTMLAudioElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlmediaelement.reflector()
-    }
-}

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLBaseElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLBaseElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLBaseElement {
     }
 }
 
-impl Reflectable for HTMLBaseElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::InheritTypes::EventTargetCast;
 use dom::bindings::codegen::InheritTypes::{HTMLBodyElementDerived, HTMLElementCast};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
+use dom::bindings::utils::Reflectable;
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId, EventTargetHelpers};
@@ -130,8 +130,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
     }
 }
 
-impl Reflectable for HTMLBodyElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLBRElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLBRElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLBRElement {
     }
 }
 
-impl Reflectable for HTMLBRElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElemen
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{HTMLButtonElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{AttributeHandlers, Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -138,8 +137,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 }
 
-impl Reflectable for HTMLButtonElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -10,7 +10,6 @@ use dom::bindings::codegen::InheritTypes::HTMLCanvasElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary, OptionalSettable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use dom::document::Document;
 use dom::element::{Element, ElementTypeId, AttributeHandlers};
@@ -156,8 +155,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
     }
 }
 
-impl Reflectable for HTMLCanvasElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -32,15 +32,15 @@ pub enum CollectionTypeId {
 
 #[dom_struct]
 pub struct HTMLCollection {
-    collection: CollectionTypeId,
     reflector_: Reflector,
+    collection: CollectionTypeId,
 }
 
 impl HTMLCollection {
     fn new_inherited(collection: CollectionTypeId) -> HTMLCollection {
         HTMLCollection {
-            collection: collection,
             reflector_: Reflector::new(),
+            collection: collection,
         }
     }
 

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, NodeCast};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
 use dom::bindings::trace::JSTraceable;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::element::{Element, AttributeHandlers, ElementHelpers};
 use dom::node::{Node, NodeHelpers, TreeIterator};
 use dom::window::Window;
@@ -246,8 +246,3 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
     }
 }
 
-impl Reflectable for HTMLCollection {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLDataElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDataElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLDataElement {
     }
 }
 
-impl Reflectable for HTMLDataElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -7,7 +7,6 @@ use dom::bindings::codegen::Bindings::HTMLDataListElementBinding::HTMLDataListEl
 use dom::bindings::codegen::InheritTypes::{HTMLDataListElementDerived, HTMLOptionElementDerived};
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -57,8 +56,3 @@ impl<'a> HTMLDataListElementMethods for JSRef<'a, HTMLDataListElement> {
     }
 }
 
-impl Reflectable for HTMLDataListElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLDirectoryElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDirectoryElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLDirectoryElement {
     }
 }
 
-impl Reflectable for HTMLDirectoryElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLDivElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDivElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLDivElement {
     }
 }
 
-impl Reflectable for HTMLDivElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLDListElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLDListElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLDListElement {
     }
 }
 
-impl Reflectable for HTMLDListElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -15,7 +15,7 @@ use dom::bindings::codegen::InheritTypes::{HTMLElementDerived, HTMLBodyElementDe
 use dom::bindings::js::{JSRef, Temporary, MutNullableJS};
 use dom::bindings::error::ErrorResult;
 use dom::bindings::error::Error::Syntax;
-use dom::bindings::utils::{Reflectable, Reflector};
+use dom::bindings::utils::Reflectable;
 use dom::cssstyledeclaration::CSSStyleDeclaration;
 use dom::document::Document;
 use dom::domstringmap::DOMStringMap;
@@ -203,8 +203,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
     }
 }
 
-impl Reflectable for HTMLElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.element.reflector()
-    }
-}

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLEmbedElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLEmbedElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLEmbedElement {
     }
 }
 
-impl Reflectable for HTMLEmbedElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetEl
 use dom::bindings::codegen::InheritTypes::{HTMLFieldSetElementDerived, NodeCast};
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLLegendElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{AttributeHandlers, Element, ElementHelpers, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -148,8 +147,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     }
 }
 
-impl Reflectable for HTMLFieldSetElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLFontElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFontElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLFontElement {
     }
 }
 
-impl Reflectable for HTMLFontElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -12,7 +12,6 @@ use dom::bindings::codegen::InheritTypes::{EventTargetCast, HTMLFormElementDeriv
 use dom::bindings::codegen::InheritTypes::{HTMLInputElementCast, HTMLTextAreaElementCast, HTMLFormElementCast};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{Element, AttributeHandlers, ElementTypeId};
 use dom::event::{Event, EventHelpers, EventBubbles, EventCancelable};
@@ -390,11 +389,6 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
     }
 }
 
-impl Reflectable for HTMLFormElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
 
 // TODO: add file support
 pub struct FormDatum {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -389,7 +389,6 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
     }
 }
 
-
 // TODO: add file support
 pub struct FormDatum {
     pub ty: DOMString,

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLFrameElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFrameElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLFrameElement {
     }
 }
 
-impl Reflectable for HTMLFrameElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLFrameSetElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLFrameSetElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLFrameSetElement {
     }
 }
 
-impl Reflectable for HTMLFrameSetElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLHeadElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHeadElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLHeadElement {
     }
 }
 
-impl Reflectable for HTMLHeadElement  {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLHeadingElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHeadingElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -50,8 +49,3 @@ impl HTMLHeadingElement {
     }
 }
 
-impl Reflectable for HTMLHeadingElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLHRElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHRElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLHRElement {
     }
 }
 
-impl Reflectable for HTMLHRElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLHtmlElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLHtmlElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLHtmlElement {
     }
 }
 
-impl Reflectable for HTMLHtmlElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -10,7 +10,6 @@ use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast};
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLIFrameElementDerived};
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{ElementTypeId, Element};
 use dom::element::AttributeHandlers;
@@ -262,8 +261,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 }
 
-impl Reflectable for HTMLIFrameElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::Bindings::HTMLImageElementBinding;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageElementMethods;
 use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLElementCast, HTMLImageElementDerived};
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{Element, ElementTypeId};
 use dom::element::AttributeHandlers;
@@ -215,8 +214,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     }
 }
 
-impl Reflectable for HTMLImageElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -570,7 +570,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 }
 
-
 impl<'a> FormControl<'a> for JSRef<'a, HTMLInputElement> {
     fn to_element(self) -> JSRef<'a, Element> {
         ElementCast::from_ref(self)

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -17,7 +17,6 @@ use dom::bindings::codegen::InheritTypes::KeyboardEventCast;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{Comparable, JS, JSRef, Root, Temporary, OptionalRootable};
 use dom::bindings::js::{ResultRootable, RootedReference, MutNullableJS};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{AttributeHandlers, Element, ElementTypeId};
 use dom::element::{RawLayoutElementHelpers, ActivationElementHelpers};
@@ -571,11 +570,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 }
 
-impl Reflectable for HTMLInputElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
 
 impl<'a> FormControl<'a> for JSRef<'a, HTMLInputElement> {
     fn to_element(self) -> JSRef<'a, Element> {

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLLabelElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLabelElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLLabelElement {
     }
 }
 
-impl Reflectable for HTMLLabelElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLLegendElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLegendElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLLegendElement {
     }
 }
 
-impl Reflectable for HTMLLegendElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLLIElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLLIElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLLIElement {
     }
 }
 
-impl Reflectable for HTMLLIElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::Bindings::HTMLLinkElementBinding::HTMLLinkElementMet
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::domtokenlist::DOMTokenList;
 use dom::element::{AttributeHandlers, Element, ElementTypeId};
@@ -138,11 +137,6 @@ impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
     }
 }
 
-impl Reflectable for HTMLLinkElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
 
 impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
     make_url_getter!(Href)

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -137,7 +137,6 @@ impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
     }
 }
 
-
 impl<'a> HTMLLinkElementMethods for JSRef<'a, HTMLLinkElement> {
     make_url_getter!(Href)
     make_setter!(SetHref, "href")

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLMapElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMapElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLMapElement {
     }
 }
 
-impl Reflectable for HTMLMapElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::js::{JSRef};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::bindings::codegen::InheritTypes::HTMLMediaElementDerived;
 use dom::document::Document;
 use dom::element::ElementTypeId;
@@ -40,8 +39,3 @@ impl HTMLMediaElement {
     }
 }
 
-impl Reflectable for HTMLMediaElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLMetaElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMetaElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLMetaElement {
     }
 }
 
-impl Reflectable for HTMLMetaElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLMeterElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLMeterElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLMeterElement {
     }
 }
 
-impl Reflectable for HTMLMeterElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLModElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLModElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLModElement {
     }
 }
 
-impl Reflectable for HTMLModElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -10,7 +10,6 @@ use dom::bindings::codegen::Bindings::HTMLObjectElementBinding::HTMLObjectElemen
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{Element, ElementTypeId};
 use dom::element::AttributeHandlers;
@@ -117,8 +116,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
     }
 }
 
-impl Reflectable for HTMLObjectElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLOListElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLOListElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLOListElement {
     }
 }
 
-impl Reflectable for HTMLOListElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding::HTMLOptGroupEl
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{HTMLOptGroupElementDerived, HTMLOptionElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{AttributeHandlers, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -99,8 +98,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
     }
 }
 
-impl Reflectable for HTMLOptGroupElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -12,7 +12,6 @@ use dom::bindings::codegen::InheritTypes::{HTMLOptionElementDerived};
 use dom::bindings::codegen::InheritTypes::{HTMLScriptElementDerived};
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
 use dom::element::{AttributeHandlers, Element, ElementHelpers, ElementTypeId};
@@ -186,8 +185,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 }
 
-impl Reflectable for HTMLOptionElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -6,7 +6,6 @@ use dom::bindings::codegen::Bindings::HTMLOutputElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOutputElementBinding::HTMLOutputElementMethods;
 use dom::bindings::codegen::InheritTypes::HTMLOutputElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -47,8 +46,3 @@ impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
     }
 }
 
-impl Reflectable for HTMLOutputElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLParagraphElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLParagraphElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLParagraphElement {
     }
 }
 
-impl Reflectable for HTMLParagraphElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLParamElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLParamElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLParamElement {
     }
 }
 
-impl Reflectable for HTMLParamElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLPreElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLPreElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLPreElement {
     }
 }
 
-impl Reflectable for HTMLPreElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLProgressElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLProgressElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLProgressElement {
     }
 }
 
-impl Reflectable for HTMLProgressElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLQuoteElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLQuoteElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLQuoteElement {
     }
 }
 
-impl Reflectable for HTMLQuoteElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -15,7 +15,6 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCas
 use dom::bindings::codegen::InheritTypes::EventTargetCast;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{ElementTypeId, Element, AttributeHandlers, ElementCreator};
 use dom::eventtarget::{EventTarget, EventTargetTypeId, EventTargetHelpers};
@@ -330,8 +329,3 @@ impl<'a> HTMLScriptElementMethods for JSRef<'a, HTMLScriptElement> {
     }
 }
 
-impl Reflectable for HTMLScriptElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -11,7 +11,6 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLSelectElementDerived
 use dom::bindings::codegen::UnionTypes::HTMLElementOrLong;
 use dom::bindings::codegen::UnionTypes::HTMLOptionElementOrHTMLOptGroupElement;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{AttributeHandlers, Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -139,8 +138,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 }
 
-impl Reflectable for HTMLSelectElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLSourceElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLSourceElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLSourceElement {
     }
 }
 
-impl Reflectable for HTMLSourceElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLSpanElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLSpanElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLSpanElement {
     }
 }
 
-impl Reflectable for HTMLSpanElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -6,7 +6,6 @@ use dom::bindings::codegen::Bindings::HTMLStyleElementBinding;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLStyleElementDerived, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -92,8 +91,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     }
 }
 
-impl Reflectable for HTMLStyleElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTableCaptionElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableCaptionElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLTableCaptionElement {
     }
 }
 
-impl Reflectable for HTMLTableCaptionElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -5,7 +5,6 @@
 use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableCellElementDerived};
 use dom::bindings::js::JSRef;
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -114,8 +113,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
     }
 }
 
-impl Reflectable for HTMLTableCellElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTableColElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableColElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLTableColElement {
     }
 }
 
-impl Reflectable for HTMLTableColElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTableDataCellElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableDataCellElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -42,8 +41,3 @@ impl HTMLTableDataCellElement {
     }
 }
 
-impl Reflectable for HTMLTableDataCellElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmltablecellelement.reflector()
-    }
-}

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -9,7 +9,6 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableCaptionElementCast};
 use dom::bindings::codegen::InheritTypes::{HTMLTableElementDerived, NodeCast};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -58,11 +57,6 @@ impl HTMLTableElement {
     }
 }
 
-impl Reflectable for HTMLTableElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
 
 impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
     //  http://www.whatwg.org/html/#dom-table-caption

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -57,7 +57,6 @@ impl HTMLTableElement {
     }
 }
 
-
 impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
     //  http://www.whatwg.org/html/#dom-table-caption
     fn GetCaption(self) -> Option<Temporary<HTMLTableCaptionElement>> {

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTableHeaderCellElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTableHeaderCellElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLTableHeaderCellElement {
     }
 }
 
-impl Reflectable for HTMLTableHeaderCellElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmltablecellelement.reflector()
-    }
-}

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -50,3 +50,46 @@ impl HTMLTableRowElement {
     }
 }
 
+
+pub trait HTMLTableRowElementHelpers {
+    fn get_background_color(&self) -> Option<RGBA>;
+}
+
+impl HTMLTableRowElementHelpers for HTMLTableRowElement {
+    fn get_background_color(&self) -> Option<RGBA> {
+        self.background_color.get()
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLTableRowElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
+        }
+
+        match attr.local_name() {
+            &atom!("bgcolor") => {
+                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok())
+            }
+            _ => {}
+        }
+    }
+
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
+        }
+
+        match attr.local_name() {
+            &atom!("bgcolor") => self.background_color.set(None),
+            _ => {}
+        }
+    }
+}

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -6,7 +6,6 @@ use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLTableRowElementBinding;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableRowElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -48,55 +47,6 @@ impl HTMLTableRowElement {
         Node::reflect_node(box HTMLTableRowElement::new_inherited(localName, prefix, document),
                            document,
                            HTMLTableRowElementBinding::Wrap)
-    }
-}
-
-impl Reflectable for HTMLTableRowElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
-
-pub trait HTMLTableRowElementHelpers {
-    fn get_background_color(&self) -> Option<RGBA>;
-}
-
-impl HTMLTableRowElementHelpers for HTMLTableRowElement {
-    fn get_background_color(&self) -> Option<RGBA> {
-        self.background_color.get()
-    }
-}
-
-impl<'a> VirtualMethods for JSRef<'a, HTMLTableRowElement> {
-    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
-        Some(htmlelement as &VirtualMethods)
-    }
-
-    fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
-        }
-
-        match attr.local_name() {
-            &atom!("bgcolor") => {
-                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok())
-            }
-            _ => {}
-        }
-    }
-
-    fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
-        }
-
-        match attr.local_name() {
-            &atom!("bgcolor") => self.background_color.set(None),
-            _ => {}
-        }
     }
 }
 

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -6,7 +6,6 @@ use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLTableSectionElementBinding;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableSectionElementDerived};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -47,55 +46,6 @@ impl HTMLTableSectionElement {
                -> Temporary<HTMLTableSectionElement> {
         let element = HTMLTableSectionElement::new_inherited(localName, prefix, document);
         Node::reflect_node(box element, document, HTMLTableSectionElementBinding::Wrap)
-    }
-}
-
-impl Reflectable for HTMLTableSectionElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
-
-pub trait HTMLTableSectionElementHelpers {
-    fn get_background_color(&self) -> Option<RGBA>;
-}
-
-impl HTMLTableSectionElementHelpers for HTMLTableSectionElement {
-    fn get_background_color(&self) -> Option<RGBA> {
-        self.background_color.get()
-    }
-}
-
-impl<'a> VirtualMethods for JSRef<'a, HTMLTableSectionElement> {
-    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
-        Some(htmlelement as &VirtualMethods)
-    }
-
-    fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
-        }
-
-        match attr.local_name() {
-            &atom!("bgcolor") => {
-                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok())
-            }
-            _ => {}
-        }
-    }
-
-    fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
-        }
-
-        match attr.local_name() {
-            &atom!("bgcolor") => self.background_color.set(None),
-            _ => {}
-        }
     }
 }
 

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -49,3 +49,45 @@ impl HTMLTableSectionElement {
     }
 }
 
+pub trait HTMLTableSectionElementHelpers {
+    fn get_background_color(&self) -> Option<RGBA>;
+}
+
+impl HTMLTableSectionElementHelpers for HTMLTableSectionElement {
+    fn get_background_color(&self) -> Option<RGBA> {
+        self.background_color.get()
+    }
+}
+
+impl<'a> VirtualMethods for JSRef<'a, HTMLTableSectionElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, attr: JSRef<Attr>) {
+        match self.super_type() {
+            Some(ref s) => s.after_set_attr(attr),
+            _ => ()
+        }
+
+        match attr.local_name() {
+            &atom!("bgcolor") => {
+                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok())
+            }
+            _ => {}
+        }
+    }
+
+    fn before_remove_attr(&self, attr: JSRef<Attr>) {
+        match self.super_type() {
+            Some(ref s) => s.before_remove_attr(attr),
+            _ => ()
+        }
+
+        match attr.local_name() {
+            &atom!("bgcolor") => self.background_color.set(None),
+            _ => {}
+        }
+    }
+}

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTemplateElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTemplateElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLTemplateElement {
     }
 }
 
-impl Reflectable for HTMLTemplateElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -329,3 +329,20 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 }
 
+impl<'a> FormControl<'a> for JSRef<'a, HTMLTextAreaElement> {
+    fn to_element(self) -> JSRef<'a, Element> {
+        ElementCast::from_ref(self)
+    }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#concept-fe-mutable
+    fn mutable(self) -> bool {
+        // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-fe-mutable
+        !(self.Disabled() || self.ReadOnly())
+    }
+
+    fn reset(self) {
+        // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-form-reset-control
+        self.SetValue(self.DefaultValue());
+        self.value_changed.set(false);
+    }
+}

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -13,7 +13,6 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCas
 use dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::codegen::InheritTypes::{KeyboardEventCast, TextDerived};
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{Element, AttributeHandlers, ElementTypeId};
 use dom::event::Event;
@@ -330,26 +329,3 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 }
 
-impl Reflectable for HTMLTextAreaElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
-
-impl<'a> FormControl<'a> for JSRef<'a, HTMLTextAreaElement> {
-    fn to_element(self) -> JSRef<'a, Element> {
-        ElementCast::from_ref(self)
-    }
-
-    // https://html.spec.whatwg.org/multipage/forms.html#concept-fe-mutable
-    fn mutable(self) -> bool {
-        // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-fe-mutable
-        !(self.Disabled() || self.ReadOnly())
-    }
-
-    fn reset(self) {
-        // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-form-reset-control
-        self.SetValue(self.DefaultValue());
-        self.value_changed.set(false);
-    }
-}

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTimeElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTimeElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLTimeElement {
     }
 }
 
-impl Reflectable for HTMLTimeElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -8,7 +8,6 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTitleElementDerived, NodeCast};
 use dom::bindings::codegen::InheritTypes::{TextCast};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -62,27 +61,6 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     fn SetText(self, value: DOMString) {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value))
-    }
-}
-
-impl Reflectable for HTMLTitleElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}
-
-impl<'a> VirtualMethods for JSRef<'a, HTMLTitleElement> {
-    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
-        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
-        Some(htmlelement as &VirtualMethods)
-    }
-
-    fn bind_to_tree(&self, is_in_doc: bool) {
-        let node: JSRef<Node> = NodeCast::from_ref(*self);
-        if is_in_doc {
-            let document = node.owner_doc().root();
-            document.send_title_to_compositor()
-        }
     }
 }
 

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -64,3 +64,17 @@ impl<'a> HTMLTitleElementMethods for JSRef<'a, HTMLTitleElement> {
     }
 }
 
+impl<'a> VirtualMethods for JSRef<'a, HTMLTitleElement> {
+    fn super_type<'a>(&'a self) -> Option<&'a VirtualMethods> {
+        let htmlelement: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn bind_to_tree(&self, is_in_doc: bool) {
+        let node: JSRef<Node> = NodeCast::from_ref(*self);
+        if is_in_doc {
+            let document = node.owner_doc().root();
+            document.send_title_to_compositor()
+        }
+    }
+}

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLTrackElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLTrackElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLTrackElement {
     }
 }
 
-impl Reflectable for HTMLTrackElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLUListElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLUListElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLUListElement {
     }
 }
 
-impl Reflectable for HTMLUListElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLUnknownElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLUnknownElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLUnknownElement {
     }
 }
 
-impl Reflectable for HTMLUnknownElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlelement.reflector()
-    }
-}

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -5,7 +5,6 @@
 use dom::bindings::codegen::Bindings::HTMLVideoElementBinding;
 use dom::bindings::codegen::InheritTypes::HTMLVideoElementDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -38,8 +37,3 @@ impl HTMLVideoElement {
     }
 }
 
-impl Reflectable for HTMLVideoElement {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.htmlmediaelement.reflector()
-    }
-}

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::LocationBinding;
 use dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::urlhelper::UrlHelper;
 use dom::window::Window;
 use page::Page;
@@ -50,8 +50,3 @@ impl<'a> LocationMethods for JSRef<'a, Location> {
     }
 }
 
-impl Reflectable for Location {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::InheritTypes::{EventCast, MessageEventDerived};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId};
 use dom::eventtarget::{EventTarget, EventTargetHelpers};
 
@@ -99,8 +99,3 @@ impl<'a> MessageEventMethods for JSRef<'a, MessageEvent> {
     }
 }
 
-impl Reflectable for MessageEvent {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.event.reflector()
-    }
-}

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::InheritTypes::{EventCast, UIEventCast, MouseEventDer
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary, OptionalSettable};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId};
 use dom::eventtarget::EventTarget;
 use dom::uievent::UIEvent;
@@ -179,8 +179,3 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
     }
 }
 
-impl Reflectable for MouseEvent {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.uievent.reflector()
-    }
-}

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::Bindings::NamedNodeMapBinding;
 use dom::bindings::codegen::Bindings::NamedNodeMapBinding::NamedNodeMapMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::element::{Element, ElementHelpers};
 use dom::window::Window;
 
@@ -47,8 +47,3 @@ impl<'a> NamedNodeMapMethods for JSRef<'a, NamedNodeMap> {
     }
 }
 
-impl Reflectable for NamedNodeMap {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::NavigatorBinding;
 use dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::navigatorinfo::NavigatorInfo;
 use dom::window::Window;
 use servo_util::str::DOMString;
@@ -56,8 +56,3 @@ impl<'a> NavigatorMethods for JSRef<'a, Navigator> {
     }
 }
 
-impl Reflectable for Navigator {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -27,7 +27,6 @@ use dom::bindings::js::{JS, JSRef, RootedReference, Temporary, Root};
 use dom::bindings::js::{OptionalSettable, TemporaryPushable, OptionalRootedRootable};
 use dom::bindings::js::{ResultRootable, OptionalRootable, MutNullableJS};
 use dom::bindings::trace::JSTraceable;
-use dom::bindings::utils;
 use dom::bindings::utils::{Reflectable, reflect_dom_object};
 use dom::characterdata::CharacterData;
 use dom::comment::Comment;

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -27,7 +27,8 @@ use dom::bindings::js::{JS, JSRef, RootedReference, Temporary, Root};
 use dom::bindings::js::{OptionalSettable, TemporaryPushable, OptionalRootedRootable};
 use dom::bindings::js::{ResultRootable, OptionalRootable, MutNullableJS};
 use dom::bindings::trace::JSTraceable;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils;
+use dom::bindings::utils::{Reflectable, reflect_dom_object};
 use dom::characterdata::CharacterData;
 use dom::comment::Comment;
 use dom::document::{Document, DocumentHelpers, IsHTMLDocument, DocumentSource};
@@ -2169,11 +2170,6 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 }
 
 
-impl Reflectable for Node {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}
 
 /// The address of a node known to be valid. These are sent from script to layout,
 /// and are also used in the HTML parser interface.

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -482,7 +482,6 @@ pub trait NodeHelpers<'a> {
     fn summarize(self) -> NodeInfo;
 }
 
-
 impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     /// Dumps the subtree rooted at this node, for debugging.
     fn dump(self) {

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::NodeIteratorBinding;
 use dom::bindings::codegen::Bindings::NodeIteratorBinding::NodeIteratorMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 
 #[dom_struct]
 pub struct NodeIterator {
@@ -28,8 +28,3 @@ impl NodeIterator {
 impl<'a> NodeIteratorMethods for JSRef<'a, NodeIterator> {
 }
 
-impl Reflectable for NodeIterator {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -19,15 +19,15 @@ pub enum NodeListType {
 
 #[dom_struct]
 pub struct NodeList {
-    list_type: NodeListType,
     reflector_: Reflector,
+    list_type: NodeListType,
 }
 
 impl NodeList {
     fn new_inherited(list_type: NodeListType) -> NodeList {
         NodeList {
-            list_type: list_type,
             reflector_: Reflector::new(),
+            list_type: list_type,
         }
     }
 

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::NodeListBinding;
 use dom::bindings::codegen::Bindings::NodeListBinding::NodeListMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::node::{Node, NodeHelpers};
 use dom::window::Window;
 
@@ -76,8 +76,3 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
     }
 }
 
-impl Reflectable for NodeList {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::PerformanceBinding;
 use dom::bindings::codegen::Bindings::PerformanceBinding::PerformanceMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::performancetiming::{PerformanceTiming, PerformanceTimingHelpers};
 use dom::window::Window;
 use time;
@@ -54,8 +54,3 @@ impl<'a> PerformanceMethods for JSRef<'a, Performance> {
     }
 }
 
-impl Reflectable for Performance {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::PerformanceTimingBinding;
 use dom::bindings::codegen::Bindings::PerformanceTimingBinding::PerformanceTimingMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::window::Window;
 
 #[dom_struct]
@@ -54,8 +54,3 @@ impl<'a> PerformanceTimingHelpers for JSRef<'a, PerformanceTiming> {
     }
 }
 
-impl Reflectable for PerformanceTiming {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -6,7 +6,6 @@ use dom::bindings::codegen::Bindings::ProcessingInstructionBinding;
 use dom::bindings::codegen::Bindings::ProcessingInstructionBinding::ProcessingInstructionMethods;
 use dom::bindings::codegen::InheritTypes::ProcessingInstructionDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -54,8 +53,3 @@ impl<'a> ProcessingInstructionMethods for JSRef<'a, ProcessingInstruction> {
     }
 }
 
-impl Reflectable for ProcessingInstruction {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.characterdata.reflector()
-    }
-}

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::InheritTypes::{EventCast, ProgressEventDerived};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId};
 use servo_util::str::DOMString;
 
@@ -68,8 +68,3 @@ impl<'a> ProgressEventMethods for JSRef<'a, ProgressEvent> {
     }
 }
 
-impl Reflectable for ProgressEvent {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.event.reflector()
-    }
-}

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::document::{Document, DocumentHelpers};
 
 #[dom_struct]
@@ -43,8 +43,3 @@ impl<'a> RangeMethods for JSRef<'a, Range> {
     }
 }
 
-impl Reflectable for Range {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::ScreenBinding;
 use dom::bindings::codegen::Bindings::ScreenBinding::ScreenMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::window::Window;
 
 #[dom_struct]
@@ -38,8 +38,3 @@ impl<'a> ScreenMethods for JSRef<'a, Screen> {
     }
 }
 
-impl Reflectable for Screen {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::StorageBinding;
 use dom::bindings::codegen::Bindings::StorageBinding::StorageMethods;
 use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::error::Fallible;
 use servo_util::str::DOMString;
 use servo_net::storage_task::StorageTask;
@@ -118,8 +118,3 @@ impl<'a> StorageMethods for JSRef<'a, Storage> {
     }
 }
 
-impl Reflectable for Storage {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -307,8 +307,3 @@ impl TestBinding {
     pub fn ReceiveVoidStatic() {}
 }
 
-impl Reflectable for TestBinding {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector
-    }
-}

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -8,7 +8,6 @@ use dom::bindings::codegen::InheritTypes::TextDerived;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -50,8 +49,3 @@ impl Text {
     }
 }
 
-impl Reflectable for Text {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.characterdata.reflector()
-    }
-}

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -119,7 +119,6 @@ impl<'a> TreeWalkerMethods for JSRef<'a, TreeWalker> {
     }
 }
 
-
 type NodeAdvancer<'a> = |node: JSRef<'a, Node>|: 'a -> Option<Temporary<Node>>;
 
 trait PrivateTreeWalkerHelpers<'a> {

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -14,7 +14,7 @@ use dom::bindings::codegen::Bindings::NodeFilterBinding::NodeFilter;
 use dom::bindings::error::{ErrorResult, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, OptionalRootable, Temporary, MutHeap};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::document::{Document, DocumentHelpers};
 use dom::node::{Node, NodeHelpers};
 
@@ -119,11 +119,6 @@ impl<'a> TreeWalkerMethods for JSRef<'a, TreeWalker> {
     }
 }
 
-impl Reflectable for TreeWalker {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 type NodeAdvancer<'a> = |node: JSRef<'a, Node>|: 'a -> Option<Temporary<Node>>;
 

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -10,7 +10,7 @@ use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary, OptionalSettable};
 
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId};
 use dom::window::Window;
 use servo_util::str::DOMString;
@@ -93,8 +93,3 @@ impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
     }
 }
 
-impl Reflectable for UIEvent {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.event.reflector()
-    }
-}

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -10,7 +10,7 @@ use dom::bindings::codegen::UnionTypes::StringOrURLSearchParams::{eURLSearchPara
 use dom::bindings::error::{Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 
 use servo_util::str::DOMString;
 
@@ -93,11 +93,6 @@ impl<'a> URLSearchParamsMethods for JSRef<'a, URLSearchParams> {
     }
 }
 
-impl Reflectable for URLSearchParams {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}
 
 pub trait URLSearchParamsHelpers {
     fn serialize(&self, encoding: Option<EncodingRef>) -> Vec<u8>;

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -93,7 +93,6 @@ impl<'a> URLSearchParamsMethods for JSRef<'a, URLSearchParams> {
     }
 }
 
-
 pub trait URLSearchParamsHelpers {
     fn serialize(&self, encoding: Option<EncodingRef>) -> Vec<u8>;
     fn update_steps(&self);

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -24,15 +24,15 @@ use std::ascii::OwnedAsciiExt;
 
 #[dom_struct]
 pub struct URLSearchParams {
-    data: DOMRefCell<HashMap<DOMString, Vec<DOMString>>>,
     reflector_: Reflector,
+    data: DOMRefCell<HashMap<DOMString, Vec<DOMString>>>,
 }
 
 impl URLSearchParams {
     fn new_inherited() -> URLSearchParams {
         URLSearchParams {
-            data: DOMRefCell::new(HashMap::new()),
             reflector_: Reflector::new(),
+            data: DOMRefCell::new(HashMap::new()),
         }
     }
 

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -5,7 +5,7 @@
 use dom::bindings::codegen::Bindings::ValidityStateBinding;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::window::Window;
 
 #[dom_struct]
@@ -29,8 +29,3 @@ impl ValidityState {
     }
 }
 
-impl Reflectable for ValidityState {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -36,7 +36,6 @@ impl WebSocket {
     }
 }
 
-
 impl<'a> WebSocketMethods for JSRef<'a, WebSocket> {
     fn Url(self) -> DOMString {
         self.url.clone()

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::Bindings::WebSocketBinding::WebSocketMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{Temporary, JSRef};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use servo_util::str::DOMString;
 
@@ -36,11 +36,6 @@ impl WebSocket {
     }
 }
 
-impl Reflectable for WebSocket {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}
 
 impl<'a> WebSocketMethods for JSRef<'a, WebSocket> {
     fn Url(self) -> DOMString {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -12,7 +12,7 @@ use dom::bindings::error::Fallible;
 use dom::bindings::error::Error::InvalidCharacter;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
+use dom::bindings::utils::Reflectable;
 use dom::browsercontext::BrowserContext;
 use dom::console::Console;
 use dom::document::Document;
@@ -293,11 +293,6 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
     }
 }
 
-impl Reflectable for Window {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}
 
 pub trait WindowHelpers {
     fn flush_layout(self, goal: ReflowGoal, query: ReflowQueryType);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -182,7 +182,6 @@ pub fn base64_atob(atob: DOMString) -> Fallible<DOMString> {
     }
 }
 
-
 impl<'a> WindowMethods for JSRef<'a, Window> {
     fn Alert(self, s: DOMString) {
         // Right now, just print to the console

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -11,7 +11,7 @@ use dom::bindings::error::Error::{Syntax, DataClone};
 use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JS, JSRef, Temporary};
 use dom::bindings::trace::JSTraceable;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflectable, reflect_dom_object};
 use dom::dedicatedworkerglobalscope::DedicatedWorkerGlobalScope;
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 use dom::messageevent::MessageEvent;
@@ -153,8 +153,3 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
     event_handler!(message, GetOnmessage, SetOnmessage)
 }
 
-impl Reflectable for Worker {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -8,7 +8,7 @@ use dom::bindings::error::{ErrorResult, Fallible};
 use dom::bindings::error::Error::{Syntax, Network, FailureUnknown};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector};
+use dom::bindings::utils::Reflectable;
 use dom::console::Console;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::workerlocation::WorkerLocation;
@@ -186,8 +186,3 @@ impl<'a> WorkerGlobalScopeHelpers for JSRef<'a, WorkerGlobalScope> {
 
 }
 
-impl Reflectable for WorkerGlobalScope {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::WorkerLocationBinding;
 use dom::bindings::codegen::Bindings::WorkerLocationBinding::WorkerLocationMethods;
 use dom::bindings::js::{JSRef, Temporary};
 use dom::bindings::global::GlobalRef;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::urlhelper::UrlHelper;
 use dom::workerglobalscope::WorkerGlobalScope;
 
@@ -49,8 +49,3 @@ impl<'a> WorkerLocationMethods for JSRef<'a, WorkerLocation> {
     }
 }
 
-impl Reflectable for WorkerLocation {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::WorkerNavigatorBinding;
 use dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::navigatorinfo::NavigatorInfo;
 use dom::workerglobalscope::WorkerGlobalScope;
 use servo_util::str::DOMString;
@@ -56,8 +56,3 @@ impl<'a> WorkerNavigatorMethods for JSRef<'a, WorkerNavigator> {
     }
 }
 
-impl Reflectable for WorkerNavigator {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        &self.reflector_
-    }
-}

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -240,7 +240,6 @@ impl XMLHttpRequest {
             }
         }
 
-
         macro_rules! notify_error_and_return(
             ($err:expr) => ({
                 notify_partial_progress(fetch_type, XHRProgress::Errored(gen_id, $err));

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -16,7 +16,7 @@ use dom::bindings::error::Error::{Network, Syntax, Security, Abort, Timeout};
 use dom::bindings::global::{GlobalField, GlobalRef, GlobalRoot};
 use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, OptionalRootedRootable};
 use dom::bindings::str::ByteString;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::{Reflectable, reflect_dom_object};
 use dom::document::Document;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
@@ -759,11 +759,6 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
     }
 }
 
-impl Reflectable for XMLHttpRequest {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}
 
 impl XMLHttpRequestDerived for EventTarget {
     fn is_xmlhttprequest(&self) -> bool {

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -7,7 +7,6 @@ use dom::bindings::codegen::Bindings::XMLHttpRequestEventTargetBinding::XMLHttpR
 use dom::bindings::codegen::InheritTypes::EventTargetCast;
 use dom::bindings::codegen::InheritTypes::XMLHttpRequestEventTargetDerived;
 use dom::bindings::js::JSRef;
-use dom::bindings::utils::{Reflectable, Reflector};
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 
 #[deriving(PartialEq)]
@@ -44,11 +43,6 @@ impl XMLHttpRequestEventTargetDerived for EventTarget {
 
 }
 
-impl Reflectable for XMLHttpRequestEventTarget {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
-    }
-}
 
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
     event_handler!(loadstart,GetOnloadstart, SetOnloadstart)

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -43,7 +43,6 @@ impl XMLHttpRequestEventTargetDerived for EventTarget {
 
 }
 
-
 impl<'a> XMLHttpRequestEventTargetMethods for JSRef<'a, XMLHttpRequestEventTarget> {
     event_handler!(loadstart,GetOnloadstart, SetOnloadstart)
     event_handler!(progress, GetOnprogress, SetOnprogress)

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::InheritTypes::XMLHttpRequestUploadDerived;
 use dom::bindings::codegen::Bindings::XMLHttpRequestUploadBinding;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Temporary;
-use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
+use dom::bindings::utils::reflect_dom_object;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
 use dom::xmlhttprequesteventtarget::XMLHttpRequestEventTargetTypeId;
@@ -26,11 +26,6 @@ impl XMLHttpRequestUpload {
         reflect_dom_object(box XMLHttpRequestUpload::new_inherited(),
                            global,
                            XMLHttpRequestUploadBinding::Wrap)
-    }
-}
-impl Reflectable for XMLHttpRequestUpload {
-    fn reflector<'a>(&'a self) -> &'a Reflector {
-        self.eventtarget.reflector()
     }
 }
 


### PR DESCRIPTION
Now `#[dom_struct]` also generates Reflectable impls, and there's another lint to ensure that a DOM struct only contains one bare DOM field (as the first field) or a Reflector.

A lot of this was generated by sed -- each autogenerated change has its own commit for easy review; these will be squashed later.
