### PR TITLE
layout: Implement CSS transitions per CSS-TRANSITIONS § 2.

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -201,6 +201,8 @@ pub enum Msg {
     ChangePageTitle(PipelineId, Option<String>),
     /// Alerts the compositor that the current page has changed its URL.
     ChangePageUrl(PipelineId, Url),
+    /// Alerts the compositor that the given pipeline has changed whether it is running animations.
+    ChangeRunningAnimationsState(PipelineId, bool),
     /// Alerts the compositor that a `PaintMsg` has been discarded.
     PaintMsgDiscarded,
     /// Replaces the current frame tree, typically called during main frame navigation.
@@ -231,6 +233,7 @@ impl Debug for Msg {
             Msg::AssignPaintedBuffers(..) => write!(f, "AssignPaintedBuffers"),
             Msg::ChangeReadyState(..) => write!(f, "ChangeReadyState"),
             Msg::ChangePaintState(..) => write!(f, "ChangePaintState"),
+            Msg::ChangeRunningAnimationsState(..) => write!(f, "ChangeRunningAnimationsState"),
             Msg::ChangePageTitle(..) => write!(f, "ChangePageTitle"),
             Msg::ChangePageUrl(..) => write!(f, "ChangePageUrl"),
             Msg::PaintMsgDiscarded(..) => write!(f, "PaintMsgDiscarded"),

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -98,6 +98,7 @@ impl CompositorEventListener for NullCompositor {
             Msg::AssignPaintedBuffers(..) |
             Msg::ChangeReadyState(..) |
             Msg::ChangePaintState(..) |
+            Msg::ChangeRunningAnimationsState(..) |
             Msg::ScrollFragmentPoint(..) |
             Msg::LoadComplete |
             Msg::PaintMsgDiscarded(..) |

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -330,13 +330,13 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
         })
     }
 
