### PR TITLE
Support root element having percentage heights in layout.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1299,8 +1299,16 @@ impl BlockFlow {
 
         // Calculate non-auto block size to pass to children.
         let content_block_size = self.fragment.style().content_block_size();
-        let explicit_content_size = match (content_block_size,
-                                           self.base.block_container_explicit_block_size) {
+
+        let parent_container_size = if self.is_root() {
+            let screen_size = LogicalSize::from_physical(self.fragment.style.writing_mode,
+                                                         layout_context.shared.screen_size);
+            Some(screen_size.block)
+        } else {
+            self.base.block_container_explicit_block_size
+        };
+
+        let explicit_content_size = match (content_block_size, parent_container_size) {
             (LengthOrPercentageOrAuto::Percentage(percent), Some(container_size)) => {
                 Some(container_size.scale_by(percent))
             }
@@ -1688,10 +1696,10 @@ impl Flow for BlockFlow {
             }
         } else if self.is_root() || self.base.flags.is_float() || self.is_inline_block() {
             // Root element margins should never be collapsed according to CSS § 8.3.1.
-            debug!("assign_block_size: assigning block_size for root flow");
+            debug!("assign_block_size: assigning block_size for root flow {:?}", flow::base(self).debug_id());
             self.assign_block_size_block_base(ctx, MarginsMayCollapseFlag::MarginsMayNotCollapse);
         } else {
-            debug!("assign_block_size: assigning block_size for block");
+            debug!("assign_block_size: assigning block_size for block {:?}", flow::base(self).debug_id());
             self.assign_block_size_block_base(ctx, MarginsMayCollapseFlag::MarginsMayCollapse);
         }
     }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -247,3 +247,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == text_justify_none_a.html text_justify_none_ref.html
 == text_overflow_basic_a.html text_overflow_basic_ref.html
 == text_align_complex_a.html text_align_complex_ref.html
+== percentage_height_root.html percentage_height_root_ref.html

--- a/tests/ref/percentage_height_root.html
+++ b/tests/ref/percentage_height_root.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            html, body {
+               margin: 0;
+               padding: 0;
+               height: 100%;
+            }
+            div {
+                height: 100%;
+                background-color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <div></div>
+    </body>
+</html>

--- a/tests/ref/percentage_height_root_ref.html
+++ b/tests/ref/percentage_height_root_ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            div {
+                position: absolute;
+                top: 0;
+                left: 0;
+                bottom: 0;
+                right: 0;
+                background-color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <div></div>
+    </body>
+</html>


### PR DESCRIPTION
This allows using standard CSS techniques to place a footer at the bottom of the page.
