### PR TITLE
Check for no parameters when invoking cargo

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -21,6 +21,8 @@ class MachCommands(CommandBase):
         'params', default=None, nargs='...',
         help="Command-line arguments to be passed through to Cargo")
     def cargo(self, params):
+        if not params:
+            params = []
         return subprocess.call(["cargo"] + params,
                                env=self.build_env())
 


### PR DESCRIPTION
When invoking `./mach cargo` the following error appeared

```
Error running mach:

    ['cargo']

The error occurred in the implementation of the invoked mach command.

This should never occur and is likely a bug in the implementation of that
command. Consider filing a bug for this issue.

If filing a bug, please include the full output of mach, including this error
message.

The details of the failure are as follows:

TypeError: can only concatenate list (not "NoneType") to list

  File "/home/tj/servo/python/servo/devenv_commands.py", line 24, in cargo
    return subprocess.call(["cargo"] + params,
```

it seems to be that all that's missing is checking whether params is None or not.
