### PR TITLE
layout: Implement ordered lists, CSS counters, and `quotes` per CSS 2.1 § 12.3-12.5.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -957,6 +957,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 }
             }
             SpecificFragmentInfo::Generic |
+            SpecificFragmentInfo::GeneratedContent(..) |
             SpecificFragmentInfo::Iframe(..) |
             SpecificFragmentInfo::Table |
             SpecificFragmentInfo::TableCell |

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -1,0 +1,561 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! The generated content assignment phase.
+//!
+//! This phase handles CSS counters, quotes, and ordered lists per CSS § 12.3-12.5. It cannot be
+//! done in parallel and is therefore a sequential pass that runs on as little of the flow tree
+//! as possible.
+
+use context::LayoutContext;
+use flow::{self, AFFECTS_COUNTERS, Flow, HAS_COUNTER_AFFECTING_CHILDREN, ImmutableFlowUtils};
+use flow::{InorderFlowTraversal};
+use fragment::{Fragment, GeneratedContentInfo, SpecificFragmentInfo, UnscannedTextFragmentInfo};
+use incremental::{self, RESOLVE_GENERATED_CONTENT};
+use text::TextRunScanner;
+
+use gfx::display_list::OpaqueNode;
+use std::collections::{DList, HashMap};
+use std::sync::Arc;
+use style::computed_values::content::ContentItem;
+use style::computed_values::{display, list_style_type};
+use style::properties::ComputedValues;
+use util::smallvec::{SmallVec, SmallVec8};
+
+// Decimal styles per CSS-COUNTER-STYLES § 6.1:
+static DECIMAL: [char; 10] = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ];
+// TODO(pcwalton): `decimal-leading-zero`
+static ARABIC_INDIC: [char; 10] = [ '٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩' ];
+// TODO(pcwalton): `armenian`, `upper-armenian`, `lower-armenian`
+static BENGALI: [char; 10] = [ '০', '১', '২', '৩', '৪', '৫', '৬', '৭', '৮', '৯' ];
+static CAMBODIAN: [char; 10] = [ '០', '១', '២', '៣', '៤', '៥', '៦', '៧', '៨', '៩' ];
+// TODO(pcwalton): Suffix for CJK decimal.
+static CJK_DECIMAL: [char; 10] = [ '〇', '一', '二', '三', '四', '五', '六', '七', '八', '九' ];
+static DEVANAGARI: [char; 10] = [ '०', '१', '२', '३', '४', '५', '६', '७', '८', '९' ];
+// TODO(pcwalton): `georgian`
+static GUJARATI: [char; 10] = ['૦', '૧', '૨', '૩', '૪', '૫', '૬', '૭', '૮', '૯'];
+static GURMUKHI: [char; 10] = ['੦', '੧', '੨', '੩', '੪', '੫', '੬', '੭', '੮', '੯'];
+// TODO(pcwalton): `hebrew`
+static KANNADA: [char; 10] = ['೦', '೧', '೨', '೩', '೪', '೫', '೬', '೭', '೮', '೯'];
+static LAO: [char; 10] = ['໐', '໑', '໒', '໓', '໔', '໕', '໖', '໗', '໘', '໙'];
+static MALAYALAM: [char; 10] = ['൦', '൧', '൨', '൩', '൪', '൫', '൬', '൭', '൮', '൯'];
+static MONGOLIAN: [char; 10] = ['᠐', '᠑', '᠒', '᠓', '᠔', '᠕', '᠖', '᠗', '᠘', '᠙'];
+static MYANMAR: [char; 10] = ['၀', '၁', '၂', '၃', '၄', '၅', '၆', '၇', '၈', '၉'];
+static ORIYA: [char; 10] = ['୦', '୧', '୨', '୩', '୪', '୫', '୬', '୭', '୮', '୯'];
+static PERSIAN: [char; 10] = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
+// TODO(pcwalton): `lower-roman`, `upper-roman`
+static TELUGU: [char; 10] = ['౦', '౧', '౨', '౩', '౪', '౫', '౬', '౭', '౮', '౯'];
+static THAI: [char; 10] = ['๐', '๑', '๒', '๓', '๔', '๕', '๖', '๗', '๘', '๙'];
+static TIBETAN: [char; 10] = ['༠', '༡', '༢', '༣', '༤', '༥', '༦', '༧', '༨', '༩'];
+
+// Alphabetic styles per CSS-COUNTER-STYLES § 6.2:
+static LOWER_ALPHA: [char; 26] = [
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+    't', 'u', 'v', 'w', 'x', 'y', 'z'
+];
+static UPPER_ALPHA: [char; 26] = [
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+    'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
+];
+static CJK_EARTHLY_BRANCH: [char; 12] = [
+    '子', '丑', '寅', '卯', '辰', '巳', '午', '未', '申', '酉', '戌', '亥'
+];
+static CJK_HEAVENLY_STEM: [char; 10] = [
+    '甲', '乙', '丙', '丁', '戊', '己', '庚', '辛', '壬', '癸'
+];
+static LOWER_GREEK: [char; 24] = [
+    'α', 'β', 'γ', 'δ', 'ε', 'ζ', 'η', 'θ', 'ι', 'κ', 'λ', 'μ', 'ν', 'ξ', 'ο', 'π', 'ρ', 'σ', 'τ',
+    'υ', 'φ', 'χ', 'ψ', 'ω'
+];
+static HIRAGANA: [char; 48] = [
+    'あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ', 'さ', 'し', 'す', 'せ', 'そ',
+    'た', 'ち', 'つ', 'て', 'と', 'な', 'に', 'ぬ', 'ね', 'の', 'は', 'ひ', 'ふ', 'へ', 'ほ',
+    'ま', 'み', 'む', 'め', 'も', 'や', 'ゆ', 'よ', 'ら', 'り', 'る', 'れ', 'ろ',
+    'わ', 'ゐ', 'ゑ', 'を', 'ん'
+];
+static HIRAGANA_IROHA: [char; 47] = [
+    'い', 'ろ', 'は', 'に', 'ほ', 'へ', 'と', 'ち', 'り', 'ぬ', 'る', 'を', 'わ', 'か', 'よ',
+    'た', 'れ', 'そ', 'つ', 'ね', 'な', 'ら', 'む', 'う', 'ゐ', 'の', 'お', 'く', 'や', 'ま',
+    'け', 'ふ', 'こ', 'え', 'て', 'あ', 'さ', 'き', 'ゆ', 'め', 'み', 'し', 'ゑ',
+    'ひ', 'も', 'せ', 'す'
+];
+static KATAKANA: [char; 48] = [
+    'ア', 'イ', 'ウ', 'エ', 'オ', 'カ', 'キ', 'ク', 'ケ', 'コ', 'サ', 'シ', 'ス', 'セ', 'ソ',
+    'タ', 'チ', 'ツ', 'テ', 'ト', 'ナ', 'ニ', 'ヌ', 'ネ', 'ノ', 'ハ', 'ヒ', 'フ', 'ヘ', 'ホ',
+    'マ', 'ミ', 'ム', 'メ', 'モ', 'ヤ', 'ユ', 'ヨ', 'ラ', 'リ', 'ル', 'レ', 'ロ',
+    'ワ', 'ヰ', 'ヱ', 'ヲ', 'ン'
+];
+static KATAKANA_IROHA: [char; 47] = [
+    'イ', 'ロ', 'ハ', 'ニ', 'ホ', 'ヘ', 'ト', 'チ', 'リ', 'ヌ', 'ル', 'ヲ', 'ワ', 'カ', 'ヨ',
+    'タ', 'レ', 'ソ', 'ツ', 'ネ', 'ナ', 'ラ', 'ム', 'ウ', 'ヰ', 'ノ', 'オ', 'ク', 'ヤ', 'マ',
+    'ケ', 'フ', 'コ', 'エ', 'テ', 'ア', 'サ', 'キ', 'ユ', 'メ', 'ミ', 'シ', 'ヱ',
+    'ヒ', 'モ', 'セ', 'ス'
+];
+
+/// The generated content resolution traversal.
+pub struct ResolveGeneratedContent<'a> {
+    /// The layout context.
+    layout_context: &'a LayoutContext<'a>,
+    /// The counter representing an ordered list item.
+    list_item: Counter,
+    /// Named CSS counters.
+    counters: HashMap<String,Counter>,
+    /// The level of quote nesting.
+    quote: u32,
+}
+
+impl<'a> ResolveGeneratedContent<'a> {
+    /// Creates a new generated content resolution traversal.
+    pub fn new(layout_context: &'a LayoutContext<'a>) -> ResolveGeneratedContent<'a> {
+        ResolveGeneratedContent {
+            layout_context: layout_context,
+            list_item: Counter::new(),
+            counters: HashMap::new(),
+            quote: 0,
+        }
+    }
+}
+
+impl<'a> InorderFlowTraversal for ResolveGeneratedContent<'a> {
+    #[inline]
+    fn process(&mut self, flow: &mut Flow, level: u32) {
+        let mut mutator = ResolveGeneratedContentFragmentMutator {
+            traversal: self,
+            level: level,
+            is_block: flow.is_block_like(),
+            incremented: false,
+        };
+        flow.mutate_fragments(&mut |fragment| mutator.mutate_fragment(fragment))
+    }
+
+    #[inline]
+    fn should_process(&mut self, flow: &mut Flow) -> bool {
+        flow::base(flow).restyle_damage.intersects(RESOLVE_GENERATED_CONTENT) ||
+            flow::base(flow).flags.intersects(AFFECTS_COUNTERS | HAS_COUNTER_AFFECTING_CHILDREN)
+    }
+}
+
+/// The object that mutates the generated content fragments.
+struct ResolveGeneratedContentFragmentMutator<'a,'b:'a> {
+    /// The traversal.
+    traversal: &'a mut ResolveGeneratedContent<'b>,
+    /// The level we're at in the flow tree.
+    level: u32,
+    /// Whether this flow is a block flow.
+    is_block: bool,
+    /// Whether we've incremented the counter yet.
+    incremented: bool,
+}
+
+impl<'a,'b> ResolveGeneratedContentFragmentMutator<'a,'b> {
+    fn mutate_fragment(&mut self, fragment: &mut Fragment) {
+        // We only reset and/or increment counters once per flow. This avoids double-incrementing
+        // counters on list items (once for the main fragment and once for the marker).
+        if !self.incremented {
+            self.reset_and_increment_counters_as_necessary(fragment);
+        }
+
+        let mut list_style_type = fragment.style().get_list().list_style_type;
+        if fragment.style().get_box().display != display::T::list_item {
+            list_style_type = list_style_type::T::none
+        }
+
+        let mut new_info = None;
+        {
+            let info =
+                if let SpecificFragmentInfo::GeneratedContent(ref mut info) = fragment.specific {
+                    info
+                } else {
+                    return
+                };
+
+            match **info {
+                GeneratedContentInfo::ListItem => {
+                    new_info = self.traversal.list_item.render(self.traversal.layout_context,
+                                                               fragment.node,
+                                                               fragment.style.clone(),
+                                                               list_style_type,
+                                                               RenderingMode::Suffix(".\u{00a0}"))
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::String(_)) => {
+                    // Nothing to do here.
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::Counter(ref counter_name,
+                                                                       counter_style)) => {
+                    let mut temporary_counter = Counter::new();
+                    let counter = self.traversal
+                                      .counters
+                                      .get(counter_name.as_slice())
+                                      .unwrap_or(&mut temporary_counter);
+                    new_info = counter.render(self.traversal.layout_context,
+                                              fragment.node,
+                                              fragment.style.clone(),
+                                              counter_style,
+                                              RenderingMode::Plain)
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::Counters(ref counter_name,
+                                                                        ref separator,
+                                                                        counter_style)) => {
+                    let mut temporary_counter = Counter::new();
+                    let counter = self.traversal
+                                      .counters
+                                      .get(counter_name.as_slice())
+                                      .unwrap_or(&mut temporary_counter);
+                    new_info = counter.render(self.traversal.layout_context,
+                                              fragment.node,
+                                              fragment.style.clone(),
+                                              counter_style,
+                                              RenderingMode::All(separator.as_slice()));
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::OpenQuote) => {
+                    new_info = Some(render_text(self.traversal.layout_context,
+                                                fragment.node,
+                                                fragment.style.clone(),
+                                                self.quote(&*fragment.style, false)));
+                    self.traversal.quote += 1
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::CloseQuote) => {
+                    if self.traversal.quote >= 1 {
+                        self.traversal.quote -= 1
+                    }
+
+                    new_info = Some(render_text(self.traversal.layout_context,
+                                                fragment.node,
+                                                fragment.style.clone(),
+                                                self.quote(&*fragment.style, true)));
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::NoOpenQuote) => {
+                    self.traversal.quote += 1
+                }
+                GeneratedContentInfo::ContentItem(ContentItem::NoCloseQuote) => {
+                    if self.traversal.quote >= 1 {
+                        self.traversal.quote -= 1
+                    }
+                }
+            }
+        };
+
+        if let Some(new_info) = new_info {
+            fragment.specific = new_info
+        }
+    }
+
+    fn reset_and_increment_counters_as_necessary(&mut self, fragment: &mut Fragment) {
+        let mut list_style_type = fragment.style().get_list().list_style_type;
+        if !self.is_block || fragment.style().get_box().display != display::T::list_item {
+            list_style_type = list_style_type::T::none
+        }
+
+        match list_style_type {
+            list_style_type::T::disc | list_style_type::T::none | list_style_type::T::circle |
+            list_style_type::T::square | list_style_type::T::disclosure_open |
+            list_style_type::T::disclosure_closed => {}
+            _ => self.traversal.list_item.increment(self.level, 1),
+        }
+
+        // Truncate down counters.
+        for (_, counter) in self.traversal.counters.iter_mut() {
+            counter.truncate_to_level(self.level);
+        }
+        self.traversal.list_item.truncate_to_level(self.level);
+
+        for &(ref counter_name, value) in fragment.style().get_counters().counter_reset.0.iter() {
+            if let Some(ref mut counter) = self.traversal.counters.get_mut(counter_name) {
+                 counter.reset(self.level, value);
+                 continue
+            }
+
+            let mut counter = Counter::new();
+            counter.reset(self.level, value);
+            self.traversal.counters.insert((*counter_name).clone(), counter);
+        }
+
+        for &(ref counter_name, value) in fragment.style()
+                                                  .get_counters()
+                                                  .counter_increment
+                                                  .0
+                                                  .iter() {
+            if let Some(ref mut counter) = self.traversal.counters.get_mut(counter_name) {
+                counter.increment(self.level, value);
+                continue
+            }
+
+            let mut counter = Counter::new();
+            counter.increment(self.level, value);
+            self.traversal.counters.insert((*counter_name).clone(), counter);
+        }
+
+        self.incremented = true
+    }
+
+    fn quote(&self, style: &ComputedValues, close: bool) -> String {
+        let quotes = &style.get_list().quotes;
+        debug_assert!(!quotes.0.is_empty());
+        let &(ref open_quote, ref close_quote) =
+            if self.traversal.quote as uint >= quotes.0.len() {
+                quotes.0.last().unwrap()
+            } else {
+                &quotes.0[self.traversal.quote as uint]
+            };
+        if close {
+            close_quote.to_string()
+        } else {
+            open_quote.to_string()
+        }
+    }
+}
+
+/// A counter per CSS 2.1 § 12.4.
+struct Counter {
+    /// The values at each level.
+    values: Vec<CounterValue>,
+}
+
+impl Counter {
+    fn new() -> Counter {
+        Counter {
+            values: Vec::new(),
+        }
+    }
+
+    fn reset(&mut self, level: u32, value: i32) {
+        // Do we have an instance of the counter at this level? If so, just mutate it.
+        if let Some(ref mut existing_value) = self.values.last_mut() {
+            if level == existing_value.level {
+                existing_value.value = value;
+                return
+            }
+        }
+
+        // Otherwise, push a new instance of the counter.
+        self.values.push(CounterValue {
+            level: level,
+            value: value,
+        })
+    }
+
+    fn truncate_to_level(&mut self, level: u32) {
+        if let Some(position) = self.values.iter().position(|value| value.level > level) {
+            self.values.truncate(position)
+        }
+    }
+
+    fn increment(&mut self, level: u32, amount: i32) {
+        if let Some(ref mut value) = self.values.last_mut() {
+            value.value += amount;
+            return
+        }
+
+        self.values.push(CounterValue {
+            level: level,
+            value: amount,
+        })
+    }
+
+    fn render(&self,
+              layout_context: &LayoutContext,
+              node: OpaqueNode,
+              style: Arc<ComputedValues>,
+              list_style_type: list_style_type::T,
+              mode: RenderingMode)
+              -> Option<SpecificFragmentInfo> {
+        let mut string = String::new();
+        match mode {
+            RenderingMode::Plain => {
+                let value = match self.values.last() {
+                    Some(ref value) => value.value,
+                    None => 0,
+                };
+                push_representation(value, list_style_type, &mut string)
+            }
+            RenderingMode::Suffix(suffix) => {
+                let value = match self.values.last() {
+                    Some(ref value) => value.value,
+                    None => 0,
+                };
+                push_representation(value, list_style_type, &mut string);
+                string.push_str(suffix)
+            }
+            RenderingMode::All(separator) => {
+                let mut first = true;
+                for value in self.values.iter() {
+                    if !first {
+                        string.push_str(separator)
+                    }
+                    first = false;
+                    push_representation(value.value, list_style_type, &mut string)
+                }
+            }
+        }
+
+        if string.is_empty() {
+            None
+        } else {
+            Some(render_text(layout_context, node, style, string))
+        }
+    }
+}
+
+/// How a counter value is to be rendered.
+enum RenderingMode<'a> {
+    /// The innermost counter value is rendered with no extra decoration.
+    Plain,
+    /// The innermost counter value is rendered with the given string suffix.
+    Suffix(&'a str),
+    /// All values of the counter are rendered with the given separator string between them.
+    All(&'a str),
+}
+
+/// The value of a counter at a given level.
+struct CounterValue {
+    /// The level of the flow tree that this corresponds to.
+    level: u32,
+    /// The value of the counter at this level.
+    value: i32,
+}
+
+/// Creates fragment info for a literal string.
+fn render_text(layout_context: &LayoutContext,
+               node: OpaqueNode,
+               style: Arc<ComputedValues>,
+               string: String)
+               -> SpecificFragmentInfo {
+    let mut fragments = DList::new();
+    let info = SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::from_text(string));
+    fragments.push_back(Fragment::from_opaque_node_and_style(node,
+                                                             style,
+                                                             incremental::rebuild_and_reflow(),
+                                                             info));
+    let fragments = TextRunScanner::new().scan_for_runs(layout_context.font_context(), fragments);
+    debug_assert!(fragments.len() == 1);
+    fragments.fragments.into_iter().next().unwrap().specific
+}
+
+/// Appends string that represents the value rendered using the system appropriate for the given
+/// `list-style-type` onto the given string.
+fn push_representation(value: i32, list_style_type: list_style_type::T, accumulator: &mut String) {
+    match list_style_type {
+        list_style_type::T::none => {}
+        list_style_type::T::disc |
+        list_style_type::T::circle |
+        list_style_type::T::square |
+        list_style_type::T::disclosure_open |
+        list_style_type::T::disclosure_closed => {
+            accumulator.push(static_representation(list_style_type))
+        }
+        list_style_type::T::decimal => push_numeric_representation(value, &DECIMAL, accumulator),
+        list_style_type::T::arabic_indic => {
+            push_numeric_representation(value, &ARABIC_INDIC, accumulator)
+        }
+        list_style_type::T::bengali => push_numeric_representation(value, &BENGALI, accumulator),
+        list_style_type::T::cambodian | list_style_type::T::khmer => {
+            push_numeric_representation(value, &CAMBODIAN, accumulator)
+        }
+        list_style_type::T::cjk_decimal => {
+            push_numeric_representation(value, &CJK_DECIMAL, accumulator)
+        }
+        list_style_type::T::devanagari => {
+            push_numeric_representation(value, &DEVANAGARI, accumulator)
+        }
+        list_style_type::T::gujarati => push_numeric_representation(value, &GUJARATI, accumulator),
+        list_style_type::T::gurmukhi => push_numeric_representation(value, &GURMUKHI, accumulator),
+        list_style_type::T::kannada => push_numeric_representation(value, &KANNADA, accumulator),
+        list_style_type::T::lao => push_numeric_representation(value, &LAO, accumulator),
+        list_style_type::T::malayalam => {
+            push_numeric_representation(value, &MALAYALAM, accumulator)
+        }
+        list_style_type::T::mongolian => {
+            push_numeric_representation(value, &MONGOLIAN, accumulator)
+        }
+        list_style_type::T::myanmar => push_numeric_representation(value, &MYANMAR, accumulator),
+        list_style_type::T::oriya => push_numeric_representation(value, &ORIYA, accumulator),
+        list_style_type::T::persian => push_numeric_representation(value, &PERSIAN, accumulator),
+        list_style_type::T::telugu => push_numeric_representation(value, &TELUGU, accumulator),
+        list_style_type::T::thai => push_numeric_representation(value, &THAI, accumulator),
+        list_style_type::T::tibetan => push_numeric_representation(value, &TIBETAN, accumulator),
+        list_style_type::T::lower_alpha => {
+            push_alphabetic_representation(value, &LOWER_ALPHA, accumulator)
+        }
+        list_style_type::T::upper_alpha => {
+            push_alphabetic_representation(value, &UPPER_ALPHA, accumulator)
+        }
+        list_style_type::T::cjk_earthly_branch => {
+            push_alphabetic_representation(value, &CJK_EARTHLY_BRANCH, accumulator)
+        }
+        list_style_type::T::cjk_heavenly_stem => {
+            push_alphabetic_representation(value, &CJK_HEAVENLY_STEM, accumulator)
+        }
+        list_style_type::T::lower_greek => {
+            push_alphabetic_representation(value, &LOWER_GREEK, accumulator)
+        }
+        list_style_type::T::hiragana => {
+            push_alphabetic_representation(value, &HIRAGANA, accumulator)
+        }
+        list_style_type::T::hiragana_iroha => {
+            push_alphabetic_representation(value, &HIRAGANA_IROHA, accumulator)
+        }
+        list_style_type::T::katakana => {
+            push_alphabetic_representation(value, &KATAKANA, accumulator)
+        }
+        list_style_type::T::katakana_iroha => {
+            push_alphabetic_representation(value, &KATAKANA_IROHA, accumulator)
+        }
+    }
+}
+
+/// Returns the static character that represents the value rendered using the given list-style, if
+/// possible.
+pub fn static_representation(list_style_type: list_style_type::T) -> char {
+    match list_style_type {
+        list_style_type::T::disc => '•',
+        list_style_type::T::circle => '◦',
+        list_style_type::T::square => '▪',
+        list_style_type::T::disclosure_open => '▾',
+        list_style_type::T::disclosure_closed => '‣',
+        _ => panic!("No static representation for this list-style-type!"),
+    }
+}
+
+/// Pushes the string that represents the value rendered using the given *alphabetic system* onto
+/// the accumulator per CSS-COUNTER-STYLES § 3.1.4.
+fn push_alphabetic_representation(mut value: i32, system: &[char], accumulator: &mut String) {
+    let mut string = SmallVec8::new();
+    while value != 0 {
+        // Step 1.
+        value = value - 1;
+        // Step 2.
+        string.push(system[(value as uint) % system.len()]);
+        // Step 3.
+        value = ((value as uint) / system.len()) as i32;
+    }
+
+    for i in range(0, string.len()).rev() {
+        accumulator.push(*string.get(i))
+    }
+}
+
+/// Pushes the string that represents the value rendered using the given *numeric system* onto the
+/// accumulator per CSS-COUNTER-STYLES § 3.1.4.
+fn push_numeric_representation(mut value: i32, system: &[char], accumulator: &mut String) {
+    // Step 1.
+    if value == 0 {
+        accumulator.push(system[0]);
+        return
+    }
+
+    // Step 2.
+    let mut string = SmallVec8::new();
+    while value != 0 {
+        // Step 2.1.
+        string.push(system[(value as uint) % system.len()]);
+        // Step 2.2.
+        value = ((value as uint) / system.len()) as i32;
+    }
+
+    // Step 3.
+    for &ch in string.iter().rev() {
+        accumulator.push(ch)
+    }
+}
+

