### PR TITLE
Make gonk compile again (not)

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -51,4 +51,4 @@ git = "https://github.com/servo/gleam"
 
 [dependencies]
 url = "0.2.16"
-time = "0.1.12"
+time = "0.1.17"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -25,7 +25,7 @@ git = "https://github.com/servo/rust-stb-image"
 
 [dependencies]
 url = "0.2.16"
-time = "0.1.12"
+time = "0.1.17"
 openssl="0.3.1"
 rustc-serialize = "0.2"
 cookie="*"

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "net 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "script 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -103,7 +103,7 @@ dependencies = [
  "net 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "script_traits 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -115,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -158,7 +158,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "msg 0.0.1",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -315,7 +315,7 @@ dependencies = [
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "style 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -382,7 +382,7 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -412,7 +412,7 @@ dependencies = [
  "phf_macros 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ dependencies = [
  "mucell 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsafe-any 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -602,7 +602,7 @@ dependencies = [
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -711,7 +711,7 @@ dependencies = [
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
  "style 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "uuid 0.1.9 (git+https://github.com/rust-lang/uuid)",
@@ -793,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -843,7 +843,7 @@ dependencies = [
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
  "task_info 0.0.1",
  "text_writer 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
  "net 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "script_traits 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -118,7 +118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -161,7 +161,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "msg 0.0.1",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -318,7 +318,7 @@ dependencies = [
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "style 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -385,7 +385,7 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -415,7 +415,7 @@ dependencies = [
  "phf_macros 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ dependencies = [
  "mucell 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsafe-any 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -610,7 +610,7 @@ dependencies = [
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -719,7 +719,7 @@ dependencies = [
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
  "style 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "uuid 0.1.9 (git+https://github.com/rust-lang/uuid)",
@@ -751,7 +751,7 @@ dependencies = [
  "net 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "script 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -820,7 +820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,7 +870,7 @@ dependencies = [
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
  "task_info 0.0.1",
  "text_writer 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ports/gonk/.cargo/config
+++ b/ports/gonk/.cargo/config
@@ -1,3 +1,6 @@
 [target.arm-linux-androideabi]
 ar = "arm-linux-androideabi-ar"
 linker = "arm-linux-androideabi-g++"
+
+[target.arm-linux-androideabi.openssl]
+rustc-flags = "-l crypto -l ssl"

--- a/ports/gonk/.cargo/config
+++ b/ports/gonk/.cargo/config
@@ -1,6 +1,6 @@
 [target.arm-linux-androideabi]
 ar = "arm-linux-androideabi-ar"
-linker = "arm-linux-androideabi-g++"
+linker = "./fake-ld.sh"
 
 [target.arm-linux-androideabi.openssl]
 rustc-flags = "-l crypto -l ssl"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -6,12 +6,17 @@ dependencies = [
  "devtools 0.0.1",
  "egl 0.1.0 (git+https://github.com/servo/rust-egl)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
+ "gfx 0.0.1",
+ "gleam 0.0.1 (git+https://github.com/servo/gleam)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
+ "net 0.0.1",
  "script 0.0.1",
  "servo 0.0.1",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -71,7 +76,7 @@ dependencies = [
  "net 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "script_traits 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -83,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -126,7 +131,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "msg 0.0.1",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 
@@ -275,7 +280,7 @@ dependencies = [
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "style 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -335,7 +340,7 @@ dependencies = [
  "phf_macros 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -354,7 +359,7 @@ dependencies = [
  "mucell 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsafe-any 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -517,7 +522,7 @@ dependencies = [
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -626,7 +631,7 @@ dependencies = [
  "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
  "style 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "uuid 0.1.9 (git+https://github.com/rust-lang/uuid)",
@@ -657,7 +662,7 @@ dependencies = [
  "net 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "script 0.0.1",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -726,7 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -768,7 +773,7 @@ dependencies = [
  "string_cache_macros 0.0.0 (git+https://github.com/servo/string-cache)",
  "task_info 0.0.1",
  "text_writer 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ports/gonk/Cargo.toml
+++ b/ports/gonk/Cargo.toml
@@ -20,6 +20,12 @@ path = "../../components/msg"
 [dependencies.script]
 path = "../../components/script"
 
+[dependencies.net]
+path = "../../components/net"
+
+[dependencies.gfx]
+path = "../../components/gfx"
+
 [dependencies.layout]
 path = "../../components/layout"
 
@@ -36,5 +42,10 @@ path = "../../components/util"
 [dependencies.egl]
 git = "https://github.com/servo/rust-egl"
 
+[dependencies.gleam]
+git = "https://github.com/servo/gleam"
+
 [dependencies]
+url = "0.2.16"
+time = "0.1.17"
 libc = "*"

--- a/ports/gonk/README.md
+++ b/ports/gonk/README.md
@@ -1,0 +1,80 @@
+# Instructions for building the Gonk port
+
+## Set up an android toolchain and NDK
+
+Follow the steps [here](https://github.com/servo/servo/wiki/Building-for-Android) for setting up the Android NDK
+and toolchain.
+## Build B2G
+
+Note: this will take a long time and will take around 20GB of space
+
+```
+git clone https://github.com/mozilla-b2g/B2G
+./config.sh flame-kk
+```
+
+If behind a firewall, put the following in your gitconfig:
+
+```
+[url "https://github"]
+        insteadOf = git://github
+[url "https://git.mozilla.org/external/caf"]
+    insteadOf = git://codeaurora.org
+```
+
+Disable the screen timeout on the device, and connect to wifi
+
+Then run
+
+```
+./build.sh libssl libsuspend libz libGLESv2 toolbox
+```
+
+## Build B2S
+
+Either set the corresponding `b2g` key in `.servobuild` to the path to the B2G clone (along with), or set the `$GONKDIR`
+environment variable.
+
+Do the same for the `ndk` and `toolchain` keys (`$ANDROID_NDK` and `$ANDROID_TOOLCHAIN` respectively)
+
+Run `./mach build-gonk` from the root directory
+
+
+## Copy the files to the Flame
+
+To reduce the size of libmozjs.so (`ports/gonk/target/arm-linux-androideabi/build/mozjs-sys-*/out/libmozjs.so`),
+you can run `strip` on it. Use the one in your toolchain (`$ANDROID_TOOLCHAIN/bin/arm-linux-androideabi-strip libmozjs.so`).
+
+Make sure the device is on, connected to wifi, with high or no screen timeout.
+
+```
+# Switch to a read-write system
+adb remount
+
+# Copy mozjs
+adb push /path/to/stripped/mozjs.so system/lib
+
+# Copy b2s
+adb push ports/gonk/target/arm-linux-androideabi system/bin
+
+# Copy resources
+adb shell mkdir sdcard/servo
+adb push resources sdcard/servo
+```
+
+
+## Run B2S
+
+Make sure you're still connected to wifi
+
+```
+adb shell stop b2g
+adb shell "echo 127 > /sys/class/leds/lcd-backlight/brightness”
+adb shell start b2g
+```
+
+Now run `adb shell`, `cd` to `system/bin`, and run `./b2s <url>`
+
+If the screen keeps alternating between B2G and B2S, run `adb shell stop b2g` (you can restart it later).
+
+

--- a/ports/gonk/fake-ld.sh
+++ b/ports/gonk/fake-ld.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+arm-linux-androideabi-g++ $@ $LDFLAGS -lGLESv2 -lsupc++ -L $GONKDIR/backup-flame/system/lib/ -L$GONKDIR/prebuilts/ndk/9/sources/cxx-stl/gnu-libstdc++/4.6/libs/armeabi/

--- a/ports/gonk/src/input.rs
+++ b/ports/gonk/src/input.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::path::Path;
+use std::old_path::Path;
 use std::mem::size_of;
 use std::mem::transmute;
 use std::mem::zeroed;

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -137,6 +137,42 @@ class MachCommands(CommandBase):
 
         return ret
 
+    @Command('build-gonk',
+             description='Build the Gonk port',
+             category='build')
+    @CommandArgument('--jobs', '-j',
+                     default=None,
+                     help='Number of jobs to run in parallel')
+    @CommandArgument('--verbose', '-v',
+                     action='store_true',
+                     help='Print verbose output')
+    @CommandArgument('--release', '-r',
+                     action='store_true',
+                     help='Build in release mode')
+    def build_gonk(self, jobs=None, verbose=False, release=False):
+        self.ensure_bootstrapped()
+
+        ret = None
+        opts = []
+        if jobs is not None:
+            opts += ["-j", jobs]
+        if verbose:
+            opts += ["-v"]
+        if release:
+            opts += ["--release"]
+
+        opts += ["--target", "arm-linux-androideabi"]
+        env=self.build_env(gonk=True)
+        build_start = time()
+        with cd(path.join("ports", "gonk")):
+            ret = subprocess.call(["cargo", "build"] + opts, env=env)
+        elapsed = time() - build_start
+
+        print("Gonk build completed in %0.2fs" % elapsed)
+
+        return ret
+
+
     @Command('build-tests',
              description='Build the Servo test suites',
              category='build')

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -88,6 +88,10 @@ class CommandBase(object):
         self.config["android"].setdefault("ndk", "")
         self.config["android"].setdefault("toolchain", "")
 
+        self.config.setdefault("gonk", {})
+        self.config["gonk"].setdefault("b2g", "")
+        self.config["gonk"].setdefault("product", "flame")
+
     _rust_snapshot_path = None
     _cargo_build_id = None
 
@@ -104,7 +108,7 @@ class CommandBase(object):
             self._cargo_build_id = open(filename).read().strip()
         return self._cargo_build_id
 
-    def build_env(self):
+    def build_env(self, gonk=False):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
         extra_path = []
@@ -141,6 +145,38 @@ class CommandBase(object):
             env["ANDROID_NDK"] = self.config["android"]["ndk"]
         if self.config["android"]["toolchain"]:
             env["ANDROID_TOOLCHAIN"] = self.config["android"]["toolchain"]
+
+        if gonk:
+            if self.config["gonk"]["b2g"]:
+                env["GONKDIR"] = self.config["gonk"]["b2g"]
+            if "GONKDIR" not in env:
+                # Things can get pretty opaque if this hasn't been set
+                print("Please set $GONKDIR in your environment or servobild file")
+                os.exit(1)
+            if self.config["gonk"]["product"]:
+                env["GONK_PRODUCT"] = self.config["gonk"]["product"]
+
+            env["CC"] = "arm-linux-androideabi-gcc"
+            env["ARCH_DIR"] = "arch-arm"
+            env["CPPFLAGS"] = ("-DANDROID -DTARGET_OS_GONK -DGR_GL_USE_NEW_SHADER_SOURCE_SIGNATURE=1 "
+                               "-isystem %(gonkdir)s/bionic/libc/%(archdir)s/include -isystem %(gonkdir)s/bionic/libc/include/ "
+                               "-isystem %(gonkdir)s/bionic/libc/kernel/common -isystem %(gonkdir)s/bionic/libc/kernel/%(archdir)s "
+                               "-isystem %(gonkdir)s/bionic/libm/include -I%(gonkdir)s/system -I%(gonkdir)s/system/core/include "
+                               "-isystem %(gonkdir)s/bionic -I%(gonkdir)s/frameworks/native/opengl/include -I%(gonkdir)s/external/zlib "
+                               "-I%(gonkdir)s/hardware/libhardware/include/hardware/") % {"gonkdir": env["GONKDIR"], "archdir": env["ARCH_DIR"] }
+            env["CXXFLAGS"] = ("-O2 -mandroid -fPIC  %(cppflags)s -I%(gonkdir)s/ndk/sources/cxx-stl/stlport/stlport "
+                                "-I%(gonkdir)s/ndk/sources/cxx-stl/system/include") % {"gonkdir": env["GONKDIR"], "cppflags": env["CPPFLAGS"] }
+            env["CFLAGS"] = ("-O2 -mandroid -fPIC  %(cppflags)s -I%(gonkdir)s/ndk/sources/cxx-stl/stlport/stlport "
+                             "-I%(gonkdir)s/ndk/sources/cxx-stl/system/include") % {"gonkdir": env["GONKDIR"], "cppflags": env["CPPFLAGS"] }
+
+            another_extra_path = path.join(env["GONKDIR"], "prebuilts", "gcc", "linux-x86", "arm", "arm-linux-androideabi-4.7", "bin")
+            env["PATH"] = "%s%s%s" % (another_extra_path, os.pathsep, env["PATH"])
+            env["LDFLAGS"] = ("-mandroid -L%(gonkdir)s/out/target/product/%(gonkproduct)s/obj/lib "
+                              "-Wl,-rpath-link=%(gonkdir)s/out/target/product/%(gonkproduct)s/obj/lib "
+                              "--sysroot=%(gonkdir)s/out/target/product/%(gonkproduct)s/obj/")  % {"gonkdir": env["GONKDIR"], "gonkproduct": env["GONK_PRODUCT"] }
+            
+            # Not strictly necessary for a vanilla build, but might be when tweaking the openssl build
+            env["OPENSSL_PATH"] = "%(gonkdir)s/out/target/product/%(gonkproduct)s/obj/lib" % {"gonkdir": env["GONKDIR"], "gonkproduct": env["GONK_PRODUCT"] }
 
         # FIXME: These are set because they are the variable names that
         # android-rs-glue expects. However, other submodules have makefiles that

--- a/servobuild.example
+++ b/servobuild.example
@@ -1,3 +1,7 @@
+# Copy this file to .servobuild in the Servo root directory
+# Be sure to set the cache-dir correctly, otherwise extra snapshots
+# may get downloaded
+
 # Tool options
 [tools]
 # Where Rust compiler snapshots and other downloads will be stored.  Can be
@@ -23,3 +27,10 @@ debug-mozjs = false
 sdk = "/opt/android-sdk"
 ndk = "/opt/android-ndk"
 toolchain = "/opt/android-toolchain"
+
+# Gonk information
+# Please fill the ndk/toolchain for android too
+[gonk]
+# Path to B2G repo and build
+b2g = "/opt/B2G"
+product = "flame"


### PR DESCRIPTION
Doesn't actually work (see below), I'm just PRing so that we can figure out why

This also removes the necessity of override submodules. I've used the `.config` to override the openssl build script and link dynamically to libopenssl/libcrypto. Adding `-DTARGET_OS_GONK` to `$CPPFLAGS` will make libtime compile without the duplicate symbol error.
