### PR TITLE
Issue 4253 - Setting timeout on a sync XHR should throw InvalidAccessErr

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -460,7 +460,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
     fn SetTimeout(self, timeout: u32) -> ErrorResult {
         if self.sync.get() {
             // FIXME: Not valid for a worker environment
-            Err(InvalidState)
+            Err(InvalidAccess)
         } else {
             self.timeout.set(timeout);
             if self.send_flag.get() {

--- a/tests/wpt/metadata/XMLHttpRequest/timeout-sync.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/timeout-sync.htm.ini
@@ -1,5 +1,0 @@
-[timeout-sync.htm]
-  type: testharness
-  [setting timeout attribute on sync request]
-    expected: FAIL
-


### PR DESCRIPTION
fix #4253 
