### PR TITLE
Implements default return values for uint attrs

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -447,7 +447,7 @@ pub trait AttributeHandlers {
     fn get_string_attribute(self, name: &Atom) -> DOMString;
     fn set_string_attribute(self, name: &Atom, value: DOMString);
     fn set_tokenlist_attribute(self, name: &Atom, value: DOMString);
-    fn get_uint_attribute(self, name: &Atom) -> u32;
+    fn get_uint_attribute(self, name: &Atom, default: u32) -> u32;
     fn set_uint_attribute(self, name: &Atom, value: u32);
 }
 
@@ -630,7 +630,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
         self.set_attribute(name, AttrValue::from_tokenlist(value));
     }
 
-    fn get_uint_attribute(self, name: &Atom) -> u32 {
+    fn get_uint_attribute(self, name: &Atom, default: u32) -> u32 {
         assert!(name.as_slice().chars().all(|ch| {
             !ch.is_ascii() || ch.to_ascii().to_lowercase() == ch.to_ascii()
         }));
@@ -639,10 +639,10 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
             Some(attribute) => {
                 match *attribute.value() {
                     UIntAttrValue(_, value) => value,
-                    _ => panic!("Expected a UIntAttrValue"),
+                    _ => default,
                 }
             }
-            None => 0,
+            None => default,
         }
     }
     fn set_uint_attribute(self, name: &Atom, value: u32) {

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -39,7 +39,7 @@ macro_rules! make_bool_getter(
 
 #[macro_export]
 macro_rules! make_uint_getter(
-    ( $attr:ident, $htmlname:expr ) => (
+    ( $attr:ident, $htmlname:expr, $default:expr ) => (
         fn $attr(self) -> u32 {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
@@ -47,11 +47,14 @@ macro_rules! make_uint_getter(
             use std::ascii::AsciiExt;
             let element: JSRef<Element> = ElementCast::from_ref(self);
             // FIXME(pcwalton): Do this at compile time, not runtime.
-            element.get_uint_attribute(&Atom::from_slice($htmlname))
+            element.get_uint_attribute(&Atom::from_slice($htmlname), $default)
         }
     );
+    ( $attr:ident, $htmlname:expr ) => (
+        make_uint_getter!($attr, $htmlname, 0)
+    );
     ($attr:ident) => {
-        make_uint_getter!($attr, stringify!($attr).to_ascii_lower().as_slice())
+        make_uint_getter!($attr, stringify!($attr).to_ascii_lower().as_slice(), 0)
     }
 )
 


### PR DESCRIPTION
Adds a `default` argument to get_uint_attribute, and updates
the make_uint_getter! macro to support this.

Relevant spec notes:
https://html.spec.whatwg.org/multipage/infrastructure.html#reflecting-content-attributes-in-idl-attributes:idl-unsigned-long

Also fixes #4221
