### PR TITLE
remove bindings codegen h/cpp files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,6 @@
 /components/script/dom/bindings/codegen/_cache
 /components/script/dom/bindings/codegen/Bindings
 /components/script/dom/bindings/codegen/test/*.rs
-/components/script/dom/bindings/codegen/RegisterBindings.cpp
-/components/script/dom/bindings/codegen/PrototypeList.h
-/components/script/dom/bindings/codegen/UnionTypes.h
-/components/script/dom/bindings/codegen/UnionConversions.h
 /.servobuild
 /_virtualenv
 *~


### PR DESCRIPTION
These files don't exist in the tree, and the codegen doesn't create them, so we shouldn't have them sitting around in .gitignore.

There are h/cpp files sitting around in the bindings codegen directory; I suppose one could make the argument that they're useful for examples, so we should keep them around, too?
