### PR TITLE
Support opt-in async network events

### DIFF
--- a/components/net/about_loader.rs
+++ b/components/net/about_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use net_traits::{LoadData, Metadata};
+use net_traits::{LoadData, Metadata,ResponseSenders};
 use net_traits::ProgressMsg::Done;
 use mime_classifier::MIMEClassifier;
 use resource_task::start_sending;
@@ -18,10 +18,9 @@ use std::borrow::IntoCow;
 use std::fs::PathExt;
 use std::sync::Arc;
 
-pub fn factory(mut load_data: LoadData, classifier: Arc<MIMEClassifier>) {
+pub fn factory(mut load_data: LoadData, start_chan: ResponseSenders, classifier: Arc<MIMEClassifier>) {
     match load_data.url.non_relative_scheme_data().unwrap() {
         "blank" => {
-            let start_chan = load_data.consumer;
             let chan = start_sending(start_chan, Metadata {
                 final_url: load_data.url,
                 content_type: Some(ContentType(Mime(TopLevel::Text, SubLevel::Html, vec![]))),
@@ -40,11 +39,10 @@ pub fn factory(mut load_data: LoadData, classifier: Arc<MIMEClassifier>) {
             load_data.url = Url::from_file_path(&*path).unwrap();
         }
         _ => {
-            let start_chan = load_data.consumer;
             start_sending(start_chan, Metadata::default(load_data.url))
                 .send(Done(Err("Unknown about: URL.".to_string()))).unwrap();
             return
         }
     };
-    file_loader::factory(load_data, classifier)
+    file_loader::factory(load_data, start_chan, classifier)
 }

--- a/components/net/data_loader.rs
+++ b/components/net/data_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use net_traits::{LoadData, Metadata};
+use net_traits::{LoadData, Metadata, ResponseSenders};
 use net_traits::ProgressMsg::{Payload, Done};
 use mime_classifier::MIMEClassifier;
 use resource_task::start_sending;
@@ -13,16 +13,15 @@ use hyper::mime::Mime;
 use std::sync::Arc;
 use url::{percent_decode, SchemeData};
 
-pub fn factory(load_data: LoadData, _classifier: Arc<MIMEClassifier>) {
+pub fn factory(load_data: LoadData, senders: ResponseSenders, _classifier: Arc<MIMEClassifier>) {
     // NB: we don't spawn a new task.
     // Hypothesis: data URLs are too small for parallel base64 etc. to be worth it.
     // Should be tested at some point.
     // Left in separate function to allow easy moving to a task, if desired.
-    load(load_data)
+    load(load_data, senders)
 }
 
-pub fn load(load_data: LoadData) {
-    let start_chan = load_data.consumer;
+pub fn load(load_data: LoadData, start_chan: ResponseSenders) {
     let url = load_data.url;
     assert!(&*url.scheme == "data");
 

--- a/components/net/file_loader.rs
+++ b/components/net/file_loader.rs
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use net_traits::{LoadData, Metadata, ProgressMsg, ResponseSenders};
+use net_traits::{LoadData, Metadata, ResponseSenders};
 use net_traits::ProgressMsg::{Payload, Done};
 use mime_classifier::MIMEClassifier;
-use resource_task::{start_sending, start_sending_sniffed};
+use resource_task::{start_sending, start_sending_sniffed, ProgressSender};
 
 use std::borrow::ToOwned;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::mpsc::Sender;
 use util::task::spawn_named;
 
 static READ_SIZE: usize = 8192;
@@ -34,7 +33,7 @@ fn read_block(reader: &mut File) -> Result<ReadStatus, String> {
     }
 }
 
-fn read_all(reader: &mut File, progress_chan: &Sender<ProgressMsg>)
+fn read_all(reader: &mut File, progress_chan: &ProgressSender)
             -> Result<(), String> {
     loop {
         match try!(read_block(reader)) {

--- a/components/net/file_loader.rs
+++ b/components/net/file_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use net_traits::{LoadData, Metadata, ProgressMsg};
+use net_traits::{LoadData, Metadata, ProgressMsg, ResponseSenders};
 use net_traits::ProgressMsg::{Payload, Done};
 use mime_classifier::MIMEClassifier;
 use resource_task::{start_sending, start_sending_sniffed};
@@ -44,9 +44,8 @@ fn read_all(reader: &mut File, progress_chan: &Sender<ProgressMsg>)
     }
 }
 
-pub fn factory(load_data: LoadData, classifier: Arc<MIMEClassifier>) {
+pub fn factory(load_data: LoadData, senders: ResponseSenders, classifier: Arc<MIMEClassifier>) {
     let url = load_data.url;
-    let start_chan = load_data.consumer;
     assert!(&*url.scheme == "file");
     spawn_named("file_loader".to_owned(), move || {
         let metadata = Metadata::default(url.clone());
@@ -58,24 +57,24 @@ pub fn factory(load_data: LoadData, classifier: Arc<MIMEClassifier>) {
                         let res = read_block(reader);
                         let (res, progress_chan) = match res {
                             Ok(ReadStatus::Partial(buf)) => {
-                                let progress_chan = start_sending_sniffed(start_chan, metadata,
+                                let progress_chan = start_sending_sniffed(senders, metadata,
                                                                           classifier, &buf);
                                 progress_chan.send(Payload(buf)).unwrap();
                                 (read_all(reader, &progress_chan), progress_chan)
                             }
                             Ok(ReadStatus::EOF) | Err(_) =>
-                                (res.map(|_| ()), start_sending(start_chan, metadata)),
+                                (res.map(|_| ()), start_sending(senders, metadata)),
                         };
                         progress_chan.send(Done(res)).unwrap();
                     }
                     Err(e) => {
-                        let progress_chan = start_sending(start_chan, metadata);
+                        let progress_chan = start_sending(senders, metadata);
                         progress_chan.send(Done(Err(e.description().to_string()))).unwrap();
                     }
                 }
             }
             Err(_) => {
-                let progress_chan = start_sending(start_chan, metadata);
+                let progress_chan = start_sending(senders, metadata);
                 progress_chan.send(Done(Err(url.to_string()))).unwrap();
             }
         }

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -35,6 +35,7 @@ use std::thunk::Invoke;
 static mut HOST_TABLE: Option<*mut HashMap<String, String>> = None;
 
 pub fn global_init() {
+<<<<<<< HEAD
     //TODO: handle bad file path
     let path = match env::var("HOST_FILE") {
         Ok(host_file_path) => host_file_path,

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -35,7 +35,6 @@ use std::thunk::Invoke;
 static mut HOST_TABLE: Option<*mut HashMap<String, String>> = None;
 
 pub fn global_init() {
-<<<<<<< HEAD
     //TODO: handle bad file path
     let path = match env::var("HOST_FILE") {
         Ok(host_file_path) => host_file_path,

--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -12,7 +12,7 @@ use cookie_storage::CookieStorage;
 use cookie;
 use mime_classifier::MIMEClassifier;
 
-use net_traits::{ControlMsg, LoadData, LoadResponse};
+use net_traits::{ControlMsg, LoadData, LoadResponse, ResponseSenders, LoadConsumer};
 use net_traits::{Metadata, ProgressMsg, ResourceTask};
 use net_traits::ProgressMsg::Done;
 use util::opts;
@@ -59,19 +59,19 @@ pub fn global_init() {
 }
 
 /// For use by loaders in responding to a Load message.
-pub fn start_sending(start_chan: Sender<LoadResponse>, metadata: Metadata) -> Sender<ProgressMsg> {
+pub fn start_sending(start_chan: ResponseSenders, metadata: Metadata) -> Sender<ProgressMsg> {
     start_sending_opt(start_chan, metadata).ok().unwrap()
 }
 
 /// For use by loaders in responding to a Load message that allows content sniffing.
-pub fn start_sending_sniffed(start_chan: Sender<LoadResponse>, metadata: Metadata,
+pub fn start_sending_sniffed(start_chan: ResponseSenders, metadata: Metadata,
                              classifier: Arc<MIMEClassifier>, partial_body: &Vec<u8>)
                              -> Sender<ProgressMsg> {
     start_sending_sniffed_opt(start_chan, metadata, classifier, partial_body).ok().unwrap()
 }
 
 /// For use by loaders in responding to a Load message that allows content sniffing.
-pub fn start_sending_sniffed_opt(start_chan: Sender<LoadResponse>, mut metadata: Metadata,
+pub fn start_sending_sniffed_opt(start_chan: ResponseSenders, mut metadata: Metadata,
                                  classifier: Arc<MIMEClassifier>, partial_body: &Vec<u8>)
                                  -> Result<Sender<ProgressMsg>, ()> {
     if opts::get().sniff_mime_types {
@@ -94,15 +94,20 @@ pub fn start_sending_sniffed_opt(start_chan: Sender<LoadResponse>, mut metadata:
 }
 
 /// For use by loaders in responding to a Load message.
-pub fn start_sending_opt(start_chan: Sender<LoadResponse>, metadata: Metadata) -> Result<Sender<ProgressMsg>, ()> {
-    let (progress_chan, progress_port) = channel();
-    let result = start_chan.send(LoadResponse {
-        metadata:      metadata,
-        progress_port: progress_port,
-    });
-    match result {
-        Ok(_) => Ok(progress_chan),
-        Err(_) => Err(())
+pub fn start_sending_opt(start_chan: ResponseSenders, metadata: Metadata) -> Result<Sender<ProgressMsg>, ()> {
+    match start_chan {
+        ResponseSenders::Channel(start_chan) => {
+            let (progress_chan, progress_port) = channel();
+            let result = start_chan.send(LoadResponse {
+                metadata:      metadata,
+                progress_port: progress_port,
+            });
+            match result {
+                Ok(_) => Ok(progress_chan),
+                Err(_) => Err(())
+            }
+        }
+        ResponseSenders::Listener(_) => panic!(),
     }
 }
 
@@ -176,8 +181,8 @@ impl ResourceManager {
     fn start(&mut self) {
         loop {
             match self.from_client.recv().unwrap() {
-              ControlMsg::Load(load_data) => {
-                self.load(load_data)
+              ControlMsg::Load(load_data, consumer) => {
+                self.load(load_data, consumer)
               }
               ControlMsg::SetCookiesForUrl(request, cookie_list, source) => {
                 let header = Header::parse_header(&[cookie_list.into_bytes()]);
@@ -199,7 +204,7 @@ impl ResourceManager {
         }
     }
 
-    fn load(&mut self, mut load_data: LoadData) {
+    fn load(&mut self, mut load_data: LoadData, consumer: LoadConsumer) {
         unsafe {
             if let Some(host_table) = HOST_TABLE {
                 load_data = replace_hosts(load_data, host_table);
@@ -208,13 +213,14 @@ impl ResourceManager {
 
         self.user_agent.as_ref().map(|ua| load_data.headers.set(UserAgent(ua.clone())));
 
-        fn from_factory(factory: fn(LoadData, Arc<MIMEClassifier>))
-                        -> Box<Invoke<(LoadData, Arc<MIMEClassifier>)> + Send> {
-            box move |(load_data, classifier)| {
-                factory(load_data, classifier)
+        fn from_factory(factory: fn(LoadData, ResponseSenders, Arc<MIMEClassifier>))
+                        -> Box<Invoke<(LoadData, ResponseSenders, Arc<MIMEClassifier>)> + Send> {
+            box move |(load_data, senders, classifier)| {
+                factory(load_data, senders, classifier)
             }
         }
 
+        let senders = ResponseSenders::from_consumer(consumer);
         let loader = match &*load_data.url.scheme {
             "file" => from_factory(file_loader::factory),
             "http" | "https" | "view-source" => http_loader::factory(self.resource_task.clone()),
@@ -222,13 +228,13 @@ impl ResourceManager {
             "about" => from_factory(about_loader::factory),
             _ => {
                 debug!("resource_task: no loader for scheme {}", load_data.url.scheme);
-                start_sending(load_data.consumer, Metadata::default(load_data.url))
+                start_sending(senders, Metadata::default(load_data.url))
                     .send(ProgressMsg::Done(Err("no loader for scheme".to_string()))).unwrap();
                 return
             }
         };
         debug!("resource_task: loading url: {}", load_data.url.serialize());
 
-        loader.invoke((load_data, self.mime_classifier.clone()));
+        loader.invoke((load_data, senders, self.mime_classifier.clone()));
     }
 }

--- a/components/net_traits/image_cache_task.rs
+++ b/components/net_traits/image_cache_task.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use image::base::Image;
+use LoadConsumer::Channel;
 use {ControlMsg, LoadData, ProgressMsg, ResourceTask};
 use url::Url;
 
@@ -84,7 +85,7 @@ impl ImageCacheTaskClient for ImageCacheTask {
 
 pub fn load_image_data(url: Url, resource_task: ResourceTask, placeholder: &[u8]) -> Result<Vec<u8>, ()> {
     let (response_chan, response_port) = channel();
-    resource_task.send(ControlMsg::Load(LoadData::new(url.clone(), response_chan))).unwrap();
+    resource_task.send(ControlMsg::Load(LoadData::new(url.clone()), Channel(response_chan))).unwrap();
 
     let mut image_data = vec!();
 

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -16,6 +16,7 @@ use std::cell::{BorrowState, RefCell, Ref, RefMut};
 ///
 /// This extends the API of `core::cell::RefCell` to allow unsafe access in
 /// certain situations, with dynamic checking in debug builds.
+#[derive(Clone)]
 pub struct DOMRefCell<T> {
     value: RefCell<T>,
 }

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -12,8 +12,8 @@ use dom::bindings::js::{JS, JSRef, Root, Unrooted};
 use dom::bindings::utils::{Reflectable, Reflector};
 use dom::workerglobalscope::{WorkerGlobalScope, WorkerGlobalScopeHelpers};
 use dom::window::{self, WindowHelpers};
-use script_task::ScriptChan;
 use devtools_traits::DevtoolsControlChan;
+use script_task::{ScriptChan, ScriptPort, ScriptMsg, ScriptTask};
 
 use msg::constellation_msg::{PipelineId, WorkerId};
 use net_traits::ResourceTask;
@@ -127,6 +127,24 @@ impl<'a> GlobalRef<'a> {
         match *self {
             GlobalRef::Window(ref window) => window.script_chan(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
+        }
+    }
+
+    /// `ScriptChan` used to send messages to the event loop of this global's
+    /// thread.
+    pub fn new_script_pair(&self) -> (Box<ScriptChan+Send>, Box<ScriptPort+Send>) {
+        match *self {
+            GlobalRef::Window(ref window) => window.new_script_pair(),
+            GlobalRef::Worker(ref worker) => worker.new_script_pair(),
+        }
+    }
+
+    /// Process a single event as if it were the next event in the task queue for
+    /// this global.
+    pub fn process_event(&self, msg: ScriptMsg) {
+        match *self {
+            GlobalRef::Window(_) => ScriptTask::process_event(msg),
+            GlobalRef::Worker(ref worker) => worker.process_event(msg),
         }
     }
 }

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -130,8 +130,9 @@ impl<'a> GlobalRef<'a> {
         }
     }
 
-    /// `ScriptChan` used to send messages to the event loop of this global's
-    /// thread.
+    /// Create a new sender/receiver pair that can be used to implement an on-demand
+    /// event loop. Used for implementing web APIs that require blocking semantics
+    /// without resorting to nested event loops.
     pub fn new_script_pair(&self) -> (Box<ScriptChan+Send>, Box<ScriptPort+Send>) {
         match *self {
             GlobalRef::Window(ref window) => window.new_script_pair(),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -207,6 +207,16 @@ impl<T: JSTraceable> JSTraceable for Option<T> {
     }
 }
 
+impl<T: JSTraceable, U: JSTraceable> JSTraceable for Result<T, U> {
+    #[inline]
+    fn trace(&self, trc: *mut JSTracer) {
+        match *self {
+            Ok(ref inner) => inner.trace(trc),
+            Err(ref inner) => inner.trace(trc),
+        }
+    }
+}
+
 impl<K,V,S> JSTraceable for HashMap<K, V, S>
     where K: Hash + Eq + JSTraceable,
           V: JSTraceable,
@@ -294,6 +304,12 @@ impl JSTraceable for Box<LayoutRPC+'static> {
     #[inline]
     fn trace(&self, _: *mut JSTracer) {
         // Do nothing
+    }
+}
+
+impl JSTraceable for () {
+    #[inline]
+    fn trace(&self, _trc: *mut JSTracer) {
     }
 }
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -21,7 +21,7 @@ use dom::messageevent::MessageEvent;
 use dom::worker::{TrustedWorkerAddress, WorkerMessageHandler, WorkerEventHandler, WorkerErrorHandler};
 use dom::workerglobalscope::{WorkerGlobalScope, WorkerGlobalScopeHelpers};
 use dom::workerglobalscope::WorkerGlobalScopeTypeId;
-use script_task::{ScriptTask, ScriptChan, ScriptMsg, TimerSource};
+use script_task::{ScriptTask, ScriptChan, ScriptMsg, TimerSource, ScriptPort};
 use script_task::StackRootTLS;
 
 use msg::constellation_msg::PipelineId;
@@ -38,7 +38,7 @@ use js::jsval::JSVal;
 use js::rust::Cx;
 
 use std::rc::Rc;
-use std::sync::mpsc::{Sender, Receiver};
+use std::sync::mpsc::{Sender, Receiver, channel};
 use url::Url;
 
 /// A ScriptChan that can be cloned freely and will silently send a TrustedWorkerAddress with
@@ -198,6 +198,8 @@ impl DedicatedWorkerGlobalScope {
 pub trait DedicatedWorkerGlobalScopeHelpers {
     fn script_chan(self) -> Box<ScriptChan+Send>;
     fn pipeline(self) -> PipelineId;
+    fn new_script_pair(self) -> (Box<ScriptChan+Send>, Box<ScriptPort+Send>);
+    fn process_event(self, msg: ScriptMsg);
 }
 
 impl<'a> DedicatedWorkerGlobalScopeHelpers for JSRef<'a, DedicatedWorkerGlobalScope> {
@@ -212,6 +214,19 @@ impl<'a> DedicatedWorkerGlobalScopeHelpers for JSRef<'a, DedicatedWorkerGlobalSc
 
     fn pipeline(self) -> PipelineId {
         self.id
+    }
+
+    fn new_script_pair(self) -> (Box<ScriptChan+Send>, Box<ScriptPort+Send>) {
+        let (tx, rx) = channel();
+        let chan = box SendableWorkerScriptChan {
+            sender: tx,
+            worker: self.worker.borrow().as_ref().unwrap().clone(),
+        };
+        (chan, box rx)
+    }
+
+    fn process_event(self, msg: ScriptMsg) {
+        self.handle_event(msg);
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -29,7 +29,7 @@ use dom::storage::Storage;
 use layout_interface::{ReflowGoal, ReflowQueryType, LayoutRPC, LayoutChan, Reflow, Msg};
 use layout_interface::{ContentBoxResponse, ContentBoxesResponse, ScriptReflow};
 use page::Page;
-use script_task::{TimerSource, ScriptChan};
+use script_task::{TimerSource, ScriptChan, ScriptPort, NonWorkerScriptChan};
 use script_task::ScriptMsg;
 use script_traits::ScriptControlChan;
 use timers::{IsInterval, TimerId, TimerManager, TimerCallback};
@@ -196,6 +196,11 @@ impl Window {
 
     pub fn parent_info(&self) -> Option<(PipelineId, SubpageId)> {
         self.parent_info
+    }
+
+    pub fn new_script_pair(&self) -> (Box<ScriptChan+Send>, Box<ScriptPort+Send>) {
+        let (tx, rx) = channel();
+        (box NonWorkerScriptChan(tx), box rx)
     }
 
     pub fn control_chan<'a>(&'a self) -> &'a ScriptControlChan {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -218,7 +218,6 @@ impl XMLHttpRequest {
     #[allow(unsafe_code)]
     fn fetch2(xhr: TrustedXHRAddress, script_chan: Box<ScriptChan+Send>,
               resource_task: ResourceTask, load_data: LoadData, sync: bool,
-              terminate_receiver: Receiver<TerminateReason>,
               cors_request: Result<Option<CORSRequest>,()>, gen_id: GenerationId) {
         let cors_request = match cors_request {
             Err(_) => {
@@ -229,13 +228,11 @@ impl XMLHttpRequest {
             Ok(req) => req,
         };
 
-        #[derive(Clone)]
         struct XHRContext {
             xhr: TrustedXHRAddress,
             gen_id: GenerationId,
             cors_request: Option<CORSRequest>,
             buf: DOMRefCell<Vec<u8>>,
-            terminate_receiver: Arc<Mutex<Receiver<TerminateReason>>>,
             got_response_complete: Cell<bool>,
         }
 
@@ -243,7 +240,6 @@ impl XMLHttpRequest {
             xhr: xhr,
             cors_request: cors_request.clone(),
             gen_id: gen_id,
-            terminate_receiver: Arc::new(Mutex::new(terminate_receiver)),
             buf: DOMRefCell::new(vec!()),
             got_response_complete: Cell::new(false),
         }));
@@ -260,8 +256,10 @@ impl XMLHttpRequest {
             impl AsyncCORSResponseListener for CORSContext {
                 fn response_available(&self, response: CORSResponse) {
                     if response.network_error {
-                        //notify_error_and_return!(Network);
-                        return; //XXXjdm
+                        let context = self.xhr.lock().unwrap();
+                        let xhr = context.xhr.to_temporary().root();
+                        xhr.r().process_partial_response(XHRProgress::Errored(context.gen_id, Network));
+                        return; //XXXjdm Err(Network)
                     }
 
                     let mut load_data = self.load_data.borrow_mut().take().unwrap();
@@ -348,25 +346,10 @@ impl XMLHttpRequest {
             fn handler(self: Box<XHRRunnable>) {
                 let this = *self;
 
-                let context = this.context.lock();
-                let context = context.unwrap();
+                let context = this.context.lock().unwrap();
                 let xhr = context.xhr.to_temporary().root();
                 if xhr.r().generation_id.get() != context.gen_id {
                     return;
-                }
-
-                {
-                    let terminate_receiver = context.terminate_receiver.lock().unwrap();
-                    if let Ok(reason) = terminate_receiver.try_recv() {
-                        match reason {
-                            TerminateReason::AbortedOrReopened => return, //Err(Abort)
-                            TerminateReason::TimedOut => {
-                                xhr.r().process_partial_response(
-                                    XHRProgress::Errored(context.gen_id, Network));
-                                return; //Err(Network)
-                            }
-                        }
-                    }
                 }
 
                 this.action.process(&*context);
@@ -856,7 +839,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
             let addr = Trusted::new(self.global.root().r().get_cx(), self,
                                     script_chan.clone());
             XMLHttpRequest::fetch2(addr, script_chan, resource_task, load_data, self.sync.get(),
-                                   terminate_receiver, cors_request, gen_id);
+                                   cors_request, gen_id);
             let timeout = self.timeout.get();
             if timeout > 0 {
                 self.set_timeout(timeout);
@@ -1015,6 +998,7 @@ trait PrivateXMLHttpRequestHelpers {
     fn set_timeout(self, timeout:u32);
     fn cancel_timeout(self);
     fn filter_response_headers(self) -> Headers;
+    fn discard_subsequent_responses(self);
 }
 
 impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
@@ -1078,7 +1062,7 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         // Ignore message if it belongs to a terminated fetch
         return_if_fetch_was_terminated!();
 
-        // Ignore messages coming from previously-errored responses
+        // Ignore messages coming from previously-errored responses or requests that have timed out
         if self.response_status.get().is_err() {
             return;
         }
@@ -1134,6 +1118,8 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                         self.ready_state.get() == XMLHttpRequestState::Loading ||
                         self.sync.get());
 
+                self.cancel_timeout();
+
                 // Part of step 11, send() (processing response end of file)
                 // XXXManishearth handle errors, if any (substep 2)
 
@@ -1149,7 +1135,9 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
                 self.dispatch_response_progress_event("loadend".to_owned());
             },
             XHRProgress::Errored(_, e) => {
-                self.response_status.set(Err(()));
+                self.cancel_timeout();
+
+                self.discard_subsequent_responses();
                 self.send_flag.set(false);
                 // XXXManishearth set response to NetworkError
                 self.change_ready_state(XMLHttpRequestState::Done);
@@ -1222,14 +1210,37 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         self.dispatch_progress_event(false, type_, len, total);
     }
     fn set_timeout(self, timeout: u32) {
+        struct XHRTimeout {
+            xhr: TrustedXHRAddress,
+            gen_id: GenerationId,
+        }
+
+        impl Runnable for XHRTimeout {
+            fn handler(self: Box<XHRTimeout>) {
+                let this = *self;
+                let xhr = this.xhr.to_temporary().root();
+                if xhr.r().ready_state.get() != XMLHttpRequestState::Done {
+                    xhr.r().process_partial_response(XHRProgress::Errored(this.gen_id, Timeout));
+                }
+            }
+        }
+
         // Sets up the object to timeout in a given number of milliseconds
         // This will cancel all previous timeouts
         let oneshot = self.timer.borrow_mut()
                           .oneshot(Duration::milliseconds(timeout as i64));
         let terminate_sender = (*self.terminate_sender.borrow()).clone();
+        let global = self.global.root();
+        let script_chan = global.r().script_chan();
+        let xhr = Trusted::new(global.r().get_cx(), self, global.r().script_chan());
+        let gen_id = self.generation_id.get();
         spawn_named("XHR:Timer".to_owned(), move || {
             match oneshot.recv() {
                 Ok(_) => {
+                    script_chan.send(ScriptMsg::RunnableMsg(box XHRTimeout {
+                        xhr: xhr,
+                        gen_id: gen_id,
+                    })).unwrap();
                     terminate_sender.map(|s| s.send(TerminateReason::TimedOut));
                 },
                 Err(_) => {
@@ -1296,6 +1307,10 @@ impl<'a> PrivateXMLHttpRequestHelpers for JSRef<'a, XMLHttpRequest> {
         headers.remove::<SetCookie2>();
         // XXXManishearth additional CORS filtering goes here
         headers
+    }
+
+    fn discard_subsequent_responses(self) {
+        self.response_status.set(Err(()));
     }
 }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -61,6 +61,7 @@ pub mod dom;
 pub mod parse;
 
 pub mod layout_interface;
+mod network_listener;
 pub mod page;
 pub mod script_task;
 mod timers;

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use script_task::{ScriptChan, ScriptMsg, Runnable};
+use net_traits::{AsyncResponseTarget, AsyncResponseListener, ResponseAction};
+use std::sync::{Arc, Mutex};
+
+/// An off-thread sink for async network event runnables. All such events are forwarded to
+/// a target thread, where they are invoked on the provided context object.
+pub struct NetworkListener<T: AsyncResponseListener + PreInvoke + Send + 'static> {
+    pub context: Arc<Mutex<T>>,
+    pub script_chan: Box<ScriptChan+Send>,
+}
+
+impl<T: AsyncResponseListener + PreInvoke + Send + 'static> AsyncResponseTarget for NetworkListener<T> {
+    fn invoke_with_listener(&self, action: ResponseAction) {
+        self.script_chan.send(ScriptMsg::RunnableMsg(box ListenerRunnable {
+            context: self.context.clone(),
+            action: action,
+        })).unwrap();
+    }
+}
+
+/// A gating mechanism that runs before invoking the runnable on the target thread.
+/// If the `should_invoke` method returns false, the runnable is discarded without
+/// being invoked.
+pub trait PreInvoke {
+    fn should_invoke(&self) -> bool {
+        true
+    }
+}
+
+/// A runnable for moving the async network events between threads.
+struct ListenerRunnable<T: AsyncResponseListener + PreInvoke + Send> {
+    context: Arc<Mutex<T>>,
+    action: ResponseAction,
+}
+
+impl<T: AsyncResponseListener + PreInvoke + Send> Runnable for ListenerRunnable<T> {
+    fn handler(self: Box<ListenerRunnable<T>>) {
+        let this = *self;
+        let context = this.context.lock().unwrap();
+        if context.should_invoke() {
+            this.action.process(&*context);
+        }
+    }
+}

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -201,6 +201,9 @@ pub trait ScriptChan {
     fn clone(&self) -> Box<ScriptChan+Send>;
 }
 
+/// An interface for receiving ScriptMsg values in an event loop. Used for synchronous DOM
+/// APIs that need to abstract over multiple kinds of event loops (worker/main thread) with
+/// different Receiver interfaces.
 pub trait ScriptPort {
     fn recv(&self) -> ScriptMsg;
 }

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -61,7 +61,7 @@ use msg::constellation_msg::{ConstellationChan};
 use msg::constellation_msg::{LoadData, PipelineId, SubpageId, MozBrowserEvent, WorkerId};
 use msg::constellation_msg::{Failure, WindowSizeData, PipelineExitType};
 use msg::constellation_msg::Msg as ConstellationMsg;
-use net_traits::{ResourceTask, ControlMsg, LoadResponse};
+use net_traits::{ResourceTask, ControlMsg, LoadResponse, LoadConsumer};
 use net_traits::LoadData as NetLoadData;
 use net_traits::image_cache_task::ImageCacheTask;
 use net_traits::storage_task::StorageTask;
@@ -1331,8 +1331,7 @@ impl ScriptTask {
                 preserved_headers: load_data.headers,
                 data: load_data.data,
                 cors: None,
-                consumer: input_chan,
-            })).unwrap();
+            }, LoadConsumer::Channel(input_chan))).unwrap();
 
             let load_response = input_port.recv().unwrap();
             script_chan.send(ScriptMsg::PageFetchComplete(id, subpage, load_response)).unwrap();

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -932,6 +932,7 @@ dependencies = [
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx 0.0.1",
+ "hyper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net 0.0.1",
  "net_traits 0.0.1",
  "profile 0.0.1",

--- a/tests/unit/net/data_loader.rs
+++ b/tests/unit/net/data_loader.rs
@@ -4,6 +4,7 @@
 
 extern crate hyper;
 
+use net_traits::ResponseSenders::Channel;
 use net_traits::LoadData;
 use net_traits::ProgressMsg::{Payload, Done};
 use self::hyper::header::ContentType;
@@ -19,7 +20,7 @@ fn assert_parse(url:          &'static str,
     use net::data_loader::load;
 
     let (start_chan, start_port) = channel();
-    load(LoadData::new(Url::parse(url).unwrap(), start_chan));
+    load(LoadData::new(Url::parse(url).unwrap()), Channel(start_chan));
 
     let response = start_port.recv().unwrap();
     assert_eq!(&response.metadata.content_type, &content_type);

--- a/tests/unit/net/resource_task.rs
+++ b/tests/unit/net/resource_task.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use net::resource_task::{new_resource_task, parse_hostsfile, replace_hosts};
-use net_traits::{ControlMsg, LoadData};
+use net_traits::{ControlMsg, LoadData, LoadConsumer};
 use net_traits::ProgressMsg;
 use std::borrow::ToOwned;
 use std::boxed;
@@ -23,7 +23,7 @@ fn test_bad_scheme() {
     let resource_task = new_resource_task(None);
     let (start_chan, start) = channel();
     let url = Url::parse("bogus://whatever").unwrap();
-    resource_task.send(ControlMsg::Load(LoadData::new(url, start_chan))).unwrap();
+    resource_task.send(ControlMsg::Load(LoadData::new(url), LoadConsumer::Channel(start_chan))).unwrap();
     let response = start.recv().unwrap();
     match response.progress_port.recv().unwrap() {
       ProgressMsg::Done(result) => { assert!(result.is_err()) }
@@ -173,7 +173,7 @@ fn test_replace_hosts() {
     let resource_task = new_resource_task(None);
     let (start_chan, _) = channel();
     let url = Url::parse(&format!("http://foo.bar.com:{}", port)).unwrap();
-    resource_task.send(ControlMsg::Load(replace_hosts(LoadData::new(url, start_chan), host_table))).unwrap();
+    resource_task.send(ControlMsg::Load(replace_hosts(LoadData::new(url), host_table), LoadConsumer::Channel(start_chan))).unwrap();
 
     match listener.accept() {
         Ok(..) => assert!(true, "received request"),


### PR DESCRIPTION
This implements a framework for opting in to receiving network events asynchronously. It also converts XMLHttpRequest to use them, and paves the way for better support for synchronous XHR using on-demand, targeted event loops instead of spinning the global event loop. This gives us complete feature parity with the existing XHR implementation, using fewer threads than before in the async case.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5156)

<!-- Reviewable:end -->
