### PR TITLE
Implement 'beforescriptexecute' and 'afterscriptexecute' events.

### DIFF
--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -246,7 +246,7 @@ impl<'a> EventMethods for JSRef<'a, Event> {
 
 pub trait EventHelpers {
     fn set_trusted(self, trusted: bool);
-    fn fire(self, target: JSRef<EventTarget>);
+    fn fire(self, target: JSRef<EventTarget>) -> bool;
 }
 
 impl<'a> EventHelpers for JSRef<'a, Event> {
@@ -255,8 +255,8 @@ impl<'a> EventHelpers for JSRef<'a, Event> {
     }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event
-    fn fire(self, target: JSRef<EventTarget>) {
+    fn fire(self, target: JSRef<EventTarget>) -> bool {
         self.set_trusted(true);
-        target.dispatch_event(self);
+        target.dispatch_event(self)
     }
 }

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/script-before-after-events.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/script-before-after-events.html.ini
@@ -1,5 +1,0 @@
-[script-before-after-events.html]
-  type: testharness
-  [\'beforescriptexecute\'/\'afterscriptexecute\' events have been fired]
-    expected: FAIL
-


### PR DESCRIPTION
Spec: https://html.spec.whatwg.org/multipage/scripting.html#execute-the-script-block, sections 2.b.2 & 2.b.9
