### PR TITLE
Cleanup and add comments to components/servo

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "compositing 0.0.1",
  "devtools 0.0.1",
+ "devtools_traits 0.0.1",
  "gfx 0.0.1",
  "glutin_app 0.0.1",
  "layout 0.0.1",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -58,6 +58,9 @@ path = "../gfx"
 [dependencies.devtools]
 path = "../devtools"
 
+[dependencies.devtools_traits]
+path = "../devtools_traits"
+
 [dependencies.glutin_app]
 path = "../../ports/glutin"
 optional = true

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Servo, the mighty web browser engine from the future.
+
 #![feature(core, env, libc, path, rustc_private, std_misc, thread_local)]
 
 #![allow(missing_copy_implementations)]
 
-#[macro_use]
-extern crate log;
-
 extern crate compositing;
 extern crate devtools;
+extern crate devtools_traits;
 extern crate net;
 extern crate msg;
 #[macro_use]
@@ -20,101 +20,88 @@ extern crate layout;
 extern crate gfx;
 extern crate libc;
 extern crate url;
+#[macro_use]
+extern crate log;
 
 use compositing::CompositorEventListener;
 use compositing::windowing::{WindowEvent, WindowMethods};
-
 use compositing::{CompositorProxy, CompositorTask, Constellation};
+
 use msg::constellation_msg::Msg as ConstellationMsg;
 use msg::constellation_msg::ConstellationChan;
+
 use script::dom::bindings::codegen::RegisterBindings;
 
 use net::image_cache_task::ImageCacheTask;
 use net::resource_task::new_resource_task;
 use net::storage_task::{StorageTaskFactory, StorageTask};
+
 use gfx::font_cache_task::FontCacheTask;
-use util::time::TimeProfiler;
+
+use util::time::{TimeProfiler, TimeProfilerChan};
 use util::memory::MemoryProfiler;
 use util::opts;
 use util::taskpool::TaskPool;
 
+use std::env;
 use std::rc::Rc;
-use std::sync::mpsc::channel;
-use std::thread::Builder;
+use std::sync::mpsc::{channel, Sender};
+use std::thread;
 
