### PR TITLE
Stop abusing format! macro when construct a String

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1090,7 +1090,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
     fn LastModified(self) -> DOMString {
         match self.last_modified {
             Some(ref t) => t.clone(),
-            None => format!("{}", time::now().strftime("%m/%d/%Y %H:%M:%S").unwrap()),
+            None => time::now().strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string(),
         }
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -616,13 +616,13 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
                 referer_url.serialize_host().map(|ref h| buf.push_str(h.as_slice()));
                 referer_url.port().as_ref().map(|&p| {
                     buf.push_str(":".as_slice());
-                    buf.push_str(format!("{}", p).as_slice());
+                    buf.push_str(p.to_string().as_slice());
                 });
                 referer_url.serialize_path().map(|ref h| buf.push_str(h.as_slice()));
                 self.request_headers.borrow_mut().set_raw("Referer".to_owned(), vec![buf.into_bytes()]);
             },
             Ok(Some(ref req)) => self.insert_trusted_header("origin".to_owned(),
-                                                            format!("{}", req.origin)),
+                                                            req.origin.to_string()),
             _ => {}
         }
 

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1298,5 +1298,5 @@ pub fn get_page(page: &Rc<Page>, pipeline_id: PipelineId) -> Rc<Page> {
 }
 
 fn dom_last_modified(tm: &Tm) -> String {
-    format!("{}", tm.to_local().strftime("%m/%d/%Y %H:%M:%S").unwrap())
+    tm.to_local().strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string()
 }

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -237,7 +237,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
     let opt_match = match getopts::getopts(args, opts.as_slice()) {
         Ok(m) => m,
         Err(f) => {
-            args_fail(format!("{}", f).as_slice());
+            args_fail(f.to_string().as_slice());
             return false;
         }
     };

--- a/tests/contenttest.rs
+++ b/tests/contenttest.rs
@@ -45,7 +45,7 @@ fn parse_config(args: Vec<String>) -> Config {
     let opts = vec!(reqopt("s", "source-dir", "source-dir", "source-dir"));
     let matches = match getopts(args, opts.as_slice()) {
       Ok(m) => m,
-      Err(f) => panic!(format!("{}", f))
+      Err(f) => panic!(f.to_string())
     };
 
     Config {
@@ -73,7 +73,7 @@ fn find_tests(config: Config) -> Vec<TestDescAndFn> {
         _ => panic!("Error reading directory."),
     };
     files.retain(|file| file.extension_str() == Some("html") );
-    return files.iter().map(|file| make_test(format!("{}", file.display()))).collect();
+    return files.iter().map(|file| make_test(file.display().to_string())).collect();
 }
 
 fn make_test(file: String) -> TestDescAndFn {


### PR DESCRIPTION
In these cases for `format!`, we're just constructing a String of the
single argument with no special format.
