### PR TITLE
Add `rust-media` as a dependency of script, in preparation for audio and video tag support

### DIFF
--- a/components/media/Cargo.toml
+++ b/components/media/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "media"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "media"
+path = "lib.rs"
+
+[dependencies.rust-media]
+git = "https://github.com/pcwalton/rust-media"
+

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate "rust-media" as rust_media;
+
+// Just a stub for now.
+

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -39,6 +39,9 @@ path = "../gfx"
 [dependencies.canvas]
 path = "../canvas"
 
+[dependencies.media]
+path = "../media"
+
 [dependencies.cssparser]
 git = "https://github.com/servo/rust-cssparser"
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -127,6 +127,11 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-core-foundation#da9a52655fce4727dcf261d6ed9a49eeddc7b131"
 
 [[package]]
+name = "core_foundation"
+version = "0.1.0"
+source = "git+https://github.com/servo/rust-core-foundation?rev=da9a52655fce4727dcf261d6ed9a49eeddc7b131#da9a52655fce4727dcf261d6ed9a49eeddc7b131"
+
+[[package]]
 name = "core_graphics"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-core-graphics#9434e2bda65d259f825104170b5fa6cc6dbaf5a9"
@@ -325,6 +330,11 @@ dependencies = [
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
+
+[[package]]
+name = "giflib-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/giflib#7cce2d216f68ad2ae773fde15c53e90b6687429b"
 
 [[package]]
 name = "gl_common"
@@ -555,6 +565,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libvpx-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libvpx?branch=servo#90d2750900d72ee20b2f99bdfb33b2c725e585b8"
+
+[[package]]
+name = "libwebm-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libwebm?branch=servo#a3f20c3da760c6c423840a9d8ddad66f9fdfb37a"
+
+[[package]]
 name = "log"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +583,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "matches"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "media"
+version = "0.0.1"
+dependencies = [
+ "rust-media 0.1.0 (git+https://github.com/pcwalton/rust-media)",
+]
 
 [[package]]
 name = "mime"
@@ -581,6 +608,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mozjs-sys"
 version = "0.0.0"
 source = "git+https://github.com/servo/mozjs#056e1d953b95d7a9545d514cf95772a0a1c69bb2"
+
+[[package]]
+name = "mp4v2-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/mp4v2?branch=servo#08458b72a063b5fbd0e7398edd19d17f348a946b"
 
 [[package]]
 name = "msg"
@@ -618,6 +650,11 @@ dependencies = [
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
+
+[[package]]
+name = "ogg-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/ogg?branch=servo#3c1758b277863d198926cc9d59e8c37c9a784bd1"
 
 [[package]]
 name = "openssl"
@@ -697,6 +734,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-media"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/rust-media#8a428094b529de2d5b86b9246934def039dc0f4d"
+dependencies = [
+ "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation?rev=da9a52655fce4727dcf261d6ed9a49eeddc7b131)",
+ "giflib-sys 0.1.0 (git+https://github.com/pcwalton/giflib)",
+ "libvpx-sys 0.1.0 (git+https://github.com/pcwalton/libvpx?branch=servo)",
+ "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
+ "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
+ "vorbis-sys 0.1.0 (git+https://github.com/pcwalton/vorbis?branch=servo)",
+]
+
+[[package]]
 name = "regex"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +772,7 @@ dependencies = [
  "hyper 0.1.10 (git+https://github.com/servo/hyper?branch=servo)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "media 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
  "plugins 0.0.1",
@@ -890,6 +942,14 @@ source = "git+https://github.com/rust-lang/uuid#3128649cde7c4ba390b31298093d6c18
 dependencies = [
  "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vorbis-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/vorbis?branch=servo#82fcb8dc370f29e0c2a2ce22914adc7e60679ed1"
+dependencies = [
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
 ]
 
 [[package]]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -130,6 +130,11 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-core-foundation#da9a52655fce4727dcf261d6ed9a49eeddc7b131"
 
 [[package]]
+name = "core_foundation"
+version = "0.1.0"
+source = "git+https://github.com/servo/rust-core-foundation?rev=da9a52655fce4727dcf261d6ed9a49eeddc7b131#da9a52655fce4727dcf261d6ed9a49eeddc7b131"
+
+[[package]]
 name = "core_graphics"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-core-graphics#9434e2bda65d259f825104170b5fa6cc6dbaf5a9"
@@ -328,6 +333,11 @@ dependencies = [
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
+
+[[package]]
+name = "giflib-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/giflib#7cce2d216f68ad2ae773fde15c53e90b6687429b"
 
 [[package]]
 name = "gl_common"
@@ -563,6 +573,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libvpx-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libvpx?branch=servo#90d2750900d72ee20b2f99bdfb33b2c725e585b8"
+
+[[package]]
+name = "libwebm-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libwebm?branch=servo#a3f20c3da760c6c423840a9d8ddad66f9fdfb37a"
+
+[[package]]
 name = "log"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +591,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "matches"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "media"
+version = "0.0.1"
+dependencies = [
+ "rust-media 0.1.0 (git+https://github.com/pcwalton/rust-media)",
+]
 
 [[package]]
 name = "mime"
@@ -589,6 +616,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mozjs-sys"
 version = "0.0.0"
 source = "git+https://github.com/servo/mozjs#056e1d953b95d7a9545d514cf95772a0a1c69bb2"
+
+[[package]]
+name = "mp4v2-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/mp4v2?branch=servo#08458b72a063b5fbd0e7398edd19d17f348a946b"
 
 [[package]]
 name = "msg"
@@ -626,6 +658,11 @@ dependencies = [
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
+
+[[package]]
+name = "ogg-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/ogg?branch=servo#3c1758b277863d198926cc9d59e8c37c9a784bd1"
 
 [[package]]
 name = "openssl"
@@ -710,6 +747,20 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rust-media"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/rust-media#16a08f08bddee2e258ef4e8b822900c7a4091a6d"
+dependencies = [
+ "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation?rev=da9a52655fce4727dcf261d6ed9a49eeddc7b131)",
+ "giflib-sys 0.1.0 (git+https://github.com/pcwalton/giflib)",
+ "libvpx-sys 0.1.0 (git+https://github.com/pcwalton/libvpx?branch=servo)",
+ "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
+ "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
+ "vorbis-sys 0.1.0 (git+https://github.com/pcwalton/vorbis?branch=servo)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +780,7 @@ dependencies = [
  "hyper 0.1.10 (git+https://github.com/servo/hyper?branch=servo)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "media 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
  "plugins 0.0.1",
@@ -917,6 +969,14 @@ source = "git+https://github.com/rust-lang/uuid#3128649cde7c4ba390b31298093d6c18
 dependencies = [
  "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vorbis-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/vorbis?branch=servo#82fcb8dc370f29e0c2a2ce22914adc7e60679ed1"
+dependencies = [
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
 ]
 
 [[package]]

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -100,6 +100,11 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-core-foundation#da9a52655fce4727dcf261d6ed9a49eeddc7b131"
 
 [[package]]
+name = "core_foundation"
+version = "0.1.0"
+source = "git+https://github.com/servo/rust-core-foundation?rev=da9a52655fce4727dcf261d6ed9a49eeddc7b131#da9a52655fce4727dcf261d6ed9a49eeddc7b131"
+
+[[package]]
 name = "core_graphics"
 version = "0.1.0"
 source = "git+https://github.com/servo/rust-core-graphics#9434e2bda65d259f825104170b5fa6cc6dbaf5a9"
@@ -292,6 +297,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "giflib-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/giflib#7cce2d216f68ad2ae773fde15c53e90b6687429b"
+
+[[package]]
 name = "gl_common"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libvpx-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libvpx?branch=servo#90d2750900d72ee20b2f99bdfb33b2c725e585b8"
+
+[[package]]
+name = "libwebm-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/libwebm?branch=servo#a3f20c3da760c6c423840a9d8ddad66f9fdfb37a"
+
+[[package]]
 name = "log"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +503,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "matches"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "media"
+version = "0.0.1"
+dependencies = [
+ "rust-media 0.1.0 (git+https://github.com/pcwalton/rust-media)",
+]
 
 [[package]]
 name = "mime"
@@ -501,6 +528,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mozjs-sys"
 version = "0.0.0"
 source = "git+https://github.com/servo/mozjs#056e1d953b95d7a9545d514cf95772a0a1c69bb2"
+
+[[package]]
+name = "mp4v2-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/mp4v2?branch=servo#08458b72a063b5fbd0e7398edd19d17f348a946b"
 
 [[package]]
 name = "msg"
@@ -538,6 +570,11 @@ dependencies = [
  "url 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
+
+[[package]]
+name = "ogg-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/ogg?branch=servo#3c1758b277863d198926cc9d59e8c37c9a784bd1"
 
 [[package]]
 name = "openssl"
@@ -622,6 +659,20 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rust-media"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/rust-media#16a08f08bddee2e258ef4e8b822900c7a4091a6d"
+dependencies = [
+ "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation?rev=da9a52655fce4727dcf261d6ed9a49eeddc7b131)",
+ "giflib-sys 0.1.0 (git+https://github.com/pcwalton/giflib)",
+ "libvpx-sys 0.1.0 (git+https://github.com/pcwalton/libvpx?branch=servo)",
+ "libwebm-sys 0.1.0 (git+https://github.com/pcwalton/libwebm?branch=servo)",
+ "mp4v2-sys 0.1.0 (git+https://github.com/pcwalton/mp4v2?branch=servo)",
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
+ "vorbis-sys 0.1.0 (git+https://github.com/pcwalton/vorbis?branch=servo)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +692,7 @@ dependencies = [
  "hyper 0.1.10 (git+https://github.com/servo/hyper?branch=servo)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "media 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
  "plugins 0.0.1",
@@ -820,6 +872,14 @@ source = "git+https://github.com/rust-lang/uuid#3128649cde7c4ba390b31298093d6c18
 dependencies = [
  "rand 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vorbis-sys"
+version = "0.1.0"
+source = "git+https://github.com/pcwalton/vorbis?branch=servo#82fcb8dc370f29e0c2a2ce22914adc7e60679ed1"
+dependencies = [
+ "ogg-sys 0.1.0 (git+https://github.com/pcwalton/ogg?branch=servo)",
 ]
 
 [[package]]


### PR DESCRIPTION
This does not actually use the library; it's just here to prevent
bitrotting.

r? @metajack @glennw 
