### PR TITLE
plugins (perf): Add a lint for usages of to_string()

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -160,7 +160,7 @@ impl Font {
 
         let glyphs = Arc::new(glyphs);
         self.shape_cache.insert(ShapeCacheEntry {
-            text: text.to_string(),
+            text: text.into_string(),
             options: *options,
         }, glyphs.clone());
         glyphs

--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -184,7 +184,7 @@ impl FontCache {
         // TODO(Issue #188): look up localized font family names if canonical name not found
         // look up canonical name
         if self.local_families.contains_key(family_name) {
-            debug!("FontList: Found font family with name={:s}", family_name.to_string());
+            debug!("FontList: Found font family with name={:s}", family_name.as_slice());
             let s = &mut self.local_families[*family_name];
 
             if s.templates.len() == 0 {
@@ -202,7 +202,7 @@ impl FontCache {
 
             None
         } else {
-            debug!("FontList: Couldn't find font family with name={:s}", family_name.to_string());
+            debug!("FontList: Couldn't find font family with name={:s}", family_name.as_slice());
             None
         }
     }

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -167,7 +167,7 @@ impl FontContext {
 
             if !cache_hit {
                 let font_template = self.font_cache_task.get_font_template(family.name()
-                                                                                 .to_string(),
+                                                                                 .into_string(),
                                                                            desc.clone());
                 match font_template {
                     Some(font_template) => {
@@ -177,14 +177,14 @@ impl FontContext {
                                                                   style.font_variant);
                         let layout_font = Rc::new(RefCell::new(layout_font));
                         self.layout_font_cache.push(LayoutFontCacheEntry {
-                            family: family.name().to_string(),
+                            family: family.name().into_string(),
                             font: Some(layout_font.clone()),
                         });
                         fonts.push(layout_font);
                     }
                     None => {
                         self.layout_font_cache.push(LayoutFontCacheEntry {
-                            family: family.name().to_string(),
+                            family: family.name().into_string(),
                             font: None,
                         });
                     }

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -68,7 +68,7 @@ impl FontTemplate {
         };
 
         FontTemplate {
-            identifier: identifier.to_string(),
+            identifier: identifier.into_string(),
             descriptor: None,
             weak_ref: maybe_weak_ref,
             strong_ref: maybe_strong_ref,

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -127,13 +127,13 @@ pub fn get_system_default_family(generic_name: &str) -> Option<String> {
 #[cfg(target_os="linux")]
 pub fn get_last_resort_font_families() -> Vec<String> {
     vec!(
-        "Fira Sans".to_string(),
-        "DejaVu Sans".to_string(),
-        "Arial".to_string()
+        "Fira Sans".into_string(),
+        "DejaVu Sans".into_string(),
+        "Arial".into_string()
     )
 }
 
 #[cfg(target_os="android")]
 pub fn get_last_resort_font_families() -> Vec<String> {
-    vec!("Roboto".to_string())
+    vec!("Roboto".into_string())
 }

--- a/components/gfx/platform/freetype/font_template.rs
+++ b/components/gfx/platform/freetype/font_template.rs
@@ -29,7 +29,7 @@ impl FontTemplateData {
 
         FontTemplateData {
             bytes: bytes,
-            identifier: identifier.to_string(),
+            identifier: identifier.into_string(),
         }
     }
 }

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -13,7 +13,7 @@ pub fn get_available_families(callback: |String|) {
     for strref in family_names.iter() {
         let family_name_ref: CFStringRef = unsafe { mem::transmute(strref) };
         let family_name_cf: CFString = unsafe { TCFType::wrap_under_get_rule(family_name_ref) };
-        let family_name = family_name_cf.to_string();
+        let family_name = family_name_cf.into_string();
         callback(family_name);
     }
 }
@@ -42,5 +42,5 @@ pub fn get_system_default_family(_generic_name: &str) -> Option<String> {
 }
 
 pub fn get_last_resort_font_families() -> Vec<String> {
-    vec!("Arial Unicode MS".to_string(), "Arial".to_string())
+    vec!("Arial Unicode MS".into_string(), "Arial".into_string())
 }

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -34,7 +34,7 @@ impl FontTemplateData {
 
         FontTemplateData {
             ctfont: ctfont,
-            identifier: identifier.to_string(),
+            identifier: identifier.into_string(),
         }
     }
 }

--- a/components/gfx/text/util.rs
+++ b/components/gfx/text/util.rs
@@ -201,21 +201,21 @@ fn test_transform_discard_newline() {
 /* FIXME: Fix and re-enable
 #[test]
 fn test_transform_compress_whitespace() {
-    let  test_strs : ~[String] = ~["  foo bar".to_string(),
-                                 "foo bar  ".to_string(),
-                                 "foo\n bar".to_string(),
-                                 "foo \nbar".to_string(),
-                                 "  foo  bar  \nbaz".to_string(),
-                                 "foo bar baz".to_string(),
-                                 "foobarbaz\n\n".to_string()];
+    let  test_strs : ~[String] = ~["  foo bar".into_string(),
+                                 "foo bar  ".into_string(),
+                                 "foo\n bar".into_string(),
+                                 "foo \nbar".into_string(),
+                                 "  foo  bar  \nbaz".into_string(),
+                                 "foo bar baz".into_string(),
+                                 "foobarbaz\n\n".into_string()];
 
-    let oracle_strs : ~[String] = ~[" foo bar".to_string(),
-                                 "foo bar ".to_string(),
-                                 "foo\n bar".to_string(),
-                                 "foo \nbar".to_string(),
-                                 " foo bar \nbaz".to_string(),
-                                 "foo bar baz".to_string(),
-                                 "foobarbaz\n\n".to_string()];
+    let oracle_strs : ~[String] = ~[" foo bar".into_string(),
+                                 "foo bar ".into_string(),
+                                 "foo\n bar".into_string(),
+                                 "foo \nbar".into_string(),
+                                 " foo bar \nbaz".into_string(),
+                                 "foo bar baz".into_string(),
+                                 "foobarbaz\n\n".into_string()];
 
     assert_eq!(test_strs.len(), oracle_strs.len());
     let mode = CompressWhitespace;
@@ -229,21 +229,21 @@ fn test_transform_compress_whitespace() {
 
 #[test]
 fn test_transform_compress_whitespace_newline() {
-    let  test_strs : ~[String] = ~["  foo bar".to_string(),
-                                 "foo bar  ".to_string(),
-                                 "foo\n bar".to_string(),
-                                 "foo \nbar".to_string(),
-                                 "  foo  bar  \nbaz".to_string(),
-                                 "foo bar baz".to_string(),
-                                 "foobarbaz\n\n".to_string()];
+    let  test_strs : ~[String] = ~["  foo bar".into_string(),
+                                 "foo bar  ".into_string(),
+                                 "foo\n bar".into_string(),
+                                 "foo \nbar".into_string(),
+                                 "  foo  bar  \nbaz".into_string(),
+                                 "foo bar baz".into_string(),
+                                 "foobarbaz\n\n".into_string()];
 
-    let oracle_strs : ~[String] = ~["foo bar".to_string(),
-                                 "foo bar ".to_string(),
-                                 "foo bar".to_string(),
-                                 "foo bar".to_string(),
-                                 " foo bar baz".to_string(),
-                                 "foo bar baz".to_string(),
-                                 "foobarbaz ".to_string()];
+    let oracle_strs : ~[String] = ~["foo bar".into_string(),
+                                 "foo bar ".into_string(),
+                                 "foo bar".into_string(),
+                                 "foo bar".into_string(),
+                                 " foo bar baz".into_string(),
+                                 "foo bar baz".into_string(),
+                                 "foobarbaz ".into_string()];
 
     assert_eq!(test_strs.len(), oracle_strs.len());
     let mode = CompressWhitespaceNewline;

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -450,7 +450,7 @@ impl<'a> FlowConstructor<'a> {
                 // Add whitespace results. They will be stripped out later on when
                 // between block elements, and retained when between inline elements.
                 let fragment_info =
-                    SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::from_text(" ".to_string()));
+                    SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::from_text(" ".into_string()));
                 let fragment = Fragment::from_opaque_node_and_style(whitespace_node,
                                                                     whitespace_style,
                                                                     whitespace_damage,
@@ -647,7 +647,7 @@ impl<'a> FlowConstructor<'a> {
                         whitespace_damage)) => {
                     // Instantiate the whitespace fragment.
                     let fragment_info = SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::from_text(
-                            " ".to_string()));
+                            " ".into_string()));
                     let fragment = Fragment::from_opaque_node_and_style(whitespace_node,
                                                                         whitespace_style,
                                                                         whitespace_damage,
@@ -944,7 +944,7 @@ impl<'a> FlowConstructor<'a> {
                                                                      .list_style_type) {
                     None => None,
                     Some(text) => {
-                        let text = text.to_string();
+                        let text = text.into_string();
                         let mut unscanned_marker_fragments = DList::new();
                         unscanned_marker_fragments.push_back(Fragment::new_from_specific_info(
                             node,

--- a/components/layout/css/matching.rs
+++ b/components/layout/css/matching.rs
@@ -241,7 +241,7 @@ impl StyleSharingCandidate {
             parent_style: parent_style,
             local_name: element.get_local_name().clone(),
             class: element.get_attr(&ns!(""), &atom!("class"))
-                          .map(|string| string.to_string()),
+                          .map(|string| string.into_string()),
             link: element.get_link().is_some(),
             namespace: (*element.get_namespace()).clone(),
             common_style_affecting_attributes:

--- a/components/layout/layout_debug.rs
+++ b/components/layout/layout_debug.rs
@@ -104,7 +104,7 @@ pub fn begin_trace(flow_root: FlowRef) {
 
     let flow_trace = json::encode(&flow::base(flow_root.deref()));
     let state = State {
-        scope_stack: vec![box ScopeData::new("root".to_string(), flow_trace)],
+        scope_stack: vec![box ScopeData::new("root".into_string(), flow_trace)],
         flow_root: flow_root,
     };
     state_key.replace(Some(RefCell::new(state)));

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -495,7 +495,7 @@ impl LayoutTask {
         // GWTODO: Need to handle unloading web fonts (when we handle unloading stylesheets!)
         let mut rw_data = self.lock_rw_data(possibly_locked_rw_data);
         iter_font_face_rules(&sheet, &rw_data.stylist.device, |family, src| {
-            self.font_cache_task.add_web_font(family.to_string(), (*src).clone());
+            self.font_cache_task.add_web_font(family.into_string(), (*src).clone());
         });
         rw_data.stylist.add_stylesheet(sheet);
         LayoutTask::return_rw_data(possibly_locked_rw_data, rw_data);

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -187,7 +187,7 @@ impl<'ln> TLayoutNode for LayoutNode<'ln> {
     fn text(&self) -> String {
         unsafe {
             if let Some(text) = TextCast::to_js(self.get_jsmanaged()) {
-                (*text.unsafe_get()).characterdata().data_for_layout().to_string()
+                (*text.unsafe_get()).characterdata().data_for_layout().into_string()
             } else if let Some(input) = HTMLInputElementCast::to_js(self.get_jsmanaged()) {
                 input.get_value_for_layout()
             } else if let Some(area) = HTMLTextAreaElementCast::to_js(self.get_jsmanaged()) {
@@ -634,10 +634,10 @@ fn get_content(content_list: &content::T) -> String {
             let iter = &mut value.clone().into_iter().peekable();
             match iter.next() {
                 Some(content::StringContent(content)) => content,
-                _ => "".to_string(),
+                _ => "".into_string(),
             }
         }
-        _ => "".to_string(),
+        _ => "".into_string(),
     }
 }
 

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -42,5 +42,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box lints::TransmutePass as LintPassObject);
     reg.register_lint_pass(box lints::UnrootedPass as LintPassObject);
     reg.register_lint_pass(box lints::PrivatizePass as LintPassObject);
+    reg.register_lint_pass(box lints::StrToStringPass as LintPassObject);
 }
 

--- a/components/plugins/lints.rs
+++ b/components/plugins/lints.rs
@@ -17,6 +17,9 @@ declare_lint!(UNROOTED_MUST_ROOT, Deny,
               "Warn and report usage of unrooted jsmanaged objects")
 declare_lint!(PRIVATIZE, Deny,
               "Allows to enforce private fields for struct definitions")
+declare_lint!(STR_TO_STRING, Warn,
+              "Warn when a String could use into_string() instead of to_string()")
+
 
 /// Lint for auditing transmutes
 ///
@@ -40,6 +43,12 @@ pub struct UnrootedPass;
 ///
 /// This lint (disable with `-A privatize`/`#[allow(privatize)]`) ensures all types marked with `#[privatize]` have no private fields
 pub struct PrivatizePass;
+
+/// Prefer str.into_string() over str.to_string()
+///
+/// The latter creates a `Formatter` and is 5x slower than the former
+pub struct StrToStringPass;
+
 
 impl LintPass for TransmutePass {
     fn get_lints(&self) -> LintArray {
@@ -247,6 +256,37 @@ impl LintPass for PrivatizePass {
                     }
                     _ => {}
                 }
+            }
+        }
+    }
+}
+
+impl LintPass for StrToStringPass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(STR_TO_STRING)
+    }
+
+    fn check_expr(&mut self, cx: &Context, expr: &ast::Expr) {
+        match expr.node {
+            ast::ExprMethodCall(ref method, _, ref args)
+                if method.node.as_str() == "to_string"
+                && is_str(cx, &*args[0]) => {
+                cx.span_lint(STR_TO_STRING, expr.span,
+                             "str.into_string() is more efficient than str.to_string(), please use it instead");
+            },
+            _ => ()
+        }
+
+        fn is_str(cx: &Context, expr: &ast::Expr) -> bool {
+            fn walk_ty<'t>(ty: ty::t) -> ty::t {
+                match ty::get(ty).sty {
+                    ty::ty_ptr(ref tm) | ty::ty_rptr(_, ref tm) => walk_ty(tm.ty),
+                    _ => ty
+                }
+            }
+            match ty::get(walk_ty(expr_ty(cx.tcx, expr))).sty {
+                ty::ty_str => true,
+                _ => false
             }
         }
     }

--- a/components/plugins/lints.rs
+++ b/components/plugins/lints.rs
@@ -17,7 +17,7 @@ declare_lint!(UNROOTED_MUST_ROOT, Deny,
               "Warn and report usage of unrooted jsmanaged objects")
 declare_lint!(PRIVATIZE, Deny,
               "Allows to enforce private fields for struct definitions")
-declare_lint!(STR_TO_STRING, Warn,
+declare_lint!(STR_TO_STRING, Deny,
               "Warn when a String could use into_string() instead of to_string()")
 
 

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -44,7 +44,7 @@ pub trait Activatable : Copy {
         // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-synthetic-mouse-event
         let win = window_from_node(*element).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(*element);
-        let mouse = MouseEvent::new(*win, "click".to_string(), false, false, Some(*win), 1,
+        let mouse = MouseEvent::new(*win, "click".into_string(), false, false, Some(*win), 1,
                                     0, 0, 0, 0, ctrlKey, shiftKey, altKey, metaKey,
                                     0, None).root();
         let event: JSRef<Event> = EventCast::from_ref(*mouse);

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -131,11 +131,11 @@ impl Attr {
 
 impl<'a> AttrMethods for JSRef<'a, Attr> {
     fn LocalName(self) -> DOMString {
-        self.local_name().as_slice().to_string()
+        self.local_name().as_slice().into_string()
     }
 
     fn Value(self) -> DOMString {
-        self.value().as_slice().to_string()
+        self.value().as_slice().into_string()
     }
 
     fn SetValue(self, value: DOMString) {
@@ -168,14 +168,14 @@ impl<'a> AttrMethods for JSRef<'a, Attr> {
     }
 
     fn Name(self) -> DOMString {
-        self.name.as_slice().to_string()
+        self.name.as_slice().into_string()
     }
 
     fn GetNamespaceURI(self) -> Option<DOMString> {
         let Namespace(ref atom) = self.namespace;
         match atom.as_slice() {
             "" => None,
-            url => Some(url.to_string()),
+            url => Some(url.into_string()),
         }
     }
 
@@ -230,7 +230,7 @@ impl<'a> AttrHelpers<'a> for JSRef<'a, Attr> {
     fn summarize(self) -> AttrInfo {
         let Namespace(ref ns) = self.namespace;
         AttrInfo {
-            namespace: ns.as_slice().to_string(),
+            namespace: ns.as_slice().into_string(),
             name: self.Name(),
             value: self.Value(),
         }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -683,7 +683,7 @@ def getJSToNativeConversionTemplate(type, descriptorProvider, failureCode=None,
             default = "None"
         else:
             assert defaultValue.type.tag() == IDLType.Tags.domstring
-            value = "str::from_utf8(data).unwrap().to_string()"
+            value = "str::from_utf8(data).unwrap().into_string()"
             if type.nullable():
                 value = "Some(%s)" % value
 
@@ -2772,7 +2772,7 @@ pub const strings: &'static [&'static str] = &[
 
 impl ToJSValConvertible for super::%s {
   fn to_jsval(&self, cx: *mut JSContext) -> JSVal {
-    strings[*self as uint].to_string().to_jsval(cx)
+    strings[*self as uint].into_string().to_jsval(cx)
   }
 }
 """ % (",\n  ".join(['"%s"' % val for val in enum.values()]), enum.identifier.name)

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -284,7 +284,7 @@ pub fn jsid_to_str(cx: *mut JSContext, id: jsid) -> DOMString {
 impl FromJSValConvertible<StringificationBehavior> for DOMString {
     fn from_jsval(cx: *mut JSContext, value: JSVal, nullBehavior: StringificationBehavior) -> Result<DOMString, ()> {
         if nullBehavior == StringificationBehavior::Empty && value.is_null() {
-            Ok("".to_string())
+            Ok("".into_string())
         } else {
             let jsstr = unsafe { JS_ValueToString(cx, value) };
             if jsstr.is_null() {

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -152,6 +152,6 @@ impl Hash for ByteString {
 
 impl FromStr for ByteString {
     fn from_str(s: &str) -> Option<ByteString> {
-        Some(ByteString::new(s.to_string().into_bytes()))
+        Some(ByteString::new(s.into_string().into_bytes()))
     }
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -36,7 +36,7 @@ impl Blob {
             reflector_: Reflector::new(),
             type_: type_,
             bytes: bytes,
-            typeString: "".to_string(),
+            typeString: "".into_string(),
             global: GlobalField::from_rooted(global)
             //isClosed_: false
         }
@@ -97,7 +97,7 @@ impl<'a> BlobMethods for JSRef<'a, Blob> {
         };
         /*
         let relativeContentType = match contentType {
-            None => "".to_string(),
+            None => "".into_string(),
             Some(str) => str
         };
         */

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -81,7 +81,7 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
     }
 
     fn SubstringData(self, offset: u32, count: u32) -> Fallible<DOMString> {
-        Ok(self.data.borrow().as_slice().slice(offset as uint, count as uint).to_string())
+        Ok(self.data.borrow().as_slice().slice(offset as uint, count as uint).into_string())
     }
 
     fn AppendData(self, arg: DOMString) -> ErrorResult {
@@ -94,7 +94,7 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
     }
 
     fn DeleteData(self, offset: u32, count: u32) -> ErrorResult {
-        self.ReplaceData(offset, count, "".to_string())
+        self.ReplaceData(offset, count, "".into_string())
     }
 
     fn ReplaceData(self, offset: u32, count: u32, arg: DOMString) -> ErrorResult {
@@ -107,7 +107,7 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
         } else {
             count
         };
-        let mut data = self.data.borrow().as_slice().slice(0, offset as uint).to_string();
+        let mut data = self.data.borrow().as_slice().slice(0, offset as uint).into_string();
         data.push_str(arg.as_slice());
         data.push_str(self.data.borrow().as_slice().slice((offset + count) as uint, length as uint));
         *self.data.borrow_mut() = data;

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -83,12 +83,12 @@ pub fn create_element(name: QualName, prefix: Option<DOMString>,
                       document: JSRef<Document>, creator: ElementCreator)
                       -> Temporary<Element> {
     if name.ns != ns!(HTML) {
-        return Element::new(name.local.as_slice().to_string(), name.ns, prefix, document);
+        return Element::new(name.local.as_slice().into_string(), name.ns, prefix, document);
     }
 
     macro_rules! make(
         ($ctor:ident $(, $arg:expr)*) => ({
-            let obj = $ctor::new(name.local.as_slice().to_string(), prefix, document $(, $arg)*);
+            let obj = $ctor::new(name.local.as_slice().into_string(), prefix, document $(, $arg)*);
             ElementCast::from_temporary(obj)
         })
     )

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -339,7 +339,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         self.ready_state.set(state);
 
         let window = self.window.root();
-        let event = Event::new(global::Window(*window), "readystatechange".to_string(),
+        let event = Event::new(global::Window(*window), "readystatechange".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
@@ -425,9 +425,9 @@ impl Document {
                 Some(string) => string.clone(),
                 None => match is_html_document {
                     // http://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-                    IsHTMLDocument::HTMLDocument => "text/html".to_string(),
+                    IsHTMLDocument::HTMLDocument => "text/html".into_string(),
                     // http://dom.spec.whatwg.org/#concept-document-content-type
-                    IsHTMLDocument::NonHTMLDocument => "application/xml".to_string()
+                    IsHTMLDocument::NonHTMLDocument => "application/xml".into_string()
                 }
             },
             last_modified: DOMRefCell::new(None),
@@ -435,7 +435,7 @@ impl Document {
             // http://dom.spec.whatwg.org/#concept-document-quirks
             quirks_mode: Cell::new(NoQuirks),
             // http://dom.spec.whatwg.org/#concept-document-encoding
-            encoding_name: DOMRefCell::new("UTF-8".to_string()),
+            encoding_name: DOMRefCell::new("UTF-8".into_string()),
             is_html_document: is_html_document == IsHTMLDocument::HTMLDocument,
             images: Default::default(),
             embeds: Default::default(),
@@ -523,8 +523,8 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     // http://dom.spec.whatwg.org/#dom-document-compatmode
     fn CompatMode(self) -> DOMString {
         match self.quirks_mode.get() {
-            LimitedQuirks | NoQuirks => "CSS1Compat".to_string(),
-            Quirks => "BackCompat".to_string()
+            LimitedQuirks | NoQuirks => "CSS1Compat".into_string(),
+            Quirks => "BackCompat".into_string()
         }
     }
 
@@ -642,7 +642,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         }
 
         let name = QualName::new(ns, Atom::from_slice(local_name_from_qname));
-        Ok(Element::create(name, prefix_from_qname.map(|s| s.to_string()), self,
+        Ok(Element::create(name, prefix_from_qname.map(|s| s.into_string()), self,
                            ElementCreator::ScriptCreated))
     }
 
@@ -657,7 +657,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         let name = Atom::from_slice(local_name.as_slice());
         // repetition used because string_cache::atom::Atom is non-copyable
         let l_name = Atom::from_slice(local_name.as_slice());
-        let value = AttrValue::String("".to_string());
+        let value = AttrValue::String("".into_string());
 
         Ok(Attr::new(*window, name, value, l_name, ns!(""), None, None))
     }
@@ -805,7 +805,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                         }
                     },
                     None => {
-                        let new_title = HTMLTitleElement::new("title".to_string(), None, self).root();
+                        let new_title = HTMLTitleElement::new("title".into_string(), None, self).root();
                         let new_title: JSRef<Node> = NodeCast::from_ref(*new_title);
 
                         if !title.is_empty() {

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -36,8 +36,8 @@ impl DocumentType {
         DocumentType {
             node: Node::new_inherited(NodeTypeId::DocumentType, document),
             name: name,
-            public_id: public_id.unwrap_or("".to_string()),
-            system_id: system_id.unwrap_or("".to_string())
+            public_id: public_id.unwrap_or("".into_string()),
+            system_id: system_id.unwrap_or("".into_string())
         }
     }
     #[allow(unrooted_must_root)]

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -130,6 +130,6 @@ impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
             DOMErrorName::EncodingError => "The encoding operation (either encoded or decoding) failed."
         };
 
-        message.to_string()
+        message.into_string()
     }
 }

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -129,18 +129,18 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
 
         {
             // Step 3.
-            let doc_type = DocumentType::new("html".to_string(), None, None, *doc).root();
+            let doc_type = DocumentType::new("html".into_string(), None, None, *doc).root();
             assert!(doc_node.AppendChild(NodeCast::from_ref(*doc_type)).is_ok());
         }
 
         {
             // Step 4.
-            let doc_html: Root<Node> = NodeCast::from_temporary(HTMLHtmlElement::new("html".to_string(), None, *doc)).root();
+            let doc_html: Root<Node> = NodeCast::from_temporary(HTMLHtmlElement::new("html".into_string(), None, *doc)).root();
             assert!(doc_node.AppendChild(*doc_html).is_ok());
 
             {
                 // Step 5.
-                let doc_head: Root<Node> = NodeCast::from_temporary(HTMLHeadElement::new("head".to_string(), None, *doc)).root();
+                let doc_head: Root<Node> = NodeCast::from_temporary(HTMLHeadElement::new("head".into_string(), None, *doc)).root();
                 assert!(doc_html.AppendChild(*doc_head).is_ok());
 
                 // Step 6.
@@ -148,7 +148,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
                     None => (),
                     Some(title_str) => {
                         // Step 6.1.
-                        let doc_title: Root<Node> = NodeCast::from_temporary(HTMLTitleElement::new("title".to_string(), None, *doc)).root();
+                        let doc_title: Root<Node> = NodeCast::from_temporary(HTMLTitleElement::new("title".into_string(), None, *doc)).root();
                         assert!(doc_head.AppendChild(*doc_title).is_ok());
 
                         // Step 6.2.
@@ -159,7 +159,7 @@ impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
             }
 
             // Step 7.
-            let doc_body: Root<HTMLBodyElement> = HTMLBodyElement::new("body".to_string(), None, *doc).root();
+            let doc_body: Root<HTMLBodyElement> = HTMLBodyElement::new("body".into_string(), None, *doc).root();
             assert!(doc_html.AppendChild(NodeCast::from_ref(*doc_body)).is_ok());
         }
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -50,7 +50,7 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
                        -> Fallible<Temporary<Document>> {
         let window = self.window.root().clone();
         let url = window.get_url();
-        let content_type = DOMParserBinding::SupportedTypeValues::strings[ty as uint].to_string();
+        let content_type = DOMParserBinding::SupportedTypeValues::strings[ty as uint].into_string();
         match ty {
             Text_html => {
                 let document = Document::new(window, Some(url.clone()),

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -78,7 +78,7 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     // http://dom.spec.whatwg.org/#dom-domtokenlist-item
     fn Item(self, index: u32) -> Option<DOMString> {
         self.attribute().root().and_then(|attr| attr.value().tokens().and_then(|tokens| {
-            tokens.get(index as uint).map(|token| token.as_slice().to_string())
+            tokens.get(index as uint).map(|token| token.as_slice().into_string())
         }))
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -701,7 +701,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
     fn get_url_attribute(self, name: &Atom) -> DOMString {
         assert!(name.as_slice() == name.as_slice().to_ascii_lower().as_slice());
         if !self.has_attribute(name) {
-            return "".to_string();
+            return "".into_string();
         }
         let url = self.get_string_attribute(name);
         let doc = document_from_node(self).root();
@@ -710,7 +710,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
         // XXXManishearth this doesn't handle `javascript:` urls properly
         match UrlParser::new().base_url(base).parse(url.as_slice()) {
             Ok(parsed) => parsed.serialize(),
-            Err(_) => "".to_string()
+            Err(_) => "".into_string()
         }
     }
     fn set_url_attribute(self, name: &Atom, value: DOMString) {
@@ -720,7 +720,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
     fn get_string_attribute(self, name: &Atom) -> DOMString {
         match self.get_attribute(ns!(""), name) {
             Some(x) => x.root().Value(),
-            None => "".to_string()
+            None => "".into_string()
         }
     }
     fn set_string_attribute(self, name: &Atom, value: DOMString) {
@@ -760,12 +760,12 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
     fn GetNamespaceURI(self) -> Option<DOMString> {
         match self.namespace {
             ns!("") => None,
-            Namespace(ref ns) => Some(ns.as_slice().to_string())
+            Namespace(ref ns) => Some(ns.as_slice().into_string())
         }
     }
 
     fn LocalName(self) -> DOMString {
-        self.local_name.as_slice().to_string()
+        self.local_name.as_slice().into_string()
     }
 
     // http://dom.spec.whatwg.org/#dom-element-prefix
@@ -929,7 +929,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         // Step 9.
         let value = self.parse_attribute(&namespace, &local_name, value);
         self.do_set_attribute(local_name.clone(), value, name,
-                              namespace.clone(), prefix.map(|s| s.to_string()),
+                              namespace.clone(), prefix.map(|s| s.into_string()),
                               |attr| {
             *attr.local_name() == local_name &&
             *attr.namespace() == namespace

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -40,8 +40,8 @@ impl ErrorEvent {
     fn new_inherited(type_id: EventTypeId) -> ErrorEvent {
         ErrorEvent {
             event: Event::new_inherited(type_id),
-            message: DOMRefCell::new("".to_string()),
-            filename: DOMRefCell::new("".to_string()),
+            message: DOMRefCell::new("".into_string()),
+            filename: DOMRefCell::new("".into_string()),
             lineno: Cell::new(0),
             colno: Cell::new(0),
             error: Cell::new(NullValue())
@@ -80,7 +80,7 @@ impl ErrorEvent {
                        init: &ErrorEventBinding::ErrorEventInit) -> Fallible<Temporary<ErrorEvent>>{
         let msg = match init.message.as_ref() {
             Some(message) => message.clone(),
-            None => "".to_string(),
+            None => "".into_string(),
         };
 
         let file_name = match init.filename.as_ref() {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -76,7 +76,7 @@ impl Event {
             current_target: Default::default(),
             target: Default::default(),
             phase: Cell::new(EventPhase::None),
-            type_: DOMRefCell::new("".to_string()),
+            type_: DOMRefCell::new("".into_string()),
             canceled: Cell::new(false),
             cancelable: Cell::new(false),
             bubbles: Cell::new(false),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -230,11 +230,11 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
     {
         let event_listener = listener.map(|listener|
                                           EventListener::new(listener.callback()));
-        self.set_inline_event_listener(ty.to_string(), event_listener);
+        self.set_inline_event_listener(ty.into_string(), event_listener);
     }
 
     fn get_event_handler_common<T: CallbackContainer>(self, ty: &str) -> Option<T> {
-        let listener = self.get_inline_event_listener(ty.to_string());
+        let listener = self.get_inline_event_listener(ty.into_string());
         listener.map(|listener| CallbackContainer::new(listener.parent.callback()))
     }
 

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -121,7 +121,7 @@ impl PrivateFormDataHelpers for FormData {
     fn get_file_from_blob(&self, value: JSRef<Blob>, filename: Option<DOMString>) -> Temporary<File> {
         let global = self.global.root();
         let f: Option<JSRef<File>> = FileCast::to_ref(value);
-        let name = filename.unwrap_or(f.map(|inner| inner.name().clone()).unwrap_or("blob".to_string()));
+        let name = filename.unwrap_or(f.map(|inner| inner.name().clone()).unwrap_or("blob".into_string()));
         File::new(&global.root_ref(), value, name)
     }
 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -106,7 +106,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
                 };
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.slice_from(2),
-                                                  attr.value().as_slice().to_string());
+                                                  attr.value().as_slice().into_string());
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -66,7 +66,7 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
         // https://html.spec.whatwg.org/multipage/forms.html#attr-button-type
         match ty.as_slice() {
             "reset" | "button" | "menu" => ty,
-            _ => "submit".to_string()
+            _ => "submit".into_string()
         }
     }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -127,7 +127,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
             let evtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.slice_from(2),
-                                                  attr.value().as_slice().to_string());
+                                                  attr.value().as_slice().into_string());
         }
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -158,7 +158,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         // TODO: Handle browsing contexts
         // TODO: Handle validation
         let event = Event::new(Window(*win),
-                               "submit".to_string(),
+                               "submit".into_string(),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable).root();
         event.set_trusted(true);
@@ -186,7 +186,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
 
         let parsed_data = match enctype {
             FormEncType::UrlEncoded => serialize(form_data.iter().map(|d| (d.name.as_slice(), d.value.as_slice()))),
-            _ => "".to_string() // TODO: Add serializers for the other encoding types
+            _ => "".into_string() // TODO: Add serializers for the other encoding types
         };
 
         let mut load_data = LoadData::new(action_components);
@@ -214,7 +214,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         fn clean_crlf(s: &str) -> DOMString {
             // https://html.spec.whatwg.org/multipage/forms.html#constructing-the-form-data-set
             // Step 4
-            let mut buf = "".to_string();
+            let mut buf = "".into_string();
             let mut prev = ' ';
             for ch in s.chars() {
                 match ch {
@@ -284,7 +284,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
                         "image" => None, // Unimplemented
                         "radio" | "checkbox" => {
                             if value.is_empty() {
-                                value = "on".to_string();
+                                value = "on".into_string();
                             }
                             Some(FormDatum {
                                 ty: ty,
@@ -346,7 +346,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
 
         let win = window_from_node(self).root();
         let event = Event::new(Window(*win),
-                               "reset".to_string(),
+                               "reset".into_string(),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
@@ -516,7 +516,7 @@ pub trait FormControl<'a> : Copy {
         if self.to_element().has_attribute(attr) {
             input(self)
         } else {
-            self.form_owner().map_or("".to_string(), |t| owner(*t.root()))
+            self.form_owner().map_or("".into_string(), |t| owner(*t.root()))
         }
     }
     fn to_element(self) -> JSRef<'a, Element>;

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -188,7 +188,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
             &atom!("src") => {
                 let window = window_from_node(*self).root();
                 let url = window.get_url();
-                self.update_image(Some((attr.value().as_slice().to_string(), &url)));
+                self.update_image(Some((attr.value().as_slice().into_string(), &url)));
             },
             _ => ()
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -116,7 +116,7 @@ impl HTMLInputElement {
             checked_changed: Cell::new(false),
             value_changed: Cell::new(false),
             size: Cell::new(DEFAULT_INPUT_SIZE),
-            textinput: DOMRefCell::new(TextInput::new(Single, "".to_string())),
+            textinput: DOMRefCell::new(TextInput::new(Single, "".into_string())),
             activation_state: DOMRefCell::new(InputActivationState::new())
         }
     }
@@ -149,15 +149,15 @@ impl LayoutHTMLInputElementHelpers for JS<HTMLInputElement> {
         unsafe fn get_raw_attr_value(input: JS<HTMLInputElement>) -> Option<String> {
             let elem: JS<Element> = input.transmute_copy();
             (*elem.unsafe_get()).get_attr_val_for_layout(&ns!(""), &atom!("value"))
-                                .map(|s| s.to_string())
+                                .map(|s| s.into_string())
         }
 
         match (*self.unsafe_get()).input_type.get() {
-            InputType::InputCheckbox | InputType::InputRadio => "".to_string(),
-            InputType::InputFile | InputType::InputImage => "".to_string(),
-            InputType::InputButton => get_raw_attr_value(self).unwrap_or_else(|| "".to_string()),
-            InputType::InputSubmit => get_raw_attr_value(self).unwrap_or_else(|| DEFAULT_SUBMIT_VALUE.to_string()),
-            InputType::InputReset => get_raw_attr_value(self).unwrap_or_else(|| DEFAULT_RESET_VALUE.to_string()),
+            InputType::InputCheckbox | InputType::InputRadio => "".into_string(),
+            InputType::InputFile | InputType::InputImage => "".into_string(),
+            InputType::InputButton => get_raw_attr_value(self).unwrap_or_else(|| "".into_string()),
+            InputType::InputSubmit => get_raw_attr_value(self).unwrap_or_else(|| DEFAULT_SUBMIT_VALUE.into_string()),
+            InputType::InputReset => get_raw_attr_value(self).unwrap_or_else(|| DEFAULT_RESET_VALUE.into_string()),
             InputType::InputPassword => {
                 let raw = get_raw_textinput_value(self);
                 String::from_char(raw.char_len(), '●')
@@ -312,7 +312,7 @@ fn broadcast_radio_checked(broadcaster: JSRef<HTMLInputElement>, group: Option<&
 
     // There is no DOM tree manipulation here, so this is safe
     let mut iter = unsafe {
-        doc_node.query_selector_iter("input[type=radio]".to_string()).unwrap()
+        doc_node.query_selector_iter("input[type=radio]".into_string()).unwrap()
                 .filter_map(|t| HTMLInputElementCast::to_ref(t))
                 .filter(|&r| in_same_group(r, owner.root_ref(), group) && broadcaster != r)
     };
@@ -438,7 +438,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             }
             &atom!("value") => {
                 if !self.value_changed.get() {
-                    self.textinput.borrow_mut().set_content(attr.value().as_slice().to_string());
+                    self.textinput.borrow_mut().set_content(attr.value().as_slice().into_string());
                     self.force_relayout();
                 }
             }
@@ -487,7 +487,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             }
             &atom!("value") => {
                 if !self.value_changed.get() {
-                    self.textinput.borrow_mut().set_content("".to_string());
+                    self.textinput.borrow_mut().set_content("".into_string());
                     self.force_relayout();
                 }
             }
@@ -643,7 +643,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
 
                     // Safe since we only manipulate the DOM tree after finding an element
                     let checked_member = unsafe {
-                        doc_node.query_selector_iter("input[type=radio]".to_string()).unwrap()
+                        doc_node.query_selector_iter("input[type=radio]".into_string()).unwrap()
                                 .filter_map(|t| HTMLInputElementCast::to_ref(t))
                                 .filter(|&r| in_same_group(r, owner.root_ref(),
                                                            group.as_ref().map(|gr| gr.as_slice())))
@@ -743,7 +743,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                 if self.mutable() {
                     let win = window_from_node(*self).root();
                     let event = Event::new(Window(*win),
-                                           "input".to_string(),
+                                           "input".into_string(),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable).root();
                     event.set_trusted(true);
@@ -751,7 +751,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                     target.DispatchEvent(*event).ok();
 
                     let event = Event::new(Window(*win),
-                                           "change".to_string(),
+                                           "change".into_string(),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable).root();
                     event.set_trusted(true);
@@ -774,7 +774,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         // This is safe because we are stopping after finding the first element
         // and only then performing actions which may modify the DOM tree
         unsafe {
-            node.query_selector_iter("input[type=submit]".to_string()).unwrap()
+            node.query_selector_iter("input[type=submit]".into_string()).unwrap()
                 .filter_map(|t| HTMLInputElementCast::to_ref(t))
                 .find(|r| r.form_owner() == owner)
                 .map(|s| s.synthetic_click_activation(ctrlKey, shiftKey, altKey, metaKey));

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -54,7 +54,7 @@ impl HTMLLinkElement {
 
 fn get_attr(element: JSRef<Element>, name: &Atom) -> Option<String> {
     let elem = element.get_attribute(ns!(""), name).root();
-    elem.map(|e| e.value().as_slice().to_string())
+    elem.map(|e| e.value().as_slice().into_string())
 }
 
 fn is_stylesheet(value: &Option<String>) -> bool {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -68,9 +68,9 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
     fn Type(self) -> DOMString {
         let elem: JSRef<Element> = ElementCast::from_ref(self);
         if elem.has_attribute(&atom!("multiple")) {
-            "select-multiple".to_string()
+            "select-multiple".into_string()
         } else {
-            "select-one".to_string()
+            "select-one".into_string()
         }
     }
 }

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -126,7 +126,7 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
     }
 
     if !(elem.is_void()) {
-        open_elements.push(elem.local_name().as_slice().to_string());
+        open_elements.push(elem.local_name().as_slice().into_string());
     }
 }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -83,7 +83,7 @@ impl HTMLTextAreaElement {
     fn new_inherited(localName: DOMString, prefix: Option<DOMString>, document: JSRef<Document>) -> HTMLTextAreaElement {
         HTMLTextAreaElement {
             htmlelement: HTMLElement::new_inherited(ElementTypeId::HTMLTextAreaElement, localName, prefix, document),
-            textinput: DOMRefCell::new(TextInput::new(Lines::Multiple, "".to_string())),
+            textinput: DOMRefCell::new(TextInput::new(Lines::Multiple, "".into_string())),
             cols: Cell::new(DEFAULT_COLS),
             rows: Cell::new(DEFAULT_ROWS),
             value_changed: Cell::new(false),
@@ -151,7 +151,7 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-type
     fn Type(self) -> DOMString {
-        "textarea".to_string()
+        "textarea".into_string()
     }
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-defaultvalue

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -45,8 +45,8 @@ impl KeyboardEvent {
     fn new_inherited() -> KeyboardEvent {
         KeyboardEvent {
             uievent: UIEvent::new_inherited(EventTypeId::KeyboardEvent),
-            key: RefCell::new("".to_string()),
-            code: RefCell::new("".to_string()),
+            key: RefCell::new("".into_string()),
+            code: RefCell::new("".into_string()),
             location: Cell::new(0),
             ctrl: Cell::new(false),
             alt: Cell::new(false),
@@ -84,7 +84,7 @@ impl KeyboardEvent {
                key_code: u32) -> Temporary<KeyboardEvent> {
         let ev = KeyboardEvent::new_uninitialized(window).root();
         ev.deref().InitKeyboardEvent(type_, canBubble, cancelable, view, key, location,
-                                     "".to_string(), repeat, "".to_string());
+                                     "".into_string(), repeat, "".into_string());
         *ev.code.borrow_mut() = code;
         ev.ctrl.set(ctrlKey);
         ev.alt.set(altKey);

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -112,7 +112,7 @@ macro_rules! make_enumerated_getter(
             // https://html.spec.whatwg.org/multipage/forms.html#attr-fs-method
             match val.as_slice() {
                 $($choices)|+ => val,
-                _ => $default.to_string()
+                _ => $default.into_string()
             }
         }
     );

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -44,7 +44,7 @@ impl MessageEvent {
     }
 
     pub fn new_uninitialized(global: GlobalRef) -> Temporary<MessageEvent> {
-        MessageEvent::new_initialized(global, UndefinedValue(), "".to_string(), "".to_string())
+        MessageEvent::new_initialized(global, UndefinedValue(), "".into_string(), "".into_string())
     }
 
     pub fn new_initialized(global: GlobalRef, data: JSVal, origin: DOMString, lastEventId: DOMString) -> Temporary<MessageEvent> {
@@ -78,8 +78,8 @@ impl MessageEvent {
                           scope: GlobalRef,
                           message: JSVal) {
         let messageevent = MessageEvent::new(
-            scope, "message".to_string(), false, false, message,
-            "".to_string(), "".to_string()).root();
+            scope, "message".into_string(), false, false, message,
+            "".into_string(), "".into_string()).root();
         let event: JSRef<Event> = EventCast::from_ref(*messageevent);
         target.dispatch_event(event);
     }

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -9,7 +9,7 @@ pub struct NavigatorInfo;
 
 impl NavigatorInfo {
     pub fn Product() -> DOMString {
-        "Gecko".to_string()
+        "Gecko".into_string()
     }
 
     pub fn TaintEnabled() -> bool {
@@ -17,21 +17,21 @@ impl NavigatorInfo {
     }
 
     pub fn AppName() -> DOMString {
-        "Netscape".to_string() // Like Gecko/Webkit
+        "Netscape".into_string() // Like Gecko/Webkit
     }
 
     pub fn AppCodeName() -> DOMString {
-        "Mozilla".to_string()
+        "Mozilla".into_string()
     }
 
     pub fn Platform() -> DOMString {
-        "".to_string()
+        "".into_string()
     }
 
     pub fn UserAgent() -> DOMString {
         match opts::get().user_agent {
             Some(ref user_agent) => user_agent.clone(),
-            None => "".to_string(),
+            None => "".into_string(),
         }
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -844,17 +844,17 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
 
         NodeInfo {
             uniqueId: self.unique_id.borrow().clone(),
-            baseURI: self.GetBaseURI().unwrap_or("".to_string()),
-            parent: self.GetParentNode().root().map(|node| node.get_unique_id()).unwrap_or("".to_string()),
+            baseURI: self.GetBaseURI().unwrap_or("".into_string()),
+            parent: self.GetParentNode().root().map(|node| node.get_unique_id()).unwrap_or("".into_string()),
             nodeType: self.NodeType() as uint,
-            namespaceURI: "".to_string(), //FIXME
+            namespaceURI: "".into_string(), //FIXME
             nodeName: self.NodeName(),
             numChildren: self.ChildNodes().root().Length() as uint,
 
             //FIXME doctype nodes only
-            name: "".to_string(),
-            publicId: "".to_string(),
-            systemId: "".to_string(),
+            name: "".into_string(),
+            publicId: "".into_string(),
+            systemId: "".into_string(),
 
             attrs: match ElementCast::to_ref(self) {
                 Some(element) => element.summarize(),
@@ -867,7 +867,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
                     .map(|elem| NodeCast::from_ref(*elem.root()) == self)
                     .unwrap_or(false),
 
-            shortValue: self.GetNodeValue().unwrap_or("".to_string()), //FIXME: truncate
+            shortValue: self.GetNodeValue().unwrap_or("".into_string()), //FIXME: truncate
             incompleteValue: false, //FIXME: reflect truncation
         }
     }
@@ -1552,7 +1552,7 @@ impl Node {
                     local: element.local_name().clone()
                 };
                 let element = Element::create(name,
-                    element.prefix().as_ref().map(|p| p.as_slice().to_string()),
+                    element.prefix().as_ref().map(|p| p.as_slice().into_string()),
                     *document, ElementCreator::ScriptCreated);
                 NodeCast::from_temporary(element)
             },
@@ -1665,19 +1665,19 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 let elem: JSRef<Element> = ElementCast::to_ref(self).unwrap();
                 elem.TagName()
             }
-            NodeTypeId::Text => "#text".to_string(),
+            NodeTypeId::Text => "#text".into_string(),
             NodeTypeId::ProcessingInstruction => {
                 let processing_instruction: JSRef<ProcessingInstruction> =
                     ProcessingInstructionCast::to_ref(self).unwrap();
                 processing_instruction.Target()
             }
-            NodeTypeId::Comment => "#comment".to_string(),
+            NodeTypeId::Comment => "#comment".into_string(),
             NodeTypeId::DocumentType => {
                 let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(self).unwrap();
                 doctype.name().clone()
             },
-            NodeTypeId::DocumentFragment => "#document-fragment".to_string(),
-            NodeTypeId::Document => "#document".to_string()
+            NodeTypeId::DocumentFragment => "#document-fragment".into_string(),
+            NodeTypeId::Document => "#document".into_string()
         }
     }
 

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -51,7 +51,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn SetFloatAttribute(self, _: f32) {}
     fn DoubleAttribute(self) -> f64 { 0. }
     fn SetDoubleAttribute(self, _: f64) {}
-    fn StringAttribute(self) -> DOMString { "".to_string() }
+    fn StringAttribute(self) -> DOMString { "".into_string() }
     fn SetStringAttribute(self, _: DOMString) {}
     fn ByteStringAttribute(self) -> ByteString { ByteString::new(vec!()) }
     fn SetByteStringAttribute(self, _: ByteString) {}
@@ -64,7 +64,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn SetInterfaceAttribute(self, _: JSRef<Blob>) {}
     fn UnionAttribute(self) -> HTMLElementOrLong { eLong(0) }
     fn SetUnionAttribute(self, _: HTMLElementOrLong) {}
-    fn Union2Attribute(self) -> EventOrString { eString("".to_string()) }
+    fn Union2Attribute(self) -> EventOrString { eString("".into_string()) }
     fn SetUnion2Attribute(self, _: EventOrString) {}
     fn ArrayAttribute(self, _: *mut JSContext) -> *mut JSObject { NullValue().to_object_or_null() }
     fn AnyAttribute(self, _: *mut JSContext) -> JSVal { NullValue() }
@@ -94,7 +94,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn SetDoubleAttributeNullable(self, _: Option<f64>) {}
     fn GetByteStringAttributeNullable(self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
     fn SetByteStringAttributeNullable(self, _: Option<ByteString>) {}
-    fn GetStringAttributeNullable(self) -> Option<DOMString> { Some("".to_string()) }
+    fn GetStringAttributeNullable(self) -> Option<DOMString> { Some("".into_string()) }
     fn SetStringAttributeNullable(self, _: Option<DOMString>) {}
     fn GetEnumAttributeNullable(self) -> Option<TestEnum> { Some(_empty) }
     fn GetInterfaceAttributeNullable(self) -> Option<Temporary<Blob>> {
@@ -104,7 +104,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn SetInterfaceAttributeNullable(self, _: Option<JSRef<Blob>>) {}
     fn GetUnionAttributeNullable(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
     fn SetUnionAttributeNullable(self, _: Option<HTMLElementOrLong>) {}
-    fn GetUnion2AttributeNullable(self) -> Option<EventOrString> { Some(eString("".to_string())) }
+    fn GetUnion2AttributeNullable(self) -> Option<EventOrString> { Some(eString("".into_string())) }
     fn SetUnion2AttributeNullable(self, _: Option<EventOrString>) {}
     fn ReceiveVoid(self) -> () {}
     fn ReceiveBoolean(self) -> bool { false }
@@ -118,7 +118,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn ReceiveUnsignedLongLong(self) -> u64 { 0 }
     fn ReceiveFloat(self) -> f32 { 0. }
     fn ReceiveDouble(self) -> f64 { 0. }
-    fn ReceiveString(self) -> DOMString { "".to_string() }
+    fn ReceiveString(self) -> DOMString { "".into_string() }
     fn ReceiveByteString(self) -> ByteString { ByteString::new(vec!()) }
     fn ReceiveEnum(self) -> TestEnum { _empty }
     fn ReceiveInterface(self) -> Temporary<Blob> {
@@ -127,7 +127,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     }
     fn ReceiveAny(self, _: *mut JSContext) -> JSVal { NullValue() }
     fn ReceiveUnion(self) -> HTMLElementOrLong { eLong(0) }
-    fn ReceiveUnion2(self) -> EventOrString { eString("".to_string()) }
+    fn ReceiveUnion2(self) -> EventOrString { eString("".into_string()) }
 
     fn ReceiveNullableBoolean(self) -> Option<bool> { Some(false) }
     fn ReceiveNullableByte(self) -> Option<i8> { Some(0) }
@@ -140,7 +140,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn ReceiveNullableUnsignedLongLong(self) -> Option<u64> { Some(0) }
     fn ReceiveNullableFloat(self) -> Option<f32> { Some(0.) }
     fn ReceiveNullableDouble(self) -> Option<f64> { Some(0.) }
-    fn ReceiveNullableString(self) -> Option<DOMString> { Some("".to_string()) }
+    fn ReceiveNullableString(self) -> Option<DOMString> { Some("".into_string()) }
     fn ReceiveNullableByteString(self) -> Option<ByteString> { Some(ByteString::new(vec!())) }
     fn ReceiveNullableEnum(self) -> Option<TestEnum> { Some(_empty) }
     fn ReceiveNullableInterface(self) -> Option<Temporary<Blob>> {
@@ -148,7 +148,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
         Some(Blob::new(&global.root_ref(), None))
     }
     fn ReceiveNullableUnion(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
-    fn ReceiveNullableUnion2(self) -> Option<EventOrString> { Some(eString("".to_string())) }
+    fn ReceiveNullableUnion2(self) -> Option<EventOrString> { Some(eString("".into_string())) }
 
     fn PassBoolean(self, _: bool) {}
     fn PassByte(self, _: i8) {}

--- a/components/script/dom/urlhelper.rs
+++ b/components/script/dom/urlhelper.rs
@@ -14,16 +14,16 @@ impl UrlHelper {
 
     pub fn Search(url: &Url) -> DOMString {
         match url.query {
-            None => "".to_string(),
-            Some(ref query) if query.as_slice() == "" => "".to_string(),
+            None => "".into_string(),
+            Some(ref query) if query.as_slice() == "" => "".into_string(),
             Some(ref query) => format!("?{}", query)
         }
     }
 
     pub fn Hash(url: &Url) -> DOMString {
         match url.fragment {
-            None => "".to_string(),
-            Some(ref hash) if hash.as_slice() == "" => "".to_string(),
+            None => "".into_string(),
+            Some(ref hash) if hash.as_slice() == "" => "".into_string(),
             Some(ref hash) => format!("#{}", hash)
         }
     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -156,7 +156,7 @@ impl XMLHttpRequest {
             timeout: Cell::new(0u32),
             with_credentials: Cell::new(false),
             upload: JS::from_rooted(XMLHttpRequestUpload::new(*global)),
-            response_url: "".to_string(),
+            response_url: "".into_string(),
             status: Cell::new(0),
             status_text: DOMRefCell::new(ByteString::new(vec!())),
             response: DOMRefCell::new(ByteString::new(vec!())),
@@ -521,12 +521,12 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             // If one of the event handlers below aborts the fetch by calling
             // abort or open we will need the current generation id to detect it.
             let gen_id = self.generation_id.get();
-            self.dispatch_response_progress_event("loadstart".to_string());
+            self.dispatch_response_progress_event("loadstart".into_string());
             if self.generation_id.get() != gen_id {
                 return Ok(());
             }
             if !self.upload_complete.get() {
-                self.dispatch_upload_progress_event("loadstart".to_string(), Some(0));
+                self.dispatch_upload_progress_event("loadstart".into_string(), Some(0));
                 if self.generation_id.get() != gen_id {
                     return Ok(());
                 }
@@ -598,9 +598,9 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
                     buf.push_str(format!("{:u}", p).as_slice());
                 });
                 referer_url.serialize_path().map(|ref h| buf.push_str(h.as_slice()));
-                self.request_headers.borrow_mut().set_raw("Referer".to_string(), vec![buf.into_bytes()]);
+                self.request_headers.borrow_mut().set_raw("Referer".into_string(), vec![buf.into_bytes()]);
             },
-            Ok(Some(ref req)) => self.insert_trusted_header("origin".to_string(),
+            Ok(Some(ref req)) => self.insert_trusted_header("origin".into_string(),
                                                             format!("{}", req.origin)),
             _ => {}
         }
@@ -700,12 +700,12 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
                 if ready_state == XHRDone || ready_state == Loading {
                     self.text_response().to_jsval(cx)
                 } else {
-                    "".to_string().to_jsval(cx)
+                    "".into_string().to_jsval(cx)
                 }
             },
             _ if self.ready_state.get() != XHRDone => NullValue(),
             Json => {
-                let decoded = UTF_8.decode(self.response.borrow().as_slice(), DecoderTrap::Replace).unwrap().to_string();
+                let decoded = UTF_8.decode(self.response.borrow().as_slice(), DecoderTrap::Replace).unwrap().into_string();
                 let decoded: Vec<u16> = decoded.as_slice().utf16_units().collect();
                 let mut vp = UndefinedValue();
                 unsafe {
@@ -727,7 +727,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             _empty | Text => {
                 match self.ready_state.get() {
                     Loading | XHRDone => Ok(self.text_response()),
-                    _ => Ok("".to_string())
+                    _ => Ok("".into_string())
                 }
             },
             _ => Err(InvalidState)
@@ -813,7 +813,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         self.ready_state.set(rs);
         let global = self.global.root();
         let event = Event::new(global.root_ref(),
-                               "readystatechange".to_string(),
+                               "readystatechange".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::Cancelable).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
@@ -847,11 +847,11 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                 self.upload_complete.set(true);
                 // Substeps 2-4
                 if !self.sync.get() {
-                    self.dispatch_upload_progress_event("progress".to_string(), None);
+                    self.dispatch_upload_progress_event("progress".into_string(), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event("load".to_string(), None);
+                    self.dispatch_upload_progress_event("load".into_string(), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event("loadend".to_string(), None);
+                    self.dispatch_upload_progress_event("loadend".into_string(), None);
                     return_if_fetch_was_terminated!();
                 }
                 // Part of step 13, send() (processing response)
@@ -879,7 +879,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                         self.change_ready_state(Loading);
                         return_if_fetch_was_terminated!();
                     }
-                    self.dispatch_response_progress_event("progress".to_string());
+                    self.dispatch_response_progress_event("progress".into_string());
                 }
             },
             DoneMsg(_) => {
@@ -895,11 +895,11 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                 self.change_ready_state(XHRDone);
                 return_if_fetch_was_terminated!();
                 // Subsubsteps 10-12
-                self.dispatch_response_progress_event("progress".to_string());
+                self.dispatch_response_progress_event("progress".into_string());
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event("load".to_string());
+                self.dispatch_response_progress_event("load".into_string());
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event("loadend".to_string());
+                self.dispatch_response_progress_event("loadend".into_string());
             },
             ErroredMsg(_, e) => {
                 self.send_flag.set(false);
@@ -916,18 +916,18 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                 let upload_complete: &Cell<bool> = &self.upload_complete;
                 if !upload_complete.get() {
                     upload_complete.set(true);
-                    self.dispatch_upload_progress_event("progress".to_string(), None);
+                    self.dispatch_upload_progress_event("progress".into_string(), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event(errormsg.to_string(), None);
+                    self.dispatch_upload_progress_event(errormsg.into_string(), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event("loadend".to_string(), None);
+                    self.dispatch_upload_progress_event("loadend".into_string(), None);
                     return_if_fetch_was_terminated!();
                 }
-                self.dispatch_response_progress_event("progress".to_string());
+                self.dispatch_response_progress_event("progress".into_string());
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event(errormsg.to_string());
+                self.dispatch_response_progress_event(errormsg.into_string());
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event("loadend".to_string());
+                self.dispatch_response_progress_event("loadend".into_string());
             }
         }
     }
@@ -1013,7 +1013,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
 
         // According to Simon, decode() should never return an error, so unwrap()ing
         // the result should be fine. XXXManishearth have a closer look at this later
-        encoding.decode(self.response.borrow().as_slice(), DecoderTrap::Replace).unwrap().to_string()
+        encoding.decode(self.response.borrow().as_slice(), DecoderTrap::Replace).unwrap().into_string()
     }
     fn filter_response_headers(self) -> Headers {
         // http://fetch.spec.whatwg.org/#concept-response-header-list

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -811,7 +811,7 @@ impl ScriptTask {
             let jsval = window.evaluate_js_with_result(evalstr);
             let strval = FromJSValConvertible::from_jsval(self.get_cx(), jsval,
                                                           StringificationBehavior::Empty);
-            (HTMLInput::InputString(strval.unwrap_or("".to_string())), doc_url)
+            (HTMLInput::InputString(strval.unwrap_or("".into_string())), doc_url)
         };
 
         parse_html(*document, parser_input, &final_url);
@@ -835,7 +835,7 @@ impl ScriptTask {
         }
 
         // https://html.spec.whatwg.org/multipage/#the-end step 4
-        let event = Event::new(global::Window(*window), "DOMContentLoaded".to_string(),
+        let event = Event::new(global::Window(*window), "DOMContentLoaded".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();
         let doctarget: JSRef<EventTarget> = EventTargetCast::from_ref(*document);
@@ -848,7 +848,7 @@ impl ScriptTask {
         // https://html.spec.whatwg.org/multipage/#the-end step 7
         document.set_ready_state(DocumentReadyState::Complete);
 
-        let event = Event::new(global::Window(*window), "load".to_string(),
+        let event = Event::new(global::Window(*window), "load".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();
         let wintarget: JSRef<EventTarget> = EventTargetCast::from_ref(*window);
@@ -970,12 +970,12 @@ impl ScriptTask {
         let ev_type = match state {
             KeyState::Pressed | KeyState::Repeated => "keydown",
             KeyState::Released => "keyup",
-        }.to_string();
+        }.into_string();
 
         let props = KeyboardEvent::key_properties(key, modifiers);
 
         let keyevent = KeyboardEvent::new(*window, ev_type, true, true, Some(*window), 0,
-                                          props.key.to_string(), props.code.to_string(),
+                                          props.key.into_string(), props.code.into_string(),
                                           props.location, is_repeating, is_composing,
                                           ctrl, alt, shift, meta,
                                           None, props.key_code).root();
@@ -986,8 +986,8 @@ impl ScriptTask {
         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#keys-cancelable-keys
         if state != KeyState::Released && props.is_printable() && !prevented {
             // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#keypress-event-order
-            let event = KeyboardEvent::new(*window, "keypress".to_string(), true, true, Some(*window),
-                                           0, props.key.to_string(), props.code.to_string(),
+            let event = KeyboardEvent::new(*window, "keypress".into_string(), true, true, Some(*window),
+                                           0, props.key.into_string(), props.code.into_string(),
                                            props.location, is_repeating, is_composing,
                                            ctrl, alt, shift, meta,
                                            props.char_code, 0).root();
@@ -1071,7 +1071,7 @@ impl ScriptTask {
                 // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
                 // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#event-type-resize
                 let uievent = UIEvent::new(window.clone(),
-                                           "resize".to_string(), false,
+                                           "resize".into_string(), false,
                                            false, Some(window.clone()),
                                            0i32).root();
                 let event: JSRef<Event> = EventCast::from_ref(*uievent);
@@ -1122,7 +1122,7 @@ impl ScriptTask {
 
                                 let event =
                                     Event::new(global::Window(*window),
-                                               "click".to_string(),
+                                               "click".into_string(),
                                                EventBubbles::Bubbles,
                                                EventCancelable::Cancelable).root();
                                 // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#trusted-events

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -86,7 +86,7 @@ impl TextInput {
                 -1
             }, true);
         }
-        self.replace_selection("".to_string());
+        self.replace_selection("".into_string());
     }
 
     /// Insert a character at the current editing point
@@ -114,12 +114,12 @@ impl TextInput {
             let lines_suffix = self.lines.slice(end.line + 1, self.lines.len());
 
             let mut insert_lines = if self.multiline {
-                insert.as_slice().split('\n').map(|s| s.to_string()).collect()
+                insert.as_slice().split('\n').map(|s| s.into_string()).collect()
             } else {
                 vec!(insert)
             };
 
-            let mut new_line = prefix.to_string();
+            let mut new_line = prefix.into_string();
             new_line.push_str(insert_lines[0].as_slice());
             insert_lines[0] = new_line;
 
@@ -281,7 +281,7 @@ impl TextInput {
 
     /// Get the current contents of the text input. Multiple lines are joined by \n.
     pub fn get_content(&self) -> DOMString {
-        let mut content = "".to_string();
+        let mut content = "".into_string();
         for (i, line) in self.lines.iter().enumerate() {
             content.push_str(line.as_slice());
             if i < self.lines.len() - 1 {
@@ -295,7 +295,7 @@ impl TextInput {
     /// any \n encountered will be stripped and force a new logical line.
     pub fn set_content(&mut self, content: DOMString) {
         self.lines = if self.multiline {
-            content.as_slice().split('\n').map(|s| s.to_string()).collect()
+            content.as_slice().split('\n').map(|s| s.into_string()).collect()
         } else {
             vec!(content)
         };

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -58,8 +58,8 @@ android_start!(main)
 #[cfg(target_os="android")]
 fn get_args() -> Vec<String> {
     vec![
-        "servo".to_string(),
-        "http://en.wikipedia.org/wiki/Rust".to_string()
+        "servo".into_string(),
+        "http://en.wikipedia.org/wiki/Rust".into_string()
     ]
 }
 

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -343,152 +343,152 @@ mod tests {
         let ss = Stylesheet::from_str(css, url, StylesheetOrigin::Author);
         let mut rule_count: int = 0;
         iter_stylesheet_style_rules(&ss, device, |_| rule_count += 1);
-        assert!(rule_count == expected_rule_count, css.to_string());
+        assert!(rule_count == expected_rule_count, css.into_string());
     }
 
     #[test]
     fn test_mq_empty() {
         test_media_rule("@media { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
     }
 
     #[test]
     fn test_mq_screen() {
         test_media_rule("@media screen { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media only screen { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Only), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Only), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media not screen { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
     }
 
     #[test]
     fn test_mq_print() {
         test_media_rule("@media print { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media only print { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Only), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Only), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media not print { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
     }
 
     #[test]
     fn test_mq_unknown() {
         test_media_rule("@media fridge { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media only glass { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Only), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Only), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media not wood { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
     }
 
     #[test]
     fn test_mq_all() {
         test_media_rule("@media all { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media only all { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Only), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Only), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media not all { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
     }
 
     #[test]
     fn test_mq_or() {
         test_media_rule("@media screen, print { }", |list, css| {
-            assert!(list.media_queries.len() == 2, css.to_string());
+            assert!(list.media_queries.len() == 2, css.into_string());
             let q0 = &list.media_queries[0];
-            assert!(q0.qualifier == None, css.to_string());
-            assert!(q0.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q0.expressions.len() == 0, css.to_string());
+            assert!(q0.qualifier == None, css.into_string());
+            assert!(q0.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q0.expressions.len() == 0, css.into_string());
 
             let q1 = &list.media_queries[1];
-            assert!(q1.qualifier == None, css.to_string());
-            assert!(q1.media_type == MediaQueryType::MediaType(MediaType::Print), css.to_string());
-            assert!(q1.expressions.len() == 0, css.to_string());
+            assert!(q1.qualifier == None, css.into_string());
+            assert!(q1.media_type == MediaQueryType::MediaType(MediaType::Print), css.into_string());
+            assert!(q1.expressions.len() == 0, css.into_string());
         });
     }
 
     #[test]
     fn test_mq_default_expressions() {
         test_media_rule("@media (min-width: 100px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 1, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 1, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Min(w)) => assert!(w == Au::from_px(100)),
                 _ => panic!("wrong expression type"),
@@ -496,11 +496,11 @@ mod tests {
         });
 
         test_media_rule("@media (max-width: 43px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 1, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 1, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Max(w)) => assert!(w == Au::from_px(43)),
                 _ => panic!("wrong expression type"),
@@ -511,11 +511,11 @@ mod tests {
     #[test]
     fn test_mq_expressions() {
         test_media_rule("@media screen and (min-width: 100px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q.expressions.len() == 1, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q.expressions.len() == 1, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Min(w)) => assert!(w == Au::from_px(100)),
                 _ => panic!("wrong expression type"),
@@ -523,11 +523,11 @@ mod tests {
         });
 
         test_media_rule("@media print and (max-width: 43px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.to_string());
-            assert!(q.expressions.len() == 1, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Print), css.into_string());
+            assert!(q.expressions.len() == 1, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Max(w)) => assert!(w == Au::from_px(43)),
                 _ => panic!("wrong expression type"),
@@ -535,11 +535,11 @@ mod tests {
         });
 
         test_media_rule("@media fridge and (max-width: 52px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.to_string());
-            assert!(q.expressions.len() == 1, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Unknown), css.into_string());
+            assert!(q.expressions.len() == 1, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Max(w)) => assert!(w == Au::from_px(52)),
                 _ => panic!("wrong expression type"),
@@ -550,11 +550,11 @@ mod tests {
     #[test]
     fn test_mq_multiple_expressions() {
         test_media_rule("@media (min-width: 100px) and (max-width: 200px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == None, css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 2, css.to_string());
+            assert!(q.qualifier == None, css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 2, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Min(w)) => assert!(w == Au::from_px(100)),
                 _ => panic!("wrong expression type"),
@@ -566,11 +566,11 @@ mod tests {
         });
 
         test_media_rule("@media not screen and (min-width: 100px) and (max-width: 200px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q.expressions.len() == 2, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q.expressions.len() == 2, css.into_string());
             match q.expressions[0] {
                 Expression::Width(Range::Min(w)) => assert!(w == Au::from_px(100)),
                 _ => panic!("wrong expression type"),
@@ -585,75 +585,75 @@ mod tests {
     #[test]
     fn test_mq_malformed_expressions() {
         test_media_rule("@media (min-width: 100blah) and (max-width: 200px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media screen and (height: 200px) { }", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media (min-width: 30em foo bar) {}", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media not {}", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media not (min-width: 300px) {}", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media , {}", |list, css| {
-            assert!(list.media_queries.len() == 1, css.to_string());
+            assert!(list.media_queries.len() == 1, css.into_string());
             let q = &list.media_queries[0];
-            assert!(q.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q.media_type == MediaQueryType::All, css.to_string());
-            assert!(q.expressions.len() == 0, css.to_string());
+            assert!(q.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q.media_type == MediaQueryType::All, css.into_string());
+            assert!(q.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media screen 4px, print {}", |list, css| {
-            assert!(list.media_queries.len() == 2, css.to_string());
+            assert!(list.media_queries.len() == 2, css.into_string());
             let q0 = &list.media_queries[0];
-            assert!(q0.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q0.media_type == MediaQueryType::All, css.to_string());
-            assert!(q0.expressions.len() == 0, css.to_string());
+            assert!(q0.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q0.media_type == MediaQueryType::All, css.into_string());
+            assert!(q0.expressions.len() == 0, css.into_string());
             let q1 = &list.media_queries[1];
-            assert!(q1.qualifier == None, css.to_string());
-            assert!(q1.media_type == MediaQueryType::MediaType(MediaType::Print), css.to_string());
-            assert!(q1.expressions.len() == 0, css.to_string());
+            assert!(q1.qualifier == None, css.into_string());
+            assert!(q1.media_type == MediaQueryType::MediaType(MediaType::Print), css.into_string());
+            assert!(q1.expressions.len() == 0, css.into_string());
         });
 
         test_media_rule("@media screen, {}", |list, css| {
-            assert!(list.media_queries.len() == 2, css.to_string());
+            assert!(list.media_queries.len() == 2, css.into_string());
             let q0 = &list.media_queries[0];
-            assert!(q0.qualifier == None, css.to_string());
-            assert!(q0.media_type == MediaQueryType::MediaType(MediaType::Screen), css.to_string());
-            assert!(q0.expressions.len() == 0, css.to_string());
+            assert!(q0.qualifier == None, css.into_string());
+            assert!(q0.media_type == MediaQueryType::MediaType(MediaType::Screen), css.into_string());
+            assert!(q0.expressions.len() == 0, css.into_string());
             let q1 = &list.media_queries[1];
-            assert!(q1.qualifier == Some(Qualifier::Not), css.to_string());
-            assert!(q1.media_type == MediaQueryType::All, css.to_string());
-            assert!(q1.expressions.len() == 0, css.to_string());
+            assert!(q1.qualifier == Some(Qualifier::Not), css.into_string());
+            assert!(q1.media_type == MediaQueryType::All, css.into_string());
+            assert!(q1.expressions.len() == 0, css.into_string());
         });
     }
 

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -950,7 +950,7 @@ pub mod longhands {
 
         #[inline]
         pub fn get_initial_value() -> computed_value::T {
-            vec![FontFamily::FamilyName("serif".to_string())]
+            vec![FontFamily::FamilyName("serif".into_string())]
         }
         /// <familiy-name>#
         /// <familiy-name> = <string> | [ <ident>+ ]


### PR DESCRIPTION
Lint by @seanmonstar

`str::to_string()` goes through a `Formatter`, `str::into_string()` is a direct copy and is apparently 5x faster.

I haven't properly benchmarked this yet, but a couple of runs with `-m` seem promising.
We might not want to merge this until we're sure that it's a net plus.

(I'm okay with keeping this lint on `Warn` instead of `Deny`, since at least at the moment warnings get 
fixed eventually)
