### PR TITLE
Add space in mach command suggestion.

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -67,7 +67,7 @@ class MachCommands(CommandBase):
 
         print("The %s profile is not built. Please run './mach build%s' "
               "and try again." % ("release" if release else "dev",
-                                   "--release" if release else ""))
+                                   " --release" if release else ""))
         sys.exit()
 
     @Command('run',


### PR DESCRIPTION
Running `./mach run --release` without a release profile built suggests running `./mach build--release`. This PR adds a space before `--release`.
