### PR TITLE
Add measurement of the flow tree's size.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1395,12 +1395,8 @@ impl<Window> CompositorEventListener for IOCompositor<Window> where Window: Wind
         while self.port.try_recv_compositor_msg().is_some() {}
 
         // Tell the profiler, memory profiler, and scrolling timer to shut down.
-        let TimeProfilerChan(ref time_profiler_chan) = self.time_profiler_chan;
-        time_profiler_chan.send(time::TimeProfilerMsg::Exit).unwrap();
-
-        let MemoryProfilerChan(ref memory_profiler_chan) = self.memory_profiler_chan;
-        memory_profiler_chan.send(memory::MemoryProfilerMsg::Exit).unwrap();
-
+        self.time_profiler_chan.send(time::TimeProfilerMsg::Exit);
+        self.memory_profiler_chan.send(memory::MemoryProfilerMsg::Exit);
         self.scrolling_timer.shutdown();
     }
 

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -29,6 +29,7 @@ use net::resource_task;
 use net::storage_task::{StorageTask, StorageTaskMsg};
 use util::cursor::Cursor;
 use util::geometry::{PagePx, ViewportPx};
+use util::memory::MemoryProfilerChan;
 use util::opts;
 use util::task::spawn_named;
 use util::time::TimeProfilerChan;
@@ -86,6 +87,9 @@ pub struct Constellation<LTF, STF> {
 
     /// A channel through which messages can be sent to the time profiler.
     pub time_profiler_chan: TimeProfilerChan,
+
+    /// A channel through which messages can be sent to the memory profiler.
+    pub memory_profiler_chan: MemoryProfilerChan,
 
     pub window_size: WindowSizeData,
 }
@@ -346,6 +350,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                  image_cache_task: ImageCacheTask,
                  font_cache_task: FontCacheTask,
                  time_profiler_chan: TimeProfilerChan,
+                 memory_profiler_chan: MemoryProfilerChan,
                  devtools_chan: Option<DevtoolsControlChan>,
                  storage_task: StorageTask)
                  -> ConstellationChan {
@@ -368,6 +373,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 pending_frames: vec!(),
                 pending_sizes: HashMap::new(),
                 time_profiler_chan: time_profiler_chan,
+                memory_profiler_chan: memory_profiler_chan,
                 window_size: WindowSizeData {
                     visible_viewport: opts::get().initial_window_size.as_f32() * ScaleFactor(1.0),
                     initial_viewport: opts::get().initial_window_size.as_f32() * ScaleFactor(1.0),
@@ -405,6 +411,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                                                 self.resource_task.clone(),
                                                 self.storage_task.clone(),
                                                 self.time_profiler_chan.clone(),
+                                                self.memory_profiler_chan.clone(),
                                                 self.window_size,
                                                 script_pipeline,
                                                 load_data.clone());

--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -16,6 +16,7 @@ use msg::constellation_msg::{LoadData, WindowSizeData, PipelineExitType};
 use net::image_cache_task::ImageCacheTask;
 use net::resource_task::ResourceTask;
 use net::storage_task::StorageTask;
+use util::memory::MemoryProfilerChan;
 use util::time::TimeProfilerChan;
 use std::rc::Rc;
 use std::sync::mpsc::{Receiver, channel};
@@ -57,6 +58,7 @@ impl Pipeline {
                            resource_task: ResourceTask,
                            storage_task: StorageTask,
                            time_profiler_chan: TimeProfilerChan,
+                           memory_profiler_chan: MemoryProfilerChan,
                            window_size: WindowSizeData,
                            script_pipeline: Option<Rc<Pipeline>>,
                            load_data: LoadData)
@@ -126,6 +128,7 @@ impl Pipeline {
                                   image_cache_task,
                                   font_cache_task,
                                   time_profiler_chan,
+                                  memory_profiler_chan,
                                   layout_shutdown_chan);
 
         Pipeline::new(id,

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -11,6 +11,7 @@ use std::ops::{Add, Sub, Mul, Neg, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr, No
 use std::u16;
 use std::vec::Vec;
 use util::geometry::Au;
+use util::memory::SizeOf;
 use util::range::{self, Range, RangeIndex, EachIndex};
 use util::vec::*;
 

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -7,6 +7,7 @@ use font::{ShapingOptions};
 use platform::font_template::FontTemplateData;
 use util::geometry::Au;
 use util::range::Range;
+use util::memory::SizeOf;
 use util::vec::{Comparator, FullBinarySearchMethods};
 use std::cmp::Ordering;
 use std::slice::Iter;
@@ -31,6 +32,13 @@ pub struct GlyphRun {
     pub glyph_store: Arc<GlyphStore>,
     /// The range of characters in the containing run.
     pub range: Range<CharIndex>,
+}
+
+impl SizeOf for GlyphRun {
+    fn size_of_excluding_self(&self) -> usize {
+        // `glyph_store` is not an owning reference so don't measure it.
+        0
+    }
 }
 
 pub struct NaturalWordSliceIterator<'a> {
@@ -371,5 +379,16 @@ impl<'a> TextRun {
             clump: None,
             slices: self.natural_word_slices_in_range(range),
         }
+    }
+}
+
+impl SizeOf for TextRun {
+    fn size_of_excluding_self(&self) -> usize {
+        // This assumes that the TextRun owns `text` and `glyphs`.
+        self.text.size_of_excluding_self() +
+            self.glyphs.size_of_excluding_self()
+
+        // XXX: the following fields may be measured in the future:
+        // - font_metrics
     }
 }

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -54,6 +54,7 @@ use rustc_serialize::{Encoder, Encodable};
 use msg::compositor_msg::LayerId;
 use servo_util::geometry::{Au, MAX_AU};
 use servo_util::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize};
