### PR TITLE
Canvas: added arcTo() support.

### DIFF
--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(collections)]
+#![feature(std_misc)]
 
 extern crate azure;
 extern crate cssparser;

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -477,6 +477,19 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
         Ok(())
     }
 
+    fn ArcTo(self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, r: f64) -> Fallible<()> {
+        if !([cp1x, cp1y, cp2x, cp2y, r].iter().all(|x| x.is_finite())) {
+            return Ok(());
+        }
+        if r < 0.0 {
+            return Err(IndexSize);
+        }
+        self.renderer.send(CanvasMsg::ArcTo(Point2D(cp1x as f32, cp1y as f32),
+                                            Point2D(cp2x as f32, cp2y as f32),
+                                            r as f32)).unwrap();
+        Ok(())
+    }
+
     // https://html.spec.whatwg.org/#dom-context-2d-imagesmoothingenabled
     fn ImageSmoothingEnabled(self) -> bool {
         self.image_smoothing_enabled.get()

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -145,7 +145,10 @@ interface CanvasPathMethods {
                      unrestricted double x,
                      unrestricted double y);
 
-  //void arcTo(double x1, double y1, double x2, double y2, double radius);
+  [Throws]
+  void arcTo(unrestricted double x1, unrestricted double y1,
+             unrestricted double x2, unrestricted double y2,
+             unrestricted double radius);
 // NOT IMPLEMENTED  [LenientFloat] void arcTo(double x1, double y1, double x2, double y2, double radiusX, double radiusY, double rotation);
 
   //void rect(double x, double y, double w, double h);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -31,7 +31,7 @@ source = "git+https://github.com/tomaka/android-rs-glue#5a68056599fb498b0cf3715f
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#9aae2113fb19a34a67a82b7ec6a5e0b34e290d29"
+source = "git+https://github.com/servo/rust-azure#c71473d94ae24fb195987660698207d5088a4042"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -36,7 +36,7 @@ source = "git+https://github.com/tomaka/android-rs-glue#5a68056599fb498b0cf3715f
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#9aae2113fb19a34a67a82b7ec6a5e0b34e290d29"
+source = "git+https://github.com/servo/rust-azure#c71473d94ae24fb195987660698207d5088a4042"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#9aae2113fb19a34a67a82b7ec6a5e0b34e290d29"
+source = "git+https://github.com/servo/rust-azure#c71473d94ae24fb195987660698207d5088a4042"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.coincide.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.coincide.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.coincide.2.html]
-  type: testharness
-  [arcTo() draws a straight line to P1 if P1 = P2]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.collinear.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.collinear.1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.collinear.1.html]
-  type: testharness
-  [arcTo() with all points on a line, and P1 between P0/P2, draws a straight line to P1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.collinear.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.collinear.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.collinear.2.html]
-  type: testharness
-  [arcTo() with all points on a line, and P2 between P0/P1, draws a straight line to P1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.collinear.3.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.collinear.3.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.collinear.3.html]
-  type: testharness
-  [arcTo() with all points on a line, and P0 between P1/P2, draws a straight line to P1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.ensuresubpath.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.ensuresubpath.1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.ensuresubpath.1.html]
-  type: testharness
-  [If there is no subpath, the first control point is added (and nothing is drawn up to it)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.ensuresubpath.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.ensuresubpath.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.ensuresubpath.2.html]
-  type: testharness
-  [If there is no subpath, the first control point is added]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.negative.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.negative.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.negative.html]
-  type: testharness
-  [arcTo() with negative radius throws an exception]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.nonfinite.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.nonfinite.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.nonfinite.html]
-  type: testharness
-  [arcTo() with Infinity/NaN is ignored]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.end.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.end.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.shape.end.html]
-  type: testharness
-  [arcTo() does not draw anything from P1 to P2]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.zero.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.zero.1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.zero.1.html]
-  type: testharness
-  [arcTo() with zero radius draws a straight line from P0 to P1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.zero.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.zero.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.zero.2.html]
-  type: testharness
-  [arcTo() with zero radius draws a straight line from P0 to P1, even when all points are collinear]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.stroke.prune.arc.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.stroke.prune.arc.html.ini
@@ -1,5 +1,0 @@
-[2d.path.stroke.prune.arc.html]
-  type: testharness
-  [Zero-length line segments from arcTo and arc are removed before stroking]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -7083,9 +7083,6 @@
   [CanvasRenderingContext2D interface: attribute direction]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double)]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double)]
     expected: FAIL
 
@@ -7303,15 +7300,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "direction" with the proper type (69)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "arcTo" with the proper type (75)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "arcTo" with the proper type (76)]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: calling arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]


### PR DESCRIPTION
Based on the implementation in Firefox.

After comparing how `arcTo` works in different browsers, I've found the code in Firefox the cleanest implentation. It also performed better on some test, for example the one on [this site](http://flashcanvas.net/examples/dl.dropbox.com/u/1865210/mindcat/arcto.html). In (Linux) Firefox 36, it looks like [this](http://i59.tinypic.com/2ch5b2d.png), while in Chromium 41, [some features are missing](http://i58.tinypic.com/30u5w8z.png).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5414)

<!-- Reviewable:end -->
