### PR TITLE
Fixing border tests regression

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -729,7 +729,8 @@ impl<'a> PaintContext<'a> {
         };
 
         let mut lighter_color;
-        let mut darker_color = color::black();;
+        let mut darker_color = color::black();
+        darker_color.a = 1.0;
         if color != darker_color {
             darker_color = self.scale_color(color, if is_groove { 1.0/3.0 } else { 2.0/3.0 });
             lighter_color = color;
@@ -774,6 +775,7 @@ impl<'a> PaintContext<'a> {
 
         // You can't scale black color (i.e. 'scaled = 0 * scale', equals black).
         let mut scaled_color = color::black();
+        scaled_color.a = 1.0;
         if color != scaled_color {
             scaled_color = match direction {
                 Direction::Top | Direction::Left => {


### PR DESCRIPTION
Before the equality operator, we never tested for the alpha channel, thus this change in behavior triggered the failure for some border tests.

This patch will force the Color object to be opaque by setting the alpha channel to 1.0. We may consider to implement next in rust-azure Color::black(bool opaque) or something like it.