--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use flow::{self, Flow};
-use flow::{IS_ABSOLUTELY_POSITIONED};
+use flow::{self, AFFECTS_COUNTERS, Flow, HAS_COUNTER_AFFECTING_CHILDREN, IS_ABSOLUTELY_POSITIONED};
 
 use std::fmt;
 use std::sync::Arc;
@@ -32,8 +31,12 @@ bitflags! {
         #[doc = "top-down."]
         const REFLOW = 0x08,
 
+        #[doc = "Re-resolve generated content. \
+                 Propagates up the flow tree because the computation is inorder."]
+        const RESOLVE_GENERATED_CONTENT = 0x10,
+
         #[doc = "The entire flow needs to be reconstructed."]
-        const RECONSTRUCT_FLOW = 0x10
+        const RECONSTRUCT_FLOW = 0x20
     }
 }
 
@@ -50,9 +53,9 @@ impl RestyleDamage {
     /// we should add to the *parent* of this flow.
     pub fn damage_for_parent(self, child_is_absolutely_positioned: bool) -> RestyleDamage {
         if child_is_absolutely_positioned {
-            self & (REPAINT | REFLOW_OUT_OF_FLOW)
+            self & (REPAINT | REFLOW_OUT_OF_FLOW | RESOLVE_GENERATED_CONTENT)
         } else {
-            self & (REPAINT | REFLOW | REFLOW_OUT_OF_FLOW)
+            self & (REPAINT | REFLOW | REFLOW_OUT_OF_FLOW | RESOLVE_GENERATED_CONTENT)
         }
     }
 
@@ -91,10 +94,11 @@ impl fmt::Debug for RestyleDamage {
         let mut first_elem = true;
 
         let to_iter =
-            [ (REPAINT,         "Repaint")
-            , (BUBBLE_ISIZES,    "BubbleISizes")
+            [ (REPAINT, "Repaint")
+            , (BUBBLE_ISIZES, "BubbleISizes")
             , (REFLOW_OUT_OF_FLOW, "ReflowOutOfFlow")
-            , (REFLOW,          "Reflow")
+            , (REFLOW, "Reflow")
+            , (RESOLVE_GENERATED_CONTENT, "ResolveGeneratedContent")
             , (RECONSTRUCT_FLOW, "ReconstructFlow")
             ];
 
@@ -126,10 +130,18 @@ macro_rules! add_if_not_equal(
     })
 );
 
+/// Returns a bitmask that represents a flow that needs to be rebuilt and reflowed.
+///
+/// Use this instead of `RestyleDamage::all()` because `RestyleDamage::all()` will result in
+/// unnecessary sequential resolution of generated content.
+pub fn rebuild_and_reflow() -> RestyleDamage {
+    REPAINT | BUBBLE_ISIZES | REFLOW_OUT_OF_FLOW | REFLOW | RECONSTRUCT_FLOW
+}
+
 pub fn compute_damage(old: &Option<Arc<ComputedValues>>, new: &ComputedValues) -> RestyleDamage {
     let old: &ComputedValues =
         match old.as_ref() {
-            None => return RestyleDamage::all(),
+            None => return rebuild_and_reflow(),
             Some(cv) => &**cv,
         };
 
@@ -186,6 +198,9 @@ impl<'a> LayoutDamageComputation for &'a mut (Flow + 'a) {
         let mut special_damage = SpecialRestyleDamage::empty();
         let is_absolutely_positioned = flow::base(self).flags.contains(IS_ABSOLUTELY_POSITIONED);
 
+        // In addition to damage, we use this phase to compute whether nodes affect CSS counters.
+        let mut has_counter_affecting_children = false;
+
         {
             let self_base = flow::mut_base(self);
             for kid in self_base.children.iter_mut() {
@@ -199,13 +214,24 @@ impl<'a> LayoutDamageComputation for &'a mut (Flow + 'a) {
                 self_base.restyle_damage
                          .insert(flow::base(kid).restyle_damage.damage_for_parent(
                                  child_is_absolutely_positioned));
+
+                has_counter_affecting_children = has_counter_affecting_children ||
+                    flow::base(kid).flags.intersects(AFFECTS_COUNTERS |
+                                                     HAS_COUNTER_AFFECTING_CHILDREN);
+
             }
         }
 
-        let self_base = flow::base(self);
+        let self_base = flow::mut_base(self);
         if self_base.flags.float_kind() != float::T::none &&
                 self_base.restyle_damage.intersects(REFLOW) {
             special_damage.insert(REFLOW_ENTIRE_DOCUMENT);
+        }
+
+        if has_counter_affecting_children {
+            self_base.flags.insert(HAS_COUNTER_AFFECTING_CHILDREN)
+        } else {
+            self_base.flags.remove(HAS_COUNTER_AFFECTING_CHILDREN)
         }
 
         special_damage
@@ -213,7 +239,7 @@ impl<'a> LayoutDamageComputation for &'a mut (Flow + 'a) {
 
     fn reflow_entire_document(self) {
         let self_base = flow::mut_base(self);
-        self_base.restyle_damage.insert(RestyleDamage::all());
+        self_base.restyle_damage.insert(rebuild_and_reflow());
         self_base.restyle_damage.remove(RECONSTRUCT_FLOW);
         for kid in self_base.children.iter_mut() {
             kid.reflow_entire_document();

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -12,9 +12,8 @@ use flow::{BaseFlow, FlowClass, Flow, MutableFlowUtils, ForceNonfloatedFlag};
 use flow::{IS_ABSOLUTELY_POSITIONED};
 use flow;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, ScannedTextFragmentInfo};
-use fragment::{SpecificFragmentInfo};
-use fragment::SplitInfo;
-use incremental::{REFLOW, REFLOW_OUT_OF_FLOW};
+use fragment::{SpecificFragmentInfo, SplitInfo};
+use incremental::{REFLOW, REFLOW_OUT_OF_FLOW, RESOLVE_GENERATED_CONTENT};
 use layout_debug;
 use model::IntrinsicISizesContribution;
 use text;
@@ -789,14 +788,22 @@ pub struct InlineFlow {
 
 impl InlineFlow {
     pub fn from_fragments(fragments: InlineFragments, writing_mode: WritingMode) -> InlineFlow {
-        InlineFlow {
+        let mut flow = InlineFlow {
             base: BaseFlow::new(None, writing_mode, ForceNonfloatedFlag::ForceNonfloated),
             fragments: fragments,
             lines: Vec::new(),
             minimum_block_size_above_baseline: Au(0),
             minimum_depth_below_baseline: Au(0),
             first_line_indentation: Au(0),
+        };
+
+        for fragment in flow.fragments.fragments.iter() {
+            if fragment.is_generated_content() {
+                flow.base.restyle_damage.insert(RESOLVE_GENERATED_CONTENT)
+            }
         }
+
+        flow
     }
 
     /// Returns the distance from the baseline for the logical block-start inline-start corner of
@@ -1397,6 +1404,12 @@ impl Flow for InlineFlow {
                                                                     relative_containing_block_mode,
                                                                     CoordinateSystem::Parent)
                                       .translate(stacking_context_position))
+        }
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        for fragment in self.fragments.fragments.iter_mut() {
+            (*mutator)(fragment)
         }
     }
 }

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -840,6 +840,14 @@ impl LayoutTask {
             layout_debug::begin_trace(layout_root.clone());
         }
 
+        // Resolve generated content.
+        profile(TimeProfilerCategory::LayoutGeneratedContent,
+                self.profiler_metadata(data),
+                self.time_profiler_chan.clone(),
+                || {
+                    sequential::resolve_generated_content(&mut layout_root, &shared_layout_context)
+                });
+
         // Perform the primary layout passes over the flow tree to compute the locations of all
         // the boxes.
         profile(TimeProfilerCategory::LayoutMain,

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -67,7 +67,9 @@ pub mod flow;
 pub mod flow_list;
 pub mod flow_ref;
 pub mod fragment;
+pub mod generated_content;
 pub mod layout_task;
+pub mod incremental;
 pub mod inline;
 pub mod list_item;
 pub mod model;
@@ -83,7 +85,6 @@ pub mod table_row;
 pub mod table_cell;
 pub mod text;
 pub mod traversal;
-pub mod incremental;
 pub mod wrapper;
 
 pub mod css {

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -8,12 +8,13 @@
 #![deny(unsafe_blocks)]
 
 use block::BlockFlow;
-use construct::FlowConstructor;
 use context::LayoutContext;
 use display_list_builder::ListItemFlowDisplayListBuilding;
 use floats::FloatKind;
 use flow::{Flow, FlowClass};
-use fragment::{Fragment, FragmentBorderBoxIterator};
+use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, GeneratedContentInfo};
+use generated_content;
+use incremental::RESOLVE_GENERATED_CONTENT;
 use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
@@ -36,19 +37,33 @@ pub struct ListItemFlow {
 }
 
 impl ListItemFlow {
-    pub fn from_node_marker_and_flotation(constructor: &mut FlowConstructor,
-                                          node: &ThreadSafeLayoutNode,
-                                          marker_fragment: Option<Fragment>,
-                                          flotation: Option<FloatKind>)
-                                          -> ListItemFlow {
-        ListItemFlow {
+    pub fn from_node_fragments_and_flotation(node: &ThreadSafeLayoutNode,
+                                             main_fragment: Fragment,
+                                             marker_fragment: Option<Fragment>,
+                                             flotation: Option<FloatKind>)
+                                             -> ListItemFlow {
+        let mut this = ListItemFlow {
             block_flow: if let Some(flotation) = flotation {
-                BlockFlow::float_from_node(constructor, node, flotation)
+                BlockFlow::float_from_node_and_fragment(node, main_fragment, flotation)
             } else {
-                BlockFlow::from_node(constructor, node)
+                BlockFlow::from_node_and_fragment(node, main_fragment)
             },
             marker: marker_fragment,
+        };
+
+        if let Some(ref marker) = this.marker {
+            match marker.style().get_list().list_style_type {
+                list_style_type::T::disc |
+                list_style_type::T::none |
+                list_style_type::T::circle |
+                list_style_type::T::square |
+                list_style_type::T::disclosure_open |
+                list_style_type::T::disclosure_closed => {}
+                _ => this.block_flow.base.restyle_damage.insert(RESOLVE_GENERATED_CONTENT),
+            }
         }
+
+        this
     }
 }
 
@@ -134,24 +149,59 @@ impl Flow for ListItemFlow {
     fn iterate_through_fragment_border_boxes(&self,
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
-        self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+        self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position);
+
+        if let Some(ref marker) = self.marker {
+            if iterator.should_process(marker) {
+                iterator.process(
+                    marker,
+                    &marker.stacking_relative_border_box(&self.block_flow
+                                                              .base
+                                                              .stacking_relative_position,
+                                                         &self.block_flow
+                                                              .base
+                                                              .absolute_position_info
+                                                              .relative_containing_block_size,
+                                                         self.block_flow
+                                                             .base
+                                                             .absolute_position_info
+                                                             .relative_containing_block_mode,
+                                                         CoordinateSystem::Parent)
+                           .translate(stacking_context_position));
+            }
+        }
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator);
+
+        if let Some(ref mut marker) = self.marker {
+            (*mutator)(marker)
+        }
     }
 }
 
-/// Returns the static text to be used for the given value of the `list-style-type` property.
-///
-/// TODO(pcwalton): Return either a string or a counter descriptor, once we support counters.
-pub fn static_text_for_list_style_type(list_style_type: list_style_type::T)
-                                       -> Option<&'static str> {
-    // Just to keep things simple, use a nonbreaking space (Unicode 0xa0) to provide the marker
-    // separation.
-    match list_style_type {
-        list_style_type::T::none => None,
-        list_style_type::T::disc => Some("•\u{a0}"),
-        list_style_type::T::circle => Some("◦\u{a0}"),
-        list_style_type::T::square => Some("▪\u{a0}"),
-        list_style_type::T::disclosure_open => Some("▾\u{a0}"),
-        list_style_type::T::disclosure_closed => Some("‣\u{a0}"),
+/// The kind of content that `list-style-type` results in.
+pub enum ListStyleTypeContent {
+    None,
+    StaticText(char),
+    GeneratedContent(Box<GeneratedContentInfo>),
+}
+
+impl ListStyleTypeContent {
+    /// Returns the content to be used for the given value of the `list-style-type` property.
+    pub fn from_list_style_type(list_style_type: list_style_type::T) -> ListStyleTypeContent {
+        // Just to keep things simple, use a nonbreaking space (Unicode 0xa0) to provide the marker
+        // separation.
+        match list_style_type {
+            list_style_type::T::none => ListStyleTypeContent::None,
+            list_style_type::T::disc | list_style_type::T::circle | list_style_type::T::square |
+            list_style_type::T::disclosure_open | list_style_type::T::disclosure_closed => {
+                let text = generated_content::static_representation(list_style_type);
+                ListStyleTypeContent::StaticText(text)
+            }
+            _ => ListStyleTypeContent::GeneratedContent(box GeneratedContentInfo::ListItem),
+        }
     }
 }
 

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -5,10 +5,11 @@
 //! Implements sequential traversals over the DOM and flow trees.
 
 use context::{LayoutContext, SharedLayoutContext};
-use flow::{self, Flow, ImmutableFlowUtils, MutableFlowUtils, PostorderFlowTraversal};
-use flow::{PreorderFlowTraversal};
+use flow::{self, Flow, ImmutableFlowUtils, InorderFlowTraversal, MutableFlowUtils};
+use flow::{PostorderFlowTraversal, PreorderFlowTraversal};
 use flow_ref::FlowRef;
 use fragment::FragmentBorderBoxIterator;
+use generated_content::ResolveGeneratedContent;
 use traversal::{BubbleISizes, RecalcStyleForNode, ConstructFlows};
 use traversal::{AssignBSizesAndStoreOverflow, AssignISizes};
 use traversal::{ComputeAbsolutePositions, BuildDisplayList};
@@ -37,6 +38,24 @@ pub fn traverse_dom_preorder(root: LayoutNode,
     let construct_flows = ConstructFlows     { layout_context: &layout_context };
 
     doit(root, recalc_style, construct_flows);
+}
+
+pub fn resolve_generated_content(root: &mut FlowRef, shared_layout_context: &SharedLayoutContext) {
+    fn doit(flow: &mut Flow, level: u32, traversal: &mut ResolveGeneratedContent) {
+        if !traversal.should_process(flow) {
+            return
+        }
+
+        traversal.process(flow, level);
+
+        for kid in flow::mut_base(flow).children.iter_mut() {
+            doit(kid, level + 1, traversal)
+        }
+    }
+
+    let layout_context = LayoutContext::new(shared_layout_context);
+    let mut traversal = ResolveGeneratedContent::new(&layout_context);
+    doit(&mut **root, 0, &mut traversal)
 }
 
 pub fn traverse_flow_tree_preorder(root: &mut FlowRef,

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -8,7 +8,6 @@
 
 use block::{BlockFlow, ISizeAndMarginsComputer, MarginsMayCollapseFlag};
 use block::{ISizeConstraintInput, ISizeConstraintSolution};
-use construct::FlowConstructor;
 use context::LayoutContext;
 use floats::FloatKind;
 use flow::{self, Flow, FlowClass, IMPACTED_BY_LEFT_FLOATS, IMPACTED_BY_RIGHT_FLOATS};
@@ -55,12 +54,12 @@ impl TableFlow {
                                   fragment: Fragment)
                                   -> TableFlow {
         let mut block_flow = BlockFlow::from_node_and_fragment(node, fragment);
-        let table_layout = if block_flow.fragment().style().get_table().table_layout ==
-                              table_layout::T::fixed {
-            TableLayout::Fixed
-        } else {
-            TableLayout::Auto
-        };
+        let table_layout =
+            if block_flow.fragment().style().get_table().table_layout == table_layout::T::fixed {
+                TableLayout::Fixed
+            } else {
+                TableLayout::Auto
+            };
         TableFlow {
             block_flow: block_flow,
             column_intrinsic_inline_sizes: Vec::new(),
@@ -69,35 +68,17 @@ impl TableFlow {
         }
     }
 
-    pub fn from_node(constructor: &mut FlowConstructor,
-                     node: &ThreadSafeLayoutNode)
-                     -> TableFlow {
-        let mut block_flow = BlockFlow::from_node(constructor, node);
-        let table_layout = if block_flow.fragment().style().get_table().table_layout ==
-                              table_layout::T::fixed {
-            TableLayout::Fixed
-        } else {
-            TableLayout::Auto
-        };
-        TableFlow {
-            block_flow: block_flow,
-            column_intrinsic_inline_sizes: Vec::new(),
-            column_computed_inline_sizes: Vec::new(),
-            table_layout: table_layout
-        }
-    }
-
-    pub fn float_from_node(constructor: &mut FlowConstructor,
-                           node: &ThreadSafeLayoutNode,
-                           float_kind: FloatKind)
-                           -> TableFlow {
-        let mut block_flow = BlockFlow::float_from_node(constructor, node, float_kind);
-        let table_layout = if block_flow.fragment().style().get_table().table_layout ==
-                              table_layout::T::fixed {
-            TableLayout::Fixed
-        } else {
-            TableLayout::Auto
-        };
+    pub fn float_from_node_and_fragment(node: &ThreadSafeLayoutNode,
+                                        fragment: Fragment,
+                                        float_kind: FloatKind)
+                                        -> TableFlow {
+        let mut block_flow = BlockFlow::float_from_node_and_fragment(node, fragment, float_kind);
+        let table_layout =
+            if block_flow.fragment().style().get_table().table_layout == table_layout::T::fixed {
+                TableLayout::Fixed
+            } else {
+                TableLayout::Auto
+            };
         TableFlow {
             block_flow: block_flow,
             column_intrinsic_inline_sizes: Vec::new(),
@@ -395,6 +376,10 @@ impl Flow for TableFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator)
     }
 }
 

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -7,10 +7,9 @@
 #![deny(unsafe_blocks)]
 
 use block::BlockFlow;
-use construct::FlowConstructor;
 use context::LayoutContext;
 use flow::{FlowClass, Flow};
-use fragment::FragmentBorderBoxIterator;
+use fragment::{Fragment, FragmentBorderBoxIterator};
 use wrapper::ThreadSafeLayoutNode;
 
 use geom::{Point2D, Rect};
@@ -26,11 +25,10 @@ pub struct TableCaptionFlow {
 }
 
 impl TableCaptionFlow {
-    pub fn from_node(constructor: &mut FlowConstructor,
-                     node: &ThreadSafeLayoutNode)
-                     -> TableCaptionFlow {
+    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode, fragment: Fragment)
+                                  -> TableCaptionFlow {
         TableCaptionFlow {
-            block_flow: BlockFlow::from_node(constructor, node)
+            block_flow: BlockFlow::from_node_and_fragment(node, fragment)
         }
     }
 }
@@ -95,6 +93,10 @@ impl Flow for TableCaptionFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator)
     }
 }
 

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -178,6 +178,10 @@ impl Flow for TableCellFlow {
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
     }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator)
+    }
 }
 
 impl fmt::Debug for TableCellFlow {

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -104,6 +104,8 @@ impl Flow for TableColGroupFlow {
     fn iterate_through_fragment_border_boxes(&self,
                                              _: &mut FragmentBorderBoxIterator,
                                              _: &Point2D<Au>) {}
+
+    fn mutate_fragments(&mut self, _: &mut FnMut(&mut Fragment)) {}
 }
 
 impl fmt::Debug for TableColGroupFlow {

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -8,10 +8,8 @@
 
 use block::BlockFlow;
 use block::ISizeAndMarginsComputer;
-use construct::FlowConstructor;
 use context::LayoutContext;
-use flow::{FlowClass, Flow, ImmutableFlowUtils};
-use flow;
+use flow::{self, FlowClass, Flow, ImmutableFlowUtils};
 use fragment::{Fragment, FragmentBorderBoxIterator};
 use layout_debug;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, InternalTable};
@@ -49,23 +47,12 @@ pub struct CellIntrinsicInlineSize {
 }
 
 impl TableRowFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode,
-                                  fragment: Fragment)
+    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode, fragment: Fragment)
                                   -> TableRowFlow {
         TableRowFlow {
             block_flow: BlockFlow::from_node_and_fragment(node, fragment),
             cell_intrinsic_inline_sizes: Vec::new(),
             column_computed_inline_sizes: Vec::new(),
-        }
-    }
-
-    pub fn from_node(constructor: &mut FlowConstructor,
-                     node: &ThreadSafeLayoutNode)
-                     -> TableRowFlow {
-        TableRowFlow {
-            block_flow: BlockFlow::from_node(constructor, node),
-            cell_intrinsic_inline_sizes: Vec::new(),
-            column_computed_inline_sizes: Vec::new()
         }
     }
 
@@ -330,6 +317,10 @@ impl Flow for TableRowFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator)
     }
 }
 

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -7,7 +7,6 @@
 #![deny(unsafe_blocks)]
 
 use block::{BlockFlow, ISizeAndMarginsComputer, MarginsMayCollapseFlag};
