### PR TITLE
Handle onload correctly and trigger the load event for <script>.

### DIFF
--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -94,7 +94,8 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
             let win = window_from_node(self).root();
             win.GetOnload()
         } else {
-            None
+            let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
+            target.get_event_handler_common("load")
         }
     }
 
@@ -102,6 +103,9 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
         if self.is_body_or_frameset() {
             let win = window_from_node(self).root();
             win.SetOnload(listener)
+        } else {
+            let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
+            target.set_event_handler_common("load", listener)
         }
     }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -13,7 +13,7 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLScriptElementDerived, HTMLScriptElementCast};
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::EventTargetCast;
-use dom::bindings::global::Window;
+use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
@@ -210,7 +210,7 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 
         window.evaluate_script_with_result(source.as_slice(), url.serialize().as_slice());
 
-        let event = Event::new(Window(*window),
+        let event = Event::new(GlobalRef::Window(*window),
                                "load".to_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -7,7 +7,6 @@ use std::ascii::AsciiExt;
 use dom::attr::Attr;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
-use dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
 use dom::bindings::codegen::Bindings::HTMLScriptElementBinding;
 use dom::bindings::codegen::Bindings::HTMLScriptElementBinding::HTMLScriptElementMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -19,8 +18,8 @@ use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{ElementTypeId, Element, AttributeHandlers, ElementCreator};
-use dom::eventtarget::{EventTarget, EventTargetTypeId};
-use dom::event::{Event, Bubbles, NotCancelable, EventHelpers};
+use dom::eventtarget::{EventTarget, EventTargetTypeId, EventTargetHelpers};
+use dom::event::{Event, EventBubbles, EventCancelable, EventHelpers};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, NodeTypeId, window_from_node, CloneChildrenFlag};
 use dom::virtualmethods::VirtualMethods;
@@ -213,10 +212,11 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 
         let event = Event::new(Window(*window),
                                "load".to_string(),
-                               Bubbles, NotCancelable).root();
+                               EventBubbles::DoesNotBubble,
+                               EventCancelable::NotCancelable).root();
         event.set_trusted(true);
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.DispatchEvent(*event).ok();
+        target.dispatch_event(*event);
     }
 
     fn is_javascript(self) -> bool {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -7,16 +7,20 @@ use std::ascii::AsciiExt;
 use dom::attr::Attr;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
+use dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
 use dom::bindings::codegen::Bindings::HTMLScriptElementBinding;
 use dom::bindings::codegen::Bindings::HTMLScriptElementBinding::HTMLScriptElementMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLScriptElementDerived, HTMLScriptElementCast};
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::EventTargetCast;
+use dom::bindings::global::Window;
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::document::Document;
 use dom::element::{ElementTypeId, Element, AttributeHandlers, ElementCreator};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
+use dom::event::{Event, Bubbles, NotCancelable, EventHelpers};
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, NodeHelpers, NodeTypeId, window_from_node, CloneChildrenFlag};
 use dom::virtualmethods::VirtualMethods;
@@ -206,6 +210,13 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
         };
 
         window.evaluate_script_with_result(source.as_slice(), url.serialize().as_slice());
+
+        let event = Event::new(Window(*window),
+                               "load".to_string(),
+                               Bubbles, NotCancelable).root();
+        event.set_trusted(true);
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
+        target.DispatchEvent(*event).ok();
     }
 
     fn is_javascript(self) -> bool {

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/script-onload-string.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/script-onload-string.html.ini
@@ -1,5 +1,0 @@
-[script-onload-string.html]
-  type: testharness
-  [Setting onload to a string should convert to null.]
-    expected: FAIL
-


### PR DESCRIPTION
Without this, facebook.com pages (with their custom module loading system and React.js) silently fail to make progress loading content, forever waiting on load events on the initial set of `<script>` elements.
