### PR TITLE
Stop using ptr.is_not_null() in script.

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -121,7 +121,7 @@ impl CallbackInterface {
 pub fn WrapCallThisObject<T: Reflectable>(cx: *mut JSContext,
                                           p: JSRef<T>) -> *mut JSObject {
     let mut obj = p.reflector().get_jsobject();
-    assert!(obj.is_not_null());
+    assert!(!obj.is_null());
 
     unsafe {
         if JS_WrapObject(cx, &mut obj) == 0 {

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -343,7 +343,7 @@ impl FromJSValConvertible<()> for ByteString {
 impl ToJSValConvertible for Reflector {
     fn to_jsval(&self, cx: *mut JSContext) -> JSVal {
         let obj = self.get_jsobject();
-        assert!(obj.is_not_null());
+        assert!(!obj.is_null());
         let mut value = ObjectValue(unsafe { &*obj });
         if unsafe { JS_WrapValue(cx, &mut value) } == 0 {
             panic!("JS_WrapValue failed.");

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -33,7 +33,7 @@ pub unsafe extern fn getPropertyDescriptor(cx: *mut JSContext, proxy: *mut JSObj
     if !InvokeGetOwnPropertyDescriptor(handler, cx, proxy, id, set, desc) {
         return false;
     }
-    if (*desc).obj.is_not_null() {
+    if !(*desc).obj.is_null() {
         return true;
     }
 
@@ -89,7 +89,7 @@ pub fn _obj_toString(cx: *mut JSContext, name: &str) -> *mut JSString {
         let length = result.len() as libc::size_t;
 
         let string = JS_NewStringCopyN(cx, chars, length);
-        assert!(string.is_not_null());
+        assert!(!string.is_null());
         return string;
     }
 }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -214,10 +214,10 @@ fn CreateInterfaceObject(cx: *mut JSContext, global: *mut JSObject, receiver: *m
     unsafe {
         let fun = JS_NewFunction(cx, Some(constructorNative), ctorNargs,
                                  JSFUN_CONSTRUCTOR, global, name);
-        assert!(fun.is_not_null());
+        assert!(!fun.is_null());
 
         let constructor = JS_GetFunctionObject(fun);
-        assert!(constructor.is_not_null());
+        assert!(!constructor.is_null());
 
         match members.staticMethods {
             Some(staticMethods) => DefineMethods(cx, constructor, staticMethods),
@@ -234,7 +234,7 @@ fn CreateInterfaceObject(cx: *mut JSContext, global: *mut JSObject, receiver: *m
             _ => (),
         }
 
-        if proto.is_not_null() {
+        if !proto.is_null() {
             assert!(JS_LinkConstructorAndPrototype(cx, constructor, proto) != 0);
         }
 
@@ -288,7 +288,7 @@ fn CreateInterfacePrototypeObject(cx: *mut JSContext, global: *mut JSObject,
                                   members: &'static NativeProperties) -> *mut JSObject {
     unsafe {
         let ourProto = JS_NewObjectWithUniqueType(cx, protoClass, &*parentProto, &*global);
-        assert!(ourProto.is_not_null());
+        assert!(!ourProto.is_null());
 
         match members.methods {
             Some(methods) => DefineMethods(cx, ourProto, methods),
@@ -366,7 +366,7 @@ impl Reflector {
     /// Initialize the reflector. (May be called only once.)
     pub fn set_jsobject(&self, object: *mut JSObject) {
         assert!(self.object.get().is_null());
-        assert!(object.is_not_null());
+        assert!(!object.is_null());
         self.object.set(object);
     }
 

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -43,7 +43,7 @@ impl BrowserContext {
     }
 
     pub fn window_proxy(&self) -> *mut JSObject {
-        assert!(self.window_proxy.is_not_null());
+        assert!(!self.window_proxy.is_null());
         self.window_proxy
     }
 
@@ -53,14 +53,14 @@ impl BrowserContext {
         let js_info = page.js_info();
 
         let WindowProxyHandler(handler) = js_info.as_ref().unwrap().dom_static.windowproxy_handler;
-        assert!(handler.is_not_null());
+        assert!(!handler.is_null());
 
         let parent = win.reflector().get_jsobject();
         let cx = js_info.as_ref().unwrap().js_context.ptr;
         let wrapper = with_compartment(cx, parent, || unsafe {
             WrapperNew(cx, parent, handler)
         });
-        assert!(wrapper.is_not_null());
+        assert!(!wrapper.is_null());
         self.window_proxy = wrapper;
     }
 }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -221,7 +221,7 @@ impl<'a> EventTargetHelpers for JSRef<'a, EventTarget> {
         let funobj = unsafe {
             JS_CloneFunctionObject(cx, JS_GetFunctionObject(handler), scope)
         };
-        assert!(funobj.is_not_null());
+        assert!(!funobj.is_null());
         self.set_event_handler_common(ty, Some(EventHandlerNonNull::new(funobj)));
     }
 

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -392,7 +392,7 @@ impl ScriptTask {
         let js_runtime = js::rust::rt();
         assert!({
             let ptr: *mut JSRuntime = (*js_runtime).ptr;
-            ptr.is_not_null()
+            !ptr.is_null()
         });
 
         // Unconstrain the runtime's threshold on nominal heap size, to avoid
@@ -407,7 +407,7 @@ impl ScriptTask {
         let js_context = js_runtime.cx();
         assert!({
             let ptr: *mut JSContext = (*js_context).ptr;
-            ptr.is_not_null()
+            !ptr.is_null()
         });
         js_context.set_default_options_and_version();
         js_context.set_logging_error_reporter();


### PR DESCRIPTION
This method is deprecated in rust master; removing its users in advance will
make a future rust upgrade smoother.
