### PR TITLE
Disable flaky reftests until a proper solution is found.

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -139,8 +139,10 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == iframe/overflow.html iframe/overflow_ref.html
 == iframe/positioning_margin.html iframe/positioning_margin_ref.html
 == iframe/hide_and_show.html iframe/hide_and_show_ref.html
-== iframe/hide_layers1.html iframe/hide_layers_ref.html
-== iframe/hide_layers2.html iframe/hide_layers_ref.html
+
+# gw: race condition here caused by pipelines never painting when removed from document
+#== iframe/hide_layers1.html iframe/hide_layers_ref.html
+#== iframe/hide_layers2.html iframe/hide_layers_ref.html
 
 == floated_generated_content_a.html floated_generated_content_b.html
 == inline_block_margin_a.html inline_block_margin_ref.html


### PR DESCRIPTION
A race condition exists where pipelines that are removed from a document
may not ever trigger a paint for that pipeline. The compositor relies
on a paint occurring for each pipeline before outputting the image when
in reftest mode.