+use servo_util::memory::SizeOf;
 use servo_util::opts;
 use std::cmp::{max, min};
 use std::fmt;
@@ -1914,6 +1915,16 @@ impl Flow for BlockFlow {
                                                                  .relative_containing_block_size,
                                                             CoordinateSystem::Parent)
                               .translate(stacking_context_position));
+    }
+}
+
+impl SizeOf for BlockFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.base.size_of_excluding_self() +
+            self.fragment.size_of_excluding_self()
+
+        // XXX: the following fields may be measured in the future:
+        // - float
     }
 }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -35,6 +35,7 @@ use flow_ref::FlowRef;
 use fragment::{Fragment, FragmentBorderBoxIterator, SpecificFragmentInfo};
 use incremental::{RECONSTRUCT_FLOW, REFLOW, REFLOW_OUT_OF_FLOW, RestyleDamage};
 use inline::InlineFlow;
+use list_item::ListItemFlow;
 use model::{CollapsibleMargins, IntrinsicISizes};
 use parallel::FlowParallelInfo;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, TableFlow};
@@ -52,6 +53,7 @@ use rustc_serialize::{Encoder, Encodable};
 use msg::compositor_msg::LayerId;
 use servo_util::geometry::{Au, ZERO_RECT};
 use servo_util::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
+use servo_util::memory::SizeOf;
 use std::mem;
 use std::fmt;
 use std::iter::Zip;
@@ -67,7 +69,7 @@ use std::sync::Arc;
 ///
 /// Note that virtual methods have a cost; we should not overuse them in Servo. Consider adding
 /// methods to `ImmutableFlowUtils` or `MutableFlowUtils` before adding more methods here.
