### PR TITLE
Add /.servo .gitignore to ignore the local compiler binary cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /components/script/dom/bindings/codegen/Bindings
 /components/script/dom/bindings/codegen/test/*.rs
 /.servobuild
+/.servo
 /tests/wpt/_virtualenv
 *~
 *#


### PR DESCRIPTION
follow up #4755
