### PR TITLE
add basic |mach rr-{record,replay}| commands

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -28,6 +28,8 @@ def read_file(filename, if_exists=False):
 
 @CommandProvider
 class MachCommands(CommandBase):
+    SERVO_BINARY_PATH = path.join("components", "servo", "target", "servo")
+
     @Command('run',
              description='Run Servo',
              category='post-build')
@@ -45,7 +47,7 @@ class MachCommands(CommandBase):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
-        args = [path.join("components", "servo", "target", "servo")]
+        args = [self.SERVO_BINARY_PATH]
 
         # Borrowed and modified from:
         # http://hg.mozilla.org/mozilla-central/file/c9cfa9b91dea/python/mozbuild/mozbuild/mach_commands.py#l883
@@ -80,7 +82,7 @@ class MachCommands(CommandBase):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
-        servo_cmd = [path.join('target', 'servo')] + params
+        servo_cmd = [self.SERVO_BINARY_PATH] + params
         rr_cmd = ['rr', '--fatal-errors', 'record']
         subprocess.check_call(rr_cmd + servo_cmd)
 

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -70,6 +70,26 @@ class MachCommands(CommandBase):
 
         subprocess.check_call(args, env=env)
 
+    @Command('rr-record',
+             description='Run Servo whilst recording execution with rr',
+             category='post-build')
+    @CommandArgument(
+        'params', nargs='...',
+        help="Command-line arguments to be passed through to Servo")
+    def rr_record(self, params):
+        env = self.build_env()
+        env["RUST_BACKTRACE"] = "1"
+
+        servo_cmd = [path.join('target', 'servo')] + params
+        rr_cmd = ['rr', '--fatal-errors', 'record']
+        subprocess.check_call(rr_cmd + servo_cmd)
+
+    @Command('rr-replay',
+             description='Replay the most recent execution of Servo that was recorded with rr',
+             category='post-build')
+    def rr_replay(self):
+        subprocess.check_call(['rr', '--fatal-errors', 'replay'])
+
     @Command('doc',
              description='Generate documentation',
              category='post-build')


### PR DESCRIPTION
These are very basic commands for invoking Servo underneath rr.  rr
currently doesn't support all the syscalls that Servo requires, but
that's easy to fix on the rr side.

Fixes #4177.
