### PR TITLE
Remove the libc feature gate from cef.

### DIFF
--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -7,7 +7,6 @@
 #![feature(plugin)]
 #![feature(link_args)]
 #![feature(thread_local)]
-#![feature(libc)]
 #![feature(unicode)]
 #![feature(core)]
 #![feature(std_misc)]


### PR DESCRIPTION
As it depends on the crates.io libc crate, the feature gate doesn't apply.
