### PR TITLE
Remove outdated warning from test-unit

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -124,9 +124,6 @@ class MachCommands(CommandBase):
                 if c != "servo":
                     ret = ret or cargo_test(c)
 
-        print("WARNING: test-unit has probably destroyed your servo binary "
-              " (see https://github.com/rust-lang/cargo/issues/961 ). You "
-              " may want to rebuild now.")
         return ret
 
     @Command('test-ref',


### PR DESCRIPTION
This warning is no longer applicable due to a change in cargo's behavior, see https://github.com/servo/servo/issues/5042
