### PR TITLE
Fix 'inline-block' sizing issues

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1117,10 +1117,10 @@ impl Flow for InlineFlow {
 
         debug!("InlineFlow::assign_inline_sizes: floats in: {:?}", self.base.floats);
 
-        self.base.position.size.inline = self.base.block_container_inline_size;
+        let inline_size = self.base.block_container_inline_size;
+        self.base.position.size.inline = inline_size;
 
         {
-            let inline_size = self.base.position.size.inline;
             let this = &mut *self;
             for fragment in this.fragments.fragments.iter_mut() {
                 fragment.compute_border_and_padding(inline_size);
@@ -1130,11 +1130,14 @@ impl Flow for InlineFlow {
             }
         }
 
-        // If there are any inline-block kids, propagate explicit block sizes down to them.
+        // If there are any inline-block kids, propagate explicit block and inline
+        // sizes down to them.
         let block_container_explicit_block_size = self.base.block_container_explicit_block_size;
         for kid in self.base.child_iter() {
-            flow::mut_base(kid).block_container_explicit_block_size =
-                block_container_explicit_block_size;
+            let kid_base = flow::mut_base(kid);
+
+            kid_base.block_container_inline_size = inline_size;
+            kid_base.block_container_explicit_block_size = block_container_explicit_block_size;
         }
     }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -141,6 +141,8 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == inline_block_margin_a.html inline_block_margin_ref.html
 == inline_block_img_a.html inline_block_img_ref.html
 == inline_block_baseline_a.html inline_block_baseline_ref.html
+== inline_block_parent_width.html inline_block_parent_width_ref.html
+== inline_block_parent_width_percentage.html inline_block_parent_width_ref.html
 == float_table_a.html float_table_ref.html
 == table_containing_block_a.html table_containing_block_ref.html
 == link_style_order.html link_style_order_ref.html

--- a/tests/ref/inline_block_parent_width.html
+++ b/tests/ref/inline_block_parent_width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="display: block; width: 300px;">
+    <div style="display: inline-block">
+        Bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+    </div>
+</div>
+</body>
+</html>

--- a/tests/ref/inline_block_parent_width_percentage.html
+++ b/tests/ref/inline_block_parent_width_percentage.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="display: block; width: 600px;">
+    <div style="width: 50%; display: inline-block;">
+        Bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+    </div>
+</div>
+</body>
+</html>

--- a/tests/ref/inline_block_parent_width_ref.html
+++ b/tests/ref/inline_block_parent_width_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="display: block; width: 300px; height: 8em;">
+    <div style="display: inline-block; width: 300px;">
+        Bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+        bloobity bloobity bloobity bloobity
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
The first commit fixes #3624, and the second commit fixes a bug uncovered by the first fix and caught by a reftest (according to CSS 2.1, inline-blocks should have the shrink-to-fit algorithm run on them when size is set to 'auto'). The two new reftests included here fail before the fix and pass afterwards.
