### PR TITLE
Implements the :checked pseudo-class for inputs

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -553,6 +553,13 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     }
 
     #[inline]
+    fn get_checked_state(self) -> bool {
+        unsafe {
+            self.element.get_checked_state_for_layout()
+        }
+    }
+
+    #[inline]
     fn has_class(self, name: &Atom) -> bool {
         unsafe {
             self.element.has_class_for_layout(name)

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -125,6 +125,7 @@ pub trait LayoutHTMLInputElementHelpers {
 }
 
 pub trait RawLayoutHTMLInputElementHelpers {
+    unsafe fn get_checked_state_for_layout(&self) -> bool;
     unsafe fn get_size_for_layout(&self) -> u32;
 }
 
@@ -163,6 +164,11 @@ impl LayoutHTMLInputElementHelpers for JS<HTMLInputElement> {
 
 impl RawLayoutHTMLInputElementHelpers for HTMLInputElement {
     #[allow(unrooted_must_root)]
+    unsafe fn get_checked_state_for_layout(&self) -> bool {
+        self.checked.get()
+    }
+
+    #[allow(unrooted_must_root)]
     unsafe fn get_size_for_layout(&self) -> u32 {
         self.size.get()
     }
@@ -181,7 +187,9 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     }
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-checked
-    make_bool_setter!(SetChecked, "checked")
+    fn SetChecked(self, checked: bool) {
+        self.update_checked_state(checked);
+    }
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-readonly
     make_bool_getter!(ReadOnly)

--- a/components/style/node.rs
+++ b/components/style/node.rs
@@ -45,6 +45,7 @@ pub trait TElement<'a> : Copy {
     fn get_id(self) -> Option<Atom>;
     fn get_disabled_state(self) -> bool;
     fn get_enabled_state(self) -> bool;
+    fn get_checked_state(self) -> bool;
     fn has_class(self, name: &Atom) -> bool;
 
     // Ordinarily I wouldn't use callbacks like this, but the alternative is

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -997,6 +997,12 @@ pub fn matches_simple_selector<'a,E,N>(selector: &SimpleSelector,
             let elem = element.as_element();
             elem.get_enabled_state()
         },
+        // https://html.spec.whatwg.org/multipage/scripting.html#selector-checked
+        Checked => {
+            *shareable = false;
+            let elem = element.as_element();
+            elem.get_checked_state()
+        }
         FirstChild => {
             *shareable = false;
             matches_first_child(element)

--- a/components/style/selectors.rs
+++ b/components/style/selectors.rs
@@ -68,6 +68,7 @@ pub enum SimpleSelector {
     Hover,
     Disabled,
     Enabled,
+    Checked,
     FirstChild, LastChild, OnlyChild,
 //    Empty,
     Root,
@@ -226,7 +227,7 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 | &AttrExists(..) | &AttrEqual(..) | &AttrIncludes(..) | &AttrDashMatch(..)
                 | &AttrPrefixMatch(..) | &AttrSubstringMatch(..) | &AttrSuffixMatch(..)
                 | &AnyLink | &Link | &Visited | &Hover | &Disabled | &Enabled
-                | &FirstChild | &LastChild | &OnlyChild | &Root
+                | &FirstChild | &LastChild | &OnlyChild | &Root | &Checked
 //                | &Empty | &Lang(*)
                 | &NthChild(..) | &NthLastChild(..)
                 | &NthOfType(..) | &NthLastOfType(..)
@@ -497,6 +498,7 @@ fn parse_simple_pseudo_class(name: &str) -> Result<SimpleSelector, ()> {
         "hover" => Ok(Hover),
         "disabled" => Ok(Disabled),
         "enabled" => Ok(Enabled),
+        "checked" => Ok(Checked),
         "first-child" => Ok(FirstChild),
         "last-child"  => Ok(LastChild),
         "only-child"  => Ok(OnlyChild),

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -10,9 +10,9 @@ input[type="checkbox"],
 input[type="radio"]     { font-family: monospace !important; border: none !important; background: transparent; }
 
 input[type="checkbox"]::before { content: "[ ]"; padding: 0; }
-input[type="checkbox"][checked]::before { content: "[✓]"; }
+input[type="checkbox"]:checked::before { content: "[✓]"; }
 input[type="radio"]::before { content: "( )"; padding: 0; }
-input[type="radio"][checked]::before { content: "(●)"; }
+input[type="radio"]:checked::before { content: "(●)"; }
 
 td[align="left"]    { text-align: left; }
 td[align="center"]  { text-align: center; }


### PR DESCRIPTION
Relevant spec:
https://html.spec.whatwg.org/multipage/scripting.html#selector-checked

Also modifies HTMLInputElement::SetChecked to no longer modify its
checked content value, instead making use of its internal checkedness
state now that we can match `:checked` properly.
