### PR TITLE
GlobalRef passed by value in reflect_dom_object, reflect_node #4165

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1830,7 +1830,7 @@ class CGWrapMethod(CGAbstractMethod):
     def __init__(self, descriptor):
         assert not descriptor.interface.isCallback()
         if not descriptor.isGlobal():
-            args = [Argument('*mut JSContext', 'aCx'), Argument('&GlobalRef', 'aScope'),
+            args = [Argument('*mut JSContext', 'aCx'), Argument('GlobalRef', 'aScope'),
                     Argument("Box<%s>" % descriptor.concreteType, 'aObject', mutable=True)]
         else:
             args = [Argument('*mut JSContext', 'aCx'),

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -340,9 +340,9 @@ pub trait Reflectable {
 pub fn reflect_dom_object<T: Reflectable>
         (obj:     Box<T>,
          global:  GlobalRef,
-         wrap_fn: extern "Rust" fn(*mut JSContext, &GlobalRef, Box<T>) -> Temporary<T>)
+         wrap_fn: extern "Rust" fn(*mut JSContext, GlobalRef, Box<T>) -> Temporary<T>)
          -> Temporary<T> {
-    wrap_fn(global.get_cx(), &global, obj)
+    wrap_fn(global.get_cx(), global, obj)
 }
 
 /// A struct to store a reference to the reflector of a DOM object.

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1157,7 +1157,7 @@ impl Node {
     pub fn reflect_node<N: Reflectable+NodeBase>
             (node:      Box<N>,
              document:  JSRef<Document>,
-             wrap_fn:   extern "Rust" fn(*mut JSContext, &GlobalRef, Box<N>) -> Temporary<N>)
+             wrap_fn:   extern "Rust" fn(*mut JSContext, GlobalRef, Box<N>) -> Temporary<N>)
              -> Temporary<N> {
         let window = document.window().root();
         reflect_dom_object(node, GlobalRef::Window(*window), wrap_fn)


### PR DESCRIPTION
Changed fn_wrap argument in reflect_dom_object() and reflect_node() to pass GlobalRef by value rather than by reference.  Fixes #4165   
