### PR TITLE
Update layer bounds on resize

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -499,7 +499,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         let need_new_root_layer = !self.update_layer_if_exists(layer_properties);
         if need_new_root_layer {
             let root_layer = self.find_pipeline_root_layer(layer_properties.pipeline_id);
-            root_layer.update_layer_except_size(layer_properties);
+            root_layer.update_layer_except_bounds(layer_properties);
 
             let root_layer_pipeline = root_layer.extra_data.borrow().pipeline.clone();
             let first_child = CompositorData::new_layer(

--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -10,7 +10,7 @@ use azure::azure_hl;
 use geom::length::Length;
 use geom::matrix::identity;
 use geom::point::{Point2D, TypedPoint2D};
-use geom::size::{Size2D, TypedSize2D};
+use geom::size::TypedSize2D;
 use geom::rect::Rect;
 use gfx::paint_task::UnusedBufferMsg;
 use layers::color::Color;
@@ -69,7 +69,7 @@ impl CompositorData {
 }
 
 pub trait CompositorLayer {
-    fn update_layer_except_size(&self, layer_properties: LayerProperties);
+    fn update_layer_except_bounds(&self, layer_properties: LayerProperties);
 
     fn update_layer(&self, layer_properties: LayerProperties);
 
@@ -166,7 +166,7 @@ pub enum ScrollEventResult {
 }
 
 impl CompositorLayer for Layer<CompositorData> {
-    fn update_layer_except_size(&self, layer_properties: LayerProperties) {
+    fn update_layer_except_bounds(&self, layer_properties: LayerProperties) {
         self.extra_data.borrow_mut().epoch = layer_properties.epoch;
         self.extra_data.borrow_mut().scroll_policy = layer_properties.scroll_policy;
 
@@ -176,12 +176,12 @@ impl CompositorLayer for Layer<CompositorData> {
     }
 
     fn update_layer(&self, layer_properties: LayerProperties) {
-        self.resize(Size2D::from_untyped(&layer_properties.rect.size));
+        *self.bounds.borrow_mut() = Rect::from_untyped(&layer_properties.rect);
 
         // Call scroll for bounds checking if the page shrunk. Use (-1, -1) as the
         // cursor position to make sure the scroll isn't propagated downwards.
         self.handle_scroll_event(TypedPoint2D(0f32, 0f32), TypedPoint2D(-1f32, -1f32));
-        self.update_layer_except_size(layer_properties);
+        self.update_layer_except_bounds(layer_properties);
     }
 
     // Add LayerBuffers to the specified layer. Returns the layer buffer set back if the layer that


### PR DESCRIPTION
This fixes a bug where fixed-position layers are not repositioned when the
window is resized.  This can be reproduced with any `position: fixed` element with a `right` or `bottom` position.  I'm not sure how to reftest this, though.

r? @mrobinson