-use construct::FlowConstructor;
 use context::LayoutContext;
 use flow::{FlowClass, Flow};
 use fragment::{Fragment, FragmentBorderBoxIterator};
@@ -40,15 +39,6 @@ impl TableRowGroupFlow {
                                   -> TableRowGroupFlow {
         TableRowGroupFlow {
             block_flow: BlockFlow::from_node_and_fragment(node, fragment),
-            column_intrinsic_inline_sizes: Vec::new(),
-            column_computed_inline_sizes: Vec::new(),
-        }
-    }
-
-    pub fn from_node(constructor: &mut FlowConstructor, node: &ThreadSafeLayoutNode)
-                     -> TableRowGroupFlow {
-        TableRowGroupFlow {
-            block_flow: BlockFlow::from_node(constructor, node),
             column_intrinsic_inline_sizes: Vec::new(),
             column_computed_inline_sizes: Vec::new(),
         }
@@ -164,6 +154,10 @@ impl Flow for TableRowGroupFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator)
     }
 }
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -13,8 +13,8 @@
 
 #![deny(unsafe_blocks)]
 
-use block::{BlockFlow, BlockNonReplaced, FloatNonReplaced, ISizeAndMarginsComputer, MarginsMayCollapseFlag};
-use construct::FlowConstructor;
+use block::{BlockFlow, BlockNonReplaced, FloatNonReplaced, ISizeAndMarginsComputer};
+use block::{MarginsMayCollapseFlag};
 use context::LayoutContext;
 use floats::FloatKind;
 use flow::{FlowClass, Flow, ImmutableFlowUtils};
