### PR TITLE
Fix TextInput's edit point after set_content: #4622

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -357,13 +357,7 @@ impl TextInput {
             vec!(content)
         };
         self.edit_point.line = min(self.edit_point.line, self.lines.len() - 1);
-
-        if self.current_line_length() == 0 {
-            self.edit_point.index = 0;
-        }
-        else {
-            self.edit_point.index = min(self.edit_point.index, self.current_line_length() - 1);
-        }
+        self.edit_point.index = min(self.edit_point.index, self.current_line_length());
     }
 }
 
@@ -519,7 +513,6 @@ fn test_textinput_set_content() {
     textinput.set_content("de".into_string());
     assert_eq!(textinput.get_content().as_slice(), "de");
     assert_eq!(textinput.edit_point.line, 0);
-    // FIXME: https://github.com/servo/servo/issues/4622.
-    assert_eq!(textinput.edit_point.index, 1);
+    assert_eq!(textinput.edit_point.index, 2);
 }
 


### PR DESCRIPTION
Fixes #4622

Previously, when the edit point was being clamped leftward by a shortened
line, it would be placed one one character too far to the left instead of
at the very end.

The "if" removed here was introduced in f686943eb40aa25e0a06837eeae6a907d9617d2b to fix a crash, but the underlying reason for the crash was the incorrect "- 1", which has been there since the beginning ( 80764f65e3e4895d3a012d6bc1d3bb8183ae15da ).
