### PR TITLE
Replace XHR events for generic ones in ScriptTask

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -19,7 +19,7 @@ use libc;
 use std::ptr;
 
 /// DOM exceptions that can be thrown by a native DOM method.
-#[deriving(Show)]
+#[deriving(Show, Clone)]
 pub enum Error {
     IndexSize,
     FailureUnknown,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -17,7 +17,6 @@ use dom::messageevent::MessageEvent;
 use dom::worker::{Worker, TrustedWorkerAddress};
 use dom::workerglobalscope::{WorkerGlobalScope, WorkerGlobalScopeHelpers};
 use dom::workerglobalscope::WorkerGlobalScopeTypeId;
-use dom::xmlhttprequest::XMLHttpRequest;
 use script_task::{ScriptTask, ScriptChan, ScriptMsg, TimerSource};
 use script_task::StackRootTLS;
 
@@ -131,11 +130,8 @@ impl DedicatedWorkerGlobalScope {
                         MessageEvent::dispatch_jsval(target, GlobalRef::Worker(scope), message);
                         global.delayed_release_worker();
                     },
-                    Ok(ScriptMsg::XHRProgress(addr, progress)) => {
-                        XMLHttpRequest::handle_progress(addr, progress)
-                    },
-                    Ok(ScriptMsg::XHRRelease(addr)) => {
-                        XMLHttpRequest::handle_release(addr)
+                    Ok(ScriptMsg::RunnableMsg(runnable)) => {
+                        runnable.handler()
                     },
                     Ok(ScriptMsg::WorkerPostMessage(addr, data, nbytes)) => {
                         Worker::handle_message(addr, data, nbytes);

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -26,7 +26,6 @@ use dom::keyboardevent::KeyboardEvent;
 use dom::node::{mod, Node, NodeHelpers, NodeDamage, NodeTypeId};
 use dom::window::{Window, WindowHelpers};
 use dom::worker::{Worker, TrustedWorkerAddress};
-use dom::xmlhttprequest::{TrustedXHRAddress, XMLHttpRequest, XHRProgress};
 use parse::html::{HTMLInput, parse_html};
 use layout_interface::{ScriptLayoutChan, LayoutChan, ReflowGoal, ReflowQueryType};
 use layout_interface;
@@ -86,6 +85,10 @@ pub enum TimerSource {
     FromWorker
 }
 
+pub trait Runnable {
+    fn handler(&self);
+}
+
 /// Messages used to control script event loops, such as ScriptTask and
 /// DedicatedWorkerGlobalScope.
 pub enum ScriptMsg {
@@ -105,10 +108,6 @@ pub enum ScriptMsg {
     /// Notifies the script that a window associated with a particular pipeline
     /// should be closed (only dispatched to ScriptTask).
     ExitWindow(PipelineId),
-    /// Notifies the script of progress on a fetch (dispatched to all tasks).
-    XHRProgress(TrustedXHRAddress, XHRProgress),
-    /// Releases one reference to the XHR object (dispatched to all tasks).
-    XHRRelease(TrustedXHRAddress),
     /// Message sent through Worker.postMessage (only dispatched to
     /// DedicatedWorkerGlobalScope).
     DOMMessage(*mut u64, size_t),
@@ -116,6 +115,8 @@ pub enum ScriptMsg {
     WorkerPostMessage(TrustedWorkerAddress, *mut u64, size_t),
     /// Releases one reference to the Worker object (dispatched to all tasks).
     WorkerRelease(TrustedWorkerAddress),
+    /// Generic message that encapsulates event handling.
+    RunnableMsg(Box<Runnable+Send>),
 }
 
 /// Encapsulates internal communication within the script task.
@@ -571,16 +572,14 @@ impl ScriptTask {
                 self.handle_navigate_msg(direction),
             ScriptMsg::ExitWindow(id) =>
                 self.handle_exit_window_msg(id),
-            ScriptMsg::XHRProgress(addr, progress) =>
-                XMLHttpRequest::handle_progress(addr, progress),
-            ScriptMsg::XHRRelease(addr) =>
-                XMLHttpRequest::handle_release(addr),
             ScriptMsg::DOMMessage(..) =>
                 panic!("unexpected message"),
             ScriptMsg::WorkerPostMessage(addr, data, nbytes) =>
                 Worker::handle_message(addr, data, nbytes),
             ScriptMsg::WorkerRelease(addr) =>
                 Worker::handle_release(addr),
+            ScriptMsg::RunnableMsg(runnable) =>
+                runnable.handler(),
         }
     }
 


### PR DESCRIPTION
This refs #3735. As discussed in the issue, I did it cloning when I couldn't dereference an attribute. The trait method should be on `&self` for object-safety reasons.
