### PR TITLE
make MouseEvent::new() and UIEvent::new() take enums for the bubbles and...

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::InheritTypes::{EventCast, EventTargetCast};
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
 use dom::element::{Element, ActivationElementHelpers};
-use dom::event::{Event, EventHelpers};
+use dom::event::{Event, EventHelpers, EventBubbles, EventCancelable};
 use dom::eventtarget::EventTarget;
 use dom::mouseevent::MouseEvent;
 use dom::node::window_from_node;
@@ -49,7 +49,7 @@ pub trait Activatable : Copy {
         let win = window_from_node(element.r()).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(element.r());
         let mouse = MouseEvent::new(win.r(), "click".to_owned(),
-                                    false, false, Some(win.r()), 1,
+                                    EventBubbles::DoesNotBubble, EventCancelable::NotCancelable, Some(win.r()), 1,
                                     0, 0, 0, 0, ctrlKey, shiftKey, altKey, metaKey,
                                     0, None).root();
         let event: JSRef<Event> = EventCast::from_ref(mouse.r());

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -516,8 +516,8 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         let y = point.y as i32;
         let event = MouseEvent::new(window.r(),
                                     "click".to_owned(),
-                                    true,
-                                    true,
+                                    EventBubbles::Bubbles,
+                                    EventCancelable::Cancelable,
                                     Some(window.r()),
                                     0i32,
                                     x, y, x, y,
@@ -579,8 +579,8 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
             let window = self.window.root();
             let mouse_event = MouseEvent::new(window.r(),
                                               "mousemove".to_owned(),
-                                              true,
-                                              true,
+                                              EventBubbles::Bubbles,
+                                              EventCancelable::Cancelable,
                                               Some(window.r()),
                                               0i32,
                                               x, y, x, y,

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -10,7 +10,7 @@ use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary};
 use dom::bindings::utils::reflect_dom_object;
-use dom::event::{Event, EventTypeId};
+use dom::event::{Event, EventTypeId, EventBubbles, EventCancelable};
 use dom::eventtarget::EventTarget;
 use dom::uievent::UIEvent;
 use dom::window::Window;
@@ -64,8 +64,8 @@ impl MouseEvent {
 
     pub fn new(window: JSRef<Window>,
                type_: DOMString,
-               canBubble: bool,
-               cancelable: bool,
+               canBubble: EventBubbles,
+               cancelable: EventCancelable,
                view: Option<JSRef<Window>>,
                detail: i32,
                screenX: i32,
@@ -79,7 +79,7 @@ impl MouseEvent {
                button: i16,
                relatedTarget: Option<JSRef<EventTarget>>) -> Temporary<MouseEvent> {
         let ev = MouseEvent::new_uninitialized(window).root();
-        ev.r().InitMouseEvent(type_, canBubble, cancelable, view, detail,
+        ev.r().InitMouseEvent(type_, canBubble == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable, view, detail,
                               screenX, screenY, clientX, clientY,
                               ctrlKey, altKey, shiftKey, metaKey,
                               button, relatedTarget);
@@ -89,9 +89,11 @@ impl MouseEvent {
     pub fn Constructor(global: GlobalRef,
                        type_: DOMString,
                        init: &MouseEventBinding::MouseEventInit) -> Fallible<Temporary<MouseEvent>> {
+        let bubbles = if init.parent.parent.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
+        let cancelable = if init.parent.parent.parent.cancelable { EventCancelable::Cancelable } else { EventCancelable::NotCancelable };
         let event = MouseEvent::new(global.as_window(), type_,
-                                    init.parent.parent.parent.bubbles,
-                                    init.parent.parent.parent.cancelable,
+                                    bubbles,
+                                    cancelable,
                                     init.parent.parent.view.r(),
                                     init.parent.parent.detail,
                                     init.screenX, init.screenY,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -11,7 +11,7 @@ use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary};
 
 use dom::bindings::utils::reflect_dom_object;
-use dom::event::{Event, EventTypeId};
+use dom::event::{Event, EventTypeId, EventBubbles, EventCancelable};
 use dom::window::Window;
 use util::str::DOMString;
 
@@ -48,20 +48,22 @@ impl UIEvent {
 
     pub fn new(window: JSRef<Window>,
                type_: DOMString,
-               can_bubble: bool,
-               cancelable: bool,
+               can_bubble: EventBubbles,
+               cancelable: EventCancelable,
                view: Option<JSRef<Window>>,
                detail: i32) -> Temporary<UIEvent> {
         let ev = UIEvent::new_uninitialized(window).root();
-        ev.r().InitUIEvent(type_, can_bubble, cancelable, view, detail);
+        ev.r().InitUIEvent(type_, can_bubble == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable, view, detail);
         Temporary::from_rooted(ev.r())
     }
 
     pub fn Constructor(global: GlobalRef,
                        type_: DOMString,
                        init: &UIEventBinding::UIEventInit) -> Fallible<Temporary<UIEvent>> {
+        let bubbles = if init.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
+        let cancelable = if init.parent.cancelable { EventCancelable::Cancelable } else { EventCancelable::NotCancelable };
         let event = UIEvent::new(global.as_window(), type_,
-                                 init.parent.bubbles, init.parent.cancelable,
+                                 bubbles, cancelable,
                                  init.view.r(), init.detail);
         Ok(event)
     }

--- a/components/script/dom/webidls/Event.webidl
+++ b/components/script/dom/webidls/Event.webidl
@@ -40,4 +40,3 @@ dictionary EventInit {
   boolean bubbles = false;
   boolean cancelable = false;
 };
-

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -32,7 +32,7 @@ use dom::bindings::trace::JSTraceable;
 use dom::bindings::utils::{wrap_for_same_compartment, pre_wrap};
 use dom::document::{Document, IsHTMLDocument, DocumentHelpers, DocumentProgressHandler, DocumentProgressTask, DocumentSource};
 use dom::element::{Element, AttributeHandlers};
-use dom::event::{Event, EventHelpers};
+use dom::event::{Event, EventHelpers, EventBubbles, EventCancelable};
 use dom::uievent::UIEvent;
 use dom::eventtarget::EventTarget;
 use dom::node::{self, Node, NodeHelpers, NodeDamage, window_from_node};
@@ -1176,8 +1176,8 @@ impl ScriptTask {
         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#event-type-resize
         let uievent = UIEvent::new(window.r(),
-                                   "resize".to_owned(), false,
-                                   false, Some(window.r()),
+                                   "resize".to_owned(), EventBubbles::DoesNotBubble,
+                                   EventCancelable::NotCancelable, Some(window.r()),
                                    0i32).root();
         let event: JSRef<Event> = EventCast::from_ref(uievent.r());
 


### PR DESCRIPTION
... cancelable arguments

for #4807 
