### PR TITLE
Fixed codegen error regarding Uint8ClampedArray

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4020,8 +4020,7 @@ class CGInterfaceTrait(CGThing):
                 elif m.isAttr() and not m.isStatic():
                     name = CGSpecializedGetter.makeNativeName(descriptor, m)
                     infallible = 'infallible' in descriptor.getExtendedAttributes(m, getter=True)
-                    needCx = typeNeedsCx(m.type)
-                    yield name, attribute_arguments(needCx), return_type(descriptor, m.type, infallible)
+                    yield name, attribute_arguments(typeNeedsCx(m.type, True)), return_type(descriptor, m.type, infallible)
 
                     if not m.readonly:
                         name = CGSpecializedSetter.makeNativeName(descriptor, m)
@@ -4030,7 +4029,7 @@ class CGInterfaceTrait(CGThing):
                             rettype = "()"
                         else:
                             rettype = "ErrorResult"
-                        yield name, attribute_arguments(needCx, m.type), rettype
+                        yield name, attribute_arguments(typeNeedsCx(m.type, False), m.type), rettype
 
             if descriptor.proxy:
                 for name, operation in descriptor.operations.iteritems():

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -17,7 +17,7 @@ use dom::bindings::utils::{Reflector, Reflectable};
 use dom::blob::Blob;
 use servo_util::str::DOMString;
 
-use js::jsapi::JSContext;
+use js::jsapi::{JSContext, JSObject};
 use js::jsval::{JSVal, NullValue};
 
 #[dom_struct]
@@ -64,6 +64,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn SetUnionAttribute(self, _: HTMLElementOrLong) {}
     fn Union2Attribute(self) -> EventOrString { eString("".to_string()) }
     fn SetUnion2Attribute(self, _: EventOrString) {}
+    fn ArrayAttribute(self, _: *mut JSContext) -> *mut JSObject { NullValue().to_object_or_null() }
     fn AnyAttribute(self, _: *mut JSContext) -> JSVal { NullValue() }
     fn SetAnyAttribute(self, _: *mut JSContext, _: JSVal) {}
 

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -71,6 +71,7 @@ interface TestBinding {
            attribute Blob interfaceAttribute;
            attribute (HTMLElement or long) unionAttribute;
            attribute (Event or DOMString) union2Attribute;
+  readonly attribute Uint8ClampedArray arrayAttribute;
            attribute any anyAttribute;
 
            attribute boolean? booleanAttributeNullable;


### PR DESCRIPTION
If we added a "readonly attribute Uint8ClampedArray arrayAttribute" in a webidl, codegen created the binding method like this: "fn ArrayAttribute(self) -> \* mut JSObject;" but called it with a "*mut JSContext" parameter.
