### PR TITLE
Rename lots of profiling-related things.

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -21,8 +21,8 @@ use msg::compositor_msg::{Epoch, LayerId, LayerMetadata, ReadyState};
 use msg::compositor_msg::{PaintListener, PaintState, ScriptListener, ScrollPolicy};
 use msg::constellation_msg::{ConstellationChan, PipelineId};
 use msg::constellation_msg::{Key, KeyState, KeyModifiers};
-use profile::mem::MemoryProfilerChan;
-use profile::time::TimeProfilerChan;
+use profile::mem;
+use profile::time;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::fmt::{Error, Formatter, Debug};
 use std::rc::Rc;
@@ -265,8 +265,8 @@ impl CompositorTask {
                           sender: Box<CompositorProxy+Send>,
                           receiver: Box<CompositorReceiver>,
                           constellation_chan: ConstellationChan,
-                          time_profiler_chan: TimeProfilerChan,
-                          memory_profiler_chan: MemoryProfilerChan)
+                          time_profiler_chan: time::ProfilerChan,
+                          mem_profiler_chan: mem::ProfilerChan)
                           -> Box<CompositorEventListener + 'static>
                           where Window: WindowMethods + 'static {
         match window {
@@ -276,14 +276,14 @@ impl CompositorTask {
                                                      receiver,
                                                      constellation_chan.clone(),
                                                      time_profiler_chan,
-                                                     memory_profiler_chan)
+                                                     mem_profiler_chan)
                     as Box<CompositorEventListener>
             }
             None => {
                 box headless::NullCompositor::create(receiver,
                                                      constellation_chan.clone(),
                                                      time_profiler_chan,
-                                                     memory_profiler_chan)
+                                                     mem_profiler_chan)
                     as Box<CompositorEventListener>
             }
         }

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -25,8 +25,8 @@ use msg::constellation_msg::Msg as ConstellationMsg;
 use net::image_cache_task::{ImageCacheTask, ImageCacheTaskClient};
 use net::resource_task::{self, ResourceTask};
 use net::storage_task::{StorageTask, StorageTaskMsg};
-use profile::mem::MemoryProfilerChan;
-use profile::time::TimeProfilerChan;
+use profile::mem;
+use profile::time;
 use util::cursor::Cursor;
 use util::geometry::PagePx;
 use util::opts;
