### PR TITLE
Move away from Root::deref.

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -32,22 +32,23 @@ pub trait Activatable : Copy {
     fn synthetic_click_activation(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool) {
         let element = self.as_element().root();
         // Step 1
-        if element.click_in_progress() {
+        if element.r().click_in_progress() {
             return;
         }
         // Step 2
-        element.set_click_in_progress(true);
+        element.r().set_click_in_progress(true);
         // Step 3
         self.pre_click_activation();
 
         // Step 4
         // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-synthetic-mouse-event
-        let win = window_from_node(*element).root();
-        let target: JSRef<EventTarget> = EventTargetCast::from_ref(*element);
-        let mouse = MouseEvent::new(*win, "click".into_string(), false, false, Some(*win), 1,
+        let win = window_from_node(element.r()).root();
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(element.r());
+        let mouse = MouseEvent::new(win.r(), "click".into_string(),
+                                    false, false, Some(win.r()), 1,
                                     0, 0, 0, 0, ctrlKey, shiftKey, altKey, metaKey,
                                     0, None).root();
-        let event: JSRef<Event> = EventCast::from_ref(*mouse);
+        let event: JSRef<Event> = EventCast::from_ref(mouse.r());
         event.set_trusted(true);
         target.dispatch_event(event);
 
@@ -60,6 +61,6 @@ pub trait Activatable : Copy {
         }
 
         // Step 6
-        element.set_click_in_progress(false);
+        element.r().set_click_in_progress(false);
     }
 }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -151,8 +151,8 @@ impl<'a> AttrMethods for JSRef<'a, Attr> {
             }
             Some(o) => {
                 let owner = o.root();
-                let value = owner.parse_attribute(&self.namespace, self.local_name(), value);
-                self.set_value(AttrSettingType::ReplacedAttr, value, *owner);
+                let value = owner.r().parse_attribute(&self.namespace, self.local_name(), value);
+                self.set_value(AttrSettingType::ReplacedAttr, value, owner.r());
             }
         }
     }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -8,6 +8,7 @@ use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, JSRef, Temporary};
+use dom::bindings::js::{OptionalRootedRootable, RootedReference};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::element::{Element, AttributeHandlers};
 use dom::node::Node;
