### PR TITLE
Fix error in layout trace viewer

### DIFF
--- a/etc/layout_viewer/viewer.html
+++ b/etc/layout_viewer/viewer.html
@@ -90,6 +90,9 @@
 
         <script>
             function get_base(node) {
+                if (node.id !== undefined) {
+                    return node;
+                }
                 if (node.data.base !== undefined) {
                     return node.data.base;
                 }


### PR DESCRIPTION
d1b433a3b3bab353f320b2f39fa953ce326d2d55 changed the encoding format for Flows.  The root is no longer wrapped inside a `data` field, but instead includes BaseFlow fields directly.  This broke the layout trace viewer, which threw an uncaught exception when the `data` property was missing.  This fixes the exception, though some functionality may still be partly broken.
