### PR TITLE
Collapsed unnecessarily verbose command combo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
     rpm-build openssl-devel cmake bzip2-devel libXcursor-devel
-pushd .
-cd /tmp
+pushd /tmp
 wget http://corefonts.sourceforge.net/msttcorefonts-2.5-1.spec
 rpmbuild -bb msttcorefonts-2.5-1.spec
 sudo yum install $HOME/rpmbuild/RPMS/noarch/msttcorefonts-2.5-1.noarch.rpm


### PR DESCRIPTION
When a path is passed to the `pushd` command, bash will push your _current_ directory to the top of the stack and then `cd` to whatever location you provided. There is no need to use two separate commands.
