### PR TITLE
Makes layout respect <textarea> rows and cols attributes

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -50,8 +50,8 @@ use dom::virtualmethods::{VirtualMethods, vtable_for};
 use devtools_traits::AttrInfo;
 use style::{mod, AuthorOrigin, BgColorSimpleColorAttribute, BorderUnsignedIntegerAttribute};
 use style::{ColSpanUnsignedIntegerAttribute, IntegerAttribute, LengthAttribute, ParserContext};
-use style::{SimpleColorAttribute, SizeIntegerAttribute, ColsIntegerAttribute, UnsignedIntegerAttribute};
-use style::{WidthLengthAttribute, matches};
+use style::{SimpleColorAttribute, SizeIntegerAttribute, ColsIntegerAttribute, RowsIntegerAttribute};
+use style::{UnsignedIntegerAttribute, WidthLengthAttribute, matches};
 use servo_util::namespace;
 use servo_util::str::{DOMString, LengthOrPercentageOrAuto};
 
@@ -330,6 +330,13 @@ impl RawLayoutElementHelpers for Element {
                 }
                 let this: &HTMLTextAreaElement = mem::transmute(self);
                 Some(this.get_cols_for_layout() as i32)
+            }
+            RowsIntegerAttribute => {
+                if !self.is_htmltextareaelement() {
+                    panic!("I'm not a textarea element!")
+                }
+                let this: &HTMLTextAreaElement = mem::transmute(self);
+                Some(this.get_rows_for_layout() as i32)
             }
         }
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -19,7 +19,7 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, ElementDerived, EventTar
 use dom::bindings::codegen::InheritTypes::{HTMLBodyElementDerived, HTMLInputElementCast};
 use dom::bindings::codegen::InheritTypes::{HTMLInputElementDerived, HTMLTableElementCast};
 use dom::bindings::codegen::InheritTypes::{HTMLTableElementDerived, HTMLTableCellElementDerived};
-use dom::bindings::codegen::InheritTypes::{HTMLTableRowElementDerived};
+use dom::bindings::codegen::InheritTypes::{HTMLTableRowElementDerived, HTMLTextAreaElementDerived};
 use dom::bindings::codegen::InheritTypes::{HTMLTableSectionElementDerived, NodeCast};
 use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, TemporaryPushable};
 use dom::bindings::js::{OptionalRootable, Root};
@@ -41,6 +41,7 @@ use dom::htmltableelement::{HTMLTableElement, HTMLTableElementHelpers};
 use dom::htmltablecellelement::{HTMLTableCellElement, HTMLTableCellElementHelpers};
 use dom::htmltablerowelement::{HTMLTableRowElement, HTMLTableRowElementHelpers};
 use dom::htmltablesectionelement::{HTMLTableSectionElement, HTMLTableSectionElementHelpers};
+use dom::htmltextareaelement::{HTMLTextAreaElement, RawLayoutHTMLTextAreaElementHelpers};
 use dom::node::{CLICK_IN_PROGRESS, ElementNodeTypeId, LayoutNodeHelpers, Node, NodeHelpers};
 use dom::node::{NodeIterator, NodeStyleDamaged, OtherNodeDamage, document_from_node};
 use dom::node::{window_from_node};
@@ -49,7 +50,7 @@ use dom::virtualmethods::{VirtualMethods, vtable_for};
 use devtools_traits::AttrInfo;
 use style::{mod, AuthorOrigin, BgColorSimpleColorAttribute, BorderUnsignedIntegerAttribute};
 use style::{ColSpanUnsignedIntegerAttribute, IntegerAttribute, LengthAttribute, ParserContext};
-use style::{SimpleColorAttribute, SizeIntegerAttribute, UnsignedIntegerAttribute};
+use style::{SimpleColorAttribute, SizeIntegerAttribute, ColsIntegerAttribute, UnsignedIntegerAttribute};
 use style::{WidthLengthAttribute, matches};
 use servo_util::namespace;
 use servo_util::str::{DOMString, LengthOrPercentageOrAuto};
@@ -322,6 +323,13 @@ impl RawLayoutElementHelpers for Element {
                 }
                 let this: &HTMLInputElement = mem::transmute(self);
                 Some(this.get_size_for_layout() as i32)