@@ -207,7 +208,7 @@ pub trait AttrHelpers<'a> {
 
 impl<'a> AttrHelpers<'a> for JSRef<'a, Attr> {
     fn set_value(self, set_type: AttrSettingType, value: AttrValue, owner: JSRef<Element>) {
-        assert!(Some(owner) == self.owner.map(|o| *o.root()));
+        assert!(Some(owner) == self.owner.root().r());
 
         let node: JSRef<Node> = NodeCast::from_ref(owner);
         let namespace_is_null = self.namespace == ns!("");

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -147,7 +147,7 @@ impl CallSetup {
     pub fn new<T: CallbackContainer>(callback: T, handling: ExceptionHandling) -> CallSetup {
         let global = global_object_for_js_object(callback.callback());
         let global = global.root();
-        let cx = global.root_ref().get_cx();
+        let cx = global.r().get_cx();
         CallSetup {
             cx: cx,
             _handling: handling

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2307,7 +2307,7 @@ class CGPerSignatureCall(CGThing):
         def process(arg, i):
             argVal = "arg" + str(i)
             if arg.type.isGeckoInterface() and not arg.type.unroll().inner.isCallback():
-                argVal += ".root_ref()"
+                argVal += ".r()"
             return argVal
         return [(a, process(a, i)) for (i, a) in enumerate(self.arguments)]
 
@@ -3540,7 +3540,7 @@ class CGProxySpecialOperation(CGPerSignatureCall):
         def process(arg):
             argVal = arg.identifier.name
             if arg.type.isGeckoInterface() and not arg.type.unroll().inner.isCallback():
-                argVal += ".root_ref()"
+                argVal += ".r()"
             return argVal
         args = [(a, process(a)) for a in self.arguments]
         if self.idlNode.isGetter():

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2199,7 +2199,7 @@ class CGCallGenerator(CGThing):
         if static:
             call = CGWrapper(call, pre="%s::" % descriptorProvider.interface.identifier.name)
         else:
-            call = CGWrapper(call, pre="%s." % object)
+            call = CGWrapper(call, pre="%s.r()." % object)
         call = CGList([call, CGWrapper(args, pre="(", post=")")])
 
         self.cgRoot.append(CGList([
@@ -2214,7 +2214,7 @@ class CGCallGenerator(CGThing):
             if static:
                 glob = ""
             else:
-                glob = "        let global = global_object_for_js_object(this.reflector().get_jsobject());\n"\
+                glob = "        let global = global_object_for_js_object(this.r().reflector().get_jsobject());\n"\
                        "        let global = global.root();\n"
 
             self.cgRoot.append(CGGeneric(

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2222,7 +2222,7 @@ class CGCallGenerator(CGThing):
                 "    Ok(result) => result,\n"
                 "    Err(e) => {\n"
                 "%s"
-                "        throw_dom_exception(cx, global.root_ref(), e);\n"
+                "        throw_dom_exception(cx, global.r(), e);\n"
                 "        return%s;\n"
                 "    },\n"
                 "};" % (glob, errorResult)))
@@ -4014,7 +4014,7 @@ let global = global_object_for_js_object(JS_CALLEE(cx, vp).to_object());
 let global = global.root();
 """)
         nativeName = MakeNativeName(self._ctor.identifier.name)
-        callGenerator = CGMethodCall(["&global.root_ref()"], nativeName, True,
+        callGenerator = CGMethodCall(["&global.r()"], nativeName, True,
                                      self.descriptor, self._ctor)
         return CGList([preamble, callGenerator])
 

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -156,7 +156,7 @@ class Descriptor(DescriptorProvider):
             self.needsRooting = True
             self.returnType = "Temporary<%s>" % ifaceName
             self.argumentType = "JSRef<%s>" % ifaceName
-            self.memberType = "Root<'b, %s>" % ifaceName
+            self.memberType = "Root<%s>" % ifaceName
             self.nativeType = "JS<%s>" % ifaceName
 
         self.concreteType = ifaceName

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -156,7 +156,7 @@ class Descriptor(DescriptorProvider):
             self.needsRooting = True
             self.returnType = "Temporary<%s>" % ifaceName
             self.argumentType = "JSRef<%s>" % ifaceName
-            self.memberType = "Root<'a, 'b, %s>" % ifaceName
+            self.memberType = "Root<'b, %s>" % ifaceName
             self.nativeType = "JS<%s>" % ifaceName
 
         self.concreteType = ifaceName

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -471,7 +471,7 @@ impl<T: Reflectable+IDLInterface> FromJSValConvertible<()> for JS<T> {
     }
 }
 
-impl<'a, 'b, T: Reflectable> ToJSValConvertible for Root<'a, 'b, T> {
+impl<'b, T: Reflectable> ToJSValConvertible for Root<'b, T> {
     fn to_jsval(&self, cx: *mut JSContext) -> JSVal {
         self.reflector().to_jsval(cx)
     }

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -471,7 +471,7 @@ impl<T: Reflectable+IDLInterface> FromJSValConvertible<()> for JS<T> {
     }
 }
 
-impl<'b, T: Reflectable> ToJSValConvertible for Root<'b, T> {
+impl<T: Reflectable> ToJSValConvertible for Root<T> {
     fn to_jsval(&self, cx: *mut JSContext) -> JSVal {
         self.reflector().to_jsval(cx)
     }

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -473,7 +473,7 @@ impl<T: Reflectable+IDLInterface> FromJSValConvertible<()> for JS<T> {
 
 impl<T: Reflectable> ToJSValConvertible for Root<T> {
     fn to_jsval(&self, cx: *mut JSContext) -> JSVal {
-        self.reflector().to_jsval(cx)
+        self.r().reflector().to_jsval(cx)
     }
 }
 

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -103,8 +103,8 @@ impl GlobalRoot {
     /// lifetime of this root.
     pub fn root_ref<'c>(&'c self) -> GlobalRef<'c> {
         match *self {
-            GlobalRoot::Window(ref window) => GlobalRef::Window(window.root_ref()),
-            GlobalRoot::Worker(ref worker) => GlobalRef::Worker(worker.root_ref()),
+            GlobalRoot::Window(ref window) => GlobalRef::Window(window.r()),
+            GlobalRoot::Worker(ref worker) => GlobalRef::Worker(worker.r()),
         }
     }
 }

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -32,9 +32,9 @@ pub enum GlobalRef<'a> {
 }
 
 /// A stack-based rooted reference to a global object.
-pub enum GlobalRoot<'b> {
-    Window(Root<'b, window::Window>),
-    Worker(Root<'b, WorkerGlobalScope>),
+pub enum GlobalRoot {
+    Window(Root<window::Window>),
+    Worker(Root<WorkerGlobalScope>),
 }
 
 /// A traced reference to a global object, for use in fields of traced Rust
@@ -98,7 +98,7 @@ impl<'a> Reflectable for GlobalRef<'a> {
     }
 }
 
-impl<'b> GlobalRoot<'b> {
+impl GlobalRoot {
     /// Obtain a safe reference to the global object that cannot outlive the
     /// lifetime of this root.
     pub fn root_ref<'c>(&'c self) -> GlobalRef<'c> {

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -32,9 +32,9 @@ pub enum GlobalRef<'a> {
 }
 
 /// A stack-based rooted reference to a global object.
-pub enum GlobalRoot<'a, 'b> {
-    Window(Root<'a, 'b, window::Window>),
-    Worker(Root<'a, 'b, WorkerGlobalScope>),
+pub enum GlobalRoot<'b> {
+    Window(Root<'b, window::Window>),
+    Worker(Root<'b, WorkerGlobalScope>),
 }
 
 /// A traced reference to a global object, for use in fields of traced Rust
@@ -98,7 +98,7 @@ impl<'a> Reflectable for GlobalRef<'a> {
     }
 }
 
-impl<'a, 'b> GlobalRoot<'a, 'b> {
+impl<'b> GlobalRoot<'b> {
     /// Obtain a safe reference to the global object that cannot outlive the
     /// lifetime of this root.
     pub fn root_ref<'c>(&'c self) -> GlobalRef<'c> {

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -101,7 +101,7 @@ impl<'a> Reflectable for GlobalRef<'a> {
 impl GlobalRoot {
     /// Obtain a safe reference to the global object that cannot outlive the
     /// lifetime of this root.
-    pub fn root_ref<'c>(&'c self) -> GlobalRef<'c> {
+    pub fn r<'c>(&'c self) -> GlobalRef<'c> {
         match *self {
             GlobalRoot::Window(ref window) => GlobalRef::Window(window.r()),
             GlobalRoot::Worker(ref worker) => GlobalRef::Worker(worker.r()),

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -91,7 +91,7 @@ impl<T: Reflectable> Temporary<T> {
     }
 
     /// Create a stack-bounded root for this value.
-    pub fn root<'b>(self) -> Root<'b, T> {
+    pub fn root(self) -> Root<T> {
         let collection = StackRoots.get().unwrap();
         unsafe {
             Root::new(&**collection, &self.inner)
@@ -150,7 +150,7 @@ impl<T: Reflectable> JS<T> {
 
 
     /// Root this JS-owned value to prevent its collection as garbage.
-    pub fn root<'b>(&self) -> Root<'b, T> {
+    pub fn root(&self) -> Root<T> {
         let collection = StackRoots.get().unwrap();
         unsafe {
             Root::new(&**collection, self)
@@ -310,7 +310,7 @@ pub trait RootedReference<T> {
     fn root_ref<'a>(&'a self) -> Option<JSRef<'a, T>>;
 }
 
-impl<'b, T: Reflectable> RootedReference<T> for Option<Root<'b, T>> {
+impl<T: Reflectable> RootedReference<T> for Option<Root<T>> {
     fn root_ref<'a>(&'a self) -> Option<JSRef<'a, T>> {
         self.as_ref().map(|root| root.root_ref())
     }
@@ -321,7 +321,7 @@ pub trait OptionalRootedReference<T> {
     fn root_ref<'a>(&'a self) -> Option<Option<JSRef<'a, T>>>;
 }
 
-impl<'b, T: Reflectable> OptionalRootedReference<T> for Option<Option<Root<'b, T>>> {
+impl<T: Reflectable> OptionalRootedReference<T> for Option<Option<Root<T>>> {
     fn root_ref<'a>(&'a self) -> Option<Option<JSRef<'a, T>>> {
         self.as_ref().map(|inner| inner.root_ref())
     }
@@ -367,11 +367,11 @@ impl<T: Assignable<U>, U: Reflectable> OptionalSettable<T> for Cell<Option<JS<U>
 
 /// Root a rootable `Option` type (used for `Option<Temporary<T>>`)
 pub trait OptionalRootable<T> {
-    fn root<'b>(self) -> Option<Root<'b, T>>;
+    fn root(self) -> Option<Root<T>>;
 }
 
 impl<T: Reflectable> OptionalRootable<T> for Option<Temporary<T>> {
-    fn root<'b>(self) -> Option<Root<'b, T>> {
+    fn root(self) -> Option<Root<T>> {
         self.map(|inner| inner.root())
     }
 }
@@ -389,22 +389,22 @@ impl<'a, T: Reflectable> OptionalUnrootable<T> for Option<JSRef<'a, T>> {
 
 /// Root a rootable `Option` type (used for `Option<JS<T>>`)
 pub trait OptionalRootedRootable<T> {
-    fn root<'b>(&self) -> Option<Root<'b, T>>;
+    fn root(&self) -> Option<Root<T>>;
 }
 
 impl<T: Reflectable> OptionalRootedRootable<T> for Option<JS<T>> {
-    fn root<'b>(&self) -> Option<Root<'b, T>> {
+    fn root(&self) -> Option<Root<T>> {
         self.as_ref().map(|inner| inner.root())
     }
 }
 
 /// Root a rootable `Option<Option>` type (used for `Option<Option<JS<T>>>`)
 pub trait OptionalOptionalRootedRootable<T> {
-    fn root<'b>(&self) -> Option<Option<Root<'b, T>>>;
+    fn root(&self) -> Option<Option<Root<T>>>;
 }
 
 impl<T: Reflectable> OptionalOptionalRootedRootable<T> for Option<Option<JS<T>>> {
-    fn root<'b>(&self) -> Option<Option<Root<'b, T>>> {
+    fn root(&self) -> Option<Option<Root<T>>> {
         self.as_ref().map(|inner| inner.root())
     }
 }
@@ -412,17 +412,17 @@ impl<T: Reflectable> OptionalOptionalRootedRootable<T> for Option<Option<JS<T>>>
 
 /// Root a rootable `Result` type (any of `Temporary<T>` or `JS<T>`)
 pub trait ResultRootable<T,U> {
-    fn root<'b>(self) -> Result<Root<'b, T>, U>;
+    fn root(self) -> Result<Root<T>, U>;
 }
 
 impl<T: Reflectable, U> ResultRootable<T, U> for Result<Temporary<T>, U> {
-    fn root<'b>(self) -> Result<Root<'b, T>, U> {
+    fn root(self) -> Result<Root<T>, U> {
         self.map(|inner| inner.root())
     }
 }
 
 impl<T: Reflectable, U> ResultRootable<T, U> for Result<JS<T>, U> {
-    fn root<'b>(self) -> Result<Root<'b, T>, U> {
+    fn root(self) -> Result<Root<T>, U> {
         self.map(|inner| inner.root())
     }
 }
@@ -459,7 +459,7 @@ impl RootCollection {
     }
 
     /// Track a stack-based root to ensure LIFO root ordering
-    fn root<'b, T: Reflectable>(&self, untracked: &Root<'b, T>) {
+    fn root<'b, T: Reflectable>(&self, untracked: &Root<T>) {
         unsafe {
             let roots = self.roots.get();
             (*roots).push(untracked.js_ptr);
@@ -468,7 +468,7 @@ impl RootCollection {
     }
 
     /// Stop tracking a stack-based root, asserting if LIFO root ordering has been violated
-    fn unroot<'b, T: Reflectable>(&self, rooted: &Root<'b, T>) {
+    fn unroot<'b, T: Reflectable>(&self, rooted: &Root<T>) {
         unsafe {
             let roots = self.roots.get();
             debug!("unrooting {} (expecting {}",
@@ -485,20 +485,20 @@ impl RootCollection {
 /// for the same JS value. `Root`s cannot outlive the associated `RootCollection` object.
 /// Attempts to transfer ownership of a `Root` via moving will trigger dynamic unrooting
 /// failures due to incorrect ordering.
-pub struct Root<'b, T> {
+pub struct Root<T> {
     /// List that ensures correct dynamic root ordering
     root_list: &'static RootCollection,
     /// Reference to rooted value that must not outlive this container
-    jsref: JSRef<'b, T>,
+    jsref: JSRef<'static, T>,
     /// On-stack JS pointer to assuage conservative stack scanner
     js_ptr: *mut JSObject,
 }
 
-impl<'b, T: Reflectable> Root<'b, T> {
+impl<T: Reflectable> Root<T> {
     /// Create a new stack-bounded root for the provided JS-owned value.
     /// It cannot not outlive its associated `RootCollection`, and it contains a `JSRef`
     /// which cannot outlive this new `Root`.
-    fn new(roots: &'static RootCollection, unrooted: &JS<T>) -> Root<'b, T> {
+    fn new(roots: &'static RootCollection, unrooted: &JS<T>) -> Root<T> {
         let root = Root {
             root_list: roots,
             jsref: JSRef {
@@ -519,13 +519,13 @@ impl<'b, T: Reflectable> Root<'b, T> {
 }
 
 #[unsafe_destructor]
-impl<'b, T: Reflectable> Drop for Root<'b, T> {
+impl<T: Reflectable> Drop for Root<T> {
     fn drop(&mut self) {
         self.root_list.unroot(self);
     }
 }
 
-impl<'b, T: Reflectable> Deref<JSRef<'b, T>> for Root<'b, T> {
+impl<'b, T: Reflectable> Deref<JSRef<'b, T>> for Root<T> {
     fn deref<'c>(&'c self) -> &'c JSRef<'b, T> {
         &self.jsref
     }

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -31,11 +31,11 @@
 //! Both `Temporary<T>` and `JS<T>` do not allow access to their inner value without explicitly
 //! creating a stack-based root via the `root` method. This returns a `Root<T>`, which causes
 //! the JS-owned value to be uncollectable for the duration of the `Root` object's lifetime.
-//! A `JSRef<T>` can be obtained from a `Root<T>` either by dereferencing the `Root<T>` (`*rooted`)
-//! or explicitly calling the `root_ref` method. These `JSRef<T>` values are not allowed to
-//! outlive their originating `Root<T>`, to ensure that all interactions with the enclosed value
-//! only occur when said value is uncollectable, and will cause static lifetime errors if
-//! misused.
+//! A `JSRef<T>` can be obtained from a `Root<T>` by calling the `r` method. (Dereferencing the
+//! object is still supported, but as it is unsafe, this is deprecated.) These `JSRef<T>` values
+//! are not allowed to outlive their originating `Root<T>`, to ensure that all interactions with
+//! the enclosed value only occur when said value is uncollectable, and will cause static lifetime
+//! errors if misused.
 //!
 //! Other miscellaneous helper traits:
 //!
@@ -307,23 +307,23 @@ impl<From, To> JS<From> {
 
 /// Get an `Option<JSRef<T>>` out of an `Option<Root<T>>`
 pub trait RootedReference<T> {
-    fn root_ref<'a>(&'a self) -> Option<JSRef<'a, T>>;
+    fn r<'a>(&'a self) -> Option<JSRef<'a, T>>;
 }
 
 impl<T: Reflectable> RootedReference<T> for Option<Root<T>> {
-    fn root_ref<'a>(&'a self) -> Option<JSRef<'a, T>> {
-        self.as_ref().map(|root| root.root_ref())
+    fn r<'a>(&'a self) -> Option<JSRef<'a, T>> {
+        self.as_ref().map(|root| root.r())
     }
 }
 
 /// Get an `Option<Option<JSRef<T>>>` out of an `Option<Option<Root<T>>>`
 pub trait OptionalRootedReference<T> {
-    fn root_ref<'a>(&'a self) -> Option<Option<JSRef<'a, T>>>;
+    fn r<'a>(&'a self) -> Option<Option<JSRef<'a, T>>>;
 }
 
 impl<T: Reflectable> OptionalRootedReference<T> for Option<Option<Root<T>>> {
-    fn root_ref<'a>(&'a self) -> Option<Option<JSRef<'a, T>>> {
-        self.as_ref().map(|inner| inner.root_ref())
+    fn r<'a>(&'a self) -> Option<Option<JSRef<'a, T>>> {
+        self.as_ref().map(|inner| inner.r())
     }
 }
 
@@ -513,7 +513,7 @@ impl<T: Reflectable> Root<T> {
 
     /// Obtain a safe reference to the wrapped JS owned-value that cannot outlive
     /// the lifetime of this root.
-    pub fn root_ref<'b>(&'b self) -> JSRef<'b,T> {
+    pub fn r<'b>(&'b self) -> JSRef<'b, T> {
         self.jsref.clone()
     }
 }

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -514,7 +514,10 @@ impl<T: Reflectable> Root<T> {
     /// Obtain a safe reference to the wrapped JS owned-value that cannot outlive
     /// the lifetime of this root.
     pub fn r<'b>(&'b self) -> JSRef<'b, T> {
-        self.jsref.clone()
+        JSRef {
+            ptr: self.jsref.ptr,
+            chain: ContravariantLifetime,
+        }
     }
 }
 

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -552,7 +552,7 @@ pub extern fn outerize_global(_cx: *mut JSContext, obj: JSHandleObject) -> *mut 
         debug!("outerizing");
         let obj = *obj.unnamed_field1;
         let win: Root<window::Window> = unwrap_jsmanaged(obj).unwrap().root();
-        win.browser_context().as_ref().unwrap().window_proxy()
+        win.r().browser_context().as_ref().unwrap().window_proxy()
     }
 }
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -121,13 +121,13 @@ impl<'a> BlobMethods for JSRef<'a, Blob> {
         let span: i64 = max(relativeEnd - relativeStart, 0);
         let global = self.global.root();
         match self.bytes {
-            None => Blob::new(&global.root_ref(), None, relativeContentType.as_slice()),
+            None => Blob::new(&global.r(), None, relativeContentType.as_slice()),
             Some(ref vec) => {
                 let start = relativeStart.to_uint().unwrap();
                 let end = (relativeStart + span).to_uint().unwrap();
                 let mut bytes: Vec<u8> = Vec::new();
                 bytes.push_all(vec.slice(start, end));
-                Blob::new(&global.root_ref(), Some(bytes), relativeContentType.as_slice())
+                Blob::new(&global.r(), Some(bytes), relativeContentType.as_slice())
             }
         }
     }

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -39,7 +39,7 @@ impl BrowserContext {
 
     pub fn active_window(&self) -> Temporary<Window> {
         let doc = self.active_document().root();
-        doc.window()
+        doc.r().window()
     }
 
     pub fn window_proxy(&self) -> *mut JSObject {
@@ -55,7 +55,7 @@ impl BrowserContext {
         let WindowProxyHandler(handler) = js_info.as_ref().unwrap().dom_static.windowproxy_handler;
         assert!(handler.is_not_null());
 
-        let parent = win.reflector().get_jsobject();
+        let parent = win.r().reflector().get_jsobject();
         let cx = js_info.as_ref().unwrap().js_context.ptr;
         let wrapper = with_compartment(cx, parent, || unsafe {
             WrapperNew(cx, parent, handler)

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -49,13 +49,14 @@ impl BrowserContext {
 
     fn create_window_proxy(&mut self) {
         let win = self.active_window().root();
+        let win = win.r();
         let page = win.page();
         let js_info = page.js_info();
 
         let WindowProxyHandler(handler) = js_info.as_ref().unwrap().dom_static.windowproxy_handler;
         assert!(handler.is_not_null());
 
-        let parent = win.r().reflector().get_jsobject();
+        let parent = win.reflector().get_jsobject();
         let cx = js_info.as_ref().unwrap().js_context.ptr;
         let wrapper = with_compartment(cx, parent, || unsafe {
             WrapperNew(cx, parent, handler)

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -40,7 +40,7 @@ impl Comment {
 
     pub fn Constructor(global: &GlobalRef, data: DOMString) -> Fallible<Temporary<Comment>> {
         let document = global.as_window().Document().root();
-        Ok(Comment::new(data, *document))
+        Ok(Comment::new(data, document.r()))
     }
 
     #[inline]

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -219,6 +219,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
 
         let owner = self.owner.root();
         let window = window_from_node(owner.r()).root();
+        let window = window.r();
         let page = window.page();
         let decl_block = parse_style_attribute(synthesized_declaration.as_slice(),
                                                &page.get_url());
@@ -267,6 +268,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
 
         let owner = self.owner.root();
         let window = window_from_node(owner.r()).root();
+        let window = window.r();
         let page = window.page();
         let decl_block = parse_style_attribute(property.as_slice(),
                                                &page.get_url());

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -85,13 +85,13 @@ trait PrivateCSSStyleDeclarationHelpers {
 impl<'a> PrivateCSSStyleDeclarationHelpers for JSRef<'a, CSSStyleDeclaration> {
     fn get_declaration(self, property: &Atom) -> Option<PropertyDeclaration> {
         let owner = self.owner.root();
-        let element: JSRef<Element> = ElementCast::from_ref(*owner);
+        let element: JSRef<Element> = ElementCast::from_ref(owner.r());
         element.get_inline_style_declaration(property).map(|decl| decl.clone())
     }
 
     fn get_important_declaration(self, property: &Atom) -> Option<PropertyDeclaration> {
         let owner = self.owner.root();
-        let element: JSRef<Element> = ElementCast::from_ref(*owner);
+        let element: JSRef<Element> = ElementCast::from_ref(owner.r());
         element.get_important_inline_style_declaration(property).map(|decl| decl.clone())
     }
 }
@@ -99,7 +99,7 @@ impl<'a> PrivateCSSStyleDeclarationHelpers for JSRef<'a, CSSStyleDeclaration> {
 impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
     fn Length(self) -> u32 {
         let owner = self.owner.root();
-        let elem: JSRef<Element> = ElementCast::from_ref(*owner);
+        let elem: JSRef<Element> = ElementCast::from_ref(owner.r());
         let len = match *elem.style_attribute().borrow() {
             Some(ref declarations) => declarations.normal.len() + declarations.important.len(),
             None => 0
@@ -109,7 +109,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
 
     fn Item(self, index: u32) -> DOMString {
         let owner = self.owner.root();
-        let elem: JSRef<Element> = ElementCast::from_ref(*owner);
+        let elem: JSRef<Element> = ElementCast::from_ref(owner.r());
         let style_attribute = elem.style_attribute().borrow();
         let result = style_attribute.as_ref().and_then(|declarations| {
             if index as uint > declarations.normal.len() {
@@ -218,7 +218,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         synthesized_declaration.push_str(value.as_slice());
 
         let owner = self.owner.root();
-        let window = window_from_node(*owner).root();
+        let window = window_from_node(owner.r()).root();
         let page = window.page();
         let decl_block = parse_style_attribute(synthesized_declaration.as_slice(),
                                                &page.get_url());
@@ -229,7 +229,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         }
 
         let owner = self.owner.root();
-        let element: JSRef<Element> = ElementCast::from_ref(*owner);
+        let element: JSRef<Element> = ElementCast::from_ref(owner.r());
 
         // Step 8
         for decl in decl_block.normal.iter() {
@@ -240,7 +240,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
 
         let document = document_from_node(element).root();
         let node: JSRef<Node> = NodeCast::from_ref(element);
-        document.content_changed(node, NodeDamage::NodeStyleDamaged);
+        document.r().content_changed(node, NodeDamage::NodeStyleDamaged);
         Ok(())
     }
 
@@ -266,11 +266,11 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         }
 
         let owner = self.owner.root();
-        let window = window_from_node(*owner).root();
+        let window = window_from_node(owner.r()).root();
         let page = window.page();
         let decl_block = parse_style_attribute(property.as_slice(),
                                                &page.get_url());
-        let element: JSRef<Element> = ElementCast::from_ref(*owner);
+        let element: JSRef<Element> = ElementCast::from_ref(owner.r());
 
         // Step 5
         for decl in decl_block.normal.iter() {
@@ -281,7 +281,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
 
         let document = document_from_node(element).root();
         let node: JSRef<Node> = NodeCast::from_ref(element);
-        document.content_changed(node, NodeDamage::NodeStyleDamaged);
+        document.r().content_changed(node, NodeDamage::NodeStyleDamaged);
         Ok(())
     }
 
@@ -315,7 +315,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
             None => {
                 // Step 5
                 let owner = self.owner.root();
-                let elem: JSRef<Element> = ElementCast::from_ref(*owner);
+                let elem: JSRef<Element> = ElementCast::from_ref(owner.r());
                 elem.remove_inline_style_property(property)
             }
         }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -42,8 +42,8 @@ impl CustomEvent {
     }
     pub fn new(global: &GlobalRef, type_: DOMString, bubbles: bool, cancelable: bool, detail: JSVal) -> Temporary<CustomEvent> {
         let ev = CustomEvent::new_uninitialized(*global).root();
-        ev.InitCustomEvent(global.get_cx(), type_, bubbles, cancelable, detail);
-        Temporary::from_rooted(*ev)
+        ev.r().InitCustomEvent(global.get_cx(), type_, bubbles, cancelable, detail);
+        Temporary::from_rooted(ev.r())
     }
     pub fn Constructor(global: &GlobalRef,
                        type_: DOMString,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -158,20 +158,20 @@ impl DedicatedWorkerGlobalScope {
                 parent_sender, own_sender, receiver).root();
 
             {
-                let _ar = AutoWorkerReset::new(*global, worker);
+                let _ar = AutoWorkerReset::new(global.r(), worker);
 
                 match js_context.evaluate_script(
-                    global.reflector().get_jsobject(), source, url.serialize(), 1) {
+                    global.r().reflector().get_jsobject(), source, url.serialize(), 1) {
                     Ok(_) => (),
                     Err(_) => println!("evaluate_script failed")
                 }
             }
 
             loop {
-                match global.receiver.recv_opt() {
+                match global.r().receiver.recv_opt() {
                     Ok((linked_worker, msg)) => {
-                        let _ar = AutoWorkerReset::new(*global, linked_worker);
-                        global.handle_event(msg);
+                        let _ar = AutoWorkerReset::new(global.r(), linked_worker);
+                        global.r().handle_event(msg);
                     }
                     Err(_) => break,
                 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -220,6 +220,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         match mode {
             Quirks => {
                 let window = self.window.root();
+                let window = window.r();
                 let LayoutChan(ref layout_chan) = window.page().layout_chan;
                 layout_chan.send(Msg::SetQuirksMode);
             }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -480,10 +480,11 @@ trait PrivateDocumentHelpers {
 impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
     fn createNodeList(self, callback: |node: JSRef<Node>| -> bool) -> Temporary<NodeList> {
         let window = self.window.root();
-        let nodes = match self.GetDocumentElement().root() {
+        let document_element = self.GetDocumentElement().root();
+        let nodes = match document_element {
             None => vec!(),
-            Some(root) => {
-                let root: JSRef<Node> = NodeCast::from_ref(*root);
+            Some(ref root) => {
+                let root: JSRef<Node> = NodeCast::from_ref(root.r());
                 root.traverse_preorder().filter(|&node| callback(node)).collect()
             }
         };

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -255,7 +255,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
             Some(elements) => {
                 let position = elements.iter()
                                        .map(|elem| elem.root())
-                                       .position(|element| *element == to_unregister)
+                                       .position(|element| element.r() == to_unregister)
                                        .expect("This element should be in registered.");
                 elements.remove(position);
                 elements.is_empty()
@@ -289,13 +289,13 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
 
                 let new_node: JSRef<Node> = NodeCast::from_ref(element);
                 let mut head: uint = 0u;
-                let root: JSRef<Node> = NodeCast::from_ref(*root);
+                let root: JSRef<Node> = NodeCast::from_ref(root.r());
                 for node in root.traverse_preorder() {
                     let elem: Option<JSRef<Element>> = ElementCast::to_ref(node);
                     match elem {
                         None => {},
                         Some(elem) => {
-                            if *(*elements)[head].root() == elem {
+                            if (*elements)[head].root().r() == elem {
                                 head += 1;
                             }
                             if new_node == node || head == elements.len() {
@@ -312,7 +312,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
 
     fn load_anchor_href(self, href: DOMString) {
         let window = self.window.root();
-        window.load_url(href);
+        window.r().load_url(href);
     }
 
     /// Attempt to find a named element in this page's document.
@@ -322,7 +322,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
             let check_anchor = |&node: &JSRef<HTMLAnchorElement>| {
                 let elem: JSRef<Element> = ElementCast::from_ref(node);
                 elem.get_attribute(ns!(""), &atom!("name")).root().map_or(false, |attr| {
-                    attr.value().as_slice() == fragid.as_slice()
+                    attr.r().value().as_slice() == fragid.as_slice()
                 })
             };
             let doc_node: JSRef<Node> = NodeCast::from_ref(self);
@@ -338,11 +338,11 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         self.ready_state.set(state);
 
         let window = self.window.root();
-        let event = Event::new(GlobalRef::Window(*window), "readystatechange".into_string(),
+        let event = Event::new(GlobalRef::Window(window.r()), "readystatechange".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        let _ = target.DispatchEvent(*event);
+        let _ = target.DispatchEvent(event.r());
     }
 
     /// Return the element that currently has focus.
@@ -372,7 +372,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
     /// Sends this document's title to the compositor.
     fn send_title_to_compositor(self) {
         let window = self.window().root();
-        window.page().send_title_to_compositor();
+        window.r().page().send_title_to_compositor();
     }
 
     fn dirty_all_nodes(self) {
@@ -466,9 +466,9 @@ impl Document {
                                           GlobalRef::Window(window),
                                           DocumentBinding::Wrap).root();
 
-        let node: JSRef<Node> = NodeCast::from_ref(*document);
-        node.set_owner_doc(*document);
-        Temporary::from_rooted(*document)
+        let node: JSRef<Node> = NodeCast::from_ref(document.r());
+        node.set_owner_doc(document.r());
+        Temporary::from_rooted(document.r())
     }
 }
 
@@ -487,7 +487,7 @@ impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
                 root.traverse_preorder().filter(|&node| callback(node)).collect()
             }
         };
-        NodeList::new_simple_list(*window, nodes)
+        NodeList::new_simple_list(window.r(), nodes)
     }
 
     fn get_html_element(self) -> Option<Temporary<HTMLHtmlElement>> {
@@ -554,20 +554,20 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     // http://dom.spec.whatwg.org/#dom-document-getelementsbytagname
     fn GetElementsByTagName(self, tag_name: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::by_tag_name(*window, NodeCast::from_ref(self), tag_name)
+        HTMLCollection::by_tag_name(window.r(), NodeCast::from_ref(self), tag_name)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbytagnamens
     fn GetElementsByTagNameNS(self, maybe_ns: Option<DOMString>, tag_name: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::by_tag_name_ns(*window, NodeCast::from_ref(self), tag_name, maybe_ns)
+        HTMLCollection::by_tag_name_ns(window.r(), NodeCast::from_ref(self), tag_name, maybe_ns)
     }
 
     // http://dom.spec.whatwg.org/#dom-document-getelementsbyclassname
     fn GetElementsByClassName(self, classes: DOMString) -> Temporary<HTMLCollection> {
         let window = self.window.root();
 
-        HTMLCollection::by_class_name(*window, NodeCast::from_ref(self), classes)
+        HTMLCollection::by_class_name(window.r(), NodeCast::from_ref(self), classes)
     }
 
     // http://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid
@@ -652,7 +652,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         let l_name = Atom::from_slice(local_name.as_slice());
         let value = AttrValue::String("".into_string());
 
-        Ok(Attr::new(*window, name, value, l_name, ns!(""), None, None))
+        Ok(Attr::new(window.r(), name, value, l_name, ns!(""), None, None))
     }
 
     // http://dom.spec.whatwg.org/#dom-document-createdocumentfragment
@@ -724,17 +724,17 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
         match interface.as_slice().to_ascii_lower().as_slice() {
             "uievents" | "uievent" => Ok(EventCast::from_temporary(
-                UIEvent::new_uninitialized(*window))),
+                UIEvent::new_uninitialized(window.r()))),
             "mouseevents" | "mouseevent" => Ok(EventCast::from_temporary(
-                MouseEvent::new_uninitialized(*window))),
+                MouseEvent::new_uninitialized(window.r()))),
             "customevent" => Ok(EventCast::from_temporary(
-                CustomEvent::new_uninitialized(GlobalRef::Window(*window)))),
+                CustomEvent::new_uninitialized(GlobalRef::Window(window.r())))),
             "htmlevents" | "events" | "event" => Ok(Event::new_uninitialized(
-                GlobalRef::Window(*window))),
+                GlobalRef::Window(window.r()))),
             "keyboardevent" | "keyevents" => Ok(EventCast::from_temporary(
-                KeyboardEvent::new_uninitialized(*window))),
+                KeyboardEvent::new_uninitialized(window.r()))),
             "messageevent" => Ok(EventCast::from_temporary(
-                MessageEvent::new_uninitialized(GlobalRef::Window(*window)))),
+                MessageEvent::new_uninitialized(GlobalRef::Window(window.r())))),
             _ => Err(NotSupported)
         }
     }
@@ -762,7 +762,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     fn Title(self) -> DOMString {
         let mut title = String::new();
         self.GetDocumentElement().root().map(|root| {
-            let root: JSRef<Node> = NodeCast::from_ref(*root);
+            let root: JSRef<Node> = NodeCast::from_ref(root.r());
             root.traverse_preorder()
                 .find(|node| node.type_id() == NodeTypeId::Element(ElementTypeId::HTMLTitleElement))
                 .map(|title_elem| {
@@ -778,7 +778,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     // http://www.whatwg.org/specs/web-apps/current-work/#document.title
     fn SetTitle(self, title: DOMString) -> ErrorResult {
         self.GetDocumentElement().root().map(|root| {
-            let root: JSRef<Node> = NodeCast::from_ref(*root);
+            let root: JSRef<Node> = NodeCast::from_ref(root.r());
             let head_node = root.traverse_preorder().find(|child| {
                 child.type_id() == NodeTypeId::Element(ElementTypeId::HTMLHeadElement)
             });
@@ -794,16 +794,16 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                         }
                         if !title.is_empty() {
                             let new_text = self.CreateTextNode(title.clone()).root();
-                            assert!(title_node.AppendChild(NodeCast::from_ref(*new_text)).is_ok());
+                            assert!(title_node.AppendChild(NodeCast::from_ref(new_text.r())).is_ok());
                         }
                     },
                     None => {
                         let new_title = HTMLTitleElement::new("title".into_string(), None, self).root();
-                        let new_title: JSRef<Node> = NodeCast::from_ref(*new_title);
+                        let new_title: JSRef<Node> = NodeCast::from_ref(new_title.r());
 
                         if !title.is_empty() {
                             let new_text = self.CreateTextNode(title.clone()).root();
-                            assert!(new_title.AppendChild(NodeCast::from_ref(*new_text)).is_ok());
+                            assert!(new_title.AppendChild(NodeCast::from_ref(new_text.r())).is_ok());
                         }
                         assert!(head.AppendChild(new_title).is_ok());
                     },
@@ -817,7 +817,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     fn GetHead(self) -> Option<Temporary<HTMLHeadElement>> {
         self.get_html_element().and_then(|root| {
             let root = root.root();
-            let node: JSRef<Node> = NodeCast::from_ref(*root);
+            let node: JSRef<Node> = NodeCast::from_ref(root.r());
             node.children().filter_map(HTMLHeadElementCast::to_ref).next().map(Temporary::from_rooted)
         })
     }
@@ -826,7 +826,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     fn GetBody(self) -> Option<Temporary<HTMLElement>> {
         self.get_html_element().and_then(|root| {
             let root = root.root();
-            let node: JSRef<Node> = NodeCast::from_ref(*root);
+            let node: JSRef<Node> = NodeCast::from_ref(root.r());
             node.children().find(|child| {
                 match child.type_id() {
                     NodeTypeId::Element(ElementTypeId::HTMLBodyElement) |
@@ -856,7 +856,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
 
         // Step 2.
         let old_body = self.GetBody().root();
-        if old_body.as_ref().map(|body| **body) == Some(new_body) {
+        if old_body.as_ref().map(|body| body.r()) == Some(new_body) {
             return Ok(());
         }
 
@@ -867,10 +867,10 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             Some(ref root) => {
                 let new_body: JSRef<Node> = NodeCast::from_ref(new_body);
 
-                let root: JSRef<Node> = NodeCast::from_ref(**root);
+                let root: JSRef<Node> = NodeCast::from_ref(root.r());
                 match old_body {
                     Some(ref child) => {
-                        let child: JSRef<Node> = NodeCast::from_ref(**child);
+                        let child: JSRef<Node> = NodeCast::from_ref(child.r());
 
                         assert!(root.ReplaceChild(new_body, child).is_ok())
                     }
@@ -889,7 +889,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                 None => return false,
             };
             element.get_attribute(ns!(""), &atom!("name")).root().map_or(false, |attr| {
-                attr.value().as_slice() == name.as_slice()
+                attr.r().value().as_slice() == name.as_slice()
             })
         })
     }
@@ -899,7 +899,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box ImagesFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
@@ -908,7 +908,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box EmbedsFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
@@ -921,7 +921,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box LinksFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
@@ -930,7 +930,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box FormsFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
@@ -939,7 +939,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box ScriptsFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
@@ -948,7 +948,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box AnchorsFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
@@ -958,19 +958,19 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
             let window = self.window.root();
             let root = NodeCast::from_ref(self);
             let filter = box AppletsFilter;
-            HTMLCollection::create(*window, root, filter)
+            HTMLCollection::create(window.r(), root, filter)
         })
     }
 
     fn Location(self) -> Temporary<Location> {
         let window = self.window.root();
-        window.Location()
+        window.r().Location()
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(self) -> Temporary<HTMLCollection> {
         let window = self.window.root();
-        HTMLCollection::children(*window, NodeCast::from_ref(self))
+        HTMLCollection::children(window.r(), NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -24,7 +24,7 @@ use dom::bindings::error::Error::{NotSupported, InvalidCharacter};
 use dom::bindings::error::Error::{HierarchyRequest, NamespaceError};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, OptionalSettable, TemporaryPushable};
-use dom::bindings::js::OptionalRootable;
+use dom::bindings::js::{OptionalRootable, RootedReference};
 use dom::bindings::utils::reflect_dom_object;
 use dom::bindings::utils::xml_name_type;
 use dom::bindings::utils::XMLName::{QName, Name, InvalidXMLName};
@@ -491,9 +491,11 @@ impl<'a> PrivateDocumentHelpers for JSRef<'a, Document> {
     }
 
     fn get_html_element(self) -> Option<Temporary<HTMLHtmlElement>> {
-        self.GetDocumentElement().root().and_then(|element| {
-            HTMLHtmlElementCast::to_ref(*element)
-        }).map(Temporary::from_rooted)
+        self.GetDocumentElement()
+            .root()
+            .r()
+            .and_then(HTMLHtmlElementCast::to_ref)
+            .map(Temporary::from_rooted)
     }
 }
 

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -45,7 +45,7 @@ impl DocumentFragment {
         let document = global.as_window().Document();
         let document = document.root();
 
-        Ok(DocumentFragment::new(*document))
+        Ok(DocumentFragment::new(document.r()))
     }
 }
 
@@ -53,7 +53,7 @@ impl<'a> DocumentFragmentMethods for JSRef<'a, DocumentFragment> {
     // http://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(self) -> Temporary<HTMLCollection> {
         let window = window_from_node(self).root();
-        HTMLCollection::children(*window, NodeCast::from_ref(self))
+        HTMLCollection::children(window.r(), NodeCast::from_ref(self))
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -47,22 +47,22 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
                        s: DOMString,
                        ty: DOMParserBinding::SupportedType)
                        -> Fallible<Temporary<Document>> {
-        let window = self.window.root().clone();
-        let url = window.get_url();
+        let window = self.window.root();
+        let url = window.r().get_url();
         let content_type = DOMParserBinding::SupportedTypeValues::strings[ty as uint].into_string();
         match ty {
             Text_html => {
-                let document = Document::new(window, Some(url.clone()),
+                let document = Document::new(window.r(), Some(url.clone()),
                                              IsHTMLDocument::HTMLDocument,
                                              Some(content_type),
-                                             DocumentSource::FromParser).root().clone();
-                parse_html(document, HTMLInput::InputString(s), &url);
-                document.set_ready_state(DocumentReadyState::Complete);
-                Ok(Temporary::from_rooted(document))
+                                             DocumentSource::FromParser).root();
+                parse_html(document.r(), HTMLInput::InputString(s), &url);
+                document.r().set_ready_state(DocumentReadyState::Complete);
+                Ok(Temporary::from_rooted(document.r()))
             }
             Text_xml => {
                 //FIXME: this should probably be FromParser when we actually parse the string (#3756).
-                Ok(Document::new(window, Some(url.clone()),
+                Ok(Document::new(window.r(), Some(url.clone()),
                                  IsHTMLDocument::NonHTMLDocument,
                                  Some(content_type),
                                  DocumentSource::NotFromParser))

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -29,7 +29,7 @@ impl DOMStringMap {
     pub fn new(element: JSRef<HTMLElement>) -> Temporary<DOMStringMap> {
         let window = window_from_node(element).root();
         reflect_dom_object(box DOMStringMap::new_inherited(element),
-                           GlobalRef::Window(window.root_ref()), DOMStringMapBinding::Wrap)
+                           GlobalRef::Window(window.r()), DOMStringMapBinding::Wrap)
     }
 }
 

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -41,17 +41,17 @@ impl<'a> DOMStringMapMethods for JSRef<'a, DOMStringMap> {
 
     fn NamedDeleter(self, name: DOMString) {
         let element = self.element.root();
-        element.delete_custom_attr(name)
+        element.r().delete_custom_attr(name)
     }
 
     fn NamedSetter(self, name: DOMString, value: DOMString) -> ErrorResult {
         let element = self.element.root();
-        element.set_custom_attr(name, value)
+        element.r().set_custom_attr(name, value)
     }
 
     fn NamedGetter(self, name: DOMString, found: &mut bool) -> DOMString {
         let element = self.element.root();
-        match element.get_custom_attr(name) {
+        match element.r().get_custom_attr(name) {
             Some(value) => {
                 *found = true;
                 value.clone()

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -35,7 +35,7 @@ impl DOMTokenList {
     pub fn new(element: JSRef<Element>, local_name: &Atom) -> Temporary<DOMTokenList> {
         let window = window_from_node(element).root();
         reflect_dom_object(box DOMTokenList::new_inherited(element, local_name.clone()),
-                           GlobalRef::Window(*window),
+                           GlobalRef::Window(window.r()),
                            DOMTokenListBinding::Wrap)
     }
 }
@@ -48,7 +48,7 @@ trait PrivateDOMTokenListHelpers {
 impl<'a> PrivateDOMTokenListHelpers for JSRef<'a, DOMTokenList> {
     fn attribute(self) -> Option<Temporary<Attr>> {
         let element = self.element.root();
-        element.get_attribute(ns!(""), &self.local_name)
+        element.r().get_attribute(ns!(""), &self.local_name)
     }
 
     fn check_token_exceptions<'a>(self, token: &'a str) -> Fallible<Atom> {
@@ -65,13 +65,13 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     // http://dom.spec.whatwg.org/#dom-domtokenlist-length
     fn Length(self) -> u32 {
         self.attribute().root().map(|attr| {
-            attr.value().tokens().map(|tokens| tokens.len()).unwrap_or(0)
+            attr.r().value().tokens().map(|tokens| tokens.len()).unwrap_or(0)
         }).unwrap_or(0) as u32
     }
 
     // http://dom.spec.whatwg.org/#dom-domtokenlist-item
     fn Item(self, index: u32) -> Option<DOMString> {
-        self.attribute().root().and_then(|attr| attr.value().tokens().and_then(|tokens| {
+        self.attribute().root().and_then(|attr| attr.r().value().tokens().and_then(|tokens| {
             tokens.get(index as uint).map(|token| token.as_slice().into_string())
         }))
     }
@@ -86,7 +86,8 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     fn Contains(self, token: DOMString) -> Fallible<bool> {
         self.check_token_exceptions(token.as_slice()).map(|token| {
             self.attribute().root().map(|attr| {
-                attr.value()
+                attr.r()
+                    .value()
                     .tokens()
                     .expect("Should have parsed this attribute")
                     .iter()
@@ -98,42 +99,42 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     // https://dom.spec.whatwg.org/#dom-domtokenlist-add
     fn Add(self, tokens: Vec<DOMString>) -> ErrorResult {
         let element = self.element.root();
-        let mut atoms = element.get_tokenlist_attribute(&self.local_name);
+        let mut atoms = element.r().get_tokenlist_attribute(&self.local_name);
         for token in tokens.iter() {
             let token = try!(self.check_token_exceptions(token.as_slice()));
             if !atoms.iter().any(|atom| *atom == token) {
                 atoms.push(token);
             }
         }
-        element.set_atomic_tokenlist_attribute(&self.local_name, atoms);
+        element.r().set_atomic_tokenlist_attribute(&self.local_name, atoms);
         Ok(())
     }
 
     // https://dom.spec.whatwg.org/#dom-domtokenlist-remove
     fn Remove(self, tokens: Vec<DOMString>) -> ErrorResult {
         let element = self.element.root();
-        let mut atoms = element.get_tokenlist_attribute(&self.local_name);
+        let mut atoms = element.r().get_tokenlist_attribute(&self.local_name);
         for token in tokens.iter() {
             let token = try!(self.check_token_exceptions(token.as_slice()));
             atoms.iter().position(|atom| *atom == token).and_then(|index| {
                 atoms.remove(index)
             });
         }
-        element.set_atomic_tokenlist_attribute(&self.local_name, atoms);
+        element.r().set_atomic_tokenlist_attribute(&self.local_name, atoms);
         Ok(())
     }
 
     // https://dom.spec.whatwg.org/#dom-domtokenlist-toggle
     fn Toggle(self, token: DOMString, force: Option<bool>) -> Fallible<bool> {
         let element = self.element.root();
-        let mut atoms = element.get_tokenlist_attribute(&self.local_name);
+        let mut atoms = element.r().get_tokenlist_attribute(&self.local_name);
         let token = try!(self.check_token_exceptions(token.as_slice()));
         match atoms.iter().position(|atom| *atom == token) {
             Some(index) => match force {
                 Some(true) => Ok(true),
                 _ => {
                     atoms.remove(index);
-                    element.set_atomic_tokenlist_attribute(&self.local_name, atoms);
+                    element.r().set_atomic_tokenlist_attribute(&self.local_name, atoms);
                     Ok(false)
                 }
             },
@@ -141,7 +142,7 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
                 Some(false) => Ok(false),
                 _ => {
                     atoms.push(token);
-                    element.set_atomic_tokenlist_attribute(&self.local_name, atoms);
+                    element.r().set_atomic_tokenlist_attribute(&self.local_name, atoms);
                     Ok(true)
                 }
             }

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -64,15 +64,15 @@ impl ErrorEvent {
                colno: u32,
                error: JSVal) -> Temporary<ErrorEvent> {
         let ev = ErrorEvent::new_uninitialized(global).root();
-        let event: JSRef<Event> = EventCast::from_ref(*ev);
+        let event: JSRef<Event> = EventCast::from_ref(ev.r());
         event.InitEvent(type_, bubbles == EventBubbles::Bubbles,
                         cancelable == EventCancelable::Cancelable);
-        *ev.message.borrow_mut() = message;
-        *ev.filename.borrow_mut() = filename;
-        ev.lineno.set(lineno);
-        ev.colno.set(colno);
-        ev.error.set(error);
-        Temporary::from_rooted(*ev)
+        *ev.r().message.borrow_mut() = message;
+        *ev.r().filename.borrow_mut() = filename;
+        ev.r().lineno.set(lineno);
+        ev.r().colno.set(colno);
+        ev.r().error.set(error);
+        Temporary::from_rooted(ev.r())
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -100,8 +100,8 @@ impl Event {
                bubbles: EventBubbles,
                cancelable: EventCancelable) -> Temporary<Event> {
         let event = Event::new_uninitialized(global).root();
-        event.InitEvent(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
-        Temporary::from_rooted(*event)
+        event.r().InitEvent(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+        Temporary::from_rooted(event.r())
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/eventdispatcher.rs
+++ b/components/script/dom/eventdispatcher.rs
@@ -43,12 +43,12 @@ pub fn dispatch_event<'a, 'b>(target: JSRef<'a, EventTarget>,
 
     /* capturing */
     for cur_target in chain.as_slice().iter().rev() {
-        let stopped = match cur_target.get_listeners_for(type_.as_slice(), ListenerPhase::Capturing) {
+        let stopped = match cur_target.r().get_listeners_for(type_.as_slice(), ListenerPhase::Capturing) {
             Some(listeners) => {
-                event.set_current_target(cur_target.deref().clone());
+                event.set_current_target(cur_target.r());
                 for listener in listeners.iter() {
                     // Explicitly drop any exception on the floor.
-                    let _ = listener.HandleEvent_(**cur_target, event, ReportExceptions);
+                    let _ = listener.HandleEvent_(cur_target.r(), event, ReportExceptions);
 
                     if event.stop_immediate() {
                         break;
@@ -88,12 +88,12 @@ pub fn dispatch_event<'a, 'b>(target: JSRef<'a, EventTarget>,
         event.set_phase(EventPhase::Bubbling);
 
         for cur_target in chain.iter() {
-            let stopped = match cur_target.get_listeners_for(type_.as_slice(), ListenerPhase::Bubbling) {
+            let stopped = match cur_target.r().get_listeners_for(type_.as_slice(), ListenerPhase::Bubbling) {
                 Some(listeners) => {
-                    event.set_current_target(cur_target.deref().clone());
+                    event.set_current_target(cur_target.r());
                     for listener in listeners.iter() {
                         // Explicitly drop any exception on the floor.
-                        let _ = listener.HandleEvent_(**cur_target, event, ReportExceptions);
+                        let _ = listener.HandleEvent_(cur_target.r(), event, ReportExceptions);
 
                         if event.stop_immediate() {
                             break;
@@ -114,7 +114,7 @@ pub fn dispatch_event<'a, 'b>(target: JSRef<'a, EventTarget>,
     let target = event.GetTarget().root();
     match target {
         Some(target) => {
-            let node: Option<JSRef<Node>> = NodeCast::to_ref(*target);
+            let node: Option<JSRef<Node>> = NodeCast::to_ref(target.r());
             match node {
                 Some(node) => {
                     let vtable = vtable_for(&node);

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -116,6 +116,6 @@ impl PrivateFormDataHelpers for FormData {
         let global = self.global.root();
         let f: Option<JSRef<File>> = FileCast::to_ref(value);
         let name = filename.unwrap_or(f.map(|inner| inner.name().clone()).unwrap_or("blob".into_string()));
-        File::new(&global.root_ref(), value, name)
+        File::new(&global.r(), value, name)
     }
 }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -62,11 +62,11 @@ impl<'a> PrivateHTMLAnchorElementHelpers for JSRef<'a, HTMLAnchorElement> {
             let attr = element.get_attribute(ns!(""), &atom!("href")).root();
             match attr {
                 Some(ref href) => {
-                    let value = href.Value();
+                    let value = href.r().Value();
                     debug!("clicked on link to {:s}", value);
                     let node: JSRef<Node> = NodeCast::from_ref(self);
                     let doc = node.owner_doc().root();
-                    doc.load_anchor_href(value);
+                    doc.r().load_anchor_href(value);
                 }
                 None => ()
             }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -56,12 +56,12 @@ impl HTMLBodyElement {
 impl<'a> HTMLBodyElementMethods for JSRef<'a, HTMLBodyElement> {
     fn GetOnunload(self) -> Option<EventHandlerNonNull> {
         let win = window_from_node(self).root();
-        win.GetOnunload()
+        win.r().GetOnunload()
     }
 
     fn SetOnunload(self, listener: Option<EventHandlerNonNull>) {
         let win = window_from_node(self).root();
-        win.SetOnunload(listener)
+        win.r().SetOnunload(listener)
     }
 }
 
@@ -95,12 +95,12 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
                   "onoffline", "ononline", "onpagehide", "onpageshow", "onpopstate",
                   "onstorage", "onresize", "onunload", "onerror"];
             let window = window_from_node(*self).root();
-            let (cx, url, reflector) = (window.get_cx(),
-                                        window.get_url(),
-                                        window.reflector().get_jsobject());
+            let (cx, url, reflector) = (window.r().get_cx(),
+                                        window.r().get_url(),
+                                        window.r().reflector().get_jsobject());
             let evtarget: JSRef<EventTarget> =
                 if FORWARDED_EVENTS.iter().any(|&event| name == event) {
-                    EventTargetCast::from_ref(*window)
+                    EventTargetCast::from_ref(window.r())
                 } else {
                     EventTargetCast::from_ref(*self)
                 };

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -49,7 +49,7 @@ impl HTMLButtonElement {
 impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     fn Validity(self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
-        ValidityState::new(*window)
+        ValidityState::new(window.r())
     }
 
     // http://www.whatwg.org/html/#dom-fe-disabled

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -86,7 +86,7 @@ impl<'a> HTMLCanvasElementMethods for JSRef<'a, HTMLCanvasElement> {
         Some(self.context.or_init(|| {
             let window = window_from_node(self).root();
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
-            CanvasRenderingContext2D::new(&GlobalRef::Window(*window), self, Size2D(w, h))
+            CanvasRenderingContext2D::new(&GlobalRef::Window(window.r()), self, Size2D(w, h))
         }))
      }
 }
@@ -118,7 +118,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
         if recreate {
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
             match self.context.get() {
-                Some(ref context) => context.root().recreate(Size2D(w, h)),
+                Some(ref context) => context.root().r().recreate(Size2D(w, h)),
                 None => ()
             }
         }
@@ -146,7 +146,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
         if recreate {
             let (w, h) = (self.width.get() as i32, self.height.get() as i32);
             match self.context.get() {
-                Some(ref context) => context.root().recreate(Size2D(w, h)),
+                Some(ref context) => context.root().r().recreate(Size2D(w, h)),
                 None => ()
             }
         }

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -181,8 +181,8 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
             CollectionTypeId::Static(ref elems) => elems.len() as u32,
             CollectionTypeId::Live(ref root, ref filter) => {
                 let root = root.root();
-                HTMLCollection::traverse(*root)
-                    .filter(|element| filter.filter(*element, *root))
+                HTMLCollection::traverse(root.r())
+                    .filter(|element| filter.filter(*element, root.r()))
                     .count() as u32
             }
         }
@@ -197,8 +197,8 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
                 .map(|elem| Temporary::new(elem.clone())),
             CollectionTypeId::Live(ref root, ref filter) => {
                 let root = root.root();
-                HTMLCollection::traverse(*root)
-                    .filter(|element| filter.filter(*element, *root))
+                HTMLCollection::traverse(root.r())
+                    .filter(|element| filter.filter(*element, root.r()))
                     .nth(index as uint)
                     .clone()
                     .map(Temporary::from_rooted)
@@ -218,13 +218,13 @@ impl<'a> HTMLCollectionMethods for JSRef<'a, HTMLCollection> {
             CollectionTypeId::Static(ref elems) => elems.iter()
                 .map(|elem| elem.root())
                 .find(|elem| {
-                    elem.get_string_attribute(&atom!("name")) == key ||
-                    elem.get_string_attribute(&atom!("id")) == key })
-                .map(|maybe_elem| Temporary::from_rooted(*maybe_elem)),
+                    elem.r().get_string_attribute(&atom!("name")) == key ||
+                    elem.r().get_string_attribute(&atom!("id")) == key })
+                .map(|maybe_elem| Temporary::from_rooted(maybe_elem.r())),
             CollectionTypeId::Live(ref root, ref filter) => {
                 let root = root.root();
-                HTMLCollection::traverse(*root)
-                    .filter(|element| filter.filter(*element, *root))
+                HTMLCollection::traverse(root.r())
+                    .filter(|element| filter.filter(*element, root.r()))
                     .find(|elem| {
                         elem.get_string_attribute(&atom!("name")) == key ||
                         elem.get_string_attribute(&atom!("id")) == key })

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -52,7 +52,7 @@ impl<'a> HTMLDataListElementMethods for JSRef<'a, HTMLDataListElement> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         let filter = box HTMLDataListOptionsFilter;
         let window = window_from_node(node).root();
-        HTMLCollection::create(*window, node, filter)
+        HTMLCollection::create(window.r(), node, filter)
     }
 }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -78,7 +78,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     fn Style(self) -> Temporary<CSSStyleDeclaration> {
         self.style_decl.or_init(|| {
             let global = window_from_node(self).root();
-            CSSStyleDeclaration::new(*global, self, CSSModificationAccess::ReadWrite)
+            CSSStyleDeclaration::new(global.r(), self, CSSModificationAccess::ReadWrite)
         })
     }
 
@@ -102,7 +102,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     fn GetOnload(self) -> Option<EventHandlerNonNull> {
         if self.is_body_or_frameset() {
             let win = window_from_node(self).root();
-            win.GetOnload()
+            win.r().GetOnload()
         } else {
             let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
             target.get_event_handler_common("load")
@@ -112,7 +112,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     fn SetOnload(self, listener: Option<EventHandlerNonNull>) {
         if self.is_body_or_frameset() {
             let win = window_from_node(self).root();
-            win.SetOnload(listener)
+            win.r().SetOnload(listener)
         } else {
             let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
             target.set_event_handler_common("load", listener)
@@ -167,7 +167,7 @@ impl<'a> HTMLElementCustomAttributeHelpers for JSRef<'a, HTMLElement> {
         let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_attribute(ns!(""), &Atom::from_slice(to_snake_case(name).as_slice())).map(|attr| {
             let attr = attr.root();
-            attr.value().as_slice().into_string()
+            attr.r().value().as_slice().into_string()
         })
     }
 
@@ -192,9 +192,9 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
         let name = attr.local_name().as_slice();
         if name.starts_with("on") {
             let window = window_from_node(*self).root();
-            let (cx, url, reflector) = (window.get_cx(),
-                                        window.get_url(),
-                                        window.reflector().get_jsobject());
+            let (cx, url, reflector) = (window.r().get_cx(),
+                                        window.r().get_url(),
+                                        window.r().reflector().get_jsobject());
             let evtarget: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
             evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                   name.slice_from(2),

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -61,12 +61,12 @@ impl<'a> HTMLFieldSetElementMethods for JSRef<'a, HTMLFieldSetElement> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         let filter = box ElementsFilter;
         let window = window_from_node(node).root();
-        HTMLCollection::create(*window, node, filter)
+        HTMLCollection::create(window.r(), node, filter)
     }
 
     fn Validity(self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
-        ValidityState::new(*window)
+        ValidityState::new(window.r())
     }
 
     // http://www.whatwg.org/html/#dom-fieldset-disabled

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -152,17 +152,17 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         // Step 1
         let doc = document_from_node(self).root();
         let win = window_from_node(self).root();
-        let base = doc.url();
+        let base = doc.r().url();
         // TODO: Handle browsing contexts
         // TODO: Handle validation
-        let event = Event::new(GlobalRef::Window(*win),
+        let event = Event::new(GlobalRef::Window(win.r()),
                                "submit".into_string(),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable).root();
-        event.set_trusted(true);
+        event.r().set_trusted(true);
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.DispatchEvent(*event).ok();
-        if event.DefaultPrevented() {
+        target.DispatchEvent(event.r()).ok();
+        if event.r().DefaultPrevented() {
             return;
         }
         // Step 6
@@ -204,7 +204,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         }
 
         // This is wrong. https://html.spec.whatwg.org/multipage/forms.html#planned-navigation
-        win.script_chan().send(ScriptMsg::TriggerLoad(win.page().id, load_data));
+        win.r().script_chan().send(ScriptMsg::TriggerLoad(win.r().page().id, load_data));
     }
 
     fn get_form_dataset<'b>(self, submitter: Option<FormSubmitter<'b>>) -> Vec<FormDatum> {
@@ -342,13 +342,13 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         }
 
         let win = window_from_node(self).root();
-        let event = Event::new(GlobalRef::Window(*win),
+        let event = Event::new(GlobalRef::Window(win.r()),
                                "reset".into_string(),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.DispatchEvent(*event).ok();
-        if event.DefaultPrevented() {
+        target.DispatchEvent(event.r()).ok();
+        if event.r().DefaultPrevented() {
             return;
         }
 
@@ -484,10 +484,10 @@ pub trait FormControl<'a> : Copy {
         let owner = elem.get_string_attribute(&atom!("form"));
         if !owner.is_empty() {
             let doc = document_from_node(elem).root();
-            let owner = doc.GetElementById(owner).root();
+            let owner = doc.r().GetElementById(owner).root();
             match owner {
                 Some(o) => {
-                    let maybe_form: Option<JSRef<HTMLFormElement>> = HTMLFormElementCast::to_ref(*o);
+                    let maybe_form: Option<JSRef<HTMLFormElement>> = HTMLFormElementCast::to_ref(o.r());
                     if maybe_form.is_some() {
                         return maybe_form.map(Temporary::from_rooted);
                     }
@@ -507,7 +507,7 @@ pub trait FormControl<'a> : Copy {
         if self.to_element().has_attribute(attr) {
             input(self)
         } else {
-            self.form_owner().map_or("".into_string(), |t| owner(*t.root()))
+            self.form_owner().map_or("".into_string(), |t| owner(t.root().r()))
         }
     }
     fn to_element(self) -> JSRef<'a, Element>;

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -87,12 +87,12 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
     fn get_url(self) -> Option<Url> {
         let element: JSRef<Element> = ElementCast::from_ref(self);
         element.get_attribute(ns!(""), &atom!("src")).root().and_then(|src| {
-            let url = src.value();
+            let url = src.r().value();
             if url.as_slice().is_empty() {
                 None
             } else {
                 let window = window_from_node(self).root();
-                UrlParser::new().base_url(&window.page().get_url())
+                UrlParser::new().base_url(&window.r().page().get_url())
                     .parse(url.as_slice()).ok()
             }
         })
@@ -188,10 +188,10 @@ impl<'a> HTMLIFrameElementMethods for JSRef<'a, HTMLIFrameElement> {
                 Some(self_url) => self_url,
                 None => return None,
             };
-            let win_url = window_from_node(self).root().page().get_url();
+            let win_url = window_from_node(self).root().r().page().get_url();
 
             if UrlHelper::SameOrigin(&self_url, &win_url) {
-                Some(window.Document())
+                Some(window.r().Document())
             } else {
                 None
             }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -112,6 +112,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
 
         // Subpage Id
         let window = window_from_node(self).root();
+        let window = window.r();
         let page = window.page();
         let subpage_id = page.get_next_subpage_id();
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -46,6 +46,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         let document = node.owner_doc().root();
         let window = document.r().window().root();
+        let window = window.r();
         let image_cache = window.image_cache_task();
         match value {
             None => {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -45,7 +45,7 @@ impl<'a> PrivateHTMLImageElementHelpers for JSRef<'a, HTMLImageElement> {
     fn update_image(self, value: Option<(DOMString, &Url)>) {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         let document = node.owner_doc().root();
-        let window = document.window().root();
+        let window = document.r().window().root();
         let image_cache = window.image_cache_task();
         match value {
             None => {
@@ -186,7 +186,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
         match attr.local_name() {
             &atom!("src") => {
                 let window = window_from_node(*self).root();
-                let url = window.get_url();
+                let url = window.r().get_url();
                 self.update_image(Some((attr.value().as_slice().into_string(), &url)));
             },
             _ => ()

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -313,7 +313,7 @@ fn broadcast_radio_checked(broadcaster: JSRef<HTMLInputElement>, group: Option<&
     let mut iter = unsafe {
         doc_node.query_selector_iter("input[type=radio]".into_string()).unwrap()
                 .filter_map(|t| HTMLInputElementCast::to_ref(t))
-                .filter(|&r| in_same_group(r, owner.root_ref(), group) && broadcaster != r)
+                .filter(|&r| in_same_group(r, owner.r(), group) && broadcaster != r)
     };
     for r in iter {
         if r.Checked() {
@@ -326,7 +326,7 @@ fn in_same_group<'a,'b>(other: JSRef<'a, HTMLInputElement>,
                         owner: Option<JSRef<'b, HTMLFormElement>>,
                         group: Option<&str>) -> bool {
     let other_owner = other.form_owner().root();
-    let other_owner = other_owner.root_ref();
+    let other_owner = other_owner.r();
     other.input_type.get() == InputType::InputRadio &&
     // TODO Both a and b are in the same home subtree.
     other_owner.equals(owner) &&
@@ -638,7 +638,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                     let checked_member = unsafe {
                         doc_node.query_selector_iter("input[type=radio]".into_string()).unwrap()
                                 .filter_map(|t| HTMLInputElementCast::to_ref(t))
-                                .filter(|&r| in_same_group(r, owner.root_ref(),
+                                .filter(|&r| in_same_group(r, owner.r(),
                                                            group.as_ref().map(|gr| gr.as_slice())))
                                 .find(|r| r.Checked())
                     };

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -307,7 +307,7 @@ fn broadcast_radio_checked(broadcaster: JSRef<HTMLInputElement>, group: Option<&
     //TODO: if not in document, use root ancestor instead of document
     let owner = broadcaster.form_owner().root();
     let doc = document_from_node(broadcaster).root();
-    let doc_node: JSRef<Node> = NodeCast::from_ref(*doc);
+    let doc_node: JSRef<Node> = NodeCast::from_ref(doc.r());
 
     // There is no DOM tree manipulation here, so this is safe
     let mut iter = unsafe {
@@ -342,7 +342,7 @@ impl<'a> HTMLInputElementHelpers for JSRef<'a, HTMLInputElement> {
     fn force_relayout(self) {
         let doc = document_from_node(self).root();
         let node: JSRef<Node> = NodeCast::from_ref(self);
-        doc.content_changed(node, NodeDamage::OtherNodeDamage)
+        doc.r().content_changed(node, NodeDamage::OtherNodeDamage)
     }
 
     fn radio_group_updated(self, group: Option<&str>) {
@@ -356,7 +356,7 @@ impl<'a> HTMLInputElementHelpers for JSRef<'a, HTMLInputElement> {
         let elem: JSRef<Element> = ElementCast::from_ref(self);
         elem.get_attribute(ns!(""), &atom!("name"))
             .root()
-            .map(|name| name.Value())
+            .map(|name| name.r().Value())
     }
 
     fn update_checked_state(self, checked: bool, dirty: bool) {
@@ -550,7 +550,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             //TODO: set the editing position for text inputs
 
             let doc = document_from_node(*self).root();
-            doc.request_focus(ElementCast::from_ref(*self));
+            doc.r().request_focus(ElementCast::from_ref(*self));
         } else if "keydown" == event.Type().as_slice() && !event.DefaultPrevented() &&
             (self.input_type.get() == InputType::InputText ||
              self.input_type.get() == InputType::InputPassword) {
@@ -631,7 +631,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                     //TODO: if not in document, use root ancestor instead of document
                     let owner = self.form_owner().root();
                     let doc = document_from_node(*self).root();
-                    let doc_node: JSRef<Node> = NodeCast::from_ref(*doc);
+                    let doc_node: JSRef<Node> = NodeCast::from_ref(doc.r());
                     let group = self.get_radio_group_name();;
 
                     // Safe since we only manipulate the DOM tree after finding an element
@@ -684,11 +684,11 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                         Some(o) => {
                             // Avoiding iterating through the whole tree here, instead
                             // we can check if the conditions for radio group siblings apply
-                            if name == o.get_radio_group_name() && // TODO should be compatibility caseless
-                               self.form_owner() == o.form_owner() &&
+                            if name == o.r().get_radio_group_name() && // TODO should be compatibility caseless
+                               self.form_owner() == o.r().form_owner() &&
                                // TODO Both a and b are in the same home subtree
-                               o.input_type.get() == InputType::InputRadio {
-                                    o.SetChecked(true);
+                               o.r().input_type.get() == InputType::InputRadio {
+                                    o.r().SetChecked(true);
                             } else {
                                 self.SetChecked(false);
                             }
@@ -716,8 +716,8 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 if self.mutable() /* and document owner is fully active */ {
                     self.form_owner().map(|o| {
-                        o.root().submit(SubmittedFrom::NotFromFormSubmitMethod,
-                                        FormSubmitter::InputElement(self.clone()))
+                        o.root().r().submit(SubmittedFrom::NotFromFormSubmitMethod,
+                                            FormSubmitter::InputElement(self.clone()))
                     });
                 }
             },
@@ -726,7 +726,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 if self.mutable() /* and document owner is fully active */ {
                     self.form_owner().map(|o| {
-                        o.root().reset(ResetFrom::NotFromFormResetMethod)
+                        o.root().r().reset(ResetFrom::NotFromFormResetMethod)
                     });
                 }
             },
@@ -735,21 +735,21 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                 // https://html.spec.whatwg.org/multipage/forms.html#radio-button-state-(type=radio):activation-behavior
                 if self.mutable() {
                     let win = window_from_node(*self).root();
-                    let event = Event::new(GlobalRef::Window(*win),
+                    let event = Event::new(GlobalRef::Window(win.r()),
                                            "input".into_string(),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable).root();
-                    event.set_trusted(true);
+                    event.r().set_trusted(true);
                     let target: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
-                    target.DispatchEvent(*event).ok();
+                    target.DispatchEvent(event.r()).ok();
 
-                    let event = Event::new(GlobalRef::Window(*win),
+                    let event = Event::new(GlobalRef::Window(win.r()),
                                            "change".into_string(),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable).root();
-                    event.set_trusted(true);
+                    event.r().set_trusted(true);
                     let target: JSRef<EventTarget> = EventTargetCast::from_ref(*self);
-                    target.DispatchEvent(*event).ok();
+                    target.DispatchEvent(event.r()).ok();
                 }
             },
             _ => ()
@@ -759,7 +759,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
     // https://html.spec.whatwg.org/multipage/forms.html#implicit-submission
     fn implicit_submission(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool) {
         let doc = document_from_node(*self).root();
-        let node: JSRef<Node> = NodeCast::from_ref(*doc);
+        let node: JSRef<Node> = NodeCast::from_ref(doc.r());
         let owner = self.form_owner();
         if owner.is_none() || ElementCast::from_ref(*self).click_in_progress() {
             return;

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -127,7 +127,8 @@ trait PrivateHTMLLinkElementHelpers {
 impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
     fn handle_stylesheet_url(self, href: &str) {
         let window = window_from_node(self).root();
-        match UrlParser::new().base_url(&window.r().page().get_url()).parse(href) {
+        let window = window.r();
+        match UrlParser::new().base_url(&window.page().get_url()).parse(href) {
             Ok(url) => {
                 let LayoutChan(ref layout_chan) = window.page().layout_chan;
                 layout_chan.send(Msg::LoadStylesheet(url));

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -53,7 +53,7 @@ impl HTMLLinkElement {
 
 fn get_attr(element: JSRef<Element>, name: &Atom) -> Option<String> {
     let elem = element.get_attribute(ns!(""), name).root();
-    elem.map(|e| e.value().as_slice().into_string())
+    elem.map(|e| e.r().value().as_slice().into_string())
 }
 
 fn is_stylesheet(value: &Option<String>) -> bool {
@@ -127,7 +127,7 @@ trait PrivateHTMLLinkElementHelpers {
 impl<'a> PrivateHTMLLinkElementHelpers for JSRef<'a, HTMLLinkElement> {
     fn handle_stylesheet_url(self, href: &str) {
         let window = window_from_node(self).root();
-        match UrlParser::new().base_url(&window.page().get_url()).parse(href) {
+        match UrlParser::new().base_url(&window.r().page().get_url()).parse(href) {
             Ok(url) => {
                 let LayoutChan(ref layout_chan) = window.page().layout_chan;
                 layout_chan.send(Msg::LoadStylesheet(url));

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -62,8 +62,8 @@ impl<'a> ProcessDataURL for JSRef<'a, HTMLObjectElement> {
         let elem: JSRef<Element> = ElementCast::from_ref(*self);
 
         // TODO: support other values
-        match (elem.get_attribute(ns!(""), &atom!("type")).map(|x| x.root().Value()),
-               elem.get_attribute(ns!(""), &atom!("data")).map(|x| x.root().Value())) {
+        match (elem.get_attribute(ns!(""), &atom!("type")).map(|x| x.root().r().Value()),
+               elem.get_attribute(ns!(""), &atom!("data")).map(|x| x.root().r().Value())) {
             (None, Some(uri)) => {
                 if is_image_data(uri.as_slice()) {
                     let data_url = Url::parse(uri.as_slice()).unwrap();
@@ -84,7 +84,7 @@ pub fn is_image_data(uri: &str) -> bool {
 impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
     fn Validity(self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
-        ValidityState::new(*window)
+        ValidityState::new(window.r())
     }
 
     // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-object-type
@@ -109,7 +109,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
         match attr.local_name() {
             &atom!("data") => {
                 let window = window_from_node(*self).root();
-                self.process_data_url(window.image_cache_task().clone());
+                self.process_data_url(window.r().image_cache_task().clone());
             },
             _ => ()
         }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -42,7 +42,7 @@ impl HTMLOutputElement {
 impl<'a> HTMLOutputElementMethods for JSRef<'a, HTMLOutputElement> {
     fn Validity(self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
-        ValidityState::new(*window)
+        ValidityState::new(window.r())
     }
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -175,11 +175,11 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
 
         let (source, url) = match element.get_attribute(ns!(""), &atom!("src")).root() {
             Some(src) => {
-                if src.deref().Value().is_empty() {
+                if src.r().Value().is_empty() {
                     // TODO: queue a task to fire a simple event named `error` at the element
                     return;
                 }
-                match UrlParser::new().base_url(&base_url).parse(src.deref().Value().as_slice()) {
+                match UrlParser::new().base_url(&base_url).parse(src.r().Value().as_slice()) {
                     Ok(url) => {
                         // TODO: Do a potentially CORS-enabled fetch with the mode being the current
                         // state of the element's `crossorigin` content attribute, the origin being
@@ -192,14 +192,14 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
                                 (source, metadata.final_url)
                             }
                             Err(_) => {
-                                error!("error loading script {}", src.deref().Value());
+                                error!("error loading script {}", src.r().Value());
                                 return;
                             }
                         }
                     }
                     Err(_) => {
                         // TODO: queue a task to fire a simple event named `error` at the element
-                        error!("error parsing URL for script {}", src.deref().Value());
+                        error!("error parsing URL for script {}", src.r().Value());
                         return;
                     }
                 }
@@ -207,20 +207,20 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
             None => (text, base_url)
         };
 
-        window.evaluate_script_with_result(source.as_slice(), url.serialize().as_slice());
+        window.r().evaluate_script_with_result(source.as_slice(), url.serialize().as_slice());
 
-        let event = Event::new(GlobalRef::Window(*window),
+        let event = Event::new(GlobalRef::Window(window.r()),
                                "load".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();
-        event.set_trusted(true);
+        event.r().set_trusted(true);
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.dispatch_event(*event);
+        target.dispatch_event(event.r());
     }
 
     fn is_javascript(self) -> bool {
         let element: JSRef<Element> = ElementCast::from_ref(self);
-        match element.get_attribute(ns!(""), &atom!("type")).root().map(|s| s.Value()) {
+        match element.get_attribute(ns!(""), &atom!("type")).root().map(|s| s.r().Value()) {
             Some(ref s) if s.is_empty() => {
                 // type attr exists, but empty means js
                 debug!("script type empty, inferring js");
@@ -234,7 +234,7 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
                 debug!("no script type");
                 match element.get_attribute(ns!(""), &atom!("language"))
                              .root()
-                             .map(|s| s.Value()) {
+                             .map(|s| s.r().Value()) {
                     Some(ref s) if s.is_empty() => {
                         debug!("script language empty, inferring js");
                         true

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -170,6 +170,7 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
         // TODO: Add support for the `defer` and `async` attributes.  (For now, we fetch all
         // scripts synchronously and execute them immediately.)
         let window = window_from_node(self).root();
+        let window = window.r();
         let page = window.page();
         let base_url = page.get_url();
 
@@ -207,9 +208,9 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
             None => (text, base_url)
         };
 
-        window.r().evaluate_script_with_result(source.as_slice(), url.serialize().as_slice());
+        window.evaluate_script_with_result(source.as_slice(), url.serialize().as_slice());
 
-        let event = Event::new(GlobalRef::Window(window.r()),
+        let event = Event::new(GlobalRef::Window(window),
                                "load".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable).root();

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -50,7 +50,7 @@ impl HTMLSelectElement {
 impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
     fn Validity(self) -> Temporary<ValidityState> {
         let window = window_from_node(self).root();
-        ValidityState::new(*window)
+        ValidityState::new(window.r())
     }
 
     // Note: this function currently only exists for test_union.html.

--- a/components/script/dom/htmlserializer.rs
+++ b/components/script/dom/htmlserializer.rs
@@ -71,8 +71,8 @@ fn serialize_comment(comment: JSRef<Comment>, html: &mut String) {
 fn serialize_text(text: JSRef<Text>, html: &mut String) {
     let text_node: JSRef<Node> = NodeCast::from_ref(text);
     match text_node.parent_node().map(|node| node.root()) {
-        Some(ref parent) if parent.is_element() => {
-            let elem: JSRef<Element> = ElementCast::to_ref(**parent).unwrap();
+        Some(ref parent) if parent.r().is_element() => {
+            let elem: JSRef<Element> = ElementCast::to_ref(parent.r()).unwrap();
             match elem.local_name().as_slice() {
                 "style" | "script" | "xmp" | "iframe" |
                 "noembed" | "noframes" | "plaintext" |
@@ -105,7 +105,7 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
     html.push_str(elem.local_name().as_slice());
     for attr in elem.attrs().iter() {
         let attr = attr.root();
-        serialize_attr(*attr, html);
+        serialize_attr(attr.r(), html);
     };
     html.push('>');
 
@@ -113,8 +113,8 @@ fn serialize_elem(elem: JSRef<Element>, open_elements: &mut Vec<String>, html: &
         "pre" | "listing" | "textarea" if *elem.namespace() == ns!(HTML) => {
             let node: JSRef<Node> = NodeCast::from_ref(elem);
             match node.first_child().map(|child| child.root()) {
-                Some(ref child) if child.is_text() => {
-                    let text: JSRef<CharacterData> = CharacterDataCast::to_ref(**child).unwrap();
+                Some(ref child) if child.r().is_text() => {
+                    let text: JSRef<CharacterData> = CharacterDataCast::to_ref(child.r()).unwrap();
                     if text.data().len() > 0 && text.data().as_slice().char_at(0) == '\n' {
                         html.push('\x0A');
                     }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -51,6 +51,7 @@ impl<'a> StyleElementHelpers for JSRef<'a, HTMLStyleElement> {
         assert!(node.is_in_doc());
 
         let win = window_from_node(node).root();
+        let win = win.r();
         let url = win.page().get_url();
 
         let data = node.GetTextContent().expect("Element.textContent must be a string");

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -75,7 +75,7 @@ impl<'a> HTMLTableElementMethods for JSRef<'a, HTMLTableElement> {
         match old_caption {
             Some(htmlelem) => {
                 let htmlelem_root = htmlelem.root();
-                let old_caption_node: JSRef<Node> = NodeCast::from_ref(*htmlelem_root);
+                let old_caption_node: JSRef<Node> = NodeCast::from_ref(htmlelem_root.r());
                 assert!(node.RemoveChild(old_caption_node).is_ok());
             }
             None => ()

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -193,7 +193,7 @@ impl<'a> PrivateHTMLTextAreaElementHelpers for JSRef<'a, HTMLTextAreaElement> {
     fn force_relayout(self) {
         let doc = document_from_node(self).root();
         let node: JSRef<Node> = NodeCast::from_ref(self);
-        doc.content_changed(node, NodeDamage::OtherNodeDamage)
+        doc.r().content_changed(node, NodeDamage::OtherNodeDamage)
     }
 }
 
@@ -312,7 +312,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
             //TODO: set the editing position for text inputs
 
             let doc = document_from_node(*self).root();
-            doc.request_focus(ElementCast::from_ref(*self));
+            doc.r().request_focus(ElementCast::from_ref(*self));
         } else if "keydown" == event.Type().as_slice() && !event.DefaultPrevented() {
             let keyevent: Option<JSRef<KeyboardEvent>> = KeyboardEventCast::to_ref(event);
             keyevent.map(|event| {

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -74,7 +74,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTitleElement> {
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         if is_in_doc {
             let document = node.owner_doc().root();
-            document.send_title_to_compositor()
+            document.r().send_title_to_compositor()
         }
     }
 }

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -82,17 +82,17 @@ impl KeyboardEvent {
                char_code: Option<u32>,
                key_code: u32) -> Temporary<KeyboardEvent> {
         let ev = KeyboardEvent::new_uninitialized(window).root();
-        ev.deref().InitKeyboardEvent(type_, canBubble, cancelable, view, key, location,
-                                     "".into_string(), repeat, "".into_string());
-        *ev.code.borrow_mut() = code;
-        ev.ctrl.set(ctrlKey);
-        ev.alt.set(altKey);
-        ev.shift.set(shiftKey);
-        ev.meta.set(metaKey);
-        ev.char_code.set(char_code);
-        ev.key_code.set(key_code);
-        ev.is_composing.set(isComposing);
-        Temporary::from_rooted(*ev)
+        ev.r().InitKeyboardEvent(type_, canBubble, cancelable, view, key, location,
+                                 "".into_string(), repeat, "".into_string());
+        *ev.r().code.borrow_mut() = code;
+        ev.r().ctrl.set(ctrlKey);
+        ev.r().alt.set(altKey);
+        ev.r().shift.set(shiftKey);
+        ev.r().meta.set(metaKey);
+        ev.r().char_code.set(char_code);
+        ev.r().key_code.set(key_code);
+        ev.r().is_composing.set(isComposing);
+        Temporary::from_rooted(ev.r())
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -101,7 +101,7 @@ impl KeyboardEvent {
         let event = KeyboardEvent::new(global.as_window(), type_,
                                        init.parent.parent.parent.bubbles,
                                        init.parent.parent.parent.cancelable,
-                                       init.parent.parent.view.root_ref(),
+                                       init.parent.parent.view.r(),
                                        init.parent.parent.detail,
                                        init.key.clone(), init.code.clone(), init.location,
                                        init.repeat, init.isComposing, init.parent.ctrlKey,

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -87,7 +87,7 @@ macro_rules! make_url_or_base_getter(
             match url.as_slice() {
                 "" => {
                     let window = window_from_node(self).root();
-                    window.get_url().serialize()
+                    window.r().get_url().serialize()
                 },
                 _ => url
             }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -58,9 +58,9 @@ impl MessageEvent {
                data: JSVal, origin: DOMString, lastEventId: DOMString)
                -> Temporary<MessageEvent> {
         let ev = MessageEvent::new_initialized(global, data, origin, lastEventId).root();
-        let event: JSRef<Event> = EventCast::from_ref(*ev);
+        let event: JSRef<Event> = EventCast::from_ref(ev.r());
         event.InitEvent(type_, bubbles, cancelable);
-        Temporary::from_rooted(*ev)
+        Temporary::from_rooted(ev.r())
     }
 
     pub fn Constructor(global: &GlobalRef,
@@ -80,7 +80,7 @@ impl MessageEvent {
         let messageevent = MessageEvent::new(
             scope, "message".into_string(), false, false, message,
             "".into_string(), "".into_string()).root();
-        let event: JSRef<Event> = EventCast::from_ref(*messageevent);
+        let event: JSRef<Event> = EventCast::from_ref(messageevent.r());
         target.dispatch_event(event);
     }
 }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -79,11 +79,11 @@ impl MouseEvent {
                button: i16,
                relatedTarget: Option<JSRef<EventTarget>>) -> Temporary<MouseEvent> {
         let ev = MouseEvent::new_uninitialized(window).root();
-        ev.InitMouseEvent(type_, canBubble, cancelable, view, detail,
-                                  screenX, screenY, clientX, clientY,
-                                  ctrlKey, altKey, shiftKey, metaKey,
-                                  button, relatedTarget);
-        Temporary::from_rooted(*ev)
+        ev.r().InitMouseEvent(type_, canBubble, cancelable, view, detail,
+                              screenX, screenY, clientX, clientY,
+                              ctrlKey, altKey, shiftKey, metaKey,
+                              button, relatedTarget);
+        Temporary::from_rooted(ev.r())
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -92,12 +92,12 @@ impl MouseEvent {
         let event = MouseEvent::new(global.as_window(), type_,
                                     init.parent.parent.parent.bubbles,
                                     init.parent.parent.parent.cancelable,
-                                    init.parent.parent.view.root_ref(),
+                                    init.parent.parent.view.r(),
                                     init.parent.parent.detail,
                                     init.screenX, init.screenY,
                                     init.clientX, init.clientY, init.parent.ctrlKey,
                                     init.parent.altKey, init.parent.shiftKey, init.parent.metaKey,
-                                    init.button, init.relatedTarget.root_ref());
+                                    init.button, init.relatedTarget.r());
         Ok(event)
     }
 }

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -33,11 +33,11 @@ impl NamedNodeMap {
 
 impl<'a> NamedNodeMapMethods for JSRef<'a, NamedNodeMap> {
     fn Length(self) -> u32 {
-        self.owner.root().attrs().len() as u32
+        self.owner.root().r().attrs().len() as u32
     }
 
     fn Item(self, index: u32) -> Option<Temporary<Attr>> {
-        self.owner.root().attrs().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
+        self.owner.root().r().attrs().as_slice().get(index as uint).map(|x| Temporary::new(x.clone()))
     }
 
     fn IndexedGetter(self, index: u32, found: &mut bool) -> Option<Temporary<Attr>> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -282,8 +282,8 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
         }
 
         let parent = self.parent_node().root();
-        parent.map(|parent| vtable_for(&*parent).child_inserted(self));
-        document.content_and_heritage_changed(self, NodeDamage::OtherNodeDamage);
+        parent.map(|parent| vtable_for(&parent.r()).child_inserted(self));
+        document.r().content_and_heritage_changed(self, NodeDamage::OtherNodeDamage);
     }
 
     // http://dom.spec.whatwg.org/#node-is-removed
@@ -314,8 +314,8 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
                         self.first_child.assign(Some(new_child));
                     },
                     Some(prev_sibling) => {
-                        prev_sibling.next_sibling.assign(Some(new_child));
-                        new_child.prev_sibling.assign(Some(*prev_sibling));
+                        prev_sibling.r().next_sibling.assign(Some(new_child));
+                        new_child.prev_sibling.assign(Some(prev_sibling.r()));
                     },
                 }
                 before.prev_sibling.assign(Some(new_child));
@@ -325,9 +325,9 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
                 match self.last_child().root() {
                     None => self.first_child.assign(Some(new_child)),
                     Some(last_child) => {
-                        assert!(last_child.next_sibling().is_none());
-                        last_child.next_sibling.assign(Some(new_child));
-                        new_child.prev_sibling.assign(Some(*last_child));
+                        assert!(last_child.r().next_sibling().is_none());
+                        last_child.r().next_sibling.assign(Some(new_child));
+                        new_child.prev_sibling.assign(Some(last_child.r()));
                     }
                 }
 
@@ -349,7 +349,7 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
                 self.first_child.assign(child.next_sibling.get());
             }
             Some(prev_sibling) => {
-                prev_sibling.next_sibling.assign(child.next_sibling.get());
+                prev_sibling.r().next_sibling.assign(child.next_sibling.get());
             }
         }
 
@@ -358,7 +358,7 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
                 self.last_child.assign(child.prev_sibling.get());
             }
             Some(next_sibling) => {
-                next_sibling.prev_sibling.assign(child.prev_sibling.get());
+                next_sibling.r().prev_sibling.assign(child.prev_sibling.get());
             }
         }
 
@@ -682,7 +682,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
                 Some(parent) => parent,
             };
 
-        for sibling in parent.root().children() {
+        for sibling in parent.root().r().children() {
             sibling.set_has_dirty_siblings(true);
         }
 
@@ -726,11 +726,11 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     fn get_bounding_content_box(self) -> Rect<Au> {
-        window_from_node(self).root().page().content_box_query(self.to_trusted_node_address())
+        window_from_node(self).root().r().page().content_box_query(self.to_trusted_node_address())
     }
 
     fn get_content_boxes(self) -> Vec<Rect<Au>> {
-        window_from_node(self).root().page().content_boxes_query(self.to_trusted_node_address())
+        window_from_node(self).root().r().page().content_boxes_query(self.to_trusted_node_address())
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-queryselector
@@ -781,7 +781,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
         unsafe {
             self.query_selector_iter(selectors).map(|mut iter| {
                 let window = window_from_node(self).root();
-                NodeList::new_simple_list(*window, iter.collect())
+                NodeList::new_simple_list(window.r(), iter.collect())
             })
         }
     }
@@ -802,7 +802,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     fn is_in_html_doc(self) -> bool {
-        self.owner_doc().root().is_html_document()
+        self.owner_doc().root().r().is_html_document()
     }
 
     fn children(self) -> NodeChildrenIterator<'a> {
@@ -825,7 +825,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
 
     fn remove_self(self) {
         match self.parent_node().root() {
-            Some(parent) => parent.remove_child(self),
+            Some(parent) => parent.r().remove_child(self),
             None => ()
         }
     }
@@ -843,11 +843,11 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
         NodeInfo {
             uniqueId: self.unique_id.borrow().clone(),
             baseURI: self.GetBaseURI().unwrap_or("".into_string()),
-            parent: self.GetParentNode().root().map(|node| node.get_unique_id()).unwrap_or("".into_string()),
+            parent: self.GetParentNode().root().map(|node| node.r().get_unique_id()).unwrap_or("".into_string()),
             nodeType: self.NodeType() as uint,
             namespaceURI: "".into_string(), //FIXME
             nodeName: self.NodeName(),
-            numChildren: self.ChildNodes().root().Length() as uint,
+            numChildren: self.ChildNodes().root().r().Length() as uint,
 
             //FIXME doctype nodes only
             name: "".into_string(),
@@ -861,8 +861,9 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
 
             isDocumentElement:
                 self.owner_doc().root()
+                    .r()
                     .GetDocumentElement()
-                    .map(|elem| NodeCast::from_ref(*elem.root()) == self)
+                    .map(|elem| NodeCast::from_ref(elem.root().r()) == self)
                     .unwrap_or(false),
 
             shortValue: self.GetNodeValue().unwrap_or("".into_string()), //FIXME: truncate
@@ -1159,7 +1160,7 @@ impl Node {
              wrap_fn:   extern "Rust" fn(*mut JSContext, GlobalRef, Box<N>) -> Temporary<N>)
              -> Temporary<N> {
         let window = document.window().root();
-        reflect_dom_object(node, GlobalRef::Window(*window), wrap_fn)
+        reflect_dom_object(node, GlobalRef::Window(window.r()), wrap_fn)
     }
 
     pub fn new_inherited(type_id: NodeTypeId, doc: JSRef<Document>) -> Node {
@@ -1210,14 +1211,14 @@ impl Node {
         // Step 1.
         match node.parent_node().root() {
             Some(parent) => {
-                Node::remove(node, *parent, SuppressObserver::Unsuppressed);
+                Node::remove(node, parent.r(), SuppressObserver::Unsuppressed);
             }
             None => (),
         }
 
         // Step 2.
         let node_doc = document_from_node(node).root();
-        if *node_doc != document {
+        if node_doc.r() != document {
             for descendant in node.traverse_preorder() {
                 descendant.set_owner_doc(document);
             }
@@ -1429,7 +1430,7 @@ impl Node {
         match node {
             Some(node) => {
                 let document = document_from_node(parent).root();
-                Node::adopt(node, *document);
+                Node::adopt(node, document.r());
             }
             None => (),
         }
@@ -1519,16 +1520,16 @@ impl Node {
                 let doctype: JSRef<DocumentType> = DocumentTypeCast::to_ref(node).unwrap();
                 let doctype = DocumentType::new(doctype.name().clone(),
                                                 Some(doctype.public_id().clone()),
-                                                Some(doctype.system_id().clone()), *document);
+                                                Some(doctype.system_id().clone()), document.r());
                 NodeCast::from_temporary(doctype)
             },
             NodeTypeId::DocumentFragment => {
-                let doc_fragment = DocumentFragment::new(*document);
+                let doc_fragment = DocumentFragment::new(document.r());
                 NodeCast::from_temporary(doc_fragment)
             },
             NodeTypeId::Comment => {
                 let comment: JSRef<Comment> = CommentCast::to_ref(node).unwrap();
-                let comment = Comment::new(comment.characterdata().data().clone(), *document);
+                let comment = Comment::new(comment.characterdata().data().clone(), document.r());
                 NodeCast::from_temporary(comment)
             },
             NodeTypeId::Document => {
@@ -1538,7 +1539,7 @@ impl Node {
                     false => IsHTMLDocument::NonHTMLDocument,
                 };
                 let window = document.window().root();
-                let document = Document::new(*window, Some(document.url().clone()),
+                let document = Document::new(window.r(), Some(document.url().clone()),
                                              is_html_doc, None,
                                              DocumentSource::NotFromParser);
                 NodeCast::from_temporary(document)
@@ -1551,67 +1552,67 @@ impl Node {
                 };
                 let element = Element::create(name,
                     element.prefix().as_ref().map(|p| p.as_slice().into_string()),
-                    *document, ElementCreator::ScriptCreated);
+                    document.r(), ElementCreator::ScriptCreated);
                 NodeCast::from_temporary(element)
             },
             NodeTypeId::Text => {
                 let text: JSRef<Text> = TextCast::to_ref(node).unwrap();
-                let text = Text::new(text.characterdata().data().clone(), *document);
+                let text = Text::new(text.characterdata().data().clone(), document.r());
                 NodeCast::from_temporary(text)
             },
             NodeTypeId::ProcessingInstruction => {
                 let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
                 let pi = ProcessingInstruction::new(pi.target().clone(),
-                                                    pi.characterdata().data().clone(), *document);
+                                                    pi.characterdata().data().clone(), document.r());
                 NodeCast::from_temporary(pi)
             },
         }.root();
 
         // Step 3.
-        let document = match DocumentCast::to_ref(*copy) {
+        let document = match DocumentCast::to_ref(copy.r()) {
             Some(doc) => doc,
-            None => *document,
+            None => document.r(),
         };
-        assert!(*copy.owner_doc().root() == document);
+        assert!(copy.r().owner_doc().root().r() == document);
 
         // Step 4 (some data already copied in step 2).
         match node.type_id() {
             NodeTypeId::Document => {
                 let node_doc: JSRef<Document> = DocumentCast::to_ref(node).unwrap();
-                let copy_doc: JSRef<Document> = DocumentCast::to_ref(*copy).unwrap();
+                let copy_doc: JSRef<Document> = DocumentCast::to_ref(copy.r()).unwrap();
                 copy_doc.set_encoding_name(node_doc.encoding_name().clone());
                 copy_doc.set_quirks_mode(node_doc.quirks_mode());
             },
             NodeTypeId::Element(..) => {
                 let node_elem: JSRef<Element> = ElementCast::to_ref(node).unwrap();
-                let copy_elem: JSRef<Element> = ElementCast::to_ref(*copy).unwrap();
+                let copy_elem: JSRef<Element> = ElementCast::to_ref(copy.r()).unwrap();
 
                 // FIXME: https://github.com/mozilla/servo/issues/1737
                 let window = document.window().root();
                 for attr in node_elem.attrs().iter().map(|attr| attr.root()) {
                     copy_elem.attrs_mut().push_unrooted(
-                        &Attr::new(*window,
-                                   attr.local_name().clone(), attr.value().clone(),
-                                   attr.name().clone(), attr.namespace().clone(),
-                                   attr.prefix().clone(), Some(copy_elem)));
+                        &Attr::new(window.r(),
+                                   attr.r().local_name().clone(), attr.r().value().clone(),
+                                   attr.r().name().clone(), attr.r().namespace().clone(),
+                                   attr.r().prefix().clone(), Some(copy_elem)));
                 }
             },
             _ => ()
         }
 
         // Step 5: cloning steps.
-        vtable_for(&node).cloning_steps(*copy, maybe_doc, clone_children);
+        vtable_for(&node).cloning_steps(copy.r(), maybe_doc, clone_children);
 
         // Step 6.
         if clone_children == CloneChildrenFlag::CloneChildren {
             for child in node.children() {
                 let child_copy = Node::clone(child, Some(document), clone_children).root();
-                let _inserted_node = Node::pre_insert(*child_copy, *copy, None);
+                let _inserted_node = Node::pre_insert(child_copy.r(), copy.r(), None);
             }
         }
 
         // Step 7.
-        Temporary::from_rooted(*copy)
+        Temporary::from_rooted(copy.r())
     }
 
     /// Sends layout data, if any, back to the layout task to be destroyed.
@@ -1708,7 +1709,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
         self.parent_node.get()
                         .and_then(|parent| {
                             let parent = parent.root();
-                            ElementCast::to_ref(*parent).map(|elem| {
+                            ElementCast::to_ref(parent.r()).map(|elem| {
                                 Temporary::from_rooted(elem)
                             })
                         })
@@ -1723,8 +1724,8 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
     fn ChildNodes(self) -> Temporary<NodeList> {
         self.child_list.or_init(|| {
             let doc = self.owner_doc().root();
-            let window = doc.window().root();
-            NodeList::new_child_list(*window, self)
+            let window = doc.r().window().root();
+            NodeList::new_child_list(window.r(), self)
         })
     }
 
@@ -1807,7 +1808,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                     None
                 } else {
                     let document = self.owner_doc().root();
-                    Some(NodeCast::from_temporary(document.CreateTextNode(value)))
+                    Some(NodeCast::from_temporary(document.r().CreateTextNode(value)))
                 }.root();
 
                 // Step 3.
@@ -1821,7 +1822,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
                 // Notify the document that the content of this node is different
                 let document = self.owner_doc().root();
-                document.content_changed(self, NodeDamage::OtherNodeDamage);
+                document.r().content_changed(self, NodeDamage::OtherNodeDamage);
             }
             NodeTypeId::DocumentType |
             NodeTypeId::Document => {}
@@ -1942,7 +1943,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
         // Step 9.
         let document = document_from_node(self).root();
-        Node::adopt(node, *document);
+        Node::adopt(node, document.r());
 
         {
             // Step 10.
@@ -2044,9 +2045,9 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
             assert!(element.attrs().len() == other_element.attrs().len());
             element.attrs().iter().map(|attr| attr.root()).all(|attr| {
                 other_element.attrs().iter().map(|attr| attr.root()).any(|other_attr| {
-                    (*attr.namespace() == *other_attr.namespace()) &&
-                    (attr.local_name() == other_attr.local_name()) &&
-                    (attr.value().as_slice() == other_attr.value().as_slice())
+                    (*attr.r().namespace() == *other_attr.r().namespace()) &&
+                    (attr.r().local_name() == other_attr.r().local_name()) &&
+                    (attr.r().value().as_slice() == other_attr.r().value().as_slice())
                 })
             })
         }
@@ -2183,7 +2184,7 @@ pub fn document_from_node<T: NodeBase+Reflectable>(derived: JSRef<T>) -> Tempora
 
 pub fn window_from_node<T: NodeBase+Reflectable>(derived: JSRef<T>) -> Temporary<Window> {
     let document = document_from_node(derived).root();
-    document.window()
+    document.r().window()
 }
 
 impl<'a> VirtualMethods for JSRef<'a, Node> {
@@ -2279,12 +2280,12 @@ impl<'a> style::TNode<'a, JSRef<'a, Element>> for JSRef<'a, Node> {
         match attr.namespace {
             style::NamespaceConstraint::Specific(ref ns) => {
                 self.as_element().get_attribute(ns.clone(), name).root()
-                    .map_or(false, |attr| test(attr.value().as_slice()))
+                    .map_or(false, |attr| test(attr.r().value().as_slice()))
             },
             style::NamespaceConstraint::Any => {
                 self.as_element().get_attributes(name).iter()
                     .map(|attr| attr.root())
-                    .any(|attr| test(attr.value().as_slice()))
+                    .any(|attr| test(attr.r().value().as_slice()))
             }
         }
     }
@@ -2338,7 +2339,7 @@ impl<'a> DisabledStateHelpers for JSRef<'a, Node> {
     fn check_parent_disabled_state_for_option(self) {
         if self.get_disabled_state() { return; }
         match self.parent_node().root() {
-            Some(ref parent) if parent.is_htmloptgroupelement() && parent.get_disabled_state() => {
+            Some(ref parent) if parent.r().is_htmloptgroupelement() && parent.r().get_disabled_state() => {
                 self.set_disabled_state(true);
                 self.set_enabled_state(false);
             },

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -307,10 +307,10 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
         assert!(new_child.next_sibling().is_none());
         match before {
             Some(ref before) => {
-                assert!(before.parent_node().root().root_ref() == Some(self));
+                assert!(before.parent_node().root().r() == Some(self));
                 match before.prev_sibling().root() {
                     None => {
-                        assert!(Some(*before) == self.first_child().root().root_ref());
+                        assert!(Some(*before) == self.first_child().root().r());
                         self.first_child.assign(Some(new_child));
                     },
                     Some(prev_sibling) => {
@@ -342,7 +342,7 @@ impl<'a> PrivateNodeHelpers for JSRef<'a, Node> {
     ///
     /// Fails unless `child` is a child of this node.
     fn remove_child(self, child: JSRef<Node>) {
-        assert!(child.parent_node().root().root_ref() == Some(self));
+        assert!(child.parent_node().root().r() == Some(self));
 
         match child.prev_sibling.get().root() {
             None => {
@@ -1811,7 +1811,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
                 }.root();
 
                 // Step 3.
-                Node::replace_all(node.root_ref(), self);
+                Node::replace_all(node.r(), self);
             }
             NodeTypeId::Comment |
             NodeTypeId::Text |

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -52,7 +52,7 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
             NodeListType::Simple(ref elems) => elems.len() as u32,
             NodeListType::Children(ref node) => {
                 let node = node.root();
-                node.children().count() as u32
+                node.r().children().count() as u32
             }
         }
     }
@@ -63,8 +63,8 @@ impl<'a> NodeListMethods for JSRef<'a, NodeList> {
             NodeListType::Simple(ref elems) => Some(Temporary::new(elems[index as uint].clone())),
             NodeListType::Children(ref node) => {
                 let node = node.root();
-                node.children().nth(index as uint)
-                                       .map(|child| Temporary::from_rooted(child))
+                node.r().children().nth(index as uint)
+                                   .map(|child| Temporary::from_rooted(child))
             }
         }
     }

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -49,7 +49,7 @@ impl<'a> PerformanceMethods for JSRef<'a, Performance> {
 
     // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/HighResolutionTime/Overview.html#dom-performance-now
     fn Now(self) -> DOMHighResTimeStamp {
-        let navStart = self.timing.root().NavigationStartPrecise();
+        let navStart = self.timing.root().r().NavigationStartPrecise();
         (time::precise_time_ns() as f64 - navStart) * 1000000u as DOMHighResTimeStamp
     }
 }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -42,9 +42,9 @@ impl ProgressEvent {
         let ev = reflect_dom_object(box ProgressEvent::new_inherited(length_computable, loaded, total),
                                     global,
                                     ProgressEventBinding::Wrap).root();
-        let event: JSRef<Event> = EventCast::from_ref(*ev);
+        let event: JSRef<Event> = EventCast::from_ref(ev.r());
         event.InitEvent(type_, can_bubble, cancelable);
-        Temporary::from_rooted(*ev)
+        Temporary::from_rooted(ev.r())
     }
     pub fn Constructor(global: &GlobalRef,
                        type_: DOMString,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -26,13 +26,13 @@ impl Range {
     pub fn new(document: JSRef<Document>) -> Temporary<Range> {
         let window = document.window().root();
         reflect_dom_object(box Range::new_inherited(),
-                           GlobalRef::Window(*window),
+                           GlobalRef::Window(window.r()),
                            RangeBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalRef) -> Fallible<Temporary<Range>> {
         let document = global.as_window().Document().root();
-        Ok(Range::new(*document))
+        Ok(Range::new(document.r()))
     }
 }
 

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -72,7 +72,8 @@ impl ServoHTMLParser {
             tokenizer: DOMRefCell::new(tok),
         };
 
-        reflect_dom_object(box parser, GlobalRef::Window(*window), ServoHTMLParserBinding::Wrap)
+        reflect_dom_object(box parser, GlobalRef::Window(window.r()),
+                           ServoHTMLParserBinding::Wrap)
     }
 
     #[inline]

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -38,13 +38,13 @@ impl Storage {
 
     fn get_url(&self) -> Url {
         let global_root = self.global.root();
-        let global_ref = global_root.root_ref();
+        let global_ref = global_root.r();
         global_ref.get_url()
     }
 
     fn get_storage_task(&self) -> StorageTask {
         let global_root = self.global.root();
-        let global_ref = global_root.root_ref();
+        let global_ref = global_root.r();
         global_ref.as_window().storage_task()
     }
 

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -59,7 +59,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn SetEnumAttribute(self, _: TestEnum) {}
     fn InterfaceAttribute(self) -> Temporary<Blob> {
         let global = self.global.root();
-        Blob::new(&global.root_ref(), None, "")
+        Blob::new(&global.r(), None, "")
     }
     fn SetInterfaceAttribute(self, _: JSRef<Blob>) {}
     fn UnionAttribute(self) -> HTMLElementOrLong { eLong(0) }
@@ -99,7 +99,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn GetEnumAttributeNullable(self) -> Option<TestEnum> { Some(_empty) }
     fn GetInterfaceAttributeNullable(self) -> Option<Temporary<Blob>> {
         let global = self.global.root();
-        Some(Blob::new(&global.root_ref(), None, ""))
+        Some(Blob::new(&global.r(), None, ""))
     }
     fn SetInterfaceAttributeNullable(self, _: Option<JSRef<Blob>>) {}
     fn GetUnionAttributeNullable(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
@@ -123,7 +123,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn ReceiveEnum(self) -> TestEnum { _empty }
     fn ReceiveInterface(self) -> Temporary<Blob> {
         let global = self.global.root();
-        Blob::new(&global.root_ref(), None, "")
+        Blob::new(&global.r(), None, "")
     }
     fn ReceiveAny(self, _: *mut JSContext) -> JSVal { NullValue() }
     fn ReceiveUnion(self) -> HTMLElementOrLong { eLong(0) }
@@ -145,7 +145,7 @@ impl<'a> TestBindingMethods for JSRef<'a, TestBinding> {
     fn ReceiveNullableEnum(self) -> Option<TestEnum> { Some(_empty) }
     fn ReceiveNullableInterface(self) -> Option<Temporary<Blob>> {
         let global = self.global.root();
-        Some(Blob::new(&global.root_ref(), None, ""))
+        Some(Blob::new(&global.r(), None, ""))
     }
     fn ReceiveNullableUnion(self) -> Option<HTMLElementOrLong> { Some(eLong(0)) }
     fn ReceiveNullableUnion2(self) -> Option<EventOrString> { Some(eString("".into_string())) }

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -40,7 +40,7 @@ impl Text {
 
     pub fn Constructor(global: &GlobalRef, text: DOMString) -> Fallible<Temporary<Text>> {
         let document = global.as_window().Document().root();
-        Ok(Text::new(text, *document))
+        Ok(Text::new(text, document.r()))
     }
 
     #[inline]

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -47,7 +47,7 @@ impl TreeWalker {
                            filter: Filter) -> Temporary<TreeWalker> {
         let window = document.window().root();
         reflect_dom_object(box TreeWalker::new_inherited(root_node, what_to_show, filter),
-                           GlobalRef::Window(*window),
+                           GlobalRef::Window(window.r()),
                            TreeWalkerBinding::Wrap)
     }
 

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -53,8 +53,8 @@ impl UIEvent {
                view: Option<JSRef<Window>>,
                detail: i32) -> Temporary<UIEvent> {
         let ev = UIEvent::new_uninitialized(window).root();
-        ev.InitUIEvent(type_, can_bubble, cancelable, view, detail);
-        Temporary::from_rooted(*ev)
+        ev.r().InitUIEvent(type_, can_bubble, cancelable, view, detail);
+        Temporary::from_rooted(ev.r())
     }
 
     pub fn Constructor(global: &GlobalRef,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -62,7 +62,7 @@ impl UIEvent {
                        init: &UIEventBinding::UIEventInit) -> Fallible<Temporary<UIEvent>> {
         let event = UIEvent::new(global.as_window(), type_,
                                  init.parent.bubbles, init.parent.cancelable,
-                                 init.view.root_ref(), init.detail);
+                                 init.view.r(), init.detail);
         Ok(event)
     }
 }

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -52,7 +52,7 @@ impl URLSearchParams {
             Some(eURLSearchParams(u)) => {
                 let u = u.root();
                 let mut map = usp.data.borrow_mut();
-                *map = u.data.borrow().clone();
+                *map = u.r().data.borrow().clone();
             },
             None => {}
         }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -89,13 +89,13 @@ impl Worker {
         let mut message = UndefinedValue();
         unsafe {
             assert!(JS_ReadStructuredClone(
-                global.root_ref().get_cx(), data as *const u64, nbytes,
+                global.r().get_cx(), data as *const u64, nbytes,
                 JS_STRUCTURED_CLONE_VERSION, &mut message,
                 ptr::null(), ptr::null_mut()) != 0);
         }
 
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(worker.r());
-        MessageEvent::dispatch_jsval(target, global.root_ref(), message);
+        MessageEvent::dispatch_jsval(target, global.r(), message);
     }
 }
 
@@ -112,7 +112,7 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
             return Err(DataClone);
         }
 
-        let address = Trusted::new(cx, self, self.global.root().root_ref().script_chan().clone());
+        let address = Trusted::new(cx, self, self.global.root().r().script_chan().clone());
         self.sender.send((address, ScriptMsg::DOMMessage(data, nbytes)));
         Ok(())
     }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -71,20 +71,20 @@ impl Worker {
 
         let (sender, receiver) = channel();
         let worker = Worker::new(global, sender.clone()).root();
-        let worker_ref = Trusted::new(global.get_cx(), *worker, global.script_chan());
+        let worker_ref = Trusted::new(global.get_cx(), worker.r(), global.script_chan());
 
         DedicatedWorkerGlobalScope::run_worker_scope(
             worker_url, worker_ref, resource_task, global.script_chan(),
             sender, receiver);
 
-        Ok(Temporary::from_rooted(*worker))
+        Ok(Temporary::from_rooted(worker.r()))
     }
 
     pub fn handle_message(address: TrustedWorkerAddress,
                           data: *mut u64, nbytes: size_t) {
         let worker = address.to_temporary().root();
 
-        let global = worker.global.root();
+        let global = worker.r().global.root();
 
         let mut message = UndefinedValue();
         unsafe {
@@ -94,7 +94,7 @@ impl Worker {
                 ptr::null(), ptr::null_mut()) != 0);
         }
 
-        let target: JSRef<EventTarget> = EventTargetCast::from_ref(*worker);
+        let target: JSRef<EventTarget> = EventTargetCast::from_ref(worker.r());
         MessageEvent::dispatch_jsval(target, global.root_ref(), message);
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -367,7 +367,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
                 *self.request_method.borrow_mut() = maybe_method.unwrap();
 
                 // Step 6
-                let base = self.global.root().root_ref().get_url();
+                let base = self.global.root().r().get_url();
                 let parsed_url = match UrlParser::new().base_url(&base).parse(url.as_slice()) {
                     Ok(parsed) => parsed,
                     Err(_) => return Err(Syntax) // Step 7
@@ -535,7 +535,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
         }
 
         let global = self.global.root();
-        let resource_task = global.root_ref().resource_task();
+        let resource_task = global.r().resource_task();
         let (start_chan, start_port) = channel();
         let mut load_data = LoadData::new(self.request_url.borrow().clone().unwrap(), start_chan);
         load_data.data = extracted;
@@ -579,7 +579,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
         *self.terminate_sender.borrow_mut() = Some(terminate_sender);
 
         // CORS stuff
-        let referer_url = self.global.root().root_ref().get_url();
+        let referer_url = self.global.root().r().get_url();
         let mode = if self.upload_events.get() {
             RequestMode::ForcedPreflight
         } else {
@@ -613,11 +613,11 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
                                          terminate_receiver, cors_request, gen_id, start_port);
         } else {
             self.fetch_time.set(time::now().to_timespec().sec);
-            let script_chan = global.root_ref().script_chan();
+            let script_chan = global.r().script_chan();
             // Pin the object before launching the fetch task. This is to ensure that
             // the object will stay alive as long as there are (possibly cancelled)
             // inflight events queued up in the script task's port.
-            let addr = Trusted::new(self.global.root().root_ref().get_cx(), self,
+            let addr = Trusted::new(self.global.root().r().get_cx(), self,
                                     script_chan.clone());
             spawn_named("XHRTask", proc() {
                 let _ = XMLHttpRequest::fetch(&mut SyncOrAsync::Async(addr, script_chan),
@@ -764,7 +764,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         assert!(self.ready_state.get() != rs)
         self.ready_state.set(rs);
         let global = self.global.root();
-        let event = Event::new(global.root_ref(),
+        let event = Event::new(global.r(),
                                "readystatechange".into_string(),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::Cancelable).root();
@@ -899,7 +899,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
     fn dispatch_progress_event(self, upload: bool, type_: DOMString, loaded: u64, total: Option<u64>) {
         let global = self.global.root();
         let upload_target = self.upload.root();
-        let progressevent = ProgressEvent::new(global.root_ref(),
+        let progressevent = ProgressEvent::new(global.r(),
                                                type_, false, false,
                                                total.is_some(), loaded,
                                                total.unwrap_or(0)).root();

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -201,7 +201,7 @@ impl XMLHttpRequest {
 
     pub fn handle_progress(addr: TrustedXHRAddress, progress: XHRProgress) {
         let xhr = addr.to_temporary().root();
-        xhr.process_partial_response(progress);
+        xhr.r().process_partial_response(progress);
     }
 
     fn fetch(fetch_type: &SyncOrAsync, resource_task: ResourceTask,
@@ -769,7 +769,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                                EventBubbles::DoesNotBubble,
                                EventCancelable::Cancelable).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(self);
-        target.dispatch_event(*event);
+        target.dispatch_event(event.r());
     }
 
     fn process_partial_response(self, progress: XHRProgress) {
@@ -908,7 +908,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         } else {
             EventTargetCast::from_ref(self)
         };
-        let event: JSRef<Event> = EventCast::from_ref(*progressevent);
+        let event: JSRef<Event> = EventCast::from_ref(progressevent.r());
         target.dispatch_event(event);
     }
 
@@ -1008,7 +1008,7 @@ impl Extractable for SendParam {
         let encoding = UTF_8 as EncodingRef;
         match *self {
             eString(ref s) => encoding.encode(s.as_slice(), EncoderTrap::Replace).unwrap(),
-            eURLSearchParams(ref usp) => usp.root().serialize(None) // Default encoding is UTF8
+            eURLSearchParams(ref usp) => usp.root().r().serialize(None) // Default encoding is UTF8
         }
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -510,8 +510,8 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
 
         if !self.sync.get() {
             // Step 8
-            let upload_target = *self.upload.root();
-            let event_target: JSRef<EventTarget> = EventTargetCast::from_ref(upload_target);
+            let upload_target = self.upload.root();
+            let event_target: JSRef<EventTarget> = EventTargetCast::from_ref(upload_target.r());
             if event_target.has_handlers() {
                 self.upload_events.set(true);
             }
@@ -898,13 +898,13 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
 
     fn dispatch_progress_event(self, upload: bool, type_: DOMString, loaded: u64, total: Option<u64>) {
         let global = self.global.root();
-        let upload_target = *self.upload.root();
+        let upload_target = self.upload.root();
         let progressevent = ProgressEvent::new(global.root_ref(),
                                                type_, false, false,
                                                total.is_some(), loaded,
                                                total.unwrap_or(0)).root();
         let target: JSRef<EventTarget> = if upload {
-            EventTargetCast::from_ref(upload_target)
+            EventTargetCast::from_ref(upload_target.r())
         } else {
             EventTargetCast::from_ref(self)
         };


### PR DESCRIPTION
This is a start towards fixing #3868. Not all callers have been fixed yet, so the `Deref` implementation remains for now.
