### PR TITLE
Replacing C libraries with Rust equivalents - student project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ source = "git+https://github.com/servo/rust-freetype#e55b06110fb2d74a2db68ead740
 [[package]]
 name = "freetype-rs"
 version = "0.0.0"
-source = "git+https://github.com/ankit3005/freetype-rs#5e55fccf39178eebceecc43397f37c9ed1d6828a"
+source = "git+https://github.com/PistonDevelopers/freetype-rs#753496406098651c83cdaf63db9f75dc42da17c7"
 
 [[package]]
 name = "freetype-sys"
@@ -228,10 +228,9 @@ dependencies = [
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
  "core_text 0.1.0 (git+https://github.com/servo/rust-core-text)",
  "fontconfig 0.1.0 (git+https://github.com/servo/rust-fontconfig)",
- "freetype-rs 0.0.0 (git+https://github.com/ankit3005/freetype-rs)",
+ "freetype-rs 0.0.0 (git+https://github.com/PistonDevelopers/freetype-rs)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "harfbuzz 0.1.0 (git+https://github.com/servo/rust-harfbuzz)",
- "image 0.1.0 (git+https://github.com/PistonDevelopers/image)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -472,6 +471,7 @@ version = "0.0.1"
 dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "http 0.1.0-pre (git+https://github.com/servo/rust-http?ref=servo)",
+ "image 0.1.0 (git+https://github.com/PistonDevelopers/image)",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.1.0 (git+https://github.com/servo/rust-url)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,10 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-freetype#e55b06110fb2d74a2db68ead740db7e98fb98060"
 
 [[package]]
+name = "freetype-rs"
+version = "0.0.0"
+
+[[package]]
 name = "freetype-sys"
 version = "2.4.11"
 source = "git+https://github.com/servo/libfreetype2#f5c49c0da1d5bc6b206c4176344012ac37524243"
@@ -223,9 +227,10 @@ dependencies = [
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
  "core_text 0.1.0 (git+https://github.com/servo/rust-core-text)",
  "fontconfig 0.1.0 (git+https://github.com/servo/rust-fontconfig)",
- "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
+ "freetype-rs 0.0.0",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "harfbuzz 0.1.0 (git+https://github.com/servo/rust-harfbuzz)",
+ "image 0.1.0 (git+https://github.com/PistonDevelopers/image)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -359,6 +364,11 @@ dependencies = [
  "openssl 0.0.0 (git+https://github.com/sfackler/rust-openssl.git)",
  "url 0.1.0 (git+https://github.com/servo/rust-url)",
 ]
+
+[[package]]
+name = "image"
+version = "0.1.0"
+source = "git+https://github.com/PistonDevelopers/image#3a398831adb22f1200cb68682e446ede187d23b9"
 
 [[package]]
 name = "io_surface"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ source = "git+https://github.com/servo/rust-freetype#e55b06110fb2d74a2db68ead740
 [[package]]
 name = "freetype-rs"
 version = "0.0.0"
+source = "git+https://github.com/ankit3005/freetype-rs#5e55fccf39178eebceecc43397f37c9ed1d6828a"
 
 [[package]]
 name = "freetype-sys"
@@ -227,7 +228,7 @@ dependencies = [
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
  "core_text 0.1.0 (git+https://github.com/servo/rust-core-text)",
  "fontconfig 0.1.0 (git+https://github.com/servo/rust-fontconfig)",
- "freetype-rs 0.0.0",
+ "freetype-rs 0.0.0 (git+https://github.com/ankit3005/freetype-rs)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "harfbuzz 0.1.0 (git+https://github.com/servo/rust-harfbuzz)",
  "image 0.1.0 (git+https://github.com/PistonDevelopers/image)",

--- a/Cargo.lock.rej
+++ b/Cargo.lock.rej
@@ -1,0 +1,22 @@
+--- Cargo.lock
++++ Cargo.lock
+@@ -361,6 +361,11 @@
+ ]
+ 
+ [[package]]
++name = "image"
++version = "0.1.0"
++source = "git+https://github.com/PistonDevelopers/image#3a398831adb22f1200cb68682e446ede187d23b9"
++
++[[package]]
+ name = "io_surface"
+ version = "0.1.0"
+ source = "git+https://github.com/servo/rust-io-surface#691cbccc320c4fb9b75e215da9b0b82539d729bd"
+@@ -461,6 +466,7 @@
+ dependencies = [
+  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
+  "http 0.1.0-pre (git+https://github.com/servo/rust-http?ref=servo)",
++ "image 0.1.0 (git+https://github.com/PistonDevelopers/image)",
+  "png 0.1.0 (git+https://github.com/servo/rust-png)",
+  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
+  "url 0.1.0 (git+https://github.com/servo/rust-url)",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -48,7 +48,7 @@ git = "https://github.com/servo/rust-harfbuzz"
 git = "https://github.com/servo/rust-fontconfig"
 
 [dependencies.freetype-rs]
-git = "https://github.com/ankit3005/freetype-rs"
+git = "https://github.com/PistonDevelopers/freetype-rs"
 
 [dependencies.core_foundation]
 git = "https://github.com/servo/rust-core-foundation"

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -35,9 +35,6 @@ git = "https://github.com/servo/rust-layers"
 [dependencies.stb_image]
 git = "https://github.com/servo/rust-stb-image"
 
-[dependencies.image]
-git = "https://github.com/PistonDevelopers/image"
-
 [dependencies.png]
 git = "https://github.com/servo/rust-png"
 
@@ -64,4 +61,3 @@ git = "https://github.com/servo/rust-core-text"
 
 [dependencies.script_traits]
 path = "../script_traits"
-

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -49,6 +49,7 @@ git = "https://github.com/servo/rust-fontconfig"
 
 [dependencies.freetype-rs]
 git = "https://github.com/PistonDevelopers/freetype-rs"
+ver = "753496406098651c83cdaf63db9f75dc42da17c7"
 
 [dependencies.core_foundation]
 git = "https://github.com/servo/rust-core-foundation"

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -51,7 +51,7 @@ git = "https://github.com/servo/rust-harfbuzz"
 git = "https://github.com/servo/rust-fontconfig"
 
 [dependencies.freetype-rs]
-path = "../../../freetype-rs"
+git = "https://github.com/ankit3005/freetype-rs"
 
 [dependencies.core_foundation]
 git = "https://github.com/servo/rust-core-foundation"

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -35,6 +35,9 @@ git = "https://github.com/servo/rust-layers"
 [dependencies.stb_image]
 git = "https://github.com/servo/rust-stb-image"
 
+[dependencies.image]
+git = "https://github.com/PistonDevelopers/image"
+
 [dependencies.png]
 git = "https://github.com/servo/rust-png"
 
@@ -47,8 +50,8 @@ git = "https://github.com/servo/rust-harfbuzz"
 [dependencies.fontconfig]
 git = "https://github.com/servo/rust-fontconfig"
 
-[dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
+[dependencies.freetype-rs]
+path = "../../../freetype-rs"
 
 [dependencies.core_foundation]
 git = "https://github.com/servo/rust-core-foundation"

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -27,7 +27,7 @@ use libc::uintptr_t;
 use render_task::RenderLayer;
 use script_traits::UntrustedNodeAddress;
 use servo_msg::compositor_msg::LayerId;
-use servo_net::image::base::Image;
+use servo_net::image::base::DynamicImage;
 use servo_util::dlist as servo_dlist;
 use servo_util::geometry::{mod, Au};
 use servo_util::range::Range;
@@ -447,7 +447,7 @@ pub enum TextOrientation {
 #[deriving(Clone)]
 pub struct ImageDisplayItem {
     pub base: BaseDisplayItem,
-    pub image: Arc<Box<Image>>,
+    pub image: Arc<Box<DynamicImage>>,
 
     /// The dimensions to which the image display item should be stretched. If this is smaller than
     /// the bounds of this display item, then the image will be repeated in the appropriate

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -553,8 +553,6 @@ impl DisplayItem {
                         bounds.origin.x = bounds.origin.x + x_offset;
                         bounds.origin.y = bounds.origin.y + y_offset;
                         bounds.size = image_item.stretch_size;
-            //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-            println!("Bounds is {} and image_item.image.clone() is {} ", bounds, image_item.stretch_size);//, source_format);
                         render_context.draw_image(bounds, image_item.image.clone());
 
                         x_offset = x_offset + image_item.stretch_size.width;

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -553,7 +553,8 @@ impl DisplayItem {
                         bounds.origin.x = bounds.origin.x + x_offset;
                         bounds.origin.y = bounds.origin.y + y_offset;
                         bounds.size = image_item.stretch_size;
-
+			//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+			println!("Bounds is {} and image_item.image.clone() is {} ", bounds, image_item.stretch_size);//, source_format);
                         render_context.draw_image(bounds, image_item.image.clone());
 
                         x_offset = x_offset + image_item.stretch_size.width;

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -553,8 +553,8 @@ impl DisplayItem {
                         bounds.origin.x = bounds.origin.x + x_offset;
                         bounds.origin.y = bounds.origin.y + y_offset;
                         bounds.size = image_item.stretch_size;
-			//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-			println!("Bounds is {} and image_item.image.clone() is {} ", bounds, image_item.stretch_size);//, source_format);
+            //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+            println!("Bounds is {} and image_item.image.clone() is {} ", bounds, image_item.stretch_size);//, source_format);
                         render_context.draw_image(bounds, image_item.image.clone());
 
                         x_offset = x_offset + image_item.stretch_size.width;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -33,6 +33,7 @@ extern crate style;
 extern crate sync;
 extern crate time;
 extern crate url;
+extern crate "image" as servo_image;
 
 // Eventually we would like the shaper to be pluggable, as many operating systems have their own
 // shapers. For now, however, this is a hard dependency.

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -43,7 +43,7 @@ extern crate harfbuzz;
 extern crate fontconfig;
 
 #[cfg(any(target_os="linux", target_os = "android"))]
-extern crate freetype;
+extern crate freetype_rs;
 
 // Mac OS-specific library dependencies
 #[cfg(target_os="macos")] extern crate core_foundation;

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -41,6 +41,7 @@ use freetype_rs::ffi::{FT_KERNING_DEFAULT, FT_STYLE_FLAG_ITALIC, FT_STYLE_FLAG_B
 use freetype_rs::ffi::{FT_SizeRec, FT_UInt, FT_Size_Metrics, FT_Vector};
 
 //use freetype::freetype::{ft_sfnt_os2};
+use freetype_rs::ffi::{ft_sfnt_os2};
 
 use freetype_rs::tt_os2::TT_OS2;
 

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -15,35 +15,16 @@ use text::util::{float_to_fixed, fixed_to_float};
 use style::computed_values::font_weight;
 use platform::font_template::FontTemplateData;
 
-//use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
-use freetype_rs::ffi::{FT_Get_Char_Index, FT_Get_Postscript_Name}; // freetype-rs
-
-//use freetype::freetype::{FT_Load_Glyph, FT_Set_Char_Size};
-use freetype_rs::ffi::{FT_Load_Glyph, FT_Set_Char_Size}; // freetype-rs
-
-//use freetype::freetype::{FT_Get_Kerning, FT_Get_Sfnt_Table};
-use freetype_rs::ffi::{FT_Get_Kerning, FT_Get_Sfnt_Table}; // freetype-rs
-
-//use freetype::freetype::{FT_New_Memory_Face, FT_Done_Face};
-use freetype_rs::ffi::{FT_New_Memory_Face, FT_Done_Face}; // freetype-rs
-
-//use freetype::freetype::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec};
-use freetype_rs::ffi::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec}; // freetype-rs
-// TODO FTErrorMethods has a succeeded fn that returns true if value of err==0. Look for alternative
-
-//use freetype::freetype::{FT_GlyphSlot, FT_Library, FT_Long, FT_ULong};
+use freetype_rs::ffi::{FT_Get_Char_Index, FT_Get_Postscript_Name};
+use freetype_rs::ffi::{FT_Load_Glyph, FT_Set_Char_Size};
+use freetype_rs::ffi::{FT_Get_Kerning, FT_Get_Sfnt_Table};
+use freetype_rs::ffi::{FT_New_Memory_Face, FT_Done_Face};
+use freetype_rs::ffi::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec};
 use freetype_rs::ffi::{FT_GlyphSlot, FT_Library, FT_Long, FT_ULong};
-
-//use freetype::freetype::{FT_KERNING_DEFAULT, FT_STYLE_FLAG_ITALIC, FT_STYLE_FLAG_BOLD};
 use freetype_rs::ffi::{FT_KERNING_DEFAULT, FT_STYLE_FLAG_ITALIC, FT_STYLE_FLAG_BOLD};
-
-//use freetype::freetype::{FT_SizeRec, FT_UInt, FT_Size_Metrics, struct_FT_Vector_};
 use freetype_rs::ffi::{FT_SizeRec, FT_UInt, FT_Size_Metrics, FT_Vector};
-
-//use freetype::freetype::{ft_sfnt_os2};
 use freetype_rs::ffi::{ft_sfnt_os2};
-
-use freetype_rs::tt_os2::TT_OS2;
+use freetype_rs::ffi::TT_OS2;
 
 use std::mem;
 use std::ptr;

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate freetype;
+extern crate freetype_rs;
+//extern crate freetype-rs;
 
 use font::{FontHandleMethods, FontMetrics, FontTableMethods};
 use font::{FontTableTag, FractionalPixel};
@@ -14,16 +15,34 @@ use text::util::{float_to_fixed, fixed_to_float};
 use style::computed_values::font_weight;
 use platform::font_template::FontTemplateData;
 
-use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
-use freetype::freetype::{FT_Load_Glyph, FT_Set_Char_Size};
-use freetype::freetype::{FT_Get_Kerning, FT_Get_Sfnt_Table};
-use freetype::freetype::{FT_New_Memory_Face, FT_Done_Face};
-use freetype::freetype::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec};
-use freetype::freetype::{FT_GlyphSlot, FT_Library, FT_Long, FT_ULong};
-use freetype::freetype::{FT_KERNING_DEFAULT, FT_STYLE_FLAG_ITALIC, FT_STYLE_FLAG_BOLD};
-use freetype::freetype::{FT_SizeRec, FT_UInt, FT_Size_Metrics, struct_FT_Vector_};
-use freetype::freetype::{ft_sfnt_os2};
-use freetype::tt_os2::TT_OS2;
+//use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
+use freetype_rs::ffi::{FT_Get_Char_Index, FT_Get_Postscript_Name}; // freetype-rs
+
+//use freetype::freetype::{FT_Load_Glyph, FT_Set_Char_Size};
+use freetype_rs::ffi::{FT_Load_Glyph, FT_Set_Char_Size}; // freetype-rs
+
+//use freetype::freetype::{FT_Get_Kerning, FT_Get_Sfnt_Table};
+use freetype_rs::ffi::{FT_Get_Kerning, FT_Get_Sfnt_Table}; // freetype-rs
+
+//use freetype::freetype::{FT_New_Memory_Face, FT_Done_Face};
+use freetype_rs::ffi::{FT_New_Memory_Face, FT_Done_Face}; // freetype-rs
+
+//use freetype::freetype::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec};
+use freetype_rs::ffi::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec}; // freetype-rs
+// TODO FTErrorMethods has a succeeded fn that returns true if value of err==0. Look for alternative
+
+//use freetype::freetype::{FT_GlyphSlot, FT_Library, FT_Long, FT_ULong};
+use freetype_rs::ffi::{FT_GlyphSlot, FT_Library, FT_Long, FT_ULong};
+
+//use freetype::freetype::{FT_KERNING_DEFAULT, FT_STYLE_FLAG_ITALIC, FT_STYLE_FLAG_BOLD};
+use freetype_rs::ffi::{FT_KERNING_DEFAULT, FT_STYLE_FLAG_ITALIC, FT_STYLE_FLAG_BOLD};
+
+//use freetype::freetype::{FT_SizeRec, FT_UInt, FT_Size_Metrics, struct_FT_Vector_};
+use freetype_rs::ffi::{FT_SizeRec, FT_UInt, FT_Size_Metrics, FT_Vector};
+
+//use freetype::freetype::{ft_sfnt_os2};
+
+use freetype_rs::tt_os2::TT_OS2;
 
 use std::mem;
 use std::ptr;
@@ -174,7 +193,7 @@ impl FontHandleMethods for FontHandle {
     fn glyph_h_kerning(&self, first_glyph: GlyphId, second_glyph: GlyphId)
                         -> FractionalPixel {
         assert!(self.face.is_not_null());
-        let mut delta = struct_FT_Vector_ { x: 0, y: 0 };
+        let mut delta = FT_Vector { x: 0, y: 0 };
         unsafe {
             FT_Get_Kerning(self.face, first_glyph, second_glyph, FT_KERNING_DEFAULT, &mut delta);
         }

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate freetype_rs;
-//extern crate freetype-rs;
 
 use font::{FontHandleMethods, FontMetrics, FontTableMethods};
 use font::{FontTableTag, FractionalPixel};

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -2,13 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use freetype::freetype::FTErrorMethods;
-use freetype::freetype::FT_Add_Default_Modules;
-use freetype::freetype::FT_Done_FreeType;
-use freetype::freetype::FT_Library;
-use freetype::freetype::FT_Memory;
-use freetype::freetype::FT_New_Library;
-use freetype::freetype::struct_FT_MemoryRec_;
+//use freetype::freetype::FTErrorMethods;
+use freetype_rs::ffi::FTErrorMethods;
+
+//use freetype::freetype::FT_Add_Default_Modules;
+use freetype_rs::ffi::FT_Add_Default_Modules;
+
+//use freetype::freetype::FT_Done_FreeType;
+use freetype_rs::ffi::FT_Done_FreeType;
+
+//use freetype::freetype::FT_Library;
+use freetype_rs::ffi::FT_Library;
+
+//use freetype::freetype::FT_Memory;
+use freetype_rs::ffi::FT_Memory;
+
+//use freetype::freetype::FT_New_Library;
+use freetype_rs::ffi::FT_New_Library;
+
+//use freetype::freetype::struct_FT_MemoryRec_;
+use freetype_rs::ffi::FT_MemoryRec;
 
 use std::ptr;
 use std::rc::Rc;
@@ -58,9 +71,9 @@ impl FontContextHandle {
     pub fn new() -> FontContextHandle {
         unsafe {
 
-            let ptr = libc::malloc(mem::size_of::<struct_FT_MemoryRec_>() as size_t);
-            let allocator: &mut struct_FT_MemoryRec_ = mem::transmute(ptr);
-            ptr::write(allocator, struct_FT_MemoryRec_ {
+            let ptr = libc::malloc(mem::size_of::<FT_MemoryRec>() as size_t);
+            let allocator: &mut FT_MemoryRec = mem::transmute(ptr);
+            ptr::write(allocator, FT_MemoryRec {
                 user: ptr::null_mut(),
                 alloc: ft_alloc,
                 free: ft_free,

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -118,7 +118,7 @@ impl<'a> RenderContext<'a>  {
         let (pixel_width, pixels, source_format) = match image.color() {
             RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
             Grey(_) => (1, raw_pixels.as_slice(), A8),
-            RGB(_) => panic!("RGB8 color type not supported"),
+            RGB(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
             GreyA(_) => panic!("KA8 color type not supported"),
 	    Palette(_) => panic!("Palette color type not supported"),
         };

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -20,7 +20,8 @@ use geom::size::Size2D;
 use libc::size_t;
 use libc::types::common::c99::{uint16_t, uint32_t};
 use png::{RGB8, RGBA8, K8, KA8};
-use servo_net::image::base::DynamicImage;
+//use servo_image::{ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8};
+use servo_net::image::base::{Image,DynamicImage};
 use servo_util::geometry::Au;
 use servo_util::opts;
 use servo_util::range::Range;
@@ -30,6 +31,7 @@ use style::computed_values::border_style;
 use sync::Arc;
 use text::TextRun;
 use text::glyph::CharIndex;
+use servo_image::GenericImage;
 
 pub struct RenderContext<'a> {
     pub draw_target: &'a DrawTarget,
@@ -110,14 +112,15 @@ impl<'a> RenderContext<'a>  {
     }
 
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
-        let size = Size2D(image.width as i32, image.height as i32);
-        let (pixel_width, pixels, source_format) = match image.pixels {
-            RGBA8(ref pixels) => (4, pixels.as_slice(), B8G8R8A8),
+	let (image_width, image_height) = image.dimensions();
+        let size = Size2D(image_width as i32, image_height as i32);
+        let (pixel_width, pixels, source_format) = match image.pixels() {
+            Rgba8(ref pixels) => (4, pixels.as_slice(), B8G8R8A8),
             K8(ref pixels) => (1, pixels.as_slice(), A8),
             RGB8(_) => panic!("RGB8 color type not supported"),
             KA8(_) => panic!("KA8 color type not supported"),
         };
-        let stride = image.width * pixel_width;
+        let stride = image_width * pixel_width;
 
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
@@ -126,7 +129,7 @@ impl<'a> RenderContext<'a>  {
                                                                             stride as i32,
                                                                             source_format);
         let source_rect = Rect(Point2D(0u as AzFloat, 0u as AzFloat),
-                               Size2D(image.width as AzFloat, image.height as AzFloat));
+                               Size2D(image_width as AzFloat, image_height as AzFloat));
         let dest_rect = bounds.to_azure_rect();
         let draw_surface_options = DrawSurfaceOptions::new(Linear, true);
         let draw_options = DrawOptions::new(1.0f64 as AzFloat, 0);

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -4,7 +4,7 @@
 
 //! Painting of display lists using Moz2D/Azure.
 
-use azure::azure_hl::{B8G8R8A8, A8, Color, ColorPattern, ColorPatternRef, DrawOptions};
+use azure::azure_hl::{B8G8R8A8, B8G8R8X8, A8, Color, ColorPattern, ColorPatternRef, DrawOptions};
 use azure::azure_hl::{DrawSurfaceOptions, DrawTarget, ExtendClamp, GradientStop, Linear};
 use azure::azure_hl::{LinearGradientPattern, LinearGradientPatternRef, SourceOp, StrokeOptions};
 use azure::scaled_font::ScaledFont;
@@ -113,17 +113,33 @@ impl<'a> RenderContext<'a>  {
 
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
 	let (image_width, image_height) = image.dimensions();
+	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+	println!("Height is {} and width is {}", image_height, image_width);
         let size = Size2D(image_width as i32, image_height as i32);
+	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+	println!("Size is {}", size);
 	let raw_pixels = image.raw_pixels();
+	//let option_img_pixels = image.as_rgb8();
+	//let img_pixels = match option_img_pixels {
+        //	Some(pixels) => pixels,
+        //	None => {return;}
+	//};
+	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+	println!("Color is {}", image.color().to_string());
         let (pixel_width, pixels, source_format) = match image.color() {
             RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
             Grey(_) => (1, raw_pixels.as_slice(), A8),
-            RGB(_) => panic!("RGB8 color type not supported"),
-            GreyA(_) => panic!("KA8 color type not supported"),
+            RGB(_) => (3, raw_pixels.as_slice(), B8G8R8X8),
+            GreyA(_) => (2, raw_pixels.as_slice(), A8)
 	    Palette(_) => panic!("Palette color type not supported"),
         };
         let stride = image_width * pixel_width;
-
+	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ	
+	println!("pixel_width is {}", pixel_width);
+	println!("Stride is {} and first 200 pixels are:", stride);
+	for e in range(0i as uint, 200i as uint) {
+	    print!("{} ", pixels[e]);         
+	}
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
         let azure_surface = draw_target_ref.create_source_surface_from_data(pixels,

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -115,7 +115,7 @@ impl<'a> RenderContext<'a>  {
 	let (image_width, image_height) = image.dimensions();
         let size = Size2D(image_width as i32, image_height as i32);
         let (pixel_width, pixels, source_format) = match image.pixels() {
-            Rgba8(ref pixels) => (4, pixels.as_slice(), B8G8R8A8),
+            RGBA8(ref pixels) => (4, pixels.as_slice(), B8G8R8A8),
             K8(ref pixels) => (1, pixels.as_slice(), A8),
             RGB8(_) => panic!("RGB8 color type not supported"),
             KA8(_) => panic!("KA8 color type not supported"),

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -4,7 +4,7 @@
 
 //! Painting of display lists using Moz2D/Azure.
 
-use azure::azure_hl::{B8G8R8A8, B8G8R8X8, A8, Color, ColorPattern, ColorPatternRef, DrawOptions};
+use azure::azure_hl::{B8G8R8A8, A8, Color, ColorPattern, ColorPatternRef, DrawOptions};
 use azure::azure_hl::{DrawSurfaceOptions, DrawTarget, ExtendClamp, GradientStop, Linear};
 use azure::azure_hl::{LinearGradientPattern, LinearGradientPatternRef, SourceOp, StrokeOptions};
 use azure::scaled_font::ScaledFont;
@@ -19,7 +19,7 @@ use geom::side_offsets::SideOffsets2D;
 use geom::size::Size2D;
 use libc::size_t;
 use libc::types::common::c99::{uint16_t, uint32_t};
-use servo_image::{Grey, RGB, GreyA, RGBA, Palette};
+use servo_image::DynamicImage::{ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8};
 use servo_net::image::base::{DynamicImage};
 use servo_util::geometry::Au;
 use servo_util::opts;
@@ -113,13 +113,11 @@ impl<'a> RenderContext<'a>  {
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
     let (image_width, image_height) = image.dimensions();
         let size = Size2D(image_width as i32, image_height as i32);
-    let raw_pixels = image.raw_pixels();
-        let (pixel_width, pixels, source_format) = match image.color() {
-            RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
-            Grey(_) => (1, raw_pixels.as_slice(), A8),
-            RGB(_) => (3, raw_pixels.as_slice(), B8G8R8X8),
-            GreyA(_) => (2, raw_pixels.as_slice(), A8),
-        Palette(_) => panic!("Palette color type not supported"),
+        let (pixel_width, pixels, source_format) = match **image {
+            ImageRgba8(ref pixels) => (4, pixels.rawbuf(), B8G8R8A8),
+            ImageLuma8(ref pixels) => (1, pixels.rawbuf(), A8),
+            ImageRgb8(_) => panic!("RGB8 color type not supported"),
+            ImageLumaA8(_) => panic!("K8 color type not supported"),
         };
         let stride = image_width * pixel_width;
         self.draw_target.make_current();

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -19,9 +19,9 @@ use geom::side_offsets::SideOffsets2D;
 use geom::size::Size2D;
 use libc::size_t;
 use libc::types::common::c99::{uint16_t, uint32_t};
-use png::{RGB8, RGBA8, K8, KA8};
-//use servo_image::{ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8};
-use servo_net::image::base::{Image,DynamicImage};
+//use png::{RGB8, RGBA8, K8, KA8};
+use servo_image::{Grey, RGB, GreyA, RGBA, Palette};
+use servo_net::image::base::{DynamicImage};
 use servo_util::geometry::Au;
 use servo_util::opts;
 use servo_util::range::Range;
@@ -31,7 +31,7 @@ use style::computed_values::border_style;
 use sync::Arc;
 use text::TextRun;
 use text::glyph::CharIndex;
-use servo_image::GenericImage;
+use servo_image::{GenericImage, ImageDecoder};
 
 pub struct RenderContext<'a> {
     pub draw_target: &'a DrawTarget,
@@ -114,11 +114,13 @@ impl<'a> RenderContext<'a>  {
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
 	let (image_width, image_height) = image.dimensions();
         let size = Size2D(image_width as i32, image_height as i32);
-        let (pixel_width, pixels, source_format) = match image.pixels() {
-            RGBA8(ref pixels) => (4, pixels.as_slice(), B8G8R8A8),
-            K8(ref pixels) => (1, pixels.as_slice(), A8),
-            RGB8(_) => panic!("RGB8 color type not supported"),
-            KA8(_) => panic!("KA8 color type not supported"),
+	let raw_pixels = image.raw_pixels();
+        let (pixel_width, pixels, source_format) = match image.color() {
+            RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
+            Grey(_) => (1, raw_pixels.as_slice(), A8),
+            RGB(_) => panic!("RGB8 color type not supported"),
+            GreyA(_) => panic!("KA8 color type not supported"),
+	    Palette(_) => panic!("Palette color type not supported"),
         };
         let stride = image_width * pixel_width;
 

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -19,7 +19,6 @@ use geom::side_offsets::SideOffsets2D;
 use geom::size::Size2D;
 use libc::size_t;
 use libc::types::common::c99::{uint16_t, uint32_t};
-//use png::{RGB8, RGBA8, K8, KA8};
 use servo_image::{Grey, RGB, GreyA, RGBA, Palette};
 use servo_net::image::base::{DynamicImage};
 use servo_util::geometry::Au;
@@ -113,19 +112,8 @@ impl<'a> RenderContext<'a>  {
 
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
     let (image_width, image_height) = image.dimensions();
-    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-    println!("Height is {} and width is {}", image_height, image_width);
         let size = Size2D(image_width as i32, image_height as i32);
-    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-    println!("Size is {}", size);
     let raw_pixels = image.raw_pixels();
-    //let option_img_pixels = image.as_rgb8();
-    //let img_pixels = match option_img_pixels {
-        //    Some(pixels) => pixels,
-        //    None => {return;}
-    //};
-    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-    println!("Color is {}", image.color().to_string());
         let (pixel_width, pixels, source_format) = match image.color() {
             RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
             Grey(_) => (1, raw_pixels.as_slice(), A8),
@@ -134,12 +122,6 @@ impl<'a> RenderContext<'a>  {
         Palette(_) => panic!("Palette color type not supported"),
         };
         let stride = image_width * pixel_width;
-    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-    println!("pixel_width is {}", pixel_width);
-    println!("Stride is {} and first 200 pixels are:", stride);
-    for e in range(0i as uint, 200i as uint) {
-        print!("{} ", pixels[e]);
-    }
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
         let azure_surface = draw_target_ref.create_source_surface_from_data(pixels,

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -130,7 +130,7 @@ impl<'a> RenderContext<'a>  {
             RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
             Grey(_) => (1, raw_pixels.as_slice(), A8),
             RGB(_) => (3, raw_pixels.as_slice(), B8G8R8X8),
-            GreyA(_) => (2, raw_pixels.as_slice(), A8)
+            GreyA(_) => (2, raw_pixels.as_slice(), A8),
 	    Palette(_) => panic!("Palette color type not supported"),
         };
         let stride = image_width * pixel_width;

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -20,7 +20,7 @@ use geom::size::Size2D;
 use libc::size_t;
 use libc::types::common::c99::{uint16_t, uint32_t};
 use png::{RGB8, RGBA8, K8, KA8};
-use servo_net::image::base::Image;
+use servo_net::image::base::DynamicImage;
 use servo_util::geometry::Au;
 use servo_util::opts;
 use servo_util::range::Range;
@@ -109,7 +109,7 @@ impl<'a> RenderContext<'a>  {
         self.draw_target.pop_clip();
     }
 
-    pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<Image>>) {
+    pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
         let size = Size2D(image.width as i32, image.height as i32);
         let (pixel_width, pixels, source_format) = match image.pixels {
             RGBA8(ref pixels) => (4, pixels.as_slice(), B8G8R8A8),

--- a/components/gfx/render_context.rs
+++ b/components/gfx/render_context.rs
@@ -112,34 +112,34 @@ impl<'a> RenderContext<'a>  {
     }
 
     pub fn draw_image(&self, bounds: Rect<Au>, image: Arc<Box<DynamicImage>>) {
-	let (image_width, image_height) = image.dimensions();
-	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-	println!("Height is {} and width is {}", image_height, image_width);
+    let (image_width, image_height) = image.dimensions();
+    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+    println!("Height is {} and width is {}", image_height, image_width);
         let size = Size2D(image_width as i32, image_height as i32);
-	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-	println!("Size is {}", size);
-	let raw_pixels = image.raw_pixels();
-	//let option_img_pixels = image.as_rgb8();
-	//let img_pixels = match option_img_pixels {
-        //	Some(pixels) => pixels,
-        //	None => {return;}
-	//};
-	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-	println!("Color is {}", image.color().to_string());
+    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+    println!("Size is {}", size);
+    let raw_pixels = image.raw_pixels();
+    //let option_img_pixels = image.as_rgb8();
+    //let img_pixels = match option_img_pixels {
+        //    Some(pixels) => pixels,
+        //    None => {return;}
+    //};
+    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+    println!("Color is {}", image.color().to_string());
         let (pixel_width, pixels, source_format) = match image.color() {
             RGBA(_) => (4, raw_pixels.as_slice(), B8G8R8A8),
             Grey(_) => (1, raw_pixels.as_slice(), A8),
             RGB(_) => (3, raw_pixels.as_slice(), B8G8R8X8),
             GreyA(_) => (2, raw_pixels.as_slice(), A8),
-	    Palette(_) => panic!("Palette color type not supported"),
+        Palette(_) => panic!("Palette color type not supported"),
         };
         let stride = image_width * pixel_width;
-	//ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ	
-	println!("pixel_width is {}", pixel_width);
-	println!("Stride is {} and first 200 pixels are:", stride);
-	for e in range(0i as uint, 200i as uint) {
-	    print!("{} ", pixels[e]);         
-	}
+    //ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+    println!("pixel_width is {}", pixel_width);
+    println!("Stride is {} and first 200 pixels are:", stride);
+    for e in range(0i as uint, 200i as uint) {
+        print!("{} ", pixels[e]);
+    }
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
         let azure_surface = draw_target_ref.create_source_surface_from_data(pixels,

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -219,7 +219,7 @@ impl FragmentDisplayListBuilding for Fragment {
         };
         debug!("(building display list) building background image");
 
-	let (img_width, img_height) = image.dimensions();
+    let (img_width, img_height) = image.dimensions();
 
         let image_width = Au::from_px(img_width as int);
         let image_height = Au::from_px(img_height as int);

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -45,6 +45,7 @@ use style::computed_values::{visibility};
 use style::{ComputedValues, Bottom, Left, RGBA, Right, Top};
 use sync::Arc;
 use url::Url;
+use servo_image::GenericImage;
 
 /// The results of display list building for a single flow.
 pub enum DisplayListBuildingResult {
@@ -218,8 +219,10 @@ impl FragmentDisplayListBuilding for Fragment {
         };
         debug!("(building display list) building background image");
 
-        let image_width = Au::from_px(image.width as int);
-        let image_height = Au::from_px(image.height as int);
+	let (img_width, img_height) = image.dimensions();
+
+        let image_width = Au::from_px(img_width as int);
+        let image_height = Au::from_px(img_height as int);
         let mut bounds = *absolute_bounds;
 
         // Clip.
@@ -258,19 +261,19 @@ impl FragmentDisplayListBuilding for Fragment {
                 bounds.origin.y = abs_y;
                 bounds.size.height = image_height;
                 ImageFragmentInfo::tile_image(&mut bounds.origin.x, &mut bounds.size.width,
-                                                abs_x, image.width);
+                                                abs_x, img_width);
             }
             background_repeat::repeat_y => {
                 bounds.origin.x = abs_x;
                 bounds.size.width = image_width;
                 ImageFragmentInfo::tile_image(&mut bounds.origin.y, &mut bounds.size.height,
-                                                abs_y, image.height);
+                                                abs_y, img_height);
             }
             background_repeat::repeat => {
                 ImageFragmentInfo::tile_image(&mut bounds.origin.x, &mut bounds.size.width,
-                                                abs_x, image.width);
+                                                abs_x, img_width);
                 ImageFragmentInfo::tile_image(&mut bounds.origin.y, &mut bounds.size.height,
-                                                abs_y, image.height);
+                                                abs_y, img_height);
             }
         };
 
@@ -278,8 +281,8 @@ impl FragmentDisplayListBuilding for Fragment {
         display_list.push(ImageDisplayItemClass(box ImageDisplayItem {
             base: BaseDisplayItem::new(bounds, self.node, clip_rect),
             image: image.clone(),
-            stretch_size: Size2D(Au::from_px(image.width as int),
-                                 Au::from_px(image.height as int)),
+            stretch_size: Size2D(Au::from_px(img_width as int),
+                                 Au::from_px(img_height as int)),
         }), level);
     }
 

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -27,6 +27,7 @@ extern crate "net" as servo_net;
 extern crate "msg" as servo_msg;
 #[phase(plugin, link)]
 extern crate "util" as servo_util;
+extern crate "image" as servo_image;
 
 #[phase(plugin)]
 extern crate string_cache_macros;

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -25,3 +25,6 @@ git = "https://github.com/servo/rust-stb-image"
 
 [dependencies.url]
 git = "https://github.com/servo/rust-url"
+
+[dependencies.image]
+git = "https://github.com/PistonDevelopers/image"

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -5,10 +5,11 @@
 use std::iter::range_step;
 //use stb_image::image as stb_image;
 use servo_image;
-//use png;
+use png;
 
 // FIXME: Images must not be copied every frame. Instead we should atomically
 // reference count them.
+pub type Image = png::Image;
 pub type DynamicImage = servo_image::DynamicImage;
 
 
@@ -49,12 +50,12 @@ pub fn load_from_memory(buffer: &[u8]) -> Option<DynamicImage> {
    else {
 	let result = servo_image::load_from_memory(buffer,servo_image::ImageFormat::JPEG);
 	if (result.is_ok()) {
-  	let v = result.unwrap();
-  	return Some(v);
+  	    let v = result.unwrap();
+  	    return Some(v);
 	}
 	else  {	
-	return None;
-		
-    }}
+	    return None;
+	}		
+   }
 
 }

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::iter::range_step;
 use servo_image;
 use png;
 
@@ -16,30 +15,6 @@ static TEST_IMAGE: &'static [u8] = include_bin!("test.jpeg");
 
 pub fn test_image_bin() -> Vec<u8> {
     TEST_IMAGE.iter().map(|&x| x).collect()
-}
-
-// TODO(pcwalton): Speed up with SIMD, or better yet, find some way to not do this.
-fn byte_swap(data: &mut [u8]) {
-    let length = data.len();
-    for i in range_step(0, length, 4) {
-        let r = data[i + 2];
-        data[i + 2] = data[i + 0];
-        data[i + 0] = r;
-    }
-}
-
-// TODO(pcwalton): Speed up with SIMD, or better yet, find some way to not do this.
-fn byte_swap_and_premultiply(data: &mut [u8]) {
-    let length = data.len();
-    for i in range_step(0, length, 4) {
-        let r = data[i + 2];
-        let g = data[i + 1];
-        let b = data[i + 0];
-        let a = data[i + 3];
-        data[i + 0] = ((r as u32) * (a as u32) / 255) as u8;
-        data[i + 1] = ((g as u32) * (a as u32) / 255) as u8;
-        data[i + 2] = ((b as u32) * (a as u32) / 255) as u8;
-    }
 }
 
 pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
@@ -65,14 +40,14 @@ pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
     }
 }
 fn get_format(ext: &str) -> Option<servo_image::ImageFormat> {
-        match ext.to_ascii().to_uppercase().as_str_ascii() {
-    "PNG" => {(return Some(servo_image::ImageFormat::PNG));},
-    "JPEG" => {(return Some(servo_image::ImageFormat::JPEG));},
-    "JPG" => {(return Some(servo_image::ImageFormat::JPEG));},
-    "GIF"=> {(return Some(servo_image::ImageFormat::GIF));},
-    "WEBP" => {(return Some(servo_image::ImageFormat::WEBP));},
-    "PPM" => {(return Some(servo_image::ImageFormat::PPM));},
-    _ => {return None ;},
-        }
+    match ext.to_ascii().to_uppercase().as_str_ascii() {
+        "PNG"  => {(return Some(servo_image::ImageFormat::PNG));},
+        "JPEG" => {(return Some(servo_image::ImageFormat::JPEG));},
+        "JPG"  => {(return Some(servo_image::ImageFormat::JPEG));},
+        "GIF"  => {(return Some(servo_image::ImageFormat::GIF));},
+        "WEBP" => {(return Some(servo_image::ImageFormat::WEBP));},
+        "PPM"  => {(return Some(servo_image::ImageFormat::PPM));},
+        _      => {return None; },
     }
+}
 

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -43,12 +43,13 @@ fn byte_swap_and_premultiply(data: &mut [u8]) {
     }
 }
 
-pub fn load_from_memory(buffer: &[u8]) -> Option<DynamicImage> {
+pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
     if buffer.len() == 0 {
         return None;
     }
    else {
-	let result = servo_image::load_from_memory(buffer,servo_image::ImageFormat::JPEG);
+	
+	let result = servo_image::load_from_memory(buffer,get_format(ext));
 	if (result.is_ok()) {
   	    let v = result.unwrap();
   	    return Some(v);
@@ -57,5 +58,16 @@ pub fn load_from_memory(buffer: &[u8]) -> Option<DynamicImage> {
 	    return None;
 	}		
    }
+   }
+fn get_format(ext: &str) -> servo_image::ImageFormat {
+		match ext.to_ascii().to_uppercase().as_str_ascii() {
+    "PNG" => {return servo_image::ImageFormat::PNG;},
+    "JPEG" => {return servo_image::ImageFormat::JPEG;},
+    "JPG" => {return servo_image::ImageFormat::JPEG;},
+    "GIF"=> {return servo_image::ImageFormat::GIF;},
+    "WEBP" => {return servo_image::ImageFormat::WEBP;},
+    "PPM" => {return servo_image::ImageFormat::PPM;},
+    _ => {return servo_image::ImageFormat::PNG;},
+		}
+	}
 
-}

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -46,18 +46,18 @@ fn byte_swap_and_premultiply(data: &mut [u8]) {
 pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
     if buffer.len() == 0 {
         return None;
-    } 
+    }
     else {
         let image_type: Option< servo_image::ImageFormat > = get_format(ext);
         if image_type == None {
             panic!("Image format not supported!");
-        } 
+        }
         else {
             let new_image_type: servo_image::ImageFormat = image_type.unwrap();
-	    let result = servo_image::load_from_memory(buffer,new_image_type);
-	    if result.is_ok() {
-  	        let mut img = result.unwrap();
-            
+            let result = servo_image::load_from_memory(buffer,new_image_type);
+            if result.is_ok() {
+                let mut img = result.unwrap();
+
                 match img {
                     ImageRgba8(ref mut img_buffer) => {
                         byte_swap_and_premultiply(img_buffer.rawbuf_mut());
@@ -67,15 +67,15 @@ pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
                         byte_swap(img_buffer.rawbuf_mut());
                         img = ImageRgba8(img_buffer)
                     },
-                    ImageLumaA8(_) => {
-                        img = ImageLuma8(img.to_luma());
+                        ImageLumaA8(_) => {
+                            img = ImageLuma8(img.to_luma());
+                            img.invert();
+                        }
+                    ImageLuma8(_) => {
                         img.invert();
                     }
-		    ImageLuma8(_) => {
-                        img.invert();		
-                    }
                 }
-  	    return Some(img);
+                return Some(img);
             }
             else  {
                 return None;

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -45,32 +45,27 @@ fn byte_swap_and_premultiply(data: &mut [u8]) {
 pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
     if buffer.len() == 0 {
         return None;
-    }
-   else {
-	//let new_image_type: servo_image::ImageFormat = servo_image::ImageFormat::PNG;
-   
+    } else {
+        //let new_image_type: servo_image::ImageFormat = servo_image::ImageFormat::PNG;
+
         let image_type: Option< servo_image::ImageFormat > = get_format(ext);
-	if image_type == None
-	{
-	panic!("Image format not supported!");
-	}
-	else{
-        let new_image_type: servo_image::ImageFormat = image_type.unwrap();
-        
-        
-	let result = servo_image::load_from_memory(buffer,new_image_type);
-	if (result.is_ok()) {
-  	    let v = result.unwrap();
-  	    return Some(v);
-	}
-	else  {	
-	    return None;
-	}		
-   }
-   }
-   }
+        if image_type == None {
+            panic!("Image format not supported!");
+        } else{
+            let new_image_type: servo_image::ImageFormat = image_type.unwrap();
+
+            let result = servo_image::load_from_memory(buffer,new_image_type);
+            if result.is_ok() {
+                let v = result.unwrap();
+                return Some(v);
+            } else  {
+                return None;
+            }
+        }
+    }
+}
 fn get_format(ext: &str) -> Option<servo_image::ImageFormat> {
-		match ext.to_ascii().to_uppercase().as_str_ascii() {
+        match ext.to_ascii().to_uppercase().as_str_ascii() {
     "PNG" => {(return Some(servo_image::ImageFormat::PNG));},
     "JPEG" => {(return Some(servo_image::ImageFormat::JPEG));},
     "JPG" => {(return Some(servo_image::ImageFormat::JPEG));},
@@ -78,6 +73,6 @@ fn get_format(ext: &str) -> Option<servo_image::ImageFormat> {
     "WEBP" => {(return Some(servo_image::ImageFormat::WEBP));},
     "PPM" => {(return Some(servo_image::ImageFormat::PPM));},
     _ => {return None ;},
-		}
-	}
+        }
+    }
 

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -54,7 +54,6 @@ pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
         } 
         else {
             let new_image_type: servo_image::ImageFormat = image_type.unwrap();
-            println!("Image format is {}", new_image_type);
 	    let result = servo_image::load_from_memory(buffer,new_image_type);
 	    if result.is_ok() {
   	        let mut img = result.unwrap();

--- a/components/net/image/base.rs
+++ b/components/net/image/base.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::iter::range_step;
-//use stb_image::image as stb_image;
 use servo_image;
 use png;
 
@@ -48,8 +47,18 @@ pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
         return None;
     }
    else {
-	
-	let result = servo_image::load_from_memory(buffer,get_format(ext));
+	//let new_image_type: servo_image::ImageFormat = servo_image::ImageFormat::PNG;
+   
+        let image_type: Option< servo_image::ImageFormat > = get_format(ext);
+	if image_type == None
+	{
+	panic!("Image format not supported!");
+	}
+	else{
+        let new_image_type: servo_image::ImageFormat = image_type.unwrap();
+        
+        
+	let result = servo_image::load_from_memory(buffer,new_image_type);
 	if (result.is_ok()) {
   	    let v = result.unwrap();
   	    return Some(v);
@@ -59,15 +68,16 @@ pub fn load_from_memory(buffer: &[u8],ext: &str) -> Option<DynamicImage> {
 	}		
    }
    }
-fn get_format(ext: &str) -> servo_image::ImageFormat {
+   }
+fn get_format(ext: &str) -> Option<servo_image::ImageFormat> {
 		match ext.to_ascii().to_uppercase().as_str_ascii() {
-    "PNG" => {return servo_image::ImageFormat::PNG;},
-    "JPEG" => {return servo_image::ImageFormat::JPEG;},
-    "JPG" => {return servo_image::ImageFormat::JPEG;},
-    "GIF"=> {return servo_image::ImageFormat::GIF;},
-    "WEBP" => {return servo_image::ImageFormat::WEBP;},
-    "PPM" => {return servo_image::ImageFormat::PPM;},
-    _ => {return servo_image::ImageFormat::PNG;},
+    "PNG" => {(return Some(servo_image::ImageFormat::PNG));},
+    "JPEG" => {(return Some(servo_image::ImageFormat::JPEG));},
+    "JPG" => {(return Some(servo_image::ImageFormat::JPEG));},
+    "GIF"=> {(return Some(servo_image::ImageFormat::GIF));},
+    "WEBP" => {(return Some(servo_image::ImageFormat::WEBP));},
+    "PPM" => {(return Some(servo_image::ImageFormat::PPM));},
+    _ => {return None ;},
 		}
 	}
 

--- a/components/net/image/holder.rs
+++ b/components/net/image/holder.rs
@@ -11,6 +11,8 @@ use std::mem;
 use sync::{Arc, Mutex};
 use url::Url;
 
+use servo_image::GenericImage;
+
 
 // FIXME: Nasty coupling here This will be a problem if we want to factor out image handling from
 // the network stack. This should probably be factored out into an interface and use dependency

--- a/components/net/image/holder.rs
+++ b/components/net/image/holder.rs
@@ -68,7 +68,7 @@ impl<NodeAddress: Send> ImageHolder<NodeAddress> {
         debug!("get_size() {}", self.url.serialize());
 
         self.get_image(node_address).map(|img| {
-	let (img_width,img_height) = img.dimensions();
+    let (img_width,img_height) = img.dimensions();
             self.cached_size = Size2D(img_width as int,
                                       img_height as int);
             self.cached_size.clone()

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -83,7 +83,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for ImageCacheTask {
 type DecoderFactory = fn() -> (proc(&[u8]) : 'static -> Option<Image>);
 
 impl ImageCacheTask {
-    pub fn new(resource_task: ResourceTask, task_pool: TaskPool) -> ImageCacheTask {
+    pub fn new(resource_task: ResourceTask, task_pool: TaskPool, time_profiler_chan: Timer) -> ImageCacheTask {
         let (chan, port) = channel();
         let chan_clone = chan.clone();
 
@@ -313,7 +313,6 @@ impl ImageCache {
             Prefetched(data) => {
                 let to_cache = self.chan.clone();
                 let url_clone = url.clone();
-                //let ref prof_chan = self.time_profiler_chan;
                 let time_profiler_chan_clone = self.time_profiler_chan.as_ref().unwrap().clone();
 
                 self.task_pool.execute(proc() {

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use image::base::{Image, load_from_memory};
+use image::base::{DynamicImage, load_from_memory};
 use resource_task;
 use resource_task::{LoadData, ResourceTask};
 
@@ -39,7 +39,7 @@ pub enum Msg {
     StorePrefetchedImageData(Url, Result<Vec<u8>, ()>),
 
     /// Used by the decoder tasks to post decoded images back to the cache
-    StoreImage(Url, Option<Arc<Box<Image>>>),
+    StoreImage(Url, Option<Arc<Box<DynamicImage>>>),
 
     /// For testing
     WaitForStore(Sender<()>),
@@ -50,7 +50,7 @@ pub enum Msg {
 
 #[deriving(Clone)]
 pub enum ImageResponseMsg {
-    ImageReady(Arc<Box<Image>>),
+    ImageReady(Arc<Box<DynamicImage>>),
     ImageNotReady,
     ImageFailed
 }
@@ -78,7 +78,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for ImageCacheTask {
     }
 }
 
-type DecoderFactory = fn() -> (proc(&[u8]) : 'static -> Option<Image>);
+type DecoderFactory = fn() -> (proc(&[u8]) : 'static -> Option<DynamicImage>);
 
 impl ImageCacheTask {
     pub fn new(resource_task: ResourceTask, task_pool: TaskPool) -> ImageCacheTask {
@@ -152,7 +152,7 @@ enum ImageState {
     Prefetching(AfterPrefetch),
     Prefetched(Vec<u8>),
     Decoding,
-    Decoded(Arc<Box<Image>>),
+    Decoded(Arc<Box<DynamicImage>>),
     Failed
 }
 
@@ -328,7 +328,7 @@ impl ImageCache {
         }
     }
 
-    fn store_image(&mut self, url: Url, image: Option<Arc<Box<Image>>>) {
+    fn store_image(&mut self, url: Url, image: Option<Arc<Box<DynamicImage>>>) {
 
         match self.get_state(&url) {
           Decoding => {

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use image::base::{DynamicImage, load_from_memory};
+use image::base::{Image, DynamicImage, load_from_memory};
 use resource_task;
 use resource_task::{LoadData, ResourceTask};
 
@@ -78,7 +78,7 @@ impl<E, S: Encoder<E>> Encodable<S, E> for ImageCacheTask {
     }
 }
 
-type DecoderFactory = fn() -> (proc(&[u8]) : 'static -> Option<DynamicImage>);
+type DecoderFactory = fn() -> (proc(&[u8]) : 'static -> Option<Image>);
 
 impl ImageCacheTask {
     pub fn new(resource_task: ResourceTask, task_pool: TaskPool) -> ImageCacheTask {

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -323,7 +323,7 @@ impl ImageCache {
                     let mut ext="";
                     for x in s.as_slice().split('.') { ext=x; }
                     println!("{}",ext);
-	
+
                     let image = profile(time::ImageDecodingCategory, None, time_profiler_chan_clone, || {
                         load_from_memory(data.as_slice(),ext)
                         });
@@ -994,7 +994,7 @@ mod tests {
     #[test]
     fn sync_cache_should_wait_for_images() {
         let mock_resource_task = mock_resource_task(box SendTestImage);
-       
+
         let image_cache_task = ImageCacheTask::new_sync(mock_resource_task.clone(), TaskPool::new(4));
         let url = Url::parse("file:///").unwrap();
 

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -313,7 +313,12 @@ impl ImageCache {
                 self.task_pool.execute(proc() {
                     let url = url_clone;
                     debug!("image_cache_task: started image decode for {:s}", url.serialize());
-                    let image = load_from_memory(data.as_slice());
+                     let s=url.serialize();
+                let mut ext="";
+                for x in s.as_slice().split('.') { ext=x; }
+                println!("{}",ext);
+	
+                    let image = load_from_memory(data.as_slice(),ext);
                     let image = image.map(|image| Arc::new(box image));
                     to_cache.send(StoreImage(url.clone(), image));
                     debug!("image_cache_task: ended image decode for {:s}", url.serialize());
@@ -980,7 +985,7 @@ mod tests {
     #[test]
     fn sync_cache_should_wait_for_images() {
         let mock_resource_task = mock_resource_task(box SendTestImage);
-
+       
         let image_cache_task = ImageCacheTask::new_sync(mock_resource_task.clone(), TaskPool::new(4));
         let url = Url::parse("file:///").unwrap();
 

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -321,7 +321,6 @@ impl ImageCache {
                     let s=url.serialize();
                     let mut ext="";
                     for x in s.as_slice().split('.') { ext=x; }
-                    println!("{}",ext);
 
                     let image = profile(time::ImageDecodingCategory, None, time_profiler_chan_clone, || {
                         load_from_memory(data.as_slice(),ext)

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -19,6 +19,7 @@ extern crate stb_image;
 extern crate sync;
 extern crate time;
 extern crate url;
+extern crate "image" as servo_image;
 
 /// Image handling.
 ///

--- a/components/util/time.rs
+++ b/components/util/time.rs
@@ -85,6 +85,7 @@ pub enum TimeProfilerCategory {
     PaintingPerTileCategory,
     PaintingPrepBuffCategory,
     PaintingCategory,
+    ImageDecodingCategory,
 }
 
 impl Formatable for TimeProfilerCategory {
@@ -122,6 +123,7 @@ impl Formatable for TimeProfilerCategory {
             PaintingPerTileCategory => "Painting Per Tile",
             PaintingPrepBuffCategory => "Buffer Prep",
             PaintingCategory => "Painting",
+            ImageDecodingCategory => "Image Decoding",
         };
         format!("{:s}{}", padding, name)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
 
         let opts_clone = opts.clone();
         let time_profiler_chan_clone = time_profiler_chan.clone();
+        let time_profiler_chan_option: Option<servo_util::time::TimeProfilerChan> = Some(time_profiler_chan_clone.clone());
 
         let (result_chan, result_port) = channel();
         let compositor_proxy_for_constellation = compositor_proxy.clone_compositor_proxy();
@@ -108,9 +109,9 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
             // image load or we risk emitting an output file missing the
             // image.
             let image_cache_task = if opts.output_file.is_some() {
-                ImageCacheTask::new_sync(resource_task.clone(), shared_task_pool)
+                ImageCacheTask::new_sync(resource_task.clone(), shared_task_pool, time_profiler_chan_option)
             } else {
-                ImageCacheTask::new(resource_task.clone(), shared_task_pool)
+                ImageCacheTask::new(resource_task.clone(), shared_task_pool, time_profiler_chan_option)
             };
             let font_cache_task = FontCacheTask::new(resource_task.clone());
             let constellation_chan = Constellation::<layout::layout_task::LayoutTask,


### PR DESCRIPTION
We are a group of students at NCSU.
As part of a Mozilla student [project](https://github.com/servo/servo/wiki/Replace-C-libraries-student-project#evaluate-replacing-c-libraries-with-modern-rust-equivalents) we have replaced the use of [rust-freetype](https://github.com/servo/rust-freetype) and [rust-stb-image](https://github.com/servo/rust-stb-image)  libraries in servo with [freetype-rs](https://github.com/PistonDevelopers/freetype-rs) and [image](https://github.com/PistonDevelopers/image) respectively.

The changes are described in more detail at  http://wiki.expertiza.ncsu.edu/index.php/CSC/ECE_517_Fall_2014/final_M1455_yaaa

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/4215)

<!-- Reviewable:end -->
