### PR TITLE
Make the gonk port work again

### DIFF
--- a/ports/gonk/src/main.rs
+++ b/ports/gonk/src/main.rs
@@ -28,6 +28,7 @@ use servo_util::opts;
 use servo_util::rtinstrument;
 use servo::Browser;
 use compositing::windowing::IdleWindowEvent;
+use compositing::windowing::InitializeCompositingWindowEvent;
 
 use std::os;
 
@@ -57,6 +58,8 @@ fn start(argc: int, argv: *const *const u8) -> int {
                 None => (),
                 Some(ref window) => input::run_input_loop(&window.event_send)
             }
+
+            browser.browser.handle_event(InitializeCompositingWindowEvent);
 
             loop {
                 let should_continue = match window {

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -13,6 +13,7 @@ use layers::platform::surface::NativeGraphicsMetadata;
 use libc::c_int;
 use msg::compositor_msg::{Blank, IdlePaintState};
 use msg::compositor_msg::{ReadyState, PaintState};
+use msg::constellation_msg::LoadData;
 use std::cell::Cell;
 use std::comm::Receiver;
 use std::rc::Rc;
@@ -790,6 +791,15 @@ impl WindowMethods for Window {
         self.paint_state.set(paint_state);
     }
 
+    fn set_page_title(&self, _: Option<String>) {
+    }
+
+    fn set_page_load_data(&self, _: LoadData) {
+    }
+
+    fn load_end(&self) {
+    }
+
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32> {
         ScaleFactor(1.0)
     }
@@ -808,6 +818,10 @@ impl WindowMethods for Window {
              event_sender: window.as_ref().unwrap().event_send.clone(),
          } as Box<CompositorProxy+Send>,
          box receiver as Box<CompositorReceiver>)
+    }
+
+    fn prepare_for_composite(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
This makes the gonk port build/work again after the recent CEF port update.
