### PR TITLE
layout: Implement `outline` per CSS 2.1 § 18.4.

### DIFF
--- a/components/gfx/display_list/optimizer.rs
+++ b/components/gfx/display_list/optimizer.rs
@@ -35,6 +35,7 @@ impl DisplayListOptimizer {
                                          display_list.block_backgrounds_and_borders.iter());
         self.add_in_bounds_display_items(&mut result.floats, display_list.floats.iter());
         self.add_in_bounds_display_items(&mut result.content, display_list.content.iter());
+        self.add_in_bounds_display_items(&mut result.outlines, display_list.outlines.iter());
         self.add_in_bounds_stacking_contexts(&mut result.children, display_list.children.iter());
         result
     }

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1177,6 +1177,11 @@ impl<'a> MutableFlowUtils for &'a mut Flow + 'a {
     /// Assumption: Absolute descendants have had their overflow calculated.
     fn store_overflow(self, _: &LayoutContext) {
         let my_position = mut_base(self).position;
+
+        // FIXME(pcwalton): We should calculate overflow on a per-fragment basis, because their
+        // styles can affect overflow regions. Consider `box-shadow`, `outline`, etc.--anything
+        // that can draw outside the border box. For now we assume overflow is the border box, but
+        // that is wrong.
         let mut overflow = my_position;
 
         if self.is_block_container() {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -191,3 +191,5 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == text_transform_uppercase_a.html text_transform_uppercase_ref.html
 == text_transform_lowercase_a.html text_transform_lowercase_ref.html
 == text_transform_capitalize_a.html text_transform_capitalize_ref.html
+== outlines_simple_a.html outlines_simple_ref.html
+== outlines_wrap_a.html outlines_wrap_ref.html

--- a/tests/ref/outlines_simple_a.html
+++ b/tests/ref/outlines_simple_a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<style>
+html, body {
+    margin: 0;
+}
+section {
+    position: relative;
+    width: 92px;
+    height: 92px;
+    border: solid red 2px;
+    outline: solid blue 2px;
+    top: 2px;
+    left: 2px;
+}
+</style>
+<body>
+<section></section>
+</body>
+</html>
+

--- a/tests/ref/outlines_simple_ref.html
+++ b/tests/ref/outlines_simple_ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<style>
+html, body {
+    margin: 0;
+}
+section {
+    position: relative;
+    width: 96px;
+    height: 96px;
+    border: solid blue 2px;
+}
+nav {
+    position: absolute;
+    width: 92px;
+    height: 92px;
+    border: solid red 2px;
+    top: 0;
+    left: 0;
+}
+</style>
+<body>
+<section><nav></nav></section>
+</body>
+</html>
+
+

--- a/tests/ref/outlines_wrap_a.html
+++ b/tests/ref/outlines_wrap_a.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that outlines draw on all four sides on word wrapped edges. -->
+<style>
+section {
+    width: 100px;
+    height: 100px;
+    border: solid black 2px;
+    font-size: 36px;
+}
+span {
+    outline: solid red 2px;
+}
+</style>
+<body>
+<section><span>I like truffles</span></section>
+</body>
+</html>

--- a/tests/ref/outlines_wrap_ref.html
+++ b/tests/ref/outlines_wrap_ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that outlines draw on all four sides on word wrapped edges. -->
+<style>
+section {
+    width: 100px;
+    height: 100px;
+    border: solid black 2px;
+    font-size: 36px;
+}
+span {
+    outline: solid red 2px;
+}
+</style>
+<body>
+<section><span>I like </span><span>truffles</span></section>
+</body>
+</html>
+


### PR DESCRIPTION
`invert` is not yet supported.

Objects that get layers will not yet display outlines properly. This is
because our overflow calculation doesn't take styles into account and
because layers are always anchored to the top left of the border box.
Since fixing this is work that is not related to outline _per se_ I'm
leaving that to a followup and making a note in the code.

r? @SimonSapin 