-    /// Paints one layer and sends the tiles back to the layer.
+    /// Paints one layer and places the painted tiles in `replies`.
     fn paint(&mut self,
               replies: &mut Vec<(LayerId, Box<LayerBufferSet>)>,
               mut tiles: Vec<BufferRequest>,
               scale: f32,
               layer_id: LayerId) {
-        profile(time::ProfilerCategory::Painting, None, self.time_profiler_chan.clone(), || {
+        time::profile(time::ProfilerCategory::Painting, None, self.time_profiler_chan.clone(), || {
             // Bail out if there is no appropriate stacking context.
             let stacking_context = if let Some(ref stacking_context) = self.root_stacking_context {
                 match display_list::find_stacking_context_with_layer_id(stacking_context,
@@ -559,8 +559,10 @@ impl WorkerThread {
             paint_context.clear();
 
             // Draw the display list.
-            profile(time::ProfilerCategory::PaintingPerTile, None,
-                    self.time_profiler_sender.clone(), || {
+            time::profile(time::ProfilerCategory::PaintingPerTile,
+                          None,
+                          self.time_profiler_sender.clone(),
+                          || {
                 stacking_context.optimize_and_draw_into_context(&mut paint_context,
                                                                 &tile_bounds,
                                                                 &matrix,

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -61,9 +61,13 @@ git = "https://github.com/servo/string-cache"
 [dependencies.png]
 git = "https://github.com/servo/rust-png"
 
+[dependencies.clock_ticks]
+git = "https://github.com/tomaka/clock_ticks"
+
 [dependencies]
 encoding = "0.2"
 url = "0.2.16"
 bitflags = "*"
 rustc-serialize = "0.3"
 libc = "*"
+

--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! CSS transitions and animations.
+
+use flow::{self, Flow};
+use incremental::{self, RestyleDamage};
+
+use clock_ticks;
+use gfx::display_list::OpaqueNode;
+use layout_task::{LayoutTask, LayoutTaskData};
+use msg::constellation_msg::{Msg, PipelineId};
+use script::layout_interface::Animation;
+use std::mem;
+use std::sync::mpsc::Sender;
+use style::animation::{GetMod, PropertyAnimation};
+use style::properties::ComputedValues;
+
+/// Inserts transitions into the queue of running animations as applicable for the given style
+/// difference. This is called from the layout worker threads.
+pub fn start_transitions_if_applicable(new_animations_sender: &Sender<Animation>,
+                                       node: OpaqueNode,
+                                       old_style: &ComputedValues,
+                                       new_style: &mut ComputedValues) {
+    for i in range(0, new_style.get_animation().transition_property.0.len()) {
+        // Create any property animations, if applicable.
+        let property_animations = PropertyAnimation::from_transition(i, old_style, new_style);
+        for property_animation in property_animations.into_iter() {
+            // Set the property to the initial value.
+            property_animation.update(new_style, 0.0);
+
+            // Kick off the animation.
+            let now = clock_ticks::precise_time_s();
+            let animation_style = new_style.get_animation();
+            let start_time = now + animation_style.transition_delay.0.get_mod(i).seconds();
+            new_animations_sender.send(Animation {
+                node: node.id(),
+                property_animation: property_animation,
+                start_time: start_time,
+                end_time: start_time +
+                    animation_style.transition_duration.0.get_mod(i).seconds(),
+            }).unwrap()
+        }
+    }
+}
+
+/// Processes any new animations that were discovered after style recalculation.
+pub fn process_new_animations(rw_data: &mut LayoutTaskData, pipeline_id: PipelineId) {
+    while let Ok(animation) = rw_data.new_animations_receiver.try_recv() {
+        rw_data.running_animations.push(animation)
+    }
+
+    let animations_are_running = !rw_data.running_animations.is_empty();
+    rw_data.constellation_chan
+           .0
+           .send(Msg::ChangeRunningAnimationsState(pipeline_id, animations_are_running))
+           .unwrap();
+}
+
+/// Recalculates style for an animation. This does *not* run with the DOM lock held.
+pub fn recalc_style_for_animation(flow: &mut Flow, animation: &Animation) {
+    let mut damage = RestyleDamage::empty();
+    flow.mutate_fragments(&mut |fragment| {
+        if fragment.node.id() != animation.node {
+            return
+        }
+
+        let now = clock_ticks::precise_time_s();
+        let mut progress = (now - animation.start_time) / animation.duration();
+        if progress > 1.0 {
+            progress = 1.0
+        }
+        if progress <= 0.0 {
+            return
+        }
+
+        let mut new_style = fragment.style.clone();
+        animation.property_animation.update(&mut *new_style.make_unique(), progress);
+        damage.insert(incremental::compute_damage(&Some(fragment.style.clone()), &new_style));
+        fragment.style = new_style
+    });
+
+    let base = flow::mut_base(flow);
+    base.restyle_damage.insert(damage);
+    for kid in base.children.iter_mut() {
+        recalc_style_for_animation(kid, animation)
+    }
+}
+
+/// Handles animation updates.
+pub fn tick_all_animations(layout_task: &LayoutTask, rw_data: &mut LayoutTaskData) {
+    let running_animations = mem::replace(&mut rw_data.running_animations, Vec::new());
+    let now = clock_ticks::precise_time_s();
+    for running_animation in running_animations.into_iter() {
+        layout_task.tick_animation(running_animation, rw_data);
+
+        if now < running_animation.end_time {
+            // Keep running the animation if it hasn't expired.
+            rw_data.running_animations.push(running_animation)
+        }
+    }
+}
+

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -25,40 +25,45 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]extern crate bitflags;
-extern crate azure;
-extern crate cssparser;
-extern crate canvas;
-extern crate geom;
-extern crate gfx;
-extern crate layout_traits;
-extern crate script;
-extern crate script_traits;
-extern crate "rustc-serialize" as rustc_serialize;
-extern crate png;
-extern crate style;
+#[macro_use]
+extern crate bitflags;
+
 #[macro_use]
 #[no_link]
 extern crate "plugins" as servo_plugins;
-extern crate net;
-extern crate msg;
+
 #[macro_use]
 extern crate profile;
-extern crate selectors;
+
 #[macro_use]
 extern crate util;
 
-extern crate string_cache;
-
+extern crate "rustc-serialize" as rustc_serialize;
 extern crate alloc;
+extern crate azure;
+extern crate canvas;
+extern crate clock_ticks;
 extern crate collections;
+extern crate cssparser;
 extern crate encoding;
+extern crate geom;
+extern crate gfx;
+extern crate layout_traits;
 extern crate libc;
+extern crate msg;
+extern crate net;
+extern crate png;
+extern crate script;
+extern crate script_traits;
+extern crate selectors;
+extern crate string_cache;
+extern crate style;
 extern crate url;
 
 // Listed first because of macro definitions
 pub mod layout_debug;
 
+pub mod animation;
 pub mod block;
 pub mod construct;
 pub mod context;

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -180,7 +180,8 @@ impl<'a> PreorderDomTraversal for RecalcStyleForNode<'a> {
                         node.cascade_node(self.layout_context.shared,
                                           parent_opt,
                                           &applicable_declarations,
-                                          self.layout_context.applicable_declarations_cache());
+                                          self.layout_context.applicable_declarations_cache(),
+                                          &self.layout_context.shared.new_animations_sender);
                     }
 
                     // Add ourselves to the LRU cache.

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -333,11 +333,16 @@ impl<'ln> LayoutNode<'ln> {
     /// While doing a reflow, the node at the root has no parent, as far as we're
     /// concerned. This method returns `None` at the reflow root.
     pub fn layout_parent_node(self, shared: &SharedLayoutContext) -> Option<LayoutNode<'ln>> {
-        let opaque_node: OpaqueNode = OpaqueNodeMethods::from_layout_node(&self);
-        if opaque_node == shared.reflow_root {
-            None
-        } else {
-            self.parent_node()
+        match shared.reflow_root {
+            None => panic!("layout_parent_node(): This layout has no access to the DOM!"),
+            Some(reflow_root) => {
+                let opaque_node: OpaqueNode = OpaqueNodeMethods::from_layout_node(&self);
+                if opaque_node == reflow_root {
+                    None
+                } else {
+                    self.parent_node()
+                }
+            }
         }
     }
 

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -29,6 +29,7 @@ use url::Url;
 /// Messages sent to the layout task from the constellation
 pub enum LayoutControlMsg {
     ExitNowMsg(PipelineExitType),
+    TickAnimationsMsg,
 }
 
 /// A channel wrapper for constellation messages

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -214,6 +214,10 @@ pub enum Msg {
     SetCursor(Cursor),
     /// Dispatch a mozbrowser event to a given iframe. Only available in experimental mode.
     MozBrowserEventMsg(PipelineId, SubpageId, MozBrowserEvent),
+    /// Indicates whether this pipeline is currently running animations.
+    ChangeRunningAnimationsState(PipelineId, bool),
+    /// Requests that the constellation instruct layout to begin a new tick of the animation.
+    TickAnimation(PipelineId),
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Using_the_Browser_API#Events

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -186,4 +186,10 @@ partial interface CSSStyleDeclaration {
   [TreatNullAs=EmptyString] attribute DOMString zIndex;
 
   [TreatNullAs=EmptyString] attribute DOMString imageRendering;
+
+  [TreatNullAs=EmptyString] attribute DOMString transition;
+  [TreatNullAs=EmptyString] attribute DOMString transitionDuration;
+  [TreatNullAs=EmptyString] attribute DOMString transitionTimingFunction;
+  [TreatNullAs=EmptyString] attribute DOMString transitionProperty;
+  [TreatNullAs=EmptyString] attribute DOMString transitionDelay;
 };

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -27,7 +27,7 @@ use dom::performance::Performance;
 use dom::screen::Screen;
 use dom::storage::Storage;
 use layout_interface::{ReflowGoal, ReflowQueryType, LayoutRPC, LayoutChan, Reflow, Msg};
-use layout_interface::{ContentBoxResponse, ContentBoxesResponse};
+use layout_interface::{ContentBoxResponse, ContentBoxesResponse, ScriptReflow};
 use page::Page;
 use script_task::{TimerSource, ScriptChan};
 use script_task::ScriptMsg;
@@ -564,17 +564,19 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         }
 
         // Send new document and relevant styles to layout.
-        let reflow = box Reflow {
+        let reflow = box ScriptReflow {
+            reflow_info: Reflow {
+                goal: goal,
+                url: self.get_url(),
+                iframe: self.parent_info.is_some(),
+                page_clip_rect: self.page_clip_rect.get(),
+            },
             document_root: root.to_trusted_node_address(),
-            url: self.get_url(),
-            iframe: self.parent_info.is_some(),
-            goal: goal,
             window_size: window_size,
             script_chan: self.control_chan.clone(),
             script_join_chan: join_chan,
             id: last_reflow_id.get(),
             query_type: query_type,
-            page_clip_rect: self.page_clip_rect.get(),
         };
 
         let LayoutChan(ref chan) = self.layout_chan;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -69,6 +69,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "clock_ticks"
+version = "0.0.4"
+source = "git+https://github.com/tomaka/clock_ticks#6a3005279bedc406b13eea09ff92447f05ca0de6"
+
+[[package]]
 name = "cocoa"
 version = "0.1.1"
 source = "git+https://github.com/servo/rust-cocoa#ca3441a14783aa0683e073f1a1f990ed21900718"
@@ -503,6 +508,7 @@ dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
+ "clock_ticks 0.0.4 (git+https://github.com/tomaka/clock_ticks)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",
  "encoding 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use properties::ComputedValues;
+use properties::longhands::transition_property::computed_value::TransitionProperty;
+use properties::longhands::transition_timing_function::computed_value::{StartEnd};
+use properties::longhands::transition_timing_function::computed_value::{TransitionTimingFunction};
+use properties::longhands::transition_property;
+use values::computed::{LengthOrPercentageOrAuto, Time};
+
+use std::num::Float;
+use util::bezier::Bezier;
+use util::geometry::Au;
+
+#[derive(Copy, Clone, Debug)]
+pub struct PropertyAnimation {
+    property: AnimatedProperty,
+    timing_function: TransitionTimingFunction,
+    duration: Time,
+}
+
+impl PropertyAnimation {
+    /// Creates a new property animation for the given transition index and old and new styles.
+    /// Any number of animations may be returned, from zero (if the property did not animate) to
+    /// one (for a single transition property) to arbitrarily many (for `all`).
+    pub fn from_transition(transition_index: usize,
+                           old_style: &ComputedValues,
+                           new_style: &mut ComputedValues)
+                           -> Vec<PropertyAnimation> {
+        let mut result = Vec::new();
+        let transition_property =
+            new_style.get_animation().transition_property.0[transition_index];
+        if transition_property != TransitionProperty::All {
+            if let Some(property_animation) =
+                    PropertyAnimation::from_transition_property(transition_property,
+                                                                transition_index,
+                                                                old_style,
+                                                                new_style) {
+                result.push(property_animation)
+            }
+            return result
+        }
+
+        for transition_property in
+                transition_property::computed_value::ALL_TRANSITION_PROPERTIES.iter() {
+            if let Some(property_animation) =
+                    PropertyAnimation::from_transition_property(*transition_property,
+                                                                transition_index,
+                                                                old_style,
+                                                                new_style) {
+                result.push(property_animation)
+            }
+        }
+
+        result
+    }
+
+    fn from_transition_property(transition_property: TransitionProperty,
+                                transition_index: usize,
+                                old_style: &ComputedValues,
+                                new_style: &mut ComputedValues)
+                                -> Option<PropertyAnimation> {
+        let animation_style = new_style.get_animation();
+        let animated_property = match transition_property {
+            TransitionProperty::All => {
+                panic!("Don't use `TransitionProperty::All` with \
+                        `PropertyAnimation::from_transition_property`!")
+            }
+            TransitionProperty::Top => {
+                AnimatedProperty::Top(old_style.get_positionoffsets().top,
+                                      new_style.get_positionoffsets().top)
+            }
+            TransitionProperty::Right => {
+                AnimatedProperty::Right(old_style.get_positionoffsets().right,
+                                        new_style.get_positionoffsets().right)
+            }
+            TransitionProperty::Bottom => {
+                AnimatedProperty::Bottom(old_style.get_positionoffsets().bottom,
+                                         new_style.get_positionoffsets().bottom)
+            }
+            TransitionProperty::Left => {
+                AnimatedProperty::Left(old_style.get_positionoffsets().left,
+                                       new_style.get_positionoffsets().left)
+            }
+        };
+
+        let property_animation = PropertyAnimation {
+            property: animated_property,
+            timing_function:
+                *animation_style.transition_timing_function.0.get_mod(transition_index),
+            duration: *animation_style.transition_duration.0.get_mod(transition_index),
+        };
+        if property_animation.does_not_animate() {
+            None
+        } else {
+            Some(property_animation)
+        }
+    }
+
+    pub fn update(&self, style: &mut ComputedValues, time: f64) {
+        let progress = match self.timing_function {
+            TransitionTimingFunction::CubicBezier(p1, p2) => {
+                // See `WebCore::AnimationBase::solveEpsilon(double)` in WebKit.
+                let epsilon = 1.0 / (200.0 * self.duration.seconds());
+                Bezier::new(p1, p2).solve(time, epsilon)
+            }
+            TransitionTimingFunction::Steps(steps, StartEnd::Start) => {
+                (time * (steps as f64)).ceil() / (steps as f64)
+            }
+            TransitionTimingFunction::Steps(steps, StartEnd::End) => {
+                (time * (steps as f64)).floor() / (steps as f64)
+            }
+        };
+        match self.property {
+            AnimatedProperty::Top(ref start, ref end) => {
+                if let Some(value) = start.interpolate(end, progress) {
+                    style.mutate_positionoffsets().top = value
+                }
+            }
+            AnimatedProperty::Right(ref start, ref end) => {
+                if let Some(value) = start.interpolate(end, progress) {
+                    style.mutate_positionoffsets().right = value
+                }
+            }
+            AnimatedProperty::Bottom(ref start, ref end) => {
+                if let Some(value) = start.interpolate(end, progress) {
+                    style.mutate_positionoffsets().bottom = value
+                }
+            }
+            AnimatedProperty::Left(ref start, ref end) => {
+                if let Some(value) = start.interpolate(end, progress) {
+                    style.mutate_positionoffsets().left = value
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn does_not_animate(&self) -> bool {
+        self.property.does_not_animate() || self.duration == Time(0.0)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum AnimatedProperty {
+    Top(LengthOrPercentageOrAuto, LengthOrPercentageOrAuto),
+    Right(LengthOrPercentageOrAuto, LengthOrPercentageOrAuto),
+    Bottom(LengthOrPercentageOrAuto, LengthOrPercentageOrAuto),
+    Left(LengthOrPercentageOrAuto, LengthOrPercentageOrAuto),
+}
+
+impl AnimatedProperty {
+    #[inline]
+    fn does_not_animate(&self) -> bool {
+        match *self {
+            AnimatedProperty::Top(ref a, ref b) |
+            AnimatedProperty::Right(ref a, ref b) |
+            AnimatedProperty::Bottom(ref a, ref b) |
+            AnimatedProperty::Left(ref a, ref b) => a == b,
+        }
+    }
+}
+
+trait Interpolate {
+    fn interpolate(&self, other: &Self, time: f64) -> Option<Self>;
+}
+
+impl Interpolate for Au {
+    #[inline]
+    fn interpolate(&self, other: &Au, time: f64) -> Option<Au> {
+        Some(Au((self.0 as f64 + (other.0 as f64 - self.0 as f64) * time).round() as i32))
+    }
+}
+
+impl Interpolate for f64 {
+    #[inline]
+    fn interpolate(&self, other: &f64, time: f64) -> Option<f64> {
+        Some(*self + (*other - *self) * time)
+    }
+}
+
+impl Interpolate for LengthOrPercentageOrAuto {
+    #[inline]
+    fn interpolate(&self, other: &LengthOrPercentageOrAuto, time: f64)
+                   -> Option<LengthOrPercentageOrAuto> {
+        match (*self, *other) {
+            (LengthOrPercentageOrAuto::Length(ref this),
+             LengthOrPercentageOrAuto::Length(ref other)) => {
+                this.interpolate(other, time).and_then(|value| {
+                    Some(LengthOrPercentageOrAuto::Length(value))
+                })
+            }
+            (LengthOrPercentageOrAuto::Percentage(ref this),
+             LengthOrPercentageOrAuto::Percentage(ref other)) => {
+                this.interpolate(other, time).and_then(|value| {
+                    Some(LengthOrPercentageOrAuto::Percentage(value))
+                })
+            }
+            (LengthOrPercentageOrAuto::Auto, LengthOrPercentageOrAuto::Auto) => {
+                Some(LengthOrPercentageOrAuto::Auto)
+            }
+            (_, _) => None,
+        }
+    }
+}
+
+/// Accesses an element of an array, "wrapping around" using modular arithmetic. This is needed
+/// to handle values of differing lengths according to CSS-TRANSITIONS § 2.
+pub trait GetMod {
+    type Item;
+    fn get_mod(&self, i: usize) -> &Self::Item;
+}
+
+impl<T> GetMod for Vec<T> {
+    type Item = T;
+    fn get_mod(&self, i: usize) -> &T {
+        &(*self)[i % self.len()]
+    }
+}
+

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -50,6 +50,7 @@ pub mod node;
 pub mod media_queries;
 pub mod font_face;
 pub mod legacy;
+pub mod animation;
 
 macro_rules! reexport_computed_values {
     ( $( $name: ident )+ ) => {

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -862,11 +862,57 @@ pub mod specified {
         "inset" => inset,
         "outset" => outset,
     }
+
+    /// A time in seconds according to CSS-VALUES § 6.2.
+    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+    pub struct Time(pub CSSFloat);
+
+    impl Time {
+        /// Returns the time in fractional seconds.
+        pub fn seconds(self) -> f64 {
+            let Time(seconds) = self;
+            seconds
+        }
+
+        /// Parses a time according to CSS-VALUES § 6.2.
+        fn parse_dimension(value: CSSFloat, unit: &str) -> Result<Time,()> {
+            if unit.eq_ignore_ascii_case("s") {
+                Ok(Time(value))
+            } else if unit.eq_ignore_ascii_case("ms") {
+                Ok(Time(value / 1000.0))
+            } else {
+                Err(())
+            }
+        }
+
+        pub fn parse(input: &mut Parser) -> Result<Time,()> {
+            match input.next() {
+                Ok(Token::Dimension(ref value, ref unit)) => {
+                    Time::parse_dimension(value.value, unit.as_slice())
+                }
+                _ => Err(()),
+            }
+        }
+    }
+
+    impl super::computed::ToComputedValue for Time {
+        type ComputedValue = Time;
+
+        #[inline]
+        fn to_computed_value(&self, _: &super::computed::Context) -> Time {
+            *self
+        }
+    }
+
+    impl ToCss for Time {
+        fn to_css<W>(&self, dest: &mut W) -> text_writer::Result where W: TextWriter {
+            dest.write_str(format!("{}ms", self.0).as_slice())
+        }
+    }
 }
 
-
 pub mod computed {
-    pub use super::specified::BorderStyle;
+    pub use super::specified::{BorderStyle, Time};
     use super::specified::{AngleOrCorner};
     use super::{specified, CSSFloat};
     pub use cssparser::Color as CSSColor;

--- a/components/util/bezier.rs
+++ b/components/util/bezier.rs
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Parametric Bézier curves.
+//!
+//! This is based on `WebCore/platform/graphics/UnitBezier.h` in WebKit.
+
+use geom::point::Point2D;
+use std::num::Float;
+
+const NEWTON_METHOD_ITERATIONS: u8 = 8;
+
+pub struct Bezier {
+    ax: f64,
+    bx: f64,
+    cx: f64,
+    ay: f64,
+    by: f64,
+    cy: f64,
+}
+
+impl Bezier {
+    #[inline]
+    pub fn new(p1: Point2D<f64>, p2: Point2D<f64>) -> Bezier {
+        let cx = 3.0 * p1.x;
+        let bx = 3.0 * (p2.x - p1.x) - cx;
+
+        let cy = 3.0 * p1.y;
+        let by = 3.0 * (p2.y - p1.y) - cy;
+
+        Bezier {
+            ax: 1.0 - cx - bx,
+            bx: bx,
+            cx: cx,
+            ay: 1.0 - cy - by,
+            by: by,
+            cy: cy,
+        }
+    }
+
+    #[inline]
+    fn sample_curve_x(&self, t: f64) -> f64 {
+        // ax * t^3 + bx * t^2 + cx * t
+        ((self.ax * t + self.bx) * t + self.cx) * t
+    }
+
+    #[inline]
+    fn sample_curve_y(&self, t: f64) -> f64 {
+        ((self.ay * t + self.by) * t + self.cy) * t
+    }
+
+    #[inline]
+    fn sample_curve_derivative_x(&self, t: f64) -> f64 {
+        (3.0 * self.ax * t + 2.0 * self.bx) * t + self.cx
+    }
+
+    #[inline]
+    fn solve_curve_x(&self, x: f64, epsilon: f64) -> f64 {
+        // Fast path: Use Newton's method.
+        let mut t = x;
+        for _ in range(0, NEWTON_METHOD_ITERATIONS) {
+            let x2 = self.sample_curve_x(t);
+            if x2.approx_eq(x, epsilon) {
+                return t
+            }
+            let dx = self.sample_curve_derivative_x(t);
+            if dx.approx_eq(0.0, 1e-6) {
+                break
+            }
+            t -= (x2 - x) / dx;
+        }
+
+        // Slow path: Use bisection.
+        let (mut lo, mut hi, mut t) = (0.0, 1.0, x);
+
+        if t < lo {
+            return lo
+        }
+        if t > hi {
+            return hi
+        }
+
+        while lo < hi {
+            let x2 = self.sample_curve_x(t);
+            if x2.approx_eq(x, epsilon) {
+                return t
+            }
+            if x > x2 {
+                lo = t
+            } else {
+                hi = t
+            }
+            t = (hi - lo) / 2.0 + lo
+        }
+
+        t
+    }
+
+    #[inline]
+    pub fn solve(&self, x: f64, epsilon: f64) -> f64 {
+        self.sample_curve_y(self.solve_curve_x(x, epsilon))
+    }
+}
+
+trait ApproxEq {
+    fn approx_eq(self, value: Self, epsilon: Self) -> bool;
+}
+
+impl ApproxEq for f64 {
+    #[inline]
+    fn approx_eq(self, value: f64, epsilon: f64) -> bool {
+        (self - value).abs() < epsilon
+    }
+}
+

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -41,6 +41,7 @@ pub use selectors::smallvec;
 
 use std::sync::Arc;
 
+pub mod bezier;
 pub mod cache;
 pub mod cursor;
 pub mod debug_utils;

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -74,6 +74,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "clock_ticks"
+version = "0.0.4"
+source = "git+https://github.com/tomaka/clock_ticks#6a3005279bedc406b13eea09ff92447f05ca0de6"
+
+[[package]]
 name = "cocoa"
 version = "0.1.1"
 source = "git+https://github.com/servo/rust-cocoa#ca3441a14783aa0683e073f1a1f990ed21900718"
@@ -508,6 +513,7 @@ dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
+ "clock_ticks 0.0.4 (git+https://github.com/tomaka/clock_ticks)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",
  "encoding 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -62,6 +62,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "clock_ticks"
+version = "0.0.4"
+source = "git+https://github.com/tomaka/clock_ticks#6a3005279bedc406b13eea09ff92447f05ca0de6"
+
+[[package]]
 name = "compositing"
 version = "0.0.1"
 dependencies = [
@@ -433,6 +438,7 @@ dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
+ "clock_ticks 0.0.4 (git+https://github.com/tomaka/clock_ticks)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",
  "encoding 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",

--- a/tests/html/transition_all.html
+++ b/tests/html/transition_all.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+section {
+    position: absolute;
+    display: block;
+    left: 0;
+    width: 64px;
+    height: 64px;
+    background: cadetblue;
+    transition: all 3s ease;
+    -moz-transition: all 3s ease;
+}
+</style>
+</head>
+<body>
+<section></section>
+<script>
+var sections = document.getElementsByTagName('section');
+sections[0].setAttribute('style', "left: 0; top: 0");
+setTimeout(function() {
+    sections[0].setAttribute('style', "left: 512px; top: 512px");
+}, 0);
+</script>
+</body>
+</html>
+
+

--- a/tests/html/transition_multiple.html
+++ b/tests/html/transition_multiple.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+section {
+    position: absolute;
+    display: block;
+    left: 0;
+    width: 64px;
+    height: 64px;
+    background: cadetblue;
+    transition: left 3s ease, top 1500ms ease;
+}
+</style>
+</head>
+<body>
+<section></section>
+<script>
+var sections = document.getElementsByTagName('section');
+sections[0].setAttribute('style', "left: 0; top: 0");
+setTimeout(function() {
+    sections[0].setAttribute('style', "left: 512px; top: 512px");
+}, 0);
+</script>
+</body>
+</html>
+
+

--- a/tests/html/transition_simple.html
+++ b/tests/html/transition_simple.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+section {
+    position: absolute;
+    display: block;
+    left: 0;
+    width: 64px;
+    height: 64px;
+    background: firebrick;
+    transition-property: left;
+    transition-duration: 3s;
+    -moz-transition-property: left;
+    -moz-transition-duration: 3s;
+    -webkit-transition-property: left;
+    -webkit-transition-duration: 3s;
+}
+#a {
+    top: 0;
+    transition-timing-function: ease;
+    -moz-transition-timing-function: ease;
+    -webkit-transition-timing-function: ease;
+}
+#b {
+    top: 64px;
+    transition-timing-function: linear;
+    -moz-transition-timing-function: linear;
+    -webkit-transition-timing-function: linear;
+}
+#c {
+    top: 128px;
+    transition-timing-function: ease-in;
+    -moz-transition-timing-function: ease-in;
+    -webkit-transition-timing-function: ease-in;
+}
+#d {
+    top: 192px;
+    transition-timing-function: ease-out;
+    -moz-transition-timing-function: ease-out;
+    -webkit-transition-timing-function: ease-out;
+}
+#e {
+    top: 256px;
+    transition-timing-function: ease-in-out;
+    -moz-transition-timing-function: ease-in-out;
+    -webkit-transition-timing-function: ease-in-out;
+}
+#f {
+    top: 320px;
+    transition-timing-function: step-start;
+    -moz-transition-timing-function: step-start;
+    -webkit-transition-timing-function: step-start;
+}
+#g {
+    top: 356px;
+    transition-timing-function: step-end;
+    -moz-transition-timing-function: step-end;
+    -webkit-transition-timing-function: step-end;
+}
+#h {
+    top: 420px;
+    transition-timing-function: steps(3, start);
+    -moz-transition-timing-function: steps(3, start);
+    -webkit-transition-timing-function: steps(3, start);
+}
+#i {
+    top: 484px;
+    transition-timing-function: steps(3, end);
+    -moz-transition-timing-function: steps(3, end);
+    -webkit-transition-timing-function: steps(3, end);
+}
+</style>
+</head>
+<body>
+<section id=a></section>
+<section id=b></section>
+<section id=c></section>
+<section id=d></section>
+<section id=e></section>
+<section id=f></section>
+<section id=g></section>
+<section id=h></section>
+<section id=i></section>
+<script>
+var sections = document.getElementsByTagName('section');
+for (var i = 0; i < sections.length; i++)
+    sections[i].setAttribute('style', "left: 0");
+setTimeout(function() {
+    for (var i = 0; i < sections.length; i++)
+        sections[i].setAttribute('style', "left: 512px");
+}, 0);
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
Transition events are not yet supported, and the only animatable
properties are `top`, `right`, `bottom`, and `left`. However, all other
features of transitions are supported. There are no automated tests at
present because I'm not sure how best to test it, but three manual tests
are included.

r? @glennw
