### PR TITLE
Remove redundant force_relayout calls.

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -245,7 +245,6 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     fn SetValue(self, value: DOMString) {
         self.textinput.borrow_mut().set_content(value);
         self.value_changed.set(true);
-        self.force_relayout();
     }
 
     // https://html.spec.whatwg.org/multipage/forms.html#dom-input-defaultvalue
@@ -383,7 +382,6 @@ impl<'a> HTMLInputElementHelpers for JSRef<'a, HTMLInputElement> {
                                         .map(|group| group.as_slice()));
         }
         //TODO: dispatch change event
-        self.force_relayout();
     }
 
     fn get_size(&self) -> u32 {
@@ -446,7 +444,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                     AttrValue::UInt(_, value) => self.size.set(value),
                     _ => panic!("Expected an AttrValue::UInt"),
                 }
-                self.force_relayout();
             }
             &atom!("type") => {
                 let value = attr.value();
@@ -465,12 +462,10 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                                                  .as_ref()
                                                  .map(|group| group.as_slice()));
                 }
-                self.force_relayout();
             }
             &atom!("value") => {
                 if !self.value_changed.get() {
                     self.textinput.borrow_mut().set_content(attr.value().as_slice().to_owned());
-                    self.force_relayout();
                 }
             }
             &atom!("name") => {
@@ -503,7 +498,6 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             }
             &atom!("size") => {
                 self.size.set(DEFAULT_INPUT_SIZE);
-                self.force_relayout();
             }
             &atom!("type") => {
                 if self.input_type.get() == InputType::InputRadio {
@@ -513,12 +507,10 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                                                 .map(|group| group.as_slice()));
                 }
                 self.input_type.set(InputType::InputText);
-                self.force_relayout();
             }
             &atom!("value") => {
                 if !self.value_changed.get() {
                     self.textinput.borrow_mut().set_content("".to_owned());
-                    self.force_relayout();
                 }
             }
             &atom!("name") => {


### PR DESCRIPTION
This is a cleanup for issue #3959 

Do I need to inline force_relayout?
