### PR TITLE
Fix broken viewport percentage length units after a viewport resize.

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -41,6 +41,10 @@ fn create_or_get_local_context(shared_layout_context: &SharedLayoutContext) -> *
                 style_sharing_candidate_cache: StyleSharingCandidateCache::new(),
             };
             r.set(unsafe { boxed::into_raw(context) });
+        } else if shared_layout_context.screen_size_changed {
+            unsafe {
+                (*r.get()).applicable_declarations_cache.evict_all();
+            }
         }
 
         r.get()
@@ -53,6 +57,9 @@ pub struct SharedLayoutContext {
 
     /// The current screen size.
     pub screen_size: Size2D<Au>,
+
+    /// Screen sized changed?
+    pub screen_size_changed: bool,
 
     /// A channel up to the constellation.
     pub constellation_chan: ConstellationChan,

--- a/components/layout/css/matching.rs
+++ b/components/layout/css/matching.rs
@@ -153,6 +153,10 @@ impl ApplicableDeclarationsCache {
     fn insert(&mut self, declarations: Vec<DeclarationBlock>, style: Arc<ComputedValues>) {
         self.cache.insert(ApplicableDeclarationsCacheEntry::new(declarations), style)
     }
+
+    pub fn evict_all(&mut self) {
+        self.cache.evict_all();
+    }
 }
 
 /// An LRU cache of the last few nodes seen, so that we can aggressively try to reuse their styles.


### PR DESCRIPTION
When a viewport is resized, the computed values for a style containing viewport percentage length units become stale. However, there's no way for those styles to be invalidated after a resize. As a solution, this commit invalidates the computed values cache after a resize has occurred, which is probably over-kill.

A better solution would probably be to track under what conditions computed values remain valid, and invalidate them as indicated.
