### PR TITLE
Change Servo release builds to include debugging.

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -34,6 +34,12 @@ default = ["glutin_app", "window"]
 window = ["glutin_app/window"]
 headless = ["glutin_app/headless"]
 
+[profile.release]
+opt-level = 3
+debug = true
+rpath = false
+lto = false
+
 [dependencies.compositing]
 path = "../compositing"
 


### PR DESCRIPTION
This makes basic symbols available in release builds.
