### PR TITLE
If root element contains "reftest-wait" class, don't mark document as ready until it's removed.

### DIFF
--- a/tests/wpt/metadata/FileAPI/url/url_xmlhttprequest_img.html.ini
+++ b/tests/wpt/metadata/FileAPI/url/url_xmlhttprequest_img.html.ini
@@ -2,4 +2,4 @@
   type: reftest
   reftype: ==
   refurl: /FileAPI/url/url_xmlhttprequest_img-ref.html
-  expected: FAIL
+  expected: TIMEOUT


### PR DESCRIPTION
This allows reftests to perform tests for incremental layout and other bugs that require rendering multiple frames.
