### PR TITLE
Remove debugging info in release mode and stop reflowing on every new image that comes in

### DIFF
--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1212,7 +1212,11 @@ impl ScriptTask {
     fn handle_reflow_event(&self, pipeline_id: PipelineId) {
         debug!("script got reflow event");
         let page = get_page(&self.root_page(), pipeline_id);
-        self.force_reflow(&*page, ReflowReason::ReceivedReflowEvent);
+        let document = page.document().root();
+        let window = window_from_node(document.r()).root();
+        window.r().reflow(ReflowGoal::ForDisplay,
+                          ReflowQueryType::NoQuery,
+                          ReflowReason::ReceivedReflowEvent);
     }
 
     /// Initiate a non-blocking fetch for a specified resource. Stores the InProgressLoad

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -34,11 +34,13 @@ default = ["glutin_app", "window"]
 window = ["glutin_app/window"]
 headless = ["glutin_app/headless"]
 
-[profile.release]
-opt-level = 3
-debug = true
-rpath = false
-lto = false
+# Uncomment to profile on Linux:
+#
+# [profile.release]
+# opt-level = 3
+# debug = true
+# rpath = false
+# lto = false
 
 [dependencies.compositing]
 path = "../compositing"

--- a/components/util/task_state.rs
+++ b/components/util/task_state.rs
@@ -26,8 +26,13 @@ bitflags! {
 macro_rules! task_types ( ( $( $fun:ident = $flag:ident ; )* ) => (
     impl TaskState {
         $(
+            #[cfg(not(ndebug))]
             pub fn $fun(self) -> bool {
                 self.contains($flag)
+            }
+            #[cfg(ndebug)]
+            pub fn $fun(self) -> bool {
+                true
             }
         )*
     }


### PR DESCRIPTION
These help Facebook Timeline a lot.

r? @metajack 
