### PR TITLE
layout: Implement `text-overflow: ellipsis` per CSS-UI-3 § 6.2.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -991,7 +991,8 @@ impl<'a> FlowConstructor<'a> {
                         let mut unscanned_marker_fragments = DList::new();
                         unscanned_marker_fragments.push_back(Fragment::new_from_specific_info(
                             node,
-                            SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::from_text(text))));
+                            SpecificFragmentInfo::UnscannedText(
+                                UnscannedTextFragmentInfo::from_text(text))));
                         let marker_fragments = TextRunScanner::new().scan_for_runs(
                             self.layout_context.font_context(),
                             unscanned_marker_fragments);

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -194,16 +194,15 @@ impl TextRunScanner {
                 mem::replace(&mut self.clump, DList::new()).into_iter().enumerate() {
             let range = *new_ranges.get(logical_offset);
             if range.is_empty() {
-                debug!("Elided an `SpecificFragmentInfo::UnscannedText` because it was zero-length after \
-                        compression; {:?}",
-                       old_fragment);
+                debug!("Elided an `SpecificFragmentInfo::UnscannedText` because it was \
+                        zero-length after compression");
                 continue
             }
 
             let text_size = old_fragment.border_box.size;
             let &mut NewLinePositions(ref mut new_line_positions) =
                 new_line_positions.get_mut(logical_offset);
-            let new_text_fragment_info =
+            let mut new_text_fragment_info =
                 box ScannedTextFragmentInfo::new(run.clone(),
                                                  range,
                                                  mem::replace(new_line_positions, Vec::new()),
@@ -211,7 +210,10 @@ impl TextRunScanner {
             let new_metrics = new_text_fragment_info.run.metrics_for_range(&range);
             let bounding_box_size = bounding_box_for_run_metrics(&new_metrics,
                                                                  old_fragment.style.writing_mode);
-            let new_fragment = old_fragment.transform(bounding_box_size, new_text_fragment_info);
+            new_text_fragment_info.content_size = bounding_box_size;
+            let new_fragment =
+                old_fragment.transform(bounding_box_size,
+                                       SpecificFragmentInfo::ScannedText(new_text_fragment_info));
             out_fragments.push(new_fragment)
         }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -40,8 +40,9 @@ use util::{PrivateLayoutData};
 use cssparser::RGBA;
 use gfx::display_list::OpaqueNode;
 use script::dom::bindings::codegen::InheritTypes::{ElementCast, HTMLIFrameElementCast};
-use script::dom::bindings::codegen::InheritTypes::{HTMLCanvasElementCast, HTMLImageElementCast, HTMLInputElementCast};
-use script::dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementCast, NodeCast, TextCast};
+use script::dom::bindings::codegen::InheritTypes::{HTMLCanvasElementCast, HTMLImageElementCast};
+use script::dom::bindings::codegen::InheritTypes::{HTMLInputElementCast, HTMLTextAreaElementCast};
+use script::dom::bindings::codegen::InheritTypes::{NodeCast, TextCast};
 use script::dom::bindings::js::JS;
 use script::dom::element::{Element, ElementTypeId};
 use script::dom::element::{LayoutElementHelpers, RawLayoutElementHelpers};
@@ -58,6 +59,8 @@ use script::dom::text::Text;
 use script::layout_interface::LayoutChan;
 use servo_msg::constellation_msg::{PipelineId, SubpageId};
 use servo_util::str::{LengthOrPercentageOrAuto, is_whitespace};
+use std::borrow::ToOwned;
+use std::cell::{Ref, RefMut};
 use std::marker::ContravariantLifetime;
 use std::mem;
 use std::sync::mpsc::Sender;
@@ -67,9 +70,6 @@ use style::{NamespaceConstraint, AttrSelector, IntegerAttribute};
 use style::{LengthAttribute, PropertyDeclarationBlock, SimpleColorAttribute};
 use style::{TElement, TElementAttributes, TNode, UnsignedIntegerAttribute};
 use url::Url;
-
-use std::borrow::ToOwned;
-use std::cell::{Ref, RefMut};
 
 /// Allows some convenience methods on generic layout nodes.
 pub trait TLayoutNode {

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -116,6 +116,7 @@ partial interface CSSStyleDeclaration {
   [TreatNullAs=EmptyString] attribute DOMString wordBreak;
   [TreatNullAs=EmptyString] attribute DOMString wordSpacing;
   [TreatNullAs=EmptyString] attribute DOMString wordWrap;
+  [TreatNullAs=EmptyString] attribute DOMString textOverflow;
 
   [TreatNullAs=EmptyString] attribute DOMString textAlign;
   [TreatNullAs=EmptyString] attribute DOMString textDecoration;

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1213,6 +1213,8 @@ pub mod longhands {
     // TODO(pcwalton): Support `word-break: keep-all` once we have better CJK support.
     ${single_keyword("word-break", "normal break-all")}
 
+    ${single_keyword("text-overflow", "clip ellipsis")}
+
     ${new_style_struct("Text", is_inherited=False)}
 
     <%self:longhand name="text-decoration">

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -232,3 +232,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == filter_opacity_a.html filter_opacity_ref.html
 == filter_sepia_a.html filter_sepia_ref.html
 == mix_blend_mode_a.html mix_blend_mode_ref.html
+!= text_overflow_a.html text_overflow_ref.html

--- a/tests/ref/text_overflow_a.html
+++ b/tests/ref/text_overflow_a.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+p {
+    width: 128px;
+    background: gold;
+    text-overflow: ellipsis;
+}
+#hideme {
+    overflow: hidden;
+}
+</style>
+</head>
+<body>
+<p id=hideme>mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+<p>mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+</body>
+</html>
+

--- a/tests/ref/text_overflow_ref.html
+++ b/tests/ref/text_overflow_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+p {
+    width: 128px;
+    background: gold;
+}
+</style>
+</head>
+<body>
+<p>mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+<p>mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm</p>
+</body>
+</html>
+
+


### PR DESCRIPTION
Only the one-value syntax is supported for now.

r? @mbrubeck 
