### PR TITLE
compositing: Implement `cursor` per CSS3-UI § 8.1.1 in the CEF/Mac port.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use compositor_layer::{CompositorData, CompositorLayer, WantsScrollEventsFlag};
-use compositor_task::{CompositorEventListener, CompositorProxy, CompositorReceiver, CompositorTask};
-use compositor_task::{LayerProperties, Msg};
+use compositor_task::{CompositorEventListener, CompositorProxy, CompositorReceiver};
+use compositor_task::{CompositorTask, LayerProperties, Msg};
 use constellation::{FrameId, FrameTreeDiff, SendableFrameTree};
 use pipeline::CompositionPipeline;
 use scrolling::ScrollingTimerProxy;
@@ -336,6 +336,10 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
             (Msg::KeyEvent(key, modified), ShutdownState::NotShuttingDown) => {
                 self.window.handle_key(key, modified);
+            }
+
+            (Msg::SetCursor(cursor), ShutdownState::NotShuttingDown) => {
+                self.window.set_cursor(cursor)
             }
 
             // When we are shutting_down, we need to avoid performing operations

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -21,6 +21,7 @@ use servo_msg::compositor_msg::{Epoch, LayerId, LayerMetadata, ReadyState};
 use servo_msg::compositor_msg::{PaintListener, PaintState, ScriptListener, ScrollPolicy};
 use servo_msg::constellation_msg::{ConstellationChan, LoadData, PipelineId};
 use servo_msg::constellation_msg::{Key, KeyState, KeyModifiers, Pressed};
+use servo_util::cursor::Cursor;
 use servo_util::memory::MemoryProfilerChan;
 use servo_util::time::TimeProfilerChan;
 use std::comm::{channel, Sender, Receiver};
@@ -213,6 +214,8 @@ pub enum Msg {
     ScrollTimeout(u64),
     /// Sends an unconsumed key event back to the compositor.
     KeyEvent(Key, KeyModifiers),
+    /// Changes the cursor.
+    SetCursor(Cursor),
 }
 
 impl Show for Msg {
@@ -231,11 +234,12 @@ impl Show for Msg {
             Msg::ChangePageTitle(..) => write!(f, "ChangePageTitle"),
             Msg::ChangePageLoadData(..) => write!(f, "ChangePageLoadData"),
             Msg::PaintMsgDiscarded(..) => write!(f, "PaintMsgDiscarded"),
+            Msg::FrameTreeUpdate(..) => write!(f, "FrameTreeUpdate"),
             Msg::SetIds(..) => write!(f, "SetIds"),
-            Msg::FrameTreeUpdate(..) => write!(f, "FrameTreeUpdateMsg"),
             Msg::LoadComplete => write!(f, "LoadComplete"),
             Msg::ScrollTimeout(..) => write!(f, "ScrollTimeout"),
             Msg::KeyEvent(..) => write!(f, "KeyEvent"),
+            Msg::SetCursor(..) => write!(f, "SetCursor"),
         }
     }
 }

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -99,10 +99,18 @@ impl CompositorEventListener for NullCompositor {
 
             Msg::CreateOrUpdateRootLayer(..) |
             Msg::CreateOrUpdateDescendantLayer(..) |
-            Msg::SetLayerOrigin(..) | Msg::Paint(..) |
-            Msg::ChangeReadyState(..) | Msg::ChangePaintState(..) | Msg::ScrollFragmentPoint(..) |
-            Msg::LoadComplete | Msg::PaintMsgDiscarded(..) | Msg::ScrollTimeout(..) | Msg::ChangePageTitle(..) |
-            Msg::ChangePageLoadData(..) | Msg::KeyEvent(..) => ()
+            Msg::SetLayerOrigin(..) |
+            Msg::Paint(..) |
+            Msg::ChangeReadyState(..) |
+            Msg::ChangePaintState(..) |
+            Msg::ScrollFragmentPoint(..) |
+            Msg::LoadComplete |
+            Msg::PaintMsgDiscarded(..) |
+            Msg::ScrollTimeout(..) |
+            Msg::ChangePageTitle(..) |
+            Msg::ChangePageLoadData(..) |
+            Msg::KeyEvent(..) |
+            Msg::SetCursor(..) => {}
         }
         true
     }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -13,6 +13,7 @@ use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeGraphicsMetadata;
 use servo_msg::compositor_msg::{PaintState, ReadyState};
 use servo_msg::constellation_msg::{Key, KeyState, KeyModifiers, LoadData};
