### PR TITLE
Move snapshot dir inside the source dir by default

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -54,9 +54,6 @@ class CommandBase(object):
         if not hasattr(self.context, "bootstrapped"):
             self.context.bootstrapped = False
 
-        if not hasattr(self.context, "sharedir"):
-            self.context.sharedir = path.join(path.expanduser("~/"), ".servo")
-
         config_path = path.join(context.topdir, ".servobuild")
         if path.exists(config_path):
             self.config = toml.loads(open(config_path).read())
@@ -65,6 +62,11 @@ class CommandBase(object):
 
         # Handle missing/default items
         self.config.setdefault("tools", {})
+        self.config["tools"].setdefault("cache-dir",
+                                        path.join(context.topdir, ".servo"))
+        # Allow "~" in cache-dir
+        context.sharedir = path.expanduser(self.config["tools"]["cache-dir"])
+
         self.config["tools"].setdefault("system-rust", False)
         self.config["tools"].setdefault("system-cargo", False)
         self.config["tools"].setdefault("rust-root", "")

--- a/servobuild.example
+++ b/servobuild.example
@@ -1,5 +1,8 @@
 # Tool options
 [tools]
+# Where Rust compiler snapshots and other downloads will be stored.  Can be
+# shared by multiple Servo reposities.  Defaults to <servo-repo>/.servo
+cache-dir = "~/.servo"
 # If system-rust is true, will use rustc/rustdoc from the path, or if
 # rust-root is specified, will make sure that rust-root is in the path
 # when building. Similarly for Cargo. This takes care of PATH as well as


### PR DESCRIPTION
As discussed in a previous weekly meeting, this avoids changing any directories outside the repo, which is better for some automation scenarios.

The servobuild.example file has a "cache-dir" setting that restores the previous default location of `~/.servo`, which is useful for developers working with multiple clones on the same machine.

I'm not sure which setting we want to use for our buildbot hosts.

r? @metajack or @larsbergstrom
