### PR TITLE
layout: Implement `overflow-wrap`/`word-wrap` per CSS-TEXT § 6.2.

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -855,8 +855,8 @@ impl ScaledFontExtensionMethods for ScaledFont {
         let mut azglyphs = vec!();
         azglyphs.reserve(range.length().to_uint());
 
-        for (glyphs, _offset, slice_range) in run.iter_slices_for_range(range) {
-            for (_i, glyph) in glyphs.iter_glyphs_for_char_range(&slice_range) {
+        for slice in run.natural_word_slices_in_range(range) {
+            for (_i, glyph) in slice.glyphs.iter_glyphs_for_char_range(&slice.range) {
                 let glyph_advance = glyph.advance();
                 let glyph_offset = glyph.offset().unwrap_or(Zero::zero());
                 let azglyph = struct__AzGlyph {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -512,18 +512,17 @@ impl LineBreaker {
         let available_inline_size = green_zone.inline - self.pending_line.bounds.size.inline -
             indentation;
         let (inline_start_fragment, inline_end_fragment) =
-            match fragment.find_split_info_for_inline_size(CharIndex(0),
-                                                           available_inline_size,
-                                                           self.pending_line_is_empty()) {
+            match fragment.calculate_split_position(available_inline_size,
+                                                    self.pending_line_is_empty()) {
                 None => {
                     debug!("LineBreaker: fragment was unsplittable; deferring to next line: {}",
                            fragment);
                     self.work_list.push_front(fragment);
                     return false
                 }
-                Some((start_split_info, end_split_info, run)) => {
+                Some(split_result) => {
                     let split_fragment = |split: SplitInfo| {
-                        let info = box ScannedTextFragmentInfo::new(run.clone(),
+                        let info = box ScannedTextFragmentInfo::new(split_result.text_run.clone(),
                                                                     split.range,
                                                                     Vec::new(),
                                                                     fragment.border_box.size);
@@ -532,8 +531,8 @@ impl LineBreaker {
                                                     fragment.border_box.size.block);
                         fragment.transform(size, info)
                     };
-                    (start_split_info.map(|x| split_fragment(x)),
-                     end_split_info.map(|x| split_fragment(x)))
+                    (split_result.inline_start.map(|x| split_fragment(x)),
+                     split_result.inline_end.map(|x| split_fragment(x)))
                 }
             };
 

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1136,6 +1136,10 @@ pub mod longhands {
 
     ${predefined_type("text-indent", "LengthOrPercentage", "computed::LP_Length(Au(0))")}
 
+    // Also known as "word-wrap" (which is more popular because of IE), but this is the preferred
+    // name per CSS-TEXT 6.2.
+    ${single_keyword("overflow-wrap", "normal break-word")}
+
     ${new_style_struct("Text", is_inherited=False)}
 
     <%self:longhand name="text-decoration">
@@ -1747,6 +1751,15 @@ pub mod shorthands {
         })
     </%self:shorthand>
 
+    // Per CSS-TEXT 6.2, "for legacy reasons, UAs must treat `word-wrap` as an alternate name for
+    // the `overflow-wrap` property, as if it were a shorthand of `overflow-wrap`."
+    <%self:shorthand name="word-wrap" sub_properties="overflow-wrap">
+        overflow_wrap::parse(input, base_url).map(|specified_value| {
+            Longhands {
+                overflow_wrap: Some(specified_value),
+            }
+        })
+    </%self:shorthand>
 }
 
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -199,3 +199,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 != border_black_ridge.html border_black_groove.html
 == text_indent_a.html text_indent_ref.html
 == word_spacing_a.html word_spacing_ref.html
+== overflow_wrap_a.html overflow_wrap_ref.html

--- a/tests/ref/overflow_wrap_a.html
+++ b/tests/ref/overflow_wrap_a.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `overflow-wrap: break-word` breaks words if it needs to, but only when
+     necessary. -->
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+html, body {
+    margin: 0;
+}
+section {
+    word-wrap: break-word;
+    width: 300px;
+    color: purple;
+}
+</style>
+</head>
+<body>
+<section>X XXXXXX</section>
+</body>
+</html>
+

--- a/tests/ref/overflow_wrap_ref.html
+++ b/tests/ref/overflow_wrap_ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `overflow-wrap: break-word` breaks words if it needs to, but only when
+     necessary. -->
+<style>
+section, nav {
+    background: purple;
+    position: absolute;
+    left: 0;
+}
+section {
+    width: 100px;
+    top: 0;
+    height: 100px;
+}
+nav {
+    top: 100px;
+    width: 300px;
+    height: 200px;
+}
+</style>
+</head>
+<body>
+<section></section><nav></nav>
+</body>
+</html>
+


### PR DESCRIPTION
This property is used by approximately 55% of page loads.

To implement the line breaking behavior, the "breaking strategy" has
been cleaned up and abstracted. This should allow us to easily support
other similar properties in the future, such as `text-overflow` and
`word-break`.

r? @glennw 