-pub trait Flow: fmt::Debug + Sync {
+pub trait Flow: fmt::Debug + SizeOf + Sync {
     // RTTI
     //
     // TODO(pcwalton): Use Rust's RTTI, once that works.
@@ -850,6 +852,22 @@ impl Drop for BaseFlow {
         if self.ref_count.load(Ordering::SeqCst) != 0 {
             panic!("Flow destroyed before its ref count hit zero—this is unsafe!")
         }
+    }
+}
+
+impl SizeOf for BaseFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.children.iter().fold(0, |n, kid| n + kid.size_of_including_self())
+
+        // XXX: other fields may be measured in the future
+    }
+
+    fn size_of_including_self(&self) -> usize {
+        // This should never be called; only size_of_excluding_self() should be
+        // called. That's because BaseFlow is always embedded within another
+        // struct (e.g. BlockFlow), and so that surrounding struct's `self`
+        // should be the one getting measured.
+        panic!("BaseFlow::size_of_excluding_self() called");
     }
 }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -857,17 +857,9 @@ impl Drop for BaseFlow {
 
 impl SizeOf for BaseFlow {
     fn size_of_excluding_self(&self) -> usize {
-        self.children.iter().fold(0, |n, kid| n + kid.size_of_including_self())
+        self.children.iter().fold(0, |n, kid| n + kid.size_of_excluding_self())
 
         // XXX: other fields may be measured in the future
-    }
-
-    fn size_of_including_self(&self) -> usize {
-        // This should never be called; only size_of_excluding_self() should be
-        // called. That's because BaseFlow is always embedded within another
-        // struct (e.g. BlockFlow), and so that surrounding struct's `self`
-        // should be the one getting measured.
-        panic!("BaseFlow::size_of_excluding_self() called");
     }
 }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -19,7 +19,7 @@ use inline::{InlineFragmentContext, InlineMetrics};
 use layout_debug;
 use model::{IntrinsicISizes, IntrinsicISizesContribution, MaybeAuto, specified};
 use model;
-use servo_util::memory::{SizeOf, size_of_vec_excluding_self};
+use servo_util::memory::SizeOf;
 use text;
 use util::OpaqueNodeMethods;
 use wrapper::{TLayoutNode, ThreadSafeLayoutNode};
@@ -619,11 +619,10 @@ impl SizeOf for ScannedTextFragmentInfo {
         // `run` is an Arc<>, but the LayoutTask owns the TextRun, and so is the right thread to
         // measure it.
         self.run.size_of_including_self() +
-            size_of_vec_excluding_self(&self.new_line_pos) +
+            self.new_line_pos.size_of_excluding_self() +
             match self.original_new_line_pos {
                 None => 0,
-                Some(ref original_new_line_pos) =>
-                    size_of_vec_excluding_self(&original_new_line_pos),
+                Some(ref original_new_line_pos) => original_new_line_pos.size_of_excluding_self(),
             }
     }
 }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -212,8 +212,7 @@ impl SizeOf for SpecificFragmentInfo {
             SpecificFragmentInfo::InlineAbsoluteHypothetical(_) => 0,
             SpecificFragmentInfo::InlineBlock(_) => 0,
 
-            SpecificFragmentInfo::ScannedText(ref info) =>
-                info.size_of_including_self(),
+            SpecificFragmentInfo::ScannedText(ref info) => info.size_of_excluding_self(),
 
             // XXX: todo
             SpecificFragmentInfo::TableColumn(_) => 0,
@@ -618,7 +617,7 @@ impl SizeOf for ScannedTextFragmentInfo {
     fn size_of_excluding_self(&self) -> usize {
         // `run` is an Arc<>, but the LayoutTask owns the TextRun, and so is the right thread to
         // measure it.
-        self.run.size_of_including_self() +
+        self.run.size_of_excluding_self() +
             self.new_line_pos.size_of_excluding_self() +
             match self.original_new_line_pos {
                 None => 0,

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -27,6 +27,7 @@ use gfx::text::glyph::CharIndex;
 use servo_util::arc_ptr_eq;
 use servo_util::geometry::{Au, ZERO_RECT};
 use servo_util::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
+use servo_util::memory::{SizeOf, size_of_vec_excluding_self};
 use servo_util::range::{Range, RangeIndex};
 use std::cmp::max;
 use std::fmt;
@@ -718,6 +719,12 @@ impl fmt::Debug for InlineFragments {
     }
 }
 
+impl SizeOf for InlineFragments {
+    fn size_of_excluding_self(&self) -> usize {
+        self.fragments.size_of_excluding_self()
+    }
+}
+
 
 impl InlineFragments {
     /// Creates an empty set of inline fragments.
@@ -1390,6 +1397,14 @@ impl Flow for InlineFlow {
                                                                     CoordinateSystem::Parent)
                                       .translate(stacking_context_position))
         }
+    }
+}
+
+impl SizeOf for InlineFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.base.size_of_excluding_self() +
+            self.fragments.size_of_excluding_self() +
+            size_of_vec_excluding_self(&self.lines)
     }
 }
 

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -27,7 +27,7 @@ use gfx::text::glyph::CharIndex;
 use servo_util::arc_ptr_eq;
 use servo_util::geometry::{Au, ZERO_RECT};
 use servo_util::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
-use servo_util::memory::{SizeOf, size_of_vec_excluding_self};
+use servo_util::memory::SizeOf;
 use servo_util::range::{Range, RangeIndex};
 use std::cmp::max;
 use std::fmt;
