### PR TITLE
Pass a String to spawn_named.

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -8,6 +8,7 @@ use geom::rect::Rect;
 use geom::size::Size2D;
 use servo_util::task::spawn_named;
 
+use std::borrow::ToOwned;
 use std::comm;
 
 #[deriving(Clone)]
@@ -39,7 +40,7 @@ impl CanvasPaintTask {
 
     pub fn start(size: Size2D<i32>) -> Sender<CanvasMsg> {
         let (chan, port) = comm::channel::<CanvasMsg>();
-        spawn_named("CanvasTask", proc() {
+        spawn_named("CanvasTask".to_owned(), proc() {
             let mut painter = CanvasPaintTask::new(size);
 
             loop {

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -33,6 +33,7 @@ use servo_util::geometry::{PagePx, ViewportPx};
 use servo_util::opts;
 use servo_util::task::spawn_named;
 use servo_util::time::TimeProfilerChan;
+use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -349,7 +350,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                  -> ConstellationChan {
         let (constellation_port, constellation_chan) = ConstellationChan::new();
         let constellation_chan_clone = constellation_chan.clone();
-        spawn_named("Constellation", proc() {
+        spawn_named("Constellation".to_owned(), proc() {
             let mut constellation: Constellation<LTF, STF> = Constellation {
                 chan: constellation_chan_clone,
                 request_port: constellation_port,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -36,6 +36,7 @@ use devtools_traits::{ServerExitMsg, DevtoolsControlMsg, NewGlobal, DevtoolScrip
 use servo_msg::constellation_msg::PipelineId;
 use servo_util::task::spawn_named;
 
+use std::borrow::ToOwned;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::comm;
@@ -57,7 +58,7 @@ mod protocol;
 /// Spin up a devtools server that listens for connections on the specified port.
 pub fn start_server(port: u16) -> Sender<DevtoolsControlMsg> {
     let (sender, receiver) = comm::channel();
-    spawn_named("Devtools", proc() {
+    spawn_named("Devtools".to_owned(), proc() {
         run_server(receiver, port)
     });
     sender
@@ -184,7 +185,7 @@ fn run_server(receiver: Receiver<DevtoolsControlMsg>, port: u16) {
             Ok(stream) => {
                 let actors = actors.clone();
                 accepted_connections.push(stream.clone());
-                spawn_named("DevtoolsClientHandler", proc() {
+                spawn_named("DevtoolsClientHandler".to_owned(), proc() {
                     // connection succeeded
                     handle_client(actors, stream.clone())
                 })

--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -9,6 +9,7 @@ use platform::font_list::get_last_resort_font_families;
 use platform::font_context::FontContextHandle;
 
 use collections::str::Str;
+use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::sync::Arc;
 use font_template::{FontTemplate, FontTemplateDescriptor};
@@ -252,7 +253,7 @@ impl FontCacheTask {
     pub fn new(resource_task: ResourceTask) -> FontCacheTask {
         let (chan, port) = channel();
 
-        spawn_named("FontCacheTask", proc() {
+        spawn_named("FontCacheTask".to_owned(), proc() {
             // TODO: Allow users to specify these.
             let mut generic_fonts = HashMap::with_capacity(5);
             add_generic_font(&mut generic_fonts, "serif", "Times New Roman");

--- a/components/net/file_loader.rs
+++ b/components/net/file_loader.rs
@@ -5,6 +5,7 @@
 use resource_task::{ProgressMsg, Metadata, LoadData, start_sending, TargetedLoadResponse, ResponseSenders};
 use resource_task::ProgressMsg::{Payload, Done};
 
+use std::borrow::ToOwned;
 use std::io;
 use std::io::File;
 use servo_util::task::spawn_named;
@@ -38,7 +39,7 @@ pub fn factory(load_data: LoadData, start_chan: Sender<TargetedLoadResponse>) {
         eventual_consumer: load_data.consumer,
     };
     let progress_chan = start_sending(senders, Metadata::default(url.clone()));
-    spawn_named("file_loader", proc() {
+    spawn_named("file_loader".to_owned(), proc() {
         let file_path: Result<Path, ()> = url.to_file_path();
         match file_path {
             Ok(file_path) => {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -18,7 +18,7 @@ use url::{Url, UrlParser};
 use std::borrow::ToOwned;
 
 pub fn factory(load_data: LoadData, start_chan: Sender<TargetedLoadResponse>) {
-    spawn_named("http_loader", proc() load(load_data, start_chan))
+    spawn_named("http_loader".to_owned(), proc() load(load_data, start_chan))
 }
 
 fn send_error(url: Url, err: String, senders: ResponseSenders) {

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -9,6 +9,7 @@ use resource_task::ProgressMsg::{Payload, Done};
 
 use servo_util::task::spawn_named;
 use servo_util::taskpool::TaskPool;
+use std::borrow::ToOwned;
 use std::comm::{channel, Receiver, Sender};
 use std::collections::HashMap;
 use std::collections::hash_map::{Occupied, Vacant};
@@ -85,7 +86,7 @@ impl ImageCacheTask {
         let (chan, port) = channel();
         let chan_clone = chan.clone();
 
-        spawn_named("ImageCacheTask", proc() {
+        spawn_named("ImageCacheTask".to_owned(), proc() {
             let mut cache = ImageCache {
                 resource_task: resource_task,
                 port: port,
@@ -106,7 +107,7 @@ impl ImageCacheTask {
     pub fn new_sync(resource_task: ResourceTask, task_pool: TaskPool) -> ImageCacheTask {
         let (chan, port) = channel();
 
-        spawn_named("ImageCacheTask (sync)", proc() {
+        spawn_named("ImageCacheTask (sync)".to_owned(), proc() {
             let inner_cache = ImageCacheTask::new(resource_task, task_pool);
 
             loop {
@@ -248,7 +249,7 @@ impl ImageCache {
                 let resource_task = self.resource_task.clone();
                 let url_clone = url.clone();
 
-                spawn_named("ImageCacheTask (prefetch)", proc() {
+                spawn_named("ImageCacheTask (prefetch)".to_owned(), proc() {
                     let url = url_clone;
                     debug!("image_cache_task: started fetch for {}", url.serialize());
 
@@ -469,7 +470,7 @@ fn load_image_data(url: Url, resource_task: ResourceTask) -> Result<Vec<u8>, ()>
 pub fn spawn_listener<A: Send>(f: proc(Receiver<A>):Send) -> Sender<A> {
     let (setup_chan, setup_port) = channel();
 
-    spawn_named("ImageCacheTask (listener)", proc() {
+    spawn_named("ImageCacheTask (listener)".to_owned(), proc() {
         let (chan, port) = channel();
         setup_chan.send(chan);
         f(port);

--- a/components/net/local_image_cache.rs
+++ b/components/net/local_image_cache.rs
@@ -10,6 +10,7 @@ multiple times and thus triggering reflows multiple times.
 
 use image_cache_task::{ImageCacheTask, ImageResponseMsg, Msg};
 
+use std::borrow::ToOwned;
 use std::comm::{Receiver, channel};
 use std::collections::HashMap;
 use std::collections::hash_map::{Occupied, Vacant};
@@ -130,7 +131,7 @@ impl<NodeAddress: Send> LocalImageCache<NodeAddress> {
                 let on_image_available: proc(ImageResponseMsg, NodeAddress):Send =
                     self.on_image_available.as_ref().unwrap().respond();
                 let url = (*url).clone();
-                spawn_named("LocalImageCache", proc() {
+                spawn_named("LocalImageCache".to_owned(), proc() {
                     let (response_chan, response_port) = channel();
                     image_cache_task.send(Msg::WaitForImage(url, response_chan));
                     on_image_available(response_port.recv(), node_address);

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -184,7 +184,7 @@ pub type ResourceTask = Sender<ControlMsg>;
 pub fn new_resource_task(user_agent: Option<String>) -> ResourceTask {
     let (setup_chan, setup_port) = channel();
     let sniffer_task = sniffer_task::new_sniffer_task();
-    spawn_named("ResourceManager", proc() {
+    spawn_named("ResourceManager".to_owned(), proc() {
         ResourceManager::new(setup_port, user_agent, sniffer_task).start();
     });
     setup_chan

--- a/components/net/storage_task.rs
+++ b/components/net/storage_task.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::borrow::ToOwned;
 use std::comm::{channel, Receiver, Sender};
 use std::collections::HashMap;
 use std::collections::TreeMap;
@@ -46,7 +47,7 @@ impl StorageTaskFactory for StorageTask {
     /// Create a StorageTask
     fn new() -> StorageTask {
         let (chan, port) = channel();
-        spawn_named("StorageManager", proc() {
+        spawn_named("StorageManager".to_owned(), proc() {
             StorageManager::new(port).start();
         });
         chan

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -257,7 +257,7 @@ impl XMLHttpRequest {
                 let req2 = req.clone();
                 // TODO: this exists only to make preflight check non-blocking
                 // perhaps should be handled by the resource_loader?
-                spawn_named("XHR:Cors", proc() {
+                spawn_named("XHR:Cors".to_owned(), proc() {
                     let response = req2.http_fetch();
                     chan.send(response);
                 });
@@ -624,7 +624,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             // inflight events queued up in the script task's port.
             let addr = Trusted::new(self.global.root().r().get_cx(), self,
                                     script_chan.clone());
-            spawn_named("XHRTask", proc() {
+            spawn_named("XHRTask".to_owned(), proc() {
                 let _ = XMLHttpRequest::fetch(&mut SyncOrAsync::Async(addr, script_chan),
                                               resource_task,
                                               load_data,
@@ -936,7 +936,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         let oneshot = self.timer.borrow_mut()
                           .oneshot(Duration::milliseconds(timeout as i64));
         let terminate_sender = (*self.terminate_sender.borrow()).clone();
-        spawn_named("XHR:Timer", proc () {
+        spawn_named("XHR:Timer".to_owned(), proc () {
             match oneshot.recv_opt() {
                 Ok(_) => {
                     terminate_sender.map(|s| s.send_opt(TerminateReason::TimedOut));

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -17,6 +17,7 @@ use servo_util::str::DOMString;
 
 use js::jsval::JSVal;
 
+use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::cmp;
 use std::collections::HashMap;
@@ -127,7 +128,7 @@ impl TimerManager {
             TimerSource::FromWorker if is_interval == IsInterval::Interval => "Worker:SetInterval",
             TimerSource::FromWindow(_) => "Window:SetTimeout",
             TimerSource::FromWorker => "Worker:SetTimeout",
-        };
+        }.to_owned();
         spawn_named(spawn_name, proc() {
             let mut tm = tm;
             let duration = Duration::milliseconds(timeout as i64);

--- a/components/util/memory.rs
+++ b/components/util/memory.rs
@@ -5,6 +5,7 @@
 //! Memory profiling functions.
 
 use libc::{c_char,c_int,c_void,size_t};
+use std::borrow::ToOwned;
 use std::io::timer::sleep;
 #[cfg(target_os="linux")]
 use std::io::File;
@@ -44,7 +45,7 @@ impl MemoryProfiler {
             Some(period) => {
                 let period = Duration::milliseconds((period * 1000f64) as i64);
                 let chan = chan.clone();
-                spawn_named("Memory profiler timer", proc() {
+                spawn_named("Memory profiler timer".to_owned(), proc() {
                     loop {
                         sleep(period);
                         if chan.send_opt(MemoryProfilerMsg::Print).is_err() {
@@ -53,7 +54,7 @@ impl MemoryProfiler {
                     }
                 });
                 // Spawn the memory profiler.
-                spawn_named("Memory profiler", proc() {
+                spawn_named("Memory profiler".to_owned(), proc() {
                     let memory_profiler = MemoryProfiler::new(port);
                     memory_profiler.start();
                 });
@@ -61,7 +62,7 @@ impl MemoryProfiler {
             None => {
                 // No-op to handle messages when the memory profiler is
                 // inactive.
-                spawn_named("Memory profiler", proc() {
+                spawn_named("Memory profiler".to_owned(), proc() {
                     loop {
                         match port.recv_opt() {
                             Err(_) | Ok(MemoryProfilerMsg::Exit) => break,

--- a/components/util/task.rs
+++ b/components/util/task.rs
@@ -9,7 +9,7 @@ use std::task::TaskBuilder;
 // use rtinstrument;
 use task_state;
 
-pub fn spawn_named<S: IntoCow<'static, String, str>>(name: S, f: proc():Send) {
+pub fn spawn_named(name: String, f: proc():Send) {
     let builder = task::TaskBuilder::new().named(name);
     builder.spawn(proc() {
         // rtinstrument::instrument(f);

--- a/components/util/time.rs
+++ b/components/util/time.rs
@@ -5,6 +5,7 @@
 //! Timing functions.
 
 use collections::TreeMap;
+use std::borrow::ToOwned;
 use std::comm::{Sender, channel, Receiver};
 use std::f64;
 use std::io::timer::sleep;
@@ -144,7 +145,7 @@ impl TimeProfiler {
             Some(period) => {
                 let period = Duration::milliseconds((period * 1000f64) as i64);
                 let chan = chan.clone();
-                spawn_named("Time profiler timer", proc() {
+                spawn_named("Time profiler timer".to_owned(), proc() {
                     loop {
                         sleep(period);
                         if chan.send_opt(TimeProfilerMsg::Print).is_err() {
@@ -153,14 +154,14 @@ impl TimeProfiler {
                     }
                 });
                 // Spawn the time profiler.
-                spawn_named("Time profiler", proc() {
+                spawn_named("Time profiler".to_owned(), proc() {
                     let mut profiler = TimeProfiler::new(port);
                     profiler.start();
                 });
             }
             None => {
                 // No-op to handle messages when the time profiler is inactive.
-                spawn_named("Time profiler", proc() {
+                spawn_named("Time profiler".to_owned(), proc() {
                     loop {
                         match port.recv_opt() {
                             Err(_) | Ok(TimeProfilerMsg::Exit) => break,


### PR DESCRIPTION
IntoString has been removed from Rust, and named() will take a String, so
there is no good reason to do otherwise here.
