### PR TITLE
Revert "Using Color equality operators to streamline code"

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -730,7 +730,8 @@ impl<'a> PaintContext<'a> {
 
         let mut lighter_color;
         let mut darker_color = color::black();;
-        if color != darker_color {
+        // TODO(Savago): Use equality operators when we sync with rust-azure.
+        if color.r != darker_color.r || color.g != darker_color.g || color.b != darker_color.b {
             darker_color = self.scale_color(color, if is_groove { 1.0/3.0 } else { 2.0/3.0 });
             lighter_color = color;
         } else {
@@ -774,7 +775,8 @@ impl<'a> PaintContext<'a> {
 
         // You can't scale black color (i.e. 'scaled = 0 * scale', equals black).
         let mut scaled_color = color::black();
-        if color != scaled_color {
+        // TODO(Savago): Use equality operators when we sync with rust-azure.
+        if color.r != scaled_color.r || color.g != scaled_color.g || color.b != scaled_color.b {
             scaled_color = match direction {
                 Direction::Top | Direction::Left => {
                     self.scale_color(color, if is_inset { 2.0/3.0 } else { 1.0     })

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -678,7 +678,10 @@ impl LayoutTask {
                     };
 
                     let black = color::black();
-                    if element_bg_color != black {
+                    // TODO: Use equality operators when we sync with rust-azure.
+                    if element_bg_color.r != black.r || element_bg_color.g != black.g ||
+                       element_bg_color.b != black.b || element_bg_color.a != black.a {
+
                         color = element_bg_color;
                         break;
                     }


### PR DESCRIPTION
Reverts servo/servo#4825

I merged this incorrectly via the big green button and busted the tree pretty badly. @Adenilson has committed to fixing the issue in rust-azure and then relanding this in a fixed state.
