### PR TITLE
Modified constellation key event handler to deal with missing frames

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -358,8 +358,10 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 }
             }
 
-            (Msg::KeyEvent(key, modified), ShutdownState::NotShuttingDown) => {
-                self.window.handle_key(key, modified);
+            (Msg::KeyEvent(key, state, modified), ShutdownState::NotShuttingDown) => {
+                if state == KeyState::Pressed {
+                    self.window.handle_key(key, modified);
+                }
             }
 
             (Msg::SetCursor(cursor), ShutdownState::NotShuttingDown) => {

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -91,9 +91,7 @@ impl ScriptListener for Box<CompositorProxy+'static+Send> {
     }
 
     fn send_key_event(&mut self, key: Key, state: KeyState, modifiers: KeyModifiers) {
-        if state == KeyState::Pressed {
-            self.send(Msg::KeyEvent(key, modifiers));
-        }
+        self.send(Msg::KeyEvent(key, state, modifiers));
     }
 }
 
@@ -218,7 +216,7 @@ pub enum Msg {
     /// composite should happen. (See the `scrolling` module.)
     ScrollTimeout(u64),
     /// Sends an unconsumed key event back to the compositor.
-    KeyEvent(Key, KeyModifiers),
+    KeyEvent(Key, KeyState, KeyModifiers),
     /// Changes the cursor.
     SetCursor(Cursor),
     /// Informs the compositor that the paint task for the given pipeline has exited.

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -893,7 +893,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                     CompositorEvent::KeyEvent(key, state, mods))).unwrap();
             },
             None => self.compositor_proxy.clone_compositor_proxy()
-                        .send(CompositorMsg::KeyEvent(key, mods))
+                        .send(CompositorMsg::KeyEvent(key, state, mods))
         }
 
     }

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -885,11 +885,17 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
     }
 
     fn handle_key_msg(&self, key: Key, state: KeyState, mods: KeyModifiers) {
-        self.current_frame().as_ref().map(|frame| {
-            let ScriptControlChan(ref chan) = frame.pipeline.borrow().script_chan;
-            chan.send(ConstellationControlMsg::SendEvent(
-                frame.pipeline.borrow().id, CompositorEvent::KeyEvent(key, state, mods))).unwrap();
-        });
+        match *self.current_frame() {
+            Some(ref frame) => {
+                let ScriptControlChan(ref chan) = frame.pipeline.borrow().script_chan;
+                chan.send(ConstellationControlMsg::SendEvent(
+                    frame.pipeline.borrow().id,
+                    CompositorEvent::KeyEvent(key, state, mods))).unwrap();
+            },
+            None => self.compositor_proxy.clone_compositor_proxy()
+                        .send(CompositorMsg::KeyEvent(key, mods))
+        }
+
     }
 
     fn handle_get_pipeline_title_msg(&mut self, pipeline_id: PipelineId) {


### PR DESCRIPTION
Fixes #4795. Code has been written to check for the existence for the current frame, but it seems to pass the condition every time.
