### PR TITLE
Merge adjacent text nodes

### DIFF
--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -109,6 +109,8 @@ impl<'a> TreeSink<TrustedNodeAddress> for servohtmlparser::Sink {
 
         let child = self.get_or_create(new_node).root();
         assert!(parent.r().InsertBefore(child.r(), Some(sibling.r())).is_ok());
+        // Merge adjacent text nodes
+        parent.r().Normalize();
         Ok(())
     }
 
@@ -125,8 +127,10 @@ impl<'a> TreeSink<TrustedNodeAddress> for servohtmlparser::Sink {
         let parent: Root<Node> = unsafe { JS::from_trusted_node_address(parent).root() };
         let child = self.get_or_create(child).root();
 
-        // FIXME(#3701): Use a simpler algorithm and merge adjacent text nodes
+        // FIXME(#3701): Use a simpler algorithm
         assert!(parent.r().AppendChild(child.r()).is_ok());
+        // Merge adjacent text nodes
+        parent.r().Normalize();
     }
 
     fn append_doctype_to_document(&mut self, name: String, public_id: String, system_id: String) {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -223,6 +223,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 != inset_blackborder.html blackborder_ref.html
 != outset_blackborder.html blackborder_ref.html
 == border_radius_clip_a.html border_radius_clip_ref.html
+== border_code_tag.html border_code_tag_ref.html
 == stacking_context_overflow_a.html stacking_context_overflow_ref.html
 == stacking_context_overflow_relative_outline_a.html stacking_context_overflow_relative_outline_ref.html
 == word_break_a.html word_break_ref.html

--- a/tests/ref/border_code_tag.html
+++ b/tests/ref/border_code_tag.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<style>
+code {
+border: 1px solid #ccc;
+width: 100%;
+}
+</style>
+</head>
+<body>
+<code>Quotes: &quot;&quot;.</code>
+</body>
+</html>

--- a/tests/ref/border_code_tag_ref.html
+++ b/tests/ref/border_code_tag_ref.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<style>
+code {
+border: 1px solid #ccc;
+width: 100%;
+}
+</style>
+</head>
+<body>
+<code>Quotes: "".</code>
+</body>
+</html>


### PR DESCRIPTION
When parsing, adjacent text nodes should be merged.
For details, see the section on Text nodes in the [DOM reference](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-1312295772).

Fixes https://github.com/servo/servo/issues/4658, where unmerged text nodes have distinct borders.
