### PR TITLE
Fix making an iframe visible when it was initially set to display:none.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -315,9 +315,9 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 chan.send(Some(self.window.native_metadata())).unwrap();
             }
 
-            (Msg::SetLayerOrigin(pipeline_id, layer_id, origin),
+            (Msg::SetLayerRect(pipeline_id, layer_id, rect),
              ShutdownState::NotShuttingDown) => {
-                self.set_layer_origin(pipeline_id, layer_id, origin);
+                self.set_layer_rect(pipeline_id, layer_id, &rect);
             }
 
             (Msg::AssignPaintedBuffers(pipeline_id, epoch, replies), ShutdownState::NotShuttingDown) => {
@@ -721,15 +721,15 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         self.composition_request = CompositionRequest::CompositeOnScrollTimeout(timestamp);
     }
 
-    fn set_layer_origin(&mut self,
-                        pipeline_id: PipelineId,
-                        layer_id: LayerId,
-                        new_origin: Point2D<f32>) {
+    fn set_layer_rect(&mut self,
+                      pipeline_id: PipelineId,
+                      layer_id: LayerId,
+                      new_rect: &Rect<f32>) {
         match self.find_layer_with_pipeline_and_layer_id(pipeline_id, layer_id) {
             Some(ref layer) => {
-                layer.bounds.borrow_mut().origin = Point2D::from_untyped(&new_origin)
+                *layer.bounds.borrow_mut() = Rect::from_untyped(new_rect)
             }
-            None => panic!("Compositor received SetLayerOrigin for nonexistent \
+            None => panic!("Compositor received SetLayerRect for nonexistent \
                             layer: {:?}", pipeline_id),
         };
 

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -188,8 +188,8 @@ pub enum Msg {
     /// Tells the compositor to create a descendant layer for a pipeline if necessary (i.e. if no
     /// layer with that ID exists).
     CreateOrUpdateDescendantLayer(LayerProperties),
-    /// Alerts the compositor that the specified layer's origin has changed.
-    SetLayerOrigin(PipelineId, LayerId, Point2D<f32>),
+    /// Alerts the compositor that the specified layer's rect has changed.
+    SetLayerRect(PipelineId, LayerId, Rect<f32>),
     /// Scroll a page in a window
     ScrollFragmentPoint(PipelineId, LayerId, Point2D<f32>),
     /// Requests that the compositor assign the painted buffers to the given layers.
@@ -231,7 +231,7 @@ impl Debug for Msg {
             Msg::GetGraphicsMetadata(..) => write!(f, "GetGraphicsMetadata"),
             Msg::CreateOrUpdateBaseLayer(..) => write!(f, "CreateOrUpdateBaseLayer"),
             Msg::CreateOrUpdateDescendantLayer(..) => write!(f, "CreateOrUpdateDescendantLayer"),
-            Msg::SetLayerOrigin(..) => write!(f, "SetLayerOrigin"),
+            Msg::SetLayerRect(..) => write!(f, "SetLayerRect"),
             Msg::ScrollFragmentPoint(..) => write!(f, "ScrollFragmentPoint"),
             Msg::AssignPaintedBuffers(..) => write!(f, "AssignPaintedBuffers"),
             Msg::ChangeReadyState(..) => write!(f, "ChangeReadyState"),

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -681,10 +681,10 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                         initial_viewport: rect.size * ScaleFactor(1.0),
                         device_pixel_ratio: device_pixel_ratio,
                     })).unwrap();
-                    compositor_proxy.send(CompositorMsg::SetLayerOrigin(
+                    compositor_proxy.send(CompositorMsg::SetLayerRect(
                         pipeline.id,
                         LayerId::null(),
-                        rect.to_untyped().origin));
+                        rect.to_untyped()));
                 } else {
                     already_sent.insert(pipeline.id);
                 }

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -104,7 +104,7 @@ impl CompositorEventListener for NullCompositor {
 
             Msg::CreateOrUpdateBaseLayer(..) |
             Msg::CreateOrUpdateDescendantLayer(..) |
-            Msg::SetLayerOrigin(..) |
+            Msg::SetLayerRect(..) |
             Msg::AssignPaintedBuffers(..) |
             Msg::ChangeReadyState(..) |
             Msg::ChangePaintState(..) |

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -137,6 +137,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == iframe/multiple_external.html iframe/multiple_external_ref.html
 == iframe/overflow.html iframe/overflow_ref.html
 == iframe/positioning_margin.html iframe/positioning_margin_ref.html
+== iframe/hide_and_show.html iframe/hide_and_show_ref.html
 
 == floated_generated_content_a.html floated_generated_content_b.html
 == inline_block_margin_a.html inline_block_margin_ref.html

--- a/tests/ref/iframe/hide_and_show.html
+++ b/tests/ref/iframe/hide_and_show.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+	<style type="text/css">
+		.hidden {
+			display: none;
+		}
+		iframe {
+			border: 0;
+		}
+	</style>
+    <body id="container">
+    	<iframe id="iframe" class="hidden" src="data:text/html,%3Cbody%20style%3D%22background%3Agreen%3B%20%22%3E"></iframe>
+    </body>
+    <script type="text/javascript">
+	    window.onload = function() {
+	    	document.getElementById("iframe").classList.remove("hidden");
+	    	document.documentElement.classList.remove("reftest-wait");
+	    }
+    </script>
+</html>

--- a/tests/ref/iframe/hide_and_show_ref.html
+++ b/tests/ref/iframe/hide_and_show_ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<style type="text/css">
+		div {
+			width: 300px;
+			height: 150px;
+			background-color: green;
+		}
+	</style>
+    <body>
+    	<div></div>
+    </body>
+</html>


### PR DESCRIPTION
When an iframe is created with display:none it sets the root layer to be zero width and height. When updating the rect of the iframe from layout send the entire rect rather than just the new origin, which handles the case where the iframe has been made visible and now has a non-zero rect.
