### PR TITLE
Stall PaintTask exit until it can release all buffers

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -216,6 +216,8 @@ pub enum Msg {
     KeyEvent(Key, KeyModifiers),
     /// Changes the cursor.
     SetCursor(Cursor),
+    /// Informs the compositor that the paint task for the given pipeline has exited.
+    PaintTaskExited(PipelineId),
 }
 
 impl Show for Msg {
@@ -240,6 +242,7 @@ impl Show for Msg {
             Msg::ScrollTimeout(..) => write!(f, "ScrollTimeout"),
             Msg::KeyEvent(..) => write!(f, "KeyEvent"),
             Msg::SetCursor(..) => write!(f, "SetCursor"),
+            Msg::PaintTaskExited(..) => write!(f, "PaintTaskExited"),
         }
     }
 }

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -111,6 +111,7 @@ impl CompositorEventListener for NullCompositor {
             Msg::ChangePageLoadData(..) |
             Msg::KeyEvent(..) |
             Msg::SetCursor(..) => {}
+            Msg::PaintTaskExited(..) => {}
         }
         true
     }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -5,7 +5,7 @@
 #![comment = "The Servo Parallel Browser Project"]
 #![license = "MPL"]
 
-#![feature(globs, phase, macro_rules)]
+#![feature(globs, phase, macro_rules, if_let)]
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -21,8 +21,7 @@ extern crate "util" as servo_util;
 
 use gfx::font_cache_task::FontCacheTask;
 use gfx::paint_task::PaintChan;
-use servo_msg::constellation_msg::{ConstellationChan, PipelineId};
-use servo_msg::constellation_msg::Failure;
+use servo_msg::constellation_msg::{ConstellationChan, Failure, PipelineId, PipelineExitType};
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
 use servo_util::time::TimeProfilerChan;
@@ -31,7 +30,7 @@ use std::comm::Sender;
 
 /// Messages sent to the layout task from the constellation
 pub enum LayoutControlMsg {
-    ExitNowMsg,
+    ExitNowMsg(PipelineExitType),
 }
 
 /// A channel wrapper for constellation messages

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -253,3 +253,10 @@ pub struct PipelineId(pub uint);
 
 #[deriving(Clone, PartialEq, Eq, Hash, Show)]
 pub struct SubpageId(pub uint);
+
+// The type of pipeline exit. During complete shutdowns, pipelines do not have to
+// release resources automatically released on process termination.
+pub enum PipelineExitType {
+    PipelineOnly,
+    Complete,
+}

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -11,7 +11,7 @@ use dom::node::LayoutDataRef;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel, UntrustedNodeAddress};
-use servo_msg::constellation_msg::WindowSizeData;
+use servo_msg::constellation_msg::{PipelineExitType, WindowSizeData};
 use servo_util::geometry::Au;
 use std::any::{Any, AnyRefExt};
 use std::comm::{channel, Receiver, Sender};
@@ -50,7 +50,7 @@ pub enum Msg {
 
     /// Requests that the layout task immediately shut down. There must be no more nodes left after
     /// this, or layout will crash.
-    ExitNow,
+    ExitNow(PipelineExitType),
 }
 
 /// Synchronous messages that script can send to layout.

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -26,6 +26,7 @@ use devtools_traits::DevtoolsControlChan;
 use libc::c_void;
 use servo_msg::constellation_msg::{ConstellationChan, PipelineId, Failure, WindowSizeData};
 use servo_msg::constellation_msg::{LoadData, SubpageId, Key, KeyState, KeyModifiers};
+use servo_msg::constellation_msg::PipelineExitType;
 use servo_msg::compositor_msg::ScriptListener;
 use servo_net::image_cache_task::ImageCacheTask;
 use servo_net::resource_task::ResourceTask;
@@ -60,7 +61,7 @@ pub enum ConstellationControlMsg {
     /// Notifies script that window has been resized but to not take immediate action.
     ResizeInactiveMsg(PipelineId, WindowSizeData),
     /// Notifies the script that a pipeline should be closed.
-    ExitPipelineMsg(PipelineId),
+    ExitPipelineMsg(PipelineId, PipelineExitType),
     /// Sends a DOM event.
     SendEventMsg(PipelineId, CompositorEvent),
     /// Notifies script that reflow is finished.


### PR DESCRIPTION
It is possible for a PaintTask to start exiting soon after sending new
buffers to the compositor. In that case, the compositor should return
the now unnecessary buffers to the PaintTask so that it can properly
free them.

To accomplish this, the compositor now keeps a hash map of paint task
channels per pipeline id. When a PaintTask exists, the constellation
informs the compositor that it can forget about it. Additionally, the
PaintTask should not wait for any buffers when the engine is doing a
complete shutdown. In that case, the compositor is already halted and
has simply let all buffers leak. We pipe through the shutdown type when
destroying the pipeline to make this decision.

Fixes #2641.
