### PR TITLE
Enable PIE so b2s will run on Lollipop

### DIFF
--- a/ports/gonk/fake-ld.sh
+++ b/ports/gonk/fake-ld.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-arm-linux-androideabi-g++ $@ $LDFLAGS -lGLESv2 -lsupc++  -L$GONKDIR/prebuilts/ndk/9/sources/cxx-stl/gnu-libstdc++/4.6/libs/armeabi/
+arm-linux-androideabi-g++ $@ $LDFLAGS -pie -lGLESv2 -lsupc++  -L$GONKDIR/prebuilts/ndk/9/sources/cxx-stl/gnu-libstdc++/4.6/libs/armeabi/


### PR DESCRIPTION
PIE is required on lollipop. PIE has been supported since jellybean.
