### PR TITLE
Add libosmesa6-dev to debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On Debian-based Linuxes:
 sudo apt-get install curl freeglut3-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     msttcorefonts gperf g++ cmake python-virtualenv \
-    libssl-dev libbz2-dev
+    libssl-dev libbz2-dev libosmesa6-dev
 ```
 
 On Fedora:


### PR DESCRIPTION
Needs to be updated for arch / fedora too, but I'm not sure what the relevant packages are.
