### PR TITLE
Use new `if let` syntax wherever possible. Fixes #4153.

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -224,23 +224,16 @@ fn create_interface_object(cx: *mut JSContext, global: *mut JSObject,
         let constructor = JS_GetFunctionObject(fun);
         assert!(!constructor.is_null());
 
-        match members.static_methods {
-            Some(static_methods) => {
-                define_methods(cx, constructor, static_methods)
-            },
-            _ => (),
+        if let Some(static_methods) = members.static_methods {
+            define_methods(cx, constructor, static_methods);
         }
 
-        match members.static_attrs {
-            Some(static_properties) => {
-                define_properties(cx, constructor, static_properties)
-            },
-            _ => (),
+        if let Some(static_properties) = members.static_attrs {
+            define_properties(cx, constructor, static_properties);
         }
 
-        match members.consts {
-            Some(constants) => define_constants(cx, constructor, constants),
-            _ => (),
+        if let Some(constants) = members.consts {
+            define_constants(cx, constructor, constants);
         }
 
         if !proto.is_null() {
@@ -304,19 +297,16 @@ fn create_interface_prototype_object(cx: *mut JSContext, global: *mut JSObject,
                                                    &*parent_proto, &*global);
         assert!(!our_proto.is_null());
 
-        match members.methods {
-            Some(methods) => define_methods(cx, our_proto, methods),
-            _ => (),
+        if let Some(methods) = members.methods {
+            define_methods(cx, our_proto, methods);
         }
 
-        match members.attrs {
-            Some(properties) => define_properties(cx, our_proto, properties),
-            _ => (),
+        if let Some(properties) = members.attrs {
+            define_properties(cx, our_proto, properties);
         }
 
-        match members.consts {
-            Some(constants) => define_constants(cx, our_proto, constants),
-            _ => (),
+        if let Some(constants) = members.consts {
+            define_constants(cx, our_proto, constants);
         }
 
         return our_proto;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1166,9 +1166,8 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -1218,9 +1217,8 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -1275,9 +1273,8 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if !tree_in_doc { return; }
@@ -1296,9 +1293,8 @@ impl<'a> VirtualMethods for JSRef<'a, Element> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         if !tree_in_doc { return; }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -85,9 +85,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let name = attr.local_name().as_slice();

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -116,9 +116,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -132,9 +131,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -149,9 +147,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -159,9 +156,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLButtonElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -209,7 +205,7 @@ impl<'a> Activatable for JSRef<'a, HTMLButtonElement> {
                     o.root().r().submit(SubmittedFrom::NotFromFormSubmitMethod,
                                         FormSubmitter::ButtonElement(self.clone()))
                 });
-            }
+            },
             _ => ()
         }
     }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -132,9 +132,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         let recreate = match attr.local_name() {
@@ -159,9 +158,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLCanvasElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let value = attr.value();

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -126,9 +126,10 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
     // https://html.spec.whatwg.org/multipage/interaction.html#dom-click
     fn Click(self) {
         let maybe_input: Option<JSRef<HTMLInputElement>> = HTMLInputElementCast::to_ref(self);
-        match maybe_input {
-            Some(i) if i.Disabled() => return,
-            _ => ()
+        if let Some(i) = maybe_input {
+            if i.Disabled() {
+                return;
+            }
         }
         let element: JSRef<Element> = ElementCast::from_ref(self);
         // https://www.w3.org/Bugs/Public/show_bug.cgi?id=27430 ?
@@ -188,9 +189,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let name = attr.local_name().as_slice();

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -84,9 +84,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -116,9 +115,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLFieldSetElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -203,9 +203,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -244,9 +243,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+           s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -256,9 +254,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLIFrameElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -183,9 +183,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -199,9 +198,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLImageElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -425,9 +425,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -485,9 +484,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -540,9 +538,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -550,9 +547,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -564,11 +560,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
     }
 
     fn handle_event(&self, event: JSRef<Event>) {
-        match self.super_type() {
-            Some(s) => {
-                s.handle_event(event);
-            }
-            _ => (),
+        if let Some(s) = self.super_type() {
+            s.handle_event(event);
         }
 
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -76,9 +76,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         let element: JSRef<Element> = ElementCast::from_ref(*self);
@@ -102,9 +101,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLLinkElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc {

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -102,9 +102,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLObjectElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -60,9 +60,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -75,14 +74,13 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptGroupElement> {
                     child.set_enabled_state(false);
                 }
             },
-            _ => ()
+            _ => (),
         }
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -129,9 +129,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -139,15 +138,14 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
                 let node: JSRef<Node> = NodeCast::from_ref(*self);
                 node.set_disabled_state(true);
                 node.set_enabled_state(false);
-            }
+            },
             _ => ()
         }
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -162,9 +160,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -172,9 +169,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLOptionElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -473,9 +473,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         if attr.local_name() == &atom!("src") && !self.parser_inserted.get() && node.is_in_doc() {
@@ -484,9 +483,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         if !self.parser_inserted.get() && node.is_in_doc() {
@@ -495,9 +493,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc && !self.parser_inserted.get() {
@@ -507,9 +504,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLScriptElement> {
 
     fn cloning_steps(&self, copy: JSRef<Node>, maybe_doc: Option<JSRef<Document>>,
                      clone_children: CloneChildrenFlag) {
-        match self.super_type() {
-            Some(ref s) => s.cloning_steps(copy, maybe_doc, clone_children),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.cloning_steps(copy, maybe_doc, clone_children);
         }
 
         // https://whatwg.org/html/#already-started

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -84,9 +84,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -100,9 +99,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -117,9 +115,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -127,9 +124,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLSelectElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -69,9 +69,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -81,9 +80,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLStyleElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         if tree_in_doc {

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -87,9 +87,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -105,9 +104,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -118,9 +118,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -139,9 +138,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -68,28 +68,28 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableRowElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
             &atom!("bgcolor") => {
-                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok())
-            }
-            _ => {}
+                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok());
+            },
+            _ => ()
         }
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
-            &atom!("bgcolor") => self.background_color.set(None),
-            _ => {}
+            &atom!("bgcolor") => {
+                self.background_color.set(None);
+            },
+            _ => ()
         }
     }
 }

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -66,28 +66,28 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableSectionElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
             &atom!("bgcolor") => {
-                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok())
-            }
-            _ => {}
+                self.background_color.set(str::parse_legacy_color(attr.value().as_slice()).ok());
+            },
+            _ => ()
         }
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
-            &atom!("bgcolor") => self.background_color.set(None),
-            _ => {}
+            &atom!("bgcolor") => {
+                self.background_color.set(None);
+            },
+            _ => ()
         }
     }
 }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -224,9 +224,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
 
         match attr.local_name() {
@@ -252,9 +251,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => ()
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
 
         match attr.local_name() {
@@ -275,9 +273,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -293,9 +290,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);
@@ -307,11 +303,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(s) => {
-                s.child_inserted(child);
-            }
-            _ => (),
+        if let Some(s) = self.super_type() {
+            s.child_inserted(child);
         }
 
         if child.is_text() && !self.value_changed.get() {
@@ -321,11 +314,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTextAreaElement> {
 
     // copied and modified from htmlinputelement.rs
     fn handle_event(&self, event: JSRef<Event>) {
-        match self.super_type() {
-            Some(s) => {
-                s.handle_event(event);
-            }
-            _ => (),
+        if let Some(s) = self.super_type() {
+            s.handle_event(event);
         }
 
         if "click" == event.Type().as_slice() && !event.DefaultPrevented() {

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -71,9 +71,8 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTitleElement> {
     }
 
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
 
         let node: JSRef<Node> = NodeCast::from_ref(*self);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1284,9 +1284,10 @@ impl Node {
         }
 
         // Step 3.
-        match child {
-            Some(child) if !parent.is_parent_of(child) => return Err(NotFound),
-            _ => ()
+        if let Some(child) = child {
+            if !parent.is_parent_of(child) {
+                return Err(NotFound);
+            }
         }
 
         // Step 4-5.
@@ -1325,14 +1326,11 @@ impl Node {
                                 if !parent.child_elements().is_empty() {
                                     return Err(HierarchyRequest);
                                 }
-                                match child {
-                                    Some(child) => {
-                                        if child.inclusively_following_siblings()
-                                            .any(|child| child.is_doctype()) {
-                                                return Err(HierarchyRequest)
-                                            }
+                                if let Some(child) = child {
+                                    if child.inclusively_following_siblings()
+                                        .any(|child| child.is_doctype()) {
+                                            return Err(HierarchyRequest);
                                     }
-                                    _ => (),
                                 }
                             },
                             // Step 6.1.1(a)
@@ -1344,14 +1342,11 @@ impl Node {
                         if !parent.child_elements().is_empty() {
                             return Err(HierarchyRequest);
                         }
-                        match child {
-                            Some(ref child) => {
-                                if child.inclusively_following_siblings()
-                                    .any(|child| child.is_doctype()) {
-                                        return Err(HierarchyRequest)
-                                    }
+                        if let Some(ref child) = child {
+                            if child.inclusively_following_siblings()
+                                .any(|child| child.is_doctype()) {
+                                    return Err(HierarchyRequest);
                             }
-                            _ => (),
                         }
                     },
                     // Step 6.3
@@ -2368,12 +2363,11 @@ impl<'a> DisabledStateHelpers for JSRef<'a, Node> {
 
     fn check_parent_disabled_state_for_option(self) {
         if self.get_disabled_state() { return; }
-        match self.parent_node().root() {
-            Some(ref parent) if parent.r().is_htmloptgroupelement() && parent.r().get_disabled_state() => {
+        if let Some(ref parent) = self.parent_node().root() {
+            if parent.r().is_htmloptgroupelement() && parent.r().get_disabled_state() {
                 self.set_disabled_state(true);
                 self.set_enabled_state(false);
-            },
-            _ => ()
+            }
         }
     }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -71,18 +71,16 @@ pub trait VirtualMethods {
     /// Called when changing or adding attributes, after the attribute's value
     /// has been updated.
     fn after_set_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.after_set_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
         }
     }
 
     /// Called when changing or removing attributes, before any modification
     /// has taken place.
     fn before_remove_attr(&self, attr: JSRef<Attr>) {
-        match self.super_type() {
-            Some(ref s) => s.before_remove_attr(attr),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
         }
     }
 
@@ -98,45 +96,38 @@ pub trait VirtualMethods {
     /// Called when a Node is appended to a tree, where 'tree_in_doc' indicates
     /// whether the tree is part of a Document.
     fn bind_to_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.bind_to_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
         }
     }
 
     /// Called when a Node is removed from a tree, where 'tree_in_doc'
     /// indicates whether the tree is part of a Document.
     fn unbind_from_tree(&self, tree_in_doc: bool) {
-        match self.super_type() {
-            Some(ref s) => s.unbind_from_tree(tree_in_doc),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
         }
     }
 
     /// Called on the parent when a node is added to its child list.
     fn child_inserted(&self, child: JSRef<Node>) {
-        match self.super_type() {
-            Some(ref s) => s.child_inserted(child),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.child_inserted(child);
         }
     }
 
     /// Called during event dispatch after the bubbling phase completes.
     fn handle_event(&self, event: JSRef<Event>) {
-        match self.super_type() {
-            Some(s) => {
-                s.handle_event(event);
-            }
-            _ => (),
+        if let Some(s) = self.super_type() {
+            s.handle_event(event);
         }
     }
 
     /// https://dom.spec.whatwg.org/#concept-node-clone (step 5)
     fn cloning_steps(&self, copy: JSRef<Node>, maybe_doc: Option<JSRef<Document>>,
                      clone_children: CloneChildrenFlag) {
-        match self.super_type() {
-            Some(ref s) => s.cloning_steps(copy, maybe_doc, clone_children),
-            _ => (),
+        if let Some(ref s) = self.super_type() {
+            s.cloning_steps(copy, maybe_doc, clone_children);
         }
     }
 }


### PR DESCRIPTION
Opening this PR to invite feedback. 

Of the many `match` statement candidates for conversion to `if let`, several included `if` guards. Since `if let` doesn't support this syntax, I used nested if statements. If this is undesirable, say the word and I can revert those cases to `match`.
