### PR TITLE
Disallow lines that span more than 160 columns.

### DIFF
--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/// Low-level wire protocol implementation. Currently only supports [JSON packets](https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport#JSON_Packets).
+//! Low-level wire protocol implementation. Currently only supports
+//! [JSON packets]
+//! (https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport#JSON_Packets).
 
 use serialize::{json, Encodable};
 use serialize::json::Json;

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1256,11 +1256,24 @@ impl Fragment {
     pub fn find_split_info_by_new_line(&self)
             -> Option<(SplitInfo, Option<SplitInfo>, Arc<Box<TextRun>> /* TODO(bjz): remove */)> {
         match self.specific {
-            SpecificFragmentInfo::Canvas(_) | SpecificFragmentInfo::Generic | SpecificFragmentInfo::Iframe(_) | SpecificFragmentInfo::Image(_) | SpecificFragmentInfo::Table | SpecificFragmentInfo::TableCell |
-            SpecificFragmentInfo::TableRow | SpecificFragmentInfo::TableWrapper => None,
-            SpecificFragmentInfo::TableColumn(_) => panic!("Table column fragments do not need to split"),
-            SpecificFragmentInfo::UnscannedText(_) => panic!("Unscanned text fragments should have been scanned by now!"),
-            SpecificFragmentInfo::InlineBlock(_) | SpecificFragmentInfo::InlineAbsoluteHypothetical(_) => {
+            SpecificFragmentInfo::Canvas(_) |
+            SpecificFragmentInfo::Generic |
+            SpecificFragmentInfo::Iframe(_) |
+            SpecificFragmentInfo::Image(_) |
+            SpecificFragmentInfo::Table |
+            SpecificFragmentInfo::TableCell |
+            SpecificFragmentInfo::TableRow |
+            SpecificFragmentInfo::TableWrapper => {
+                None
+            }
+            SpecificFragmentInfo::TableColumn(_) => {
+                panic!("Table column fragments do not need to split")
+            }
+            SpecificFragmentInfo::UnscannedText(_) => {
+                panic!("Unscanned text fragments should have been scanned by now!")
+            }
+            SpecificFragmentInfo::InlineBlock(_) |
+            SpecificFragmentInfo::InlineAbsoluteHypothetical(_) => {
                 panic!("Inline blocks or inline absolute hypothetical fragments do not get split")
             }
             SpecificFragmentInfo::ScannedText(ref text_fragment_info) => {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -111,7 +111,9 @@ impl Element {
         create_element(name, prefix, document, creator)
     }
 
-    pub fn new_inherited(type_id: ElementTypeId, local_name: DOMString, namespace: Namespace, prefix: Option<DOMString>, document: JSRef<Document>) -> Element {
+    pub fn new_inherited(type_id: ElementTypeId, local_name: DOMString,
+                         namespace: Namespace, prefix: Option<DOMString>,
+                         document: JSRef<Document>) -> Element {
         Element {
             node: Node::new_inherited(NodeTypeId::Element(type_id), document),
             local_name: Atom::from_slice(local_name.as_slice()),

--- a/components/util/smallvec.rs
+++ b/components/util/smallvec.rs
@@ -531,7 +531,10 @@ pub mod tests {
         let mut v = SmallVec16::new();
         v.push("hello".into_string());
         v.push("there".into_string());
-        assert_eq!(v.as_slice(), vec!["hello".into_string(), "there".into_string()].as_slice());
+        assert_eq!(v.as_slice(), vec![
+            "hello".into_string(),
+            "there".into_string(),
+        ].as_slice());
     }
 
     #[test]
@@ -541,7 +544,12 @@ pub mod tests {
         v.push("there".into_string());
         v.push("burma".into_string());
         v.push("shave".into_string());
-        assert_eq!(v.as_slice(), vec!["hello".into_string(), "there".into_string(), "burma".into_string(), "shave".into_string()].as_slice());
+        assert_eq!(v.as_slice(), vec![
+            "hello".into_string(),
+            "there".into_string(),
+            "burma".into_string(),
+            "shave".into_string(),
+        ].as_slice());
     }
 
     #[test]
@@ -556,7 +564,14 @@ pub mod tests {
         v.push("burma".into_string());
         v.push("shave".into_string());
         assert_eq!(v.as_slice(), vec![
-            "hello".into_string(), "there".into_string(), "burma".into_string(), "shave".into_string(), "hello".into_string(), "there".into_string(), "burma".into_string(), "shave".into_string(),
+            "hello".into_string(),
+            "there".into_string(),
+            "burma".into_string(),
+            "shave".into_string(),
+            "hello".into_string(),
+            "there".into_string(),
+            "burma".into_string(),
+            "shave".into_string(),
         ].as_slice());
     }
 }

--- a/python/tidy.py
+++ b/python/tidy.py
@@ -56,6 +56,13 @@ def check_license(contents):
         yield (1, "incorrect license")
 
 
+def check_length(contents):
+    lines = contents.splitlines(True)
+    for idx, line in enumerate(lines):
+        if len(line) >= 160:
+            yield (idx + 1, "(much) overlong line")
+
+
 def check_whitespace(contents):
     lines = contents.splitlines(True)
     for idx, line in enumerate(lines):
@@ -88,7 +95,7 @@ def scan():
     all_files = collect_file_names(directories_to_check)
     files_to_check = filter(should_check, all_files)
 
-    checking_functions = [check_license, check_whitespace]
+    checking_functions = [check_license, check_length, check_whitespace]
     errors = collect_errors_for_files(files_to_check, checking_functions)
     errors = list(errors)
 


### PR DESCRIPTION
The Rust style guide suggests 100, but we have too many violations in the
tree already. This check can be tightened over time.
