### PR TITLE
Use event polling instead of blocking when outputting to a file.

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.0.2"
-source = "git+https://github.com/servo/glutin?ref=servo#936519a44f77f6b646c504eff38fe7d57a17b1f4"
+source = "git+https://github.com/servo/glutin?ref=servo#4b1039622fab13fed23e111a35e65e5186540808"
 dependencies = [
  "android_glue 0.0.1 (git+https://github.com/servo/android-rs-glue?ref=servo)",
  "cocoa 0.1.1 (git+https://github.com/servo/rust-cocoa)",

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -95,7 +95,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == overflow_simple_a.html overflow_simple_b.html
 == noscript.html noscript_ref.html
 == pseudo_inherit.html pseudo_inherit_ref.html
-flaky_linux,experimental == vertical-lr-blocks.html vertical-lr-blocks_ref.html
+flaky_cpu,experimental == vertical-lr-blocks.html vertical-lr-blocks_ref.html
 == float_intrinsic_height.html float_intrinsic_height_ref.html
 == table_auto_width.html table_auto_width_ref.html
 == inline_whitespace_b.html inline_whitespace_ref.html


### PR DESCRIPTION
This stops some ref tests on linux blocking while waiting for
user input events and never outputting the file.

Also mark vertical writing test as flaky on all platforms. Due
to unrelated timing reasons, this fails reliably on mac when glutin
is enabled. The related bug with details on the root cause is #3926.
