### PR TITLE
layout: Implement `text-transform`.

### DIFF
--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1185,6 +1185,9 @@ pub mod longhands {
 
     ${single_keyword("white-space", "normal pre nowrap")}
 
+    // TODO(pcwalton): `full-width`
+    ${single_keyword("text-transform", "none capitalize uppercase lowercase")}
+
     // CSS 2.1, Section 17 - Tables
     ${new_style_struct("Table", is_inherited=False)}
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -187,3 +187,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == incremental_float_a.html incremental_float_ref.html
 == opacity_simple_a.html opacity_simple_ref.html
 == opacity_stacking_context_a.html opacity_stacking_context_ref.html
+== text_transform_none_a.html text_transform_none_ref.html
+== text_transform_uppercase_a.html text_transform_uppercase_ref.html
+== text_transform_lowercase_a.html text_transform_lowercase_ref.html
+== text_transform_capitalize_a.html text_transform_capitalize_ref.html

--- a/tests/ref/text_transform_capitalize_a.html
+++ b/tests/ref/text_transform_capitalize_a.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: capitalize` works. -->
+<body>
+<h1 style='text-transform: capitalize; font-family: Hiragino Maru Gothic Pro'>ュゥゥゥゥ can do ányThing at ゾムボ.cOm</h1>
+</body>
+</html>
+

--- a/tests/ref/text_transform_capitalize_ref.html
+++ b/tests/ref/text_transform_capitalize_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: capitalize` works. -->
+<body>
+<h1 style='font-family: Hiragino Maru Gothic Pro'>ュゥゥゥゥ Can Do ÁnyThing At ゾムボ.cOm</h1>
+</body>
+</html>
+
+

--- a/tests/ref/text_transform_lowercase_a.html
+++ b/tests/ref/text_transform_lowercase_a.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: lowercase` works. -->
+<body>
+<h1 style='text-transform: lowercase; font-family: Hiragino Maru Gothic Pro'>YoU CaN dO ÁnYtHiNg At ゾムボ.cOm</h1>
+</body>
+</html>
+

--- a/tests/ref/text_transform_lowercase_ref.html
+++ b/tests/ref/text_transform_lowercase_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: lowercase` works. -->
+<body>
+<h1 style='font-family: Hiragino Maru Gothic Pro'>you can do ánything at ゾムボ.com</h1>
+</body>
+</html>
+
+

--- a/tests/ref/text_transform_none_a.html
+++ b/tests/ref/text_transform_none_a.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: none` works. -->
+<body>
+<h1 style='text-transform: none; font-family: Hiragino Maru Gothic Pro'>You can do anything at ゾムボ.com</h1>
+</body>
+</html>
+

--- a/tests/ref/text_transform_none_ref.html
+++ b/tests/ref/text_transform_none_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: none` works. -->
+<body>
+<h1 style='font-family: Hiragino Maru Gothic Pro'>You can do anything at ゾムボ.com</h1>
+</body>
+</html>
+
+

--- a/tests/ref/text_transform_uppercase_a.html
+++ b/tests/ref/text_transform_uppercase_a.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: uppercase` works. -->
+<body>
+<h1 style='text-transform: uppercase; font-family: Hiragino Maru Gothic Pro'>You çan do anything at ゾムボ.com</h1>
+</body>
+</html>
+

--- a/tests/ref/text_transform_uppercase_ref.html
+++ b/tests/ref/text_transform_uppercase_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<!-- Tests that `text-transform: uppercase` works. -->
+<body>
+<h1 style='font-family: Hiragino Maru Gothic Pro'>YOU ÇAN DO ANYTHING AT ゾムボ.COM</h1>
+</body>
+</html>
+
+


### PR DESCRIPTION
The Unicode awareness of `text-transform` is implemented as well as
possible given the Rust standard library's Unicode support. In
particular, the notion of an alphabetic character is used instead of a
letter.

Gecko has a subclass of text run to handle text transforms, but I
implemented this in a simpler way.

r? @SimonSapin 
