### PR TITLE
Switch the default windowing system to glutin. See below for details.

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -27,8 +27,8 @@ path = "../../tests/contenttest.rs"
 harness = false
 
 [features]
-default = ["glfw_app"]
-glutin = ["glutin_app"]
+default = ["glutin_app"]
+glfw = ["glfw_app"]
 
 [dependencies.compositing]
 path = "../compositing"

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -14,9 +14,9 @@ extern crate servo;
 extern crate time;
 extern crate "util" as servo_util;
 
-#[cfg(all(feature = "glutin",not(test)))]
+#[cfg(all(feature = "glutin_app",not(test)))]
 extern crate "glutin_app" as app;
-#[cfg(all(feature = "glfw_app",not(test)))]
+#[cfg(all(feature = "glfw",not(test)))]
 extern crate "glfw_app" as app;
 
 #[cfg(not(test))]

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -64,10 +64,7 @@ class MachCommands(CommandBase):
             with cd(path.join(apk_builder_dir, "apk-builder")):
                 subprocess.call(["cargo", "build"], env=self.build_env())
 
-            # FIXME: This can be simplified when glutin becomes the default
-            #        and glfw has been removed.
-            opts += ["--target", "arm-linux-androideabi", "--no-default-features"]
-            features += ["glutin"]
+            opts += ["--target", "arm-linux-androideabi"]
 
         if debug_mozjs or self.config["build"]["debug-mozjs"]:
             features += ["script/debugmozjs"]

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -276,6 +276,9 @@ fn capture(reftest: &Reftest, side: uint) -> (u32, u32, Vec<u8>) {
     if reftest.experimental {
         command.arg("--experimental");
     }
+    if cfg!(target_os = "linux") {
+        command.args(["-r", "mesa"].as_slice());
+    }
     let retval = match command.status() {
         Ok(status) => status,
         Err(e) => panic!("failed to execute process: {}", e),


### PR DESCRIPTION
This change makes glutin the default windowing system on mac/linux.

If you run into any issues with the glutin system, you can temporarily
build the GLFW system with the following command:

cd components/servo
../../mach cargo build --no-default-features --features=glfw

Once any glutin related issues have been sorted out, the GLFW
port will be removed.
