### PR TITLE
Handle overlapping border-radius corners

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -223,6 +223,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 != inset_blackborder.html blackborder_ref.html
 != outset_blackborder.html blackborder_ref.html
 == border_radius_clip_a.html border_radius_clip_ref.html
+== border_radius_overlapping_a.html border_radius_overlapping_ref.html
 == stacking_context_overflow_a.html stacking_context_overflow_ref.html
 == stacking_context_overflow_relative_outline_a.html stacking_context_overflow_relative_outline_ref.html
 == word_break_a.html word_break_ref.html

--- a/tests/ref/border_radius_overlapping_a.html
+++ b/tests/ref/border_radius_overlapping_a.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div style='box-sizing:border-box; width:6em; height:2em; border-radius:.5em 2em .5em 2em; background-color:red;'></div>
+    </body>
+</html>

--- a/tests/ref/border_radius_overlapping_ref.html
+++ b/tests/ref/border_radius_overlapping_ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div style='box-sizing:border-box; width:6em; height:2em; border-radius:.4em 1.6em .4em 1.6em; background-color:red;'></div>
+    </body>
+</html>


### PR DESCRIPTION
Fixes #4125

Conforming to section 5.5 (Rounded Corners/Overlapping Curves) of "CSS Background and Borders Module Level 3", border radii on elements whose border curves would have overlapped are uniformly scaled down to the point that they no longer do.

http://dev.w3.org/csswg/css-backgrounds/#corner-overlap
