### PR TITLE
Ban Cell<JS<T>> and Cell<JSVal<T>> (partial #4336)

### DIFF
--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -49,6 +49,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_lint_pass(box lints::privatize::PrivatizePass as LintPassObject);
     reg.register_lint_pass(box lints::inheritance_integrity::InheritancePass as LintPassObject);
     reg.register_lint_pass(box lints::str_to_string::StrToStringPass as LintPassObject);
+    reg.register_lint_pass(box lints::ban::BanPass as LintPassObject);
 }
 
 

--- a/components/plugins/lints/ban.rs
+++ b/components/plugins/lints/ban.rs
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use syntax::ast;
+use rustc::lint::{Context, LintPass, LintArray};
+use utils::match_ty_unwrap;
+
+declare_lint!(BANNED_TYPE, Deny,
+              "Ban various unsafe type combinations")
+
+/// Lint for banning various unsafe types
+///
+/// Banned types:
+///
+/// - `Cell<JSVal>`
+/// - `Cell<JS<T>>`
+pub struct BanPass;
+
+impl LintPass for BanPass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(BANNED_TYPE)
+    }
+
+    fn check_ty(&mut self, cx: &Context, ty: &ast::Ty) {
+        if match_ty_unwrap(ty, &["std","cell","Cell"])
+            .and_then(|t| t.get(0))
+            .and_then(|t| match_ty_unwrap(&**t, &["dom", "bindings", "js", "JS"]))
+            .is_some() {
+            cx.span_lint(BANNED_TYPE, ty.span, "Banned type Cell<JS<T>> detected. Use MutHeap<JS<T>> instead")
+        }
+        if match_ty_unwrap(ty, &["std","cell","Cell"])
+            .and_then(|t| t.get(0))
+            .and_then(|t| match_ty_unwrap(&**t, &["js", "jsval", "JSVal"]))
+            .is_some() {
+            cx.span_lint(BANNED_TYPE, ty.span, "Banned type Cell<JSVal> detected. Use MutHeap<JSVal> instead")
+        }
+    }
+}

--- a/components/plugins/lints/mod.rs
+++ b/components/plugins/lints/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+pub mod ban;
 pub mod inheritance_integrity;
 pub mod privatize;
 pub mod str_to_string;

--- a/components/script/dom/bindings/DESIGN.md
+++ b/components/script/dom/bindings/DESIGN.md
@@ -37,3 +37,4 @@ For supporting SpiderMonkey’s exact GC rooting, we introduce [some types](http
 - `Root<T>` contains the pointer to `JSObject` which the represented DOM type has. SpiderMonkey's conservative stack scanner scans it's pointers and marks a pointed `JSObject` as GC root.
 - `JSRef` is just a reference to the value rooted by `Root<T>`.
 - `RootCollection` is used to dynamically check if rooting satisfies LIFO ordering, because SpiderMonkey's GC requires LIFO order (See also: [Exact Stack Rooting - Storing a GCPointer on the CStack](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/GC/Exact_Stack_Rooting)).
+ - `MutHeap<T>` is a version of `Cell<T>` that is safe to use for internal mutability of  Spidermonkey heap objects like `JSVal` and `JS<T>`


### PR DESCRIPTION
Didn't do the `Vec<Temporary<T>>` banning since we might want to whitelist something there. I'll work on that next.