@@ -151,6 +151,12 @@ pub struct Line {
     /// FFF float
     /// ~~~
     pub green_zone: LogicalSize<Au>,
+}
+
+impl SizeOf for Line {
+    fn size_of_excluding_self(&self) -> usize {
+        0
+    }
 }
 
 int_range_index! {
@@ -1404,7 +1410,7 @@ impl SizeOf for InlineFlow {
     fn size_of_excluding_self(&self) -> usize {
         self.base.size_of_excluding_self() +
             self.fragments.size_of_excluding_self() +
-            size_of_vec_excluding_self(&self.lines)
+            self.lines.size_of_excluding_self()
     }
 }
 

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -888,6 +888,11 @@ impl LayoutTask {
             layout_root.dump();
         }
 
+        // njn: currently just measuring the size and printing every time a reflow happens. The
+        // meaurement should instead be done in response to a message from the MemoryProfiler task,
+        // and the result passed back for presentation.
+        println!("total-size = {}", layout_root.size_of_excluding_self());
+
         rw_data.generation += 1;
 
         // Tell script that we're done.

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -353,13 +353,13 @@ impl LayoutTask {
             PortToRead::Pipeline => {
                 match self.pipeline_port.recv().unwrap() {
                     LayoutControlMsg::ExitNowMsg(exit_type) => {
-                        self.handle_script_request(Msg::ExitNow(exit_type), possibly_locked_rw_data)
+                        self.handle_request_helper(Msg::ExitNow(exit_type), possibly_locked_rw_data)
                     }
                 }
             },
             PortToRead::Script => {
                 let msg = self.port.recv().unwrap();
-                self.handle_script_request(msg, possibly_locked_rw_data)
+                self.handle_request_helper(msg, possibly_locked_rw_data)
             }
         }
     }
@@ -390,8 +390,8 @@ impl LayoutTask {
         }
     }
 
-    /// Receives and dispatches messages from the script task.
-    fn handle_script_request<'a>(&'a self,
+    /// Receives and dispatches messages from other tasks.
+    fn handle_request_helper<'a>(&'a self,
                                  request: Msg,
                                  possibly_locked_rw_data: &mut Option<MutexGuard<'a,
                                                                                  LayoutTaskData>>)

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -20,6 +20,7 @@ use geom::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use servo_util::geometry::Au;
 use servo_util::logical_geometry::LogicalRect;
+use servo_util::memory::SizeOf;
 use servo_util::opts;
 use style::properties::ComputedValues;
 use style::computed_values::list_style_type;
@@ -135,6 +136,13 @@ impl Flow for ListItemFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for ListItemFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self() +
+            self.marker.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -23,6 +23,7 @@ use wrapper::ThreadSafeLayoutNode;
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
 use servo_util::logical_geometry::LogicalRect;
+use servo_util::memory::SizeOf;
 use std::cmp::max;
 use std::fmt;
 use style::properties::ComputedValues;
@@ -395,6 +396,12 @@ impl Flow for TableFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for TableFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -16,6 +16,7 @@ use wrapper::ThreadSafeLayoutNode;
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
 use servo_util::logical_geometry::LogicalRect;
+use servo_util::memory::SizeOf;
 use std::fmt;
 use style::properties::ComputedValues;
 use std::sync::Arc;
@@ -95,6 +96,12 @@ impl Flow for TableCaptionFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for TableCaptionFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -18,6 +18,7 @@ use wrapper::ThreadSafeLayoutNode;
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
 use servo_util::logical_geometry::LogicalRect;
+use servo_util::memory::SizeOf;
 use std::fmt;
 use style::properties::ComputedValues;
 use style::legacy::UnsignedIntegerAttribute;
@@ -177,6 +178,12 @@ impl Flow for TableCellFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for TableCellFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -15,6 +15,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::{Au, ZERO_RECT};
+use servo_util::memory::{SizeOf, size_of_vec_excluding_self};
 use std::cmp::max;
 use std::fmt;
 use style::values::computed::LengthOrPercentageOrAuto;
