### PR TITLE
Ensure wpt is bootstrapped before running

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -204,6 +204,7 @@ class MachCommands(CommandBase):
              description='Run the web platform tests',
              category='testing')
     def test_wpt_failure(self):
+        self.ensure_bootstrapped()
         return not subprocess.call([
             "bash",
             path.join("tests", "wpt", "run.sh"),
@@ -221,6 +222,8 @@ class MachCommands(CommandBase):
         "params", default=None, nargs='...',
         help="command-line arguments to be passed through to wpt/run.sh")
     def test_wpt(self, processes=None, params=None):
+        self.ensure_bootstrapped()
+
         if params is None:
             params = []
         else:


### PR DESCRIPTION
`./mach test-wpt` will fail in non-obvious ways unless all wpt submodules have recursively been checked out first.  This ensure they have been when running the command in a checkout of Servo that hasn't been bootstrapped yet.
