### PR TITLE
Add HOST_FILE environment variable for test-wpt

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -120,7 +120,7 @@ class CommandBase(object):
             self._cargo_build_id = open(filename).read().strip()
         return self._cargo_build_id
 
-    def build_env(self, gonk=False):
+    def build_env(self, gonk=False, hosts_file_path=None):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
         extra_path = []
@@ -205,6 +205,9 @@ class CommandBase(object):
             env["NDK_HOME"] = env["ANDROID_NDK"]
         if "ANDROID_TOOLCHAIN" in env:
             env["NDK_STANDALONE"] = env["ANDROID_TOOLCHAIN"]
+
+        if hosts_file_path:
+            env['HOST_FILE'] = hosts_file_path
 
         return env
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -30,8 +30,8 @@ class MachCommands(CommandBase):
         if self.context.built_tests:
             return
         returncode = Registrar.dispatch('build-tests', context=self.context)
-	if returncode:
-	    sys.exit(returncode)
+        if returncode:
+            sys.exit(returncode)
         self.context.built_tests = True
 
     def find_test(self, prefix):
@@ -235,7 +235,8 @@ class MachCommands(CommandBase):
 
         processes = str(multiprocessing.cpu_count()) if processes is None else processes
         params = params + ["--processes", processes]
+        hosts_file_path = path.join('tests', 'wpt', 'hosts')
 
         return subprocess.call(
             ["bash", path.join("tests", "wpt", "run.sh")] + params,
-            env=self.build_env())
+            env=self.build_env(hosts_file_path=hosts_file_path))

--- a/tests/wpt/hosts
+++ b/tests/wpt/hosts
@@ -1,0 +1,6 @@
+127.0.0.1 web-platform.test
+127.0.0.1 www.web-platform.test
+127.0.0.1 www1.web-platform.test
+127.0.0.1 www2.web-platform.test
+127.0.0.1 xn--n8j6ds53lwwkrqhv28a.web-platform.test
+127.0.0.1 xn--lve-6lad.web-platform.test


### PR DESCRIPTION
`./mach test tests/wpt/web-platform-tests/html/browsers/history/the-location-interface/security_location_0.sub.htm` is still failing with the same message as reported in #3219.
