### PR TITLE
Make the argument to dispatch_event_with_target non-optional.

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -108,7 +108,7 @@ impl EventTarget {
 
 pub trait EventTargetHelpers {
     fn dispatch_event_with_target(self,
-                                  target: Option<JSRef<EventTarget>>,
+                                  target: JSRef<EventTarget>,
                                   event: JSRef<Event>) -> bool;
     fn dispatch_event(self, event: JSRef<Event>) -> bool;
     fn set_inline_event_listener(self,
@@ -130,13 +130,13 @@ pub trait EventTargetHelpers {
 
 impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
     fn dispatch_event_with_target(self,
-                                  target: Option<JSRef<EventTarget>>,
+                                  target: JSRef<EventTarget>,
                                   event: JSRef<Event>) -> bool {
-        dispatch_event(self, target, event)
+        dispatch_event(self, Some(target), event)
     }
 
     fn dispatch_event(self, event: JSRef<Event>) -> bool {
-        self.dispatch_event_with_target(None, event)
+        dispatch_event(self, None, event)
     }
 
     fn set_inline_event_listener(self,

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -859,7 +859,7 @@ impl ScriptTask {
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();
         let wintarget: JSRef<EventTarget> = EventTargetCast::from_ref(*window);
-        let _ = wintarget.dispatch_event_with_target(Some(doctarget), *event);
+        let _ = wintarget.dispatch_event_with_target(doctarget, *event);
 
         *page.fragment_name.borrow_mut() = final_url.fragment.clone();
 


### PR DESCRIPTION
The name of the method makes it clear it's supposed to be used with a target
override, so we might as well enforce that.
