### PR TITLE
Replace int/uint with isize/usize.

### DIFF
--- a/components/util/bloom.rs
+++ b/components/util/bloom.rs
@@ -6,10 +6,10 @@
 
 use string_cache::{Atom, Namespace};
 
-const KEY_SIZE: uint = 12;
-const ARRAY_SIZE: uint = 1 << KEY_SIZE;
+const KEY_SIZE: usize = 12;
+const ARRAY_SIZE: usize = 1 << KEY_SIZE;
 const KEY_MASK: u32 = (1 << KEY_SIZE) - 1;
-const KEY_SHIFT: uint = 16;
+const KEY_SHIFT: usize = 16;
 
 /// A counting Bloom filter with 8-bit counters.  For now we assume
 /// that having two hash functions is enough, but we may revisit that
@@ -81,22 +81,22 @@ impl BloomFilter {
 
     #[inline]
     fn first_slot(&self, hash: u32) -> &u8 {
-        &self.counters[hash1(hash) as uint]
+        &self.counters[hash1(hash) as usize]
     }
 
     #[inline]
     fn first_mut_slot(&mut self, hash: u32) -> &mut u8 {
-        &mut self.counters[hash1(hash) as uint]
+        &mut self.counters[hash1(hash) as usize]
     }
 
     #[inline]
     fn second_slot(&self, hash: u32) -> &u8 {
-        &self.counters[hash2(hash) as uint]
+        &self.counters[hash2(hash) as usize]
     }
 
     #[inline]
     fn second_mut_slot(&mut self, hash: u32) -> &mut u8 {
-        &mut self.counters[hash2(hash) as uint]
+        &mut self.counters[hash2(hash) as usize]
     }
 
     #[inline]
@@ -168,7 +168,7 @@ pub trait BloomHash {
     fn bloom_hash(&self) -> u32;
 }
 
-impl BloomHash for int {
+impl BloomHash for isize {
     #[allow(exceeding_bitshifts)]
     #[inline]
     fn bloom_hash(&self) -> u32 {
@@ -176,7 +176,7 @@ impl BloomHash for int {
     }
 }
 
-impl BloomHash for uint {
+impl BloomHash for usize {
     #[allow(exceeding_bitshifts)]
     #[inline]
     fn bloom_hash(&self) -> u32 {
@@ -220,34 +220,34 @@ fn create_and_insert_some_stuff() {
 
     let mut bf = BloomFilter::new();
 
-    for i in range(0u, 1000) {
+    for i in range(0us, 1000) {
         bf.insert(&i);
     }
 
-    for i in range(0u, 1000) {
+    for i in range(0us, 1000) {
         assert!(bf.might_contain(&i));
     }
 
     let false_positives =
-        range(1001u, 2000).filter(|i| bf.might_contain(i)).count();
+        range(1001us, 2000).filter(|i| bf.might_contain(i)).count();
 
     assert!(false_positives < 10); // 1%.
 
-    for i in range(0u, 100) {
+    for i in range(0us, 100) {
         bf.remove(&i);
     }
 
-    for i in range(100u, 1000) {
+    for i in range(100us, 1000) {
         assert!(bf.might_contain(&i));
     }
 
-    let false_positives = range(0u, 100).filter(|i| bf.might_contain(i)).count();
+    let false_positives = range(0us, 100).filter(|i| bf.might_contain(i)).count();
 
     assert!(false_positives < 2); // 2%.
 
     bf.clear();
 
-    for i in range(0u, 2000) {
+    for i in range(0us, 2000) {
         assert!(!bf.might_contain(&i));
     }
 }
@@ -264,13 +264,13 @@ mod bench {
     fn create_insert_1000_remove_100_lookup_100(b: &mut test::Bencher) {
         b.iter(|| {
             let mut bf = BloomFilter::new();
-            for i in iter::range(0u, 1000) {
+            for i in iter::range(0us, 1000) {
                 bf.insert(&i);
             }
-            for i in iter::range(0u, 100) {
+            for i in iter::range(0us, 100) {
                 bf.remove(&i);
             }
-            for i in iter::range(100u, 200) {
+            for i in iter::range(100us, 200) {
                 test::black_box(bf.might_contain(&i));
             }
         });
@@ -280,11 +280,11 @@ mod bench {
     fn might_contain(b: &mut test::Bencher) {
         let mut bf = BloomFilter::new();
 
-        for i in iter::range(0u, 1000) {
+        for i in iter::range(0us, 1000) {
             bf.insert(&i);
         }
 
-        let mut i = 0u;
+        let mut i = 0us;
 
         b.bench_n(1000, |b| {
             b.iter(|| {
@@ -299,7 +299,7 @@ mod bench {
         let mut bf = BloomFilter::new();
 
         b.bench_n(1000, |b| {
-            let mut i = 0u;
+            let mut i = 0us;
 
             b.iter(|| {
                 test::black_box(bf.insert(&i));
@@ -311,12 +311,12 @@ mod bench {
     #[bench]
     fn remove(b: &mut test::Bencher) {
         let mut bf = BloomFilter::new();
-        for i in range(0u, 1000) {
+        for i in range(0us, 1000) {
             bf.insert(&i);
         }
 
         b.bench_n(1000, |b| {
-            let mut i = 0u;
+            let mut i = 0us;
 
             b.iter(|| {
                 bf.remove(&i);
@@ -324,12 +324,12 @@ mod bench {
             });
         });
 
-        test::black_box(bf.might_contain(&0u));
+        test::black_box(bf.might_contain(&0us));
     }
 
     #[bench]
     fn hash_a_uint(b: &mut test::Bencher) {
-        let mut i = 0u;
+        let mut i = 0us;
         b.iter(|| {
             test::black_box(hash(&i));
             i += 1;

--- a/components/util/cache.rs
+++ b/components/util/cache.rs
@@ -72,7 +72,7 @@ impl<K, V> Cache<K,V> for HashCache<K,V>
 
 #[test]
 fn test_hashcache() {
-    let mut cache: HashCache<uint, Cell<&str>> = HashCache::new();
+    let mut cache: HashCache<usize, Cell<&str>> = HashCache::new();
 
     cache.insert(1, Cell::new("one"));
     assert!(cache.find(&1).is_some());
@@ -85,11 +85,11 @@ fn test_hashcache() {
 
 pub struct LRUCache<K, V> {
     entries: Vec<(K, V)>,
-    cache_size: uint,
+    cache_size: usize,
 }
 
 impl<K: Clone + PartialEq, V: Clone> LRUCache<K,V> {
-    pub fn new(size: uint) -> LRUCache<K, V> {
+    pub fn new(size: usize) -> LRUCache<K, V> {
         LRUCache {
           entries: vec!(),
           cache_size: size,
@@ -97,7 +97,7 @@ impl<K: Clone + PartialEq, V: Clone> LRUCache<K,V> {
     }
 
     #[inline]
-    pub fn touch(&mut self, pos: uint) -> V {
+    pub fn touch(&mut self, pos: usize) -> V {
         let last_index = self.entries.len() - 1;
         if pos != last_index {
             let entry = self.entries.remove(pos);
@@ -149,7 +149,7 @@ pub struct SimpleHashCache<K,V> {
 }
 
 impl<K:Clone+PartialEq+Hash<SipHasher>,V:Clone> SimpleHashCache<K,V> {
-    pub fn new(cache_size: uint) -> SimpleHashCache<K,V> {
+    pub fn new(cache_size: usize) -> SimpleHashCache<K,V> {
         let mut r = rand::thread_rng();
         SimpleHashCache {
             entries: repeat(None).take(cache_size).collect(),
@@ -159,15 +159,15 @@ impl<K:Clone+PartialEq+Hash<SipHasher>,V:Clone> SimpleHashCache<K,V> {
     }
 
     #[inline]
-    fn to_bucket(&self, h: uint) -> uint {
+    fn to_bucket(&self, h: usize) -> usize {
         h % self.entries.len()
     }
 
     #[inline]
-    fn bucket_for_key<Q:Hash<SipHasher>>(&self, key: &Q) -> uint {
+    fn bucket_for_key<Q:Hash<SipHasher>>(&self, key: &Q) -> usize {
         let mut hasher = SipHasher::new_with_keys(self.k0, self.k1);
         key.hash(&mut hasher);
-        self.to_bucket(hasher.result() as uint)
+        self.to_bucket(hasher.result() as usize)
     }
 }
 
@@ -210,7 +210,7 @@ fn test_lru_cache() {
     let four = Cell::new("four");
 
     // Test normal insertion.
-    let mut cache: LRUCache<uint,Cell<&str>> = LRUCache::new(2); // (_, _) (cache is empty)
+    let mut cache: LRUCache<usize,Cell<&str>> = LRUCache::new(2); // (_, _) (cache is empty)
     cache.insert(1, one);    // (1, _)
     cache.insert(2, two);    // (1, 2)
     cache.insert(3, three);  // (2, 3)

--- a/components/util/debug_utils.rs
+++ b/components/util/debug_utils.rs
@@ -12,7 +12,7 @@ fn hexdump_slice(buf: &[u8]) {
     let mut stderr = io::stderr();
     stderr.write(b"    ").unwrap();
     for (i, &v) in buf.iter().enumerate() {
-        let output = format!("{:02X} ", v as uint);
+        let output = format!("{:02X} ", v as usize);
         stderr.write(output.as_bytes()).unwrap();
         match i % 16 {
             15 => { stderr.write(b"\n    ").unwrap(); },

--- a/components/util/dlist.rs
+++ b/components/util/dlist.rs
@@ -9,7 +9,7 @@ use std::mem;
 use std::ptr;
 
 struct RawDList<T> {
-    length: uint,
+    length: usize,
     head: *mut RawNode<T>,
     tail: *mut RawNode<T>,
 }

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -4,7 +4,6 @@
 
 #![feature(unsafe_destructor)]
 #![feature(plugin)]
-#![feature(int_uint)]
 #![feature(old_impl_check)]
 #![feature(box_syntax)]
 

--- a/components/util/memory.rs
+++ b/components/util/memory.rs
@@ -171,7 +171,7 @@ macro_rules! option_try(
 );
 
 #[cfg(target_os="linux")]
-fn get_proc_self_statm_field(field: uint) -> Option<u64> {
+fn get_proc_self_statm_field(field: usize) -> Option<u64> {
     let mut f = File::open(&Path::new("/proc/self/statm"));
     match f.read_to_string() {
         Ok(contents) => {

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -35,14 +35,14 @@ pub struct Opts {
     /// How many threads to use for CPU painting (`-t`).
     ///
     /// FIXME(pcwalton): This is not currently used. All painting is sequential.
-    pub n_paint_threads: uint,
+    pub n_paint_threads: usize,
 
     /// True to use GPU painting via Skia-GL, false to use CPU painting via Skia (`-g`). Note that
     /// compositing is always done on the GPU.
     pub gpu_painting: bool,
 
     /// The maximum size of each tile in pixels (`-s`).
-    pub tile_size: uint,
+    pub tile_size: usize,
 
     /// The ratio of device pixels per px at the default scale. If unspecified, will use the
     /// platform default setting.
@@ -61,7 +61,7 @@ pub struct Opts {
 
     /// The number of threads to use for layout (`-y`). Defaults to 1, which results in a recursive
     /// sequential algorithm.
-    pub layout_threads: uint,
+    pub layout_threads: usize,
 
     pub nonincremental_layout: bool,
 
@@ -102,7 +102,7 @@ pub struct Opts {
     pub devtools_port: Option<u16>,
 
     /// The initial requested size of the window.
-    pub initial_window_size: TypedSize2D<ScreenPx, uint>,
+    pub initial_window_size: TypedSize2D<ScreenPx, usize>,
 
     /// An optional string allowing the user agent to be set for testing.
     pub user_agent: Option<String>,
@@ -250,7 +250,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         opt_match.free.clone()
     };
 
-    let tile_size: uint = match opt_match.opt_str("s") {
+    let tile_size: usize = match opt_match.opt_str("s") {
         Some(tile_size_str) => tile_size_str.parse().unwrap(),
         None => 512,
     };
@@ -259,7 +259,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         ScaleFactor(dppx_str.parse().unwrap())
     );
 
-    let mut n_paint_threads: uint = match opt_match.opt_str("t") {
+    let mut n_paint_threads: usize = match opt_match.opt_str("t") {
         Some(n_paint_threads_str) => n_paint_threads_str.parse().unwrap(),
         None => 1,      // FIXME: Number of cores.
     };
@@ -274,7 +274,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
 
     let gpu_painting = !FORCE_CPU_PAINTING && opt_match.opt_present("g");
 
-    let mut layout_threads: uint = match opt_match.opt_str("y") {
+    let mut layout_threads: usize = match opt_match.opt_str("y") {
         Some(layout_threads_str) => layout_threads_str.parse().unwrap(),
         None => cmp::max(rt::default_sched_threads() * 3 / 4, 1),
     };
@@ -295,7 +295,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
 
     let initial_window_size = match opt_match.opt_str("resolution") {
         Some(res_string) => {
-            let res: Vec<uint> = res_string.split('x').map(|r| r.parse().unwrap()).collect();
+            let res: Vec<usize> = res_string.split('x').map(|r| r.parse().unwrap()).collect();
             TypedSize2D(res[0], res[1])
         }
         None => {

--- a/components/util/persistent_list.rs
+++ b/components/util/persistent_list.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 pub struct PersistentList<T> {
     head: PersistentListLink<T>,
-    length: uint,
+    length: usize,
 }
 
 struct PersistentListEntry<T> {
@@ -29,7 +29,7 @@ impl<T> PersistentList<T> where T: Send + Sync {
     }
 
     #[inline]
-    pub fn len(&self) -> uint {
+    pub fn len(&self) -> usize {
         self.length
     }
 

--- a/components/util/range.rs
+++ b/components/util/range.rs
@@ -14,12 +14,12 @@ pub trait RangeIndex<T>: Int + fmt::Show {
     fn get(self) -> T;
 }
 
-impl RangeIndex<int> for int {
+impl RangeIndex<isize> for isize {
     #[inline]
-    fn new(x: int) -> int { x }
+    fn new(x: isize) -> isize { x }
 
     #[inline]
-    fn get(self) -> int { self }
+    fn get(self) -> isize { self }
 }
 
 /// Implements a range index type with operator overloads
@@ -32,8 +32,8 @@ macro_rules! int_range_index {
 
         impl $Self {
             #[inline]
-            pub fn to_uint(self) -> uint {
-                self.get() as uint
+            pub fn to_uint(self) -> usize {
+                self.get() as usize
             }
         }
 
@@ -54,11 +54,11 @@ macro_rules! int_range_index {
             fn one() -> $Self { $Self(1) }
             fn min_value() -> $Self { $Self(::std::num::Int::min_value()) }
             fn max_value() -> $Self { $Self(::std::num::Int::max_value()) }
-            fn count_ones(self) -> uint { self.get().count_ones() }
-            fn leading_zeros(self) -> uint { self.get().leading_zeros() }
-            fn trailing_zeros(self) -> uint { self.get().trailing_zeros() }
-            fn rotate_left(self, n: uint) -> $Self { $Self(self.get().rotate_left(n)) }
-            fn rotate_right(self, n: uint) -> $Self { $Self(self.get().rotate_right(n)) }
+            fn count_ones(self) -> usize { self.get().count_ones() }
+            fn leading_zeros(self) -> usize { self.get().leading_zeros() }
+            fn trailing_zeros(self) -> usize { self.get().trailing_zeros() }
+            fn rotate_left(self, n: usize) -> $Self { $Self(self.get().rotate_left(n)) }
+            fn rotate_right(self, n: usize) -> $Self { $Self(self.get().rotate_right(n)) }
             fn swap_bytes(self) -> $Self { $Self(self.get().swap_bytes()) }
             fn checked_add(self, other: $Self) -> Option<$Self> {
                 self.get().checked_add(other.get()).map($Self)
@@ -168,16 +168,16 @@ macro_rules! int_range_index {
             }
         }
 
-        impl Shl<uint> for $Self {
+        impl Shl<usize> for $Self {
             type Output = $Self;
-            fn shl(self, n: uint) -> $Self {
+            fn shl(self, n: usize) -> $Self {
                 $Self(self.get() << n)
             }
         }
 
-        impl Shr<uint> for $Self {
+        impl Shr<usize> for $Self {
             type Output = $Self;
-            fn shr(self, n: uint) -> $Self {
+            fn shr(self, n: usize) -> $Self {
                 $Self(self.get() >> n)
             }
         }
@@ -216,7 +216,7 @@ impl<T: Int, I: RangeIndex<T>> Iterator for EachIndex<T, I> {
     }
 
     #[inline]
-    fn size_hint(&self) -> (uint, Option<uint>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 }
@@ -371,7 +371,7 @@ impl<T: Int, I: RangeIndex<T>> Range<I>
     #[inline]
     pub fn is_valid_for_string(&self, s: &str) -> bool {
         let s_len = s.len();
-        match num::cast::<uint, T>(s_len) {
+        match num::cast::<usize, T>(s_len) {
             Some(len) => {
                 let len = RangeIndex::new(len);
                 self.begin() < len

--- a/components/util/sort.rs
+++ b/components/util/sort.rs
@@ -6,24 +6,24 @@
 
 use std::cmp::Ordering;
 
-fn quicksort_helper<T>(arr: &mut [T], left: int, right: int, compare: fn(&T, &T) -> Ordering) {
+fn quicksort_helper<T>(arr: &mut [T], left: isize, right: isize, compare: fn(&T, &T) -> Ordering) {
     if right <= left {
         return
     }
 
-    let mut i: int = left - 1;
-    let mut j: int = right;
-    let mut p: int = i;
-    let mut q: int = j;
+    let mut i: isize = left - 1;
+    let mut j: isize = right;
+    let mut p: isize = i;
+    let mut q: isize = j;
     unsafe {
-        let v: *mut T = &mut arr[right as uint];
+        let v: *mut T = &mut arr[right as usize];
         loop {
             i += 1;
-            while compare(&arr[i as uint], &*v) == Ordering::Less {
+            while compare(&arr[i as usize], &*v) == Ordering::Less {
                 i += 1
             }
             j -= 1;
-            while compare(&*v, &arr[j as uint]) == Ordering::Less {
+            while compare(&*v, &arr[j as usize]) == Ordering::Less {
                 if j == left {
                     break
                 }
@@ -32,31 +32,31 @@ fn quicksort_helper<T>(arr: &mut [T], left: int, right: int, compare: fn(&T, &T)
             if i >= j {
                 break
             }
-            arr.swap(i as uint, j as uint);
-            if compare(&arr[i as uint], &*v) == Ordering::Equal {
+            arr.swap(i as usize, j as usize);
+            if compare(&arr[i as usize], &*v) == Ordering::Equal {
                 p += 1;
-                arr.swap(p as uint, i as uint)
+                arr.swap(p as usize, i as usize)
             }
-            if compare(&*v, &arr[j as uint]) == Ordering::Equal {
+            if compare(&*v, &arr[j as usize]) == Ordering::Equal {
                 q -= 1;
-                arr.swap(j as uint, q as uint)
+                arr.swap(j as usize, q as usize)
             }
         }
     }
 
-    arr.swap(i as uint, right as uint);
+    arr.swap(i as usize, right as usize);
     j = i - 1;
     i += 1;
-    let mut k: int = left;
+    let mut k: isize = left;
     while k < p {
-        arr.swap(k as uint, j as uint);
+        arr.swap(k as usize, j as usize);
         k += 1;
         j -= 1;
-        assert!(k < arr.len() as int);
+        assert!(k < arr.len() as isize);
     }
     k = right - 1;
     while k > q {
-        arr.swap(i as uint, k as uint);
+        arr.swap(i as usize, k as usize);
         k -= 1;
         i += 1;
         assert!(k != 0);
@@ -76,7 +76,7 @@ pub fn quicksort_by<T>(arr: &mut [T], compare: fn(&T, &T) -> Ordering) {
     }
 
     let len = arr.len();
-    quicksort_helper(arr, 0, (len - 1) as int, compare);
+    quicksort_helper(arr, 0, (len - 1) as isize, compare);
 }
 
 #[cfg(test)]
@@ -90,9 +90,9 @@ pub mod test {
     pub fn random() {
         let mut rng = rand::thread_rng();
         for _ in range(0u32, 50000u32) {
-            let len: uint = rng.gen();
-            let mut v: Vec<int> = rng.gen_iter::<int>().take((len % 32) + 1).collect();
-            fn compare_ints(a: &int, b: &int) -> Ordering { a.cmp(b) }
+            let len: usize = rng.gen();
+            let mut v: Vec<isize> = rng.gen_iter::<isize>().take((len % 32) + 1).collect();
+            fn compare_ints(a: &isize, b: &isize) -> Ordering { a.cmp(b) }
             sort::quicksort_by(v.as_mut_slice(), compare_ints);
             for i in range(0, v.len() - 1) {
                 assert!(v[i] <= v[i + 1])

--- a/components/util/taskpool.rs
+++ b/components/util/taskpool.rs
@@ -25,7 +25,7 @@ pub struct TaskPool {
 }
 
 impl TaskPool {
-    pub fn new(tasks: uint) -> TaskPool {
+    pub fn new(tasks: usize) -> TaskPool {
         assert!(tasks > 0);
         let (tx, rx) = channel();
 

--- a/components/util/tid.rs
+++ b/components/util/tid.rs
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::sync::atomic::{AtomicUint, ATOMIC_UINT_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use std::rc::Rc;
 use std::cell::RefCell;
 
-static mut next_tid: AtomicUint = ATOMIC_UINT_INIT;
+static mut next_tid: AtomicUsize = ATOMIC_USIZE_INIT;
 
-thread_local!(static TASK_LOCAL_TID: Rc<RefCell<Option<uint>>> = Rc::new(RefCell::new(None)));
+thread_local!(static TASK_LOCAL_TID: Rc<RefCell<Option<usize>>> = Rc::new(RefCell::new(None)));
 
 /// Every task gets one, that's unique.
-pub fn tid() -> uint {
+pub fn tid() -> usize {
     TASK_LOCAL_TID.with(|ref k| {
         let ret =
             match *k.borrow() {

--- a/components/util/vec.rs
+++ b/components/util/vec.rs
@@ -15,11 +15,11 @@ pub trait Comparator<K,T> {
 
 pub trait BinarySearchMethods<'a, T: Ord + PartialOrd + PartialEq> {
     fn binary_search_(&self, key: &T) -> Option<&'a T>;
-    fn binary_search_index(&self, key: &T) -> Option<uint>;
+    fn binary_search_index(&self, key: &T) -> Option<usize>;
 }
 
 pub trait FullBinarySearchMethods<T> {
-    fn binary_search_index_by<K,C:Comparator<K,T>>(&self, key: &K, cmp: C) -> Option<uint>;
+    fn binary_search_index_by<K,C:Comparator<K,T>>(&self, key: &K, cmp: C) -> Option<usize>;
 }
 
 impl<'a, T: Ord + PartialOrd + PartialEq> BinarySearchMethods<'a, T> for &'a [T] {
@@ -27,28 +27,28 @@ impl<'a, T: Ord + PartialOrd + PartialEq> BinarySearchMethods<'a, T> for &'a [T]
         self.binary_search_index(key).map(|i| &self[i])
     }
 
-    fn binary_search_index(&self, key: &T) -> Option<uint> {
+    fn binary_search_index(&self, key: &T) -> Option<usize> {
         self.binary_search_index_by(key, DefaultComparator)
     }
 }
 
 impl<'a, T> FullBinarySearchMethods<T> for &'a [T] {
-    fn binary_search_index_by<K,C:Comparator<K,T>>(&self, key: &K, cmp: C) -> Option<uint> {
+    fn binary_search_index_by<K,C:Comparator<K,T>>(&self, key: &K, cmp: C) -> Option<usize> {
         if self.len() == 0 {
             return None;
         }
 
-        let mut low : int = 0;
-        let mut high : int = (self.len() as int) - 1;
+        let mut low : isize = 0;
+        let mut high : isize = (self.len() as isize) - 1;
 
         while low <= high {
             // http://googleresearch.blogspot.com/2006/06/extra-extra-read-all-about-it-nearly.html
-            let mid = ((low as uint) + (high as uint)) >> 1;
+            let mid = ((low as usize) + (high as usize)) >> 1;
             let midv = &self[mid];
 
             match cmp.compare(key, midv) {
-                Ordering::Greater => low = (mid as int) + 1,
-                Ordering::Less => high = (mid as int) - 1,
+                Ordering::Greater => low = (mid as isize) + 1,
+                Ordering::Less => high = (mid as isize) - 1,
                 Ordering::Equal => return Some(mid),
             }
         }

--- a/components/util/workqueue.rs
+++ b/components/util/workqueue.rs
@@ -14,7 +14,7 @@ use libc::funcs::posix88::unistd::usleep;
 use rand::{Rng, XorShiftRng};
 use std::mem;
 use std::rand::weak_rng;
-use std::sync::atomic::{AtomicUint, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use deque::{Abort, BufferPool, Data, Empty, Stealer, Worker};
 
@@ -34,7 +34,7 @@ pub struct WorkUnit<QueueData, WorkData> {
 /// Messages from the supervisor to the worker.
 enum WorkerMsg<QueueData: 'static, WorkData: 'static> {
     /// Tells the worker to start work.
-    Start(Worker<WorkUnit<QueueData, WorkData>>, *mut AtomicUint, *const QueueData),
+    Start(Worker<WorkUnit<QueueData, WorkData>>, *mut AtomicUsize, *const QueueData),
     /// Tells the worker to stop. It can be restarted again with a `WorkerMsg::Start`.
     Stop,
     /// Tells the worker thread to terminate.
@@ -46,7 +46,7 @@ unsafe impl<QueueData: 'static, WorkData: 'static> Send for WorkerMsg<QueueData,
 /// Messages to the supervisor.
 enum SupervisorMsg<QueueData: 'static, WorkData: 'static> {
     Finished,
-    ReturnDeque(uint, Worker<WorkUnit<QueueData, WorkData>>),
+    ReturnDeque(usize, Worker<WorkUnit<QueueData, WorkData>>),
 }
 
 unsafe impl<QueueData: 'static, WorkData: 'static> Send for SupervisorMsg<QueueData, WorkData> {}
@@ -64,7 +64,7 @@ struct WorkerInfo<QueueData: 'static, WorkData: 'static> {
 /// Information specific to each worker thread that the thread keeps.
 struct WorkerThread<QueueData: 'static, WorkData: 'static> {
     /// The index of this worker.
-    index: uint,
+    index: usize,
     /// The communication port from the supervisor.
     port: Receiver<WorkerMsg<QueueData, WorkData>>,
     /// The communication channel on which messages are sent to the supervisor.
@@ -111,7 +111,7 @@ impl<QueueData: Send, WorkData: Send> WorkerThread<QueueData, WorkData> {
                         let mut i = 0;
                         let mut should_continue = true;
                         loop {
-                            let victim = (self.rng.next_u32() as uint) % self.other_deques.len();
+                            let victim = (self.rng.next_u32() as usize) % self.other_deques.len();
                             match self.other_deques[victim].steal() {
                                 Empty | Abort => {
                                     // Continue.
@@ -179,7 +179,7 @@ impl<QueueData: Send, WorkData: Send> WorkerThread<QueueData, WorkData> {
 /// A handle to the work queue that individual work units have.
 pub struct WorkerProxy<'a, QueueData: 'a, WorkData: 'a> {
     worker: &'a mut Worker<WorkUnit<QueueData, WorkData>>,
-    ref_count: *mut AtomicUint,
+    ref_count: *mut AtomicUsize,
     queue_data: *const QueueData,
 }
 
@@ -209,7 +209,7 @@ pub struct WorkQueue<QueueData: 'static, WorkData: 'static> {
     /// A port on which deques can be received from the workers.
     port: Receiver<SupervisorMsg<QueueData, WorkData>>,
     /// The amount of work that has been enqueued.
-    work_count: uint,
+    work_count: usize,
     /// Arbitrary user data.
     pub data: QueueData,
 }
@@ -219,7 +219,7 @@ impl<QueueData: Send, WorkData: Send> WorkQueue<QueueData, WorkData> {
     /// it.
     pub fn new(task_name: &'static str,
                state: task_state::TaskState,
-               thread_count: uint,
+               thread_count: usize,
                user_data: QueueData) -> WorkQueue<QueueData, WorkData> {
         // Set up data structures.
         let (supervisor_chan, supervisor_port) = channel();
@@ -288,7 +288,7 @@ impl<QueueData: Send, WorkData: Send> WorkQueue<QueueData, WorkData> {
     /// Synchronously runs all the enqueued tasks and waits for them to complete.
     pub fn run(&mut self) {
         // Tell the workers to start.
-        let mut work_count = AtomicUint::new(self.work_count);
+        let mut work_count = AtomicUsize::new(self.work_count);
         for worker in self.workers.iter_mut() {
             worker.chan.send(WorkerMsg::Start(worker.deque.take().unwrap(), &mut work_count, &self.data)).unwrap()
         }


### PR DESCRIPTION
I don't like warning messages, so more patch might follow.
I didn't change function names even in test/benchmark code, in case someone expects them.
