### PR TITLE
Add a `./mach clean-snapshots` command to remove old Cargo and Rust.

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -152,3 +152,29 @@ class MachCommands(CommandBase):
             ["git", "submodule", "--quiet", "sync", "--recursive"])
         subprocess.check_call(
             ["git", "submodule", "update", "--init", "--recursive"])
+
+    @Command('clean-snapshots',
+             description='Clean unused snapshots of Rust and Cargo',
+             category='bootstrap')
+    @CommandArgument('--force', '-f',
+                     action='store_true',
+                     help='Actually remove stuff')
+    def clean_snapshots(self, force=False):
+        rust_current = self.rust_snapshot_path().split('/')[0]
+        cargo_current = self.cargo_build_id()
+        print("Current Rust version: " + rust_current)
+        print("Current Cargo version: " + cargo_current)
+        action = "Removing " if force else "Would remove "
+        for current, base in [(rust_current, "rust"), (cargo_current, "cargo")]:
+            base = path.join(self.context.sharedir, base)
+            for name in os.listdir(base):
+                if name != current:
+                    name = path.join(base, name)
+                    if force:
+                        print("Removing " + name)
+                        shutil.rmtree(name)
+                    else:
+                        print("Would remove " + name)
+        if not force:
+            print("Nothing done. "
+                  "Run `./mach clean-snapshots -f` to actually remove.")

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -164,17 +164,20 @@ class MachCommands(CommandBase):
         cargo_current = self.cargo_build_id()
         print("Current Rust version: " + rust_current)
         print("Current Cargo version: " + cargo_current)
-        action = "Removing " if force else "Would remove "
+        removing_anything = False
         for current, base in [(rust_current, "rust"), (cargo_current, "cargo")]:
             base = path.join(self.context.sharedir, base)
             for name in os.listdir(base):
                 if name != current:
+                    removing_anything = True
                     name = path.join(base, name)
                     if force:
                         print("Removing " + name)
                         shutil.rmtree(name)
                     else:
                         print("Would remove " + name)
-        if not force:
+        if not removing_anything:
+            print("Nothing to remove.")
+        elif not force:
             print("Nothing done. "
                   "Run `./mach clean-snapshots -f` to actually remove.")


### PR DESCRIPTION
Bootstrapping automatically downloads new Rust and Cargo snapshots as needed into versioned directories, but do not remove now-unused versions. This is the desired behavior for `git bisect` to be usable.

However, this means that old version keep accumulating, taking up disk space. This adds a mach command to remove snapshots other than the ones currently being used. It is never run automatically.

To be safe, the command defaults to only printing what would be removed, and only removes stuff when run with a `-f` argument.

r? @mbrubeck
