### PR TITLE
Actually print the contents of Flow Tree into console.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1133,8 +1133,7 @@ impl<'a> ImmutableFlowUtils for &'a (Flow + 'a) {
             indent.push_str("| ")
         }
 
-        // TODO: ICE, already fixed in rustc.
-        //println!("{}+ {:?}", indent, self);
+        println!("{}+ {:?}", indent, self);
 
         for kid in imm_child_iter(self) {
             kid.dump_with_level(level + 1)


### PR DESCRIPTION
Actually print the contents of Flow Tree into console.

When executing servo with proper flags (i.e. --debug dump-flow-tree), it should print the flow tree. We had the code, but it was commented.
