### PR TITLE
Fix warnings about RefCell<T>.try_borrow()

### DIFF
--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -52,7 +52,7 @@ impl<T> DOMRefCell<T> {
     ///
     /// For safety checks in debug builds only.
     pub fn is_mutably_borrowed(&self) -> bool {
-        self.value.try_borrow().is_some()
+        self.value.borrow_state() == BorrowState::Writing
     }
 
     /// Attempts to immutably borrow the wrapped value.

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -10,7 +10,7 @@ use js::jsapi::{JSTracer};
 use util::task_state;
 use util::task_state::{SCRIPT, IN_GC};
 
-use std::cell::{RefCell, Ref, RefMut};
+use std::cell::{BorrowState, RefCell, Ref, RefMut};
 
 /// A mutable field in the DOM.
 ///
@@ -67,7 +67,10 @@ impl<T> DOMRefCell<T> {
     /// Panics if this is called off the script thread.
     pub fn try_borrow<'a>(&'a self) -> Option<Ref<'a, T>> {
         debug_assert!(task_state::get().is_script());
-        self.value.try_borrow()
+        match self.value.borrow_state() {
+            BorrowState::Writing => None,
+            _ => Some(self.value.borrow()),
+        }
     }
 
     /// Mutably borrows the wrapped value.
@@ -82,7 +85,10 @@ impl<T> DOMRefCell<T> {
     /// Panics if this is called off the script thread.
     pub fn try_borrow_mut<'a>(&'a self) -> Option<RefMut<'a, T>> {
         debug_assert!(task_state::get().is_script());
-        self.value.try_borrow_mut()
+        match self.value.borrow_state() {
+            BorrowState::Unused => Some(self.value.borrow_mut()),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
follow up #4893