@@ -57,23 +57,6 @@ impl TableWrapperFlow {
                                   fragment: Fragment)
                                   -> TableWrapperFlow {
         let mut block_flow = BlockFlow::from_node_and_fragment(node, fragment);
-        let table_layout = if block_flow.fragment().style().get_table().table_layout ==
-                              table_layout::T::fixed {
-            TableLayout::Fixed
-        } else {
-            TableLayout::Auto
-        };
-        TableWrapperFlow {
-            block_flow: block_flow,
-            column_intrinsic_inline_sizes: vec!(),
-            table_layout: table_layout
-        }
-    }
-
-    pub fn from_node(constructor: &mut FlowConstructor,
-                     node: &ThreadSafeLayoutNode)
-                     -> TableWrapperFlow {
-        let mut block_flow = BlockFlow::from_node(constructor, node);
         let table_layout = if block_flow.fragment().style().get_table().table_layout ==
                               table_layout::T::fixed {
             TableLayout::Fixed
@@ -382,6 +365,10 @@ impl Flow for TableWrapperFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              stacking_context_position: &Point2D<Au>) {
         self.block_flow.iterate_through_fragment_border_boxes(iterator, stacking_context_position)
+    }
+
+    fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
+        self.block_flow.mutate_fragments(mutator)
     }
 }
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -13,7 +13,7 @@ use context::LayoutContext;
 use flow::{Flow, MutableFlowUtils};
 use flow::{PreorderFlowTraversal, PostorderFlowTraversal};
 use flow;
