### PR TITLE
Fix warnings in gonk port

### DIFF
--- a/ports/gonk/src/input.rs
+++ b/ports/gonk/src/input.rs
@@ -2,16 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::old_path::Path;
+use std::path::Path;
 use std::mem::size_of;
 use std::mem::transmute;
 use std::mem::zeroed;
 use std::os::errno;
 use std::os::unix::AsRawFd;
 use std::num::Float;
-use std::old_io::File;
+use std::fs::File;
 use std::thread::Thread;
 use std::sync::mpsc::Sender;
+use std::io::Read;
 
 use geom::point::TypedPoint2D;
 

--- a/ports/gonk/src/lib.rs
+++ b/ports/gonk/src/lib.rs
@@ -6,7 +6,6 @@
 #![feature(box_syntax)]
 #![feature(int_uint)]
 #![feature(core, path, rustc_private)]
-#![feature(std_misc, env)]
 // For FFI
 #![allow(non_snake_case, dead_code)]
 

--- a/ports/gonk/src/main.rs
+++ b/ports/gonk/src/main.rs
@@ -6,7 +6,7 @@
 #![deny(unused_variables)]
 
 #![feature(int_uint)]
-#![feature(core, os, path, io, std_misc, env)]
+#![feature(core, os, path, io, std_misc)]
 // For FFI
 #![allow(non_snake_case, dead_code)]
 

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -632,18 +632,16 @@ impl Window {
     pub fn new() -> Rc<Window> {
         let mut hwc_mod = ptr::null();
         unsafe {
-            let cstr = CString::from_slice("hwcomposer".as_bytes());
-            let ptr = cstr.as_ptr();
-            let ret = hw_get_module(ptr, &mut hwc_mod);
+            let cstr = CString::new("hwcomposer").unwrap();
+            let ret = hw_get_module(cstr.as_ptr(), &mut hwc_mod);
             assert!(ret == 0, "Failed to get HWC module!");
         }
 
         let mut hwc_device: *mut hwc_composer_device;
         unsafe {
             let mut device = ptr::null();
-            let cstr = CString::from_slice("composer".as_bytes());
-            let ptr = cstr.as_ptr();
-            let ret = ((*(*hwc_mod).methods).open)(hwc_mod, ptr, &mut device);
+            let cstr = CString::new("composer").unwrap();
+            let ret = ((*(*hwc_mod).methods).open)(hwc_mod, cstr.as_ptr(), &mut device);
             assert!(ret == 0, "Failed to get HWC device!");
             hwc_device = transmute(device);
             // Require HWC 1.1 or newer
@@ -667,13 +665,11 @@ impl Window {
         let mut alloc_dev: *mut alloc_device;
         unsafe {
             let mut device = ptr::null();
-            let cstr = CString::from_slice("gralloc".as_bytes());
-            let ptr = cstr.as_ptr();
-            let ret1 = hw_get_module(ptr, &mut gralloc_mod);
+            let cstr = CString::new("gralloc").unwrap();
+            let ret1 = hw_get_module(cstr.as_ptr(), &mut gralloc_mod);
             assert!(ret1 == 0, "Failed to get gralloc moudle!");
-            let cstr2 = CString::from_slice("gpu0".as_bytes());
-            let ptr2 = cstr2.as_ptr();
-            let ret2 = ((*(*gralloc_mod).methods).open)(gralloc_mod, ptr2, &mut device);
+            let cstr2 = CString::new("gpu0").unwrap();
+            let ret2 = ((*(*gralloc_mod).methods).open)(gralloc_mod, cstr2.as_ptr(), &mut device);
             assert!(ret2 == 0, "Failed to get gralloc moudle!");
             alloc_dev = transmute(device);
         }


### PR DESCRIPTION
This fixes a bunch of warnings in the gonk code. Not all of them, but we're only left with three now.
