### PR TITLE
Fixes for positioning of RTL blocks.

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -300,6 +300,7 @@ impl Flow for TableFlow {
                                                       containing_block_inline_size);
 
         let inline_start_content_edge = self.block_flow.fragment.border_padding.inline_start;
+        let inline_end_content_edge = self.block_flow.fragment.border_padding.inline_end;
         let padding_and_borders = self.block_flow.fragment.border_padding.inline_start_end();
         let spacing_per_cell = self.spacing();
         let spacing = spacing_per_cell.horizontal *
@@ -352,6 +353,7 @@ impl Flow for TableFlow {
         };
         self.block_flow.propagate_assigned_inline_size_to_children(layout_context,
                                                                    inline_start_content_edge,
+                                                                   inline_end_content_edge,
                                                                    content_inline_size,
                                                                    Some(info));
     }

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -128,12 +128,17 @@ impl Flow for TableCellFlow {
         let inline_start_content_edge =
             self.block_flow.fragment.border_box.start.i +
             self.block_flow.fragment.border_padding.inline_start;
+        let inline_end_content_edge =
+            self.block_flow.base.block_container_inline_size -
+            self.block_flow.fragment.border_padding.inline_start_end() -
+            self.block_flow.fragment.border_box.size.inline;
         let padding_and_borders = self.block_flow.fragment.border_padding.inline_start_end();
         let content_inline_size =
             self.block_flow.fragment.border_box.size.inline - padding_and_borders;
 
         self.block_flow.propagate_assigned_inline_size_to_children(layout_context,
                                                                    inline_start_content_edge,
+                                                                   inline_end_content_edge,
                                                                    content_inline_size,
                                                                    None);
     }

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -238,6 +238,7 @@ impl Flow for TableRowFlow {
         // FIXME: In case of border-collapse: collapse, inline_start_content_edge should be
         // border_inline_start.
         let inline_start_content_edge = Au(0);
+        let inline_end_content_edge = Au(0);
 
         let inline_size_computer = InternalTable;
         inline_size_computer.compute_used_inline_size(&mut self.block_flow,
@@ -285,6 +286,7 @@ impl Flow for TableRowFlow {
         };
         self.block_flow.propagate_assigned_inline_size_to_children(layout_context,
                                                                    inline_start_content_edge,
+                                                                   inline_end_content_edge,
                                                                    containing_block_inline_size,
                                                                    Some(info));
     }

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -102,6 +102,7 @@ impl Flow for TableRowGroupFlow {
         // FIXME: In case of border-collapse: collapse, inline-start_content_edge should be
         // the border width on the inline-start side.
         let inline_start_content_edge = Au::new(0);
+        let inline_end_content_edge = Au::new(0);
         let content_inline_size = containing_block_inline_size;
 
         let inline_size_computer = InternalTable;
@@ -115,6 +116,7 @@ impl Flow for TableRowGroupFlow {
         };
         self.block_flow.propagate_assigned_inline_size_to_children(layout_context,
                                                                    inline_start_content_edge,
+                                                                   inline_end_content_edge,
                                                                    content_inline_size,
                                                                    Some(info));
     }

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -293,6 +293,12 @@ impl Flow for TableWrapperFlow {
         let inline_start_content_edge = self.block_flow.fragment.border_box.start.i;
         let content_inline_size = self.block_flow.fragment.border_box.size.inline;
 
+        // FIXME (mbrubeck): Test mixed RTL/LTR table layout, make sure this is right.
+        let inline_end_content_edge = self.block_flow.base.block_container_inline_size -
+                                      self.block_flow.fragment.margin.inline_end -
+                                      content_inline_size -
+                                      inline_start_content_edge;
+
         // In case of fixed layout, column inline-sizes are calculated in table flow.
         let assigned_column_inline_sizes = match self.table_layout {
             TableLayout::Fixed => None,
@@ -310,6 +316,7 @@ impl Flow for TableWrapperFlow {
                 self.block_flow.propagate_assigned_inline_size_to_children(
                     layout_context,
                     inline_start_content_edge,
+                    inline_end_content_edge,
                     content_inline_size,
                     None)
             }
@@ -321,6 +328,7 @@ impl Flow for TableWrapperFlow {
                 self.block_flow
                     .propagate_assigned_inline_size_to_children(layout_context,
                                                                 inline_start_content_edge,
+                                                                inline_end_content_edge,
                                                                 content_inline_size,
                                                                 Some(info));
             }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -236,6 +236,7 @@ experimental != overconstrained_block.html overconstrained_block_ref.html
 == root_height_a.html root_height_b.html
 == root_margin_collapse_a.html root_margin_collapse_b.html
 == root_pseudo_a.html root_pseudo_b.html
+experimental == rtl_body.html rtl_body_ref.html
 experimental == rtl_simple.html rtl_simple_ref.html
 == setattribute_id_restyle_a.html setattribute_id_restyle_b.html
 == stacking_context_overflow_a.html stacking_context_overflow_ref.html

--- a/tests/ref/rtl_body.html
+++ b/tests/ref/rtl_body.html
@@ -1,0 +1,17 @@
+<head>
+  <style>
+    body {
+      direction: rtl;
+      margin: 0;
+    }
+    #outer {
+      background: green;
+
+      width: 300px;
+      height: 100px;
+    }
+  </style>
+</head>
+<body>
+<div id="outer"></div>
+</body>

--- a/tests/ref/rtl_body_ref.html
+++ b/tests/ref/rtl_body_ref.html
@@ -1,0 +1,20 @@
+<head>
+  <style>
+    body {
+      margin: 0;
+    }
+    #outer {
+      background: green;
+
+      width: 300px;
+      height: 100px;
+
+      position:absolute;
+      top: 0;
+      right: 0;
+    }
+  </style>
+</head>
+<body>
+<div id="outer"></div>
+</body>


### PR DESCRIPTION
This fixes a bug in finding the top left corner of an RTL block in physical coordinates.  (The old code used the `start` point of the `position` rect, which is not always the top left.)

It also fixes the setting of `position.start.i` in certain mixed LTR/RTL cases.

There is still a bug related to `position.size` for RTL blocks with margins.  See the FIXME comments for details.

r? @pcwalton or @SimonSapin
