### PR TITLE
Add an environment variable to override cache-dir

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -69,8 +69,9 @@ class CommandBase(object):
 
         # Handle missing/default items
         self.config.setdefault("tools", {})
-        self.config["tools"].setdefault("cache-dir",
-                                        path.join(context.topdir, ".servo"))
+        default_cache_dir = os.environ.get("SERVO_CACHE_DIR",
+                                           path.join(context.topdir, ".servo"))
+        self.config["tools"].setdefault("cache-dir", default_cache_dir)
         resolverelative("tools", "cache-dir")
 
         self.config["tools"].setdefault("cargo-home-dir",


### PR DESCRIPTION
This will be set in servo/saltfs to prevent our buildbot builders from re-downloading the build tools for every build.

r? @larsbergstrom or @metajack or @Manishearth
