### PR TITLE
Don't categorize HTMLInputElement as a TableCellFragment

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -272,7 +272,6 @@ impl<'a> FlowConstructor<'a> {
             Some(ElementNodeTypeId(HTMLTableColElementTypeId)) => {
                 TableColumnFragment(TableColumnFragmentInfo::new(node))
             }
-            Some(ElementNodeTypeId(HTMLInputElementTypeId)) |
             Some(ElementNodeTypeId(HTMLTableDataCellElementTypeId)) |
             Some(ElementNodeTypeId(HTMLTableHeaderCellElementTypeId)) => TableCellFragment,
             Some(ElementNodeTypeId(HTMLTableRowElementTypeId)) |


### PR DESCRIPTION
Closes  #4196.

r? @jdm
