### PR TITLE
Change glutin headless mode to be a build config, as it breaks some Linux distros linking to both.

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.0.2"
-source = "git+https://github.com/servo/glutin?ref=servo#db27370a1cbafcbfcaeee52a44076a61b3e0573c"
+source = "git+https://github.com/servo/glutin?ref=servo#ec6b4d0fff12ef607db422508ae005ba91406f5b"
 dependencies = [
  "android_glue 0.0.1 (git+https://github.com/servo/android-rs-glue?ref=servo)",
  "cocoa 0.1.1 (git+https://github.com/servo/rust-cocoa)",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -27,8 +27,10 @@ path = "../../tests/contenttest.rs"
 harness = false
 
 [features]
-default = ["glutin_app"]
+default = ["glutin_app", "window"]
 glfw = ["glfw_app"]
+window = ["glutin_app/window"]
+headless = ["glutin_app/headless"]
 
 [dependencies.compositing]
 path = "../compositing"

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -11,7 +11,6 @@ use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
 use getopts;
-use std::borrow::ToOwned;
 use std::collections::HashSet;
 use std::cmp;
 use std::io;
@@ -19,12 +18,6 @@ use std::mem;
 use std::os;
 use std::ptr;
 use std::rt;
-
-#[deriving(Clone, Copy)]
-pub enum RenderApi {
-    OpenGL,
-    Mesa,
-}
 
 /// Global flags for Servo, currently set on the command line.
 #[deriving(Clone)]
@@ -113,8 +106,6 @@ pub struct Opts {
     /// Whether to show an error when display list geometry escapes flow overflow regions.
     pub validate_display_list_geometry: bool,
 
-    pub render_api: RenderApi,
-
     /// A specific path to find required resources (such as user-agent.css).
     pub resources_path: Option<String>,
 }
@@ -183,7 +174,6 @@ pub fn default_opts() -> Opts {
         dump_flow_tree: false,
         validate_display_list_geometry: false,
         profile_tasks: false,
-        render_api: RenderApi::OpenGL,
         resources_path: None,
     }
 }
@@ -303,15 +293,6 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         }
     };
 
-    let render_api = match opt_match.opt_str("r").unwrap_or("gl".to_owned()).as_slice() {
-        "mesa" => RenderApi::Mesa,
-        "gl" => RenderApi::OpenGL,
-        _ => {
-            args_fail("Unknown render api specified");
-            return false;
-        }
-    };
-
     let opts = Opts {
         urls: urls,
         n_paint_threads: n_paint_threads,
@@ -337,7 +318,6 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         enable_text_antialiasing: !debug_options.contains(&"disable-text-aa"),
         dump_flow_tree: debug_options.contains(&"dump-flow-tree"),
         validate_display_list_geometry: debug_options.contains(&"validate-display-list-geometry"),
-        render_api: render_api,
         resources_path: opt_match.opt_str("resources-path"),
     };
 

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "glutin"
 version = "0.0.2"
-source = "git+https://github.com/servo/glutin?ref=servo#db27370a1cbafcbfcaeee52a44076a61b3e0573c"
+source = "git+https://github.com/servo/glutin?ref=servo#ec6b4d0fff12ef607db422508ae005ba91406f5b"
 dependencies = [
  "android_glue 0.0.1 (git+https://github.com/servo/android-rs-glue?ref=servo)",
  "cocoa 0.1.1 (git+https://github.com/servo/rust-cocoa)",

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -11,7 +11,6 @@ use libc::{c_char, c_int, c_void};
 use rustrt::local::Local;
 use rustrt::task;
 use servo_util::opts;
-use servo_util::opts::RenderApi;
 use std::borrow::ToOwned;
 use std::c_str::CString;
 use std::rt;
@@ -105,7 +104,6 @@ pub extern "C" fn cef_initialize(args: *const cef_main_args_t,
         user_agent: None,
         dump_flow_tree: false,
         validate_display_list_geometry: false,
-        render_api: RenderApi::OpenGL,
         resources_path: resources_path(),
     });
 

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -7,6 +7,10 @@ authors = ["The Servo Project Developers"]
 name = "glutin_app"
 path = "lib.rs"
 
+[features]
+window = ["glutin/window"]
+headless = ["glutin/headless"]
+
 [dependencies.compositing]
 path = "../../components/compositing"
 
@@ -25,7 +29,6 @@ path = "../../components/util"
 [dependencies.glutin]
 git = "https://github.com/servo/glutin"
 branch = "servo"
-features = ["window", "headless"]
 
 [dependencies.gleam]
 git = "https://github.com/servo/gleam"

--- a/ports/glutin/lib.rs
+++ b/ports/glutin/lib.rs
@@ -40,5 +40,5 @@ pub fn create_window() -> Rc<Window> {
     let size = opts.initial_window_size.as_f32() * scale_factor;
 
     // Open a window.
-    Window::new(foreground, size.as_uint(), opts.render_api)
+    Window::new(foreground, size.as_uint())
 }

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -276,9 +276,6 @@ fn capture(reftest: &Reftest, side: uint) -> (u32, u32, Vec<u8>) {
     if reftest.experimental {
         command.arg("--experimental");
     }
-    if cfg!(target_os = "linux") {
-        command.args(["-r", "mesa"].as_slice());
-    }
     let retval = match command.status() {
         Ok(status) => status,
         Err(e) => panic!("failed to execute process: {}", e),


### PR DESCRIPTION
The majority of this change is simply re-arranging the code in the glutin port so that the windowed/headless code is configured at build time rather than runtime. There shouldn't be any functional difference as a result of this change.