+            }
+            ColsIntegerAttribute => {
+                if !self.is_htmltextareaelement() {
+                    panic!("I'm not a textarea element!")
+                }
+                let this: &HTMLTextAreaElement = mem::transmute(self);
+                Some(this.get_cols_for_layout() as i32)
             }
         }
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -35,6 +35,7 @@ pub struct HTMLTextAreaElement {
     htmlelement: HTMLElement,
     textinput: DOMRefCell<TextInput>,
     cols: Cell<u32>,
+    rows: Cell<u32>,
 
     // https://html.spec.whatwg.org/multipage/forms.html#concept-textarea-dirty
     value_changed: Cell<bool>,
@@ -52,6 +53,7 @@ pub trait LayoutHTMLTextAreaElementHelpers {
 
 pub trait RawLayoutHTMLTextAreaElementHelpers {
     unsafe fn get_cols_for_layout(&self) -> u32;
+    unsafe fn get_rows_for_layout(&self) -> u32;
 }
 
 impl LayoutHTMLTextAreaElementHelpers for JS<HTMLTextAreaElement> {
@@ -66,6 +68,11 @@ impl RawLayoutHTMLTextAreaElementHelpers for HTMLTextAreaElement {
     unsafe fn get_cols_for_layout(&self) -> u32 {
         self.cols.get()
     }
+
+    #[allow(unrooted_must_root)]
+    unsafe fn get_rows_for_layout(&self) -> u32 {
+        self.rows.get()
+    }
 }
 
 static DEFAULT_COLS: u32 = 20;
@@ -77,6 +84,7 @@ impl HTMLTextAreaElement {
             htmlelement: HTMLElement::new_inherited(HTMLTextAreaElementTypeId, localName, prefix, document),
             textinput: DOMRefCell::new(TextInput::new(Multiple, "".to_string())),
             cols: Cell::new(DEFAULT_COLS),
+            rows: Cell::new(DEFAULT_ROWS),
             value_changed: Cell::new(false),
         }
     }
@@ -205,6 +213,12 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
                     _ => panic!("Expected a UIntAttrValue"),
                 }
             },
+            &atom!("rows") => {
+                match *attr.value() {
+                    UIntAttrValue(_, value) => self.rows.set(value),
+                    _ => panic!("Expected a UIntAttrValue"),
+                }
+            },
             _ => ()
         }
     }
@@ -224,6 +238,9 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             },
             &atom!("cols") => {
                 self.cols.set(DEFAULT_COLS);
+            },
+            &atom!("rows") => {
+                self.rows.set(DEFAULT_ROWS);
             },
             _ => ()
         }

--- a/components/style/legacy.rs
+++ b/components/style/legacy.rs
@@ -26,6 +26,7 @@ pub enum LengthAttribute {
 pub enum IntegerAttribute {
     /// `<input size>`
     SizeIntegerAttribute,
+    ColsIntegerAttribute,
 }
 
 /// Legacy presentational attributes that take a nonnegative integer as defined in HTML5 § 2.4.4.2.
@@ -152,6 +153,23 @@ impl PresentationalHintSynthesis for Stylist {
                             }
                             _ => specified::Au_(Au::from_px(value as int)),
                         };
