### PR TITLE
if-let in net, plugin, script: #4153

### DIFF
--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(default_type_params, globs, phase)]
+#![feature(default_type_params, globs, phase, if_let)]
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]

--- a/components/net/local_image_cache.rs
+++ b/components/net/local_image_cache.rs
@@ -118,25 +118,22 @@ impl<NodeAddress: Send> LocalImageCache<NodeAddress> {
         self.image_cache_task.send(Msg::GetImage((*url).clone(), response_chan));
 
         let response = response_port.recv();
-        match response {
-            ImageResponseMsg::ImageNotReady => {
-                // Need to reflow when the image is available
-                // FIXME: Instead we should be just passing a Future
-                // to the caller, then to the display list. Finally,
-                // the compositor should be responsible for waiting
-                // on the image to load and triggering layout
-                let image_cache_task = self.image_cache_task.clone();
-                assert!(self.on_image_available.is_some());
-                let on_image_available: proc(ImageResponseMsg, NodeAddress):Send =
-                    self.on_image_available.as_ref().unwrap().respond();
-                let url = (*url).clone();
-                spawn_named("LocalImageCache", proc() {
-                    let (response_chan, response_port) = channel();
-                    image_cache_task.send(Msg::WaitForImage(url, response_chan));
-                    on_image_available(response_port.recv(), node_address);
-                });
-            }
-            _ => ()
+        if ImageResponseMsg::ImageNotReady == response {
+            // Need to reflow when the image is available
+            // FIXME: Instead we should be just passing a Future
+            // to the caller, then to the display list. Finally,
+            // the compositor should be responsible for waiting
+            // on the image to load and triggering layout
+            let image_cache_task = self.image_cache_task.clone();
+            assert!(self.on_image_available.is_some());
+            let on_image_available: proc(ImageResponseMsg, NodeAddress):Send =
+                self.on_image_available.as_ref().unwrap().respond();
+            let url = (*url).clone();
+            spawn_named("LocalImageCache", proc() {
+                let (response_chan, response_port) = channel();
+                image_cache_task.send(Msg::WaitForImage(url, response_chan));
+                on_image_available(response_port.recv(), node_address);
+            });
         }
 
         // Put a copy of the response in the cache

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -12,7 +12,7 @@
 //!  - `#[dom_struct]` : Implies `#[privatize]`,`#[jstraceable]`, and `#[must_root]`.
 //!     Use this for structs that correspond to a DOM type
 
-#![feature(macro_rules, plugin_registrar, quote, phase)]
+#![feature(macro_rules, plugin_registrar, quote, phase, if_let)]
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]

--- a/components/script/cors.rs
+++ b/components/script/cors.rs
@@ -72,9 +72,8 @@ impl CORSRequest {
 
     fn new(mut referer: Url, destination: Url, mode: RequestMode, method: Method,
            headers: Headers) -> CORSRequest {
-        match referer.scheme_data {
-            SchemeData::Relative(ref mut data) => data.path = vec!(),
-            _ => {}
+        if let SchemeData::Relative(ref mut data) = referer.scheme_data {
+            data.path = vec!();
         };
         referer.fragment = None;
         referer.query = None;

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -22,6 +22,7 @@ use string_cache::{Atom, Namespace};
 use std::cell::Ref;
 use std::mem;
 
+#[deriving(PartialEq, Eq)]
 pub enum AttrSettingType {
     FirstSetAttr,
     ReplacedAttr,
@@ -206,10 +207,8 @@ impl<'a> AttrHelpers<'a> for JSRef<'a, Attr> {
         let node: JSRef<Node> = NodeCast::from_ref(owner);
         let namespace_is_null = self.namespace == ns!("");
 
-        match set_type {
-            AttrSettingType::ReplacedAttr if namespace_is_null =>
-                vtable_for(&node).before_remove_attr(self),
-            _ => ()
+        if AttrSettingType::ReplacedAttr == set_type && namespace_is_null {
+            vtable_for(&node).before_remove_attr(self);
         }
 
         *self.value.borrow_mut() = value;

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -219,19 +219,16 @@ fn CreateInterfaceObject(cx: *mut JSContext, global: *mut JSObject, receiver: *m
         let constructor = JS_GetFunctionObject(fun);
         assert!(constructor.is_not_null());
 
-        match members.staticMethods {
-            Some(staticMethods) => DefineMethods(cx, constructor, staticMethods),
-            _ => (),
+        if let Some(staticMethods) = members.staticMethods {
+            DefineMethods(cx, constructor, staticMethods);
         }
 
-        match members.staticAttrs {
-            Some(staticProperties) => DefineProperties(cx, constructor, staticProperties),
-            _ => (),
+        if let Some(staticProperties) = members.staticAttrs {
+            DefineProperties(cx, constructor, staticProperties);
         }
 
-        match members.consts {
-            Some(constants) => DefineConstants(cx, constructor, constants),
-            _ => (),
+        if let Some(constants) = members.consts {
+            DefineConstants(cx, constructor, constants);
         }
 
         if proto.is_not_null() {
@@ -290,19 +287,16 @@ fn CreateInterfacePrototypeObject(cx: *mut JSContext, global: *mut JSObject,
         let ourProto = JS_NewObjectWithUniqueType(cx, protoClass, &*parentProto, &*global);
         assert!(ourProto.is_not_null());
 
-        match members.methods {
-            Some(methods) => DefineMethods(cx, ourProto, methods),
-            _ => (),
+        if let Some(methods) = members.methods {
+            DefineMethods(cx, ourProto, methods);
         }
 
-        match members.attrs {
-            Some(properties) => DefineProperties(cx, ourProto, properties),
-            _ => (),
+        if let Some(properties) = members.attrs {
+            DefineProperties(cx, ourProto, properties);
         }
 
-        match members.consts {
-            Some(constants) => DefineConstants(cx, ourProto, constants),
-            _ => (),
+        if let Some(constants) = members.consts {
+            DefineConstants(cx, ourProto, constants);
         }
 
         return ourProto;
@@ -566,7 +560,7 @@ pub unsafe fn delete_property_by_id(cx: *mut JSContext, object: *mut JSObject,
 }
 
 /// Results of `xml_name_type`.
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum XMLName {
     QName,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -92,7 +92,7 @@ impl Reflectable for Element {
     }
 }
 
-#[deriving(PartialEq, Show)]
+#[deriving(PartialEq, Eq, Show)]
 #[jstraceable]
 pub enum ElementTypeId {
     HTMLElement,
@@ -1154,9 +1154,8 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -1206,9 +1205,8 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -1263,44 +1261,36 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if !tree_in_doc { return; }
 
-        match self.get_attribute(ns!(""), &atom!("id")).root() {
-            Some(attr) => {
-                let doc = document_from_node(*self).root();
-                let value = attr.Value();
-                if !value.is_empty() {
-                    let value = Atom::from_slice(value.as_slice());
-                    doc.register_named_element(*self, value);
-                }
+        if let Some(attr) = self.get_attribute(ns!(""), &atom!("id")).root() {
+            let doc = document_from_node(*self).root();
+            let value = attr.Value();
+            if !value.is_empty() {
+                let value = Atom::from_slice(value.as_slice());
+                doc.register_named_element(*self, value);
             }
-            _ => ()
         }
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         if !tree_in_doc { return; }
 
-        match self.get_attribute(ns!(""), &atom!("id")).root() {
-            Some(attr) => {
-                let doc = document_from_node(*self).root();
-                let value = attr.Value();
-                if !value.is_empty() {
-                    let value = Atom::from_slice(value.as_slice());
-                    doc.unregister_named_element(*self, value);
-                }
+        if let Some(ref attr) = self.get_attribute(ns!(""), &atom!("id")).root() {
+            let doc = document_from_node(*self).root();
+            let value = attr.Value();
+            if !value.is_empty() {
+                let value = Atom::from_slice(value.as_slice());
+                doc.unregister_named_element(*self, value);
             }
-            _ => ()
         }
     }
 }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -248,24 +248,21 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
                         ty: DOMString,
                         listener: Option<EventListener>,
                         capture: bool) {
-        match listener {
-            Some(listener) => {
-                let mut handlers = self.handlers.borrow_mut();
-                let entry = match handlers.entry(ty) {
-                    Occupied(entry) => entry.into_mut(),
-                    Vacant(entry) => entry.set(vec!()),
-                };
+        if let Some(listener) = listener {
+            let mut handlers = self.handlers.borrow_mut();
+            let entry = match handlers.entry(ty) {
+                Occupied(entry) => entry.into_mut(),
+                Vacant(entry) => entry.set(vec!()),
+            };
 
-                let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
-                let new_entry = EventListenerEntry {
-                    phase: phase,
-                    listener: EventListenerType::Additive(listener)
-                };
-                if entry.as_slice().position_elem(&new_entry).is_none() {
-                    entry.push(new_entry);
-                }
-            },
-            _ => (),
+            let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
+            let new_entry = EventListenerEntry {
+                phase: phase,
+                listener: EventListenerType::Additive(listener)
+            };
+            if entry.as_slice().position_elem(&new_entry).is_none() {
+                entry.push(new_entry);
+            }
         }
     }
 
@@ -273,23 +270,20 @@ impl<'a> EventTargetMethods for JSRef<'a, EventTarget> {
                            ty: DOMString,
                            listener: Option<EventListener>,
                            capture: bool) {
-        match listener {
-            Some(listener) => {
-                let mut handlers = self.handlers.borrow_mut();
-                let mut entry = handlers.get_mut(&ty);
-                for entry in entry.iter_mut() {
-                    let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
-                    let old_entry = EventListenerEntry {
-                        phase: phase,
-                        listener: EventListenerType::Additive(listener)
-                    };
-                    let position = entry.as_slice().position_elem(&old_entry);
-                    for &position in position.iter() {
-                        entry.remove(position);
-                    }
+        if let Some(listener) = listener {
+            let mut handlers = self.handlers.borrow_mut();
+            let mut entry = handlers.get_mut(&ty);
+            for entry in entry.iter_mut() {
+                let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
+                let old_entry = EventListenerEntry {
+                    phase: phase,
+                    listener: EventListenerType::Additive(listener)
+                };
+                let position = entry.as_slice().position_elem(&old_entry);
+                for &position in position.iter() {
+                    entry.remove(position);
                 }
-            },
-            _ => (),
+            }
         }
     }
 

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -82,9 +82,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let name = attr.local_name().as_slice();

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -81,9 +81,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -97,9 +96,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -114,9 +112,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -124,9 +121,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -101,9 +101,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         let recreate = match attr.local_name() {
@@ -120,17 +119,15 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
 
         if recreate {
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            match self.context.get() {
-                Some(ref context) => context.root().recreate(Size2D(w, h)),
-                None => ()
+            if let Some(ref context) = self.context.get() {
+                context.root().recreate(Size2D(w, h));
             }
         }
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let value = attr.value();
@@ -148,9 +145,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
 
         if recreate {
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            match self.context.get() {
-                Some(ref context) => context.root().recreate(Size2D(w, h)),
-                None => ()
+            if let Some(ref context) = self.context.get() {
+                context.root().recreate(Size2D(w, h));
             }
         }
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -112,9 +112,10 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     // https://html.spec.whatwg.org/multipage/interaction.html#dom-click
     fn Click(self) {
         let maybe_input = HTMLInputElementCast::to_ref(self);
-        match maybe_input {
-            Some(i) if i.Disabled() => return,
-            _ => ()
+        if let Some(i) = maybe_input {
+            if i.Disabled() {
+                return;
+            }
         }
         let element: JSRef<Element> = ElementCast::from_ref(self);
         // https://www.w3.org/Bugs/Public/show_bug.cgi?id=27430 ?
@@ -129,9 +130,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let name = attr.local_name().as_slice();

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -84,9 +84,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -116,9 +115,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -207,9 +207,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -239,9 +238,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -251,9 +249,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -179,9 +179,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -195,9 +194,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -45,7 +45,7 @@ const DEFAULT_SUBMIT_VALUE: &'static str = "Submit";
 const DEFAULT_RESET_VALUE: &'static str = "Reset";
 
 #[jstraceable]
-#[deriving(PartialEq)]
+#[deriving(PartialEq, Eq)]
 #[allow(dead_code)]
 enum InputType {
     InputSubmit,
@@ -393,9 +393,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -453,9 +452,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -508,9 +506,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -518,9 +515,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -532,17 +528,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn handle_event(&self, event: JSRef<Event>) {
-        match self.super_type() {
-            Some(s) => {
-                s.handle_event(event);
-            }
-            _ => (),
+        if let Some(s) = self.super_type() {
+            s.handle_event(event);
         }
 
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {
-            match self.input_type.get() {
-                InputType::InputRadio => self.update_checked_state(true, true),
-                _ => {}
+            if InputType::InputRadio == self.input_type.get() {
+                self.update_checked_state(true, true);
             }
 
             // TODO: Dispatch events for non activatable inputs

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -74,9 +74,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let element: JSRef<Element> = ElementCast::from_ref(*self);
@@ -100,9 +99,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc {
@@ -111,11 +109,10 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
             let rel = get_attr(element, &atom!("rel"));
             let href = get_attr(element, &atom!("href"));
 
-            match (rel, href) {
-                (ref rel, Some(ref href)) if is_stylesheet(rel) => {
+            if let (ref rel, Some(ref href)) = (rel, href) {
+                if is_stylesheet(rel) {
                     self.handle_stylesheet_url(href.as_slice());
                 }
-                _ => {}
             }
         }
     }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -63,16 +63,13 @@ impl<'a> ProcessDataURL for JSRef<'a, HTMLObjectElement> {
         let elem: JSRef<Element> = ElementCast::from_ref(*self);
 
         // TODO: support other values
-        match (elem.get_attribute(ns!(""), &atom!("type")).map(|x| x.root().Value()),
+        if let (None, Some(uri)) = (elem.get_attribute(ns!(""), &atom!("type")).map(|x| x.root().Value()),
                elem.get_attribute(ns!(""), &atom!("data")).map(|x| x.root().Value())) {
-            (None, Some(uri)) => {
-                if is_image_data(uri.as_slice()) {
-                    let data_url = Url::parse(uri.as_slice()).unwrap();
-                    // Issue #84
-                    image_cache.send(image_cache_task::Prefetch(data_url));
-                }
+            if is_image_data(uri.as_slice()) {
+                let data_url = Url::parse(uri.as_slice()).unwrap();
+                // Issue #84
+                image_cache.send(image_cache_task::Prefetch(data_url));
             }
-            _ => { }
         }
     }
 }
@@ -102,9 +99,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -60,9 +60,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -80,9 +79,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -129,9 +129,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -145,9 +144,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -162,9 +160,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -172,9 +169,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -265,9 +265,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         if attr.local_name() == &atom!("src") && !self.parser_inserted.get() && node.is_in_doc() {
@@ -276,9 +275,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         if !self.parser_inserted.get() && node.is_in_doc() {
@@ -287,9 +285,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc && !self.parser_inserted.get() {
@@ -299,9 +296,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
 
     fn cloning_steps(&self, copy: JSRef<Node>, maybe_doc: Option<JSRef<Document>>,
                      clone_children: CloneChildrenFlag) {
-        match self.super_type() {
-            Some(ref s) => s.cloning_steps(copy, maybe_doc, clone_children),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.cloning_steps(copy, maybe_doc, clone_children);
         }
 
         // https://whatwg.org/html/#already-started

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -82,9 +82,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -98,9 +97,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -115,9 +113,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -125,9 +122,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -69,9 +69,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -81,9 +80,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc {

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -82,9 +82,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -100,9 +99,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -205,9 +205,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -233,9 +232,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -256,9 +254,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -274,9 +271,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -288,11 +284,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(s) => {
-                s.child_inserted(child);
-            }
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
 
         if child.is_text() && !self.value_changed.get() {
@@ -302,11 +295,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
 
     // copied and modified from htmlinputelement.rs
     fn handle_event(&self, event: JSRef<Event>) {
-        match self.super_type() {
-            Some(s) => {
-                s.handle_event(event);
-            }
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.handle_event(event);
         }
 
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -173,13 +173,10 @@ impl<'a> PrivateTreeWalkerHelpers<'a> for JSRef<'a, TreeWalker> {
                         Ok(NodeFilterConstants::FILTER_SKIP) => {
                             // "1. Let child be node's first child if type is first,
                             //     and node's last child if type is last."
-                            match next_child(node) {
+                            if let Some(child) = next_child(node) {
                                 // "2. If child is not null, set node to child and goto Main."
-                                Some(child) => {
-                                    node_op = Some(child.root().clone());
-                                    continue 'main
-                                },
-                                None => {}
+                                node_op = Some(child.root().clone());
+                                continue 'main
                             }
                         },
                         _ => {}
@@ -482,9 +479,8 @@ impl<'a> TreeWalkerHelpers<'a> for JSRef<'a, TreeWalker> {
         loop {
             // "1. While result is not FILTER_REJECT and node has a child, run these subsubsteps:"
             loop {
-                match result {
-                    Ok(NodeFilterConstants::FILTER_REJECT) => break,
-                    _ => {}
+                if let Ok(NodeFilterConstants::FILTER_REJECT) = result {
+                    break;
                 }
                 match node.first_child() {
                     None => break,

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -71,72 +71,64 @@ pub trait VirtualMethods {
     /// Called when changing or adding attributes, after the attribute's value
     /// has been updated.
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
     }
 
     /// Called when changing or removing attributes, before any modification
     /// has taken place.
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
     }
 
     /// Returns the right AttrValue variant for the attribute with name `name`
     /// on this element.
     fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
-        match self.super_type() {
-            Some(ref s) => s.parse_plain_attribute(name, value),
-            _ => AttrValue::String(value),
+        if let Some(ref s) = self.super_type() {
+            s.parse_plain_attribute(name, value)
+        } else {
+            AttrValue::String(value)
         }
     }
 
     /// Called when a Node is appended to a tree, where 'tree_in_doc' indicates
     /// whether the tree is part of a Document.
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
     }
 
     /// Called when a Node is removed from a tree, where 'tree_in_doc'
     /// indicates whether the tree is part of a Document.
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
     }
 
     /// Called on the parent when a node is added to its child list.
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
     }
 
     /// Called during event dispatch after the bubbling phase completes.
     fn handle_event(&self, event: JSRef<Event>) {
-        match self.super_type() {
-            Some(s) => {
-                s.handle_event(event);
-            }
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.handle_event(event);
         }
     }
 
     /// https://dom.spec.whatwg.org/#concept-node-clone (step 5)
     fn cloning_steps(&self, copy: JSRef<Node>, maybe_doc: Option<JSRef<Document>>,
                      clone_children: CloneChildrenFlag) {
-        match self.super_type() {
-            Some(ref s) => s.cloning_steps(copy, maybe_doc, clone_children),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.cloning_steps(copy, maybe_doc, clone_children);
         }
     }
 }


### PR DESCRIPTION
Fixes #4153 

Old PR: #4218
Due to extensive problems encountered in merging with upstream changes, I decided to work on a new branch instead. This commit follows instructions given by @Manishearth in [Critic for the old PR](https://critic.hoppipolla.co.uk/r/3372).

Replaced appropriate simple `match` statements involving destructure with `if let` and those not involving destructure with `if`. Those with matches to `atom!`s are left unchanged.
Crates affected:
- net
- plugin
- script
