### PR TITLE
Send back unused buffers to the right pipeline

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -21,7 +21,7 @@ use gfx::color;
 use gfx::paint_task::Msg as PaintMsg;
 use gfx::paint_task::PaintRequest;
 use layers::geometry::{DevicePixel, LayerPixel};
-use layers::layers::{BufferRequest, Layer, LayerBufferSet};
+use layers::layers::{BufferRequest, Layer, LayerBuffer, LayerBufferSet};
 use layers::rendergl;
 use layers::rendergl::RenderContext;
 use layers::scene::Scene;
@@ -1036,16 +1036,12 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         return results;
     }
 
-    fn send_back_unused_buffers(&mut self) {
-        match self.root_pipeline {
-            Some(ref pipeline) => {
-                let unused_buffers = self.scene.collect_unused_buffers();
-                if unused_buffers.len() != 0 {
-                    let message = PaintMsg::UnusedBuffer(unused_buffers);
-                    let _ = pipeline.paint_chan.send(message);
-                }
-            },
-            None => {}
+    fn send_back_unused_buffers(&mut self,
+                                unused_buffers: Vec<(Rc<Layer<CompositorData>>,
+                                                     Vec<Box<LayerBuffer>>)>) {
+        for (layer, buffers) in unused_buffers.into_iter() {
+            let pipeline = self.get_pipeline(layer.get_pipeline_id());
+            let _ = pipeline.paint_chan.send_opt(PaintMsg::UnusedBuffer(buffers));
         }
     }
 
@@ -1073,11 +1069,11 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     /// Returns true if any buffer requests were sent or false otherwise.
     fn send_buffer_requests_for_all_layers(&mut self) -> bool {
         let mut layers_and_requests = Vec::new();
-        self.scene.get_buffer_requests(&mut layers_and_requests,
-                                       Rect(TypedPoint2D(0f32, 0f32), self.window_size.as_f32()));
+        let mut unused_buffers = Vec::new();
+        self.scene.get_buffer_requests(&mut layers_and_requests, &mut unused_buffers);
 
         // Return unused tiles first, so that they can be reused by any new BufferRequests.
-        self.send_back_unused_buffers();
+        self.send_back_unused_buffers(unused_buffers);
 
         if layers_and_requests.len() == 0 {
             return false;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -446,7 +446,7 @@ source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#253fd0eb7e49b356393e14abdf34c76152cba10f"
+source = "git+https://github.com/servo/rust-layers#8eec5bd428b57391329dbdb3656241a065b261d9"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -52,6 +52,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
+ "gfx 0.0.1",
  "util 0.0.1",
 ]
 
@@ -80,7 +81,6 @@ dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
  "core_text 0.1.0 (git+https://github.com/servo/rust-core-text)",
- "devtools 0.0.1",
  "devtools_traits 0.0.1",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx 0.0.1",
@@ -145,6 +145,7 @@ version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
  "msg 0.0.1",
+ "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -444,7 +445,7 @@ source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#253fd0eb7e49b356393e14abdf34c76152cba10f"
+source = "git+https://github.com/servo/rust-layers#8eec5bd428b57391329dbdb3656241a065b261d9"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -366,7 +366,7 @@ source = "git+https://github.com/bjz/gl-rs.git#230e6c9ed611cddfcb6682dee9686471d
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#253fd0eb7e49b356393e14abdf34c76152cba10f"
+source = "git+https://github.com/servo/rust-layers#8eec5bd428b57391329dbdb3656241a065b261d9"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",


### PR DESCRIPTION
Update to latest rust-layers and send back all buffers to their
original pipeline.
