### PR TITLE
gfx: Perform more aggressive caching in `FontContext::get_layout_font_group_for_style()`.

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -66,6 +66,9 @@ branch = "upstream-2014-06-16"
 [dependencies.script_traits]
 path = "../script_traits"
 
+[dependencies.string_cache]
+git = "https://github.com/servo/string-cache"
+
 [dependencies]
 url = "0.2.16"
 time = "0.1.12"

--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -9,16 +9,17 @@ use platform::font_list::get_last_resort_font_families;
 use platform::font_context::FontContextHandle;
 
 use collections::str::Str;
+use font_template::{FontTemplate, FontTemplateDescriptor};
+use net::resource_task::{ResourceTask, load_whole_resource};
+use platform::font_template::FontTemplateData;
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::mpsc::{Sender, Receiver, channel};
-use font_template::{FontTemplate, FontTemplateDescriptor};
-use platform::font_template::FontTemplateData;
-use net::resource_task::{ResourceTask, load_whole_resource};
-use util::task::spawn_named;
-use util::str::LowercaseString;
+use string_cache::Atom;
 use style::font_face::Source;
+use util::str::LowercaseString;
+use util::task::spawn_named;
 
 /// A list of font templates that make up a given font family.
 struct FontFamily {
@@ -77,7 +78,7 @@ impl FontFamily {
 pub enum Command {
     GetFontTemplate(String, FontTemplateDescriptor, Sender<Reply>),
     GetLastResortFontTemplate(FontTemplateDescriptor, Sender<Reply>),
-    AddWebFont(String, Source, Sender<()>),
+    AddWebFont(Atom, Source, Sender<()>),
     Exit(Sender<()>),
 }
 
@@ -315,7 +316,7 @@ impl FontCacheTask {
         }
     }
 
-    pub fn add_web_font(&self, family: String, src: Source) {
+    pub fn add_web_font(&self, family: Atom, src: Source) {
         let (response_chan, response_port) = channel();
         self.chan.send(Command::AddWebFont(family, src, response_chan)).unwrap();
         response_port.recv().unwrap();

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -11,11 +11,11 @@ use std::borrow::ToOwned;
 use std::sync::{Arc, Weak};
 use style::computed_values::{font_stretch, font_weight};
 
-/// Describes how to select a font from a given family.
-/// This is very basic at the moment and needs to be
-/// expanded or refactored when we support more of the
-/// font styling parameters.
-#[derive(Clone, Copy)]
+/// Describes how to select a font from a given family. This is very basic at the moment and needs
+/// to be expanded or refactored when we support more of the font styling parameters.
+///
+/// NB: If you change this, you will need to update `style::properties::compute_font_hash()`.
+#[derive(Clone, Copy, Eq, Hash)]
 pub struct FontTemplateDescriptor {
     pub weight: font_weight::T,
     pub stretch: font_stretch::T,

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -35,6 +35,7 @@ extern crate net;
 #[macro_use]
 extern crate util;
 extern crate msg;
+extern crate string_cache;
 extern crate style;
 extern crate skia;
 extern crate time;

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -597,7 +597,7 @@ impl LayoutTask {
 
         if mq.evaluate(&rw_data.stylist.device) {
             iter_font_face_rules(&sheet, &rw_data.stylist.device, &|family, src| {
-                self.font_cache_task.add_web_font(family.to_owned(), (*src).clone());
+                self.font_cache_task.add_web_font((*family).clone(), (*src).clone());
             });
             rw_data.stylist.add_stylesheet(sheet);
         }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "script_traits 0.0.1",
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
+ "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "style 0.0.1",
  "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -10,7 +10,6 @@ use log;
 
 use stylesheets::Origin;
 
-
 pub struct ParserContext<'a> {
     pub base_url: &'a Url,
     pub selector_context: SelectorParserContext,

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -318,8 +318,8 @@ pub fn iter_stylesheet_style_rules<F>(stylesheet: &Stylesheet, device: &media_qu
 
 
 #[inline]
-pub fn iter_font_face_rules<F>(stylesheet: &Stylesheet, device: &Device,
-                               callback: &F) where F: Fn(&str, &Source) {
+pub fn iter_font_face_rules<F>(stylesheet: &Stylesheet, device: &Device, callback: &F)
+                               where F: Fn(&Atom, &Source) {
     iter_font_face_rules_inner(&stylesheet.rules, device, callback)
 }
 

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -13,7 +13,7 @@ macro_rules! define_css_keyword_enum {
     };
     ($name: ident: $( $css: expr => $variant: ident ),+) => {
         #[allow(non_camel_case_types)]
-        #[derive(Clone, Eq, PartialEq, FromPrimitive, Copy)]
+        #[derive(Clone, Eq, PartialEq, FromPrimitive, Copy, Hash)]
         pub enum $name {
             $( $variant ),+
         }

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "script_traits 0.0.1",
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
+ "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "style 0.0.1",
  "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "script_traits 0.0.1",
  "skia 0.0.20130412 (git+https://github.com/servo/skia?branch=upstream-2014-06-16)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
+ "string_cache 0.0.0 (git+https://github.com/servo/string-cache)",
  "style 0.0.1",
  "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
There are several optimizations here:
- We make font families atoms, to allow for quicker comparisons.
- We precalculate an FNV hash of the relevant fields of the font style
  structure.
- When obtaining a platform font group, we first check pointer equality
  for the font style. If there's no match, we go to the FNV hash. Only
  if both caches miss do we construct and cache a font group. Note that
  individual fonts are _also_ cached; thus there are two layers of
  caching here.

15% improvement in total layout thread time for Facebook Timeline.

r? @glennw (since you last worked on `get_layout_font_group_for_style()` IIRC)
