### PR TITLE
Don't include the root element when calling Element#getElementsByTagNameNS

### DIFF
--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -119,7 +119,10 @@ impl HTMLCollection {
             namespace_filter: Option<Namespace>
         }
         impl CollectionFilter for TagNameNSFilter {
-            fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
+                if NodeCast::from_ref(elem) == root {
+                    return false
+                }
                 let ns_match = match self.namespace_filter {
                     Some(ref namespace) => {
                         *elem.namespace() == *namespace

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -62,7 +62,10 @@ impl HTMLCollection {
             namespace_filter: Option<Namespace>
         }
         impl CollectionFilter for AllElementFilter {
-            fn filter(&self, elem: JSRef<Element>, _root: JSRef<Node>) -> bool {
+            fn filter(&self, elem: JSRef<Element>, root: JSRef<Node>) -> bool {
+                if NodeCast::from_ref(elem) == root {
+                    return false
+                }
                 match self.namespace_filter {
                     None => true,
                     Some(ref namespace) => *elem.namespace() == *namespace

--- a/tests/wpt/metadata/dom/nodes/Element-getElementsByTagName.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-getElementsByTagName.html.ini
@@ -5,7 +5,3 @@
 
   [hasOwnProperty, getOwnPropertyDescriptor, getOwnPropertyNames]
     expected: FAIL
-
-  [getElementsByTagName(\'*\')]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/nodes/Element-getElementsByTagNameNS.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-getElementsByTagNameNS.html.ini
@@ -5,10 +5,3 @@
 
   [getElementsByTagNameNS(\'*\', \'*\')]
     expected: FAIL
-
-  [Matching the context object (wildcard namespace)]
-    expected: FAIL
-
-  [Matching the context object (specific namespace)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/nodes/Element-getElementsByTagNameNS.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-getElementsByTagNameNS.html.ini
@@ -1,7 +1,0 @@
-[Element-getElementsByTagNameNS.html]
-  type: testharness
-  [getElementsByTagNameNS(\'http://www.w3.org/1999/xhtml\', \'*\')]
-    expected: FAIL
-
-  [getElementsByTagNameNS(\'*\', \'*\')]
-    expected: FAIL


### PR DESCRIPTION
This fixes #4349.
