### PR TITLE
layout: Implement `text-rendering` per SVG 1.1 § 11.7.4.

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -105,7 +105,9 @@ bitflags! {
         #[doc="Set if the text is entirely whitespace."]
         const IS_WHITESPACE_SHAPING_FLAG = 0x01,
         #[doc="Set if we are to ignore ligatures."]
-        const IGNORE_LIGATURES_SHAPING_FLAG = 0x02
+        const IGNORE_LIGATURES_SHAPING_FLAG = 0x02,
+        #[doc="Set if we are to disable kerning."]
+        const DISABLE_KERNING_SHAPING_FLAG = 0x04
     }
 }
 

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -4,8 +4,8 @@
 
 extern crate harfbuzz;
 
-use font::{Font, FontHandleMethods, FontTableMethods, FontTableTag, IGNORE_LIGATURES_SHAPING_FLAG};
-use font::{ShapingOptions};
+use font::{DISABLE_KERNING_SHAPING_FLAG, Font, FontHandleMethods, FontTableMethods, FontTableTag};
+use font::{IGNORE_LIGATURES_SHAPING_FLAG, ShapingOptions};
 use platform::font::FontTable;
 use text::glyph::{CharIndex, GlyphStore, GlyphId, GlyphData};
 use text::shaping::ShaperMethods;
@@ -50,6 +50,8 @@ use std::ptr;
 static NO_GLYPH: i32 = -1;
 static CONTINUATION_BYTE: i32 = -2;
 
+static KERN: u32 = ((b'k' as u32) << 24) | ((b'e' as u32) << 16) | ((b'r' as u32) << 8) |
+    (b'n' as u32);
 static LIGA: u32 = ((b'l' as u32) << 24) | ((b'i' as u32) << 16) | ((b'g' as u32) << 8) |
     (b'a' as u32);
 
@@ -237,6 +239,14 @@ impl ShaperMethods for Shaper {
             if options.flags.contains(IGNORE_LIGATURES_SHAPING_FLAG) {
                 features.push(hb_feature_t {
                     _tag: LIGA,
+                    _value: 0,
+                    _start: 0,
+                    _end: hb_buffer_get_length(hb_buffer),
+                })
+            }
+            if options.flags.contains(DISABLE_KERNING_SHAPING_FLAG) {
+                features.push(hb_feature_t {
+                    _tag: KERN,
                     _value: 0,
                     _start: 0,
                     _end: hb_buffer_get_length(hb_buffer),

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1483,6 +1483,8 @@ pub mod longhands {
     // TODO(pcwalton): `full-width`
     ${single_keyword("text-transform", "none capitalize uppercase lowercase")}
 
+    ${single_keyword("text-rendering", "auto optimizespeed optimizelegibility geometricprecision")}
+
     // CSS 2.1, Section 17 - Tables
     ${new_style_struct("Table", is_inherited=False)}
 

--- a/tests/html/text_rendering.html
+++ b/tests/html/text_rendering.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    font-size: 24pt;
+    font-family: "PT Sans";
+    font-weight: bold;
+}
+#a {
+    text-rendering: optimizelegibility;
+}
+#b {
+    text-rendering: geometricprecision;
+}
+#c {
+    text-rendering: optimizespeed;
+}
+</style>
+</head>
+<body>
+<div id=a>Harry finally caught the Snitch.</div>
+<div id=b>Harry finally caught the Snitch.</div>
+<div id=c>Harry finally caught the Snitch.</div>
+</body>
+</html>
+


### PR DESCRIPTION
Like Gecko, we treat `geometricprecision` the same as
`optimizelegibility` for now.

r? @mbrubeck 
