### PR TITLE
Make change page url message consistent with other compositor messages.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -5,7 +5,7 @@
 use compositor_layer::{CompositorData, CompositorLayer, WantsScrollEventsFlag};
 use compositor_task::{CompositorEventListener, CompositorProxy, CompositorReceiver};
 use compositor_task::{CompositorTask, LayerProperties, Msg};
-use constellation::{FrameId, SendableFrameTree};
+use constellation::SendableFrameTree;
 use pipeline::CompositionPipeline;
 use scrolling::ScrollingTimerProxy;
 use windowing;
@@ -274,8 +274,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.change_page_title(pipeline_id, title);
             }
 
-            (Msg::ChangePageUrl(frame_id, url), ShutdownState::NotShuttingDown) => {
-                self.change_page_url(frame_id, url);
+            (Msg::ChangePageUrl(pipeline_id, url), ShutdownState::NotShuttingDown) => {
+                self.change_page_url(pipeline_id, url);
             }
 
             (Msg::PaintMsgDiscarded, ShutdownState::NotShuttingDown) => {
@@ -441,7 +441,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
     }
 
-    fn change_page_url(&mut self, _: FrameId, url: Url) {
+    fn change_page_url(&mut self, _: PipelineId, url: Url) {
         self.window.set_page_url(url);
     }
 

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -202,7 +202,7 @@ pub enum Msg {
     /// Alerts the compositor that the current page has changed its title.
     ChangePageTitle(PipelineId, Option<String>),
     /// Alerts the compositor that the current page has changed its URL.
-    ChangePageUrl(FrameId, Url),
+    ChangePageUrl(PipelineId, Url),
     /// Alerts the compositor that a `PaintMsg` has been discarded.
     PaintMsgDiscarded,
     /// Replaces the current frame tree, typically called during main frame navigation.

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -335,7 +335,7 @@ impl NavigationContext {
     fn set_current(&mut self, new_frame: Rc<FrameTree>, compositor_proxy: &mut CompositorProxy) {
         self.current = Some(new_frame.clone());
         compositor_proxy.send(CompositorMsg::ChangePageUrl(
-            new_frame.id,
+            new_frame.pipeline.borrow().id,
             new_frame.pipeline.borrow().url.clone()));
     }
 }


### PR DESCRIPTION
This doesn't have any effect on functionality, it just simplifies a few upcoming changes with how FrameIds work.