+use servo_util::cursor::Cursor;
 use servo_util::geometry::ScreenPx;
 use std::fmt::{FormatError, Formatter, Show};
 use std::rc::Rc;
@@ -123,6 +124,9 @@ pub trait WindowMethods {
     /// some type of platform-specific graphics context current. Returns true if the composite may
     /// proceed and false if it should not.
     fn prepare_for_composite(&self) -> bool;
+
+    /// Sets the cursor to be used in the window.
+    fn set_cursor(&self, cursor: Cursor);
 
     /// Process a key event.
     fn handle_key(&self, key: Key, mods: KeyModifiers);

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -13,15 +13,13 @@ use flow_ref::FlowRef;
 use traversal::{RecalcStyleForNode, ConstructFlows};
 use traversal::{BubbleISizes, AssignISizes, AssignBSizesAndStoreOverflow};
 use traversal::{ComputeAbsolutePositions, BuildDisplayList};
-use url::Url;
 use util::{LayoutDataAccess, LayoutDataWrapper};
 use wrapper::{layout_node_to_unsafe_layout_node, layout_node_from_unsafe_layout_node, LayoutNode};
 use wrapper::{PostorderNodeMutTraversal, UnsafeLayoutNode};
 use wrapper::{PreorderDomTraversal, PostorderDomTraversal};
 
 use servo_util::opts;
-use servo_util::time::{TimeProfilerChan, profile, TimerMetadataFrameType, TimerMetadataReflowType};
-use servo_util::time;
+use servo_util::time::{mod, ProfilerMetadata, TimeProfilerChan, profile};
 use servo_util::workqueue::{WorkQueue, WorkUnit, WorkerProxy};
 use std::mem;
 use std::ptr;
@@ -422,9 +420,7 @@ pub fn traverse_dom_preorder(root: LayoutNode,
 }
 
 pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
-                                   url: &Url,
-                                   iframe: TimerMetadataFrameType,
-                                   reflow_type: TimerMetadataReflowType,
+                                   profiler_metadata: ProfilerMetadata,
                                    time_profiler_chan: TimeProfilerChan,
                                    shared_layout_context: &SharedLayoutContext,
                                    queue: &mut WorkQueue<*const SharedLayoutContext,UnsafeFlow>) {
@@ -436,7 +432,7 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 
     queue.data = shared_layout_context as *const _;
 
-    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, reflow_type)), time_profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, profiler_metadata, time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: assign_inline_sizes,
             data: mut_owned_flow_to_unsafe_flow(root),
