### PR TITLE
Mach test inference fix

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -63,7 +63,7 @@ class MachCommands(CommandBase):
 
         for test_dir, test_name, path_flag in test_dirs:
             if not path_flag:
-                path_arg = []
+                path_flag = []
             if test_dir in maybe_path:
                 args = ([mach_command, test_name] + path_flag +
                         [maybe_path] + params[1:])


### PR DESCRIPTION
Somehow didn't catch this when renaming a variable.
