### PR TITLE
Remove allow(missing_copy_implementations) attributes.

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -10,8 +10,6 @@
 #![feature(rustc_private)]
 #![feature(std_misc)]
 
-#![allow(missing_copy_implementations)]
-
 #[macro_use]
 extern crate log;
 

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -17,8 +17,6 @@
 #![feature(std_misc)]
 #![feature(unboxed_closures)]
 
-#![allow(missing_copy_implementations)]
-
 #![plugin(regex_macros)]
 
 extern crate "cookie" as cookie_rs;

--- a/components/plugins/lints/unrooted_must_root.rs
+++ b/components/plugins/lints/unrooted_must_root.rs
@@ -23,7 +23,6 @@ declare_lint!(UNROOTED_MUST_ROOT, Deny,
 ///  - Not being bound locally in a `let` statement, assignment, `for` loop, or `match` statement.
 ///
 /// This helps catch most situations where pointers like `JS<T>` are used in a way that they can be invalidated by a GC pass.
-#[allow(missing_copy_implementations)]
 pub struct UnrootedPass;
 
 // Checks if a type has the #[must_root] annotation.

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -10,8 +10,6 @@
 #![feature(collections)]
 #![feature(rustc_private)]
 
-#![allow(missing_copy_implementations)]
-
 #![plugin(string_cache_plugin)]
 #![plugin(mod_path)]
 

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -100,7 +100,6 @@ pub enum MediaType {
     Unknown,
 }
 
-#[allow(missing_copy_implementations)]
 #[derive(Debug)]
 pub struct Device {
     pub media_type: MediaType,

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -3395,7 +3395,6 @@ pub mod shorthands {
             use parser::ParserContext;
             use properties::longhands;
 
-            #[allow(missing_copy_implementations)]
             pub struct Longhands {
                 % for sub_property in shorthand.sub_properties:
                     pub ${sub_property.ident}:
@@ -4203,7 +4202,6 @@ pub mod style_structs {
     use super::longhands;
 
     % for style_struct in STYLE_STRUCTS:
-        #[allow(missing_copy_implementations)]
         #[derive(PartialEq, Clone)]
         pub struct ${style_struct.name} {
             % for longhand in style_struct.longhands:

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -878,7 +878,6 @@ pub mod computed {
     use url::Url;
     use util::geometry::Au;
 
-    #[allow(missing_copy_implementations)]  // It’s kinda big
     pub struct Context {
         pub inherited_font_weight: longhands::font_weight::computed_value::T,
         pub inherited_font_size: longhands::font_size::computed_value::T,

--- a/components/util/fnv.rs
+++ b/components/util/fnv.rs
@@ -15,7 +15,6 @@ use std::num::wrapping::WrappingOps;
 ///
 /// This uses FNV hashing, as described here:
 /// http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-#[allow(missing_copy_implementations)]
 pub struct FnvHasher(u64);
 
 impl Default for FnvHasher {


### PR DESCRIPTION
This is now the default.
