### PR TITLE
Minor fix to Arch developer setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ popd
 On Arch Linux:
 
 ``` sh
-sudo pacman -S base-devel git python2 python2-virtualenv mesa ttf-font cmake bzip2
+sudo pacman -S --needed base-devel git python2 python2-virtualenv mesa ttf-font cmake bzip2
 ```
 
 Cross-compilation for Android:


### PR DESCRIPTION
Add the flag that says "Don't reinstall already-installed packages".
Otherwise the suggested command means "reinstall all these packages".
