### PR TITLE
Make 'args' a list in the mach run handler.

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -56,7 +56,7 @@ class MachCommands(CommandBase):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
-        args = self.get_binary_path(release)
+        args = [self.get_binary_path(release)]
 
         # Borrowed and modified from:
         # http://hg.mozilla.org/mozilla-central/file/c9cfa9b91dea/python/mozbuild/mozbuild/mach_commands.py#l883


### PR DESCRIPTION
This fixes a regression from 894e58f714de0f3d65aeb943dbf8f569feb8c1d6.
