### PR TITLE
layout: Implement `text-align: justify` and `text-justify` per

### DIFF
--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use util::vec::*;
-use util::range;
-use util::range::{Range, RangeIndex, EachIndex};
-use util::geometry::Au;
-
+use geom::point::Point2D;
 use std::cmp::{Ordering, PartialOrd};
 use std::iter::repeat;
-use std::num::{ToPrimitive, NumCast};
 use std::mem;
+use std::num::{ToPrimitive, NumCast};
 use std::ops::{Add, Sub, Mul, Neg, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr, Not};
 use std::u16;
 use std::vec::Vec;
-use geom::point::Point2D;
+use util::geometry::Au;
+use util::range::{mod, Range, RangeIndex, EachIndex};
+use util::vec::*;
 
 /// GlyphEntry is a port of Gecko's CompressedGlyph scheme for storing glyph data compactly.
 ///
@@ -256,7 +254,7 @@ impl GlyphEntry {
 #[derive(Clone, Show, Copy)]
 struct DetailedGlyph {
     id: GlyphId,
-    // glyph's advance, in the text's direction (RTL or RTL)
+    // glyph's advance, in the text's direction (LTR or RTL)
     advance: Au,
     // glyph's offset from the font's em-box (from top-left)
     offset: Point2D<Au>,
@@ -296,6 +294,7 @@ impl Ord for DetailedGlyphRecord {
 // until a lookup is actually performed; this matches the expected
 // usage pattern of setting/appending all the detailed glyphs, and
 // then querying without setting.
+#[derive(Clone)]
 struct DetailedGlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
@@ -424,6 +423,7 @@ pub struct GlyphData {
 }
 
 impl GlyphData {
+    /// Creates a new entry for one glyph.
     pub fn new(id: GlyphId,
                advance: Au,
                offset: Option<Point2D<Au>>,
@@ -501,6 +501,7 @@ impl<'a> GlyphInfo<'a> {
 /// |               +---+---+                     |
 /// +---------------------------------------------+
 /// ~~~
+#[derive(Clone)]
 pub struct GlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
@@ -547,7 +548,12 @@ impl<'a> GlyphStore {
         self.detail_store.ensure_sorted();
     }
 
-    pub fn add_glyph_for_char_index(&mut self, i: CharIndex, data: &GlyphData) {
+    /// Adds a single glyph. If `character` is present, this represents a single character;
+    /// otherwise, this glyph represents multiple characters.
+    pub fn add_glyph_for_char_index(&mut self,
+                                    i: CharIndex,
+                                    character: Option<char>,
+                                    data: &GlyphData) {
         fn glyph_is_compressible(data: &GlyphData) -> bool {
             is_simple_glyph_id(data.id)
                 && is_simple_advance(data.advance)
@@ -555,10 +561,10 @@ impl<'a> GlyphStore {
                 && data.cluster_start  // others are stored in detail buffer
         }
 
-        assert!(data.ligature_start); // can't compress ligature continuation glyphs.
-        assert!(i < self.char_len());
+        debug_assert!(data.ligature_start); // can't compress ligature continuation glyphs.
+        debug_assert!(i < self.char_len());
 
-        let entry = match (data.is_missing, glyph_is_compressible(data)) {
+        let mut entry = match (data.is_missing, glyph_is_compressible(data)) {
             (true, _) => GlyphEntry::missing(1),
             (false, true) => GlyphEntry::simple(data.id, data.advance),
             (false, false) => {
@@ -566,7 +572,14 @@ impl<'a> GlyphStore {
                 self.detail_store.add_detailed_glyphs_for_entry(i, glyph);
                 GlyphEntry::complex(data.cluster_start, data.ligature_start, 1)
             }
-        }.adapt_character_flags_of_entry(self.entry_buffer[i.to_uint()]);
+        };
+
+        // FIXME(pcwalton): Is this necessary? I think it's a no-op.
+        entry = entry.adapt_character_flags_of_entry(self.entry_buffer[i.to_uint()]);
+
+        if character == Some(' ') {
+            entry = entry.set_char_is_space()
+        }
 
         self.entry_buffer[i.to_uint()] = entry;
     }
@@ -691,13 +704,43 @@ impl<'a> GlyphStore {
         let entry = self.entry_buffer[i.to_uint()];
         self.entry_buffer[i.to_uint()] = entry.set_can_break_before(t);
     }
+
+    pub fn space_count_in_range(&self, range: &Range<CharIndex>) -> u32 {
+        let mut spaces = 0;
+        for index in range.each_index() {
+            if self.char_is_space(index) {
+                spaces += 1
+            }
+        }
+        spaces
+    }
+
+    pub fn distribute_extra_space_in_range(&mut self, range: &Range<CharIndex>, space: f64) {
+        debug_assert!(space >= 0.0);
+        if range.is_empty() {
+            return
+        }
+        for index in range.each_index() {
+            // TODO(pcwalton): Handle spaces that are detailed glyphs -- these are uncommon but
+            // possible.
+            let mut entry = &mut self.entry_buffer[index.to_uint()];
+            if entry.is_simple() && entry.char_is_space() {
+                // FIXME(pcwalton): This can overflow for very large font-sizes.
+                let advance =
+                    ((entry.value & GLYPH_ADVANCE_MASK) >> (GLYPH_ADVANCE_SHIFT as uint)) +
+                    Au::from_frac_px(space).to_u32().unwrap();
+                entry.value = (entry.value & !GLYPH_ADVANCE_MASK) |
+                    (advance << (GLYPH_ADVANCE_SHIFT as uint));
+            }
+        }
+    }
 }
 
 /// An iterator over the glyphs in a character range in a `GlyphStore`.
 pub struct GlyphIterator<'a> {
-    store:       &'a GlyphStore,
-    char_index:  CharIndex,
-    char_range:  EachIndex<int, CharIndex>,
+    store: &'a GlyphStore,
+    char_index: CharIndex,
+    char_range: EachIndex<int, CharIndex>,
     glyph_range: Option<EachIndex<int, CharIndex>>,
 }
 

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -464,7 +464,7 @@ impl Shaper {
                                           false,
                                           true,
                                           true);
-                glyphs.add_glyph_for_char_index(char_idx, &data);
+                glyphs.add_glyph_for_char_index(char_idx, Some(character), &data);
             } else {
                 // collect all glyphs to be assigned to the first character.
                 let mut datas = vec!();

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -120,7 +120,7 @@ impl<'a> Iterator for CharacterSliceIterator<'a> {
 
         debug_assert!(!self.range.is_empty());
         let index_to_return = self.range.begin();
-        self.range.adjust_by(CharIndex(1), CharIndex(0));
+        self.range.adjust_by(CharIndex(1), CharIndex(-1));
         if self.range.is_empty() {
             // We're done.
             self.glyph_run = None
@@ -297,7 +297,7 @@ impl<'a> TextRun {
 
     pub fn advance_for_range(&self, range: &Range<CharIndex>) -> Au {
         // TODO(Issue #199): alter advance direction for RTL
-        // TODO(Issue #98): using inter-char and inter-word spacing settings  when measuring text
+        // TODO(Issue #98): using inter-char and inter-word spacing settings when measuring text
         self.natural_word_slices_in_range(range)
             .fold(Au(0), |advance, slice| {
                 advance + slice.glyphs.advance_for_char_range(&slice.range)

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -121,6 +121,7 @@ partial interface CSSStyleDeclaration {
   [TreatNullAs=EmptyString] attribute DOMString textAlign;
   [TreatNullAs=EmptyString] attribute DOMString textDecoration;
   [TreatNullAs=EmptyString] attribute DOMString textIndent;
+  [TreatNullAs=EmptyString] attribute DOMString textJustify;
   [TreatNullAs=EmptyString] attribute DOMString textOrientation;
   [TreatNullAs=EmptyString] attribute DOMString textRendering;
   [TreatNullAs=EmptyString] attribute DOMString textTransform;

--- a/components/style/properties/mod.rs.mako
+++ b/components/style/properties/mod.rs.mako
@@ -1218,6 +1218,9 @@ pub mod longhands {
 
     ${single_keyword("text-overflow", "clip ellipsis")}
 
+    // TODO(pcwalton): Support `text-justify: distribute`.
+    ${single_keyword("text-justify", "auto none inter-word")}
+
     ${new_style_struct("Text", is_inherited=False)}
 
     <%self:longhand name="text-decoration">

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -241,3 +241,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == mix_blend_mode_a.html mix_blend_mode_ref.html
 != text_overflow_a.html text_overflow_ref.html
 == floated_list_item_a.html floated_list_item_ref.html
+== text_align_justify_a.html text_align_justify_ref.html
+== text_justify_none_a.html text_justify_none_ref.html
+== text_overflow_basic_a.html text_overflow_basic_ref.html
+== text_align_complex_a.html text_align_complex_ref.html

--- a/tests/ref/outlines_wrap_ref.html
+++ b/tests/ref/outlines_wrap_ref.html
@@ -13,7 +13,7 @@ span {
 }
 </style>
 <body>
-<section><span>I like </span><span>truffles</span></section>
+<section><span>I like</span> <span>truffles</span></section>
 </body>
 </html>
 

--- a/tests/ref/text_align_complex_a.html
+++ b/tests/ref/text_align_complex_a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+
+	* { margin: 0px !important; padding: 0px !important; }
+	
+	div {
+		width: 100px;
+		font-size: 10px;
+		font-family: Ahem, monospace;
+		padding: 10px !important;
+	}
+	
+</style>
+</head>
+<body>
+
+<section style="text-align: right; color: #f00;">
+	<div style="background: #fdd;">  xx xx xx xxxx</div>
+	<div style="background: #fdd;">  xx xx xx xxxxxxxxxxxxx</div>
+	<div style="background: #fdd;">xxxxxxxxxxxxx  xx xx xx      xxxx</div>
+</section>
+
+<section style="text-align: center; color: #0f0;">
+	<div style="background: #dfd;"> xx xx xx    xxxx   </div>
+	<div style="background: #dfd;"> xx xx xx xxxxxxxxxxxxx</div>
+	<div style="background: #dfd;">xxxxxxxxxxxxx xx xx xx    xxxx   </div>
+</section>
+
+<section style="text-align: justify; color: #00f;">
+	<div style="background: #ddf;">xx  xx  xx xxxx</div>
+	<div style="background: #ddf;">xx  xx  xx xxxxxxxxxxxxx</div>
+	<div style="background: #ddf;">xxxxxxxxxxxxx xx  xx  xx xxxx      </div>
+</section>
+</body>
+</html>
+

--- a/tests/ref/text_align_complex_ref.html
+++ b/tests/ref/text_align_complex_ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+
+	* { margin: 0px !important; padding: 0px !important; }
+	
+	div {
+		width: 100px;
+		font-size: 10px;
+		font-family: Ahem, monospace;
+		padding: 10px !important;
+	}
+	
+	section.reference { text-align: left !important; }
+	section.reference > div { white-space: pre; }
+	
+</style>
+</head>
+<body>
+
+<section class="reference" style="text-align: right; color: #f00;">
+	<div style="background: #fdd;">  xx xx xx<br />      xxxx</div>
+	<div style="background: #fdd;">  xx xx xx<br />xxxxxxxxxxxxx</div>
+	<div style="background: #fdd;">xxxxxxxxxxxxx<br />  xx xx xx<br />      xxxx</div>
+</section>
+
+<section class="reference" style="text-align: center; color: #0f0;">
+	<div style="background: #dfd;"> xx xx xx <br />   xxxx   </div>
+	<div style="background: #dfd;"> xx xx xx <br />xxxxxxxxxxxxx</div>
+	<div style="background: #dfd;">xxxxxxxxxxxxx<br /> xx xx xx <br />   xxxx   </div>
+</section>
+
+<section class="reference" style="text-align: justify; color: #00f;">
+	<div style="background: #ddf;">xx  xx  xx<br />xxxx</div>
+	<div style="background: #ddf;">xx  xx  xx<br />xxxxxxxxxxxxx</div>
+	<div style="background: #ddf;">xxxxxxxxxxxxx<br />xx  xx  xx<br />xxxx      </div>
+</section>
+</body>
+</html>
+

--- a/tests/ref/text_align_justify_a.html
+++ b/tests/ref/text_align_justify_a.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+p {
+    text-align: justify;
+    width: 135px;
+    font-size: 25px;
+    color: blue;
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<p>X X X X X</p>
+</body>
+</html>
+

--- a/tests/ref/text_align_justify_ref.html
+++ b/tests/ref/text_align_justify_ref.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that basic `text-align: justify` works. -->
+<style>
+section {
+    background: blue;
+    position: absolute;
+    width: 25px;
+    height: 25px;
+}
+#a, #d {
+    left: 0;
+}
+#a, #b, #c {
+    top: 0;
+}
+#d, #e {
+    top: 25px;
+}
+#b {
+    left: 55px;
+}
+#c {
+    left: 110px;
+}
+#e {
+    left: 50px;
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+<section id=c></section>
+<section id=d></section>
+<section id=e></section>
+</body>
+</html>
+
+

--- a/tests/ref/text_justify_none_a.html
+++ b/tests/ref/text_justify_none_a.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `text-justify: none` disables justification. -->
+<style>
+p {
+    text-align: justify;
+    text-justify: none;
+}
+</style>
+</head>
+<body>
+<p>MANY YEARS AGO PRINCE DARKNESS "GANNON" STOLE ONE OF THE TRIFORCE WITH POWER. PRINCESS ZELDA HAD ONE OF THE TRIFORCE WITH WISDOM. SHE DIVIDED IT INTO 8 UNITS TO HIDE IT FROM "GANNON" BEFORE SHE WAS CAPTURED. GO FIND THE "8" UNITS "LINK" TO SAVE HER.</p>
+</body>
+</html>

--- a/tests/ref/text_justify_none_ref.html
+++ b/tests/ref/text_justify_none_ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `text-justify: none` disables justification. -->
+<style>
+p {
+    text-align: left;
+}
+</style>
+</head>
+<body>
+<p>MANY YEARS AGO PRINCE DARKNESS "GANNON" STOLE ONE OF THE TRIFORCE WITH POWER. PRINCESS ZELDA HAD ONE OF THE TRIFORCE WITH WISDOM. SHE DIVIDED IT INTO 8 UNITS TO HIDE IT FROM "GANNON" BEFORE SHE WAS CAPTURED. GO FIND THE "8" UNITS "LINK" TO SAVE HER.</p>
+</body>
+</html>

--- a/tests/ref/text_overflow_basic_a.html
+++ b/tests/ref/text_overflow_basic_a.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+section {
+    border: solid black 1px;
+    width: 10em;
+}
+</style>
+</head>
+<body>
+<section>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx<br>asdf asdf asdf</section>
+</body>
+</html>
+

--- a/tests/ref/text_overflow_basic_ref.html
+++ b/tests/ref/text_overflow_basic_ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+section {
+    border: solid black 1px;
+    width: 10em;
+}
+</style>
+</head>
+<body>
+<section>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx asdf asdf asdf</section>
+</body>
+</html>
+


### PR DESCRIPTION
CSS-TEXT-3 § 7.3.

`text-justify: distribute` is not supported.

The behavior of `text-justify: none` does not seem to match what Firefox
and Chrome do, but it seems to match the spec.

Closes #213.

r? @mbrubeck 
