### PR TITLE
Post-rustup warning fixes

### DIFF
--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 extern crate azure;
 extern crate geom;

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 #[phase(plugin, link)]
 extern crate log;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -6,6 +6,7 @@
 #![crate_type = "rlib"]
 
 #![allow(non_snake_case)]
+#![allow(missing_copy_implementations)]
 
 #![feature(phase)]
 

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -6,6 +6,7 @@
 #![crate_type = "rlib"]
 
 #![allow(non_snake_case)]
+#![allow(missing_copy_implementations)]
 #![feature(globs)]
 
 extern crate "msg" as servo_msg;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 #![feature(phase)]
 #[phase(plugin, link)]

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -29,6 +29,7 @@ use servo_util::geometry::{Au, MAX_RECT};
 use servo_util::opts;
 use servo_util::range::Range;
 use std::default::Default;
+use std::f32;
 use std::mem;
 use std::num::{Float, FloatMath};
 use std::ptr;
@@ -383,13 +384,13 @@ impl<'a> PaintContext<'a> {
         let box_BR = box_TL + Point2D(bounds.size.width, bounds.size.height);
 
         let rad_R: AzFloat = 0.;
-        let rad_BR = rad_R  + Float::frac_pi_4();
-        let rad_B  = rad_BR + Float::frac_pi_4();
-        let rad_BL = rad_B  + Float::frac_pi_4();
-        let rad_L  = rad_BL + Float::frac_pi_4();
-        let rad_TL = rad_L  + Float::frac_pi_4();
-        let rad_T  = rad_TL + Float::frac_pi_4();
-        let rad_TR = rad_T  + Float::frac_pi_4();
+        let rad_BR = rad_R  + f32::consts::FRAC_PI_4;
+        let rad_B  = rad_BR + f32::consts::FRAC_PI_4;
+        let rad_BL = rad_B  + f32::consts::FRAC_PI_4;
+        let rad_L  = rad_BL + f32::consts::FRAC_PI_4;
+        let rad_TL = rad_L  + f32::consts::FRAC_PI_4;
+        let rad_T  = rad_TL + f32::consts::FRAC_PI_4;
+        let rad_TR = rad_T  + f32::consts::FRAC_PI_4;
 
         fn dx(x: AzFloat) -> Point2D<AzFloat> {
             Point2D(x, 0.)
@@ -572,29 +573,29 @@ impl<'a> PaintContext<'a> {
         path_builder.arc(Point2D(bounds.max_x() - radii.top_right,
                                  bounds.origin.y + radii.top_right),
                          radii.top_right,
-                         1.5f32 * Float::frac_pi_2(),
-                         Float::two_pi(),
+                         1.5f32 * f32::consts::FRAC_PI_2,
+                         f32::consts::PI_2,
                          false);                                                            // 3
         path_builder.line_to(Point2D(bounds.max_x(), bounds.max_y() - radii.bottom_right)); // 4
         path_builder.arc(Point2D(bounds.max_x() - radii.bottom_right,
                                  bounds.max_y() - radii.bottom_right),
                          radii.bottom_right,
                          0.0,
-                         Float::frac_pi_2(),
+                         f32::consts::FRAC_PI_2,
                          false);                                                            // 5
         path_builder.line_to(Point2D(bounds.origin.x + radii.bottom_left, bounds.max_y())); // 6
         path_builder.arc(Point2D(bounds.origin.x + radii.bottom_left,
                                  bounds.max_y() - radii.bottom_left),
                          radii.bottom_left,
-                         Float::frac_pi_2(),
-                         Float::pi(),
+                         f32::consts::FRAC_PI_2,
+                         f32::consts::PI,
                          false);                                                            // 7
         path_builder.line_to(Point2D(bounds.origin.x, bounds.origin.y + radii.top_left));   // 8
         path_builder.arc(Point2D(bounds.origin.x + radii.top_left,
                                  bounds.origin.y + radii.top_left),
                          radii.top_left,
-                         Float::pi(),
-                         1.5f32 * Float::frac_pi_2(),
+                         f32::consts::PI,
+                         1.5f32 * f32::consts::FRAC_PI_2,
                          false);                                                            // 1
     }
 

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -28,7 +28,7 @@ use freetype::tt_os2::TT_OS2;
 use std::mem;
 use std::num::Float;
 use std::ptr;
-use std::string;
+use std::string::String;
 
 use std::sync::Arc;
 
@@ -121,10 +121,10 @@ impl FontHandleMethods for FontHandle {
         self.font_data.clone()
     }
     fn family_name(&self) -> String {
-        unsafe { string::raw::from_buf(&*(*self.face).family_name as *const i8 as *const u8) }
+        unsafe { String::from_raw_buf(&*(*self.face).family_name as *const i8 as *const u8) }
     }
     fn face_name(&self) -> String {
-        unsafe { string::raw::from_buf(&*FT_Get_Postscript_Name(self.face) as *const i8 as *const u8) }
+        unsafe { String::from_raw_buf(&*FT_Get_Postscript_Name(self.face) as *const i8 as *const u8) }
     }
     fn is_italic(&self) -> bool {
         unsafe { (*self.face).style_flags & FT_STYLE_FLAG_ITALIC != 0 }

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -23,7 +23,7 @@ use fontconfig::fontconfig::{
 use libc;
 use libc::c_int;
 use std::ptr;
-use std::string;
+use std::string::String;
 
 static FC_FAMILY: &'static [u8] = b"family\0";
 static FC_FILE: &'static [u8] = b"file\0";
@@ -38,7 +38,7 @@ pub fn get_available_families(callback: |String|) {
             let mut family: *mut FcChar8 = ptr::null_mut();
             let mut v: c_int = 0;
             while FcPatternGetString(*font, FC_FAMILY.as_ptr() as *mut i8, v, &mut family) == FcResultMatch {
-                let family_name = string::raw::from_buf(family as *const i8 as *const u8);
+                let family_name = String::from_raw_buf(family as *const i8 as *const u8);
                 callback(family_name);
                 v += 1;
             }
@@ -73,7 +73,7 @@ pub fn get_variations_for_family(family_name: &str, callback: |String|) {
             let font = (*matches).fonts.offset(i);
             let mut file: *mut FcChar8 = ptr::null_mut();
             let file = if FcPatternGetString(*font, FC_FILE.as_ptr() as *mut i8, 0, &mut file) == FcResultMatch {
-                string::raw::from_buf(file as *const i8 as *const u8)
+                String::from_raw_buf(file as *const i8 as *const u8)
             } else {
                 panic!();
             };
@@ -112,7 +112,7 @@ pub fn get_system_default_family(generic_name: &str) -> Option<String> {
         let family_name = if result == FcResultMatch {
             let mut match_string: *mut FcChar8 = ptr::null_mut();
             FcPatternGetString(family_match, FC_FAMILY.as_ptr() as *mut i8, 0, &mut match_string);
-            let result = string::raw::from_buf(match_string as *const i8 as *const u8);
+            let result = String::from_raw_buf(match_string as *const i8 as *const u8);
             FcPatternDestroy(family_match);
             Some(result)
         } else {

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -28,10 +28,10 @@ struct LocalLayoutContext {
     style_sharing_candidate_cache: StyleSharingCandidateCache,
 }
 
-thread_local!(static local_context_key: Cell<*mut LocalLayoutContext> = Cell::new(ptr::null_mut()))
+thread_local!(static LOCAL_CONTEXT_KEY: Cell<*mut LocalLayoutContext> = Cell::new(ptr::null_mut()))
 
 fn create_or_get_local_context(shared_layout_context: &SharedLayoutContext) -> *mut LocalLayoutContext {
-    local_context_key.with(|ref r| {
+    LOCAL_CONTEXT_KEY.with(|ref r| {
         if r.get().is_null() {
             let context = box LocalLayoutContext {
                 font_context: FontContext::new(shared_layout_context.font_cache_task.clone()),

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -7,6 +7,7 @@
 #![deny(unused_imports)]
 #![deny(unused_variables)]
 #![allow(unrooted_must_root)]
+#![allow(missing_copy_implementations)]
 
 #[phase(plugin, link)]
 extern crate log;

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 extern crate gfx;
 extern crate script_traits;

--- a/components/msg/lib.rs
+++ b/components/msg/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 extern crate azure;
 extern crate geom;

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 extern crate collections;
 extern crate geom;

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -16,6 +16,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 #[phase(plugin,link)]
 extern crate syntax;

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -272,9 +272,8 @@ pub fn jsstring_to_str(cx: *mut JSContext, s: *mut JSString) -> DOMString {
     unsafe {
         let mut length = 0;
         let chars = JS_GetStringCharsAndLength(cx, s, &mut length);
-        slice::raw::buf_as_slice(chars, length as uint, |char_vec| {
-            String::from_utf16(char_vec).unwrap()
-        })
+        let char_vec = slice::from_raw_buf(&chars, length as uint);
+        String::from_utf16(char_vec).unwrap()
     }
 }
 
@@ -328,14 +327,14 @@ impl FromJSValConvertible<()> for ByteString {
 
             let mut length = 0;
             let chars = JS_GetStringCharsAndLength(cx, string, &mut length);
-            slice::raw::buf_as_slice(chars, length as uint, |char_vec| {
-                if char_vec.iter().any(|&c| c > 0xFF) {
-                    // XXX Throw
-                    Err(())
-                } else {
-                    Ok(ByteString::new(char_vec.iter().map(|&c| c as u8).collect()))
-                }
-            })
+            let char_vec = slice::from_raw_buf(&chars, length as uint);
+
+            if char_vec.iter().any(|&c| c > 0xFF) {
+                // XXX Throw
+                Err(())
+            } else {
+                Ok(ByteString::new(char_vec.iter().map(|&c| c as u8).collect()))
+            }
         }
     }
 }

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -51,7 +51,7 @@ use dom::node::Node;
 use js::jsapi::JSObject;
 use js::jsval::JSVal;
 use layout_interface::TrustedNodeAddress;
-use script_task::StackRoots;
+use script_task::STACK_ROOTS;
 
 use servo_util::smallvec::{SmallVec, SmallVec16};
 use std::cell::{Cell, UnsafeCell};
@@ -101,7 +101,7 @@ impl<T: Reflectable> Temporary<T> {
 
     /// Create a stack-bounded root for this value.
     pub fn root(self) -> Root<T> {
-        StackRoots.with(|ref collection| {
+        STACK_ROOTS.with(|ref collection| {
             let RootCollectionPtr(collection) = collection.get().unwrap();
             unsafe {
                 Root::new(&*collection, &self.inner)
@@ -164,7 +164,7 @@ impl<T: Reflectable> JS<T> {
 
     /// Root this JS-owned value to prevent its collection as garbage.
     pub fn root(&self) -> Root<T> {
-        StackRoots.with(|ref collection| {
+        STACK_ROOTS.with(|ref collection| {
             let RootCollectionPtr(collection) = collection.get().unwrap();
             unsafe {
                 Root::new(&*collection, self)

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -87,14 +87,14 @@ impl EventTarget {
     }
 
     pub fn get_listeners(&self, type_: &str) -> Option<Vec<EventListener>> {
-        self.handlers.borrow().find_equiv(type_).map(|listeners| {
+        self.handlers.borrow().get(type_).map(|listeners| {
             listeners.iter().map(|entry| entry.listener.get_listener()).collect()
         })
     }
 
     pub fn get_listeners_for(&self, type_: &str, desired_phase: ListenerPhase)
         -> Option<Vec<EventListener>> {
-        self.handlers.borrow().find_equiv(type_).map(|listeners| {
+        self.handlers.borrow().get(type_).map(|listeners| {
             let filtered = listeners.iter().filter(|entry| entry.phase == desired_phase);
             filtered.map(|entry| entry.listener.get_listener()).collect()
         })

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -81,7 +81,7 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
     }
 
     fn Get(self, name: DOMString) -> Option<FileOrString> {
-        if self.data.borrow().contains_key_equiv(&name) {
+        if self.data.borrow().contains_key(&name) {
             match (*self.data.borrow())[name][0].clone() {
                 FormDatum::StringData(ref s) => Some(eString(s.clone())),
                 FormDatum::FileData(ref f) => {
@@ -94,7 +94,7 @@ impl<'a> FormDataMethods for JSRef<'a, FormData> {
     }
 
     fn Has(self, name: DOMString) -> bool {
-        self.data.borrow().contains_key_equiv(&name)
+        self.data.borrow().contains_key(&name)
     }
     #[allow(unrooted_must_root)]
     fn Set(self, name: DOMString, value: JSRef<Blob>, filename: Option<DOMString>) {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -246,7 +246,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         // TODO: This is an incorrect way of getting controls owned
         //       by the form, but good enough until html5ever lands
-        let mut data_set = node.traverse_preorder().filter_map(|child| {
+        let data_set = node.traverse_preorder().filter_map(|child| {
             if child.get_disabled_state() {
                 return None;
             }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -782,7 +782,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     fn query_selector_all(self, selectors: DOMString) -> Fallible<Temporary<NodeList>> {
         // Step 1.
         unsafe {
-            self.query_selector_iter(selectors).map(|mut iter| {
+            self.query_selector_iter(selectors).map(|iter| {
                 let window = window_from_node(self).root();
                 NodeList::new_simple_list(window.r(), iter.collect())
             })

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -80,11 +80,11 @@ impl<'a> URLSearchParamsMethods for JSRef<'a, URLSearchParams> {
     }
 
     fn Get(self, name: DOMString) -> Option<DOMString> {
-        self.data.borrow().find_equiv(&name).map(|v| v[0].clone())
+        self.data.borrow().get(&name).map(|v| v[0].clone())
     }
 
     fn Has(self, name: DOMString) -> bool {
-        self.data.borrow().contains_key_equiv(&name)
+        self.data.borrow().contains_key(&name)
     }
 
     fn Set(self, name: DOMString, value: DOMString) {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -923,7 +923,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
 
     fn dispatch_response_progress_event(self, type_: DOMString) {
         let len = self.response.borrow().len() as u64;
-        let total = self.response_headers.borrow().get::<ContentLength>().map(|x| {x.len() as u64});
+        let total = self.response_headers.borrow().get::<ContentLength>().map(|x| {**x as u64});
         self.dispatch_progress_event(false, type_, len, total);
     }
     fn set_timeout(self, timeout: u32) {

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -7,6 +7,7 @@
 #![deny(unused_imports)]
 #![deny(unused_variables)]
 #![allow(non_snake_case)]
+#![allow(missing_copy_implementations)]
 
 #![doc="The script crate contains all matters DOM."]
 

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -85,7 +85,7 @@ use std::rc::Rc;
 use std::u32;
 use time::{Tm, strptime};
 
-thread_local!(pub static StackRoots: Cell<Option<RootCollectionPtr>> = Cell::new(None))
+thread_local!(pub static STACK_ROOTS: Cell<Option<RootCollectionPtr>> = Cell::new(None))
 
 #[deriving(Copy)]
 pub enum TimerSource {
@@ -161,7 +161,7 @@ pub struct StackRootTLS;
 
 impl StackRootTLS {
     pub fn new(roots: &RootCollection) -> StackRootTLS {
-        StackRoots.with(|ref r| {
+        STACK_ROOTS.with(|ref r| {
             r.set(Some(RootCollectionPtr(roots as *const _)))
         });
         StackRootTLS
@@ -170,7 +170,7 @@ impl StackRootTLS {
 
 impl Drop for StackRootTLS {
     fn drop(&mut self) {
-        StackRoots.with(|ref r| r.set(None));
+        STACK_ROOTS.with(|ref r| r.set(None));
     }
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 extern crate devtools_traits;
 extern crate geom;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 #[phase(plugin, link)]
 extern crate log;

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 #![feature(phase)]
 #[phase(plugin, link)] extern crate log;

--- a/components/util/debug_utils.rs
+++ b/components/util/debug_utils.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::io::Writer;
 use std::mem;
 use std::mem::size_of;
-use std::slice::raw::buf_as_slice;
+use std::slice;
 
 fn hexdump_slice(buf: &[u8]) {
     let mut stderr = io::stderr();
@@ -28,6 +28,7 @@ pub fn hexdump<T>(obj: &T) {
     unsafe {
         let buf: *const u8 = mem::transmute(obj);
         debug!("dumping at {:p}", buf);
-        buf_as_slice(buf, size_of::<T>(), hexdump_slice);
+        let from_buf = slice::from_raw_buf(&buf, size_of::<T>());
+        hexdump_slice(from_buf);
     }
 }

--- a/components/util/deque/mod.rs
+++ b/components/util/deque/mod.rs
@@ -168,12 +168,10 @@ impl<T: Send> BufferPool<T> {
     }
 
     fn free(&self, buf: Box<Buffer<T>>) {
-        unsafe {
-            let mut pool = self.pool.lock();
-            match pool.iter().position(|v| v.size() > buf.size()) {
-                Some(i) => pool.insert(i, buf),
-                None => pool.push(buf),
-            }
+        let mut pool = self.pool.lock();
+        match pool.iter().position(|v| v.size() > buf.size()) {
+            Some(i) => pool.insert(i, buf),
+            None => pool.push(buf),
         }
     }
 }

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(unused_imports)]
 #![deny(unused_variables)]
+#![allow(missing_copy_implementations)]
 
 #![feature(phase)]
 #[phase(plugin, link)]

--- a/components/util/memory.rs
+++ b/components/util/memory.rs
@@ -155,7 +155,7 @@ fn get_jemalloc_stat(name: &'static str) -> Option<u64> {
     let mut oldlen = size_of::<size_t>() as size_t;
     let rv: c_int;
     unsafe {
-        rv = je_mallctl(c_name.unwrap(), oldp, &mut oldlen, null_mut(), 0);
+        rv = je_mallctl(c_name.into_inner(), oldp, &mut oldlen, null_mut(), 0);
     }
     if rv == 0 { Some(old as u64) } else { None }
 }

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -9,7 +9,7 @@ use std::ascii::AsciiExt;
 use std::iter::Filter;
 use std::num::Int;
 use std::str::{CharEq, CharSplits, FromStr};
-use unicode::char::to_lowercase;
+use unicode::char::UnicodeChar;
 
 pub type DOMString = String;
 pub type StaticCharVec = &'static [char];
@@ -328,7 +328,7 @@ pub struct LowercaseString {
 impl LowercaseString {
     pub fn new(s: &str) -> LowercaseString {
         LowercaseString {
-            inner: s.chars().map(to_lowercase).collect(),
+            inner: s.chars().map(|c| c.to_lowercase()).collect(),
         }
     }
 }

--- a/components/util/task.rs
+++ b/components/util/task.rs
@@ -33,7 +33,7 @@ pub fn spawn_named_with_send_on_failure<T: Send>(name: &'static str,
     let watcher_name = format!("{}Watcher", watched_name);
     TaskBuilder::new().named(watcher_name).spawn(proc() {
         //rtinstrument::instrument(proc() {
-            match future_result.unwrap() {
+            match future_result.into_inner() {
                 Ok(()) => (),
                 Err(..) => {
                     debug!("{} failed, notifying constellation", name);

--- a/components/util/tid.rs
+++ b/components/util/tid.rs
@@ -8,11 +8,11 @@ use std::cell::RefCell;
 
 static mut next_tid: AtomicUint = INIT_ATOMIC_UINT;
 
-thread_local!(static task_local_tid: Rc<RefCell<Option<uint>>> = Rc::new(RefCell::new(None)))
+thread_local!(static TASK_LOCAL_TID: Rc<RefCell<Option<uint>>> = Rc::new(RefCell::new(None)))
 
 /// Every task gets one, that's unique.
 pub fn tid() -> uint {
-    task_local_tid.with(|ref k| {
+    TASK_LOCAL_TID.with(|ref k| {
         let ret =
             match *k.borrow() {
                 None => unsafe { next_tid.fetch_add(1, SeqCst) },


### PR DESCRIPTION
Notes:
- This adds `#![allow(missing_copy_implementations)]` to components/*/lib.rs. I'm not sure how to approach the missing Copy warnings (are there things for which Copy should NOT be implemented, and how can I tell?) so I stuck this in to make life easier when looking through the warnings. I can easily remove this if necessary. 
- This leaves the following type of warnings, which I couldn't figure out how to approach (I'll investigate it later if no one else wants to).

```
css/matching.rs:72:23: 72:35 warning: use of deprecated item: Use overloaded core::cmp::PartialEq, #[warn(deprecated)] on by default
css/matching.rs:72         this_as_query.equiv(other)
                                         ^~~~~~~~~~~~
css/matching.rs:95:10: 95:49 warning: use of deprecated item: Use overloaded core::cmp::PartialEq, #[warn(deprecated)] on by default
css/matching.rs:95 impl<'a> Equiv<ApplicableDeclarationsCacheEntry> for ApplicableDeclarationsCacheQuery<'a> {
```
