### PR TITLE
layout: Implement floated list items.

### DIFF
--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -15,6 +15,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
+use servo_util::logical_geometry::LogicalRect;
 use std::fmt;
 use style::ComputedValues;
 use std::sync::Arc;
@@ -84,6 +85,10 @@ impl Flow for TableCaptionFlow {
 
     fn compute_overflow(&self) -> Rect<Au> {
         self.block_flow.compute_overflow()
+    }
+
+    fn generated_containing_block_rect(&self) -> LogicalRect<Au> {
+        self.block_flow.generated_containing_block_rect()
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -17,6 +17,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
+use servo_util::logical_geometry::LogicalRect;
 use std::fmt;
 use style::{UnsignedIntegerAttribute, ComputedValues};
 use std::sync::Arc;
@@ -165,6 +166,10 @@ impl Flow for TableCellFlow {
 
     fn compute_overflow(&self) -> Rect<Au> {
         self.block_flow.compute_overflow()
+    }
+
+    fn generated_containing_block_rect(&self) -> LogicalRect<Au> {
+        self.block_flow.generated_containing_block_rect()
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -20,6 +20,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
+use servo_util::logical_geometry::LogicalRect;
 use std::cmp::max;
 use std::fmt;
 use style::ComputedValues;
@@ -318,6 +319,10 @@ impl Flow for TableRowFlow {
 
     fn compute_overflow(&self) -> Rect<Au> {
         self.block_flow.compute_overflow()
+    }
+
+    fn generated_containing_block_rect(&self) -> LogicalRect<Au> {
+        self.block_flow.generated_containing_block_rect()
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -17,6 +17,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
+use servo_util::logical_geometry::LogicalRect;
 use std::fmt;
 use style::ComputedValues;
 use std::sync::Arc;
@@ -153,6 +154,10 @@ impl Flow for TableRowGroupFlow {
 
     fn compute_overflow(&self) -> Rect<Au> {
         self.block_flow.compute_overflow()
+    }
+
+    fn generated_containing_block_rect(&self) -> LogicalRect<Au> {
+        self.block_flow.generated_containing_block_rect()
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -233,3 +233,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == filter_sepia_a.html filter_sepia_ref.html
 == mix_blend_mode_a.html mix_blend_mode_ref.html
 != text_overflow_a.html text_overflow_ref.html
+== floated_list_item_a.html floated_list_item_ref.html

--- a/tests/ref/floated_list_item_a.html
+++ b/tests/ref/floated_list_item_a.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that list items can be floated. -->
+<style>
+ul div {
+    display: list-item;
+    float: left;
+    list-style: none;
+    margin: 0;
+}
+ul {
+    margin: 0;
+    padding: 0;
+}
+</style>
+</head>
+<body>
+<ul>
+    <div>Foo</div>
+    <div>Bar</div>
+    <div>Baz</div>
+</ul>
+</body>
+</html>
+

--- a/tests/ref/floated_list_item_ref.html
+++ b/tests/ref/floated_list_item_ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that list items can be floated. -->
+<style>
+ul div {
+    float: left;
+    margin: 0;
+}
+ul {
+    margin: 0;
+    padding: 0;
+}
+</style>
+</head>
+<body>
+<ul>
+    <div>Foo</div>
+    <div>Bar</div>
+    <div>Baz</div>
+</ul>
+</body>
+</html>
+


### PR DESCRIPTION
This patch also makes Servo not crash when
`generated_containing_block_rect()` is called on a list item (as, for
example, GitHub does), and for good measure I added the fix to other
flows as well.

r? @mbrubeck 
