### PR TITLE
Gonk upgrade

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -30,7 +30,7 @@ path = "../../tests/contenttest.rs"
 harness = false
 
 [features]
-default = ["window"]
+default = ["glutin_app", "window"]
 window = ["glutin_app/window"]
 headless = ["glutin_app/headless"]
 
@@ -60,6 +60,7 @@ path = "../devtools"
 
 [dependencies.glutin_app]
 path = "../../ports/glutin"
+optional = true
 
 [dependencies.android_glue]
 path = "../../support/android-rs-glue/glue"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -3,9 +3,11 @@ name = "b2s"
 version = "0.0.1"
 dependencies = [
  "compositing 0.0.1",
+ "devtools 0.0.1",
  "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "layout 0.0.1",
  "msg 0.0.1",
  "script 0.0.1",
  "servo 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -13,6 +13,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_glue"
+version = "0.0.1"
+source = "git+https://github.com/tomaka/android-rs-glue#ebea1a239b15fb83caf9c9749d3421650522dc99"
+dependencies = [
+ "compile_msg 0.1.3 (git+https://github.com/huonw/compile_msg)",
+]
+
+[[package]]
 name = "azure"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-azure#779233af589e797f07e9e2f3f45017fb55c33c68"
@@ -28,11 +36,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "canvas"
 version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
+ "gfx 0.0.1",
  "util 0.0.1",
 ]
 
