### PR TITLE
Ensures that iframe navigation updates the parent iframe element subpage id.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -608,6 +608,16 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
         // Set paint permissions correctly for the compositor layers.
         self.revoke_paint_permission(prev_pipeline_id);
         self.send_frame_tree_and_grant_paint_permission();
+
+        // Update the owning iframe to point to the new subpage id.
+        // This makes things like contentDocument work correctly.
+        if let Some((parent_pipeline_id, subpage_id)) = pipeline_info {
+            let ScriptControlChan(ref script_chan) = self.pipeline(parent_pipeline_id).script_chan;
+            let (_, new_subpage_id) = self.pipeline(next_pipeline_id).parent_info.unwrap();
+            script_chan.send(ConstellationControlMsg::UpdateSubpageId(parent_pipeline_id,
+                                                                      subpage_id,
+                                                                      new_subpage_id)).unwrap();
+        }
     }
 
     fn handle_key_msg(&self, key: Key, state: KeyState, mods: KeyModifiers) {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -73,6 +73,7 @@ pub trait HTMLIFrameElementHelpers {
     fn generate_new_subpage_id(self) -> (SubpageId, Option<SubpageId>);
     fn navigate_child_browsing_context(self, url: Url);
     fn dispatch_mozbrowser_event(self, event_name: String, event_detail: Option<String>);
+    fn update_subpage_id(self, new_subpage_id: SubpageId);
 }
 
 impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
@@ -155,6 +156,10 @@ impl<'a> HTMLIFrameElementHelpers for JSRef<'a, HTMLIFrameElement> {
             let event: JSRef<Event> = EventCast::from_ref(custom_event.r());
             event.fire(target);
         }
+    }
+
+    fn update_subpage_id(self, new_subpage_id: SubpageId) {
+        self.subpage_id.set(Some(new_subpage_id));
     }
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -74,6 +74,8 @@ pub enum ConstellationControlMsg {
     Navigate(PipelineId, SubpageId, LoadData),
     /// Requests the script task forward a mozbrowser event to an iframe it owns
     MozBrowserEvent(PipelineId, SubpageId, String, Option<String>),
+    /// Updates the current subpage id of a given iframe
+    UpdateSubpageId(PipelineId, SubpageId, SubpageId),
 }
 
 unsafe impl Send for ConstellationControlMsg {


### PR DESCRIPTION
This fixes the case of clicking a link in an iframe, going back, then clicking the link again.
