### PR TITLE
Implement Element.outerHTML setter

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -10,13 +10,11 @@ use dom::attr::AttrValue;
 use dom::namednodemap::NamedNodeMap;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
-use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::ElementBinding;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use dom::bindings::codegen::Bindings::NamedNodeMapBinding::NamedNodeMapMethods;
-use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, ElementDerived, EventTargetCast};
 use dom::bindings::codegen::InheritTypes::{HTMLBodyElementDerived, HTMLInputElementCast};
 use dom::bindings::codegen::InheritTypes::{HTMLInputElementDerived, HTMLTableElementCast};
@@ -24,7 +22,6 @@ use dom::bindings::codegen::InheritTypes::{HTMLTableElementDerived, HTMLTableCel
 use dom::bindings::codegen::InheritTypes::{HTMLTableRowElementDerived, HTMLTextAreaElementDerived};
 use dom::bindings::codegen::InheritTypes::{HTMLTableSectionElementDerived, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
-use dom::bindings::codegen::InheritTypes::HTMLFormElementDerived;
 use dom::bindings::error::{ErrorResult, Fallible};
 use dom::bindings::error::Error;
 use dom::bindings::error::Error::{InvalidCharacter, Syntax};
@@ -37,7 +34,6 @@ use dom::create::create_element;
 use dom::domrect::DOMRect;
 use dom::domrectlist::DOMRectList;
 use dom::document::{Document, DocumentHelpers, LayoutDocumentHelpers};
-use dom::document::{DocumentSource, IsHTMLDocument};
 use dom::domtokenlist::DOMTokenList;
 use dom::event::{Event, EventHelpers};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -55,10 +51,9 @@ use dom::node::{CLICK_IN_PROGRESS, LayoutNodeHelpers, Node, NodeHelpers, NodeTyp
 use dom::node::{document_from_node, NodeDamage};
 use dom::node::{window_from_node};
 use dom::nodelist::NodeList;
-use dom::servohtmlparser::FragmentContext;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
 use devtools_traits::AttrInfo;
-use parse::html::{HTMLInput, parse_html};
+use parse::html::HTMLInput;
 use style::legacy::{SimpleColorAttribute, UnsignedIntegerAttribute, IntegerAttribute, LengthAttribute};
 use selectors::matching::matches;
 use style::properties::{PropertyDeclarationBlock, PropertyDeclaration, parse_style_attribute};
@@ -1169,61 +1164,20 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
             rect.origin.x + rect.size.width)
     }
 
+    // https://dvcs.w3.org/hg/innerhtml/raw-file/tip/index.html#extensions-to-the-element-interface
     fn GetInnerHTML(self) -> Fallible<DOMString> {
         //XXX TODO: XML case
         self.serialize(ChildrenOnly)
     }
 
     fn SetInnerHTML(self, value: DOMString) -> Fallible<()> {
-        let window = window_from_node(self).root();
-        let context_document = document_from_node(self).root();
+        // 1. Let fragment be the result of invoking the fragment parsing algorithm
+        //    with the new value as markup, and the context object as the context element.
+        // 2. Replace all with fragment within the context object.
         let context_node: JSRef<Node> = NodeCast::from_ref(self);
-        let url = context_document.r().url();
-
-        // Follows https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
-
-        // 1. Create a new Document node, and mark it as being an HTML document.
-        let document = Document::new(window.r(), Some(url.clone()),
-                                     IsHTMLDocument::HTMLDocument,
-                                     None, None,
-                                     DocumentSource::FromParser).root();
-
-        // 2. If the node document of the context element is in quirks mode,
-        //    then let the Document be in quirks mode. Otherwise,
-        //    the node document of the context element is in limited-quirks mode,
-        //    then let the Document be in limited-quirks mode. Otherwise,
-        //    leave the Document in no-quirks mode.
-        document.r().set_quirks_mode(context_document.r().quirks_mode());
-
-        // 11. Set the parser's form element pointer to the nearest node to
-        //     the context element that is a form element (going straight up
-        //     the ancestor chain, and including the element itself, if it
-        //     is a form element), if any. (If there is no such form element,
-        //     the form element pointer keeps its initial value, null.)
-        let form = context_node.inclusive_ancestors()
-                               .find(|element| element.is_htmlformelement());
-        let fragment_context = FragmentContext {
-            context_elem: context_node,
-            form_elem: form,
-        };
-        parse_html(document.r(), HTMLInput::InputString(value), &url, Some(fragment_context));
-
-        // "14. Return the child nodes of root, in tree order."
-        // We do this by deleting all nodes of the context node,
-        // and then moving all nodes parsed into the new root_node
-        // into the context node.
-        while let Some(child) = context_node.GetFirstChild() {
-            try!(context_node.RemoveChild(child.root().r()));
-        }
-        let root_element = document.r().GetDocumentElement().expect("no document element").root();
-        let root_node: JSRef<Node> = NodeCast::from_ref(root_element.r());
-        while let Some(child) = root_node.GetFirstChild() {
-            let child = child.root();
-            try!(root_node.RemoveChild(child.r()));
-            try!(context_node.AppendChild(child.r()));
-        }
-
-        Ok(())
+        context_node.parse_fragment(HTMLInput::InputString(value))
+                    .and_then(|frag| Ok(Node::replace_all(Some(NodeCast::from_ref(frag.root().r())),
+                                                          context_node)))
     }
 
     fn GetOuterHTML(self) -> Fallible<DOMString> {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1176,9 +1176,9 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         //    with the new value as markup, and the context object as the context element.
         // 2. Replace all with fragment within the context object.
         let context_node: JSRef<Node> = NodeCast::from_ref(self);
-        context_node.parse_fragment(value)
-                    .and_then(|frag| Ok(Node::replace_all(Some(NodeCast::from_ref(frag.root().r())),
-                                                          context_node)))
+        let frag = try!(context_node.parse_fragment(value));
+        Node::replace_all(Some(NodeCast::from_ref(frag.root().r())), context_node);
+        Ok(())
     }
 
     fn GetOuterHTML(self) -> Fallible<DOMString> {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1217,13 +1217,10 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         // 5. Let fragment be the result of invoking the fragment parsing algorithm with
         //    the new value as markup, and parent as the context element.
         // 6. Replace the context object with fragment within the context object's parent.
-        parent.r().parse_fragment(value)
-                  .and_then(|frag| {
-                      let frag = frag.root();
-                      let frag_node: JSRef<Node> = NodeCast::from_ref(frag.r());
-                      try!(context_parent.r().ReplaceChild(frag_node, context_node));
-                      Ok(())
-                  })
+        let frag = try!(parent.r().parse_fragment(value));
+        try!(context_parent.r().ReplaceChild(NodeCast::from_ref(frag.root().r()),
+                                             context_node));
+        Ok(())
     }
 
     // http://dom.spec.whatwg.org/#dom-parentnode-children

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -55,7 +55,6 @@ use dom::node::{window_from_node};
 use dom::nodelist::NodeList;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
 use devtools_traits::AttrInfo;
-use parse::html::HTMLInput;
 use style::legacy::{SimpleColorAttribute, UnsignedIntegerAttribute, IntegerAttribute, LengthAttribute};
 use selectors::matching::matches;
 use style::properties::{PropertyDeclarationBlock, PropertyDeclaration, parse_style_attribute};
@@ -1177,7 +1176,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         //    with the new value as markup, and the context object as the context element.
         // 2. Replace all with fragment within the context object.
         let context_node: JSRef<Node> = NodeCast::from_ref(self);
-        context_node.parse_fragment(HTMLInput::InputString(value))
+        context_node.parse_fragment(value)
                     .and_then(|frag| Ok(Node::replace_all(Some(NodeCast::from_ref(frag.root().r())),
                                                           context_node)))
     }
