### PR TITLE
Dont draw interior borders for text run fragments

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -195,14 +195,17 @@ impl InlineFragmentsAccumulator {
             mut fragments,
             enclosing_style
         } = self;
+        if let Some(enclosing_style) = enclosing_style {
+            let frag_len = fragments.len();
+            for (idx, frag) in fragments.iter_mut().enumerate() {
 
-        match enclosing_style {
-            Some(enclosing_style) => {
-                for frag in fragments.iter_mut() {
-                    frag.add_inline_context_style(enclosing_style.clone());
-                }
+                // frag is first inline fragment in the inline node
+                let is_first = idx == 0;
+                // frag is the last inline fragment in the inline node
+                let is_last = idx == frag_len - 1;
+
+                frag.add_inline_context_style(enclosing_style.clone(), is_first, is_last);
             }
-            None => {}
         }
         fragments
     }

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -17,6 +17,7 @@ use util::geometry::Au;
 use url::Url;
 use cssparser::{Parser, Color, RGBA, AtRuleParser, DeclarationParser,
                 DeclarationListParser, parse_important, ToCss};
+use geom::num::Zero;
 use geom::SideOffsets2D;
 
 use values::specified::BorderStyle;
@@ -3531,6 +3532,21 @@ pub fn make_inline(style: &ComputedValues) -> ComputedValues {
     let mut style = (*style).clone();
     style.box_.make_unique().display = longhands::display::computed_value::T::inline;
     style.box_.make_unique().position = longhands::position::computed_value::T::static_;
+    style
+}
+
+/// Sets `border_${side}_width` to the passed in values.
+/// If `border_${side}_width` == 0 also sets `border_${side}_style` = none.
+#[inline]
+pub fn make_border(style: &ComputedValues, border_width: LogicalMargin<Au>) -> ComputedValues {
+    let mut style = (*style).clone();
+    let physical_border = LogicalMargin::to_physical(&border_width, style.writing_mode);
+    % for side in ["top", "right", "bottom", "left"]:
+        style.border.make_unique().border_${side}_width = physical_border.${side};
+        if physical_border.${side} == Zero::zero() {
+            style.border.make_unique().border_${side}_style = BorderStyle::none;
+        }
+    % endfor
     style
 }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -31,6 +31,7 @@
 == img_dynamic_remove.html img_dynamic_remove_ref.html
 == upper_id_attr.html upper_id_attr_ref.html
 # inline_border_a.html inline_border_b.html
+== border_code_tag.html border_code_tag_ref.html
 == anon_block_inherit_a.html anon_block_inherit_b.html
 == attr_exists_selector.html attr_exists_selector_ref.html
 == attr_selector_case_sensitivity.html attr_selector_case_sensitivity_ref.html

--- a/tests/ref/border_code_tag.html
+++ b/tests/ref/border_code_tag.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<style>
+code {
+border: 2px solid #ccc;
+}
+</style>
+</head>
+<body>
+<code>Quotes: &quot;&quot;.</code>
+</body>
+</html>

--- a/tests/ref/border_code_tag_ref.html
+++ b/tests/ref/border_code_tag_ref.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<style>
+code {
+border: 2px solid #ccc;
+}
+</style>
+</head>
+<body>
+<code>Quotes: "".</code>
+</body>
+</html>


### PR DESCRIPTION
Inline fragments that are part of a text run don't have interior borders.
So don't draw interior borders or include them when calculating positioning.

Fixes https://github.com/servo/servo/issues/4658, where multiple text nodes that are adjacent have distinct borders.

r? @Ms2ger, @pcwalton 
