### PR TITLE
Fix concatentation error on no args to `./mach rustc`

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -48,6 +48,8 @@ class MachCommands(CommandBase):
         'params', default=None, nargs='...',
         help="Command-line arguments to be passed through to rustc")
     def rustc(self, params):
+        if params is None:
+            params = []
         return subprocess.call(["rustc"] + params, env=self.build_env())
 
     @Command('rust-root',


### PR DESCRIPTION
Since default argument to params is None, concatenating it with a
list will raise an error.  This behaviour prevents `./mach rustc`
to be called when system-rust is defined in .servobuild.

Currently it will only work when followed by an argument, i.e.
`./mach rustc -arg`.

Testing this patch: `./mach rustc` should not raise an error.