+                        matching_rules_list.vec_push(DeclarationBlock::from_declaration(
+                                WidthDeclaration(SpecifiedValue(specified::LPA_Length(
+                                            value)))));
+                        *shareable = false
+                    }
+                    Some(_) | None => {}
+                }
+            }
+            name if *name == atom!("textarea") => {
+                match element.get_integer_attribute(ColsIntegerAttribute) {
+                    Some(value) if value != 0 => {
+                        // TODO ServoCharacterWidth uses the size math for <input type="text">, but
+                        // the math for <textarea> is a little different since we need to take
+                        // scrollbar size into consideration (but we don't have a scrollbar yet!)
+                        //
+                        // https://html.spec.whatwg.org/multipage/rendering.html#textarea-effective-width
+                        let value = specified::ServoCharacterWidth(value);
                         matching_rules_list.vec_push(DeclarationBlock::from_declaration(
                                 WidthDeclaration(SpecifiedValue(specified::LPA_Length(
                                             value)))));

--- a/components/style/legacy.rs
+++ b/components/style/legacy.rs
@@ -6,8 +6,8 @@
 //! `<input size>`, and so forth.
 
 use node::{TElement, TElementAttributes, TNode};
-use properties::{BackgroundColorDeclaration, BorderBottomWidthDeclaration};
-use properties::{BorderLeftWidthDeclaration, BorderRightWidthDeclaration};
+use properties::{BackgroundColorDeclaration, BorderBottomWidthDeclaration, CSSFloat};
+use properties::{BorderLeftWidthDeclaration, BorderRightWidthDeclaration, HeightDeclaration};
 use properties::{BorderTopWidthDeclaration, SpecifiedValue, WidthDeclaration, specified};
 use selector_matching::{DeclarationBlock, Stylist};
 
@@ -27,6 +27,7 @@ pub enum IntegerAttribute {
     /// `<input size>`
     SizeIntegerAttribute,
     ColsIntegerAttribute,
+    RowsIntegerAttribute,
 }
 
 /// Legacy presentational attributes that take a nonnegative integer as defined in HTML5 § 2.4.4.2.
@@ -164,7 +165,7 @@ impl PresentationalHintSynthesis for Stylist {
             name if *name == atom!("textarea") => {
                 match element.get_integer_attribute(ColsIntegerAttribute) {
                     Some(value) if value != 0 => {
-                        // TODO ServoCharacterWidth uses the size math for <input type="text">, but
+                        // TODO(mttr) ServoCharacterWidth uses the size math for <input type="text">, but
                         // the math for <textarea> is a little different since we need to take
                         // scrollbar size into consideration (but we don't have a scrollbar yet!)
                         //
@@ -172,6 +173,19 @@ impl PresentationalHintSynthesis for Stylist {
                         let value = specified::ServoCharacterWidth(value);
                         matching_rules_list.vec_push(DeclarationBlock::from_declaration(
                                 WidthDeclaration(SpecifiedValue(specified::LPA_Length(
+                                            value)))));
+                        *shareable = false
+                    }
+                    Some(_) | None => {}
+                }
+                match element.get_integer_attribute(RowsIntegerAttribute) {
+                    Some(value) if value != 0 => {
+                        // TODO(mttr) This should take scrollbar size into consideration.
+                        //
+                        // https://html.spec.whatwg.org/multipage/rendering.html#textarea-effective-height
+                        let value = specified::Em(value as CSSFloat);
+                        matching_rules_list.vec_push(DeclarationBlock::from_declaration(
+                                HeightDeclaration(SpecifiedValue(specified::LPA_Length(
                                             value)))));
                         *shareable = false
                     }

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -57,7 +57,7 @@ pub use cssparser::{Color, RGBA};
 pub use legacy::{BgColorSimpleColorAttribute, BorderUnsignedIntegerAttribute};
 pub use legacy::{ColSpanUnsignedIntegerAttribute, IntegerAttribute, LengthAttribute};
 pub use legacy::{SimpleColorAttribute, SizeIntegerAttribute, UnsignedIntegerAttribute};
-pub use legacy::{WidthLengthAttribute};
+pub use legacy::{WidthLengthAttribute, ColsIntegerAttribute};
 pub use font_face::{Source, LocalSource, UrlSource_};
 
 mod stylesheets;

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -57,7 +57,7 @@ pub use cssparser::{Color, RGBA};
 pub use legacy::{BgColorSimpleColorAttribute, BorderUnsignedIntegerAttribute};
 pub use legacy::{ColSpanUnsignedIntegerAttribute, IntegerAttribute, LengthAttribute};
 pub use legacy::{SimpleColorAttribute, SizeIntegerAttribute, UnsignedIntegerAttribute};
-pub use legacy::{WidthLengthAttribute, ColsIntegerAttribute};
+pub use legacy::{WidthLengthAttribute, ColsIntegerAttribute, RowsIntegerAttribute};
 pub use font_face::{Source, LocalSource, UrlSource_};
 
 mod stylesheets;


### PR DESCRIPTION
...with a bit of a caveat: sizing has the same problem as seen in #4378, and it is _significantly_ more noticeable when using `rows`.

Fixes #4291
