### PR TITLE
Fix script: adapt to stricter macro syntax

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -87,8 +87,12 @@ pub fn create_element(name: QualName, prefix: Option<DOMString>,
     }
 
     macro_rules! make(
-        ($ctor:ident $(, $arg:expr)*) => ({
-            let obj = $ctor::new(name.local.as_slice().into_string(), prefix, document $(, $arg)*);
+        ($ctor:ident) => ({
+            let obj = $ctor::new(name.local.as_slice().into_string(), prefix, document);
+            ElementCast::from_temporary(obj)
+        });
+        ($ctor:ident, $($arg:expr),+) => ({
+            let obj = $ctor::new(name.local.as_slice().into_string(), prefix, document, $($arg),+);
             ElementCast::from_temporary(obj)
         })
     );

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -73,13 +73,13 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
     make_setter!(SetAction, "action");
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-form-autocomplete
-    make_enumerated_getter!(Autocomplete, "on", "off");
+    make_enumerated_getter!(Autocomplete, "on", ("off"));
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-form-autocomplete
     make_setter!(SetAutocomplete, "autocomplete");
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-enctype
-    make_enumerated_getter!(Enctype, "application/x-www-form-urlencoded", "text/plain" | "multipart/form-data");
+    make_enumerated_getter!(Enctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-enctype
     make_setter!(SetEnctype, "enctype");
@@ -95,7 +95,7 @@ impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
     }
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-method
-    make_enumerated_getter!(Method, "get", "post" | "dialog");
+    make_enumerated_getter!(Method, "get", ("post") | ("dialog"));
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-method
     make_setter!(SetMethod, "method");

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -225,13 +225,13 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     make_uint_setter!(SetSize, "size");
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-type
-    make_enumerated_getter!(Type, "text", "hidden" | "search" | "tel" |
-                                  "url" | "email" | "password" |
-                                  "datetime" | "date" | "month" |
-                                  "week" | "time" | "datetime-local" |
-                                  "number" | "range" | "color" |
-                                  "checkbox" | "radio" | "file" |
-                                  "submit" | "image" | "reset" | "button");
+    make_enumerated_getter!(Type, "text", ("hidden") | ("search") | ("tel") |
+                                  ("url") | ("email") | ("password") |
+                                  ("datetime") | ("date") | ("month") |
+                                  ("week") | ("time") | ("datetime-local") |
+                                  ("number") | ("range") | ("color") |
+                                  ("checkbox") | ("radio") | ("file") |
+                                  ("submit") | ("image") | ("reset") | ("button"));
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-type
     make_setter!(SetType, "type");
@@ -267,13 +267,13 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     make_setter!(SetFormAction, "formaction");
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formenctype
-    make_enumerated_getter!(FormEnctype, "application/x-www-form-urlencoded", "text/plain" | "multipart/form-data");
+    make_enumerated_getter!(FormEnctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formenctype
     make_setter!(SetFormEnctype, "formenctype");
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formmethod
-    make_enumerated_getter!(FormMethod, "get", "post" | "dialog");
+    make_enumerated_getter!(FormMethod, "get", ("post") | ("dialog"));
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formmethod
     make_setter!(SetFormMethod, "formmethod");

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -15,7 +15,7 @@ macro_rules! make_getter(
         }
     );
     ($attr:ident) => {
-        make_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice())
+        make_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice());
     }
 );
 
@@ -33,7 +33,7 @@ macro_rules! make_bool_getter(
         }
     );
     ($attr:ident) => {
-        make_bool_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice())
+        make_bool_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice());
     }
 );
 
@@ -51,7 +51,7 @@ macro_rules! make_uint_getter(
         }
     );
     ($attr:ident) => {
-        make_uint_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice())
+        make_uint_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice());
     }
 );
 
@@ -70,7 +70,7 @@ macro_rules! make_url_getter(
     );
     ($attr:ident) => {
         // FIXME(pcwalton): Do this at compile time, not runtime.
-        make_url_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice())
+        make_url_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice());
     }
 );
 
@@ -94,13 +94,13 @@ macro_rules! make_url_or_base_getter(
         }
     );
     ($attr:ident) => {
-        make_url_or_base_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice())
+        make_url_or_base_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice());
     }
 );
 
 #[macro_export]
 macro_rules! make_enumerated_getter(
-    ( $attr:ident, $htmlname:expr, $default:expr, $($choices: pat)|+) => (
+    ( $attr:ident, $htmlname:expr, $default:expr, $(($choices: pat))|+) => (
         fn $attr(self) -> DOMString {
             use dom::element::{Element, AttributeHandlers};
             use dom::bindings::codegen::InheritTypes::ElementCast;
@@ -116,8 +116,8 @@ macro_rules! make_enumerated_getter(
             }
         }
     );
-    ($attr:ident, $default:expr, $($choices: pat)|+) => {
-        make_enumerated_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice(), $default, $($choices)|+)
+    ($attr:ident, $default:expr, $(($choices: pat))|+) => {
+        make_enumerated_getter!($attr, stringify!($attr).to_ascii_lowercase().as_slice(), $default, $(($choices))|+);
     }
 );
 
@@ -202,13 +202,13 @@ macro_rules! define_event_handler(
 
 macro_rules! event_handler(
     ($event_type: ident, $getter: ident, $setter: ident) => (
-        define_event_handler!(EventHandlerNonNull, $event_type, $getter, $setter)
+        define_event_handler!(EventHandlerNonNull, $event_type, $getter, $setter);
     )
 );
 
 macro_rules! error_event_handler(
     ($event_type: ident, $getter: ident, $setter: ident) => (
-        define_event_handler!(OnErrorEventHandlerNonNull, $event_type, $getter, $setter)
+        define_event_handler!(OnErrorEventHandlerNonNull, $event_type, $getter, $setter);
     )
 );
 
@@ -217,13 +217,13 @@ macro_rules! error_event_handler(
 // As more methods get added, just update them here.
 macro_rules! global_event_handlers(
     () => (
-        event_handler!(load, GetOnload, SetOnload)
-        global_event_handlers!(NoOnload)
+        event_handler!(load, GetOnload, SetOnload);
+        global_event_handlers!(NoOnload);
 
     );
     (NoOnload) => (
-        event_handler!(click, GetOnclick, SetOnclick)
-        event_handler!(input, GetOninput, SetOninput)
-        event_handler!(change, GetOnchange, SetOnchange)
+        event_handler!(click, GetOnclick, SetOnclick);
+        event_handler!(input, GetOninput, SetOninput);
+        event_handler!(change, GetOnchange, SetOnchange);
     )
 );

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -41,7 +41,7 @@ extern crate "msg" as servo_msg;
 extern crate url;
 extern crate uuid;
 extern crate string_cache;
-#[macro_use]
+#[plugin] #[macro_use]
 extern crate string_cache_macros;
 
 pub mod cors;


### PR DESCRIPTION
- semicolons are often required after macro invocations
- `pat` fragment must not be followed by `|`, `ident` fragment must not be followed by sequence repetition
- string_cache_macros must me used with `#[plugin]` for `ns!` to be available