@@ -45,13 +59,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.1.1"
+source = "git+https://github.com/servo/rust-cocoa#7f976d95666fec0fd1382e305d534a5e73586a3d"
+dependencies = [
+ "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "compile_msg"
+version = "0.1.3"
+source = "git+https://github.com/huonw/compile_msg#b19da50cacf5b11bbc065da6b449f6b4fe7c019a"
+
+[[package]]
 name = "compositing"
 version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
  "core_text 0.1.0 (git+https://github.com/servo/rust-core-text)",
- "devtools 0.0.1",
  "devtools_traits 0.0.1",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx 0.0.1",
@@ -70,7 +96,7 @@ dependencies = [
 [[package]]
 name = "cookie"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/servo/cookie-rs?branch=lenientparse_backport#47ffa4d3c6f85d28f222d6e1d54635fff5622ea3"
 dependencies = [
  "openssl 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -116,6 +142,7 @@ version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
  "msg 0.0.1",
+ "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -232,6 +259,14 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gdi32-sys"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "geom"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-geom#a4a4a03aa024412bf3f4e093c0198b433c6ad63f"
@@ -268,6 +303,19 @@ version = "0.0.3"
 source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d54863d0"
 
 [[package]]
+name = "gl_common"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gl_common"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.0.12"
 source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d54863d0"
@@ -279,12 +327,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gleam"
 version = "0.0.1"
 source = "git+https://github.com/servo/gleam#375779e0e8e1eaa8ff1a732c81fa91808a7f6c63"
 dependencies = [
  "gl_common 0.0.3 (git+https://github.com/bjz/gl-rs.git)",
  "gl_generator 0.0.12 (git+https://github.com/bjz/gl-rs.git)",
+]
+
+[[package]]
+name = "glutin"
+version = "0.0.4-pre"
+source = "git+https://github.com/servo/glutin?branch=servo#7d602af694bdb400944990846f91d1043e2a2bc8"
+dependencies = [
+ "android_glue 0.0.1 (git+https://github.com/tomaka/android-rs-glue)",
+ "cocoa 0.1.1 (git+https://github.com/servo/rust-cocoa)",
+ "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
+ "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
+ "gdi32-sys 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glutin_app"
+version = "0.0.1"
+dependencies = [
+ "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",
+ "compositing 0.0.1",
+ "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
+ "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
+ "gleam 0.0.1 (git+https://github.com/servo/gleam)",
+ "glutin 0.0.4-pre (git+https://github.com/servo/glutin?branch=servo)",
+ "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "msg 0.0.1",
+ "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "util 0.0.1",
 ]
 
 [[package]]
@@ -322,9 +415,9 @@ source = "git+https://github.com/servo/html5ever#d35dfaaf0d85007057a299afc370d07
 [[package]]
 name = "hyper"
 version = "0.1.1"
-source = "git+https://github.com/servo/hyper?branch=servo#7f48a7e945180a4f762dc75236210d20a69b4a6a"
+source = "git+https://github.com/servo/hyper?branch=old_servo_new_cookies#7a346f481d683705709526594aa5f13b5c923bc1"
 dependencies = [
- "cookie 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.1.8 (git+https://github.com/servo/cookie-rs?branch=lenientparse_backport)",
  "log 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mucell 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,9 +449,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "khronos_api"
 version = "0.0.5"
 source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d54863d0"
+
+[[package]]
+name = "khronos_api"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "layers"
@@ -415,6 +521,11 @@ version = "0.1.6"
 source = "git+https://github.com/Kimundi/lazy-static.rs#31a7aa0176ecd70b4aab274a40d1e2cd78c1fbf8"
 
 [[package]]
+name = "libc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libressl-pnacl-sys"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,7 +571,7 @@ dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
- "hyper 0.1.1 (git+https://github.com/servo/hyper?branch=servo)",
+ "hyper 0.1.1 (git+https://github.com/servo/hyper?branch=old_servo_new_cookies)",
  "io_surface 0.1.0 (git+https://github.com/servo/rust-io-surface)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "style 0.0.1",
@@ -477,8 +588,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "net"
 version = "0.0.1"
 dependencies = [
+ "cookie 0.1.8 (git+https://github.com/servo/cookie-rs?branch=lenientparse_backport)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
- "hyper 0.1.1 (git+https://github.com/servo/hyper?branch=servo)",
+ "hyper 0.1.1 (git+https://github.com/servo/hyper?branch=old_servo_new_cookies)",
  "openssl 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
@@ -497,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libressl-pnacl-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -527,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -574,7 +686,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx 0.0.1",
  "html5ever 0.0.0 (git+https://github.com/servo/html5ever)",
- "hyper 0.1.1 (git+https://github.com/servo/hyper?branch=servo)",
+ "hyper 0.1.1 (git+https://github.com/servo/hyper?branch=old_servo_new_cookies)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -608,6 +720,7 @@ dependencies = [
  "compositing 0.0.1",
  "devtools 0.0.1",
  "gfx 0.0.1",
+ "glutin_app 0.0.1",
  "layout 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
@@ -707,6 +820,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "user32-sys"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "util"
 version = "0.0.1"
 dependencies = [
@@ -729,6 +850,11 @@ source = "git+https://github.com/rust-lang/uuid#3ea51ffa0682c820e8c8b505de078e3b
 dependencies = [
  "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xlib"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -13,14 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_glue"
-version = "0.0.1"
-source = "git+https://github.com/tomaka/android-rs-glue#ebea1a239b15fb83caf9c9749d3421650522dc99"
-dependencies = [
- "compile_msg 0.1.3 (git+https://github.com/huonw/compile_msg)",
-]
-
-[[package]]
 name = "azure"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-azure#779233af589e797f07e9e2f3f45017fb55c33c68"
@@ -34,11 +26,6 @@ dependencies = [
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "xlib 0.1.0 (git+https://github.com/servo/rust-xlib)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "canvas"
@@ -57,19 +44,6 @@ source = "git+https://github.com/servo/rust-cgl#7b7090729f65e2287c3d80651df02e54
 dependencies = [
  "gleam 0.0.1 (git+https://github.com/servo/gleam)",
 ]
-
-[[package]]
-name = "cocoa"
-version = "0.1.1"
-source = "git+https://github.com/servo/rust-cocoa#7f976d95666fec0fd1382e305d534a5e73586a3d"
-dependencies = [
- "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "compile_msg"
-version = "0.1.3"
-source = "git+https://github.com/huonw/compile_msg#b19da50cacf5b11bbc065da6b449f6b4fe7c019a"
 
 [[package]]
 name = "compositing"
@@ -259,14 +233,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "gdi32-sys"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "geom"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-geom#a4a4a03aa024412bf3f4e093c0198b433c6ad63f"
@@ -303,19 +269,6 @@ version = "0.0.3"
 source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d54863d0"
 
 [[package]]
-name = "gl_common"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "gl_common"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gl_generator"
 version = "0.0.12"
 source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d54863d0"
@@ -327,57 +280,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gl_generator"
-version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gl_common 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gleam"
 version = "0.0.1"
 source = "git+https://github.com/servo/gleam#375779e0e8e1eaa8ff1a732c81fa91808a7f6c63"
 dependencies = [
  "gl_common 0.0.3 (git+https://github.com/bjz/gl-rs.git)",
  "gl_generator 0.0.12 (git+https://github.com/bjz/gl-rs.git)",
-]
-
-[[package]]
-name = "glutin"
-version = "0.0.4-pre"
-source = "git+https://github.com/servo/glutin?branch=servo#7d602af694bdb400944990846f91d1043e2a2bc8"
-dependencies = [
- "android_glue 0.0.1 (git+https://github.com/tomaka/android-rs-glue)",
- "cocoa 0.1.1 (git+https://github.com/servo/rust-cocoa)",
- "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
- "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
- "gdi32-sys 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "glutin_app"
-version = "0.0.1"
-dependencies = [
- "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",
- "compositing 0.0.1",
- "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
- "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
- "gleam 0.0.1 (git+https://github.com/servo/gleam)",
- "glutin 0.0.4-pre (git+https://github.com/servo/glutin?branch=servo)",
- "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
- "msg 0.0.1",
- "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "util 0.0.1",
 ]
 
 [[package]]
@@ -449,22 +357,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "khronos_api"
 version = "0.0.5"
 source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d54863d0"
-
-[[package]]
-name = "khronos_api"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "layers"
@@ -519,11 +414,6 @@ dependencies = [
 name = "lazy_static"
 version = "0.1.6"
 source = "git+https://github.com/Kimundi/lazy-static.rs#31a7aa0176ecd70b4aab274a40d1e2cd78c1fbf8"
-
-[[package]]
-name = "libc"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libressl-pnacl-sys"
@@ -720,7 +610,6 @@ dependencies = [
  "compositing 0.0.1",
  "devtools 0.0.1",
  "gfx 0.0.1",
- "glutin_app 0.0.1",
  "layout 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
@@ -820,14 +709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "user32-sys"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "util"
 version = "0.0.1"
 dependencies = [
@@ -850,11 +731,6 @@ source = "git+https://github.com/rust-lang/uuid#3ea51ffa0682c820e8c8b505de078e3b
 dependencies = [
  "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xlib"

--- a/ports/gonk/Cargo.toml
+++ b/ports/gonk/Cargo.toml
@@ -20,6 +20,12 @@ path = "../../components/msg"
 [dependencies.script]
 path = "../../components/script"
 
+[dependencies.layout]
+path = "../../components/layout"
+
+[dependencies.devtools]
+path = "../../components/devtools"
+
 [dependencies.servo]
 path = "../../components/servo"
 default-features = false

--- a/ports/gonk/Cargo.toml
+++ b/ports/gonk/Cargo.toml
@@ -3,7 +3,7 @@ name = "b2s"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 
-build = "make -f makefile.cargo"
+build = "build.rs"
 
 [dependencies.compositing]
 path = "../../components/compositing"

--- a/ports/gonk/build.rs
+++ b/ports/gonk/build.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::io::process::{Command, ProcessExit, StdioContainer};
+use std::os;
+
+
+fn main() {
+    let out_dir = os::getenv("OUT_DIR").unwrap();
+    let result = Command::new("make")
+        .args(&["-f", "makefile.cargo"])
+        .stdout(StdioContainer::InheritFd(1))
+        .stderr(StdioContainer::InheritFd(2))
+        .status()
+        .unwrap();
+    assert_eq!(result, ProcessExit::ExitStatus(0));
+    println!("cargo:rustc-flags=-L native={}", out_dir);
+}

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -15,7 +15,7 @@ use msg::compositor_msg::{ReadyState, PaintState};
 use msg::constellation_msg::{Key, KeyModifiers};
 use msg::constellation_msg::LoadData;
 use std::cell::Cell;
-use std::comm::Receiver;
+use std::sync::mpsc::{channel, Sender, Receiver};
 use std::rc::Rc;
 use std::mem::transmute;
 use std::mem::size_of;
@@ -50,7 +50,7 @@ pub struct native_handle {
     version: c_int,
     numFds: c_int,
     numInts: c_int,
-    data: [c_int, ..0],
+    data: [c_int; 0],
 }
 
 // system/core/include/system/window.h
@@ -59,7 +59,7 @@ pub struct native_handle {
 pub struct ANativeBase {
     magic: u32,
     version: u32,
-    reserved: [int, ..4],
+    reserved: [int; 4],
     incRef: extern fn(*mut ANativeBase),
     decRef: extern fn(*mut ANativeBase),
 }
@@ -72,9 +72,9 @@ pub struct ANativeWindowBuffer {
     stride: c_int,
     format: c_int,
     usage: c_int,
-    reserved: [*mut c_void, ..2],
+    reserved: [*mut c_void; 2],
     handle: *const native_handle,
-    reserved_proc: [*mut c_void, ..8],
+    reserved_proc: [*mut c_void; 8],
 }
 
 #[repr(C)]
@@ -85,7 +85,7 @@ pub struct ANativeWindow {
     maxSwapInterval: c_int,
     xdpi: f32,
     ydpi: f32,
-    oem: [int, ..4],
+    oem: [int; 4],
     setSwapInterval: extern fn(*mut ANativeWindow, c_int) -> c_int,
     //dequeueBuffer_DEPRECATED: extern fn(*mut ANativeWindow, *mut *mut ANativeWindowBuffer) -> c_int,
     //lockBuffer_DEPRECATED: extern fn(*mut ANativeWindow, *mut ANativeWindowBuffer) -> c_int,
@@ -119,7 +119,7 @@ pub struct hw_module {
     author: *const c_char,
     methods: *mut hw_module_methods,
     dso: *mut u32,
-    reserved: [u32, ..(32-7)],
+    reserved: [u32; (32-7)],
 }
 
 #[repr(C)]
@@ -127,7 +127,7 @@ pub struct hw_device {
     tag: u32,
     version: u32,
     module: *mut hw_module,
-    reserved: [u32, ..12],
+    reserved: [u32; 12],
     close: extern fn(*mut hw_device) -> c_int,
 }
 
@@ -183,8 +183,8 @@ pub struct hwc_layer {
     acquireFenceFd: c_int,
     releaseFenceFd: c_int,
     planeAlpha: u8,
-    pad: [u8, ..3],
-    reserved: [i32, ..(24 - 19)],
+    pad: [u8; 3],
+    reserved: [i32; (24 - 19)],
 }
 
 #[repr(C)]
@@ -195,7 +195,7 @@ pub struct hwc_display_contents {
     outbufAcquireFenceFd: c_int,
     flags: u32,
     numHwLayers: size_t,
-    hwLayers: [hwc_layer, ..2],
+    hwLayers: [hwc_layer; 2],
 }
 
 #[repr(C)]
@@ -224,7 +224,7 @@ pub struct hwc_composer_device {
     dump: extern fn(*mut hwc_composer_device, *const c_char, c_int),
     getDisplayConfigs: extern fn(*mut hwc_composer_device, c_int, *mut u32, *mut size_t) -> c_int,
     getDisplayAttributes: extern fn(*mut hwc_composer_device, c_int, u32, *const u32, *mut i32) -> c_int,
-    reserved: [*mut c_void, ..4],
+    reserved: [*mut c_void; 4],
 }
 
 // system/core/include/system/graphics.h
@@ -237,7 +237,7 @@ pub struct android_ycbcr {
     ystride: size_t,
     cstride: size_t,
     chroma_step: size_t,
-    reserved: [u32, ..8],
+    reserved: [u32; 8],
 }
 
 // hardware/libhardware/include/hardware/gralloc.h
@@ -251,7 +251,7 @@ pub struct gralloc_module {
     unlock: extern fn(*const gralloc_module, *const native_handle) -> c_int,
     perform: extern fn(*const gralloc_module, c_int, ...) -> c_int,
     lock_ycbcr: extern fn(*const gralloc_module, *const native_handle, c_int, c_int, c_int, c_int, c_int, *mut android_ycbcr) -> c_int,
-    reserved: [*mut c_void, ..6],
+    reserved: [*mut c_void; 6],
 }
 
 #[repr(C)]
@@ -261,7 +261,7 @@ pub struct alloc_device {
     alloc: extern fn(*mut alloc_device, c_int, c_int, c_int, c_int, *mut *const native_handle, *mut c_int) -> c_int,
     free: extern fn(*mut alloc_device, *const native_handle) -> c_int,
     dump: Option<extern fn(*mut alloc_device, *mut c_char, c_int)>,
-    reserved: [*mut c_void, ..7],
+    reserved: [*mut c_void; 7],
 }
 
 #[repr(C)]
@@ -282,13 +282,13 @@ pub struct GonkNativeWindow {
     usage: c_int,
     last_fence: c_int,
     last_idx: i32,
-    bufs: [Option<*mut GonkNativeWindowBuffer>, ..2],
-    fences: [c_int, ..2],
+    bufs: [Option<*mut GonkNativeWindowBuffer>; 2],
+    fences: [c_int; 2],
 }
 
 impl ANativeBase {
     fn magic(a: char, b: char, c: char, d: char) -> u32 {
-        a as u32 << 24 | b as u32 << 16 | c as u32 << 8 | d as u32
+        (a as u32) << 24 | (b as u32) << 16 | (c as u32) << 8 | d as u32
     }
 }
 
@@ -452,7 +452,7 @@ extern fn gnw_decRef(base: *mut ANativeBase) {
 
 impl GonkNativeWindow {
     pub fn new(alloc_dev: *mut alloc_device, hwc_dev: *mut hwc_composer_device, width: i32, height: i32, usage: c_int) -> *mut GonkNativeWindow {
-        let mut win = box GonkNativeWindow {
+        let mut win = Box::new(GonkNativeWindow {
             window: ANativeWindow {
                 common: ANativeBase {
                     magic: ANativeBase::magic('_', 'w', 'n', 'd'),
@@ -495,7 +495,7 @@ impl GonkNativeWindow {
             last_idx: -1,
             bufs: unsafe { zeroed() },
             fences: [-1, -1],
-        };
+        });
 
         unsafe { transmute(win) }
     }
@@ -557,7 +557,7 @@ impl GonkNativeWindow {
             ],
         };
         unsafe {
-            let mut displays: [*mut hwc_display_contents, ..3] = [ &mut list, ptr::null_mut(), ptr::null_mut(), ];
+            let mut displays: [*mut hwc_display_contents; 3] = [ &mut list, ptr::null_mut(), ptr::null_mut(), ];
             let _ = ((*self.hwc_dev).prepare)(self.hwc_dev, displays.len() as size_t, transmute(displays.as_mut_ptr()));
             let _ = ((*self.hwc_dev).set)(self.hwc_dev, displays.len() as size_t, transmute(displays.as_mut_ptr()));
             if list.retireFenceFd >= 0 {
@@ -583,7 +583,7 @@ extern fn gnwb_decRef(base: *mut ANativeBase) {
 
 impl GonkNativeWindowBuffer {
     pub fn new(dev: *mut alloc_device, width: i32, height: i32, format: c_int, usage: c_int) -> *mut GonkNativeWindowBuffer {
-        let mut buf = box GonkNativeWindowBuffer {
+        let mut buf = Box::new(GonkNativeWindowBuffer {
             buffer: ANativeWindowBuffer {
                 common: ANativeBase {
                     magic: ANativeBase::magic('_', 'b', 'f', 'r'),
@@ -602,7 +602,7 @@ impl GonkNativeWindowBuffer {
                 reserved_proc: unsafe { zeroed() },
             },
             count: 1,
-        };
+        });
 
         let ret = unsafe { ((*dev).alloc)(dev, width, height, format, usage, &mut buf.buffer.handle, &mut buf.buffer.stride) };
         assert!(ret == 0, "Failed to allocate gralloc buffer!");
@@ -646,12 +646,12 @@ impl Window {
             assert!((*hwc_device).common.version > (1 << 8), "HWC too old!");
         }
 
-        let attrs: [u32, ..4] = [
+        let attrs: [u32; 4] = [
             HWC_DISPLAY_WIDTH,
             HWC_DISPLAY_HEIGHT,
             HWC_DISPLAY_DPI_X,
             HWC_DISPLAY_NO_ATTRIBUTE];
-        let mut values: [i32, ..4] = [0, 0, 0, 0];
+        let mut values: [i32; 4] = [0, 0, 0, 0];
         unsafe {
             // In theory, we should check the return code.
             // However, there are HALs which implement this wrong.
@@ -818,11 +818,11 @@ impl WindowMethods for Window {
     fn create_compositor_channel(window: &Option<Rc<Window>>)
                                  -> (Box<CompositorProxy+Send>, Box<CompositorReceiver>) {
         let (sender, receiver) = channel();
-        (box GonkCompositorProxy {
+        (Box::new(GonkCompositorProxy {
              sender: sender,
              event_sender: window.as_ref().unwrap().event_send.clone(),
-         } as Box<CompositorProxy+Send>,
-         box receiver as Box<CompositorReceiver>)
+         }) as Box<CompositorProxy+Send>,
+         Box::new(receiver) as Box<CompositorReceiver>)
     }
 
     fn set_cursor(&self, _: Cursor) {
@@ -845,10 +845,10 @@ impl CompositorProxy for GonkCompositorProxy {
         self.event_sender.send(WindowEvent::Idle);
     }
     fn clone_compositor_proxy(&self) -> Box<CompositorProxy+Send> {
-        box GonkCompositorProxy {
+        Box::new(GonkCompositorProxy {
             sender: self.sender.clone(),
             event_sender: self.event_sender.clone(),
-        } as Box<CompositorProxy+Send>
+        }) as Box<CompositorProxy+Send>
     }
 }
 

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -763,7 +763,7 @@ impl Window {
     }
 
     pub fn wait_events(&self) -> WindowEvent {
-        self.event_recv.recv()
+        self.event_recv.recv().unwrap()
     }
 }
 


### PR DESCRIPTION
This does a rustup to our current rustc. 
<s> Gonk now compiles, but doesn't run. Trying to fix this, but thought I'd PR my progress. </s>

It runs now!

This needs a couple of things to work:
- An override of time  (https://github.com/rust-lang/time/commit/7f105d4dd2bde23d4b8516dc02566cfc46b60b22), with `timegm(struct tm *tm)`  from `src/time_helpers.c` commented out
- An override of openssl (https://github.com/sfackler/rust-openssl/commit/1a60bccb6a863e9287288439e104a16cdc8c9a68), with [this patch](http://hastebin.com/onovacofuj.diff)
- An override of gl-rs (https://github.com/bjz/gl-rs/commit/230e6c9ed611cddfcb6682dee9686471d54863d0), with submodules updated. This is because the lockfile is messed up due to conflicting github and registry deps. While I could fix this by forking things, this goes away next rustup anyway (the deps all move to a common source), so I just worked around it with a clone.
- An override of `gleam` on current master (https://github.com/servo/gleam/commit/6adb2a7f690987c487a1181c490d6c3dbc056a78)
- An override of `rust-layers` at https://github.com/servo/rust-layers/commit/253fd0eb7e49b356393e14abdf34c76152cba10f  with https://github.com/servo/rust-layers/commit/3c69a091b219a3b363ce4ace58aee790eb858db1 cherry-picked on top of it
- Env vars similar to [this](http://hastebin.com/hawadubolu.bash)
- After the last failed link step, run `../../mach rustc` with the same args (extracted from `../../mach cargo -v`), along with `-C link-args="$LDFLAGS -lGLESv2 -L $GONKDIR/backup-flame/system/lib/"`
- (Steps for creating a B2G build [here](https://www.irccloud.com/pastebin/VG2lHBVP))

r? @larsbergstrom

(No need for a merge, just a check on the unsafe stuff would be fine)