-use incremental::{RestyleDamage, BUBBLE_ISIZES, REFLOW, REFLOW_OUT_OF_FLOW};
+use incremental::{self, BUBBLE_ISIZES, REFLOW, REFLOW_OUT_OF_FLOW, RestyleDamage};
 use wrapper::{layout_node_to_unsafe_layout_node, LayoutNode};
 use wrapper::{PostorderNodeMutTraversal, ThreadSafeLayoutNode, UnsafeLayoutNode};
 use wrapper::{PreorderDomTraversal, PostorderDomTraversal};
@@ -171,7 +171,8 @@ impl<'a> PreorderDomTraversal for RecalcStyleForNode<'a> {
                                         &mut applicable_declarations,
                                         &mut shareable);
                     } else {
-                        ThreadSafeLayoutNode::new(&node).set_restyle_damage(RestyleDamage::all())
+                        ThreadSafeLayoutNode::new(&node).set_restyle_damage(
+                            incremental::rebuild_and_reflow())
                     }
 
                     // Perform the CSS cascade.
@@ -377,3 +378,4 @@ impl<'a> PostorderFlowTraversal for BuildDisplayList<'a> {
         flow.build_display_list(self.layout_context);
     }
 }
+

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -103,6 +103,11 @@ partial interface CSSStyleDeclaration {
   [TreatNullAs=EmptyString] attribute DOMString listStyleType;
   [TreatNullAs=EmptyString] attribute DOMString listStyleImage;
 
+  [TreatNullAs=EmptyString] attribute DOMString quotes;
+
+  [TreatNullAs=EmptyString] attribute DOMString counterIncrement;
+  [TreatNullAs=EmptyString] attribute DOMString counterReset;
+
   [TreatNullAs=EmptyString] attribute DOMString overflow;
   [TreatNullAs=EmptyString] attribute DOMString overflowX;
   [TreatNullAs=EmptyString] attribute DOMString overflowY;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#1e5bbf16eee3adeec1e911c7eaa8f2be02cd4c67"
+source = "git+https://github.com/servo/rust-selectors#2a492d522ef596a05c3677bb74bf8a5b73d01855"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/components/util/time.rs
+++ b/components/util/time.rs
@@ -81,6 +81,7 @@ pub enum TimeProfilerCategory {
     LayoutSelectorMatch,
     LayoutTreeBuilder,
     LayoutDamagePropagate,
+    LayoutGeneratedContent,
     LayoutMain,
     LayoutParallelWarmup,
     LayoutShaping,
@@ -99,6 +100,7 @@ impl Formatable for TimeProfilerCategory {
             TimeProfilerCategory::LayoutStyleRecalc |
             TimeProfilerCategory::LayoutRestyleDamagePropagation |
             TimeProfilerCategory::LayoutNonIncrementalReset |
+            TimeProfilerCategory::LayoutGeneratedContent |
             TimeProfilerCategory::LayoutMain |
             TimeProfilerCategory::LayoutDispListBuild |
             TimeProfilerCategory::LayoutShaping |
@@ -119,6 +121,7 @@ impl Formatable for TimeProfilerCategory {
             TimeProfilerCategory::LayoutSelectorMatch => "Selector Matching",
             TimeProfilerCategory::LayoutTreeBuilder => "Tree Building",
             TimeProfilerCategory::LayoutDamagePropagate => "Damage Propagation",
+            TimeProfilerCategory::LayoutGeneratedContent => "Generated Content Resolution",
             TimeProfilerCategory::LayoutMain => "Primary Layout Pass",
             TimeProfilerCategory::LayoutParallelWarmup => "Parallel Warmup",
             TimeProfilerCategory::LayoutShaping => "Shaping",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#1e5bbf16eee3adeec1e911c7eaa8f2be02cd4c67"
+source = "git+https://github.com/servo/rust-selectors#2a492d522ef596a05c3677bb74bf8a5b73d01855"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#1e5bbf16eee3adeec1e911c7eaa8f2be02cd4c67"
+source = "git+https://github.com/servo/rust-selectors#2a492d522ef596a05c3677bb74bf8a5b73d01855"
 dependencies = [
  "bitflags 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -65,6 +65,8 @@ flaky_cpu == append_style_a.html append_style_b.html
 == case-insensitive-font-family.html case-insensitive-font-family-ref.html
 == clear_generated_content_table_a.html clear_generated_content_table_ref.html
 == clip_a.html clip_ref.html
+== counters_nested_a.html counters_nested_ref.html
+== counters_simple_a.html counters_simple_ref.html
 == data_img_a.html data_img_b.html
 == empty_cells_a.html empty_cells_ref.html
 == filter_opacity_a.html filter_opacity_ref.html
@@ -177,6 +179,9 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == nth_last_of_type_pseudo_a.html nth_last_of_type_pseudo_b.html
 == nth_of_type_pseudo_a.html nth_of_type_pseudo_b.html
 == object_element_a.html object_element_b.html
+== ol_japanese_iroha_a.html ol_japanese_iroha_ref.html
+!= ol_japanese_iroha_bullet_styles.html ol_japanese_iroha_ref.html
+== ol_simple_a.html ol_simple_ref.html
 == only_child_pseudo_a.html only_child_pseudo_b.html
 == only_of_type_pseudo_a.html only_of_type_pseudo_b.html
 == opacity_simple_a.html opacity_simple_ref.html
@@ -220,6 +225,7 @@ experimental != overconstrained_block.html overconstrained_block_ref.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html
 == pseudo_element_a.html pseudo_element_b.html
 == pseudo_inherit.html pseudo_inherit_ref.html
+== quotes_simple_a.html quotes_simple_ref.html
 == root_height_a.html root_height_b.html
 == root_margin_collapse_a.html root_margin_collapse_b.html
 == root_pseudo_a.html root_pseudo_b.html

--- a/tests/ref/counters_nested_a.html
+++ b/tests/ref/counters_nested_a.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `counters` works with nested counters. -->
+<style>
+section {
+    counter-reset: section 0;
+}
+h1, h2, h3 {
+    counter-increment: section 1;
+    font-size: 24px;
+}
+h1:before, h2:before, h3:before {
+    content: counters(section, ".") ". ";
+}
+</style>
+</head>
+<body>
+<section>
+    <h1>Foo</h1>
+    <section>
+        <h2>Boo</h2>
+        <h2>Quux</h2>
+        <section>
+            <h3>Blah</h3>
+        </section>
+    </section>
+    <h1>Bar</h1>
+    <section></section>
+    <h2>Boo</h2>
+    <h2>Quux</h2>
+    <h1>Baz</h1>
+</section>
+</body>
+</html>
+

--- a/tests/ref/counters_nested_ref.html
+++ b/tests/ref/counters_nested_ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `counters` works with nested counters. -->
+<style>
+h1, h2, h3 {
+    font-size: 24px;
+}
+</style>
+</head>
+<body>
+<section>
+    <h1>1. Foo</h1>
+    <section>
+        <h2>1.1. Boo</h2>
+        <h2>1.2. Quux</h2>
+        <section>
+            <h3>1.2.1. Blah</h3>
+        </section>
+    </section>
+    <h1>1.3. Bar</h1>
+    <section></section>
+    <h2>1.1. Boo</h2>
+    <h2>1.2. Quux</h2>
+    <h1>1.3. Baz</h1>
+</section>
+</body>
+</html>
+

--- a/tests/ref/counters_simple_a.html
+++ b/tests/ref/counters_simple_a.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `counter` works. -->
+<style>
+h1, h2, h3 {
+    font-size: 24px;
+}
+h1 {
+    counter-increment: section 1;
+    counter-reset: subsection 0;
+}
+h1:before {
+    content: counter(section) ". ";
+}
+h2 {
+    counter-increment: subsection 1;
+    counter-reset: subsubsection 0;
+}
+h2:before {
+    content: counter(section) "." counter(subsection) ". ";
+}
+h3 {
+    counter-increment: subsubsection;
+}
+h3:before {
+    content: counter(section) "." counter(subsection) "." counter(subsubsection) ". ";
+}
+</style>
+</head>
+<body>
+<h1>Foo</h1>
+    <h2>Boo</h2>
+    <h2>Quux</h2>
+        <h3>Blah</h3>
+<h1>Bar</h1>
+    <h2>Boo</h2>
+    <h2>Quux</h2>
+<h1>Baz</h1>
+</body>
+</html>
+

--- a/tests/ref/counters_simple_ref.html
+++ b/tests/ref/counters_simple_ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that `counter` works. -->
+<style>
+h1, h2, h3 {
+    font-size: 24px;
+}
+</style>
+</head>
+<body>
+<h1>1. Foo</h1>
+    <h2>1.1. Boo</h2>
+    <h2>1.2. Quux</h2>
+        <h3>1.2.1. Blah</h3>
+<h1>2. Bar</h1>
+    <h2>2.1. Boo</h2>
+    <h2>2.2. Quux</h2>
+<h1>3. Baz</h1>
+</body>
+</html>
+

--- a/tests/ref/fonts/takao-p-gothic/COPYING.html
+++ b/tests/ref/fonts/takao-p-gothic/COPYING.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja-JP"><!-- InstanceBegin template="/Templates/master.dwt" codeOutsideHTMLIsLocked="false" -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Content-Style-Type" content="text/css" />
+<meta http-equiv="Content-Script-Type" content="text/javascript" />
+
+<!-- InstanceBeginEditable name="doctitle" -->
+<title>IPAフォントライセンスv1.0/IPA Font License Agreement v1.0</title>
+<!-- InstanceEndEditable -->
+
+<meta name="Description" content="IPA(独立行政法人 情報処理推進機構)が提供する「IPAフォント」の使用許諾契約書" />
+<meta name="Keywords" content="IPAフォント,フォント" />
+<meta name="Copyright" content="Copyright &copy; Information-technology Promotion Agency, Japan. All rights reserved 2009" />
+<meta name="Author" content="Information-technology Promotion Agency, Japan." />
+<meta http-equiv="imagetoolbar" content="false" />
+
+</head>
+
+<body id="comment-detail">
+			
+			<h4 id="LicenceTOP">IPA Font License Agreement v1.0 <a href="#LicenceJP">日本語/Japanese</a>　<a href="#LicenceEng">English</a></h4>
+
+			<h3 id="LicenceJP">IPAフォントライセンスv1.0 </h3>
+			<p>許諾者は、この使用許諾（以下「本契約」といいます。）に定める条件の下で、許諾プログラム（1条に定義するところによります。）を提供します。受領者（1条に定義するところによります。）が、許諾プログラムを使用し、複製し、または頒布する行為、その他、本契約に定める権利の利用を行った場合、受領者は本契約に同意したものと見なします。</p>
+
+			<h4>第1条　用語の定義</h4>
+			<p>本契約において、次の各号に掲げる用語は、当該各号に定めるところによります。</p>
+			<ol class="mainclass">
+			<li>「デジタル･フォント･プログラム」とは、フォントを含み、レンダリングしまたは表示するために用いられるコンピュータ・プログラムをいいます。</li>
+			<li>「許諾プログラム」とは、許諾者が本契約の下で許諾するデジタル･フォント･プログラムをいいます。</li>
+			<li>「派生プログラム」とは、許諾プログラムの一部または全部を、改変し、加除修正等し、入れ替え、その他翻案したデジタル･フォント･プログラムをいい、許諾プログラムの一部もしくは全部から文字情報を取り出し、またはデジタル･ドキュメント･ファイルからエンベッドされたフォントを取り出し、取り出された文字情報をそのまま、または改変をなして新たなデジタル・フォント・プログラムとして製作されたものを含みます。</li>
+			<li>「デジタル・コンテンツ」とは、デジタル・データ形式によってエンド・ユーザに提供される制作物のことをいい、動画・静止画等の映像コンテンツおよびテレビ番組等の放送コンテンツ、ならびに文字テキスト、画像、図形等を含んで構成された制作物を含みます。</li>
+			<li>「デジタル・ドキュメント・ファイル」とは、PDFファイルその他、各種ソフトウェア･プログラムによって製作されたデジタル・コンテンツであって、その中にフォントを表示するために許諾プログラムの全部または一部が埋め込まれた（エンベッドされた）ものをいいます。フォントが「エンベッドされた」とは、当該フォントが埋め込まれた特定の「デジタル・ドキュメント・ファイル」においてのみ表示されるために使用されている状態を指し、その特定の「デジタル・ドキュメント・ファイル」以外でフォントを表示するために使用できるデジタル・フォント・プログラムに含まれている場合と区別されます。</li>
+			<li>「コンピュータ｣とは、本契約においては、サーバを含みます。</li>
+			<li>「複製その他の利用」とは、複製、譲渡、頒布、貸与、公衆送信、上映、展示、翻案その他の利用をいいます。</li>
+			<li>「受領者」とは、許諾プログラムを本契約の下で受領した人をいい、受領者から許諾プログラムを受領した人を含みます。</li>
+			</ol>
+			<h4>第２条 使用許諾の付与</h4>
+			<p>許諾者は受領者に対し、本契約の条項に従い、すべての国で、許諾プログラムを使用することを許諾します。ただし、許諾プログラムに存在する一切の権利はすべて許諾者が保有しています。本契約は、本契約で明示的に定められている場合を除き、いかなる意味においても、許諾者が保有する許諾プログラムに関する一切の権利および、いかなる商標、商号、もしくはサービス・マークに関する権利をも受領者に移転するものではありません。</p>
+			<ol class="mainclass">
+			<li>受領者は本契約に定める条件に従い、許諾プログラムを任意の数のコンピュータにインストールし、当該コンピュータで使用することができます。</li>
+			<li> 受領者はコンピュータにインストールされた許諾プログラムをそのまま、または改変を行ったうえで、印刷物およびデジタル・コンテンツにおいて、文字テキスト表現等として使用することができます。</li>
+			<li>受領者は前項の定めに従い作成した印刷物およびデジタル・コンテンツにつき、その商用・非商用の別、および放送、通信、各種記録メディアなどの媒体の形式を問わず、複製その他の利用をすることができます。</li>
+			<li>受領者がデジタル・ドキュメント・ファイルからエンベッドされたフォントを取り出して派生プログラムを作成した場合には、かかる派生プログラムは本契約に定める条件に従う必要があります。</li>
+			<li>許諾プログラムのエンベッドされたフォントがデジタル・ドキュメント・ファイル内のデジタル・コンテンツをレンダリングするためにのみ使用される場合において、受領者が当該デジタル・ドキュメント・ファイルを複製その他の利用をする場合には、受領者はかかる行為に関しては本契約の下ではいかなる義務をも負いません。</li>
+			<li>受領者は、3条2項の定めに従い、商用・非商用を問わず、許諾プログラムをそのままの状態で改変することなく複製して第三者への譲渡し、公衆送信し、その他の方法で再配布することができます(以下、「再配布」といいます。)。</li>
+			<li>受領者は、上記の許諾プログラムについて定められた条件と同様の条件に従って、派生プログラムを作成し、使用し、複製し、再配布することができます。ただし、受領者が派生プログラムを再配布する場合には、3条1項の定めに従うものとします。</li>
+			</ol>
+
+			<h4>第３条　制限</h4>
+			<p>前条により付与された使用許諾は、以下の制限に服します。</p>
+			<ol class="mainclass">
+			<li>派生プログラムが前条4項及び7項に基づき再配布される場合には、以下の全ての条件を満たさなければなりません。
+			<ul style="list-style-type:none;">
+			<li>(1)	派生プログラムを再配布する際には、下記もまた、当該派生プログラムと一緒に再配布され、オンラインで提供され、または、郵送費・媒体及び取扱手数料の合計を超えない実費と引き換えに媒体を郵送する方法により提供されなければなりません。
+			<ul style="list-style-type:none;">
+			<li>(a)	派生プログラムの写し; および</li>
+			<li>(b)	派生プログラムを作成する過程でフォント開発プログラムによって作成された追加のファイルであって派生プログラムをさらに加工するにあたって利用できるファイルが存在すれば、当該ファイル</li>
+			</ul >
+			</li>
+
+			<li>(2)	派生プログラムの受領者が、派生プログラムを、このライセンスの下で最初にリリースされた許諾プログラム（以下、「オリジナル・プログラム」といいます。）に置き換えることができる方法を再配布するものとします。かかる方法は、オリジナル・ファイルからの差分ファイルの提供、または、派生プログラムをオリジナル・プログラムに置き換える方法を示す指示の提供などが考えられます。</li>
+			<li>(3)	派生プログラムを、本契約書に定められた条件の下でライセンスしなければなりません。</li>
+			<li>(4)	派生プログラムのプログラム名、フォント名またはファイル名として、許諾プログラムが用いているのと同一の名称、またはこれを含む名称を使用してはなりません。</li>
+			<li>(5)	本項の要件を満たすためにオンラインで提供し、または媒体を郵送する方法で提供されるものは、その提供を希望するいかなる者によっても提供が可能です。</li>
+			</ul >
+			</li>
+			<li>受領者が前条6項に基づき許諾プログラムを再配布する場合には、以下の全ての条件を満たさなければなりません。
+			<ul style="list-style-type:none;">
+			<li>(1)	許諾プログラムの名称を変更してはなりません。</li>
+			<li>(2)	許諾プログラムに加工その他の改変を加えてはなりません。</li>
+			<li>(3)	本契約の写しを許諾プログラムに添付しなければなりません。</li>
+			</ul >
+			</li>
+			<li>許諾プログラムは、現状有姿で提供されており、許諾プログラムまたは派生プログラムについて、許諾者は一切の明示または黙示の保証（権利の所在、非侵害、商品性、特定目的への適合性を含むがこれに限られません）を行いません。いかなる場合にも、その原因を問わず、契約上の責任か厳格責任か過失その他の不法行為責任かにかかわらず、また事前に通知されたか否かにかかわらず、許諾者は、許諾プログラムまたは派生プログラムのインストール、使用、複製その他の利用または本契約上の権利の行使によって生じた一切の損害（直接・間接・付随的・特別・拡大・懲罰的または結果的損害）（商品またはサービスの代替品の調達、システム障害から生じた損害、現存するデータまたはプログラムの紛失または破損、逸失利益を含むがこれに限られません）について責任を負いません。</li>
+			<li>許諾プログラムまたは派生プログラムのインストール、使用、複製その他の利用に関して、許諾者は技術的な質問や問い合わせ等に対する対応その他、いかなるユーザ・サポートをも行う義務を負いません。</li>
+			</ol>
+
+			<h4>第４条　契約の終了</h4>
+			<ol class="mainclass">
+			<li>本契約の有効期間は、受領者が許諾プログラムを受領した時に開始し、受領者が許諾プログラムを何らかの方法で保持する限り続くものとします。</li>
+			<li>前項の定めにかかわらず、受領者が本契約に定める各条項に違反したときは、本契約は、何らの催告を要することなく、自動的に終了し、当該受領者はそれ以後、許諾プログラムおよび派生プログラムを一切使用しまたは複製その他の利用をすることができないものとします。ただし、かかる契約の終了は、当該違反した受領者から許諾プログラムまたは派生プログラムの配布を受けた受領者の権利に影響を及ぼすものではありません。</li>
+			</ol>
+
+			<h4>第５条　準拠法</h4>
+			<ol class="mainclass">
+			<li>IPAは、本契約の変更バージョンまたは新しいバージョンを公表することができます。その場合には、受領者は、許諾プログラムまたは派生プログラムの使用、複製その他の利用または再配布にあたり、本契約または変更後の契約のいずれかを選択することができます。その他、上記に記載されていない条項に関しては日本の著作権法および関連法規に従うものとします。</li>
+			<li>本契約は、日本法に基づき解釈されます。</li>
+			</ol>
+			<p><a href="#LicenceTOP">TOP</a></p>
+
+			<hr/>
+			<h3 id="LicenceEng">IPA Font License Agreement v1.0 </h3>
+			<p>The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”).&nbsp; Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient (as defined in Article 1 below) constitutes the Recipient’s acceptance of this Agreement.</p>
+
+			<h4>Article 1 (Definitions)</h4>
+			<ol class="mainclass">
+			<li>“Digital Font Program” shall mean
+			a computer program containing, or used to render or display fonts.</li>
+			<li>“Licensed Program” shall mean a
+			Digital Font Program licensed by the Licensor under this Agreement.</li>
+			<li>“Derived Program” shall mean a Digital Font Program created as a result of a modification, addition, deletion, replacement or any other adaptation to or of a part or all of the Licensed Program, and includes a case where a Digital Font Program newly created by retrieving font information from a part or all of the Licensed Program or Embedded Fonts from a Digital Document File with or without modification of the retrieved font information. </li>
+			<li>“Digital Content” shall mean products provided to end users in the form of digital data, including video content, motion and/or still pictures, TV programs or other broadcasting content and products consisting of character text, pictures, photographic images, graphic symbols and/or the like.</li>
+			<li>“Digital Document File” shall mean a PDF file or other Digital Content created by various software programs in which a part or all of the Licensed Program becomes embedded or contained in the file for the display of the font (“Embedded Fonts”).  Embedded Fonts are used only in the display of characters in the particular Digital Document File within which they are embedded, and shall be distinguished from those in any Digital Font Program, which may be used for display of characters outside that particular Digital Document File.</li>
+			<li>“Computer” shall include a server in this Agreement.</li>
+			<li>“Reproduction and Other Exploitation” shall mean reproduction, transfer, distribution, lease, public transmission, presentation, exhibition, adaptation and any other exploitation.</li>
+			<li>“Recipient” shall mean anyone who receives the Licensed Program under this Agreement, including one that receives the Licensed Program from a Recipient.</li>
+			</ol>
+
+			<h4>Article 2 (Grant of License)</h4>
+			<p>The Licensor grants to the Recipient a license to use the Licensed Program in any and all countries in accordance with each of the provisions set forth in this Agreement. However, any and all rights underlying in the Licensed Program shall be held by the Licensor. In no sense is this Agreement intended to transfer any right relating to the Licensed Program held by the Licensor except as specifically set forth herein or any right relating to any trademark, trade name, or service mark to the Recipient.</p>
+			<ol class="mainclass">
+			<li>The Recipient may install the Licensed Program on any number of Computers and use the same in accordance with the provisions set forth in this Agreement.</li>
+			<li>The Recipient may use the Licensed Program, with or without modification in printed materials or in Digital Content as an expression of character texts or the like.</li>
+			<li>The Recipient may conduct Reproduction and Other Exploitation of the printed materials and Digital Content created in accordance with the preceding Paragraph, for commercial or non-commercial purposes and in any form of media including but not limited to broadcasting, communication and various recording media.</li>
+			<li>If any Recipient extracts Embedded Fonts from a Digital Document File to create a Derived Program, such Derived Program shall be subject to the terms of this agreement.</li> 
+			<li>If any Recipient performs Reproduction or Other Exploitation of a Digital Document File in which Embedded Fonts of the Licensed Program are used only for rendering the Digital Content within such Digital Document File then such Recipient shall have no further obligations under this Agreement in relation to such actions.</li>
+			<li>The Recipient may reproduce the Licensed Program as is without modification and transfer such copies, publicly transmit or otherwise redistribute the Licensed Program to a third party for commercial or non-commercial purposes (“Redistribute”), in accordance with the provisions set forth in Article 3 Paragraph 2.</li>
+			<li>The Recipient may create, use, reproduce and/or Redistribute a Derived Program under the terms stated above for the Licensed Program: provided, that the Recipient shall follow the provisions set forth in Article 3 Paragraph 1 when Redistributing the Derived Program. </li>
+			</ol>
+
+			<h4>Article 3 (Restriction)</h4>
+			<p>The license granted in the preceding Article shall be subject to the following restrictions:</p>
+			<ol class="mainclass">
+			<li>If a Derived Program is Redistributed pursuant to Paragraph 4 and 7 of the preceding Article, the following conditions must be met :
+			<ul style="list-style-type:none;">
+			<li>(1)The following must be also Redistributed together with the Derived Program, or be made available online or by means of mailing mechanisms in exchange for a cost which does not exceed the total costs of postage, storage medium and handling fees:
+			<ul style="list-style-type:none;">
+			<li>(a)a copy of the Derived Program; and</li>
+			<li>(b)any additional file created by the font developing program in the course of creating the Derived Program that can be used for further modification of the Derived Program, if any.</li>
+			</ul >
+			</li>
+			<li>(2)It is required to also Redistribute means to enable recipients of the Derived Program to replace the Derived Program with the Licensed Program first released under this License (the “Original Program”).  Such means may be to provide a difference file from the Original Program, or instructions setting out a method to replace the Derived Program with the Original Program.</li>
+			<li>(3)The Recipient must license the Derived Program under the terms and conditions of this Agreement.</li>
+			<li>(4)No one may use or include the name of the Licensed Program as a program name, font name or file name of the Derived Program.</li>
+			<li>(5) Any material to be made available online or by means of mailing a medium to satisfy the requirements of this paragraph may be provided, verbatim, by any party wishing to do so.</li>
+			</ul >
+			</li>
+			<li>If the Recipient Redistributes the Licensed Program pursuant to Paragraph 6 of the preceding Article, the Recipient shall meet all of the following conditions:
+			<ul style="list-style-type:none;">
+			<li>(1)The Recipient may not change the name of the Licensed Program.</li>
+			<li>(2)The Recipient may not alter or otherwise modify the Licensed Program.</li>
+			<li>(3)The Recipient must attach a copy of this Agreement to the Licensed Program.</li>
+			</ul >
+			</li>
+			<li>THIS LICENSED PROGRAM IS PROVIDED BY THE LICENSOR “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTY AS TO THE LICENSED PROGRAM OR ANY DERIVED PROGRAM, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED.  IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXTENDED, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO; PROCUREMENT OF SUBSTITUTED GOODS OR SERVICE; DAMAGES ARISING FROM SYSTEM FAILURE; LOSS OR CORRUPTION OF EXISTING DATA OR PROGRAM; LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE INSTALLATION, USE, THE REPRODUCTION OR OTHER EXPLOITATION OF THE LICENSED PROGRAM OR ANY DERIVED PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</li>
+			<li>The Licensor is under no obligation to respond to any technical questions or inquiries, or provide any other user support in connection with the installation, use or the Reproduction and Other Exploitation of the Licensed Program or Derived Programs thereof.</li>
+			</ol>
+
+			<h4>Article 4 (Termination of Agreement)</h4>
+			<ol class="mainclass">
+			<li>The term of this Agreement shall begin from the time of receipt of the Licensed Program by the Recipient and shall continue as long as the Recipient retains any such Licensed Program in any way.</li>
+			<li>Notwithstanding the provision set forth in the preceding Paragraph, in the event of the breach of any of the provisions set forth in this Agreement by the Recipient, this Agreement shall automatically terminate without any notice. In the case of such termination, the Recipient may not use or conduct Reproduction and Other Exploitation of the Licensed Program or a Derived Program: provided that such termination shall not affect any rights of any other Recipient receiving the Licensed Program or the Derived Program from such Recipient who breached this Agreement.</li>
+			</ol>
+
+			<h4>Article 5 (Governing Law)</h4>
+			<ol class="mainclass">
+			<li>IPA may publish revised and/or new versions of this License.  In such an event, the Recipient may select either this Agreement or any subsequent version of the Agreement in using, conducting the Reproduction and Other Exploitation of, or Redistributing the Licensed Program or a Derived Program. Other matters not specified above shall be subject to the Copyright Law of Japan and other related laws and regulations of Japan.</li>
+			<li>This Agreement shall be construed under the laws of Japan.</li>
+			</ol>
+			<p><a href="#LicenceTOP">TOP</a></p>
+
+	</body>
+</html>

--- a/tests/ref/ol_japanese_iroha_a.html
+++ b/tests/ref/ol_japanese_iroha_a.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that Japanese iroha ordering works in list items. -->
+<style>
+body {
+    font-family: "Hiragino Maru Gothic Pro", TakaoPGothic, sans-serif;
+}
+ol {
+    list-style-position: inside;
+    list-style-type: hiragana-iroha;
+}
+li {
+}
+</style>
+</head>
+<body>
+<ol>
+    <li>Gryffindor</li>
+    <li>Hufflepuff</li>
+    <li>Ravenclaw</li>
+    <li>Slytherin</li>
+</ol>
+</body>
+</html>
+
+

--- a/tests/ref/ol_japanese_iroha_a.html
+++ b/tests/ref/ol_japanese_iroha_a.html
@@ -3,8 +3,12 @@
 <head>
 <!-- Tests that Japanese iroha ordering works in list items. -->
 <style>
+@font-face {
+    font-family: TakaoPGothic;
+    src: url(fonts/takao-p-gothic/TakaoPGothic.ttf);
+}
 body {
-    font-family: "Hiragino Maru Gothic Pro", TakaoPGothic, sans-serif;
+    font-family: TakaoPGothic;
 }
 ol {
     list-style-position: inside;

--- a/tests/ref/ol_japanese_iroha_bullet_styles.html
+++ b/tests/ref/ol_japanese_iroha_bullet_styles.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Ensures that U+3044, U+308D, U+306F, and U+306B are all supported in the current font. -->
+<style>
+body {
+    font-family: "Hiragino Maru Gothic Pro", TakaoPGothic, sans-serif;
+}
+ol {
+    list-style-position: inside;
+    list-style-type: none;
+}
+</style>
+</head>
+<body>
+<ol>
+    <li>&#x3044;. Gryffindor</li>
+    <li>&#x3044;. Hufflepuff</li>
+    <li>&#x3044;. Ravenclaw</li>
+    <li>&#x3044;. Slytherin</li>
+</ol>
+</body>
+</html>
+
+

--- a/tests/ref/ol_japanese_iroha_bullet_styles.html
+++ b/tests/ref/ol_japanese_iroha_bullet_styles.html
@@ -3,8 +3,12 @@
 <head>
 <!-- Ensures that U+3044, U+308D, U+306F, and U+306B are all supported in the current font. -->
 <style>
+@font-face {
+    font-family: TakaoPGothic;
+    src: url(fonts/takao-p-gothic/TakaoPGothic.ttf);
+}
 body {
-    font-family: "Hiragino Maru Gothic Pro", TakaoPGothic, sans-serif;
+    font-family: TakaoPGothic;
 }
 ol {
     list-style-position: inside;

--- a/tests/ref/ol_japanese_iroha_ref.html
+++ b/tests/ref/ol_japanese_iroha_ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that Japanese iroha ordering works in list items.
+
+     FIXME(pcwalton): This shouldn't have a "." after the kana. -->
+<style>
+body {
+    font-family: "Hiragino Maru Gothic Pro", TakaoPGothic, sans-serif;
+}
+ol {
+    list-style-position: inside;
+    list-style-type: none;
+}
+</style>
+</head>
+<body>
+<ol>
+    <li>&#x3044;. Gryffindor</li>
+    <li>&#x308d;. Hufflepuff</li>
+    <li>&#x306f;. Ravenclaw</li>
+    <li>&#x306b;. Slytherin</li>
+</ol>
+</body>
+</html>
+
+

--- a/tests/ref/ol_japanese_iroha_ref.html
+++ b/tests/ref/ol_japanese_iroha_ref.html
@@ -5,8 +5,12 @@
 
      FIXME(pcwalton): This shouldn't have a "." after the kana. -->
 <style>
+@font-face {
+    font-family: TakaoPGothic;
+    src: url(fonts/takao-p-gothic/TakaoPGothic.ttf);
+}
 body {
-    font-family: "Hiragino Maru Gothic Pro", TakaoPGothic, sans-serif;
+    font-family: TakaoPGothic;
 }
 ol {
     list-style-position: inside;

--- a/tests/ref/ol_simple_a.html
+++ b/tests/ref/ol_simple_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+li {
+    list-style-type: decimal;
+    list-style-position: inside;
+}
+</style>
+</head>
+<body>
+<ol>
+    <li>Foo</li>
+    <li>Bar</li>
+    <li>Baz</li>
+</ol>
+</body>
+</html>
+

--- a/tests/ref/ol_simple_ref.html
+++ b/tests/ref/ol_simple_ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+li {
+    list-style-type: none;
+    list-style-position: inside;
+}
+</style>
+</head>
+<body>
+<ol>
+    <li>1. Foo</li>
+    <li>2. Bar</li>
+    <li>3. Baz</li>
+</ol>
+</body>
+</html>
+

--- a/tests/ref/quotes_simple_a.html
+++ b/tests/ref/quotes_simple_a.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that the initial value of `quotes` works. -->
+</head>
+<body>
+I remember when I first read <q>Hagrid said, <q>You're a wizard, Harry!</q></q>
+</body>
+</html>
+

--- a/tests/ref/quotes_simple_ref.html
+++ b/tests/ref/quotes_simple_ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that the initial value of `quotes` works. -->
+</head>
+<body>
+I remember when I first read &#x201c;Hagrid said, &#x2018;You're a wizard, Harry!&#x2019;&#x201d;
+</body>
+</html>
+
+

--- a/tests/wpt/metadata/html/semantics/grouping-content/the-li-element/grouping-li-reftest-002.html.ini
+++ b/tests/wpt/metadata/html/semantics/grouping-content/the-li-element/grouping-li-reftest-002.html.ini
@@ -2,4 +2,4 @@
   type: reftest
   reftype: ==
   refurl: /html/semantics/grouping-content/the-li-element/grouping-li-reftest-002-ref.html
-  expected: FAIL
+  expected: PASS

--- a/tests/wpt/metadata/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001.html.ini
+++ b/tests/wpt/metadata/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001.html.ini
@@ -2,4 +2,4 @@
   type: reftest
   reftype: ==
   refurl: /html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001-ref.html
-  expected: FAIL
+  expected: PASS


### PR DESCRIPTION
Only simple alphabetic and numeric counter styles are supported. (This
is most of them though.)

Although this PR adds a sequential pass to layout, I verified that on
pages that contain a reasonable number of ordered lists (Reddit
`/r/rust`), the time spent in generated content resolution is dwarfed by
the time spent in the parallelizable parts of layout. So I don't expect
this to negatively affect our parallelism expect perhaps in pathological
cases.

Reconstructed from #5138 via raw diffing.

r? @SimonSapin 
