### PR TITLE
Add [no_link] attribute to plugins crate

### DIFF
--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -9,7 +9,7 @@
 
 #[macro_use]
 extern crate log;
-#[plugin]
+#[plugin] #[no_link]
 extern crate "plugins" as servo_plugins;
 
 extern crate servo;


### PR DESCRIPTION
Fixes errors linking to our CEF embedding library. r? @glennw
