### PR TITLE
view-source protocol and text/plain handling

### DIFF
--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -333,7 +333,7 @@ impl ResourceManager {
 
         let loader = match load_data.url.scheme.as_slice() {
             "file" => from_factory(file_loader::factory),
-            "http" | "https" => http_loader::factory(self.resource_task.clone()),
+            "http" | "https" | "view-source" => http_loader::factory(self.resource_task.clone()),
             "data" => from_factory(data_loader::factory),
             "about" => from_factory(about_loader::factory),
             _ => {

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -82,6 +82,7 @@ use js;
 use url::Url;
 
 use libc;
+use std::ascii::AsciiExt;
 use std::any::Any;
 use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell};
@@ -984,10 +985,18 @@ impl ScriptTask {
             headers.get().map(|&LastModified(ref tm)| dom_last_modified(tm))
         });
 
+        let content_type = match response.metadata.content_type {
+            Some((ref t, ref st)) if t.as_slice().eq_ignore_ascii_case("text") &&
+                                    st.as_slice().eq_ignore_ascii_case("plain") => {
+                Some("text/plain".to_owned())
+            }
+            _ => None
+        };
+
         let document = Document::new(window.r(),
                                      Some(final_url.clone()),
                                      IsHTMLDocument::HTMLDocument,
-                                     None,
+                                     content_type,
                                      last_modified,
                                      DocumentSource::FromParser).root();
 

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/read-text/load-text-plain.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/read-text/load-text-plain.html.ini
@@ -1,11 +1,5 @@
 [load-text-plain.html]
   type: testharness
-  [Checking document metadata for text file]
-    expected: FAIL
-
-  [Checking DOM for text file]
-    expected: FAIL
-
   [Checking contents for text file]
     expected: FAIL
 


### PR DESCRIPTION
Implements view-source protocol by having a view-source handler, and modifying the content type to be text/plain if that is used. 

Implements text/plain handling. This allows view-source content to display as plain text.

Example usage:

```
./mach run http://cd.pn/x.txt
./mach run view-source:http://tinyvid.tv/
```

This fixes issue #4181. Issue #3649 includes "support text/plain" so this possibly fixes some of that issue as well.
