### PR TITLE
Canvas: added lineTo support.

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -27,6 +27,7 @@ pub enum CanvasMsg {
     ClosePath,
     Fill,
     MoveTo(Point2D<f32>),
+    LineTo(Point2D<f32>),
     BezierCurveTo(Point2D<f32>, Point2D<f32>, Point2D<f32>),
     SetFillStyle(FillOrStrokeStyle),
     SetStrokeStyle(FillOrStrokeStyle),
@@ -77,6 +78,7 @@ impl<'a> CanvasPaintTask<'a> {
                     CanvasMsg::ClosePath => painter.close_path(),
                     CanvasMsg::Fill => painter.fill(),
                     CanvasMsg::MoveTo(ref point) => painter.move_to(point),
+                    CanvasMsg::LineTo(ref point) => painter.line_to(point),
                     CanvasMsg::BezierCurveTo(ref cp1, ref cp2, ref pt) => {
                         painter.bezier_curve_to(cp1, cp2, pt)
                     }
@@ -138,6 +140,10 @@ impl<'a> CanvasPaintTask<'a> {
 
     fn move_to(&self, point: &Point2D<AzFloat>) {
         self.path_builder.move_to(*point)
+    }
+
+    fn line_to(&self, point: &Point2D<AzFloat>) {
+        self.path_builder.line_to(*point)
     }
 
     fn bezier_curve_to(&self,

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -150,6 +150,10 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
         self.renderer.send(CanvasMsg::MoveTo(Point2D(x as f32, y as f32))).unwrap();
     }
 
+    fn LineTo(self, x: f64, y: f64) {
+        self.renderer.send(CanvasMsg::LineTo(Point2D(x as f32, y as f32)));
+    }
+
     fn BezierCurveTo(self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, x: f64, y: f64) {
         self.renderer.send(CanvasMsg::BezierCurveTo(Point2D(cp1x as f32, cp1y as f32),
                                                     Point2D(cp2x as f32, cp2y as f32),

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -123,7 +123,7 @@ interface CanvasPathMethods {
   // shared path API methods
   void closePath();
   void moveTo(/*unrestricted*/ double x, /*unrestricted*/ double y);
-  //void lineTo(double x, double y);
+  void lineTo(double x, double y);
   //void quadraticCurveTo(double cpx, double cpy, double x, double y);
 
   void bezierCurveTo(/*unrestricted*/ double cp1x,

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -251,5 +251,6 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == text_align_complex_a.html text_align_complex_ref.html
 == percentage_height_root.html percentage_height_root_ref.html
 == canvas_transform_a.html canvas_transform_ref.html
+== canvas_lineto_a.html canvas_lineto_ref.html
 != text_decoration_smoke_a.html text_decoration_smoke_ref.html
 == hide_after_create.html hide_after_create_ref.html

--- a/tests/ref/canvas_lineto_a.html
+++ b/tests/ref/canvas_lineto_a.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+  }
+</style>
+<canvas id="c" width="150" height="150" >
+Your browser does not support the HTML5 canvas tag.</canvas>
+
+<script>
+var c = document.getElementById("c");
+var ctx = c.getContext("2d");
+
+ctx.beginPath();
+ctx.moveTo(20, 20);
+ctx.lineTo(20, 130);
+ctx.lineTo(130, 130);
+ctx.lineTo(130, 20);
+ctx.closePath();
+
+ctx.fillStyle = '#90EE90';
+ctx.fill();
+</script>
+
+</body>
+</html>

--- a/tests/ref/canvas_lineto_ref.html
+++ b/tests/ref/canvas_lineto_ref.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+  }
+  div {
+    background: #90EE90;
+    width: 110px;
+    height: 110px;
+    margin: 20px;
+  }
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.closed.basic.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.closed.basic.html.ini
@@ -1,5 +1,0 @@
-[2d.path.fill.closed.basic.html]
-  type: testharness
-  [Canvas test: 2d.path.fill.closed.basic]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.add.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.add.html.ini
@@ -1,5 +1,0 @@
-[2d.path.fill.winding.add.html]
-  type: testharness
-  [Canvas test: 2d.path.fill.winding.add]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.subtract.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.subtract.1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.fill.winding.subtract.1.html]
-  type: testharness
-  [Canvas test: 2d.path.fill.winding.subtract.1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.subtract.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.subtract.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.fill.winding.subtract.2.html]
-  type: testharness
-  [Canvas test: 2d.path.fill.winding.subtract.2]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.subtract.3.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.winding.subtract.3.html.ini
@@ -1,5 +1,0 @@
-[2d.path.fill.winding.subtract.3.html]
-  type: testharness
-  [Canvas test: 2d.path.fill.winding.subtract.3]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/transformations/2d.transformation.setTransform.skewed.html.ini
+++ b/tests/wpt/metadata/2dcontext/transformations/2d.transformation.setTransform.skewed.html.ini
@@ -1,5 +1,0 @@
-[2d.transformation.setTransform.skewed.html]
-  type: testharness
-  [Canvas test: 2d.transformation.setTransform.skewed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/transformations/2d.transformation.transform.skewed.html.ini
+++ b/tests/wpt/metadata/2dcontext/transformations/2d.transformation.transform.skewed.html.ini
@@ -1,5 +1,0 @@
-[2d.transformation.transform.skewed.html]
-  type: testharness
-  [transform() with skewy matrix transforms correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -7116,9 +7116,6 @@
   [CanvasRenderingContext2D interface: attribute direction]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation lineTo(unrestricted double,unrestricted double)]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation quadraticCurveTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double)]
     expected: FAIL
 
@@ -7375,12 +7372,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "direction" with the proper type (69)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "lineTo" with the proper type (72)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling lineTo(unrestricted double,unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "quadraticCurveTo" with the proper type (73)]


### PR DESCRIPTION
This patch enables the use of `lineTo()` on the canvas.
