### PR TITLE
Fix overflowed arithmetic.

### DIFF
--- a/components/util/deque/mod.rs
+++ b/components/util/deque/mod.rs
@@ -391,7 +391,7 @@ impl<T: Send> Buffer<T> {
         // NB: not entirely obvious, but thanks to 2's complement,
         // casting delta to usize and then adding gives the desired
         // effect.
-        let buf = Buffer::new(self.log_size + delta as usize);
+        let buf = Buffer::new(self.log_size.wrapping_add(delta as usize));
         for i in range(t, b) {
             buf.put(i, self.get(i));
         }


### PR DESCRIPTION
This uses wrapping_add, which was always the intended operation.

Fixes #5275.
