### PR TITLE
Don't add margin/border/padding twice to position

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1453,9 +1453,7 @@ impl BlockFlow {
 
         let info = PlacementInfo {
             size: LogicalSize::new(self.fragment.style.writing_mode,
-                                   self.base.position.size.inline +
-                                        self.fragment.margin.inline_start_end() +
-                                        self.fragment.border_padding.inline_start_end(),
+                                   self.base.position.size.inline,
                                    self.fragment.border_box.size.block),
             ceiling: self.base.position.start.b,
             max_inline_size: MAX_AU,


### PR DESCRIPTION
I think this should have been changed in #3618 but was missed. r? @pcwalton

I wasn't able to come up with a good test case for this, partly because of other bugs related to floats and formatting contexts.
