### PR TITLE
Fix gonk warnings, add to tidy

### DIFF
--- a/ports/gonk/src/input.rs
+++ b/ports/gonk/src/input.rs
@@ -97,16 +97,16 @@ fn read_input_device(device_path: &Path,
     };
     let fd = device.as_raw_fd();
 
-    let x_info: linux_input_absinfo = unsafe { zeroed() };
-    let y_info: linux_input_absinfo = unsafe { zeroed() };
+    let mut x_info: linux_input_absinfo = unsafe { zeroed() };
+    let mut y_info: linux_input_absinfo = unsafe { zeroed() };
     unsafe {
-        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_X), &x_info);
+        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_X), &mut x_info);
         if ret < 0 {
             println!("Couldn't get ABS_MT_POSITION_X info {} {}", ret, errno());
         }
     }
     unsafe {
-        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_Y), &y_info);
+        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_Y), &mut y_info);
         if ret < 0 {
             println!("Couldn't get ABS_MT_POSITION_Y info {} {}", ret, errno());
         }
@@ -166,9 +166,9 @@ fn read_input_device(device_path: &Path,
                             if dist < 16 {
                                 let click_pt = TypedPoint2D(slotA.x as f32, slotA.y as f32);
                                 println!("Dispatching click!");
-                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseDown(0, click_pt))).ok();
-                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseUp(0, click_pt))).ok();
-                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::Click(0, click_pt))).ok();
+                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseDown(0, click_pt))).ok().unwrap();
+                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseUp(0, click_pt))).ok().unwrap();
+                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::Click(0, click_pt))).ok().unwrap();
                             }
                         } else {
                             println!("Touch down");
@@ -184,14 +184,14 @@ fn read_input_device(device_path: &Path,
                     } else {
                         println!("Touch move x: {}, y: {}", slotA.x, slotA.y);
                         sender.send(WindowEvent::Scroll(TypedPoint2D((slotA.x - last_x) as f32, (slotA.y - last_y) as f32),
-                                                        TypedPoint2D(slotA.x, slotA.y))).ok();
+                                                        TypedPoint2D(slotA.x, slotA.y))).ok().unwrap();
                         last_x = slotA.x;
                         last_y = slotA.y;
                         if touch_count >= 2 {
                             let slotB = &slots[1];
                             let cur_dist = dist(slotA.x, slotB.x, slotA.y, slotB.y);
                             println!("Zooming {} {} {} {}", cur_dist, last_dist, screen_dist, ((screen_dist + (cur_dist - last_dist))/screen_dist));
-                            sender.send(WindowEvent::Zoom((screen_dist + (cur_dist - last_dist))/screen_dist)).ok();
+                            sender.send(WindowEvent::Zoom((screen_dist + (cur_dist - last_dist))/screen_dist)).ok().unwrap();
                             last_dist = cur_dist;
                         }
                     }

--- a/ports/gonk/src/input.rs
+++ b/ports/gonk/src/input.rs
@@ -74,7 +74,7 @@ const ABS_MT_POSITION_X: u16 = 0x35;
 const ABS_MT_POSITION_Y: u16 = 0x36;
 const ABS_MT_TRACKING_ID: u16 = 0x39;
 
-struct input_slot {
+struct InputSlot {
     tracking_id: i32,
     x: i32,
     y: i32,
@@ -97,30 +97,30 @@ fn read_input_device(device_path: &Path,
     };
     let fd = device.as_raw_fd();
 
-    let mut xInfo: linux_input_absinfo = unsafe { zeroed() };
-    let mut yInfo: linux_input_absinfo = unsafe { zeroed() };
+    let x_info: linux_input_absinfo = unsafe { zeroed() };
+    let y_info: linux_input_absinfo = unsafe { zeroed() };
     unsafe {
-        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_X), &xInfo);
+        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_X), &x_info);
         if ret < 0 {
             println!("Couldn't get ABS_MT_POSITION_X info {} {}", ret, errno());
         }
     }
     unsafe {
-        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_Y), &yInfo);
+        let ret = ioctl(fd, ev_ioc_g_abs(ABS_MT_POSITION_Y), &y_info);
         if ret < 0 {
             println!("Couldn't get ABS_MT_POSITION_Y info {} {}", ret, errno());
         }
     }
 