@@ -1218,7 +1217,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
         // 5. Let fragment be the result of invoking the fragment parsing algorithm with
         //    the new value as markup, and parent as the context element.
         // 6. Replace the context object with fragment within the context object's parent.
-        parent.r().parse_fragment(HTMLInput::InputString(value))
+        parent.r().parse_fragment(value)
                   .and_then(|frag| {
                       let frag = frag.root();
                       let frag_node: JSRef<Node> = NodeCast::from_ref(frag.r());

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1194,7 +1194,7 @@ impl<'a> ElementMethods for JSRef<'a, Element> {
             Some(parent) => parent.root()
         };
 
-        let parent: Root<Node> = match context_parent.r().type_id() {
+        let parent = match context_parent.r().type_id() {
             // Step 3.
             NodeTypeId::Document => return Err(NoModificationAllowed),
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -936,16 +936,16 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     fn parse_fragment(self, markup: DOMString) -> Fallible<Temporary<DocumentFragment>> {
         let context_node: JSRef<Node> = NodeCast::from_ref(self);
         let context_document = document_from_node(self).root();
-        let new_children =
-            if context_document.r().is_html_document() {
-                parse_html_fragment(context_node, markup)
-            } else {
-                // FIXME: XML case
-                unimplemented!()
-            };
+        let mut new_children: RootedVec<JS<Node>> = RootedVec::new();
+        if context_document.r().is_html_document() {
+            parse_html_fragment(context_node, markup, &mut new_children);
+        } else {
+            // FIXME: XML case
+            unimplemented!();
+        }
         let fragment = DocumentFragment::new(context_document.r()).root();
         let fragment_node: JSRef<Node> = NodeCast::from_ref(fragment.r());
-        for node in new_children {
+        for node in new_children.iter() {
             fragment_node.AppendChild(node.root().r()).unwrap();
         }
         Ok(Temporary::from_rooted(fragment.r()))

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -946,7 +946,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
         let fragment = DocumentFragment::new(context_document.r()).root();
         let fragment_node: JSRef<Node> = NodeCast::from_ref(fragment.r());
         for node in new_children {
-            let _ = fragment_node.AppendChild(node.root().r());
+            fragment_node.AppendChild(node.root().r()).unwrap();
         }
         Ok(Temporary::from_rooted(fragment.r()))
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -46,7 +46,7 @@ use dom::window::{Window, WindowHelpers};
 use geom::rect::Rect;
 use layout_interface::{LayoutChan, Msg};
 use devtools_traits::NodeInfo;
-use parse::html::{HTMLInput, parse_html_fragment};
+use parse::html::parse_html_fragment;
 use script_traits::UntrustedNodeAddress;
 use util::geometry::Au;
 use util::str::{DOMString, null_str_as_empty};
@@ -504,7 +504,7 @@ pub trait NodeHelpers<'a> {
 
     fn teardown(self);
 
-    fn parse_fragment(self, markup: HTMLInput) -> Fallible<Temporary<DocumentFragment>>;
+    fn parse_fragment(self, markup: DOMString) -> Fallible<Temporary<DocumentFragment>>;
 }
 
 impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
@@ -933,7 +933,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     // https://dvcs.w3.org/hg/innerhtml/raw-file/tip/index.html#dfn-concept-parse-fragment
-    fn parse_fragment(self, markup: HTMLInput) -> Fallible<Temporary<DocumentFragment>> {
+    fn parse_fragment(self, markup: DOMString) -> Fallible<Temporary<DocumentFragment>> {
         let context_node: JSRef<Node> = NodeCast::from_ref(self);
         let context_document = document_from_node(self).root();
         let new_children =

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -46,6 +46,7 @@ use dom::window::{Window, WindowHelpers};
 use geom::rect::Rect;
 use layout_interface::{LayoutChan, Msg};
 use devtools_traits::NodeInfo;
+use parse::html::{HTMLInput, parse_html_fragment};
 use script_traits::UntrustedNodeAddress;
 use util::geometry::Au;
 use util::str::{DOMString, null_str_as_empty};
@@ -502,6 +503,8 @@ pub trait NodeHelpers<'a> {
     fn summarize(self) -> NodeInfo;
 
     fn teardown(self);
+
+    fn parse_fragment(self, markup: HTMLInput) -> Fallible<Temporary<DocumentFragment>>;
 }
 
 impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
@@ -929,6 +932,24 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
         }
     }
 
+    // https://dvcs.w3.org/hg/innerhtml/raw-file/tip/index.html#dfn-concept-parse-fragment
+    fn parse_fragment(self, markup: HTMLInput) -> Fallible<Temporary<DocumentFragment>> {
+        let context_node: JSRef<Node> = NodeCast::from_ref(self);
+        let context_document = document_from_node(self).root();
+        let new_children =
+            if context_document.r().is_html_document() {
+                parse_html_fragment(context_node, markup)
+            } else {
+                // FIXME: XML case
+                unimplemented!()
+            };
+        let fragment = DocumentFragment::new(context_document.r()).root();
+        let fragment_node: JSRef<Node> = NodeCast::from_ref(fragment.r());
+        for node in new_children {
+            try!(fragment_node.AppendChild(node.root().r()));
+        }
+        Ok(Temporary::from_rooted(fragment.r()))
+    }
 }
 
 /// If the given untrusted node address represents a valid DOM node in the given runtime,
@@ -1456,7 +1477,7 @@ impl Node {
     }
 
     // http://dom.spec.whatwg.org/#concept-node-replace-all
-    fn replace_all(node: Option<JSRef<Node>>, parent: JSRef<Node>) {
+    pub fn replace_all(node: Option<JSRef<Node>>, parent: JSRef<Node>) {
         // Step 1.
         match node {
             Some(node) => {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -946,7 +946,7 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
         let fragment = DocumentFragment::new(context_document.r()).root();
         let fragment_node: JSRef<Node> = NodeCast::from_ref(fragment.r());
         for node in new_children {
-            try!(fragment_node.AppendChild(node.root().r()));
+            let _ = fragment_node.AppendChild(node.root().r());
         }
         Ok(Temporary::from_rooted(fragment.r()))
     }

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -66,7 +66,7 @@ partial interface Element {
   [Throws,TreatNullAs=EmptyString]
   attribute DOMString innerHTML;
   [Throws,TreatNullAs=EmptyString]
-  readonly attribute DOMString outerHTML;
+  attribute DOMString outerHTML;
 };
 
 Element implements ChildNode;

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -12,6 +12,7 @@ use dom::bindings::codegen::InheritTypes::{DocumentTypeCast, TextCast, CommentCa
 use dom::bindings::codegen::InheritTypes::ProcessingInstructionCast;
 use dom::bindings::codegen::InheritTypes::HTMLFormElementDerived;
 use dom::bindings::js::{JS, JSRef, Temporary, OptionalRootable, Root};
+use dom::bindings::trace::RootedVec;
 use dom::comment::Comment;
 use dom::document::{Document, DocumentHelpers};
 use dom::document::{DocumentSource, IsHTMLDocument};
@@ -331,7 +332,9 @@ pub fn parse_html(document: JSRef<Document>,
 }
 
 // https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
-pub fn parse_html_fragment(context_node: JSRef<Node>, input: DOMString) -> Vec<Temporary<Node>> {
+pub fn parse_html_fragment(context_node: JSRef<Node>,
+                           input: DOMString,
+                           output: &mut RootedVec<JS<Node>>) {
     let window = window_from_node(context_node).root();
     let context_document = document_from_node(context_node).root();
     let url = context_document.r().url();
@@ -357,7 +360,7 @@ pub fn parse_html_fragment(context_node: JSRef<Node>, input: DOMString) -> Vec<T
     // Step 14.
     let root_element = document.r().GetDocumentElement().expect("no document element").root();
     let root_node: JSRef<Node> = NodeCast::from_ref(root_element.r());
-    root_node.children()
-             .map(|node| Temporary::from_rooted(node))
-             .collect()
+    for child in root_node.children() {
+        output.push(JS::from_rooted(child));
+    }
 }

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -31,6 +31,7 @@ use encoding::all::UTF_8;
 use encoding::types::{Encoding, DecoderTrap};
 
 use net_traits::{ProgressMsg, LoadResponse};
+use util::str::DOMString;
 use util::task_state;
 use util::task_state::IN_HTML_PARSER;
 use std::ascii::AsciiExt;
@@ -330,7 +331,7 @@ pub fn parse_html(document: JSRef<Document>,
 }
 
 // https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
-pub fn parse_html_fragment(context_node: JSRef<Node>, input: HTMLInput) -> Vec<Temporary<Node>> {
+pub fn parse_html_fragment(context_node: JSRef<Node>, input: DOMString) -> Vec<Temporary<Node>> {
     let window = window_from_node(context_node).root();
     let context_document = document_from_node(context_node).root();
     let url = context_document.r().url();
@@ -359,7 +360,7 @@ pub fn parse_html_fragment(context_node: JSRef<Node>, input: HTMLInput) -> Vec<T
         context_elem: context_node,
         form_elem: form,
     };
-    parse_html(document.r(), input, &url, Some(fragment_context));
+    parse_html(document.r(), HTMLInput::InputString(input), &url, Some(fragment_context));
 
     // "14. Return the child nodes of root, in tree order."
     let root_element = document.r().GetDocumentElement().expect("no document element").root();

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -336,24 +336,16 @@ pub fn parse_html_fragment(context_node: JSRef<Node>, input: DOMString) -> Vec<T
     let context_document = document_from_node(context_node).root();
     let url = context_document.r().url();
 
-    // 1. Create a new Document node, and mark it as being an HTML document.
+    // Step 1.
     let document = Document::new(window.r(), Some(url.clone()),
                                  IsHTMLDocument::HTMLDocument,
                                  None, None,
                                  DocumentSource::FromParser).root();
 
-    // 2. If the node document of the context element is in quirks mode,
-    //    then let the Document be in quirks mode. Otherwise,
-    //    the node document of the context element is in limited-quirks mode,
-    //    then let the Document be in limited-quirks mode. Otherwise,
-    //    leave the Document in no-quirks mode.
+    // Step 2.
     document.r().set_quirks_mode(context_document.r().quirks_mode());
 
-    // 11. Set the parser's form element pointer to the nearest node to
-    //     the context element that is a form element (going straight up
-    //     the ancestor chain, and including the element itself, if it
-    //     is a form element), if any. (If there is no such form element,
-    //     the form element pointer keeps its initial value, null.)
+    // Step 11.
     let form = context_node.inclusive_ancestors()
                            .find(|element| element.is_htmlformelement());
     let fragment_context = FragmentContext {
@@ -362,7 +354,7 @@ pub fn parse_html_fragment(context_node: JSRef<Node>, input: DOMString) -> Vec<T
     };
     parse_html(document.r(), HTMLInput::InputString(input), &url, Some(fragment_context));
 
-    // "14. Return the child nodes of root, in tree order."
+    // Step 14.
     let root_element = document.r().GetDocumentElement().expect("no document element").root();
     let root_node: JSRef<Node> = NodeCast::from_ref(root_element.r());
     root_node.children()

--- a/tests/wpt/metadata/dom/nodes/Document-getElementById.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-getElementById.html.ini
@@ -1,8 +1,0 @@
-[Document-getElementById.html]
-  type: testharness
-  [add id attribute via outerHTML]
-    expected: FAIL
-
-  [remove id attribute via outerHTML]
-    expected: FAIL
-


### PR DESCRIPTION
The first commit refactors the fragment parsing and innerHTML setter. This makes the code mirror the structure of the spec more closely, and also prepares for reusing code with the outerHTML setter.
