### PR TITLE
Improve Compositor message names

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -129,11 +129,11 @@ impl PaintListener for Box<CompositorProxy+'static+Send> {
         port.recv()
     }
 
-    fn paint(&mut self,
-             pipeline_id: PipelineId,
-             epoch: Epoch,
-             replies: Vec<(LayerId, Box<LayerBufferSet>)>) {
-        self.send(Msg::Paint(pipeline_id, epoch, replies));
+    fn assign_painted_buffers(&mut self,
+                              pipeline_id: PipelineId,
+                              epoch: Epoch,
+                              replies: Vec<(LayerId, Box<LayerBufferSet>)>) {
+        self.send(Msg::AssignPaintedBuffers(pipeline_id, epoch, replies));
     }
 
     fn initialize_layers_for_pipeline(&mut self,
@@ -170,8 +170,8 @@ pub enum Msg {
     Exit(Sender<()>),
 
     /// Informs the compositor that the constellation has completed shutdown.
-    /// Required because the constellation can have pending calls to make (e.g. SetIds)
-    /// at the time that we send it an ExitMsg.
+    /// Required because the constellation can have pending calls to make
+    /// (e.g. SetFrameTree) at the time that we send it an ExitMsg.
     ShutdownComplete,
 
     /// Requests the compositor's graphics metadata. Graphics metadata is what the painter needs
@@ -191,8 +191,8 @@ pub enum Msg {
     SetLayerOrigin(PipelineId, LayerId, Point2D<f32>),
     /// Scroll a page in a window
     ScrollFragmentPoint(PipelineId, LayerId, Point2D<f32>),
-    /// Requests that the compositor paint the given layer buffer set for the given page size.
-    Paint(PipelineId, Epoch, Vec<(LayerId, Box<LayerBufferSet>)>),
+    /// Requests that the compositor assign the painted buffers to the given layers.
+    AssignPaintedBuffers(PipelineId, Epoch, Vec<(LayerId, Box<LayerBufferSet>)>),
     /// Alerts the compositor to the current status of page loading.
     ChangeReadyState(PipelineId, ReadyState),
     /// Alerts the compositor to the current status of painting.
@@ -203,8 +203,8 @@ pub enum Msg {
     ChangePageLoadData(FrameId, LoadData),
     /// Alerts the compositor that a `PaintMsg` has been discarded.
     PaintMsgDiscarded,
-    /// Sets the channel to the current layout and paint tasks, along with their ID.
-    SetIds(SendableFrameTree, Sender<()>, ConstellationChan),
+    /// Replaces the current frame tree, typically called during main frame navigation.
+    SetFrameTree(SendableFrameTree, Sender<()>, ConstellationChan),
     /// Sends an updated version of the frame tree.
     FrameTreeUpdate(FrameTreeDiff, Sender<()>),
     /// The load of a page has completed.
@@ -230,14 +230,14 @@ impl Show for Msg {
             Msg::CreateOrUpdateDescendantLayer(..) => write!(f, "CreateOrUpdateDescendantLayer"),
             Msg::SetLayerOrigin(..) => write!(f, "SetLayerOrigin"),
             Msg::ScrollFragmentPoint(..) => write!(f, "ScrollFragmentPoint"),
-            Msg::Paint(..) => write!(f, "Paint"),
+            Msg::AssignPaintedBuffers(..) => write!(f, "AssignPaintedBuffers"),
             Msg::ChangeReadyState(..) => write!(f, "ChangeReadyState"),
             Msg::ChangePaintState(..) => write!(f, "ChangePaintState"),
             Msg::ChangePageTitle(..) => write!(f, "ChangePageTitle"),
             Msg::ChangePageLoadData(..) => write!(f, "ChangePageLoadData"),
             Msg::PaintMsgDiscarded(..) => write!(f, "PaintMsgDiscarded"),
             Msg::FrameTreeUpdate(..) => write!(f, "FrameTreeUpdate"),
-            Msg::SetIds(..) => write!(f, "SetIds"),
+            Msg::SetFrameTree(..) => write!(f, "SetFrameTree"),
             Msg::LoadComplete => write!(f, "LoadComplete"),
             Msg::ScrollTimeout(..) => write!(f, "ScrollTimeout"),
             Msg::KeyEvent(..) => write!(f, "KeyEvent"),

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -147,7 +147,7 @@ impl PaintListener for Box<CompositorProxy+'static+Send> {
         for metadata in metadata.iter() {
             let layer_properties = LayerProperties::new(pipeline_id, epoch, metadata);
             if first {
-                self.send(Msg::CreateOrUpdateRootLayer(layer_properties));
+                self.send(Msg::CreateOrUpdateBaseLayer(layer_properties));
                 first = false
             } else {
                 self.send(Msg::CreateOrUpdateDescendantLayer(layer_properties));
@@ -183,7 +183,7 @@ pub enum Msg {
 
     /// Tells the compositor to create the root layer for a pipeline if necessary (i.e. if no layer
     /// with that ID exists).
-    CreateOrUpdateRootLayer(LayerProperties),
+    CreateOrUpdateBaseLayer(LayerProperties),
     /// Tells the compositor to create a descendant layer for a pipeline if necessary (i.e. if no
     /// layer with that ID exists).
     CreateOrUpdateDescendantLayer(LayerProperties),
@@ -226,7 +226,7 @@ impl Show for Msg {
             Msg::Exit(..) => write!(f, "Exit"),
             Msg::ShutdownComplete(..) => write!(f, "ShutdownComplete"),
             Msg::GetGraphicsMetadata(..) => write!(f, "GetGraphicsMetadata"),
-            Msg::CreateOrUpdateRootLayer(..) => write!(f, "CreateOrUpdateRootLayer"),
+            Msg::CreateOrUpdateBaseLayer(..) => write!(f, "CreateOrUpdateBaseLayer"),
             Msg::CreateOrUpdateDescendantLayer(..) => write!(f, "CreateOrUpdateDescendantLayer"),
             Msg::SetLayerOrigin(..) => write!(f, "SetLayerOrigin"),
             Msg::ScrollFragmentPoint(..) => write!(f, "ScrollFragmentPoint"),

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -1019,10 +1019,10 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
 
     fn set_ids(&mut self, frame_tree: &Rc<FrameTree>) {
         let (chan, port) = channel();
-        debug!("Constellation sending SetIds");
-        self.compositor_proxy.send(CompositorMsg::SetIds(frame_tree.to_sendable(),
-                                                         chan,
-                                                         self.chan.clone()));
+        debug!("Constellation sending SetFrameTree");
+        self.compositor_proxy.send(CompositorMsg::SetFrameTree(frame_tree.to_sendable(),
+                                                               chan,
+                                                               self.chan.clone()));
         match port.recv_opt() {
             Ok(()) => {
                 let mut iter = frame_tree.iter();

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -98,7 +98,7 @@ impl CompositorEventListener for NullCompositor {
             // we'll notice and think about whether it needs a response, like
             // SetFrameTree.
 
-            Msg::CreateOrUpdateRootLayer(..) |
+            Msg::CreateOrUpdateBaseLayer(..) |
             Msg::CreateOrUpdateDescendantLayer(..) |
             Msg::SetLayerOrigin(..) |
             Msg::AssignPaintedBuffers(..) |

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -86,7 +86,7 @@ impl CompositorEventListener for NullCompositor {
                 chan.send(None);
             }
 
-            Msg::SetIds(_, response_chan, _) => {
+            Msg::SetFrameTree(_, response_chan, _) => {
                 response_chan.send(());
             }
 
@@ -96,12 +96,12 @@ impl CompositorEventListener for NullCompositor {
 
             // Explicitly list ignored messages so that when we add a new one,
             // we'll notice and think about whether it needs a response, like
-            // SetIds.
+            // SetFrameTree.
 
             Msg::CreateOrUpdateRootLayer(..) |
             Msg::CreateOrUpdateDescendantLayer(..) |
             Msg::SetLayerOrigin(..) |
-            Msg::Paint(..) |
+            Msg::AssignPaintedBuffers(..) |
             Msg::ChangeReadyState(..) |
             Msg::ChangePaintState(..) |
             Msg::ScrollFragmentPoint(..) |

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -278,7 +278,7 @@ impl<C> PaintTask<C> where C: PaintListener + Send {
                     }
 
                     debug!("PaintTask: returning surfaces");
-                    self.compositor.paint(self.id, self.epoch, replies);
+                    self.compositor.assign_painted_buffers(self.id, self.epoch, replies);
                 }
                 Msg::UnusedBuffer(unused_buffers) => {
                     debug!("PaintTask: Received {} unused buffers", unused_buffers.len());

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -94,11 +94,11 @@ pub trait PaintListener for Sized? {
                                       metadata: Vec<LayerMetadata>,
                                       epoch: Epoch);
 
-    /// Sends new tiles for the given layer to the compositor.
-    fn paint(&mut self,
-             pipeline_id: PipelineId,
-             epoch: Epoch,
-             replies: Vec<(LayerId, Box<LayerBufferSet>)>);
+    /// Sends new buffers for the given layers to the compositor.
+    fn assign_painted_buffers(&mut self,
+                              pipeline_id: PipelineId,
+                              epoch: Epoch,
+                              replies: Vec<(LayerId, Box<LayerBufferSet>)>);
 
     fn paint_msg_discarded(&mut self);
     fn set_paint_state(&mut self, PipelineId, PaintState);


### PR DESCRIPTION
These names no longer reflect what the messages do, so rename them to
SetFrameTree, AssignPaintedBuffers, and CreateOrUpdateBaseLayer.