-    let touchWidth = xInfo.maximum - xInfo.minimum;
-    let touchHeight = yInfo.maximum - yInfo.minimum;
+    let touchWidth = x_info.maximum - x_info.minimum;
+    let touchHeight = y_info.maximum - y_info.minimum;
 
-    println!("xMin: {}, yMin: {}, touchWidth: {}, touchHeight: {}", xInfo.minimum, yInfo.minimum, touchWidth, touchHeight);
+    println!("xMin: {}, yMin: {}, touchWidth: {}, touchHeight: {}", x_info.minimum, y_info.minimum, touchWidth, touchHeight);
 
     // XXX: Why isn't size_of treated as constant?
     // let buf: [u8; (16 * size_of::<linux_input_event>())];
     let mut buf: [u8; (16 * 16)] = unsafe { zeroed() };
-    let mut slots: [input_slot; 10] = unsafe { zeroed() };
+    let mut slots: [InputSlot; 10] = unsafe { zeroed() };
     for slot in slots.iter_mut() {
         slot.tracking_id = -1;
     }
@@ -166,9 +166,9 @@ fn read_input_device(device_path: &Path,
                             if dist < 16 {
                                 let click_pt = TypedPoint2D(slotA.x as f32, slotA.y as f32);
                                 println!("Dispatching click!");
-                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseDown(0, click_pt)));
-                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseUp(0, click_pt)));
-                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::Click(0, click_pt)));
+                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseDown(0, click_pt))).ok();
+                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseUp(0, click_pt))).ok();
+                                sender.send(WindowEvent::MouseWindowEventClass(MouseWindowEvent::Click(0, click_pt))).ok();
                             }
                         } else {
                             println!("Touch down");
@@ -183,14 +183,15 @@ fn read_input_device(device_path: &Path,
                         }
                     } else {
                         println!("Touch move x: {}, y: {}", slotA.x, slotA.y);
-                        sender.send(WindowEvent::Scroll(TypedPoint2D((slotA.x - last_x) as f32, (slotA.y - last_y) as f32), TypedPoint2D(slotA.x, slotA.y)));
+                        sender.send(WindowEvent::Scroll(TypedPoint2D((slotA.x - last_x) as f32, (slotA.y - last_y) as f32),
+                                                        TypedPoint2D(slotA.x, slotA.y))).ok();
                         last_x = slotA.x;
                         last_y = slotA.y;
                         if touch_count >= 2 {
                             let slotB = &slots[1];
                             let cur_dist = dist(slotA.x, slotB.x, slotA.y, slotB.y);
                             println!("Zooming {} {} {} {}", cur_dist, last_dist, screen_dist, ((screen_dist + (cur_dist - last_dist))/screen_dist));
-                            sender.send(WindowEvent::Zoom((screen_dist + (cur_dist - last_dist))/screen_dist));
+                            sender.send(WindowEvent::Zoom((screen_dist + (cur_dist - last_dist))/screen_dist)).ok();
                             last_dist = cur_dist;
                         }
                     }
