### PR TITLE
Bug #3219 - Assign hostfile using the HOST_FILE environment variable.

### DIFF
--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -12,6 +12,7 @@ extern crate libc;
 extern crate servo;
 extern crate time;
 extern crate util;
+extern crate "net" as servo_net;
 
 #[cfg(not(test))]
 extern crate "glutin_app" as app;
@@ -28,6 +29,9 @@ use libc::c_int;
 
 #[cfg(not(test))]
 use util::opts;
+
+#[cfg(not(test))]
+use servo_net::resource_task;
 
 #[cfg(not(test))]
 use servo::Browser;
@@ -113,6 +117,7 @@ fn setup_logging() {
 fn main() {
     if opts::from_cmdline_args(get_args().as_slice()) {
         setup_logging();
+        resource_task::global_init();
 
         let window = if opts::get().headless {
             None


### PR DESCRIPTION
This is a fix for bug #3219 . This patch allows the user to specify a disposiable hostfile using the `HOST_FILE` environment variable. Therefore, we can run tests on test servers without actually changing the system hostfile. 
