### PR TITLE
Canvas: added arc() support.

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -29,6 +29,7 @@ pub enum CanvasMsg {
     MoveTo(Point2D<f32>),
     LineTo(Point2D<f32>),
     BezierCurveTo(Point2D<f32>, Point2D<f32>, Point2D<f32>),
+    Arc(Point2D<f32>, f32, f32, f32, bool),
     SetFillStyle(FillOrStrokeStyle),
     SetStrokeStyle(FillOrStrokeStyle),
     SetTransform(Matrix2D<f32>),
@@ -81,6 +82,9 @@ impl<'a> CanvasPaintTask<'a> {
                     CanvasMsg::LineTo(ref point) => painter.line_to(point),
                     CanvasMsg::BezierCurveTo(ref cp1, ref cp2, ref pt) => {
                         painter.bezier_curve_to(cp1, cp2, pt)
+                    }
+                    CanvasMsg::Arc(ref center, radius, start, end, ccw) => {
+                        painter.arc(center, radius, start, end, ccw)
                     }
                     CanvasMsg::SetFillStyle(style) => painter.set_fill_style(style),
                     CanvasMsg::SetStrokeStyle(style) => painter.set_stroke_style(style),
@@ -151,6 +155,15 @@ impl<'a> CanvasPaintTask<'a> {
                        cp2: &Point2D<AzFloat>,
                        endpoint: &Point2D<AzFloat>) {
         self.path_builder.bezier_curve_to(cp1, cp2, endpoint)
+    }
+
+    fn arc(&self,
+           center: &Point2D<AzFloat>,
+           radius: AzFloat,
+           start_angle: AzFloat,
+           end_angle: AzFloat,
+           ccw: bool) {
+        self.path_builder.arc(*center, radius, start_angle, end_angle, ccw)
     }
 
     fn set_fill_style(&mut self, style: FillOrStrokeStyle) {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -160,6 +160,11 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
                                                     Point2D(x as f32, y as f32))).unwrap();
     }
 
+    fn Arc(self, x: f64, y: f64, r: f64, start: f64, end: f64, ccw: bool) {
+        self.renderer.send(CanvasMsg::Arc(Point2D(x as f32, y as f32), r as f32,
+                                          start as f32, end as f32, ccw)).unwrap();
+    }
+
     fn StrokeStyle(self) -> StringOrCanvasGradientOrCanvasPattern {
         // FIXME(pcwalton, #4761): This is not spec-compliant. See:
         //

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -138,7 +138,7 @@ interface CanvasPathMethods {
 
   //void rect(double x, double y, double w, double h);
 
-  //void arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false); 
+  void arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false);
 // NOT IMPLEMENTED  [LenientFloat] void ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, boolean anticlockwise);
 };
 

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.angle.1.html]
-  type: testharness
-  [arc() draws pi/2 .. -pi anticlockwise correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.angle.2.html]
-  type: testharness
-  [arc() draws -3pi/2 .. -pi anticlockwise correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.3.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.3.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.angle.3.html]
-  type: testharness
-  [arc() wraps angles mod 2pi when anticlockwise and end > start+2pi]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.4.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.4.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.angle.4.html]
-  type: testharness
-  [arc() draws a full circle when clockwise and end > start+2pi]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.5.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.5.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.angle.5.html]
-  type: testharness
-  [arc() wraps angles mod 2pi when clockwise and start > end+2pi]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.6.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.angle.6.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.angle.6.html]
-  type: testharness
-  [arc() draws a full circle when anticlockwise and start > end+2pi]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.default.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.default.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.default.html]
-  type: testharness
-  [arc() with missing last argument defaults to clockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.scale.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.scale.1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.scale.1.html]
-  type: testharness
-  [Non-uniformly scaled arcs are the right shape]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -7398,12 +7398,6 @@
   [CanvasRenderingContext2D interface: calling rect(unrestricted double,unrestricted double,unrestricted double,unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "arc" with the proper type (78)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling arc(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,boolean) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "ellipse" with the proper type (79)]
     expected: FAIL
 


### PR DESCRIPTION
This patch enables the use of `arc()` on the canvas.
I couldn't add reftest this time, as it involves some antialiasing issues, and so the reference doesn't match.