@@ -209,10 +210,10 @@ fn read_input_device(device_path: &Path,
                 (EV_ABS, ABS_MT_WIDTH_MINOR) => (),
                 (EV_ABS, ABS_MT_ORIENTATION) => (),
                 (EV_ABS, ABS_MT_POSITION_X) => {
-                    slots[current_slot].x = event.value - xInfo.minimum;
+                    slots[current_slot].x = event.value - x_info.minimum;
                 },
                 (EV_ABS, ABS_MT_POSITION_Y) => {
-                    slots[current_slot].y = event.value - yInfo.minimum;
+                    slots[current_slot].y = event.value - y_info.minimum;
                 },
                 (EV_ABS, ABS_MT_TRACKING_ID) => {
                     let current_id = slots[current_slot].tracking_id;

--- a/ports/gonk/src/lib.rs
+++ b/ports/gonk/src/lib.rs
@@ -125,11 +125,11 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                 };
 
                 let ConstellationChan(ref chan) = constellation_chan;
-                chan.send(ConstellationMsg::InitLoadUrl(url)).ok();
+                chan.send(ConstellationMsg::InitLoadUrl(url)).ok().unwrap();
             }
 
             // Send the constallation Chan as the result
-            result_chan.send(constellation_chan).ok();
+            result_chan.send(constellation_chan).ok().unwrap();
         });
 
         let constellation_chan = result_port.recv().unwrap();

--- a/ports/gonk/src/lib.rs
+++ b/ports/gonk/src/lib.rs
@@ -5,6 +5,10 @@
 #![feature(thread_local)]
 #![feature(box_syntax)]
 #![feature(int_uint)]
+#![feature(core, path, rustc_private)]
+#![feature(std_misc, env)]
+// For FFI
+#![allow(non_snake_case, dead_code)]
 
 #[macro_use]
 extern crate log;
@@ -51,7 +55,7 @@ use util::opts;
 use util::taskpool::TaskPool;
 
 #[cfg(not(test))]
-use std::os;
+use std::env;
 #[cfg(not(test))]
 use std::rc::Rc;
 #[cfg(not(test))]
@@ -111,7 +115,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                                                           storage_task);
 
             // Send the URL command to the constellation.
-            let cwd = os::getcwd().unwrap();
+            let cwd = env::current_dir().unwrap();
             for url in opts.urls.iter() {
                 let url = match url::Url::parse(url.as_slice()) {
                     Ok(url) => url,
@@ -121,11 +125,11 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                 };
 
                 let ConstellationChan(ref chan) = constellation_chan;
-                chan.send(ConstellationMsg::InitLoadUrl(url));
+                chan.send(ConstellationMsg::InitLoadUrl(url)).ok();
             }
 
             // Send the constallation Chan as the result
-            result_chan.send(constellation_chan);
+            result_chan.send(constellation_chan).ok();
         });
 
         let constellation_chan = result_port.recv().unwrap();

--- a/ports/gonk/src/main.rs
+++ b/ports/gonk/src/main.rs
@@ -5,6 +5,11 @@
 #![deny(unused_imports)]
 #![deny(unused_variables)]
 
+#![feature(int_uint)]
+#![feature(core, os, path, io, std_misc, env)]
+// For FFI
+#![allow(non_snake_case, dead_code)]
+
 extern crate servo;
 extern crate time;
 extern crate util;
@@ -22,7 +27,7 @@ use util::opts;
 use servo::Browser;
 use compositing::windowing::WindowEvent;
 
-use std::os;
+use std::env;
 
 mod window;
 mod input;
