### PR TITLE
Implementing transparent_black()

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -508,7 +508,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             epoch: Epoch(0),
             id: LayerId::null(),
             rect: Rect::zero(),
-            background_color: color::black(),
+            background_color: color::transparent_black(),
             scroll_policy: ScrollPolicy::Scrollable,
         };
 

--- a/components/gfx/color.rs
+++ b/components/gfx/color.rs
@@ -24,6 +24,11 @@ pub fn rgba(r: AzFloat, g: AzFloat, b: AzFloat, a: AzFloat) -> AzColor {
 
 #[inline]
 pub fn black() -> AzColor {
+    AzColor { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
+}
+
+#[inline]
+pub fn transparent_black() -> AzColor {
     AzColor { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }
 }
 

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -729,9 +729,8 @@ impl<'a> PaintContext<'a> {
         };
 
         let mut lighter_color;
-        let mut darker_color = color::black();;
-        // TODO(Savago): Use equality operators when we sync with rust-azure.
-        if color.r != darker_color.r || color.g != darker_color.g || color.b != darker_color.b {
+        let mut darker_color = color::black();
+        if color != darker_color {
             darker_color = self.scale_color(color, if is_groove { 1.0/3.0 } else { 2.0/3.0 });
             lighter_color = color;
         } else {
@@ -775,8 +774,7 @@ impl<'a> PaintContext<'a> {
 
         // You can't scale black color (i.e. 'scaled = 0 * scale', equals black).
         let mut scaled_color = color::black();
-        // TODO(Savago): Use equality operators when we sync with rust-azure.
-        if color.r != scaled_color.r || color.g != scaled_color.g || color.b != scaled_color.b {
+        if color != scaled_color {
             scaled_color = match direction {
                 Direction::Top | Direction::Left => {
                     self.scale_color(color, if is_inset { 2.0/3.0 } else { 1.0     })

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -154,7 +154,7 @@ impl<'a> PaintContext<'a> {
     }
 
     pub fn clear(&self) {
-        let pattern = ColorPattern::new(color::black());
+        let pattern = ColorPattern::new(color::transparent_black());
         let rect = Rect(Point2D(self.page_rect.origin.x as AzFloat,
                                 self.page_rect.origin.y as AzFloat),
                         Size2D(self.screen_rect.size.width as AzFloat,

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -678,9 +678,7 @@ impl LayoutTask {
                     };
 
                     let black = color::transparent_black();
-                    // TODO: Use equality operators when we sync with rust-azure.
-                    if element_bg_color.r != black.r || element_bg_color.g != black.g ||
-                       element_bg_color.b != black.b || element_bg_color.a != black.a {
+                    if element_bg_color != black {
 
                         color = element_bg_color;
                         break;

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -677,7 +677,7 @@ impl LayoutTask {
                                          .to_gfx_color()
                     };
 
-                    let black = color::black();
+                    let black = color::transparent_black();
                     // TODO: Use equality operators when we sync with rust-azure.
                     if element_bg_color.r != black.r || element_bg_color.g != black.g ||
                        element_bg_color.b != black.b || element_bg_color.a != black.a {


### PR DESCRIPTION
This patch set will implement a new helper function for transparent black, while changing the behavior of helper black() function returning opaque black by default.

It will also use the new Color equality operator to streamline the code in some points.
