### PR TITLE
Using Color equality operators to streamline code

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -730,8 +730,7 @@ impl<'a> PaintContext<'a> {
 
         let mut lighter_color;
         let mut darker_color = color::black();;
-        // TODO(Savago): Use equality operators when we sync with rust-azure.
-        if color.r != darker_color.r || color.g != darker_color.g || color.b != darker_color.b {
+        if color != darker_color {
             darker_color = self.scale_color(color, if is_groove { 1.0/3.0 } else { 2.0/3.0 });
             lighter_color = color;
         } else {
@@ -775,8 +774,7 @@ impl<'a> PaintContext<'a> {
 
         // You can't scale black color (i.e. 'scaled = 0 * scale', equals black).
         let mut scaled_color = color::black();
-        // TODO(Savago): Use equality operators when we sync with rust-azure.
-        if color.r != scaled_color.r || color.g != scaled_color.g || color.b != scaled_color.b {
+        if color != scaled_color {
             scaled_color = match direction {
                 Direction::Top | Direction::Left => {
                     self.scale_color(color, if is_inset { 2.0/3.0 } else { 1.0     })

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -678,10 +678,7 @@ impl LayoutTask {
                     };
 
                     let black = color::black();
-                    // TODO: Use equality operators when we sync with rust-azure.
-                    if element_bg_color.r != black.r || element_bg_color.g != black.g ||
-                       element_bg_color.b != black.b || element_bg_color.a != black.a {
-
+                    if element_bg_color != black {
                         color = element_bg_color;
                         break;
                     }


### PR DESCRIPTION
Using Color equality operators to streamline code in PaintContext and LayoutTask.
