### PR TITLE
Make submodule sync silent (and recursive).

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -202,7 +202,7 @@ class CommandBase(object):
         if self.context.bootstrapped:
             return
 
-        subprocess.check_call(["git", "submodule", "sync"])
+        subprocess.check_call(["git", "submodule", "--quiet", "sync", "--recursive"])
         submodules = subprocess.check_output(["git", "submodule", "status"])
         for line in submodules.split('\n'):
             components = line.strip().split(' ')


### PR DESCRIPTION
This eliminates the

```
Synchronizing submodule url for 'support/android-rs-glue'
Synchronizing submodule url for 'tests/wpt/web-platform-tests'
```

messages that appeared for every `mach build` command.
