### PR TITLE
Remove now unused id field for frame tree.

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -5,7 +5,7 @@
 //! Communication with the compositor task.
 
 pub use windowing;
-pub use constellation::{FrameId, SendableFrameTree};
+pub use constellation::SendableFrameTree;
 
 use compositor;
 use headless;

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -8,7 +8,7 @@ use dom::document::{Document, DocumentHelpers};
 use dom::node::NodeHelpers;
 use dom::window::Window;
 
-use msg::constellation_msg::{PipelineId, SubpageId};
+use msg::constellation_msg::PipelineId;
 use util::smallvec::SmallVec;
 use std::cell::Cell;
 use std::rc::Rc;
@@ -19,9 +19,6 @@ use url::Url;
 pub struct Page {
     /// Pipeline id associated with this page.
     id: PipelineId,
-
-    /// Subpage id associated with this page, if any.
-    subpage_id: Option<SubpageId>,
 
     /// The outermost frame containing the document and window.
     frame: DOMRefCell<Option<Frame>>,
@@ -65,10 +62,9 @@ impl IterablePage for Rc<Page> {
 }
 
 impl Page {
-    pub fn new(id: PipelineId, subpage_id: Option<SubpageId>, url: Url) -> Page {
+    pub fn new(id: PipelineId, url: Url) -> Page {
         Page {
             id: id,
-            subpage_id: subpage_id,
             frame: DOMRefCell::new(None),
             url: url,
             needs_reflow: Cell::new(true),

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -909,8 +909,7 @@ impl ScriptTask {
         let cx = cx.as_ref().unwrap();
 
         // Create a new frame tree entry.
-        let page = Rc::new(Page::new(incomplete.pipeline_id, incomplete.subpage_id.map(|p| p.1),
-                                     final_url.clone()));
+        let page = Rc::new(Page::new(incomplete.pipeline_id, final_url.clone()));
         if !root_page_exists {
             // We have a new root frame tree.
             *self.page.borrow_mut() = Some(page.clone());


### PR DESCRIPTION
This will be re-introduced in a follow up PR with a different usage, but I'm trying to create small, independent PRs that are easier to review than one large change.
