### PR TITLE
Rename HTMLIFrameElement.containing_page_pipeline_id

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -740,17 +740,17 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
 
     // The script task associated with pipeline_id has loaded a URL in an iframe via script. This
     // will result in a new pipeline being spawned and a frame tree being added to
-    // containing_page_pipeline_id's frame tree's children. This message is never the result of a
+    // contained_page_pipeline_id's frame tree's children. This message is never the result of a
     // page navigation.
     fn handle_script_loaded_url_in_iframe_msg(&mut self,
                                               url: Url,
-                                              containing_page_pipeline_id: PipelineId,
+                                              contained_page_pipeline_id: PipelineId,
                                               new_subpage_id: SubpageId,
                                               old_subpage_id: Option<SubpageId>,
                                               sandbox: IFrameSandboxState) {
         // Start by finding the frame trees matching the pipeline id,
         // and add the new pipeline to their sub frames.
-        let frame_trees = self.find_all(containing_page_pipeline_id);
+        let frame_trees = self.find_all(contained_page_pipeline_id);
         if frame_trees.is_empty() {
             panic!("Constellation: source pipeline id of ScriptLoadedURLInIFrame is not in
                     navigation context, nor is it in a pending frame. This should be
@@ -759,7 +759,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
 
         // Compare the pipeline's url to the new url. If the origin is the same,
         // then reuse the script task in creating the new pipeline
-        let source_pipeline = self.pipelines.get(&containing_page_pipeline_id).expect("Constellation:
+        let source_pipeline = self.pipelines.get(&contained_page_pipeline_id).expect("Constellation:
             source Id of ScriptLoadedURLInIFrameMsg does have an associated pipeline in
             constellation. This should be impossible.").clone();
 
@@ -781,12 +781,12 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         let new_frame_pipeline_id = self.get_next_pipeline_id();
         let pipeline = self.new_pipeline(
             new_frame_pipeline_id,
-            Some((containing_page_pipeline_id, new_subpage_id)),
+            Some((contained_page_pipeline_id, new_subpage_id)),
             script_pipeline,
             LoadData::new(url)
         );
 
-        let rect = self.pending_sizes.remove(&(containing_page_pipeline_id, new_subpage_id));
+        let rect = self.pending_sizes.remove(&(contained_page_pipeline_id, new_subpage_id));
         for frame_tree in frame_trees.iter() {
             self.create_or_update_child_pipeline(frame_tree.clone(),
                                                  pipeline.clone(),

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -149,7 +149,7 @@ pub trait TLayoutNode {
                     Some(elem) => elem,
                     None => panic!("not an iframe element!")
                 };
-            ((*iframe_element.unsafe_get()).containing_page_pipeline_id().unwrap(),
+            ((*iframe_element.unsafe_get()).contained_page_pipeline_id().unwrap(),
              (*iframe_element.unsafe_get()).subpage_id().unwrap())
         }
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -47,7 +47,7 @@ enum SandboxAllowance {
 pub struct HTMLIFrameElement {
     htmlelement: HTMLElement,
     subpage_id: Cell<Option<SubpageId>>,
-    containing_page_pipeline_id: Cell<Option<PipelineId>>,
+    contained_page_pipeline_id: Cell<Option<PipelineId>>,
     sandbox: Cell<Option<u8>>,
 }
 
@@ -108,7 +108,7 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
         let page = window.page();
         let (new_subpage_id, old_subpage_id) = self.generate_new_subpage_id(page);
 
-        self.containing_page_pipeline_id.set(Some(page.id));
+        self.contained_page_pipeline_id.set(Some(page.id));
 
         let ConstellationChan(ref chan) = page.constellation_chan;
     chan.send(ConstellationMsg::ScriptLoadedURLInIFrame(url,
@@ -124,7 +124,7 @@ impl HTMLIFrameElement {
         HTMLIFrameElement {
             htmlelement: HTMLElement::new_inherited(HTMLElementTypeId::HTMLIFrameElement, localName, prefix, document),
             subpage_id: Cell::new(None),
-            containing_page_pipeline_id: Cell::new(None),
+            contained_page_pipeline_id: Cell::new(None),
             sandbox: Cell::new(None),
         }
     }
@@ -136,8 +136,8 @@ impl HTMLIFrameElement {
     }
 
     #[inline]
-    pub fn containing_page_pipeline_id(&self) -> Option<PipelineId> {
-        self.containing_page_pipeline_id.get()
+    pub fn contained_page_pipeline_id(&self) -> Option<PipelineId> {
+        self.contained_page_pipeline_id.get()
     }
 
     #[inline]


### PR DESCRIPTION
Rename containing_page_pipeline_id to contained_page_pipeline_id.

Fixes #4843.