@@ -449,15 +445,13 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 }
 
 pub fn build_display_list_for_subtree(root: &mut FlowRef,
-                                      url: &Url,
-                                      iframe: TimerMetadataFrameType,
-                                      reflow_type: TimerMetadataReflowType,
+                                      profiler_metadata: ProfilerMetadata,
                                       time_profiler_chan: TimeProfilerChan,
                                       shared_layout_context: &SharedLayoutContext,
                                       queue: &mut WorkQueue<*const SharedLayoutContext,UnsafeFlow>) {
     queue.data = shared_layout_context as *const _;
 
-    profile(time::LayoutParallelWarmupCategory, Some((url, iframe, reflow_type)), time_profiler_chan, || {
+    profile(time::LayoutParallelWarmupCategory, profiler_metadata, time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: compute_absolute_positions,
             data: mut_owned_flow_to_unsafe_flow(root),

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -8,6 +8,9 @@ authors = ["The Servo Project Developers"]
 name = "msg"
 path = "lib.rs"
 
+[dependencies.style]
+path = "../style"
+
 [dependencies.util]
 path = "../util"
 

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -11,6 +11,7 @@ use geom::scale_factor::ScaleFactor;
 use hyper::header::Headers;
 use hyper::method::{Method, Get};
 use layers::geometry::DevicePixel;
+use servo_util::cursor::Cursor;
 use servo_util::geometry::{PagePx, ViewportPx};
 use std::comm::{channel, Sender, Receiver};
 use url::Url;
@@ -208,6 +209,8 @@ pub enum Msg {
     /// Requests that the constellation inform the compositor of the title of the pipeline
     /// immediately.
     GetPipelineTitleMsg(PipelineId),
+    /// Requests that the constellation inform the compositor of the a cursor change.
+    SetCursorMsg(Cursor),
 }
 
 /// Similar to net::resource_task::LoadData

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1150,7 +1150,6 @@ impl ScriptTask {
         let page = get_page(&*self.page.borrow(), pipeline_id);
         match page.get_nodes_under_mouse(&point) {
             Some(node_address) => {
-
                 let mut target_list = vec!();
                 let mut target_compare = false;
 
@@ -1166,23 +1165,19 @@ impl ScriptTask {
                 }
 
                 for node_address in node_address.iter() {
-
                     let temp_node =
-                        node::from_untrusted_node_address(
-                            self.js_runtime.ptr, *node_address);
+                        node::from_untrusted_node_address(self.js_runtime.ptr, *node_address);
 
                     let maybe_node = temp_node.root().ancestors().find(|node| node.is_element());
                     match maybe_node {
                         Some(node) => {
                             node.set_hover_state(true);
-
                             match *mouse_over_targets {
-                                Some(ref mouse_over_targets) => {
-                                    if !target_compare {
-                                        target_compare = !mouse_over_targets.contains(&JS::from_rooted(node));
-                                    }
+                                Some(ref mouse_over_targets) if !target_compare => {
+                                    target_compare =
+                                        !mouse_over_targets.contains(&JS::from_rooted(node));
                                 }
-                                None => {}
+                                _ => {}
                             }
                             target_list.push(JS::from_rooted(node));
                         }
@@ -1192,15 +1187,15 @@ impl ScriptTask {
                 match *mouse_over_targets {
                     Some(ref mouse_over_targets) => {
                         if mouse_over_targets.len() != target_list.len() {
-                            target_compare = true;
+                            target_compare = true
                         }
                     }
-                    None => { target_compare = true; }
+                    None => target_compare = true,
                 }
 
                 if target_compare {
                     if mouse_over_targets.is_some() {
-                        self.force_reflow(&*page);
+                        self.force_reflow(&*page)
                     }
                     *mouse_over_targets = Some(target_list);
                 }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "hyper 0.0.1 (git+https://github.com/servo/hyper?ref=servo)",
  "io_surface 0.1.0 (git+https://github.com/servo/rust-io-surface)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "style 0.0.1",
  "url 0.1.0 (git+https://github.com/servo/rust-url)",
  "util 0.0.1",
 ]

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -32,7 +32,7 @@ import re
 
 def to_rust_ident(name):
     name = name.replace("-", "_")
-    if name in ["static", "super", "box"]:  # Rust keywords
+    if name in ["static", "super", "box", "move"]:  # Rust keywords
         name += "_"
     return name
 
@@ -1348,6 +1348,139 @@ pub mod longhands {
     ${switch_to_style_struct("Box")}
 
     ${single_keyword("box-sizing", "content-box border-box")}
+
+    ${new_style_struct("Pointing", is_inherited=True)}
+
+    <%self:single_component_value name="cursor">
+        use servo_util::cursor as util_cursor;
+        pub use super::computed_as_specified as to_computed_value;
+
+        pub mod computed_value {
+            use servo_util::cursor::Cursor;
+            #[deriving(Clone, PartialEq, Show)]
+            pub enum T {
+                AutoCursor,
+                SpecifiedCursor(Cursor),
+            }
+        }
+        pub type SpecifiedValue = computed_value::T;
+        #[inline]
+        pub fn get_initial_value() -> computed_value::T {
+            computed_value::T::AutoCursor
+        }
+        pub fn from_component_value(value: &ComponentValue, _: &Url)
+                                    -> Result<SpecifiedValue,()> {
+            match value {
+                &Ident(ref value) if value.eq_ignore_ascii_case("auto") => Ok(T::AutoCursor),
+                &Ident(ref value) if value.eq_ignore_ascii_case("none") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NoCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("default") => {
+                    Ok(T::SpecifiedCursor(util_cursor::DefaultCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("pointer") => {
+                    Ok(T::SpecifiedCursor(util_cursor::PointerCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("context-menu") => {
+                    Ok(T::SpecifiedCursor(util_cursor::ContextMenuCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("help") => {
+                    Ok(T::SpecifiedCursor(util_cursor::HelpCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("progress") => {
+                    Ok(T::SpecifiedCursor(util_cursor::ProgressCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("wait") => {
+                    Ok(T::SpecifiedCursor(util_cursor::WaitCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("cell") => {
+                    Ok(T::SpecifiedCursor(util_cursor::CellCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("crosshair") => {
+                    Ok(T::SpecifiedCursor(util_cursor::CrosshairCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("text") => {
+                    Ok(T::SpecifiedCursor(util_cursor::TextCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("vertical-text") => {
+                    Ok(T::SpecifiedCursor(util_cursor::VerticalTextCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("alias") => {
+                    Ok(T::SpecifiedCursor(util_cursor::AliasCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("copy") => {
+                    Ok(T::SpecifiedCursor(util_cursor::CopyCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("move") => {
+                    Ok(T::SpecifiedCursor(util_cursor::MoveCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("no-drop") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NoDropCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("not-allowed") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NotAllowedCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("grab") => {
+                    Ok(T::SpecifiedCursor(util_cursor::GrabCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("grabbing") => {
+                    Ok(T::SpecifiedCursor(util_cursor::GrabbingCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("e-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::EResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("n-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("ne-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NeResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("nw-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NwResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("s-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::SResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("se-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::SeResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("sw-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::SwResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("w-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::WResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("ew-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::EwResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("ns-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NsResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("nesw-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NeswResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("nwse-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::NwseResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("col-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::ColResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("row-resize") => {
+                    Ok(T::SpecifiedCursor(util_cursor::RowResizeCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("all-scroll") => {
+                    Ok(T::SpecifiedCursor(util_cursor::AllScrollCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("zoom-in") => {
+                    Ok(T::SpecifiedCursor(util_cursor::ZoomInCursor))
+                }
+                &Ident(ref value) if value.eq_ignore_ascii_case("zoom-out") => {
+                    Ok(T::SpecifiedCursor(util_cursor::ZoomOutCursor))
+                }
+                _ => Err(())
+            }
+        }
+    </%self:single_component_value>
 
     // Box-shadow, etc.
     ${new_style_struct("Effects", is_inherited=False)}

--- a/components/util/cursor.rs
+++ b/components/util/cursor.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A list of common mouse cursors per CSS3-UI § 8.1.1.
+
+#[deriving(Clone, PartialEq, FromPrimitive, Show)]
+#[repr(u8)]
+pub enum Cursor {
+    NoCursor = 0,
+    DefaultCursor = 1,
+    PointerCursor = 2,
+    ContextMenuCursor = 3,
+    HelpCursor = 4,
+    ProgressCursor = 5,
+    WaitCursor = 6,
+    CellCursor = 7,
+    CrosshairCursor = 8,
+    TextCursor = 9,
+    VerticalTextCursor = 10,
+    AliasCursor = 11,
+    CopyCursor = 12,
+    MoveCursor = 13,
+    NoDropCursor = 14,
+    NotAllowedCursor = 15,
+    GrabCursor = 16,
+    GrabbingCursor = 17,
+    EResizeCursor = 18,
+    NResizeCursor = 19,
+    NeResizeCursor = 20,
+    NwResizeCursor = 21,
+    SResizeCursor = 22,
+    SeResizeCursor = 23,
+    SwResizeCursor = 24,
+    WResizeCursor = 25,
+    EwResizeCursor = 26,
+    NsResizeCursor = 27,
+    NeswResizeCursor = 28,
+    NwseResizeCursor = 29,
+    ColResizeCursor = 30,
+    RowResizeCursor = 31,
+    AllScrollCursor = 32,
+    ZoomInCursor = 33,
+    ZoomOutCursor = 34,
+}
+

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 
 pub mod bloom;
 pub mod cache;
+pub mod cursor;
 pub mod debug_utils;
 pub mod dlist;
 pub mod fnv;

--- a/components/util/time.rs
+++ b/components/util/time.rs
@@ -259,8 +259,10 @@ pub enum TimerMetadataReflowType {
     FirstReflow,
 }
 
+pub type ProfilerMetadata<'a> = Option<(&'a Url, TimerMetadataFrameType, TimerMetadataReflowType)>;
+
 pub fn profile<T>(category: TimeProfilerCategory,
-                  meta: Option<(&Url, TimerMetadataFrameType, TimerMetadataReflowType)>,
+                  meta: ProfilerMetadata,
                   time_profiler_chan: TimeProfilerChan,
                   callback: || -> T)
                   -> T {

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "hyper 0.0.1 (git+https://github.com/servo/hyper?ref=servo)",
  "io_surface 0.1.0 (git+https://github.com/servo/rust-io-surface)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "style 0.0.1",
  "url 0.1.0 (git+https://github.com/servo/rust-url)",
  "util 0.0.1",
 ]

--- a/ports/cef/browser_host.rs
+++ b/ports/cef/browser_host.rs
@@ -109,6 +109,13 @@ cef_class_impl! {
             }
         }
 
+        fn send_mouse_move_event(&_this, event: *const cef_mouse_event, _mouse_exited: c_int)
+                                 -> () {
+            let event: &cef_mouse_event = event;
+            let point = TypedPoint2D((*event).x as f32, (*event).y as f32);
+            core::send_window_event(WindowEvent::MouseWindowMoveEventClass(point))
+        }
+
         fn send_mouse_wheel_event(&_this,
                                   event: *const cef_mouse_event,
                                   delta_x: c_int,

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -10,7 +10,7 @@
 use eutil::Downcast;
 use interfaces::CefBrowser;
 use render_handler::CefRenderHandlerExtensions;
-use types::cef_rect_t;
+use types::{cef_cursor_handle_t, cef_rect_t};
 use wrappers::Utf16Encoder;
 
 use compositing::compositor_task::{mod, CompositorProxy, CompositorReceiver};
@@ -25,9 +25,21 @@ use servo_msg::constellation_msg::{Key, KeyModifiers};
 use servo_msg::compositor_msg::{Blank, FinishedLoading, Loading, PerformingLayout, PaintState};
 use servo_msg::compositor_msg::{ReadyState};
 use servo_msg::constellation_msg::LoadData;
+use servo_util::cursor::Cursor;
 use servo_util::geometry::ScreenPx;
 use std::cell::RefCell;
 use std::rc::Rc;
+
+#[cfg(target_os="macos")]
+use servo_util::cursor::{AliasCursor, AllScrollCursor, ColResizeCursor, ContextMenuCursor};
+#[cfg(target_os="macos")]
+use servo_util::cursor::{CopyCursor, CrosshairCursor, EResizeCursor, EwResizeCursor};
+#[cfg(target_os="macos")]
+use servo_util::cursor::{GrabCursor, GrabbingCursor, NResizeCursor, NoCursor, NoDropCursor};
+#[cfg(target_os="macos")]
+use servo_util::cursor::{NsResizeCursor, NotAllowedCursor, PointerCursor, RowResizeCursor};
+#[cfg(target_os="macos")]
+use servo_util::cursor::{SResizeCursor, TextCursor, VerticalTextCursor, WResizeCursor};
 
 #[cfg(target_os="macos")]
 use std::ptr;
@@ -86,6 +98,42 @@ impl Window {
     /// Currently unimplemented.
     pub fn wait_events(&self) -> WindowEvent {
         WindowEvent::Idle
+    }
+
+    /// Returns the Cocoa cursor for a CSS cursor. These match Firefox, except where Firefox
+    /// bundles custom resources (which we don't yet do).
+    #[cfg(target_os="macos")]
+    fn cursor_handle_for_cursor(&self, cursor: Cursor) -> cef_cursor_handle_t {
+        use cocoa::base::{class, msg_send, selector};
+
+        let cocoa_name = match cursor {
+            NoCursor => return 0 as cef_cursor_handle_t,
+            ContextMenuCursor => "contextualMenuCursor",
+            GrabbingCursor => "closedHandCursor",
+            CrosshairCursor => "crosshairCursor",
+            CopyCursor => "dragCopyCursor",
+            AliasCursor => "dragLinkCursor",
+            TextCursor => "IBeamCursor",
+            GrabCursor | AllScrollCursor => "openHandCursor",
+            NoDropCursor | NotAllowedCursor => "operationNotAllowedCursor",
+            PointerCursor => "pointingHandCursor",
+            SResizeCursor => "resizeDownCursor",
+            WResizeCursor => "resizeLeftCursor",
+            EwResizeCursor | ColResizeCursor => "resizeLeftRightCursor",
+            EResizeCursor => "resizeRightCursor",
+            NResizeCursor => "resizeUpCursor",
+            NsResizeCursor | RowResizeCursor => "resizeUpDownCursor",
+            VerticalTextCursor => "IBeamCursorForVerticalLayout",
+            _ => "arrowCursor",
+        };
+        unsafe {
+            msg_send()(class("NSCursor"), selector(cocoa_name))
+        }
+    }
+
+    #[cfg(not(target_os="macos"))]
+    fn cursor_handle_for_cursor(&self, _: Cursor) -> cef_cursor_handle_t {
+        0
     }
 }
 
@@ -264,6 +312,20 @@ impl WindowMethods for Window {
 
     fn handle_key(&self, _: Key, _: KeyModifiers) {
         // TODO(negge)
+    }
+
+    fn set_cursor(&self, cursor: Cursor) {
+        let browser = self.cef_browser.borrow();
+        match *browser {
+            None => {}
+            Some(ref browser) => {
+                let cursor_handle = self.cursor_handle_for_cursor(cursor);
+                browser.get_host()
+                       .get_client()
+                       .get_render_handler()
+                       .on_cursor_change(browser.clone(), cursor_handle)
+            }
+        }
     }
 }
 

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -18,3 +18,4 @@ input[type="radio"]:checked::before { content: "(●)"; }
 td[align="left"]    { text-align: left; }
 td[align="center"]  { text-align: center; }
 td[align="right"]   { text-align: right; }
+

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -89,7 +89,7 @@ rt { display: ruby-text; }
 
 :link { color: #0000EE; }
 :visited { color: #551A8B; }
-:link, :visited { text-decoration: underline; }
+:link, :visited { text-decoration: underline; cursor: pointer; }
 a:link[rel~=help], a:visited[rel~=help],
 area:link[rel~=help], area:visited[rel~=help] { cursor: help; }
 


### PR DESCRIPTION
I'm not sure how we want to handle Linux cursors, and GLFW has no
ability to set cursors (short of disabling it and managing it yourself).

If you test this in the wild you will probably hit #4357 until that PR lands.