@@ -91,10 +91,10 @@ pub struct Constellation<LTF, STF> {
     pending_frames: Vec<FrameChange>,
 
     /// A channel through which messages can be sent to the time profiler.
-    pub time_profiler_chan: TimeProfilerChan,
+    pub time_profiler_chan: time::ProfilerChan,
 
     /// A channel through which messages can be sent to the memory profiler.
-    pub memory_profiler_chan: MemoryProfilerChan,
+    pub mem_profiler_chan: mem::ProfilerChan,
 
     phantom: PhantomData<(LTF, STF)>,
 
@@ -173,8 +173,8 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                  resource_task: ResourceTask,
                  image_cache_task: ImageCacheTask,
                  font_cache_task: FontCacheTask,
-                 time_profiler_chan: TimeProfilerChan,
-                 memory_profiler_chan: MemoryProfilerChan,
+                 time_profiler_chan: time::ProfilerChan,
+                 mem_profiler_chan: mem::ProfilerChan,
                  devtools_chan: Option<DevtoolsControlChan>,
                  storage_task: StorageTask)
                  -> ConstellationChan {
@@ -199,7 +199,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 root_frame_id: None,
                 next_frame_id: FrameId(0),
                 time_profiler_chan: time_profiler_chan,
-                memory_profiler_chan: memory_profiler_chan,
+                mem_profiler_chan: mem_profiler_chan,
                 window_size: WindowSizeData {
                     visible_viewport: opts::get().initial_window_size.as_f32() * ScaleFactor::new(1.0),
                     initial_viewport: opts::get().initial_window_size.as_f32() * ScaleFactor::new(1.0),
@@ -242,7 +242,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                                                     self.resource_task.clone(),
                                                     self.storage_task.clone(),
                                                     self.time_profiler_chan.clone(),
-                                                    self.memory_profiler_chan.clone(),
+                                                    self.mem_profiler_chan.clone(),
                                                     initial_window_rect,
                                                     script_channel,
                                                     load_data,

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -10,9 +10,7 @@ use geom::size::TypedSize2D;
 use msg::constellation_msg::Msg as ConstellationMsg;
 use msg::constellation_msg::{ConstellationChan, WindowSizeData};
 use profile::mem;
-use profile::mem::MemoryProfilerChan;
 use profile::time;
-use profile::time::TimeProfilerChan;
 
 /// Starts the compositor, which listens for messages on the specified port.
 ///
@@ -24,34 +22,34 @@ pub struct NullCompositor {
     /// A channel to the constellation.
     constellation_chan: ConstellationChan,
     /// A channel to the time profiler.
-    time_profiler_chan: TimeProfilerChan,
+    time_profiler_chan: time::ProfilerChan,
     /// A channel to the memory profiler.
-    memory_profiler_chan: MemoryProfilerChan,
+    mem_profiler_chan: mem::ProfilerChan,
 }
 
 impl NullCompositor {
     fn new(port: Box<CompositorReceiver>,
            constellation_chan: ConstellationChan,
-           time_profiler_chan: TimeProfilerChan,
-           memory_profiler_chan: MemoryProfilerChan)
+           time_profiler_chan: time::ProfilerChan,
+           mem_profiler_chan: mem::ProfilerChan)
            -> NullCompositor {
         NullCompositor {
             port: port,
             constellation_chan: constellation_chan,
             time_profiler_chan: time_profiler_chan,
-            memory_profiler_chan: memory_profiler_chan,
+            mem_profiler_chan: mem_profiler_chan,
         }
     }
 
     pub fn create(port: Box<CompositorReceiver>,
                   constellation_chan: ConstellationChan,
-                  time_profiler_chan: TimeProfilerChan,
-                  memory_profiler_chan: MemoryProfilerChan)
+                  time_profiler_chan: time::ProfilerChan,
+                  mem_profiler_chan: mem::ProfilerChan)
                   -> NullCompositor {
         let compositor = NullCompositor::new(port,
                                              constellation_chan,
                                              time_profiler_chan,
-                                             memory_profiler_chan);
+                                             mem_profiler_chan);
 
         // Tell the constellation about the initial fake size.
         {
@@ -120,8 +118,8 @@ impl CompositorEventListener for NullCompositor {
         // another task from finishing (i.e. SetIds)
         while self.port.try_recv_compositor_msg().is_some() {}
 
-        self.time_profiler_chan.send(time::TimeProfilerMsg::Exit);
-        self.memory_profiler_chan.send(mem::MemoryProfilerMsg::Exit);
+        self.time_profiler_chan.send(time::ProfilerMsg::Exit);
+        self.mem_profiler_chan.send(mem::ProfilerMsg::Exit);
     }
 
     fn pinch_zoom_level(&self) -> f32 {

--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -19,8 +19,8 @@ use msg::constellation_msg::{LoadData, WindowSizeData, PipelineExitType};
 use net::image_cache_task::ImageCacheTask;
 use net::resource_task::ResourceTask;
 use net::storage_task::StorageTask;
-use profile::mem::MemoryProfilerChan;
-use profile::time::TimeProfilerChan;
+use profile::mem;
+use profile::time;
 use std::sync::mpsc::{Receiver, channel};
 use url::Url;
 use util::geometry::{PagePx, ViewportPx};
@@ -64,8 +64,8 @@ impl Pipeline {
                            font_cache_task: FontCacheTask,
                            resource_task: ResourceTask,
                            storage_task: StorageTask,
-                           time_profiler_chan: TimeProfilerChan,
-                           memory_profiler_chan: MemoryProfilerChan,
+                           time_profiler_chan: time::ProfilerChan,
+                           mem_profiler_chan: mem::ProfilerChan,
                            window_rect: Option<TypedRect<PagePx, f32>>,
                            script_chan: Option<ScriptControlChan>,
                            load_data: LoadData,
@@ -150,7 +150,7 @@ impl Pipeline {
                                   image_cache_task,
                                   font_cache_task,
                                   time_profiler_chan,
-                                  memory_profiler_chan,
+                                  mem_profiler_chan,
                                   layout_shutdown_chan);
 
         Pipeline::new(id,

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -20,7 +20,7 @@ use wrapper::{layout_node_to_unsafe_layout_node, layout_node_from_unsafe_layout_
 use wrapper::{PostorderNodeMutTraversal, UnsafeLayoutNode};
 use wrapper::{PreorderDomTraversal, PostorderDomTraversal};
 
-use profile::time::{TimeProfilerCategory, ProfilerMetadata, TimeProfilerChan, profile};
+use profile::time::{self, ProfilerCategory, ProfilerMetadata, profile};
 use std::mem;
 use std::ptr;
 use std::sync::atomic::{AtomicIsize, Ordering};
@@ -430,7 +430,7 @@ pub fn traverse_dom_preorder(root: LayoutNode,
 
 pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
                                    profiler_metadata: ProfilerMetadata,
-                                   time_profiler_chan: TimeProfilerChan,
+                                   time_profiler_chan: time::ProfilerChan,
                                    shared_layout_context: &SharedLayoutContext,
                                    queue: &mut WorkQueue<SharedLayoutContextWrapper,UnsafeFlow>) {
     if opts::get().bubble_inline_sizes_separately {
@@ -441,7 +441,7 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 
     queue.data = SharedLayoutContextWrapper(shared_layout_context as *const _);
 
-    profile(TimeProfilerCategory::LayoutParallelWarmup, profiler_metadata,
+    profile(time::ProfilerCategory::LayoutParallelWarmup, profiler_metadata,
             time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: assign_inline_sizes,
@@ -456,12 +456,12 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 
 pub fn build_display_list_for_subtree(root: &mut FlowRef,
                                       profiler_metadata: ProfilerMetadata,
-                                      time_profiler_chan: TimeProfilerChan,
+                                      time_profiler_chan: time::ProfilerChan,
                                       shared_layout_context: &SharedLayoutContext,
                                       queue: &mut WorkQueue<SharedLayoutContextWrapper,UnsafeFlow>) {
     queue.data = SharedLayoutContextWrapper(shared_layout_context as *const _);
 
-    profile(TimeProfilerCategory::LayoutParallelWarmup, profiler_metadata,
+    profile(time::ProfilerCategory::LayoutParallelWarmup, profiler_metadata,
             time_profiler_chan, || {
         queue.push(WorkUnit {
             fun: compute_absolute_positions,

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -20,8 +20,8 @@ use gfx::paint_task::PaintChan;
 use msg::constellation_msg::{ConstellationChan, Failure, PipelineId, PipelineExitType};
 use net::image_cache_task::ImageCacheTask;
 use net::resource_task::ResourceTask;
-use profile::mem::MemoryProfilerChan;
-use profile::time::TimeProfilerChan;
+use profile::mem;
+use profile::time;
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel};
 use std::sync::mpsc::{Sender, Receiver};
 use url::Url;
@@ -50,7 +50,7 @@ pub trait LayoutTaskFactory {
               resource_task: ResourceTask,
               img_cache_task: ImageCacheTask,
               font_cache_task: FontCacheTask,
-              time_profiler_chan: TimeProfilerChan,
-              memory_profiler_chan: MemoryProfilerChan,
+              time_profiler_chan: time::ProfilerChan,
+              mem_profiler_chan: mem::ProfilerChan,
               shutdown_chan: Sender<()>);
 }

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -11,7 +11,7 @@ use dom::node::LayoutData;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use msg::constellation_msg::{PipelineExitType, WindowSizeData};
-use profile::mem::{MemoryReporter, MemoryReportsChan};
+use profile::mem::{Reporter, ReportsChan};
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel, UntrustedNodeAddress};
 use std::any::Any;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -47,7 +47,7 @@ pub enum Msg {
 
     /// Requests that the layout task measure its memory usage. The resulting reports are sent back
     /// via the supplied channel.
-    CollectMemoryReports(MemoryReportsChan),
+    CollectReports(ReportsChan),
 
     /// Requests that the layout task enter a quiescent state in which no more messages are
     /// accepted except `ExitMsg`. A response message will be sent on the supplied channel when
@@ -66,7 +66,7 @@ pub enum Msg {
 ///
 ///   1) read-only with respect to LayoutTaskData,
 ///   2) small,
-//    3) and really needs to be fast.
+///   3) and really needs to be fast.
 pub trait LayoutRPC {
     /// Requests the dimensions of the content box, as in the `getBoundingClientRect()` call.
     fn content_box(&self) -> ContentBoxResponse;
@@ -133,11 +133,11 @@ impl LayoutChan {
     }
 }
 
-impl MemoryReporter for LayoutChan {
+impl Reporter for LayoutChan {
     // Just injects an appropriate event into the layout task's queue.
-    fn collect_reports(&self, reports_chan: MemoryReportsChan) -> bool {
+    fn collect_reports(&self, reports_chan: ReportsChan) -> bool {
         let LayoutChan(ref c) = *self;
-        c.send(Msg::CollectMemoryReports(reports_chan)).is_ok()
+        c.send(Msg::CollectReports(reports_chan)).is_ok()
     }
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -41,9 +41,9 @@ use net::storage_task::{StorageTaskFactory, StorageTask};
 #[cfg(not(test))]
 use gfx::font_cache_task::FontCacheTask;
 #[cfg(not(test))]
-use profile::mem::MemoryProfiler;
+use profile::mem;
 #[cfg(not(test))]
-use profile::time::TimeProfiler;
+use profile::time;
 #[cfg(not(test))]
 use util::opts;
 #[cfg(not(test))]
@@ -70,8 +70,8 @@ impl Browser  {
 
         let (compositor_proxy, compositor_receiver) =
             WindowMethods::create_compositor_channel(&window);
-        let time_profiler_chan = TimeProfiler::create(opts.time_profiler_period);
-        let memory_profiler_chan = MemoryProfiler::create(opts.memory_profiler_period);
+        let time_profiler_chan = time::Profiler::create(opts.time_profiler_period);
+        let mem_profiler_chan = mem::Profiler::create(opts.mem_profiler_period);
         let devtools_chan = opts.devtools_port.map(|port| {
             devtools::start_server(port)
         });
@@ -100,7 +100,7 @@ impl Browser  {
                                                       image_cache_task,
                                                       font_cache_task,
                                                       time_profiler_chan.clone(),
-                                                      memory_profiler_chan.clone(),
+                                                      mem_profiler_chan.clone(),
                                                       devtools_chan,
                                                       storage_task);
 
@@ -124,7 +124,7 @@ impl Browser  {
                                                 compositor_receiver,
                                                 constellation_chan,
                                                 time_profiler_chan,
-                                                memory_profiler_chan);
+                                                mem_profiler_chan);
 
         Browser {
             compositor: compositor,

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -51,7 +51,7 @@ pub mod linked_list;
 pub mod fnv;
 pub mod geometry;
 pub mod logical_geometry;
-pub mod memory;
+pub mod mem;
 pub mod namespace;
 pub mod opts;
 pub mod persistent_list;

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -47,7 +47,7 @@ pub struct Opts {
 
     /// `None` to disable the memory profiler or `Some` with an interval in seconds to enable it
     /// and cause it to produce output on that interval (`-m`).
-    pub memory_profiler_period: Option<f64>,
+    pub mem_profiler_period: Option<f64>,
 
     /// Enable experimental web features (`-e`).
     pub enable_experimental: bool,
@@ -176,7 +176,7 @@ pub fn default_opts() -> Opts {
         tile_size: 512,
         device_pixels_per_px: None,
         time_profiler_period: None,
-        memory_profiler_period: None,
+        mem_profiler_period: None,
         enable_experimental: false,
         layout_threads: 1,
         nonincremental_layout: false,
@@ -286,7 +286,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
     let time_profiler_period = opt_match.opt_default("p", "5").map(|period| {
         period.parse().unwrap()
     });
-    let memory_profiler_period = opt_match.opt_default("m", "5").map(|period| {
+    let mem_profiler_period = opt_match.opt_default("m", "5").map(|period| {
         period.parse().unwrap()
     });
 
@@ -330,7 +330,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         tile_size: tile_size,
         device_pixels_per_px: device_pixels_per_px,
         time_profiler_period: time_profiler_period,
-        memory_profiler_period: memory_profiler_period,
+        mem_profiler_period: mem_profiler_period,
         enable_experimental: opt_match.opt_present("e"),
         layout_threads: layout_threads,
         nonincremental_layout: nonincremental_layout,

--- a/ports/gonk/src/lib.rs
+++ b/ports/gonk/src/lib.rs
@@ -46,9 +46,9 @@ use net::resource_task::new_resource_task;
 #[cfg(not(test))]
 use gfx::font_cache_task::FontCacheTask;
 #[cfg(not(test))]
-use profile::mem::MemoryProfiler;
+use profile::mem;
 #[cfg(not(test))]
-use profile::time::TimeProfiler;
+use profile::time;
 #[cfg(not(test))]
 use util::opts;
 #[cfg(not(test))]
@@ -79,15 +79,15 @@ impl Browser {
 
         let (compositor_proxy, compositor_receiver) =
             WindowMethods::create_compositor_channel(&window);
-        let time_profiler_chan = TimeProfiler::create(opts.time_profiler_period);
-        let memory_profiler_chan = MemoryProfiler::create(opts.memory_profiler_period);
+        let time_profiler_chan = time::Profiler::create(opts.time_profiler_period);
+        let mem_profiler_chan = mem::Profiler::create(opts.mem_profiler_period);
         let devtools_chan = opts.devtools_port.map(|port| {
             devtools::start_server(port)
         });
 
         let opts_clone = opts.clone();
         let time_profiler_chan_clone = time_profiler_chan.clone();
-        let memory_profiler_chan_clone = memory_profiler_chan.clone();
+        let mem_profiler_chan_clone = mem_profiler_chan.clone();
 
         let (result_chan, result_port) = channel();
         let compositor_proxy_for_constellation = compositor_proxy.clone_compositor_proxy();
@@ -115,7 +115,7 @@ impl Browser {
                                                           image_cache_task,
                                                           font_cache_task,
                                                           time_profiler_chan_clone,
-                                                          memory_profiler_chan_clone,
+                                                          mem_profiler_chan_clone,
                                                           devtools_chan,
                                                           storage_task);
 
@@ -145,7 +145,7 @@ impl Browser {
                                                 compositor_receiver,
                                                 constellation_chan,
                                                 time_profiler_chan,
-                                                memory_profiler_chan);
+                                                mem_profiler_chan);
 
         Browser {
             compositor: compositor,


### PR DESCRIPTION
```
------------------------------------------------------------------------
BEFORE                              AFTER
------------------------------------------------------------------------
util::memory                        util::mem
- heap_size_of                      - heap_size_of (unchanged)
- SizeOf                            - HeapSizeOf
  - size_of_excluding_self            - heap_size_of_children

prof::mem                           prof::mem
- MemoryProfilerChan                - ProfilerChan
- MemoryReport                      - Report
- MemoryReportsChan                 - ReportsChan
- MemoryReporter                    - Reporter
- MemoryProfilerMsg                 - ProfilerMsg
  - {R,UnR}egisterMemoryReporter      - {R,UnR}egisterReporter
- MemoryProfiler                    - Prof
- ReportsForest                     - ReportsForest (unchanged)
- ReportsTree                       - ReportsTree   (unchanged)
- SystemMemoryReporter              - SystemReporter

prof::time                          prof::time
- TimeProfilerChan                  - ProfilerChan
- TimerMetadata                     - TimerMetadata (unchanged)
- Formatable                        - Formattable [spelling!]
- TimeProfilerMsg                   - ProfilerMsg
- TimeProfilerCategory              - ProfilerCategory
- TimeProfilerBuckets               - ProfilerBuckets
- TimeProfiler                      - Profiler
- TimerMetadataFrameType            - TimerMetadataFrameType (unchanged)
- TimerMetadataReflowType           - TimerMetadataReflowType (unchanged)
- ProfilerMetadata                  - ProfilerMetadata (unchanged)
```

In a few places both prof::time and prof::mem are used, and so
module-qualification is needed to avoid overlap, e.g. time::Profiler and
mem::Profiler. Likewise with std::mem and prof::mem. This is not a big
deal.