+/// The in-process interface to Servo.
+///
+/// It does  everything necessary  to render  the web, primarily
+/// orchestrating  the interaction  between  JavaScript, CSS  layout,
+/// rendering, and the client window.
+///
+/// Clients create a `Browser` for a given reference-counted type
+/// implementing `WindowMethods`, which is the bridge to whatever
+/// application Servo is embedded in. Clients then create an event
+/// loop to pump messages between the embedding application and
+/// various browser components.
 pub struct Browser<Window> {
     compositor: Box<CompositorEventListener + 'static>,
 }
 
 impl<Window> Browser<Window> where Window: WindowMethods + 'static {
     pub fn new(window: Option<Rc<Window>>) -> Browser<Window> {
-        use std::env;
+        util::opts::set_experimental_enabled(opts::get().enable_experimental);
 
-        ::util::opts::set_experimental_enabled(opts::get().enable_experimental);
+        // Global configuration options, parsed from the command line.
         let opts = opts::get();
+
+        // Create the global vtables used by the (generated) DOM
+        // bindings to implement JS proxies.
         RegisterBindings::RegisterProxyHandlers();
 
+        // Use this thread pool to load-balance simple tasks, such as
+        // image decoding.
         let shared_task_pool = TaskPool::new(8);
 
-        let (compositor_proxy, compositor_receiver) =
-            WindowMethods::create_compositor_channel(&window);
         let time_profiler_chan = TimeProfiler::create(opts.time_profiler_period);
         let memory_profiler_chan = MemoryProfiler::create(opts.memory_profiler_period);
         let devtools_chan = opts.devtools_port.map(|port| {
             devtools::start_server(port)
         });
 
-        let opts_clone = opts.clone();
-        let time_profiler_chan_clone = time_profiler_chan.clone();
+        // Get both endpoints of a special channel for communication between
+        // the client window and the compositor. This channel is unique because
+        // messages to client may need to pump a platform-specific event loop
+        // to deliver the message.
+        let (compositor_proxy, compositor_receiver) =
+            WindowMethods::create_compositor_channel(&window);
 
-        let (result_chan, result_port) = channel();
-        let compositor_proxy_for_constellation = compositor_proxy.clone_compositor_proxy();
-        Builder::new()
-            .spawn(move || {
-            let opts = &opts_clone;
-            // Create a Servo instance.
-            let resource_task = new_resource_task(opts.user_agent.clone());
-            // If we are emitting an output file, then we need to block on
-            // image load or we risk emitting an output file missing the
-            // image.
-            let image_cache_task = if opts.output_file.is_some() {
-                ImageCacheTask::new_sync(resource_task.clone(), shared_task_pool)
-            } else {
-                ImageCacheTask::new(resource_task.clone(), shared_task_pool)
-            };
-            let font_cache_task = FontCacheTask::new(resource_task.clone());
-            let storage_task: StorageTask = StorageTaskFactory::new();
-            let constellation_chan = Constellation::<layout::layout_task::LayoutTask,
-                                                     script::script_task::ScriptTask>::start(
-                                                          compositor_proxy_for_constellation,
-                                                          resource_task,
-                                                          image_cache_task,
-                                                          font_cache_task,
-                                                          time_profiler_chan_clone,
-                                                          devtools_chan,
-                                                          storage_task);
+        // Create the constellation, which maintains the engine
+        // pipelines, including the script and layout threads,as well
+        // as the navigation context.
+        let constellation_chan = create_constellation(opts.clone(),
+                                                      compositor_proxy.clone_compositor_proxy(),
+                                                      time_profiler_chan.clone(),
+                                                      devtools_chan,
+                                                      shared_task_pool);
 
-            // Send the URL command to the constellation.
-            let cwd = env::current_dir().unwrap();
-            for url in opts.urls.iter() {
-                let url = match url::Url::parse(&*url) {
-                    Ok(url) => url,
-                    Err(url::ParseError::RelativeUrlWithoutBase)
-                    => url::Url::from_file_path(&cwd.join(&*url)).unwrap(),
-                    Err(_) => panic!("URL parsing failed"),
-                };
-
-                let ConstellationChan(ref chan) = constellation_chan;
-                chan.send(ConstellationMsg::InitLoadUrl(url)).unwrap();
-            }
-
-            // Send the constallation Chan as the result
-            result_chan.send(constellation_chan).unwrap();
-        });
-
-        let constellation_chan = result_port.recv().unwrap();
-
-        debug!("preparing to enter main loop");
+        // The compositor coordinates with the client window to create the final
+        // rendered page and display it somewhere.
         let compositor = CompositorTask::create(window,
                                                 compositor_proxy,
                                                 compositor_receiver,
@@ -127,6 +114,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         }
     }
 
+    /// Processes events from the embedding client.
     pub fn handle_event(&mut self, event: WindowEvent) -> bool {
         self.compositor.handle_event(event)
     }
@@ -148,3 +136,52 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
     }
 }
 
+fn create_constellation(opts: opts::Opts,
+                        compositor_proxy: Box<CompositorProxy+Send>,
+                        time_profiler_chan: TimeProfilerChan,
+                        devtools_chan: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
+                        shared_task_pool: TaskPool) -> ConstellationChan {
+    let (result_chan, result_port) = channel();
+    thread::Builder::new().spawn(move || {
+        // Create a Servo instance.
+        let resource_task = new_resource_task(opts.user_agent.clone());
+        // If we are emitting an output file, then we need to block on
+        // image load or we risk emitting an output file missing the
+        // image.
+        let image_cache_task = if opts.output_file.is_some() {
+            ImageCacheTask::new_sync(resource_task.clone(), shared_task_pool)
+        } else {
+            ImageCacheTask::new(resource_task.clone(), shared_task_pool)
+        };
+        let font_cache_task = FontCacheTask::new(resource_task.clone());
+        let storage_task: StorageTask = StorageTaskFactory::new();
+        let constellation_chan = Constellation::<layout::layout_task::LayoutTask,
+        script::script_task::ScriptTask>::start(
+            compositor_proxy,
+            resource_task,
+            image_cache_task,
+            font_cache_task,
+            time_profiler_chan,
+            devtools_chan,
+            storage_task);
+
+        // Send the URL command to the constellation.
+        let cwd = env::current_dir().unwrap();
+        for url in opts.urls.iter() {
+            let url = match url::Url::parse(&*url) {
+                Ok(url) => url,
+                Err(url::ParseError::RelativeUrlWithoutBase)
+                    => url::Url::from_file_path(&cwd.join(&*url)).unwrap(),
+                Err(_) => panic!("URL parsing failed"),
+            };
+
+            let ConstellationChan(ref chan) = constellation_chan;
+            chan.send(ConstellationMsg::InitLoadUrl(url)).unwrap();
+        }
+
+        // Send the constallation Chan as the result
+        result_chan.send(constellation_chan).unwrap();
+    });
+
+    result_port.recv().unwrap()
+}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -104,7 +104,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
             WindowMethods::create_compositor_channel(&window);
 
         // Create the constellation, which maintains the engine
