### PR TITLE
localStorage shim, fixes #5195

### DIFF
--- a/components/net/storage_task.rs
+++ b/components/net/storage_task.rs
@@ -11,26 +11,32 @@ use url::Url;
 use util::str::DOMString;
 use util::task::spawn_named;
 
+#[derive(Copy)]
+pub enum StorageType {
+    Session,
+    Local
+}
+
 /// Request operations on the storage data associated with a particular url
 pub enum StorageTaskMsg {
     /// gets the number of key/value pairs present in the associated storage data
-    Length(Sender<u32>, Url),
+    Length(Sender<u32>, Url, StorageType),
 
     /// gets the name of the key at the specified index in the associated storage data
-    Key(Sender<Option<DOMString>>, Url, u32),
+    Key(Sender<Option<DOMString>>, Url, StorageType, u32),
 
     /// gets the value associated with the given key in the associated storage data
-    GetItem(Sender<Option<DOMString>>, Url, DOMString),
+    GetItem(Sender<Option<DOMString>>, Url, StorageType, DOMString),
 
     /// sets the value of the given key in the associated storage data
     /// TODO throw QuotaExceededError in case of error
-    SetItem(Sender<bool>, Url, DOMString, DOMString),
+    SetItem(Sender<bool>, Url, StorageType, DOMString, DOMString),
 
     /// removes the key/value pair for the given key in the associated storage data
-    RemoveItem(Sender<bool>, Url, DOMString),
+    RemoveItem(Sender<bool>, Url, StorageType, DOMString),
 
     /// clears the associated storage data by removing all the key/value pairs
-    Clear(Sender<bool>, Url),
+    Clear(Sender<bool>, Url, StorageType),
 
     /// shut down this task
     Exit
@@ -56,14 +62,16 @@ impl StorageTaskFactory for StorageTask {
 
 struct StorageManager {
     port: Receiver<StorageTaskMsg>,
-    data: HashMap<String, BTreeMap<DOMString, DOMString>>,
+    session_data: HashMap<String, BTreeMap<DOMString, DOMString>>,
+    local_data: HashMap<String, BTreeMap<DOMString, DOMString>>,
 }
 
 impl StorageManager {
     fn new(port: Receiver<StorageTaskMsg>) -> StorageManager {
         StorageManager {
             port: port,
-            data: HashMap::new(),
+            session_data: HashMap::new(),
+            local_data: HashMap::new(),
         }
     }
 }
@@ -72,23 +80,23 @@ impl StorageManager {
     fn start(&mut self) {
         loop {
             match self.port.recv().unwrap() {
-                StorageTaskMsg::Length(sender, url) => {
-                    self.length(sender, url)
+                StorageTaskMsg::Length(sender, url, storage_type) => {
+                    self.length(sender, url, storage_type)
                 }
-                StorageTaskMsg::Key(sender, url, index) => {
-                    self.key(sender, url, index)
+                StorageTaskMsg::Key(sender, url, storage_type, index) => {
+                    self.key(sender, url, storage_type, index)
                 }
-                StorageTaskMsg::SetItem(sender, url, name, value) => {
-                    self.set_item(sender, url, name, value)
+                StorageTaskMsg::SetItem(sender, url, storage_type, name, value) => {
+                    self.set_item(sender, url, storage_type, name, value)
                 }
-                StorageTaskMsg::GetItem(sender, url, name) => {
-                    self.get_item(sender, url, name)
+                StorageTaskMsg::GetItem(sender, url, storage_type, name) => {
+                    self.get_item(sender, url, storage_type, name)
                 }
-                StorageTaskMsg::RemoveItem(sender, url, name) => {
-                    self.remove_item(sender, url, name)
+                StorageTaskMsg::RemoveItem(sender, url, storage_type, name) => {
+                    self.remove_item(sender, url, storage_type, name)
                 }
-                StorageTaskMsg::Clear(sender, url) => {
-                    self.clear(sender, url)
+                StorageTaskMsg::Clear(sender, url, storage_type) => {
+                    self.clear(sender, url, storage_type)
                 }
                 StorageTaskMsg::Exit => {
                     break
@@ -97,25 +105,42 @@ impl StorageManager {
         }
     }
 
-    fn length(&self, sender: Sender<u32>, url: Url) {
-        let origin = self.get_origin_as_string(url);
-        sender.send(self.data.get(&origin).map_or(0u, |entry| entry.len()) as u32).unwrap();
+    fn select_data(& self, storage_type: StorageType) -> &HashMap<String, BTreeMap<DOMString, DOMString>> {
+        match storage_type {
+            StorageType::Session => &self.session_data,
+            StorageType::Local => &self.local_data
+        }
     }
 
-    fn key(&self, sender: Sender<Option<DOMString>>, url: Url, index: u32) {
+    fn select_data_mut(&mut self, storage_type: StorageType) -> &mut HashMap<String, BTreeMap<DOMString, DOMString>> {
+        match storage_type {
+            StorageType::Session => &mut self.session_data,
+            StorageType::Local => &mut self.local_data
+        }
+    }
+
+    fn length(&self, sender: Sender<u32>, url: Url, storage_type: StorageType) {
         let origin = self.get_origin_as_string(url);
-        sender.send(self.data.get(&origin)
+        let data = self.select_data(storage_type);
+        sender.send(data.get(&origin).map_or(0u, |entry| entry.len()) as u32).unwrap();
+    }
+
+    fn key(&self, sender: Sender<Option<DOMString>>, url: Url, storage_type: StorageType, index: u32) {
+        let origin = self.get_origin_as_string(url);
+        let data = self.select_data(storage_type);
+        sender.send(data.get(&origin)
                     .and_then(|entry| entry.keys().nth(index as uint))
                     .map(|key| key.clone())).unwrap();
     }
 
-    fn set_item(&mut self, sender: Sender<bool>, url: Url, name: DOMString, value: DOMString) {
+    fn set_item(&mut self, sender: Sender<bool>, url: Url, storage_type: StorageType, name: DOMString, value: DOMString) {
         let origin = self.get_origin_as_string(url);
-        if !self.data.contains_key(&origin) {
-            self.data.insert(origin.clone(), BTreeMap::new());
+        let data = self.select_data_mut(storage_type);
+        if !data.contains_key(&origin) {
+            data.insert(origin.clone(), BTreeMap::new());
         }
 
-        let updated = self.data.get_mut(&origin).map(|entry| {
+        let updated = data.get_mut(&origin).map(|entry| {
             if entry.get(&origin).map_or(true, |item| item.as_slice() != value.as_slice()) {
                 entry.insert(name.clone(), value.clone());
                 true
@@ -127,22 +152,25 @@ impl StorageManager {
         sender.send(updated).unwrap();
     }
 
-    fn get_item(&self, sender: Sender<Option<DOMString>>, url: Url, name: DOMString) {
+    fn get_item(&self, sender: Sender<Option<DOMString>>, url: Url, storage_type: StorageType, name: DOMString) {
         let origin = self.get_origin_as_string(url);
-        sender.send(self.data.get(&origin)
+        let data = self.select_data(storage_type);
+        sender.send(data.get(&origin)
                     .and_then(|entry| entry.get(&name))
                     .map(|value| value.to_string())).unwrap();
     }
 
-    fn remove_item(&mut self, sender: Sender<bool>, url: Url, name: DOMString) {
+    fn remove_item(&mut self, sender: Sender<bool>, url: Url, storage_type: StorageType, name: DOMString) {
         let origin = self.get_origin_as_string(url);
-        sender.send(self.data.get_mut(&origin)
+        let data = self.select_data_mut(storage_type);
+        sender.send(data.get_mut(&origin)
                     .map_or(false, |entry| entry.remove(&name).is_some())).unwrap();
     }
 
-    fn clear(&mut self, sender: Sender<bool>, url: Url) {
+    fn clear(&mut self, sender: Sender<bool>, url: Url, storage_type: StorageType) {
         let origin = self.get_origin_as_string(url);
-        sender.send(self.data.get_mut(&origin)
+        let data = self.select_data_mut(storage_type);
+        sender.send(data.get_mut(&origin)
                     .map_or(false, |entry| {
                         if !entry.is_empty() {
                             entry.clear();

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -48,6 +48,7 @@ use layout_interface::{LayoutRPC, LayoutChan};
 use libc;
 use msg::constellation_msg::{PipelineId, SubpageId, WindowSizeData};
 use net::image_cache_task::ImageCacheTask;
+use net::storage_task::StorageType;
 use script_traits::ScriptControlChan;
 use script_traits::UntrustedNodeAddress;
 use msg::compositor_msg::ScriptListener;
@@ -231,6 +232,7 @@ no_jsmanaged_fields!(UntrustedNodeAddress);
 no_jsmanaged_fields!(LengthOrPercentageOrAuto);
 no_jsmanaged_fields!(RGBA);
 no_jsmanaged_fields!(Matrix2D<T>);
+no_jsmanaged_fields!(StorageType);
 
 impl JSTraceable for Box<ScriptChan+Send> {
     #[inline]

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -134,3 +134,10 @@ interface WindowSessionStorage {
   readonly attribute Storage sessionStorage;
 };
 Window implements WindowSessionStorage;
+
+// https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage
+[NoInterfaceObject]
+interface WindowLocalStorage {
+  readonly attribute Storage localStorage;
+};
+Window implements WindowLocalStorage;

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -8367,9 +8367,6 @@
   [Window interface: calling createImageBitmap(ImageBitmapSource,long,long,long,long) on window with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Window interface: window must inherit property "localStorage" with the proper type (124)]
-    expected: FAIL
-
   [BarProp interface: existence and properties of interface object]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_local_key.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_key.html.ini
@@ -1,5 +1,4 @@
 [event_local_key.html]
   type: testharness
-  [Web Storage]
-    expected: FAIL
+  expected: TIMEOUT 
 

--- a/tests/wpt/metadata/webstorage/event_local_newvalue.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_newvalue.html.ini
@@ -1,5 +1,4 @@
 [event_local_newvalue.html]
   type: testharness
-  [Web Storage]
-    expected: FAIL
+  expected: TIMEOUT
 

--- a/tests/wpt/metadata/webstorage/event_local_oldvalue.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_oldvalue.html.ini
@@ -1,5 +1,3 @@
 [event_local_oldvalue.html]
   type: testharness
-  [Web Storage]
-    expected: FAIL
-
+  expected: TIMEOUT 

--- a/tests/wpt/metadata/webstorage/event_local_storagearea.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_storagearea.html.ini
@@ -1,5 +1,3 @@
 [event_local_storagearea.html]
   type: testharness
-  [Web Storage]
-    expected: FAIL
-
+  expected: TIMEOUT

--- a/tests/wpt/metadata/webstorage/event_local_url.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_url.html.ini
@@ -1,5 +1,3 @@
 [event_local_url.html]
   type: testharness
-  [Web Storage]
-    expected: FAIL
-
+  expected: TIMEOUT

--- a/tests/wpt/metadata/webstorage/idlharness.html.ini
+++ b/tests/wpt/metadata/webstorage/idlharness.html.ini
@@ -6,42 +6,6 @@
   [Storage interface object length]
     expected: FAIL
 
-  [Storage must be primary interface of window.localStorage]
-    expected: FAIL
-
-  [Stringification of window.localStorage]
-    expected: FAIL
-
-  [Storage interface: window.localStorage must inherit property "length" with the proper type (0)]
-    expected: FAIL
-
-  [Storage interface: window.localStorage must inherit property "key" with the proper type (1)]
-    expected: FAIL
-
-  [Storage interface: calling key(unsigned long) on window.localStorage with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Storage interface: window.localStorage must inherit property "getItem" with the proper type (2)]
-    expected: FAIL
-
-  [Storage interface: calling getItem(DOMString) on window.localStorage with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Storage interface: window.localStorage must inherit property "setItem" with the proper type (3)]
-    expected: FAIL
-
-  [Storage interface: calling setItem(DOMString,DOMString) on window.localStorage with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Storage interface: window.localStorage must inherit property "removeItem" with the proper type (4)]
-    expected: FAIL
-
-  [Storage interface: calling removeItem(DOMString) on window.localStorage with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Storage interface: window.localStorage must inherit property "clear" with the proper type (5)]
-    expected: FAIL
-
   [StorageEvent interface: existence and properties of interface object]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/missing_arguments.html.ini
+++ b/tests/wpt/metadata/webstorage/missing_arguments.html.ini
@@ -1,19 +1,5 @@
 [missing_arguments.html]
   type: testharness
-  [Should throw TypeError for function "function () { localStorage.key(); }".]
-    expected: FAIL
-
-  [Should throw TypeError for function "function () { localStorage.getItem(); }".]
-    expected: FAIL
-
-  [Should throw TypeError for function "function () { localStorage.setItem(); }".]
-    expected: FAIL
-
-  [Should throw TypeError for function "function () { localStorage.setItem("a"); }".]
-    expected: FAIL
-
-  [Should throw TypeError for function "function () { localStorage.removeItem(); }".]
-    expected: FAIL
 
   [Should throw TypeError for function "function () { new StorageEvent(); }".]
     expected: FAIL

--- a/tests/wpt/metadata/webstorage/storage_local_builtins.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_builtins.html.ini
@@ -1,3 +1,4 @@
 [storage_local_builtins.html]
   type: testharness
-  expected: TIMEOUT
+  [Web Storage]
+    expected: FAIL

--- a/tests/wpt/metadata/webstorage/storage_local_clear.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_clear.html.ini
@@ -1,5 +1,0 @@
-[storage_local_clear.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_clear_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_clear_js.html.ini
@@ -1,5 +1,0 @@
-[storage_local_clear_js.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_getitem.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_getitem.html.ini
@@ -1,5 +1,0 @@
-[storage_local_getitem.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_getitem_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_getitem_js.html.ini
@@ -1,5 +1,0 @@
-[storage_local_getitem_js.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_in_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_in_js.html.ini
@@ -1,8 +1,5 @@
 [storage_local_in_js.html]
   type: testharness
-  [Web Storage]
-    expected: FAIL
-
   [Web Storage 1]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/storage_local_index_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_index_js.html.ini
@@ -1,5 +1,4 @@
 [storage_local_index_js.html]
   type: testharness
-  [Web Storage]
+  [Web Storage 3]
     expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_key.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_key.html.ini
@@ -1,5 +1,5 @@
 [storage_local_key.html]
   type: testharness
-  [Web Storage]
+  [Web Storage 3]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/storage_local_length.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_length.html.ini
@@ -1,5 +1,0 @@
-[storage_local_length.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_length_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_length_js.html.ini
@@ -1,5 +1,0 @@
-[storage_local_length_js.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_removeitem.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_removeitem.html.ini
@@ -1,5 +1,0 @@
-[storage_local_removeitem.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_removeitem_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_removeitem_js.html.ini
@@ -1,5 +1,0 @@
-[storage_local_removeitem_js.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_setitem.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_setitem.html.ini
@@ -1,5 +1,0 @@
-[storage_local_setitem.html]
-  type: testharness
-  [Web Storage]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/storage_local_setitem_js.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_setitem_js.html.ini
@@ -1,5 +1,14 @@
 [storage_local_setitem_js.html]
   type: testharness
-  [Web Storage]
+  [Web Storage 4]
     expected: FAIL
-
+  [Web Storage 6]
+    expected: FAIL
+  [Web Storage 7]
+    expected: FAIL
+  [Web Storage 8]
+    expected: FAIL
+  [Web Storage 9]
+    expected: FAIL
+  [Web Storage 10]
+    expected: FAIL


### PR DESCRIPTION
@jdm This initial version has a few outstanding issues that I wanted to invite input on. Specifically:
1. I had some difficulty finding a home for the `StorageType` enum. Structs defined outside of the `script` module don't seem to be able to use the `#[jstraceable]` annotation and the `net` module (where `StorageTask` lives) doesn't have access to `script`. Per Simon Sapin's suggestion, I worked around this temporarily by creating a `TraceableStorageType` stand-in struct that was traceable and which could be translated into a regular `StorageType` when being sent to the `StorageTask`. Unsure of the best way to resolve this hack. Thoughts?
2. Apart from the `Storage` constructor used in `Window::SessionStorage` and the new `Window::LocalStorage`, there's also a method called `Storage::Constructor`. I'm unclear on what (if anything) will actually invoke this, so I'm not sure which variant of `StorageType` to use here. I've temporarily created an `Unknown` variant of `StorageType` as a placeholder.
3. I discovered that the web platform tests directory's localStorage tests. Many of them now pass despite the configured expectation that they fail. However, several do not pass. Is there a good way for me to add debug logging or otherwise get a sense of which assertion failed / what went wrong?

Thanks for your continued help!
