### PR TITLE
Fix the fedora bzip2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On Fedora:
 sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
-    rpm-build openssl-devel cmake bzip2
+    rpm-build openssl-devel cmake bzip2-devel
 pushd .
 cd /tmp
 wget http://corefonts.sourceforge.net/msttcorefonts-2.5-1.spec


### PR DESCRIPTION
The bzip2 devel package is bzip2-devel, not just bzip2. This fixes
linking on fedora machines:

  note: /usr/bin/ld: cannot find -lbz2
  collect2: error: ld returned 1 exit status

  error: aborting due to previous error
  Could not compile `servo`.

Signed-off-by: Damien Lespiau damien.lespiau@intel.com
