### PR TITLE
Only unwrap the object once when finalizing.

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4040,10 +4040,9 @@ let this: *const %s = unwrap::<%s>(obj);
 
 def finalizeHook(descriptor, hookName, context):
     release = """\
-let value = unwrap::<%s>(obj);
-let _ = Box::from_raw(value as *mut %s);
+let _ = Box::from_raw(this as *mut %s);
 debug!("%s finalize: {:p}", this);\
-""" % (descriptor.concreteType, descriptor.concreteType, descriptor.concreteType)
+""" % (descriptor.concreteType, descriptor.concreteType)
     return release
 
 class CGClassTraceHook(CGAbstractClassHook):


### PR DESCRIPTION
Previously, we had 'value' and 'this' locals, both storing a pointer to the
DOM object, for no good reason.
