### PR TITLE
Fix #2108 by renaming unwrap functions to native_from_reflector

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -108,7 +108,7 @@ class CastableObjectUnwrapper():
 
     def __str__(self):
         return string.Template("""\
-match unwrap_jsmanaged(${source}) {
+match native_from_reflector_jsmanaged(${source}) {
     Ok(val) => val,
     Err(()) => {
 ${codeOnFailure}
@@ -1711,7 +1711,7 @@ def UnionTypes(descriptors, dictionaries, callbacks, config):
         'dom::bindings::codegen::PrototypeList',
         'dom::bindings::conversions::FromJSValConvertible',
         'dom::bindings::conversions::ToJSValConvertible',
-        'dom::bindings::conversions::unwrap_jsmanaged',
+        'dom::bindings::conversions::native_from_reflector_jsmanaged',
         'dom::bindings::conversions::StringificationBehavior::Default',
         'dom::bindings::error::throw_not_in_union',
         'dom::bindings::js::Unrooted',
@@ -4015,7 +4015,7 @@ class CGAbstractClassHook(CGAbstractExternMethod):
 
     def definition_body_prologue(self):
         return CGGeneric("""\
-let this: *const %s = unwrap::<%s>(obj);
+let this: *const %s = native_from_reflector::<%s>(obj);
 """ % (self.descriptor.concreteType, self.descriptor.concreteType))
 
     def definition_body(self):
@@ -4628,7 +4628,7 @@ class CGBindingRoot(CGThing):
             'dom::bindings::callback::{CallSetup,ExceptionHandling}',
             'dom::bindings::callback::wrap_call_this_object',
             'dom::bindings::conversions::{FromJSValConvertible, ToJSValConvertible}',
-            'dom::bindings::conversions::{unwrap, unwrap_jsmanaged}',
+            'dom::bindings::conversions::{native_from_reflector, native_from_reflector_jsmanaged}',
             'dom::bindings::conversions::DOM_OBJECT_SLOT',
             'dom::bindings::conversions::IDLInterface',
             'dom::bindings::conversions::jsid_to_str',

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -428,7 +428,7 @@ pub unsafe fn dom_object_slot(obj: *mut JSObject) -> u32 {
 }
 
 /// Get the DOM object from the given reflector.
-pub unsafe fn unwrap<T>(obj: *mut JSObject) -> *const T {
+pub unsafe fn native_from_reflector<T>(obj: *mut JSObject) -> *const T {
     use js::jsapi::JS_GetReservedSlot;
 
     let slot = dom_object_slot(obj);
@@ -462,7 +462,7 @@ unsafe fn get_dom_class(obj: *mut JSObject) -> Result<DOMClass, ()> {
 /// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
 /// not a reflector for a DOM object of the given type (as defined by the
 /// proto_id and proto_depth).
-pub fn unwrap_jsmanaged<T>(mut obj: *mut JSObject) -> Result<Unrooted<T>, ()>
+pub fn native_from_reflector_jsmanaged<T>(mut obj: *mut JSObject) -> Result<Unrooted<T>, ()>
     where T: Reflectable + IDLInterface
 {
     use js::glue::{IsWrapper, UnwrapObject};
@@ -491,7 +491,7 @@ pub fn unwrap_jsmanaged<T>(mut obj: *mut JSObject) -> Result<Unrooted<T>, ()>
         let proto_depth = <T as IDLInterface>::get_prototype_depth();
         if dom_class.interface_chain[proto_depth] == proto_id {
             debug!("good prototype");
-            Ok(Unrooted::from_raw(unwrap(obj)))
+            Ok(Unrooted::from_raw(native_from_reflector(obj)))
         } else {
             debug!("bad prototype");
             Err(())
@@ -506,7 +506,7 @@ impl<T: Reflectable+IDLInterface> FromJSValConvertible for Unrooted<T> {
         if !value.is_object() {
             return Err(());
         }
-        unwrap_jsmanaged(value.to_object())
+        native_from_reflector_jsmanaged(value.to_object())
     }
 }
 

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -6,7 +6,7 @@
 
 use dom::bindings::codegen::PrototypeList;
 use dom::bindings::codegen::PrototypeList::MAX_PROTO_CHAIN_LENGTH;
-use dom::bindings::conversions::{unwrap_jsmanaged, is_dom_class};
+use dom::bindings::conversions::{native_from_reflector_jsmanaged, is_dom_class};
 use dom::bindings::error::throw_type_error;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{Temporary, Root};
@@ -576,7 +576,7 @@ pub extern fn outerize_global(_cx: *mut JSContext, obj: JSHandleObject) -> *mut 
     unsafe {
         debug!("outerizing");
         let obj = *obj.unnamed_field1;
-        let win: Root<window::Window> = unwrap_jsmanaged(obj).unwrap().root();
+        let win: Root<window::Window> = native_from_reflector_jsmanaged(obj).unwrap().root();
         win.r().browser_context().as_ref().unwrap().window_proxy()
     }
 }

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::conversions::unwrap_jsmanaged;
+use dom::bindings::conversions::native_from_reflector_jsmanaged;
 use dom::bindings::conversions::{ToJSValConvertible};
 use dom::bindings::js::{JS, JSRef, Temporary, Root};
 use dom::bindings::js::{OptionalRootable, OptionalRootedRootable, ResultRootable};
@@ -108,7 +108,7 @@ unsafe fn GetSubframeWindow(cx: *mut JSContext, proxy: *mut JSObject, id: jsid) 
     let index = get_array_index_from_id(cx, id);
     if let Some(index) = index {
         let target = GetProxyPrivate(proxy).to_object();
-        let win: Root<Window> = unwrap_jsmanaged(target).unwrap().root();
+        let win: Root<Window> = native_from_reflector_jsmanaged(target).unwrap().root();
         let mut found = false;
         return win.r().IndexedGetter(index, &mut found);
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -913,7 +913,7 @@ pub fn from_untrusted_node_address(runtime: *mut JSRuntime, candidate: Untrusted
         if object.is_null() {
             panic!("Attempted to create a `JS<Node>` from an invalid pointer!")
         }
-        let boxed_node: *const Node = conversions::unwrap(object);
+        let boxed_node: *const Node = conversions::native_from_reflector(object);
         Temporary::from_unrooted(Unrooted::from_raw(boxed_node))
     }
 }


### PR DESCRIPTION
Fix for issue #2108. That issue mentions an `unwrap_object` which doesn't seem to exist so I renamed `unwrap` to `native_from_reflector` and `unwrap_jsmanaged` to `native_from_reflector_jsmanaged`. The latter is a bit unweildy - maybe a shorter name might be better?
