### PR TITLE
Free the interface prototype array when Window is finalized

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4061,7 +4061,12 @@ let this: *const %s = native_from_reflector::<%s>(obj);
         assert(False)
 
 def finalizeHook(descriptor, hookName, context):
-    release = """\
+    release = ""
+    if descriptor.isGlobal():
+        release += """\
+finalize_global(obj);
+"""
+    release += """\
 let _ = Box::from_raw(this as *mut %s);
 debug!("%s finalize: {:p}", this);\
 """ % (descriptor.concreteType, descriptor.concreteType)
@@ -4650,6 +4655,7 @@ class CGBindingRoot(CGThing):
             'dom::bindings::utils::{DOMJSClass, JSCLASS_DOM_GLOBAL}',
             'dom::bindings::utils::{find_enum_string_index, get_array_index_from_id}',
             'dom::bindings::utils::{get_property_on_prototype, get_proto_or_iface_array}',
+            'dom::bindings::utils::finalize_global',
             'dom::bindings::utils::has_property_on_prototype',
             'dom::bindings::utils::is_platform_object',
             'dom::bindings::utils::{Reflectable}',


### PR DESCRIPTION
Fixes #1871

I thought I'd take a look at this for a first contribution to servo. A couple of things I'm not 100% sure on are:

1) `get_proto_or_iface_array` returns a `*mut *mut JSObj`, which I'm assuming is really an array of pointers to `JSObj`s. So dropping its return value will drop the memory for the array of pointers. Do we also need to drop each element, or is that handled by GC?

2) Are there any tests I need to add for this? I don't know if there are existing leak tests, or if leaks are mostly discovered by profiling.
