### PR TITLE
Issue 4497 Fix: Converts WorkerPostMessage into a Runnable.

### DIFF
--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -16,7 +16,7 @@ use dom::bindings::utils::{Reflectable, reflect_dom_object};
 use dom::dedicatedworkerglobalscope::DedicatedWorkerGlobalScope;
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 use dom::messageevent::MessageEvent;
-use script_task::{ScriptChan, ScriptMsg};
+use script_task::{ScriptChan, ScriptMsg, Runnable};
 
 use servo_util::str::DOMString;
 
@@ -120,3 +120,24 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
     event_handler!(message, GetOnmessage, SetOnmessage)
 }
 
+pub struct WorkerMessageHandler {
+    addr: TrustedWorkerAddress,
+    data: *mut u64,
+    nbytes: size_t
+}
+
+impl WorkerMessageHandler {
+    pub fn new(addr: TrustedWorkerAddress, data: *mut u64, nbytes: size_t) -> WorkerMessageHandler {
+        WorkerMessageHandler {
+            addr: addr,
+            data: data,
+            nbytes: nbytes,
+        }
+    }
+}
+
+impl Runnable for WorkerMessageHandler {
+    fn handler(&self){
+        Worker::handle_message(self.addr.clone(), self.data, self.nbytes);
+    }
+}

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -27,7 +27,6 @@ use dom::keyboardevent::KeyboardEvent;
 use dom::mouseevent::MouseEvent;
 use dom::node::{mod, Node, NodeHelpers, NodeDamage, NodeTypeId};
 use dom::window::{Window, WindowHelpers};
-use dom::worker::{Worker, TrustedWorkerAddress};
 use parse::html::{HTMLInput, parse_html};
 use layout_interface::{ScriptLayoutChan, LayoutChan, ReflowGoal, ReflowQueryType};
 use layout_interface;
@@ -115,8 +114,6 @@ pub enum ScriptMsg {
     /// Message sent through Worker.postMessage (only dispatched to
     /// DedicatedWorkerGlobalScope).
     DOMMessage(*mut u64, size_t),
-    /// Posts a message to the Worker object (dispatched to all tasks).
-    WorkerPostMessage(TrustedWorkerAddress, *mut u64, size_t),
     /// Generic message that encapsulates event handling.
     RunnableMsg(Box<Runnable+Send>),
     /// A DOM object's last pinned reference was removed (dispatched to all tasks).
@@ -600,8 +597,6 @@ impl ScriptTask {
                 self.handle_exit_window_msg(id),
             ScriptMsg::DOMMessage(..) =>
                 panic!("unexpected message"),
-            ScriptMsg::WorkerPostMessage(addr, data, nbytes) =>
-                Worker::handle_message(addr, data, nbytes),
             ScriptMsg::RunnableMsg(runnable) =>
                 runnable.handler(),
             ScriptMsg::RefcountCleanup(addr) =>


### PR DESCRIPTION
A lot of tests were failing when I ran `./mach test tests/wpt/web-platform-tests/workers --processes=4` and
`./mach test tests/wpt/web-platform-tests/XMLHttpRequest --processes=4` on master. So I could not completely test it. I verified that the tests that were failing were the same, before and after the change.

Is there any way to run it here?
