### PR TITLE
Fix setting display:none after a layout where the element was visible.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1170,8 +1170,9 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
             // results of children.
             (display::T::none, _, _) => {
                 for child in node.children() {
-                    drop(child.swap_out_construction_result())
+                    child.set_flow_construction_result(ConstructionResult::None);
                 }
+                node.set_flow_construction_result(ConstructionResult::None);
             }
 
             // Table items contribute table flow construction results.

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -251,3 +251,4 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == percentage_height_root.html percentage_height_root_ref.html
 == canvas_transform_a.html canvas_transform_ref.html
 != text_decoration_smoke_a.html text_decoration_smoke_ref.html
+== hide_after_create.html hide_after_create_ref.html

--- a/tests/ref/hide_after_create.html
+++ b/tests/ref/hide_after_create.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+	<style type="text/css">
+		.hidden {
+			display: none;
+		}
+		body {
+			background-color: green;
+		}
+		iframe {
+			background-color: red;
+			border: 0;
+		}
+	</style>
+    <body>
+    	<iframe id="iframe" src="about:blank"></iframe>
+    </body>
+    <script type="text/javascript">
+	    window.onload = function() {
+	    	document.getElementById("iframe").classList.add("hidden");
+                document.documentElement.classList.remove("reftest-wait");
+	    }
+    </script>
+</html>

--- a/tests/ref/hide_after_create_ref.html
+++ b/tests/ref/hide_after_create_ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<style type="text/css">
+		body {
+			background-color: green;
+		}
+	</style>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
Prior to incremental layout, the code would remove the existing
construction result. However, with incremental layout the construction result
is cloned rather than removed. This change ensures that the previous
construction result is cleared when an element's display type
changes to none.
