### PR TITLE
Perform reflow if load events dirty any nodes.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1387,6 +1387,8 @@ impl DocumentProgressHandler {
                                EventCancelable::NotCancelable).root();
         let doctarget: JSRef<EventTarget> = EventTargetCast::from_ref(document.r());
         let _ = doctarget.DispatchEvent(event.r());
+
+        window.r().reflow(ReflowGoal::ForDisplay, ReflowQueryType::NoQuery, ReflowReason::DOMContentLoaded);
     }
 
     fn set_ready_state_complete(&self) {
@@ -1418,6 +1420,8 @@ impl DocumentProgressHandler {
             let target: JSRef<EventTarget> = EventTargetCast::from_ref(frame_element.r());
             event.r().fire(target);
         });
+
+        window_ref.reflow(ReflowGoal::ForDisplay, ReflowQueryType::NoQuery, ReflowReason::DocumentLoaded);
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -75,6 +75,8 @@ pub enum ReflowReason {
     Timer,
     Viewport,
     WindowResize,
+    DOMContentLoaded,
+    DocumentLoaded,
 }
 
 #[dom_struct]
@@ -510,8 +512,6 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
             return
         }
 
-        debug!("script: performing reflow for goal {:?}", goal);
-
         // Layout will let us know when it's done.
         let (join_chan, join_port) = channel();
 
@@ -840,6 +840,8 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
         ReflowReason::Timer => debug_msg.push_str("\tTimer"),
         ReflowReason::Viewport => debug_msg.push_str("\tViewport"),
         ReflowReason::WindowResize => debug_msg.push_str("\tWindowResize"),
+        ReflowReason::DOMContentLoaded => debug_msg.push_str("\tDOMContentLoaded"),
+        ReflowReason::DocumentLoaded => debug_msg.push_str("\tDocumentLoaded"),
     }
 
     println!("{}", debug_msg);


### PR DESCRIPTION
This fixes some test failures that begin occurring when other events (such as resize) are fixed to only occur when needed.