@@ -32,7 +37,8 @@ struct BrowserWrapper {
 }
 
 fn main() {
-    if opts::from_cmdline_args(os::args().as_slice()) {
+    if opts::from_cmdline_args(env::args().map(|a| a.into_string().unwrap())
+                                          .collect::<Vec<_>>().as_slice()) {
         let window = if opts::get().headless {
             None
         } else {

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -849,8 +849,8 @@ struct GonkCompositorProxy {
 impl CompositorProxy for GonkCompositorProxy {
     fn send(&mut self, msg: compositor_task::Msg) {
         // Send a message and kick the OS event loop awake.
-        self.sender.send(msg).ok();
-        self.event_sender.send(WindowEvent::Idle).ok();
+        self.sender.send(msg).ok().unwrap();
+        self.event_sender.send(WindowEvent::Idle).ok().unwrap();
     }
     fn clone_compositor_proxy(&self) -> Box<CompositorProxy+Send> {
         Box::new(GonkCompositorProxy {

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -439,12 +439,12 @@ extern fn api_disconnect(window: *mut GonkNativeWindow,
 }
 
 extern fn gnw_incRef(base: *mut ANativeBase) {
-    let mut win: &mut GonkNativeWindow = unsafe { transmute(base) };
+    let win: &mut GonkNativeWindow = unsafe { transmute(base) };
     win.count += 1;
 }
 
 extern fn gnw_decRef(base: *mut ANativeBase) {
-    let mut win: &mut GonkNativeWindow = unsafe { transmute(base) };
+    let win: &mut GonkNativeWindow = unsafe { transmute(base) };
     win.count -= 1;
     if win.count == 0 {
         unsafe { transmute::<_, Box<GonkNativeWindow>>(base) };
@@ -453,7 +453,7 @@ extern fn gnw_decRef(base: *mut ANativeBase) {
 
 impl GonkNativeWindow {
     pub fn new(alloc_dev: *mut alloc_device, hwc_dev: *mut hwc_composer_device, width: i32, height: i32, usage: c_int) -> *mut GonkNativeWindow {
-        let mut win = Box::new(GonkNativeWindow {
+        let win = Box::new(GonkNativeWindow {
             window: ANativeWindow {
                 common: ANativeBase {
                     magic: ANativeBase::magic('_', 'w', 'n', 'd'),
@@ -570,12 +570,12 @@ impl GonkNativeWindow {
 }
 
 extern fn gnwb_incRef(base: *mut ANativeBase) {
-    let mut buf: &mut GonkNativeWindowBuffer = unsafe { transmute(base) };
+    let buf: &mut GonkNativeWindowBuffer = unsafe { transmute(base) };
     buf.count += 1;
 }
 
 extern fn gnwb_decRef(base: *mut ANativeBase) {
-    let mut buf: &mut GonkNativeWindowBuffer = unsafe { transmute(base) };
+    let buf: &mut GonkNativeWindowBuffer = unsafe { transmute(base) };
     buf.count -= 1;
     if buf.count == 0 {
         unsafe { transmute::<_, Box<GonkNativeWindowBuffer>>(base) };
@@ -849,8 +849,8 @@ struct GonkCompositorProxy {
 impl CompositorProxy for GonkCompositorProxy {
     fn send(&mut self, msg: compositor_task::Msg) {
         // Send a message and kick the OS event loop awake.
-        self.sender.send(msg);
-        self.event_sender.send(WindowEvent::Idle);
+        self.sender.send(msg).ok();
+        self.event_sender.send(WindowEvent::Idle).ok();
     }
     fn clone_compositor_proxy(&self) -> Box<CompositorProxy+Send> {
         Box::new(GonkCompositorProxy {

--- a/python/tidy.py
+++ b/python/tidy.py
@@ -13,7 +13,7 @@ import os
 import fnmatch
 from licenseck import licenses
 
-directories_to_check = ["src", "components"]
+directories_to_check = ["ports/gonk", "components"]
 filetypes_to_check = [".rs", ".rc", ".cpp", ".c", ".h", ".py"]
 
 ignored_files = [
@@ -25,6 +25,8 @@ ignored_files = [
     "components/script/dom/bindings/codegen/*",
     "components/style/properties/mod.rs",
     "components/servo/target/*",
+    "ports/gonk/target/*",
+    "ports/gonk/src/native_window_glue.cpp",
 
     # MIT license
     "components/util/deque/mod.rs",


### PR DESCRIPTION
Rust still reports that the `*mut ANativeWindow` argument in `gnw_perform` in `gonk/src/window.rs` is ffi unsafe,
however `ANativeWindow` is marked as `#[repr(C)]` and should be okay.
