### PR TITLE
Print trees in the memory profiler's output.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -482,7 +482,7 @@ impl LayoutTask {
         let rw_data = self.lock_rw_data(possibly_locked_rw_data);
         let stacking_context = rw_data.stacking_context.as_ref();
         reports.push(MemoryReport {
-            name: format!("display-list::{}", self.url),
+            path: path!["pages", format!("url({})", self.url), "display-list"],
             size: stacking_context.map_or(0, |sc| sc.size_of_excluding_self() as u64),
         });
 


### PR DESCRIPTION
Memory reports are much nicer to read when grouped into trees, which requires giving each report a path instead of a name.

Sample output:

```
Begin memory reports
|
|    2.51 MiB -- pages
|       2.51 MiB -- url(file:///home/njn/moz/servo/../servo-static-suite/wikipedia/Guardians%20of%20the%20Galaxy%20(film)%20-%20Wikipedia,%20the%20free%20encyclopedia.html)
|          2.51 MiB -- display-list
|
|  238.89 MiB -- resident-according-to-smaps
|     188.31 MiB -- anonymous (rw-p)
|      27.29 MiB -- /home/njn/moz/servo/components/servo/target/debug/servo (r-xp)
|       7.82 MiB -- other
|       6.65 MiB -- [heap] (rw-p)
|       3.55 MiB -- /usr/lib/x86_64-linux-gnu/dri/i965_dri.so (r-xp)
|       1.42 MiB -- /lib/x86_64-linux-gnu/libc-2.19.so (r-xp)
|       1.13 MiB -- /home/njn/moz/servo/components/servo/target/debug/servo (r--p)
|       0.74 MiB -- /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0 (r-xp)
|       0.73 MiB -- /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.20 (r-xp)
|       0.65 MiB -- /lib/x86_64-linux-gnu/libm-2.19.so (r-xp)
|       0.60 MiB -- /lib/x86_64-linux-gnu/libglib-2.0.so.0.4200.1 (r-xp)
|
|   71.08 MiB -- jemalloc-heap-active
|   59.11 MiB -- jemalloc-heap-allocated
|  180.00 MiB -- jemalloc-heap-mapped
|  232.87 MiB -- resident
|   54.43 MiB -- system-heap-allocated
| 3130.11 MiB -- vsize
|
End memory reports
```
