### PR TITLE
rm unnecessary old_impl_check

### DIFF
--- a/components/util/cache.rs
+++ b/components/util/cache.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![old_impl_check]
-
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_state::DefaultState;


### PR DESCRIPTION
Brings us to zero old impls. \o/

Feel free to add this to a larger warning fix PR
