### PR TITLE
Remove WA for borders ref test

### DIFF
--- a/tests/ref/borders_a.html
+++ b/tests/ref/borders_a.html
@@ -2,9 +2,6 @@
 <html>
 <head>
 <style>
-html {    
-    background-color: white;
-}
 #none{
     border-style: none;
     border-width: 10px;


### PR DESCRIPTION
The borders_a.html ref test had a WA to avoid displaying a spurious
black pixel at (0,0). Details are at
https://github.com/servo/servo/issues/2879

The WA can be removed since the bug is no longer reproducible.
