### PR TITLE
Remove RethrowContentExceptions and related infrastructure.

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -20,10 +20,6 @@ use std::ptr;
 pub enum ExceptionHandling {
     /// Report any exception and don't throw it to the caller code.
     ReportExceptions,
-    /// Throw an exception to the caller code if the thrown exception is a
-    /// binding object for a DOMError from the caller's scope, otherwise report
-    /// it.
-    RethrowContentExceptions,
     /// Throw any exception to the caller code.
     RethrowExceptions
 }


### PR DESCRIPTION
We do not intend to implement the DOM in JS, so this code isn't necessary.