-        // pipelines, including the script and layout threads,as well
+        // pipelines, including the script and layout threads, as well
         // as the navigation context.
         let constellation_chan = create_constellation(opts.clone(),
                                                       compositor_proxy.clone_compositor_proxy(),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -24,37 +24,22 @@ extern crate url;
 use compositing::CompositorEventListener;
 use compositing::windowing::{WindowEvent, WindowMethods};
 
-#[cfg(not(test))]
 use compositing::{CompositorProxy, CompositorTask, Constellation};
-#[cfg(not(test))]
 use msg::constellation_msg::Msg as ConstellationMsg;
-#[cfg(not(test))]
 use msg::constellation_msg::ConstellationChan;
-#[cfg(not(test))]
 use script::dom::bindings::codegen::RegisterBindings;
 
-#[cfg(not(test))]
 use net::image_cache_task::ImageCacheTask;
-#[cfg(not(test))]
 use net::resource_task::new_resource_task;
-#[cfg(not(test))]
 use net::storage_task::{StorageTaskFactory, StorageTask};
-#[cfg(not(test))]
 use gfx::font_cache_task::FontCacheTask;
-#[cfg(not(test))]
 use util::time::TimeProfiler;
-#[cfg(not(test))]
 use util::memory::MemoryProfiler;
-#[cfg(not(test))]
 use util::opts;
-#[cfg(not(test))]
 use util::taskpool::TaskPool;
 
-#[cfg(not(test))]
 use std::rc::Rc;
-#[cfg(not(test))]
 use std::sync::mpsc::channel;
-#[cfg(not(test))]
 use std::thread::Builder;
 
 pub struct Browser<Window> {
@@ -62,7 +47,6 @@ pub struct Browser<Window> {
 }
 
 impl<Window> Browser<Window> where Window: WindowMethods + 'static {
-    #[cfg(not(test))]
     pub fn new(window: Option<Rc<Window>>) -> Browser<Window> {
         use std::env;
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -3,6 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Servo, the mighty web browser engine from the future.
+//
+// This is a very simple library that wires all of Servo's components
+// together as type `Browser`, along with a generic client
+// implementing the `WindowMethods` trait, to create a working web
+// browser.
+//
+// The `Browser` type is responsible for configuring a
+// `Constellation`, which does the heavy lifting of coordinating all
+// of Servo's internal subsystems, including the `ScriptTask` and the
+// `LayoutTask`, as well maintains the navigation context.
+//
+// The `Browser` is fed events from a generic type that implements the
+// `WindowMethods` trait.
 
 #![feature(core, env, libc, path, rustc_private, thread_local)]
 
@@ -34,7 +47,7 @@ use script::dom::bindings::codegen::RegisterBindings;
 
 use net::image_cache_task::ImageCacheTask;
 use net::resource_task::new_resource_task;
-use net::storage_task::{StorageTaskFactory, StorageTask};
+use net::storage_task::StorageTaskFactory;
 
 use gfx::font_cache_task::FontCacheTask;
 
@@ -49,8 +62,8 @@ use std::sync::mpsc::Sender;
 
 /// The in-process interface to Servo.
 ///
-/// It does  everything necessary  to render  the web, primarily
-/// orchestrating  the interaction  between  JavaScript, CSS  layout,
+/// It does everything necessary to render the web, primarily
+/// orchestrating the interaction between JavaScript, CSS layout,
 /// rendering, and the client window.
 ///
 /// Clients create a `Browser` for a given reference-counted type
@@ -113,7 +126,6 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         }
     }
 
-    /// Processes events from the embedding client.
     pub fn handle_event(&mut self, event: WindowEvent) -> bool {
         self.compositor.handle_event(event)
     }
@@ -140,7 +152,9 @@ fn create_constellation(opts: opts::Opts,
                         time_profiler_chan: TimeProfilerChan,
                         devtools_chan: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
                         shared_task_pool: TaskPool) -> ConstellationChan {
+
     let resource_task = new_resource_task(opts.user_agent.clone());
+
     // If we are emitting an output file, then we need to block on
     // image load or we risk emitting an output file missing the
     // image.
@@ -149,8 +163,10 @@ fn create_constellation(opts: opts::Opts,
     } else {
         ImageCacheTask::new(resource_task.clone(), shared_task_pool)
     };
+
     let font_cache_task = FontCacheTask::new(resource_task.clone());
-    let storage_task: StorageTask = StorageTaskFactory::new();
+    let storage_task = StorageTaskFactory::new();
+
     let constellation_chan = Constellation::<layout::layout_task::LayoutTask,
                                              script::script_task::ScriptTask>::start(
                                                  compositor_proxy,
@@ -161,7 +177,8 @@ fn create_constellation(opts: opts::Opts,
                                                  devtools_chan,
                                                  storage_task);
 
-    // Send the URL command to the constellation.
+    // If the global configuration asked to load a URL then send
+    // it to the constellation.
     let cwd = env::current_dir().unwrap();
     for url in opts.urls.iter() {
         let url = match url::Url::parse(&*url) {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Servo, the mighty web browser engine from the future.
-//
-// This is a very simple library that wires all of Servo's components
-// together as type `Browser`, along with a generic client
-// implementing the `WindowMethods` trait, to create a working web
-// browser.
-//
-// The `Browser` type is responsible for configuring a
-// `Constellation`, which does the heavy lifting of coordinating all
-// of Servo's internal subsystems, including the `ScriptTask` and the
-// `LayoutTask`, as well maintains the navigation context.
-//
-// The `Browser` is fed events from a generic type that implements the
-// `WindowMethods` trait.
+//! Servo, the mighty web browser engine from the future.
+//!
+//! This is a very simple library that wires all of Servo's components
+//! together as type `Browser`, along with a generic client
+//! implementing the `WindowMethods` trait, to create a working web
+//! browser.
+//!
+//! The `Browser` type is responsible for configuring a
+//! `Constellation`, which does the heavy lifting of coordinating all
+//! of Servo's internal subsystems, including the `ScriptTask` and the
+//! `LayoutTask`, as well maintains the navigation context.
+//!
+//! The `Browser` is fed events from a generic type that implements the
+//! `WindowMethods` trait.
 
 #![feature(core, env, libc, path, rustc_private, thread_local)]
 

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! The `servo` engine test application.
+//! The `servo` test application.
 //!
 //! Creates a `Browser` instance with a simple implementation of
 //! the compositor's `WindowMethods` to create a working web browser.
 //!
 //! This browser's implementation of `WindowMethods` is built on top
-//! of [glutin], the cross-platform OpenGL utility and // windowing
+//! of [glutin], the cross-platform OpenGL utility and windowing
 //! library.
 //!
 //! For the engine itself look next door in lib.rs.

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// The `servo` engine test application.
-//
-// Creates a `Browser` instance with a simple implementation of
-// the compositor's `WindowMethods` to create a working web browser.
-//
-// This browser's implementation of `WindowMethods` is built on top
-// of [glutin], the cross-platform OpenGL utility and // windowing
-// library.
-//
-// For the engine itself look next door in lib.rs.
-//
-// [glutin]: https://github.com/tomaka/glutin
+//! The `servo` engine test application.
+//!
+//! Creates a `Browser` instance with a simple implementation of
+//! the compositor's `WindowMethods` to create a working web browser.
+//!
+//! This browser's implementation of `WindowMethods` is built on top
+//! of [glutin], the cross-platform OpenGL utility and // windowing
+//! library.
+//!
+//! For the engine itself look next door in lib.rs.
+//!
+//! [glutin]: https://github.com/tomaka/glutin
 
 #![feature(env, os)]
 

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -20,10 +20,6 @@ use net::resource_task;
 use servo::Browser;
 use compositing::windowing::WindowEvent;
 
-struct BrowserWrapper {
-    browser: Browser<app::window::Window>,
-}
-
 fn main() {
     if opts::from_cmdline_args(&*get_args()) {
         setup_logging();
@@ -77,6 +73,10 @@ fn main() {
         } = browser;
         browser.shutdown();
     }
+}
+
+struct BrowserWrapper {
+    browser: Browser<app::window::Window>,
 }
 
 impl app::NestedEventLoopListener for BrowserWrapper {

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -4,103 +4,24 @@
 
 #![feature(env, os)]
 
-#[cfg(target_os="android")]
-extern crate libc;
-
 extern crate servo;
 extern crate time;
 extern crate util;
 extern crate net;
-
 extern crate "glutin_app" as app;
-
 extern crate compositing;
 
 #[cfg(target_os="android")]
 #[macro_use]
 extern crate android_glue;
 
-#[cfg(target_os="android")]
-use libc::c_int;
-
 use util::opts;
-
 use net::resource_task;
-
 use servo::Browser;
 use compositing::windowing::WindowEvent;
 
-#[cfg(target_os="android")]
-use std::borrow::ToOwned;
-
 struct BrowserWrapper {
     browser: Browser<app::window::Window>,
-}
-
-#[cfg(target_os="android")]
-android_start!(main);
-
-#[cfg(target_os="android")]
-fn get_args() -> Vec<String> {
-    vec![
-        "servo".to_owned(),
-        "http://en.wikipedia.org/wiki/Rust".to_owned()
-    ]
-}
-
-#[cfg(not(target_os="android"))]
-fn get_args() -> Vec<String> {
-    use std::env;
-    env::args().map(|s| s.into_string().unwrap()).collect()
-}
-
-#[cfg(target_os="android")]
-struct FilePtr(*mut libc::types::common::c95::FILE);
-
-#[cfg(target_os="android")]
-unsafe impl Send for FilePtr {}
-
-#[cfg(target_os="android")]
-fn redirect_output(file_no: c_int) {
-    use libc::funcs::posix88::unistd::{pipe, dup2};
-    use libc::funcs::posix88::stdio::fdopen;
-    use libc::funcs::c95::stdio::fgets;
-    use util::task::spawn_named;
-    use std::mem;
-    use std::ffi::CString;
-    use std::str::from_utf8;
-
-    unsafe {
-        let mut pipes: [c_int; 2] = [ 0, 0 ];
-        pipe(pipes.as_mut_ptr());
-        dup2(pipes[1], file_no);
-        let mode = CString::from_slice("r".as_bytes());
-        let input_file = FilePtr(fdopen(pipes[0], mode.as_ptr()));
-        spawn_named("android-logger".to_owned(), move || {
-            loop {
-                let mut read_buffer: [u8; 1024] = mem::zeroed();
-                let FilePtr(input_file) = input_file;
-                fgets(read_buffer.as_mut_ptr() as *mut i8, read_buffer.len() as i32, input_file);
-                let cs = CString::from_slice(&read_buffer);
-                match from_utf8(cs.as_bytes()) {
-                    Ok(s) => android_glue::write_log(s),
-                    _ => {}
-                }
-            }
-        });
-    }
-}
-
-#[cfg(target_os="android")]
-fn setup_logging() {
-    use libc::consts::os::posix88::{STDERR_FILENO, STDOUT_FILENO};
-    //os::setenv("RUST_LOG", "servo,gfx,msg,util,layers,js,std,rt,extra");
-    redirect_output(STDERR_FILENO);
-    redirect_output(STDOUT_FILENO);
-}
-
-#[cfg(not(target_os="android"))]
-fn setup_logging() {
 }
 
 fn main() {
@@ -174,3 +95,77 @@ impl app::NestedEventLoopListener for BrowserWrapper {
     }
 }
 
+#[cfg(target_os="android")]
+fn setup_logging() {
+    android::setup_logging();
+}
+
+#[cfg(not(target_os="android"))]
+fn setup_logging() {
+}
+
+#[cfg(target_os="android")]
+fn get_args() -> Vec<String> {
+    vec![
+        "servo".to_owned(),
+        "http://en.wikipedia.org/wiki/Rust".to_owned()
+    ]
+}
+
+#[cfg(not(target_os="android"))]
+fn get_args() -> Vec<String> {
+    use std::env;
+    env::args().map(|s| s.into_string().unwrap()).collect()
+}
+
+#[cfg(target_os = "android")]
+mod android {
+    extern crate libc;
+
+    use libc::c_int;
+    use std::borrow::ToOwned;
+
+    pub fn setup_logging() {
+        use libc::consts::os::posix88::{STDERR_FILENO, STDOUT_FILENO};
+        //os::setenv("RUST_LOG", "servo,gfx,msg,util,layers,js,std,rt,extra");
+        redirect_output(STDERR_FILENO);
+        redirect_output(STDOUT_FILENO);
+    }
+
+    android_start!(main);
+
+    struct FilePtr(*mut libc::types::common::c95::FILE);
+
+    unsafe impl Send for FilePtr {}
+
+    fn redirect_output(file_no: c_int) {
+        use libc::funcs::posix88::unistd::{pipe, dup2};
+        use libc::funcs::posix88::stdio::fdopen;
+        use libc::funcs::c95::stdio::fgets;
+        use util::task::spawn_named;
+        use std::mem;
+        use std::ffi::CString;
+        use std::str::from_utf8;
+
+        unsafe {
+            let mut pipes: [c_int; 2] = [ 0, 0 ];
+            pipe(pipes.as_mut_ptr());
+            dup2(pipes[1], file_no);
+            let mode = CString::from_slice("r".as_bytes());
+            let input_file = FilePtr(fdopen(pipes[0], mode.as_ptr()));
+            spawn_named("android-logger".to_owned(), move || {
+                loop {
+                    let mut read_buffer: [u8; 1024] = mem::zeroed();
+                    let FilePtr(input_file) = input_file;
+                    fgets(read_buffer.as_mut_ptr() as *mut i8, read_buffer.len() as i32, input_file);
+                    let cs = CString::from_slice(&read_buffer);
+                    match from_utf8(cs.as_bytes()) {
+                        Ok(s) => android_glue::write_log(s),
+                        _ => {}
+                    }
+                }
+            });
+        }
+    }
+
+}

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -12,10 +12,8 @@ extern crate time;
 extern crate util;
 extern crate net;
 
-#[cfg(not(test))]
 extern crate "glutin_app" as app;
 
-#[cfg(not(test))]
 extern crate compositing;
 
 #[cfg(target_os="android")]
@@ -25,21 +23,16 @@ extern crate android_glue;
 #[cfg(target_os="android")]
 use libc::c_int;
 
-#[cfg(not(test))]
 use util::opts;
 
-#[cfg(not(test))]
 use net::resource_task;
 
-#[cfg(not(test))]
 use servo::Browser;
-#[cfg(not(test))]
 use compositing::windowing::WindowEvent;
 
 #[cfg(target_os="android")]
 use std::borrow::ToOwned;
 
-#[cfg(not(test))]
 struct BrowserWrapper {
     browser: Browser<app::window::Window>,
 }


### PR DESCRIPTION
This primarily makes reading servo/main.rs or servo/lib.rs top-down a more pleasant and enlightening experience.

I couldn't see that all the `#[cfg(not(test))]` were doing anything and assumed they were cruft.
