### PR TITLE
Change time::profile's meta booleans to enums.

### DIFF
--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -20,7 +20,7 @@ use wrapper::{PostorderNodeMutTraversal, UnsafeLayoutNode};
 use wrapper::{PreorderDomTraversal, PostorderDomTraversal};
 
 use servo_util::opts;
-use servo_util::time::{TimeProfilerChan, profile};
+use servo_util::time::{TimeProfilerChan, profile, TimerMetadataFrameType, TimerMetadataReflowType};
 use servo_util::time;
 use servo_util::workqueue::{WorkQueue, WorkUnit, WorkerProxy};
 use std::mem;
@@ -423,8 +423,8 @@ pub fn traverse_dom_preorder(root: LayoutNode,
 
 pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
                                    url: &Url,
-                                   iframe: bool,
-                                   first_reflow: bool,
+                                   iframe: TimerMetadataFrameType,
+                                   reflow_type: TimerMetadataReflowType,
                                    time_profiler_chan: TimeProfilerChan,
                                    shared_layout_context: &SharedLayoutContext,
                                    queue: &mut WorkQueue<*const SharedLayoutContext,UnsafeFlow>) {
@@ -436,7 +436,7 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 
     queue.data = shared_layout_context as *const _;
 
-    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, first_reflow)), time_profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, reflow_type)), time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: assign_inline_sizes,
             data: mut_owned_flow_to_unsafe_flow(root),
@@ -450,14 +450,14 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 
 pub fn build_display_list_for_subtree(root: &mut FlowRef,
                                       url: &Url,
-                                      iframe: bool,
-                                      first_reflow: bool,
+                                      iframe: TimerMetadataFrameType,
+                                      reflow_type: TimerMetadataReflowType,
                                       time_profiler_chan: TimeProfilerChan,
                                       shared_layout_context: &SharedLayoutContext,
                                       queue: &mut WorkQueue<*const SharedLayoutContext,UnsafeFlow>) {
     queue.data = shared_layout_context as *const _;
 
-    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, first_reflow)), time_profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, reflow_type)), time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: compute_absolute_positions,
             data: mut_owned_flow_to_unsafe_flow(root),


### PR DESCRIPTION
This makes these parameters self-documenting.
This patch does not attempt to push those enums into the data
structures that feed calls to this function.

Fixes #4158.
