### PR TITLE
Reftests for viewport percentage length units

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -274,6 +274,10 @@ flaky_cpu,experimental == vertical-lr-blocks.html vertical-lr-blocks_ref.html
 == vertical_align_top_a.html vertical_align_top_ref.html
 == vertical_align_top_bottom_a.html vertical_align_top_bottom_ref.html
 == vertical_align_top_span_a.html vertical_align_top_span_ref.html
+resolution=800x600 == viewport_percentage_vmin_vmax.html viewport_percentage_vmin_vmax_a.html
+resolution=600x800 == viewport_percentage_vmin_vmax.html viewport_percentage_vmin_vmax_b.html
+resolution=800x600 == viewport_percentage_vw_vh.html viewport_percentage_vw_vh_a.html
+resolution=600x800 == viewport_percentage_vw_vh.html viewport_percentage_vw_vh_b.html
 == visibility_hidden.html visibility_hidden_ref.html
 == whitespace_nowrap_a.html whitespace_nowrap_ref.html
 == whitespace_pre.html whitespace_pre_ref.html

--- a/tests/ref/viewport_percentage_vmin_vmax.html
+++ b/tests/ref/viewport_percentage_vmin_vmax.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      #box {
+        background: green;
+        height: 50vmax;
+        width: 50vmin;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+    </div>
+  </body>
+</html>

--- a/tests/ref/viewport_percentage_vmin_vmax_a.html
+++ b/tests/ref/viewport_percentage_vmin_vmax_a.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      #box {
+        background: green;
+        height: 400px;
+        width: 300px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+    </div>
+  </body>
+</html>

--- a/tests/ref/viewport_percentage_vmin_vmax_b.html
+++ b/tests/ref/viewport_percentage_vmin_vmax_b.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      #box {
+        background: green;
+        height: 400px;
+        width: 300px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+    </div>
+  </body>
+</html>

--- a/tests/ref/viewport_percentage_vw_vh.html
+++ b/tests/ref/viewport_percentage_vw_vh.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      #box {
+        background: green;
+        height: 50vh;
+        width: 50vw;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+    </div>
+  </body>
+</html>

--- a/tests/ref/viewport_percentage_vw_vh_a.html
+++ b/tests/ref/viewport_percentage_vw_vh_a.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      #box {
+        background: green;
+        height: 300px;
+        width: 400px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+    </div>
+  </body>
+</html>

--- a/tests/ref/viewport_percentage_vw_vh_b.html
+++ b/tests/ref/viewport_percentage_vw_vh_b.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      #box {
+        background: green;
+        height: 400px;
+        width: 300px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Looking for some review, due to a couple of issues:
- The vmin/vmax tests fail due to exit status being 1 instead of 0. However, when I manually check them via `./mach run tests/ref/viewport_percentage_vmax_vmin{,a,b,c}.html`, the pages render correctly
- Resizing is incredibly flaky. I've checked (via logging), and the actual calculation of the computed length is correct for a given viewport size. However, the box dimensions end up all over the place. I've attached a screenshot to demonstrate (the box is supposed to cover the top-left quarter of the window).
  ![screen shot 2015-03-05 at 8 50 50 pm](https://cloud.githubusercontent.com/assets/1111588/6520012/5e5d7ac4-c379-11e4-8d56-f4c57616ac44.png)

Fixes #5165.
