### PR TITLE
Add --no-ssl flag for bypassing SSL checking

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -23,6 +23,7 @@ use std::sync::mpsc::{Sender, channel};
 use std::thunk::Invoke;
 use util::task::spawn_named;
 use util::resource_files::resources_dir_path;
+use util::opts;
 use url::{Url, UrlParser};
 
 use std::borrow::ToOwned;
@@ -89,7 +90,12 @@ fn load(mut load_data: LoadData, start_chan: Sender<TargetedLoadResponse>, cooki
 function: \"SSL3_GET_SERVER_CERTIFICATE\", \
 reason: \"certificate verify failed\" }]";
 
-        let mut connector = HttpConnector(Some(box verifier as Box<FnMut(&mut SslContext)>));
+        let mut connector = if opts::get().nossl {
+            HttpConnector(None)
+        } else {
+            HttpConnector(Some(box verifier as Box<FnMut(&mut SslContext)>))
+        };
+
         let mut req = match Request::with_connector(load_data.method.clone(), url.clone(), &mut connector) {
             Ok(req) => req,
             Err(HttpError::HttpIoError(IoError {kind: IoErrorKind::OtherIoError,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -58,6 +58,8 @@ pub struct Opts {
 
     pub nonincremental_layout: bool,
 
+    pub nossl: bool,
+
     pub output_file: Option<String>,
     pub headless: bool,
     pub hard_fail: bool,
@@ -177,6 +179,7 @@ pub fn default_opts() -> Opts {
         enable_experimental: false,
         layout_threads: 1,
         nonincremental_layout: false,
+        nossl: false,
         output_file: None,
         headless: true,
         hard_fail: true,
@@ -216,6 +219,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         getopts::optflag("x", "exit", "Exit after load flag"),
         getopts::optopt("y", "layout-threads", "Number of threads to use for layout", "1"),
         getopts::optflag("i", "nonincremental-layout", "Enable to turn off incremental layout."),
+        getopts::optflag("", "no-ssl", "Disables ssl certificate verification."),
         getopts::optflag("z", "headless", "Headless mode"),
         getopts::optflag("f", "hard-fail", "Exit on task failure instead of displaying about:failure"),
         getopts::optflagopt("", "devtools", "Start remote devtools server on port", "6000"),
@@ -291,6 +295,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
     };
 
     let nonincremental_layout = opt_match.opt_present("i");
+    let nossl = opt_match.opt_present("no-ssl");
 
     let mut bubble_inline_sizes_separately = debug_options.contains(&"bubble-widths");
     let trace_layout = debug_options.contains(&"trace-layout");
@@ -325,6 +330,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         enable_experimental: opt_match.opt_present("e"),
         layout_threads: layout_threads,
         nonincremental_layout: nonincremental_layout,
+        nossl: nossl,
         output_file: opt_match.opt_str("o"),
         headless: opt_match.opt_present("z"),
         hard_fail: opt_match.opt_present("f"),


### PR DESCRIPTION
SSL is broken-ish (eg tw.yahoo.com, html.spec.whatwg.org don't work since we don't verify SAN properly), this flag can let devs bypass the protection for testing purposes.
