### PR TITLE
layout: Implement `overflow-x` and `overflow-y` per CSS-OVERFLOW § 3.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -57,9 +57,10 @@ use servo_util::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize};
 use servo_util::opts;
 use std::cmp::{max, min};
 use std::fmt;
+use style::computed_values::{overflow_x, overflow_y, position, box_sizing, display, float};
 use style::properties::ComputedValues;
-use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
-use style::computed_values::{overflow, position, box_sizing, display, float};
+use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto};
+use style::values::computed::{LengthOrPercentageOrNone};
 use std::sync::Arc;
 
 /// Information specific to floated blocks.
@@ -1431,7 +1432,10 @@ impl BlockFlow {
             display::T::inline_block => {
                 FormattingContextType::Other
             }
-            _ if style.get_box().overflow != overflow::T::visible => FormattingContextType::Block,
+            _ if style.get_box().overflow_x != overflow_x::T::visible ||
+                    style.get_box().overflow_y != overflow_y::T(overflow_x::T::visible) => {
+                FormattingContextType::Block
+            }
             _ => FormattingContextType::None,
         }
     }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -34,7 +34,7 @@ use std::mem;
 use std::num::ToPrimitive;
 use std::ops::{Add, Sub, Mul, Div, Rem, Neg, Shl, Shr, Not, BitOr, BitAnd, BitXor};
 use std::u16;
-use style::computed_values::{overflow, text_align, text_justify, text_overflow, vertical_align};
+use style::computed_values::{overflow_x, text_align, text_justify, text_overflow, vertical_align};
 use style::computed_values::{white_space};
 use style::properties::ComputedValues;
 use std::sync::Arc;
@@ -653,8 +653,8 @@ impl LineBreaker {
         let available_inline_size = self.pending_line.green_zone.inline -
             self.pending_line.bounds.size.inline - indentation;
         match (fragment.style().get_inheritedtext().text_overflow,
-               fragment.style().get_box().overflow) {
-            (text_overflow::T::clip, _) | (_, overflow::T::visible) => {}
+               fragment.style().get_box().overflow_x) {
+            (text_overflow::T::clip, _) | (_, overflow_x::T::visible) => {}
             (text_overflow::T::ellipsis, _) => {
                 need_ellipsis = fragment.border_box.size.inline > available_inline_size;
             }

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -103,6 +103,8 @@ partial interface CSSStyleDeclaration {
   [TreatNullAs=EmptyString] attribute DOMString listStyleImage;
 
   [TreatNullAs=EmptyString] attribute DOMString overflow;
+  [TreatNullAs=EmptyString] attribute DOMString overflowX;
+  [TreatNullAs=EmptyString] attribute DOMString overflowY;
   [TreatNullAs=EmptyString] attribute DOMString overflowWrap;
 
   [TreatNullAs=EmptyString] attribute DOMString tableLayout;

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -690,6 +690,8 @@ pub mod computed {
         pub font_size: longhands::font_size::computed_value::T,
         pub root_font_size: longhands::font_size::computed_value::T,
         pub display: longhands::display::computed_value::T,
+        pub overflow_x: longhands::overflow_x::computed_value::T,
+        pub overflow_y: longhands::overflow_y::computed_value::T,
         pub positioned: bool,
         pub floated: bool,
         pub border_top_present: bool,

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -255,6 +255,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == canvas_lineto_a.html canvas_lineto_ref.html
 != text_decoration_smoke_a.html text_decoration_smoke_ref.html
 == hide_after_create.html hide_after_create_ref.html
+== overflow_xy_a.html overflow_xy_ref.html
 == text_shadow_simple_a.html text_shadow_simple_ref.html
 == text_shadow_decorations_a.html text_shadow_decorations_ref.html
 == text_shadow_blur_a.html text_shadow_blur_ref.html

--- a/tests/ref/overflow_xy_a.html
+++ b/tests/ref/overflow_xy_a.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `overflow-x` and `overflow-y` work. -->
+<style>
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    left: 0;
+}
+#x {
+    overflow-x: hidden;
+    overflow-y: visible;    /* computes to `auto` */
+    top: 0;
+}
+#y {
+    overflow: hidden;
+    top: 200px;
+}
+div {
+    position: absolute;
+    width: 200px;
+    height: 200px;
+    top: 0;
+    left: 0;
+    background: green;
+}
+</style>
+</head>
+<body>
+<section id=x><div></div></section>
+<section id=y><div></div></section>
+</body>
+</html>
+

--- a/tests/ref/overflow_xy_ref.html
+++ b/tests/ref/overflow_xy_ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `overflow-x` and `overflow-y` work. -->
+<style>
+section {
+    position: absolute;
+    left: 0;
+    background: green;
+}
+#x {
+    top: 0;
+    width: 100px;
+    height: 100px;
+}
+#y {
+    top: 200px;
+    width: 100px;
+    height: 100px;
+}
+</style>
+</head>
+<body>
+<section id=x></section>
+<section id=y></section>
+</body>
+</html>
+
+


### PR DESCRIPTION
Rebase of #4567. Fix #4567.
