### PR TITLE
Retain buffer for CGDataProviderCreateWithData. Fixes #5084.

### DIFF
--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -16,6 +16,7 @@ use std::borrow::ToOwned;
 pub struct FontTemplateData {
     pub ctfont: Option<CTFont>,
     pub identifier: String,
+    pub font_data: Option<Vec<u8>>
 }
 
 unsafe impl Send for FontTemplateData {}
@@ -24,7 +25,7 @@ unsafe impl Sync for FontTemplateData {}
 impl FontTemplateData {
     pub fn new(identifier: &str, font_data: Option<Vec<u8>>) -> FontTemplateData {
         let ctfont = match font_data {
-            Some(bytes) => {
+            Some(ref bytes) => {
                 let fontprov = CGDataProvider::from_buffer(bytes.as_slice());
                 let cgfont_result = CGFont::from_data_provider(fontprov);
                 match cgfont_result {
@@ -40,6 +41,7 @@ impl FontTemplateData {
         FontTemplateData {
             ctfont: ctfont,
             identifier: identifier.to_owned(),
+            font_data: font_data
         }
     }
 }


### PR DESCRIPTION
CGDataProviderCreateWithData just wraps the underlying buffer. The
underlying buffer needs to be kept around until the data provider is
freed. Adding the buffer to the FontTemplateData struct ensures it
sticks around.
