### PR TITLE
Handle null when evaluating JS value. Fixes #4235.

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -37,9 +37,11 @@ pub fn handle_evaluate_js(page: &Rc<Page>, pipeline: PipelineId, eval: String, r
     } else if rval.is_string() {
         //FIXME: use jsstring_to_str when jsval grows to_jsstring
         devtools_traits::StringValue(FromJSValConvertible::from_jsval(cx, rval, conversions::Default).unwrap())
+    } else if rval.is_null() {
+        devtools_traits::NullValue
     } else {
         //FIXME: jsvals don't have an is_int32/is_number yet
-        assert!(rval.is_object_or_null());
+        assert!(rval.is_object());
         panic!("object values unimplemented")
     });
 }


### PR DESCRIPTION
Rebased from #4241.
