### PR TITLE
Reap layout data whenever a node is removed from the tree.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1326,6 +1326,13 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
         let mut layout_data_ref = self.mutate_layout_data();
         let layout_data = layout_data_ref.as_mut().expect("no layout data");
 
+        match result {
+            ConstructionResult::None => {
+                layout_data.clear();
+            }
+            _ => {}
+        }
+
         let dst = self.get_construction_result(layout_data);
 
         *dst = result;

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -35,7 +35,7 @@ use gfx::paint_task::Msg as PaintMsg;
 use layout_traits::{LayoutControlMsg, LayoutTaskFactory};
 use log;
 use script::dom::bindings::js::LayoutJS;
-use script::dom::node::{LayoutDataRef, Node, NodeTypeId};
+use script::dom::node::{LayoutData, Node, NodeTypeId};
 use script::dom::element::ElementTypeId;
 use script::dom::htmlelement::HTMLElementTypeId;
 use script::layout_interface::{ContentBoxResponse, ContentBoxesResponse};
@@ -937,11 +937,10 @@ impl LayoutTask {
     }
 
     /// Handles a message to destroy layout data. Layout data must be destroyed on *this* task
-    /// because it contains local managed pointers.
-    unsafe fn handle_reap_layout_data(layout_data: LayoutDataRef) {
-        let mut layout_data_ref = layout_data.borrow_mut();
-        let _: Option<LayoutDataWrapper> = mem::transmute(
-            mem::replace(&mut *layout_data_ref, None));
+    /// because the struct type is transmuted to a different type on the script side.
+    unsafe fn handle_reap_layout_data(layout_data: LayoutData) {
+        let layout_data_wrapper: LayoutDataWrapper = mem::transmute(layout_data);
+        layout_data_wrapper.clear();
     }
 
     /// Returns profiling information which is passed to the time profiler.

--- a/components/layout/util.rs
+++ b/components/layout/util.rs
@@ -78,6 +78,12 @@ pub struct LayoutDataWrapper {
     pub data: Box<PrivateLayoutData>,
 }
 
+impl LayoutDataWrapper {
+    pub fn clear(&self) {
+        // TODO: Clear items related to this node, e.g. compositor layers
+    }
+}
+
 #[allow(dead_code)]
 fn static_assertion(x: Option<LayoutDataWrapper>) {
     unsafe {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -6,7 +6,7 @@
 //! interface helps reduce coupling between these two components, and enables
 //! the DOM to be placed in a separate crate from layout.
 
-use dom::node::LayoutDataRef;
+use dom::node::LayoutData;
 
 use geom::point::Point2D;
 use geom::rect::Rect;
@@ -41,7 +41,7 @@ pub enum Msg {
     /// Destroys layout data associated with a DOM node.
     ///
     /// TODO(pcwalton): Maybe think about batching to avoid message traffic.
-    ReapLayoutData(LayoutDataRef),
+    ReapLayoutData(LayoutData),
 
     /// Requests that the layout task enter a quiescent state in which no more messages are
     /// accepted except `ExitMsg`. A response message will be sent on the supplied channel when


### PR DESCRIPTION
Also introduce a clear() function to layout data which will be used to clear items such as compositor layouts.

Clear the layout data when a node becomes display:none.
