### PR TITLE
Implements layout reflow debugging.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -27,7 +27,7 @@ use dom::performance::Performance;
 use dom::screen::Screen;
 use dom::storage::Storage;
 use layout_interface::{ReflowGoal, ReflowQueryType};
-use page::Page;
+use page::{Page, ReflowEvent};
 use script_task::{TimerSource, ScriptChan};
 use script_task::ScriptMsg;
 use script_traits::ScriptControlChan;
@@ -374,7 +374,7 @@ impl<'a, T: Reflectable> ScriptHelpers for JSRef<'a, T> {
 
 impl<'a> WindowHelpers for JSRef<'a, Window> {
     fn flush_layout(self, goal: ReflowGoal, query: ReflowQueryType) {
-        self.page().flush_layout(goal, query);
+        self.page().flush_layout(goal, query, ReflowEvent::FlushLayout);
     }
 
     fn init_browser_context(self, doc: JSRef<Document>, frame_element: Option<JSRef<Element>>) {

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -53,6 +53,9 @@ extern crate string_cache;
 #[no_link] #[macro_use] #[plugin]
 extern crate string_cache_macros;
 
+#[macro_use]
+extern crate "util" as servo_util;
+
 pub mod cors;
 
 #[macro_use]

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -31,6 +31,7 @@ use util::geometry::{Au, MAX_RECT};
 use util::geometry;
 use util::str::DOMString;
 use util::smallvec::SmallVec;
+use servo_util::opts;
 use std::cell::{Cell, Ref, RefMut};
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::mpsc::TryRecvError::{Empty, Disconnected};
@@ -106,6 +107,16 @@ pub struct Page {
     pub devtools_chan: Option<DevtoolsControlChan>,
 }
 
+pub enum ReflowEvent {
+    FlushLayout,
+    ForcedReflow,
+    LoadPage,
+    MouseEvents,
+    WindowResize,
+    BoxQuery,
+    Viewport,
+}
+
 pub struct PageIterator {
     stack: Vec<Rc<Page>>,
 }
@@ -175,10 +186,10 @@ impl Page {
         }
     }
 
-    pub fn flush_layout(&self, goal: ReflowGoal, query: ReflowQueryType) {
+    pub fn flush_layout(&self, goal: ReflowGoal, query: ReflowQueryType, trigger: ReflowEvent) {
         let frame = self.frame();
         let window = frame.as_ref().unwrap().window.root();
-        self.reflow(goal, window.r().control_chan().clone(), &mut **window.r().compositor(), query);
+        self.reflow(goal, window.r().control_chan().clone(), &mut **window.r().compositor(), query, trigger);
     }
 
     pub fn layout(&self) -> &LayoutRPC {
@@ -186,14 +197,14 @@ impl Page {
     }
 
     pub fn content_box_query(&self, content_box_request: TrustedNodeAddress) -> Rect<Au> {
-        self.flush_layout(ReflowGoal::ForScriptQuery, ReflowQueryType::ContentBoxQuery(content_box_request));
+        self.flush_layout(ReflowGoal::ForScriptQuery, ReflowQueryType::ContentBoxQuery(content_box_request), ReflowEvent::BoxQuery);
         self.join_layout(); //FIXME: is this necessary, or is layout_rpc's mutex good enough?
         let ContentBoxResponse(rect) = self.layout_rpc.content_box();
         rect
     }
 
     pub fn content_boxes_query(&self, content_boxes_request: TrustedNodeAddress) -> Vec<Rect<Au>> {
-        self.flush_layout(ReflowGoal::ForScriptQuery, ReflowQueryType::ContentBoxesQuery(content_boxes_request));
+        self.flush_layout(ReflowGoal::ForScriptQuery, ReflowQueryType::ContentBoxesQuery(content_boxes_request), ReflowEvent::BoxQuery);
         self.join_layout(); //FIXME: is this necessary, or is layout_rpc's mutex good enough?
         let ContentBoxesResponse(rects) = self.layout_rpc.content_boxes();
         rects
@@ -352,7 +363,13 @@ impl Page {
                   goal: ReflowGoal,
                   script_chan: ScriptControlChan,
                   _: &mut ScriptListener,
-                  query_type: ReflowQueryType) {
+                  query_type: ReflowQueryType,
+                  trigger: ReflowEvent) {
+
+        if opts::get().relayout_event {
+            Page::debug_reflow_events(trigger);
+        }
+
         let root = match *self.frame() {
             None => return,
             Some(ref frame) => {
@@ -453,6 +470,18 @@ impl Page {
             None => {}
         }
         results
+    }
+
+    fn debug_reflow_events(trigger: ReflowEvent) {
+        match trigger {
+            ReflowEvent::FlushLayout => println!("**** Reflow: flush event."),
+            ReflowEvent::ForcedReflow => println!("**** Reflow: forced event."),
+            ReflowEvent::LoadPage => println!("**** Reflow: load event."),
+            ReflowEvent::MouseEvents => println!("**** Reflow: mouse event."),
+            ReflowEvent::WindowResize => println!("**** Reflow: Window resize event."),
+            ReflowEvent::BoxQuery => println!("**** Reflow: content box query."),
+            ReflowEvent::Viewport => println!("**** Reflow: viewport."),
+        }
     }
 }
 

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -113,6 +113,9 @@ pub struct Opts {
     /// Dumps the flow tree after a layout.
     pub dump_display_list: bool,
 
+    /// Emits notifications when there is a relayout.
+    pub relayout_event: bool,
+
     /// Whether to show an error when display list geometry escapes flow overflow regions.
     pub validate_display_list_geometry: bool,
 
@@ -136,6 +139,7 @@ pub fn print_debug_usage(app: &str)  {
     print_option("disable-text-aa", "Disable antialiasing of rendered text.");
     print_option("dump-flow-tree", "Print the flow tree after each layout.");
     print_option("dump-display-list", "Print the display list after each layout.");
+    print_option("relayout-event", "Print notifications when there is a relayout.");
     print_option("profile-tasks", "Instrument each task, writing the output to a file.");
     print_option("show-compositor-borders", "Paint borders along layer and tile boundaries.");
     print_option("show-fragment-borders", "Paint borders along fragment boundaries.");
@@ -188,6 +192,7 @@ pub fn default_opts() -> Opts {
         user_agent: None,
         dump_flow_tree: false,
         dump_display_list: false,
+        relayout_event: false,
         validate_display_list_geometry: false,
         profile_tasks: false,
         resources_path: None,
@@ -336,6 +341,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         enable_text_antialiasing: !debug_options.contains(&"disable-text-aa"),
         dump_flow_tree: debug_options.contains(&"dump-flow-tree"),
         dump_display_list: debug_options.contains(&"dump-display-list"),
+        relayout_event: debug_options.contains(&"relayout-event"),
         validate_display_list_geometry: debug_options.contains(&"validate-display-list-geometry"),
         resources_path: opt_match.opt_str("resources-path"),
     };


### PR DESCRIPTION
By passing a parameter (--relayout-event), it will print when a reflow happens and its origin (e.g. mouse event, page load, etc).

See #5079.
