### PR TITLE
Fix breakage of `./mach test`

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -100,7 +100,10 @@ class MachCommands(CommandBase):
                      help="Specific component to test")
     @CommandArgument('test_name', nargs=argparse.REMAINDER,
                      help="Only run tests that match this pattern")
-    def test_unit(self, test_name, component=None):
+    def test_unit(self, test_name=None, component=None):
+        if test_name is None:
+            test_name = []
+
         self.ensure_bootstrapped()
         self.ensure_built_tests()
 


### PR DESCRIPTION
When running commands through Registrar.dispatch, mach does not behave
in the same way it would as if it were running through the command line.
Defaults normally provided through a combination of @CommandArgument and
argparse magic are ignored.

I have some ideas as to how to fix this, but until then, this will allow
`./mach test` to run through test-unit properly.
