### PR TITLE
Use `append` instead of `extend` where possible

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -743,8 +743,8 @@ impl InlineFragments {
     }
 
     /// Merges another set of inline fragments with this one.
-    pub fn push_all(&mut self, fragments: InlineFragments) {
-        self.fragments.extend(fragments.fragments.into_iter());
+    pub fn push_all(&mut self, mut other: InlineFragments) {
+        self.fragments.append(&mut other.fragments);
     }
 
     /// A convenience function to return the fragment at a given index.

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -73,9 +73,9 @@ fn main() {
         match maybe_extension {
             Some(extension) => {
                 if extension.to_ascii_lowercase().as_slice() == "list" && file.is_file() {
-                    let tests = parse_lists(&file, servo_args, render_mode, all_tests.len());
+                    let mut tests = parse_lists(&file, servo_args, render_mode, all_tests.len());
                     println!("\t{} [{} tests]", file.display(), tests.len());
-                    all_tests.extend(tests.into_iter());
+                    all_tests.append(&mut tests);
                 }
             }
             _ => {}


### PR DESCRIPTION
The new `Vec::append` method is clearer and potentially faster.
