### PR TITLE
This is the companion patch to rust-azure, removing the second

### DIFF
--- a/components/gfx/color.rs
+++ b/components/gfx/color.rs
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use azure::AzFloat;
-use azure::azure_hl::Color as AzColor;
+use azure::azure::AzColor;
 
-pub type Color = AzColor;
+#[inline]
+pub fn new(r: AzFloat, g: AzFloat, b: AzFloat, a: AzFloat) -> AzColor {
+         AzColor { r: r, g: g, b: b, a: a }
+    }
 
 #[inline]
 pub fn rgb(r: u8, g: u8, b: u8) -> AzColor {

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -16,7 +16,6 @@
 
 #![deny(unsafe_blocks)]
 
-use color::Color;
 use display_list::optimizer::DisplayListOptimizer;
 use paint_context::{PaintContext, ToAzureRect};
 use self::DisplayItem::*;
@@ -25,6 +24,8 @@ use text::glyph::CharIndex;
 use text::TextRun;
 
 use azure::azure::AzFloat;
+use azure::azure_hl::{Color};
+
 use collections::dlist::{self, DList};
 use geom::{Point2D, Rect, SideOffsets2D, Size2D, Matrix2D};
 use geom::num::Zero;

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -687,7 +687,10 @@ impl<'a> PaintContext<'a> {
     }
 
     fn scale_color(&self, color: Color, scale_factor: f32) -> Color {
-        return Color::new(color.r * scale_factor, color.g * scale_factor, color.b * scale_factor, color.a);
+        return color::new(color.r * scale_factor,
+                          color.g * scale_factor,
+                          color.b * scale_factor,
+                          color.a);
     }
 
     fn draw_double_border_segment(&self,
@@ -735,8 +738,8 @@ impl<'a> PaintContext<'a> {
             lighter_color = color;
         } else {
             // You can't scale black color (i.e. 'scaled = 0 * scale', equals black).
-            darker_color = Color::new(0.3, 0.3, 0.3, color.a);
-            lighter_color = Color::new(0.7, 0.7, 0.7, color.a);
+            darker_color = color::new(0.3, 0.3, 0.3, color.a);
+            lighter_color = color::new(0.7, 0.7, 0.7, color.a);
         }
 
         let (outer_color, inner_color) = match (direction, is_groove) {
@@ -787,16 +790,16 @@ impl<'a> PaintContext<'a> {
             scaled_color = match direction {
                 Direction::Top | Direction::Left => {
                     if is_inset {
-                        Color::new(0.3, 0.3, 0.3, color.a)
+                        color::new(0.3, 0.3, 0.3, color.a)
                     } else {
-                        Color::new(0.7, 0.7, 0.7, color.a)
+                        color::new(0.7, 0.7, 0.7, color.a)
                     }
                 }
                 Direction::Right | Direction::Bottom => {
                     if is_inset {
-                        Color::new(0.7, 0.7, 0.7, color.a)
+                        color::new(0.7, 0.7, 0.7, color.a)
                     } else {
-                        Color::new(0.3, 0.3, 0.3, color.a)
+                        color::new(0.3, 0.3, 0.3, color.a)
                     }
                 }
             };

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -12,6 +12,7 @@
 #[macro_use]
 extern crate log;
 
+extern crate azure;
 extern crate cssparser;
 extern crate canvas;
 extern crate geom;

--- a/components/layout/util.rs
+++ b/components/layout/util.rs
@@ -9,6 +9,7 @@ use incremental::RestyleDamage;
 use parallel::DomParallelInfo;
 use wrapper::{LayoutNode, TLayoutNode, ThreadSafeLayoutNode};
 
+use azure::azure_hl::{Color};
 use gfx::display_list::OpaqueNode;
 use gfx;
 use libc::{c_void, uintptr_t};
@@ -169,11 +170,11 @@ impl OpaqueNodeMethods for OpaqueNode {
 /// Allows a CSS color to be converted into a graphics color.
 pub trait ToGfxColor {
     /// Converts a CSS color to a graphics color.
-    fn to_gfx_color(&self) -> gfx::color::Color;
+    fn to_gfx_color(&self) -> Color;
 }
 
 impl ToGfxColor for style::values::RGBA {
-    fn to_gfx_color(&self) -> gfx::color::Color {
+    fn to_gfx_color(&self) -> Color {
         gfx::color::rgba(self.red, self.green, self.blue, self.alpha)
     }
 }


### PR DESCRIPTION
This is the companion patch to rust-azure, removing the second color type use.

I also noticed that rust-layers has YACT (Yet Another Color Type), maybe it is time to have a libcolor of some type to be shared by everyone (servo, rust-azure, rust-layers and maybe the css parser).
