### PR TITLE
Implements a DisplayList dumper

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -709,6 +709,12 @@ impl LayoutTask {
                                                        color,
                                                        ScrollPolicy::Scrollable));
             let origin = Rect(Point2D(Au(0), Au(0)), root_size);
+
+            if opts::get().dump_display_list {
+                println!("#### start printing display list.");
+                display_list.print_items(String::from_str("#"));
+            }
+
             let stacking_context = Arc::new(StackingContext::new(display_list,
                                                                  &origin,
                                                                  &origin,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -110,6 +110,9 @@ pub struct Opts {
     /// Dumps the flow tree after a layout.
     pub dump_flow_tree: bool,
 
+    /// Dumps the flow tree after a layout.
+    pub dump_display_list: bool,
+
     /// Whether to show an error when display list geometry escapes flow overflow regions.
     pub validate_display_list_geometry: bool,
 
@@ -132,6 +135,7 @@ pub fn print_debug_usage(app: &str)  {
     print_option("bubble-widths", "Bubble intrinsic widths separately like other engines.");
     print_option("disable-text-aa", "Disable antialiasing of rendered text.");
     print_option("dump-flow-tree", "Print the flow tree after each layout.");
+    print_option("dump-display-list", "Print the display list after each layout.");
     print_option("profile-tasks", "Instrument each task, writing the output to a file.");
     print_option("show-compositor-borders", "Paint borders along layer and tile boundaries.");
     print_option("show-fragment-borders", "Paint borders along fragment boundaries.");
@@ -183,6 +187,7 @@ pub fn default_opts() -> Opts {
         initial_window_size: TypedSize2D(800, 600),
         user_agent: None,
         dump_flow_tree: false,
+        dump_display_list: false,
         validate_display_list_geometry: false,
         profile_tasks: false,
         resources_path: None,
@@ -330,6 +335,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         show_debug_parallel_layout: debug_options.contains(&"show-parallel-layout"),
         enable_text_antialiasing: !debug_options.contains(&"disable-text-aa"),
         dump_flow_tree: debug_options.contains(&"dump-flow-tree"),
+        dump_display_list: debug_options.contains(&"dump-display-list"),
         validate_display_list_geometry: debug_options.contains(&"validate-display-list-geometry"),
         resources_path: opt_match.opt_str("resources-path"),
     };


### PR DESCRIPTION
This patch will iterate through the DisplayList after the reflow is done and print its elements (as also any sub-lists associated to a child node stacking context).
