### PR TITLE
Make UntrustedNodeAddress a newtype.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -159,7 +159,7 @@ impl ImageResponder<UntrustedNodeAddress> for LayoutImageResponder {
         let f: proc(ImageResponseMsg, UntrustedNodeAddress):Send =
             proc(_, node_address) {
                 let ScriptControlChan(chan) = script_chan;
-                debug!("Dirtying {:x}", node_address as uint);
+                debug!("Dirtying {:x}", node_address.0 as uint);
                 let mut nodes = SmallVec1::new();
                 nodes.vec_push(node_address);
                 drop(chan.send_opt(ConstellationControlMsg::SendEvent(

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -325,7 +325,7 @@ impl<'ln> LayoutNode<'ln> {
 
     pub fn debug_id(self) -> uint {
         let opaque: OpaqueNode = OpaqueNodeMethods::from_layout_node(&self);
-        opaque.to_untrusted_node_address() as uint
+        opaque.to_untrusted_node_address().0 as uint
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -886,7 +886,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
 pub fn from_untrusted_node_address(runtime: *mut JSRuntime, candidate: UntrustedNodeAddress)
     -> Temporary<Node> {
     unsafe {
-        let candidate: uintptr_t = mem::transmute(candidate);
+        let candidate: uintptr_t = mem::transmute(candidate.0);
         let object: *mut JSObject = jsfriendapi::bindgen::JS_GetAddressableObject(runtime,
                                                                                   candidate);
         if object.is_null() {

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1131,7 +1131,7 @@ impl ScriptTask {
         let page = get_page(&*self.page.borrow(), pipeline_id);
         match page.hit_test(&point) {
             Some(node_address) => {
-                debug!("node address is {}", node_address);
+                debug!("node address is {}", node_address.0);
 
                 let temp_node =
                         node::from_untrusted_node_address(

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -39,7 +39,9 @@ use serialize::{Encodable, Encoder};
 
 /// The address of a node. Layout sends these back. They must be validated via
 /// `from_untrusted_node_address` before they can be used, because we do not trust layout.
-pub type UntrustedNodeAddress = *const c_void;
+#[allow(raw_pointer_deriving)]
+#[deriving(Copy, Clone)]
+pub struct UntrustedNodeAddress(pub *const c_void);
 
 pub struct NewLayoutInfo {
     pub old_pipeline_id: PipelineId,


### PR DESCRIPTION
This will allow us to make it Send after the Rust upgrade.
