### PR TITLE
Fix hover state on elements with transparent background colours.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -28,6 +28,7 @@ use azure::azure_hl::{Color};
 
 use collections::dlist::{self, DList};
 use geom::{Point2D, Rect, SideOffsets2D, Size2D, Matrix2D};
+use geom::approxeq::ApproxEq;
 use geom::num::Zero;
 use libc::uintptr_t;
 use paint_task::PaintLayer;
@@ -912,7 +913,9 @@ impl DisplayItem {
 
         match *self {
             DisplayItem::SolidColorClass(ref solid_color) => {
-                paint_context.draw_solid_color(&solid_color.base.bounds, solid_color.color)
+                if !solid_color.color.a.approx_eq(&0.0) {
+                    paint_context.draw_solid_color(&solid_color.base.bounds, solid_color.color)
+                }
             }
 
             DisplayItem::TextClass(ref text) => {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -21,7 +21,6 @@ use list_item::ListItemFlow;
 use model;
 use util::{OpaqueNodeMethods, ToGfxColor};
 
-use geom::approxeq::ApproxEq;
 use geom::{Point2D, Rect, Size2D, SideOffsets2D};
 use gfx::color;
 use gfx::display_list::{BLUR_INFLATION_FACTOR, BaseDisplayItem, BorderDisplayItem};
@@ -291,16 +290,14 @@ impl FragmentDisplayListBuilding for Fragment {
         // inefficient. What we really want is something like "nearest ancestor element that
         // doesn't have a fragment".
         let background_color = style.resolve_color(style.get_background().background_color);
-        if !background_color.alpha.approx_eq(&0.0) {
-            display_list.push(DisplayItem::SolidColorClass(box SolidColorDisplayItem {
-                base: BaseDisplayItem::new(*absolute_bounds,
-                                           DisplayItemMetadata::new(self.node,
-                                                                    style,
-                                                                    Cursor::DefaultCursor),
-                                           clip.clone()),
-                color: background_color.to_gfx_color(),
-            }), level);
-        }
+        display_list.push(DisplayItem::SolidColorClass(box SolidColorDisplayItem {
+            base: BaseDisplayItem::new(*absolute_bounds,
+                                       DisplayItemMetadata::new(self.node,
+                                                                style,
+                                                                Cursor::DefaultCursor),
+                                       clip.clone()),
+            color: background_color.to_gfx_color(),
+        }), level);
 
         // The background image is painted on top of the background color.
         // Implements background image, per spec:


### PR DESCRIPTION
Move culling of transparent display items to paint task rather than display list builder, so that hit testing detects mouse over on transparent background elements.
