### PR TITLE
Adds borrow_for_script_deallocation and unsafe_mut_js_info method to avo...

### DIFF
--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -41,6 +41,13 @@ impl<T> DOMRefCell<T> {
         &*self.value.as_unsafe_cell().get()
     }
 
+    /// Borrow the contents for the purpose of script deallocation.
+    ///
+    pub unsafe fn borrow_for_script_deallocation<'a>(&'a self) -> &'a mut T {
+        debug_assert!(task_state::get().contains(SCRIPT));
+        &mut *self.value.as_unsafe_cell().get()
+    }
+
     /// Is the cell mutably borrowed?
     ///
     /// For safety checks in debug builds only.

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -188,9 +188,3 @@ impl LiveDOMReferences {
         })
     }
 }
-
-impl Drop for LiveDOMReferences {
-    fn drop(&mut self) {
-        assert!(self.table.borrow().keys().count() == 0);
-    }
-}

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -273,6 +273,10 @@ impl Page {
         self.js_info.borrow_mut()
     }
 
+    pub unsafe fn unsafe_mut_js_info<'a>(&'a self) -> &'a mut Option<JSPageInfo> {
+        self.js_info.borrow_for_script_deallocation()
+    }
+
     pub fn js_info<'a>(&'a self) -> Ref<'a, Option<JSPageInfo>> {
         self.js_info.borrow()
     }

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -248,11 +248,13 @@ impl<'a> Drop for ScriptMemoryFailsafe<'a> {
     fn drop(&mut self) {
         match self.owner {
             Some(owner) => {
-                let page = owner.page.borrow_mut();
-                for page in page.iter() {
-                    *page.mut_js_info() = None;
+                unsafe {
+                    let page = owner.page.borrow_for_script_deallocation();
+                    for page in page.iter() {
+                        *page.unsafe_mut_js_info() = None;
+                    }
+                    *owner.js_context.borrow_for_script_deallocation() = None;
                 }
-                *owner.js_context.borrow_mut() = None;
             }
             None => (),
         }


### PR DESCRIPTION
...id 'DOMRefCell already mutably borrowed' messages. This is just a temporary fix until the Rust standard library allows borrowing already-borrowed RefCell values during unwinding.

It also removes LiveDOMReferences destructor that it's a no-op but it contains an assert that was being violated causing an endless cycle of destructor calls ending up in a stack overflow.
