### PR TITLE
Eagerly report errors when evaluating JS on a global scope. Fixes #4966.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -10,7 +10,7 @@ use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::InheritTypes::EventTargetCast;
 use dom::bindings::global::global_object_for_js_object;
-use dom::bindings::error::Fallible;
+use dom::bindings::error::{report_pending_exception, Fallible};
 use dom::bindings::error::Error::InvalidCharacter;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
@@ -362,6 +362,7 @@ impl<'a, T: Reflectable> ScriptHelpers for JSRef<'a, T> {
                                        code.len() as libc::c_uint,
                                        filename.as_ptr(), 1, &mut rval) == 0 {
                     debug!("error evaluating JS string");
+                    report_pending_exception(cx, global);
                 }
                 rval
             }

--- a/tests/wpt/metadata/html/browsers/windows/browsing-context-names/browsing-context-choose-parent.html.ini
+++ b/tests/wpt/metadata/html/browsers/windows/browsing-context-names/browsing-context-choose-parent.html.ini
@@ -1,3 +1,5 @@
 [browsing-context-choose-parent.html]
   type: testharness
   expected: TIMEOUT
+  [The parent browsing context must be chosen if the given name is '_parent']
+    expected: NOTRUN


### PR DESCRIPTION
I believe this problem was introduced with the mozjs error reporting changes, since we don't see errors reported from `<script>` blocks any more.
