### PR TITLE
layout: Implement `clip` per CSS 2.1 § 11.1.2.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1774,8 +1774,8 @@ impl Flow for BlockFlow {
         } else {
             self.base.stacking_relative_position
         };
-        let clip_rect = self.fragment.clip_rect_for_children(self.base.clip_rect,
-                                                             origin_for_children);
+        let clip_rect = self.fragment.clip_rect_for_children(&self.base.clip_rect,
+                                                             &origin_for_children);
 
         // Process children.
         let writing_mode = self.base.writing_mode;

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1215,8 +1215,8 @@ impl Flow for InlineFlow {
                 _ => continue,
             };
 
-            let clip_rect = fragment.clip_rect_for_children(self.base.clip_rect,
-                                                            stacking_relative_position);
+            let clip_rect = fragment.clip_rect_for_children(&self.base.clip_rect,
+                                                            &stacking_relative_position);
 
             match fragment.specific {
                 SpecificFragmentInfo::InlineBlock(ref mut info) => {

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -247,7 +247,7 @@ source = "git+https://github.com/alexcrichton/gcc-rs#903e8f8a2e3766ad3d514404d45
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#5e52790076fc238a395d1777c4280fa46a1555fa"
+source = "git+https://github.com/servo/rust-geom#da6b4a36a5549cf78bf702f0b9387b5c8cf61498"
 
 [[package]]
 name = "gfx"

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -333,3 +333,4 @@ pub fn f32_rect_to_au_rect(rect: Rect<f32>) -> Rect<Au> {
     Rect(Point2D(Au::from_frac32_px(rect.origin.x), Au::from_frac32_px(rect.origin.y)),
          Size2D(Au::from_frac32_px(rect.size.width), Au::from_frac32_px(rect.size.height)))
 }
+

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -243,7 +243,7 @@ source = "git+https://github.com/alexcrichton/gcc-rs#903e8f8a2e3766ad3d514404d45
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#5e52790076fc238a395d1777c4280fa46a1555fa"
+source = "git+https://github.com/servo/rust-geom#da6b4a36a5549cf78bf702f0b9387b5c8cf61498"
 
 [[package]]
 name = "gfx"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -207,7 +207,7 @@ source = "git+https://github.com/alexcrichton/gcc-rs#d35c34c871dd75f97fadf04cb0e
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#5e52790076fc238a395d1777c4280fa46a1555fa"
+source = "git+https://github.com/servo/rust-geom#da6b4a36a5549cf78bf702f0b9387b5c8cf61498"
 
 [[package]]
 name = "gfx"

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -218,3 +218,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == empty_cells_a.html empty_cells_ref.html
 == table_caption_top_a.html table_caption_top_ref.html
 == table_caption_bottom_a.html table_caption_bottom_ref.html
+== clip_a.html clip_ref.html

--- a/tests/ref/clip_a.html
+++ b/tests/ref/clip_a.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that various `clip` values per CSS 2.1 work. -->
+<style>
+section {
+    position: absolute;
+    padding: 32px;
+    width: 64px;
+    height: 64px;
+    background: green;
+    border: solid 32px red;
+}
+section:before {
+    content: "";
+    display: block;
+    padding: 0;
+    width: 64px;
+    height: 64px;
+    background: blue;
+}
+#a {
+    top: 0;
+    left: 0;
+    clip: rect(auto, auto, auto, auto);
+}
+#b {
+    top: 192px;
+    left: 0;
+    clip: rect(32px, auto, auto, 128px);
+}
+#c {
+    top: 0;
+    left: 192px;
+    clip: rect(32px, 128px, 64px, 0);
+}
+#d {
+    top: 192px;
+    left: 192px;
+    clip: rect(64px, 0, 64px, 0);
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+<section id=c></section>
+<section id=d></section>
+</body>
+</html>
+
+

--- a/tests/ref/clip_ref.html
+++ b/tests/ref/clip_ref.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that various `clip` values per CSS 2.1 work. -->
+<style>
+section {
+    position: absolute;
+}
+#a {
+    top: 0;
+    left: 0;
+    width: 192px;
+    height: 192px;
+    background: red;
+}
+#b {
+    top: 32px;
+    left: 32px;
+    width: 128px;
+    height: 128px;
+    background: green;
+}
+#c {
+    top: 64px;
+    left: 64px;
+    width: 64px;
+    height: 64px;
+    background: blue;
+}
+#d {
+    top: 32px;
+    left: 192px;
+    width: 32px;
+    height: 32px;
+    background: red;
+}
+#e {
+    top: 32px;
+    left: 224px;
+    width: 96px;
+    height: 32px;
+    background: green;
+}
+#f {
+    top: 224px;
+    left: 128px;
+    width: 64px;
+    height: 160px;
+    background: red;
+}
+#g {
+    top: 224px;
+    left: 128px;
+    width: 32px;
+    height: 128px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+<section id=c></section>
+<section id=d></section>
+<section id=e></section>
+<section id=f></section>
+<section id=g></section>
+</body>
+</html>
+


### PR DESCRIPTION
Only the recommended, comma-separated syntax is supported.

r? @SimonSapin 
