### PR TITLE
layout: Implement `border-spacing` per CSS 2.1 § 17.6.1 and the legacy `cellspacing` attribute per HTML5 § 14.3.9.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -886,7 +886,8 @@ impl Fragment {
             SpecificFragmentInfo::InlineBlock(_) => {
                 QuantitiesIncludedInIntrinsicInlineSizes::all()
             }
-            SpecificFragmentInfo::Table | SpecificFragmentInfo::TableCell => {
+            SpecificFragmentInfo::Table |
+            SpecificFragmentInfo::TableCell => {
                 INTRINSIC_INLINE_SIZE_INCLUDES_PADDING |
                     INTRINSIC_INLINE_SIZE_INCLUDES_BORDER |
                     INTRINSIC_INLINE_SIZE_INCLUDES_SPECIFIED

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -20,7 +20,7 @@ use floats::FloatKind;
 use flow::{FlowClass, Flow, ImmutableFlowUtils};
 use flow::{IMPACTED_BY_LEFT_FLOATS, IMPACTED_BY_RIGHT_FLOATS};
 use fragment::{Fragment, FragmentBorderBoxIterator};
-use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize};
+use table::{ChildInlineSizeInfo, ColumnComputedInlineSize, ColumnIntrinsicInlineSize};
 use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
@@ -28,11 +28,11 @@ use util::geometry::Au;
 use std::cmp::{max, min};
 use std::fmt;
 use std::ops::Add;
-use style::properties::ComputedValues;
+use std::sync::Arc;
 use style::computed_values::table_layout;
+use style::properties::ComputedValues;
 use style::values::CSSFloat;
 use style::values::computed::LengthOrPercentageOrAuto;
-use std::sync::Arc;
 
 #[derive(Copy, RustcEncodable, Debug)]
 pub enum TableLayout {
@@ -98,11 +98,19 @@ impl TableWrapperFlow {
         // when normally the child computes it itself. But it has to be this way because the
         // padding will affect where we place the child. This is an odd artifact of the way that
         // tables are separated into table flows and table wrapper flows.
-        let available_inline_size = self.block_flow.fragment.border_box.size.inline;
-        let mut table_border_padding = Au(0);
+        let mut available_inline_size = self.block_flow.fragment.border_box.size.inline;
+        let (mut table_border_padding, mut spacing) = (Au(0), Au(0));
         for kid in self.block_flow.base.child_iter() {
             if kid.is_table() {
                 let kid_block = kid.as_block();
+                let spacing_per_cell = kid_block.fragment
+                                                .style()
+                                                .get_inheritedtable()
+                                                .border_spacing
+                                                .horizontal;
+                spacing = spacing_per_cell * (self.column_intrinsic_inline_sizes.len() as i32 + 1);
+                available_inline_size = self.block_flow.fragment.border_box.size.inline;
+
                 kid_block.fragment.compute_border_and_padding(available_inline_size);
                 kid_block.fragment.compute_block_direction_margins(available_inline_size);
                 kid_block.fragment.compute_inline_direction_margins(available_inline_size);
@@ -114,18 +122,21 @@ impl TableWrapperFlow {
         // FIXME(pcwalton, spec): INTRINSIC § 8 does not properly define how to compute this, but
         // says "the basic idea is the same as the shrink-to-fit width that CSS2.1 defines". So we
         // just use the shrink-to-fit inline size.
-        let available_inline_size = match self.block_flow.fragment.style().content_inline_size() {
-            LengthOrPercentageOrAuto::Auto => self.block_flow
-                                                  .get_shrink_to_fit_inline_size(available_inline_size),
-            // FIXME(mttr) This fixes #4421 without breaking our current reftests, but I'm
-            // not completely sure this is "correct".
-            //
-            // That said, `available_inline_size` is, as far as I can tell, equal to the table's
-            // computed width property (W) and is used from this point forward in a way that seems
-            // to correspond with CSS 2.1 § 17.5.2.2 under "Column and caption widths
-            // influence the final table width as follows: ..."
-            _ => available_inline_size,
-        };
+        let mut available_inline_size =
+            match self.block_flow.fragment.style().content_inline_size() {
+                LengthOrPercentageOrAuto::Auto => {
+                    self.block_flow.get_shrink_to_fit_inline_size(available_inline_size)
+                }
+                // FIXME(mttr): This fixes #4421 without breaking our current reftests, but I'm
+                // not completely sure this is "correct".
+                //
+                // That said, `available_inline_size` is, as far as I can tell, equal to the
+                // table's computed width property (W) and is used from this point forward in a way
+                // that seems to correspond with CSS 2.1 § 17.5.2.2 under "Column and caption
+                // widths influence the final table width as follows: …"
+                _ => available_inline_size,
+            };
+        available_inline_size = available_inline_size - spacing;
 
         // Compute all the guesses for the column sizes, and sum them.
         let mut total_guess = AutoLayoutCandidateGuess::new();
@@ -153,8 +164,8 @@ impl TableWrapperFlow {
         //
         // FIXME(pcwalton, spec): How do I deal with fractional excess?
         let excess_inline_size = available_inline_size - total_used_inline_size;
-        if excess_inline_size > Au(0) &&
-                selection == SelectedAutoLayoutCandidateGuess::UsePreferredGuessAndDistributeExcessInlineSize {
+        if excess_inline_size > Au(0) && selection ==
+                SelectedAutoLayoutCandidateGuess::UsePreferredGuessAndDistributeExcessInlineSize {
             let mut info = ExcessInlineSizeDistributionInfo::new();
             for column_intrinsic_inline_size in self.column_intrinsic_inline_sizes.iter() {
                 info.update(column_intrinsic_inline_size)
@@ -173,10 +184,12 @@ impl TableWrapperFlow {
             total_used_inline_size = available_inline_size
         }
 
+
+
         self.block_flow.fragment.border_box.size.inline = total_used_inline_size +
-            table_border_padding;
+            table_border_padding + spacing;
         self.block_flow.base.position.size.inline = total_used_inline_size +
-            table_border_padding + self.block_flow.fragment.margin.inline_start_end();
+            table_border_padding + spacing + self.block_flow.fragment.margin.inline_start_end();
     }
 
     fn compute_used_inline_size(&mut self,
@@ -301,11 +314,15 @@ impl Flow for TableWrapperFlow {
                     None)
             }
             Some(ref assigned_column_inline_sizes) => {
-                self.block_flow.propagate_assigned_inline_size_to_children(
-                    layout_context,
-                    inline_start_content_edge,
-                    content_inline_size,
-                    Some(assigned_column_inline_sizes.as_slice()));
+                let info = ChildInlineSizeInfo {
+                    column_computed_inline_sizes: assigned_column_inline_sizes.as_slice(),
+                    spacing: self.block_flow.fragment.style().get_inheritedtable().border_spacing,
+                };
+                self.block_flow
+                    .propagate_assigned_inline_size_to_children(layout_context,
+                                                                inline_start_content_edge,
+                                                                content_inline_size,
+                                                                Some(info));
             }
         }
 
@@ -458,13 +475,16 @@ impl AutoLayoutCandidateGuess {
     fn calculate(&self, selection: SelectedAutoLayoutCandidateGuess) -> Au {
         match selection {
             SelectedAutoLayoutCandidateGuess::UseMinimumGuess => self.minimum_guess,
-            SelectedAutoLayoutCandidateGuess::InterpolateBetweenMinimumGuessAndMinimumPercentageGuess(weight) => {
+            SelectedAutoLayoutCandidateGuess::
+                    InterpolateBetweenMinimumGuessAndMinimumPercentageGuess(weight) => {
                 interp(self.minimum_guess, self.minimum_percentage_guess, weight)
             }
-            SelectedAutoLayoutCandidateGuess::InterpolateBetweenMinimumPercentageGuessAndMinimumSpecifiedGuess(weight) => {
+            SelectedAutoLayoutCandidateGuess::
+                    InterpolateBetweenMinimumPercentageGuessAndMinimumSpecifiedGuess(weight) => {
                 interp(self.minimum_percentage_guess, self.minimum_specified_guess, weight)
             }
-            SelectedAutoLayoutCandidateGuess::InterpolateBetweenMinimumSpecifiedGuessAndPreferredGuess(weight) => {
+            SelectedAutoLayoutCandidateGuess::
+                    InterpolateBetweenMinimumSpecifiedGuessAndPreferredGuess(weight) => {
                 interp(self.minimum_specified_guess, self.preferred_guess, weight)
             }
             SelectedAutoLayoutCandidateGuess::UsePreferredGuessAndDistributeExcessInlineSize => {
@@ -590,9 +610,17 @@ impl ExcessInlineSizeDistributionInfo {
             total_distributed_excess_size: &mut Au) {
         let proportion =
             if self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage > Au(0) {
-                column_intrinsic_inline_size.preferred.to_subpx() /
-                    self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage
-                        .to_subpx()
+                // FIXME(spec, pcwalton): Gecko and WebKit do *something* here when there are
+                // nonconstrained columns with no percentage *and* no preferred width. What do they
+                // do?
+                if !column_intrinsic_inline_size.constrained &&
+                        column_intrinsic_inline_size.percentage == 0.0 {
+                    column_intrinsic_inline_size.preferred.to_subpx() /
+                        self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage
+                            .to_subpx()
+                } else {
+                    0.0
+                }
             } else if self.count_of_nonconstrained_columns_with_no_percentage > 0 {
                 1.0 / (self.count_of_nonconstrained_columns_with_no_percentage as CSSFloat)
             } else if self.preferred_inline_size_of_constrained_columns_with_no_percentage >

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -635,8 +635,8 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     #[inline]
     fn has_nonzero_border(self) -> bool {
         unsafe {
-            match self.element
-                      .get_unsigned_integer_attribute_for_layout(UnsignedIntegerAttribute::Border) {
+            match self.element.get_unsigned_integer_attribute_for_layout(
+                    UnsignedIntegerAttribute::Border) {
                 None | Some(0) => false,
                 _ => true,
             }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -317,6 +317,16 @@ impl RawLayoutElementHelpers for Element {
                     None
                 }
             }
+            UnsignedIntegerAttribute::CellSpacing => {
+                if self.is_htmltableelement() {
+                    let this: &HTMLTableElement = mem::transmute(self);
+                    this.get_cellspacing()
+                } else {
+                    // Don't panic since `display` can cause this to be called on arbitrary
+                    // elements.
+                    None
+                }
+            }
             UnsignedIntegerAttribute::ColSpan => {
                 if self.is_htmltablecellelement() {
                     let this: &HTMLTableCellElement = mem::transmute(self);

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -26,6 +26,7 @@ pub struct HTMLTableElement {
     htmlelement: HTMLElement,
     background_color: Cell<Option<RGBA>>,
     border: Cell<Option<u32>>,
+    cellspacing: Cell<Option<u32>>,
     width: Cell<LengthOrPercentageOrAuto>,
 }
 
@@ -45,6 +46,7 @@ impl HTMLTableElement {
                                                     document),
             background_color: Cell::new(None),
             border: Cell::new(None),
+            cellspacing: Cell::new(None),
             width: Cell::new(LengthOrPercentageOrAuto::Auto),
         }
     }
@@ -94,6 +96,7 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
 pub trait HTMLTableElementHelpers {
     fn get_background_color(&self) -> Option<RGBA>;
     fn get_border(&self) -> Option<u32>;
+    fn get_cellspacing(&self) -> Option<u32>;
     fn get_width(&self) -> LengthOrPercentageOrAuto;
 }
 
@@ -104,6 +107,10 @@ impl HTMLTableElementHelpers for HTMLTableElement {
 
     fn get_border(&self) -> Option<u32> {
         self.border.get()
+    }
+
+    fn get_cellspacing(&self) -> Option<u32> {
+        self.cellspacing.get()
     }
 
     fn get_width(&self) -> LengthOrPercentageOrAuto {
@@ -132,6 +139,9 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableElement> {
                                                                      .as_slice()
                                                                      .chars()).unwrap_or(1)))
             }
+            &atom!("cellspacing") => {
+                self.cellspacing.set(str::parse_unsigned_integer(attr.value().as_slice().chars()))
+            }
             &atom!("width") => self.width.set(str::parse_length(attr.value().as_slice())),
             _ => ()
         }
@@ -145,6 +155,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableElement> {
         match attr.local_name() {
             &atom!("bgcolor") => self.background_color.set(None),
             &atom!("border") => self.border.set(None),
+            &atom!("cellspacing") => self.cellspacing.set(None),
             &atom!("width") => self.width.set(LengthOrPercentageOrAuto::Auto),
             _ => ()
         }

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -41,8 +41,10 @@ partial interface CSSStyleDeclaration {
   [TreatNullAs=EmptyString] attribute DOMString backgroundSize;
 
   [TreatNullAs=EmptyString] attribute DOMString border;
+  [TreatNullAs=EmptyString] attribute DOMString borderCollapse;
   [TreatNullAs=EmptyString] attribute DOMString borderColor;
   [TreatNullAs=EmptyString] attribute DOMString borderRadius;
+  [TreatNullAs=EmptyString] attribute DOMString borderSpacing;
   [TreatNullAs=EmptyString] attribute DOMString borderStyle;
   [TreatNullAs=EmptyString] attribute DOMString borderWidth;
   [TreatNullAs=EmptyString] attribute DOMString borderBottom;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mod_path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
+ "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -36,6 +36,7 @@ git = "https://github.com/servo/string-cache"
 [dependencies]
 text_writer = "0.1.1"
 encoding = "0.2"
+rustc-serialize = "0.2"
 matches = "0.1"
 url = "0.2.16"
 mod_path = "0.1"

--- a/components/style/legacy.rs
+++ b/components/style/legacy.rs
@@ -14,7 +14,7 @@ use values::specified::CSSColor;
 use values::{CSSFloat, specified};
 use properties::DeclaredValue::SpecifiedValue;
 use properties::PropertyDeclaration;
-use properties::longhands;
+use properties::longhands::{self, border_spacing};
 use selector_matching::Stylist;
 
 use cssparser::Color;
@@ -43,6 +43,8 @@ pub enum IntegerAttribute {
 pub enum UnsignedIntegerAttribute {
     /// `<td border>`
     Border,
+    /// `<table cellspacing>`
+    CellSpacing,
     /// `<td colspan>`
     ColSpan,
 }
@@ -143,6 +145,21 @@ impl PresentationalHintSynthesis for Stylist {
                     element,
                     matching_rules_list,
                     shareable);
+                match element.get_unsigned_integer_attribute(
+                        UnsignedIntegerAttribute::CellSpacing) {
+                    None => {}
+                    Some(length) => {
+                        let width_value = specified::Length::Absolute(Au::from_px(length as int));
+                        matching_rules_list.vec_push(from_declaration(
+                                PropertyDeclaration::BorderSpacing(
+                                    SpecifiedValue(
+                                        border_spacing::SpecifiedValue {
+                                            horizontal: width_value,
+                                            vertical: width_value,
+                                        }))));
+                        *shareable = false
+                    }
+                }
             }
             name if *name == atom!("body") || *name == atom!("tr") || *name == atom!("thead") ||
                     *name == atom!("tbody") || *name == atom!("tfoot") => {

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -28,6 +28,7 @@ extern crate cssparser;
 extern crate matches;
 
 extern crate encoding;
+extern crate "rustc-serialize" as rustc_serialize;
 extern crate string_cache;
 extern crate selectors;
 

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -193,16 +193,19 @@ impl Stylist {
 
         let mut shareable = true;
 
-        // Step 1: Virtual rules that are synthesized from legacy HTML attributes.
-        self.synthesize_presentational_hints_for_legacy_attributes(element,
-                                                                   applicable_declarations,
-                                                                   &mut shareable);
 
-        // Step 2: Normal rules.
+        // Step 1: Normal user-agent rules.
         map.user_agent.normal.get_all_matching_rules(element,
                                                      parent_bf,
                                                      applicable_declarations,
                                                      &mut shareable);
+
+        // Step 2: Presentational hints.
+        self.synthesize_presentational_hints_for_legacy_attributes(element,
+                                                                   applicable_declarations,
+                                                                   &mut shareable);
+
+        // Step 3: User and author normal rules.
         map.user.normal.get_all_matching_rules(element,
                                                parent_bf,
                                                applicable_declarations,
@@ -212,27 +215,27 @@ impl Stylist {
                                                  applicable_declarations,
                                                  &mut shareable);
 
-        // Step 3: Normal style attributes.
+        // Step 4: Normal style attributes.
         style_attribute.map(|sa| {
             shareable = false;
             applicable_declarations.vec_push(
                 GenericDeclarationBlock::from_declarations(sa.normal.clone()))
         });
 
-        // Step 4: Author-supplied `!important` rules.
+        // Step 5: Author-supplied `!important` rules.
         map.author.important.get_all_matching_rules(element,
                                                     parent_bf,
                                                     applicable_declarations,
                                                     &mut shareable);
 
-        // Step 5: `!important` style attributes.
+        // Step 6: `!important` style attributes.
         style_attribute.map(|sa| {
             shareable = false;
             applicable_declarations.vec_push(
                 GenericDeclarationBlock::from_declarations(sa.important.clone()))
         });
 
-        // Step 6: User and UA `!important` rules.
+        // Step 7: User and UA `!important` rules.
         map.user.important.get_all_matching_rules(element,
                                                   parent_bf,
                                                   applicable_declarations,
@@ -277,3 +280,4 @@ impl PerPseudoElementSelectorMap {
         }
     }
 }
+

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -48,6 +48,9 @@ flaky_cpu == append_style_a.html append_style_b.html
 == border_code_tag.html border_code_tag_ref.html
 == border_radius_clip_a.html border_radius_clip_ref.html
 == border_radius_overlapping_a.html border_radius_overlapping_ref.html
+== border_spacing_a.html border_spacing_ref.html
+== border_spacing_auto_layout_a.html border_spacing_ref.html
+== border_spacing_fixed_layout_a.html border_spacing_ref.html
 == border_style_none_a.html border_style_none_b.html
 == borders_a.html borders_b.html
 != box_shadow_blur_a.html box_shadow_blur_ref.html
@@ -141,6 +144,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == issue-1324.html issue-1324-ref.html
 == last_child_pseudo_a.html last_child_pseudo_b.html
 == last_of_type_pseudo_a.html last_of_type_pseudo_b.html
+== legacy_cellspacing_attribute_a.html border_spacing_ref.html
 == legacy_input_size_attribute_override_a.html legacy_input_size_attribute_override_ref.html
 == legacy_table_border_attribute_a.html legacy_table_border_attribute_ref.html
 == legacy_td_bgcolor_attribute_a.html legacy_td_bgcolor_attribute_ref.html

--- a/tests/ref/border_spacing_a.html
+++ b/tests/ref/border_spacing_a.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `border-spacing` works. -->
+<style>
+body, html {
+    margin: 0;
+}
+table {
+    border: none;
+    border-spacing: 6px;
+    padding: 0;
+}
+tr {
+    border-spacing: 64px;  /* should have no effect */
+    padding: 0;
+}
+td {
+    border: none;
+    border-spacing: 100px;  /* should have no effect */
+    padding: 0;
+    background: blue;
+}
+</style>
+</head>
+<body>
+<table>
+    <tr><td width=32 style="height: 32px;"></td><td width=64></td></tr>
+    <tr><td width=32 style="height: 32px;"></td><td width=64></td></tr>
+</table>
+</body>
+</html>
+

--- a/tests/ref/border_spacing_auto_layout_a.html
+++ b/tests/ref/border_spacing_auto_layout_a.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!--
+    Tests that `border-spacing` with automatic table layout works when not all the column sizes
+    are specified.
+-->
+<style>
+body, html {
+    margin: 0;
+}
+table {
+    border: none;
+    border-spacing: 6px;
+    padding: 0;
+    width: 114px;
+}
+tr {
+    padding: 0;
+}
+td {
+    border: none;
+    padding: 0;
+    background: blue;
+}
+</style>
+</head>
+<body>
+<table>
+    <tr><td style="width: 32px; height: 32px;"></td><td>&nbsp;</td></tr>
+    <tr><td style="width: 32px; height: 32px;"></td><td>&nbsp;</td></tr>
+</table>
+</body>
+</html>
+

--- a/tests/ref/border_spacing_fixed_layout_a.html
+++ b/tests/ref/border_spacing_fixed_layout_a.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!--
+    Tests that `border-spacing` with automatic table layout works when not all the column sizes
+    are specified.
+-->
+<style>
+body, html {
+    margin: 0;
+}
+table {
+    border: none;
+    border-spacing: 6px;
+    padding: 0;
+    width: 114px;
+    table-layout: fixed;
+}
+tr {
+    padding: 0;
+}
+td {
+    border: none;
+    padding: 0;
+    background: blue;
+}
+</style>
+</head>
+<body>
+<table>
+    <tr><td style="width: 32px; height: 32px;"></td><td>&nbsp;</td></tr>
+    <tr><td style="width: 32px; height: 32px;"></td><td>&nbsp;</td></tr>
+</table>
+</body>
+</html>
+

--- a/tests/ref/border_spacing_ref.html
+++ b/tests/ref/border_spacing_ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `border-spacing` works. -->
+<style>
+div {
+    background: blue;
+    position: absolute;
+    height: 32px;
+}
+#a, #c {
+    width: 32px;
+}
+#b, #d {
+    width: 64px;
+}
+#a, #b {
+    top: 6px;
+}
+#c, #d {
+    top: 44px;
+}
+#a, #c {
+    left: 6px;
+}
+#b, #d {
+    left: 44px;
+}
+</style>
+</head>
+<body>
+<div id=a></div>
+<div id=b></div>
+<div id=c></div>
+<div id=d></div>
+</body>
+</html>
+
+

--- a/tests/ref/float_table_a.html
+++ b/tests/ref/float_table_a.html
@@ -17,6 +17,7 @@
                 color: red;
                 float: right;
                 line-height: 1;
+                border-spacing: 0;
             }
             td {
                 padding: 0;

--- a/tests/ref/legacy_cellspacing_attribute_a.html
+++ b/tests/ref/legacy_cellspacing_attribute_a.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that the legacy `cellspacing` attribute works. -->
+<style>
+body, html {
+    margin: 0;
+}
+table {
+    border: none;
+    padding: 0;
+}
+tr {
+    padding: 0;
+}
+td {
+    border: none;
+    padding: 0;
+    background: blue;
+}
+</style>
+</head>
+<body>
+<table cellspacing=6>
+    <tr><td width=32 style="height: 32px;"></td><td width=64></td></tr>
+    <tr><td width=32 style="height: 32px;"></td><td width=64></td></tr>
+</table>
+</body>
+</html>
+

--- a/tests/ref/table_colspan_fixed_a.html
+++ b/tests/ref/table_colspan_fixed_a.html
@@ -4,6 +4,7 @@
 table {
     width: 300px;
     table-layout: fixed;
+    border-spacing: 0;
 }
 td[colspan="2"] {
     background-color: blue;

--- a/tests/ref/table_expansion_to_fit_a.html
+++ b/tests/ref/table_expansion_to_fit_a.html
@@ -5,6 +5,7 @@
 * {
     margin: 0;
     padding: 0;
+    border-spacing: 0;
 }
 </style>
 </head>

--- a/tests/ref/table_padding_a.html
+++ b/tests/ref/table_padding_a.html
@@ -1,35 +1,36 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<style type="text/css">
-			@font-face {
-				font-family: 'ahem';
-				src: url(fonts/ahem/ahem.ttf);
-			}
-			body {
-				margin: 0;
-				font-family: 'ahem';
-				font-size: 100px;
-				line-height: 1;
-			}
-			table {
-				background:green;
-				padding: 150px;
-				box-sizing: content-box;
-			}
-			th {
-				color: yellow;
-				padding: 0;
-			}
-		</style>
-	</head>
-	<body>
-		<table>
-			<tbody>
-				<tr>
-					<th>X</th>
-				</tr>
-			</tbody>
-		</table>
-	</body>
+    <head>
+        <style type="text/css">
+            @font-face {
+                font-family: 'ahem';
+                src: url(fonts/ahem/ahem.ttf);
+            }
+            body {
+                margin: 0;
+                font-family: 'ahem';
+                font-size: 100px;
+                line-height: 1;
+            }
+            table {
+                background:green;
+                padding: 150px;
+                box-sizing: content-box;
+                border-spacing: 0;
+            }
+            th {
+                color: yellow;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <table>
+            <tbody>
+                <tr>
+                    <th>X</th>
+                </tr>
+            </tbody>
+        </table>
+    </body>
 </html>


### PR DESCRIPTION
Table layout code has been refactored to push the spacing down to
rowgroups and rows; this will aid the implementation of
`border-collapse` as well.

r? @SimonSapin 