@@ -104,6 +105,15 @@ impl Flow for TableColGroupFlow {
     fn iterate_through_fragment_border_boxes(&self,
                                              _: &mut FragmentBorderBoxIterator,
                                              _: &Point2D<Au>) {}
+}
+
+impl SizeOf for TableColGroupFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.base.size_of_excluding_self() +
+            self.fragment.size_of_excluding_self() +
+            self.cols.size_of_excluding_self() +
+            size_of_vec_excluding_self(&self.inline_sizes)
+    }
 }
 
 impl fmt::Debug for TableColGroupFlow {

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -15,7 +15,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::{Au, ZERO_RECT};
-use servo_util::memory::{SizeOf, size_of_vec_excluding_self};
+use servo_util::memory::SizeOf;
 use std::cmp::max;
 use std::fmt;
 use style::values::computed::LengthOrPercentageOrAuto;
@@ -112,7 +112,7 @@ impl SizeOf for TableColGroupFlow {
         self.base.size_of_excluding_self() +
             self.fragment.size_of_excluding_self() +
             self.cols.size_of_excluding_self() +
-            size_of_vec_excluding_self(&self.inline_sizes)
+            self.inline_sizes.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -21,6 +21,7 @@ use wrapper::ThreadSafeLayoutNode;
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
 use servo_util::logical_geometry::LogicalRect;
+use servo_util::memory::SizeOf;
 use std::cmp::max;
 use std::fmt;
 use style::properties::ComputedValues;
@@ -330,6 +331,12 @@ impl Flow for TableRowFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for TableRowFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -18,6 +18,7 @@ use wrapper::ThreadSafeLayoutNode;
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
 use servo_util::logical_geometry::LogicalRect;
+use servo_util::memory::SizeOf;
 use std::fmt;
 use style::properties::ComputedValues;
 use std::sync::Arc;
@@ -164,6 +165,12 @@ impl Flow for TableRowGroupFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for TableRowGroupFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self()
     }
 }
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -25,6 +25,7 @@ use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
 use servo_util::geometry::Au;
+use servo_util::memory::SizeOf;
 use std::cmp::{max, min};
 use std::fmt;
 use std::ops::Add;
@@ -382,6 +383,12 @@ impl Flow for TableWrapperFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+}
+
+impl SizeOf for TableWrapperFlow {
+    fn size_of_excluding_self(&self) -> usize {
+        self.block_flow.size_of_excluding_self()
     }
 }
 

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -20,6 +20,7 @@ use gfx::paint_task::PaintChan;
 use msg::constellation_msg::{ConstellationChan, Failure, PipelineId, PipelineExitType};
 use net::image_cache_task::ImageCacheTask;
 use net::resource_task::ResourceTask;
+use util::memory::MemoryProfilerChan;
 use util::time::TimeProfilerChan;
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel};
 use std::sync::mpsc::{Sender, Receiver};
@@ -48,5 +49,6 @@ pub trait LayoutTaskFactory {
               img_cache_task: ImageCacheTask,
               font_cache_task: FontCacheTask,
               time_profiler_chan: TimeProfilerChan,
+              memory_profiler_chan: MemoryProfilerChan,
               shutdown_chan: Sender<()>);
 }

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -13,6 +13,7 @@ use geom::rect::Rect;
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel, UntrustedNodeAddress};
 use msg::constellation_msg::{PipelineExitType, WindowSizeData};
 use util::geometry::Au;
+use util::memory::{MemoryReporter, MemoryReportsChan};
 use std::any::Any;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::boxed::BoxAny;
