### PR TITLE
Add handling for unreported exceptions when invoking callback objects.

### DIFF
--- a/components/script/dom/eventdispatcher.rs
+++ b/components/script/dom/eventdispatcher.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::callback::ExceptionHandling::ReportExceptions;
+use dom::bindings::callback::ExceptionHandling::Report;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::InheritTypes::{EventTargetCast, NodeCast, NodeDerived};
 use dom::bindings::js::{JS, JSRef, OptionalRootable, Root};
@@ -48,7 +48,7 @@ pub fn dispatch_event<'a, 'b>(target: JSRef<'a, EventTarget>,
                 event.set_current_target(cur_target.r());
                 for listener in listeners.iter() {
                     // Explicitly drop any exception on the floor.
-                    let _ = listener.HandleEvent_(cur_target.r(), event, ReportExceptions);
+                    let _ = listener.HandleEvent_(cur_target.r(), event, Report);
 
                     if event.stop_immediate() {
                         break;
@@ -74,7 +74,7 @@ pub fn dispatch_event<'a, 'b>(target: JSRef<'a, EventTarget>,
         for listeners in opt_listeners.iter() {
             for listener in listeners.iter() {
                 // Explicitly drop any exception on the floor.
-                let _ = listener.HandleEvent_(target, event, ReportExceptions);
+                let _ = listener.HandleEvent_(target, event, Report);
 
                 if event.stop_immediate() {
                     break;
@@ -93,7 +93,7 @@ pub fn dispatch_event<'a, 'b>(target: JSRef<'a, EventTarget>,
                     event.set_current_target(cur_target.r());
                     for listener in listeners.iter() {
                         // Explicitly drop any exception on the floor.
-                        let _ = listener.HandleEvent_(cur_target.r(), event, ReportExceptions);
+                        let _ = listener.HandleEvent_(cur_target.r(), event, Report);
 
                         if event.stop_immediate() {
                             break;

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::callback::ExceptionHandling::RethrowExceptions;
+use dom::bindings::callback::ExceptionHandling::Rethrow;
 use dom::bindings::codegen::Bindings::TreeWalkerBinding;
 use dom::bindings::codegen::Bindings::TreeWalkerBinding::TreeWalkerMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -325,7 +325,7 @@ impl<'a> PrivateTreeWalkerHelpers<'a> for JSRef<'a, TreeWalker> {
         match self.filter {
             Filter::None => Ok(NodeFilterConstants::FILTER_ACCEPT),
             Filter::Native(f) => Ok((f)(node)),
-            Filter::JS(callback) => callback.AcceptNode_(self, node, RethrowExceptions)
+            Filter::JS(callback) => callback.AcceptNode_(self, node, Rethrow)
         }
     }
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::cell::DOMRefCell;
-use dom::bindings::callback::ExceptionHandling::ReportExceptions;
+use dom::bindings::callback::ExceptionHandling::Report;
 use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::js::JSRef;
 use dom::bindings::utils::Reflectable;
@@ -189,7 +189,7 @@ impl TimerManager {
         // TODO: Must handle rooting of funval and args when movable GC is turned on
         match data.callback {
             TimerCallback::FunctionTimerCallback(function) => {
-                let _ = function.Call_(this, data.args, ReportExceptions);
+                let _ = function.Call_(this, data.args, Report);
             }
             TimerCallback::StringTimerCallback(code_str) => {
                 this.evaluate_js_on_global_with_result(code_str.as_slice());

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#e01a846241bd98ac424878e3f8d3e9b989c79242"
+source = "git+https://github.com/servo/rust-mozjs#5a69e377d6ab7ea8601f711443994f1c8172c7a8"
 dependencies = [
  "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs)",
 ]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#e01a846241bd98ac424878e3f8d3e9b989c79242"
+source = "git+https://github.com/servo/rust-mozjs#5a69e377d6ab7ea8601f711443994f1c8172c7a8"
 dependencies = [
  "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs)",
 ]

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#e01a846241bd98ac424878e3f8d3e9b989c79242"
+source = "git+https://github.com/servo/rust-mozjs#5a69e377d6ab7ea8601f711443994f1c8172c7a8"
 dependencies = [
  "mozjs-sys 0.0.0 (git+https://github.com/servo/mozjs)",
 ]


### PR DESCRIPTION
Rebased version of #4399 that addresses points 2 & 5 from https://critic.hoppipolla.co.uk/showcomment?chain=9848 . Introduction of an AutoJSAPI equivalent and setting the error reporter to null will come later, as they are much larger changes and we're currently blocking any further updates to rust-mozjs that are unrelated to error reporting. 
