### PR TITLE
Don't include the root element when calling Element#getElementsByTagName

### DIFF
--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -85,7 +85,10 @@ impl HTMLCollection {
             ascii_lower_tag: Atom,
         }
         impl CollectionFilter for TagNameFilter {
-            fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
+                if NodeCast::from_ref(elem) == root {
+                    return false
+                }
                 if elem.html_element_in_html_document() {
                     *elem.local_name() == self.ascii_lower_tag
                 } else {

--- a/tests/wpt/metadata/dom/nodes/Element-getElementsByTagName.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-getElementsByTagName.html.ini
@@ -8,7 +8,3 @@
 
   [getElementsByTagName(\'*\')]
     expected: FAIL
-
-  [Matching the context object]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes #4249