@@ -42,6 +43,10 @@ pub enum Msg {
     ///
     /// TODO(pcwalton): Maybe think about batching to avoid message traffic.
     ReapLayoutData(LayoutData),
+
+    /// Requests that the layout task measure its memory usage. The resulting reports are sent back
+    /// via the supplied channel.
+    CollectMemoryReports(MemoryReportsChan),
 
     /// Requests that the layout task enter a quiescent state in which no more messages are
     /// accepted except `ExitMsg`. A response message will be sent on the supplied channel when
@@ -124,6 +129,14 @@ impl LayoutChan {
     pub fn new() -> (Receiver<Msg>, LayoutChan) {
         let (chan, port) = channel();
         (port, LayoutChan(chan))
+    }
+}
+
+impl MemoryReporter for LayoutChan {
+    // Just injects an appropriate event into the layout task's queue.
+    fn collect_reports(&self, reports_chan: MemoryReportsChan) {
+        let LayoutChan(ref c) = *self;
+        c.send(Msg::CollectMemoryReports(reports_chan)).unwrap();
     }
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -82,6 +82,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
 
         let opts_clone = opts.clone();
         let time_profiler_chan_clone = time_profiler_chan.clone();
+        let memory_profiler_chan_clone = memory_profiler_chan.clone();
 
         let (result_chan, result_port) = channel();
         let compositor_proxy_for_constellation = compositor_proxy.clone_compositor_proxy();
@@ -109,6 +110,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                                                           image_cache_task,
                                                           font_cache_task,
                                                           time_profiler_chan_clone,
+                                                          memory_profiler_chan_clone,
                                                           devtools_chan,
                                                           storage_task);
 

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -677,6 +677,7 @@ pub mod computed {
     use std::fmt;
     use url::Url;
     use util::geometry::Au;
+    use util::memory::SizeOf;
 
     #[allow(missing_copy_implementations)]  // It’s kinda big
     pub struct Context {
@@ -780,6 +781,12 @@ pub mod computed {
                 &LengthOrPercentageOrAuto::Percentage(percentage) => write!(f, "{}%", percentage * 100.),
                 &LengthOrPercentageOrAuto::Auto => write!(f, "auto"),
             }
+        }
+    }
+
+    impl SizeOf for LengthOrPercentageOrAuto {
+        fn size_of_excluding_self(&self) -> usize {
+            0
         }
     }
 

--- a/components/util/memory.rs
+++ b/components/util/memory.rs
@@ -97,18 +97,11 @@ impl<T: SizeOf> SizeOf for Option<T> {
     }
 }
 
-// Use this for Vec<T> when T implements `SizeOf`.
 impl<T: SizeOf> SizeOf for Vec<T> {
     fn size_of_excluding_self(&self) -> usize {
-        size_of_vec_excluding_self(self) +
+        heap_size_of(self.as_ptr() as *const c_void) +
             self.iter().fold(0, |n, elem| n + elem.size_of_excluding_self())
     }
-}
-
-// Use this for Vec<T> when T does not implement `SizeOf`. Ideally we'd be able to implement the
-// `SizeOf` trait directly, but that implementation would conflict with the `Vec<T: SizeOf>` above.
-pub fn size_of_vec_excluding_self<T>(v: &Vec<T>) -> usize {
-    heap_size_of(v.as_ptr() as *const c_void)
 }
 
 pub struct MemoryProfilerChan(pub Sender<MemoryProfilerMsg>);

--- a/components/util/range.rs
+++ b/components/util/range.rs
@@ -184,6 +184,12 @@ macro_rules! int_range_index {
                 $Self(self.get() >> n)
             }
         }
+
+        impl SizeOf for $Self {
+            fn size_of_excluding_self(&self) -> usize {
+                0
+            }
+        }
     )
 }
 

--- a/ports/gonk/src/lib.rs
+++ b/ports/gonk/src/lib.rs
@@ -86,6 +86,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
 
         let opts_clone = opts.clone();
         let time_profiler_chan_clone = time_profiler_chan.clone();
+        let memory_profiler_chan_clone = memory_profiler_chan.clone();
 
         let (result_chan, result_port) = channel();
         let compositor_proxy_for_constellation = compositor_proxy.clone_compositor_proxy();
@@ -113,6 +114,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                                                           image_cache_task,
                                                           font_cache_task,
                                                           time_profiler_chan_clone,
+                                                          memory_profiler_chan_clone,
                                                           devtools_chan,
                                                           storage_task);
 


### PR DESCRIPTION
This is a DRAFT patch. The way the measurement is incorporated needs to
be fixed, but I'm putting it up now in order to get feedback because
this code exemplifies the likely structure of all future fine-grained
memory reporting in Servo, which is heavily influenced by the
corresponding code in Firefox.

Comments marked with "njn" in particular are places where things are
uncertain and/or incomplete.

Note also that we also will need a DMD-like tool that can verify the
correctness of these measurements (which is almost impossible,
otherwise) and also find places where additional measurements should be
added. This requires alloc/dealloc wrapping, which I've been
experimenting with and soliciting feedback for, without much success
yet.

BTW, it's not clear to me at the moment if the flow tree is a persistent
data structure or one that's rebuilt from scratch on each reflow. At
this point I rather hope it's the former.
