### PR TITLE
Remove some unnecessary uses of `as_slice`

### DIFF
--- a/components/script/cors.rs
+++ b/components/script/cors.rs
@@ -171,7 +171,7 @@ impl CORSRequest {
         };
         // Substep 4
         if methods.len() == 0 || preflight.mode == RequestMode::ForcedPreflight {
-            methods = methods_substep4.as_slice();
+            methods = &methods_substep4;
         }
         // Substep 5
         if !is_simple_method(&self.method) &&
@@ -183,7 +183,7 @@ impl CORSRequest {
             if is_simple_header(&h) {
                 continue;
             }
-            if !headers.iter().any(|ref h2| h.name().eq_ignore_ascii_case(h2.as_slice())) {
+            if !headers.iter().any(|ref h2| h.name().eq_ignore_ascii_case(h2)) {
                 return error;
             }
         }
@@ -254,7 +254,7 @@ pub enum HeaderOrMethod {
 impl HeaderOrMethod {
     fn match_header(&self, header_name: &str) -> bool {
         match *self {
-            HeaderOrMethod::HeaderData(ref s) => s.as_slice().eq_ignore_ascii_case(header_name),
+            HeaderOrMethod::HeaderData(ref s) => s.eq_ignore_ascii_case(header_name),
             _ => false
         }
     }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -26,7 +26,7 @@ pub fn handle_evaluate_js(page: &Rc<Page>, pipeline: PipelineId, eval: String, r
     let page = get_page(&*page, pipeline);
     let window = page.window().root();
     let cx = window.r().get_cx();
-    let rval = window.r().evaluate_js_on_global_with_result(eval.as_slice());
+    let rval = window.r().evaluate_js_on_global_with_result(&eval);
 
     reply.send(if rval.is_undefined() {
         EvaluateJSReply::VoidValue
@@ -69,7 +69,7 @@ fn find_node_by_unique_id(page: &Rc<Page>, pipeline: PipelineId, node_id: String
     let node: JSRef<Node> = NodeCast::from_ref(document.r());
 
     for candidate in node.traverse_preorder() {
-        if candidate.get_unique_id().as_slice() == node_id.as_slice() {
+        if candidate.get_unique_id() == node_id {
             return Temporary::from_rooted(candidate);
         }
     }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -78,7 +78,7 @@ impl Str for AttrValue {
             AttrValue::String(ref value) |
                 AttrValue::TokenList(ref value, _) |
                 AttrValue::UInt(ref value, _) => &value,
-            AttrValue::Atom(ref value) => value.as_slice(),
+            AttrValue::Atom(ref value) => &value,
         }
     }
 }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -24,7 +24,7 @@ impl ByteString {
     /// otherwise.
     pub fn as_str<'a>(&'a self) -> Option<&'a str> {
         let ByteString(ref vec) = *self;
-        str::from_utf8(vec.as_slice()).ok()
+        str::from_utf8(&vec).ok()
     }
 
     /// Returns the underlying vector as a slice.

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -52,7 +52,7 @@ impl<'a> CanvasGradientMethods for JSRef<'a, CanvasGradient> {
 
         self.stops.borrow_mut().push(CanvasGradientStop {
             offset: (*offset) as f64,
-            color: parse_color(color.as_slice()).unwrap_or(default_black),
+            color: parse_color(&color).unwrap_or(default_black),
         });
     }
 }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -493,7 +493,7 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
     fn SetStrokeStyle(self, value: StringOrCanvasGradientOrCanvasPattern) {
         match value {
             StringOrCanvasGradientOrCanvasPattern::eString(string) => {
-                match parse_color(string.as_slice()) {
+                match parse_color(&string) {
                     Ok(rgba) => {
                         self.stroke_color.set(rgba);
                         self.renderer
@@ -521,7 +521,7 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
     fn SetFillStyle(self, value: StringOrCanvasGradientOrCanvasPattern) {
         match value {
             StringOrCanvasGradientOrCanvasPattern::eString(string) => {
-                match parse_color(string.as_slice()) {
+                match parse_color(&string) {
                     Ok(rgba) => {
                         self.fill_color.set(rgba);
                         self.renderer
@@ -640,7 +640,7 @@ impl Drop for CanvasRenderingContext2D {
 }
 
 pub fn parse_color(string: &str) -> Result<RGBA,()> {
-    match CSSColor::parse(&mut Parser::new(string.as_slice())) {
+    match CSSColor::parse(&mut Parser::new(&string)) {
         Ok(CSSColor::RGBA(rgba)) => Ok(rgba),
         _ => Err(()),
     }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -52,7 +52,7 @@ macro_rules! css_properties(
 fn serialize_list(list: &Vec<PropertyDeclaration>) -> DOMString {
     let mut result = String::new();
     for declaration in list.iter() {
-        result.push_str(serialize_value(declaration).as_slice());
+        result.push_str(&serialize_value(declaration));
         result.push_str(" ");
     }
     result
@@ -131,10 +131,10 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
     // http://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
     fn GetPropertyValue(self, property: DOMString) -> DOMString {
         // Step 1
-        let property = Atom::from_slice(property.as_slice().to_ascii_lowercase().as_slice());
+        let property = Atom::from_slice(&property.to_ascii_lowercase());
 
         // Step 2
-        let longhand_properties = longhands_from_shorthand(property.as_slice());
+        let longhand_properties = longhands_from_shorthand(&property);
         if let Some(longhand_properties) = longhand_properties {
             // Step 2.1
             let mut list = vec!();
@@ -142,7 +142,7 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
             // Step 2.2
             for longhand in longhand_properties.iter() {
                 // Step 2.2.1
-                let declaration = self.get_declaration(&Atom::from_slice(longhand.as_slice()));
+                let declaration = self.get_declaration(&Atom::from_slice(&longhand));
 
                 // Step 2.2.2 & 2.2.3
                 match declaration {
@@ -166,15 +166,15 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
     // http://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertypriority
     fn GetPropertyPriority(self, property: DOMString) -> DOMString {
         // Step 1
-        let property = Atom::from_slice(property.as_slice().to_ascii_lowercase().as_slice());
+        let property = Atom::from_slice(&property.to_ascii_lowercase());
 
         // Step 2
-        let longhand_properties = longhands_from_shorthand(property.as_slice());
+        let longhand_properties = longhands_from_shorthand(&property);
         if let Some(longhand_properties) = longhand_properties {
             // Step 2.1 & 2.2 & 2.3
             if longhand_properties.iter()
                                   .map(|longhand| self.GetPropertyPriority(longhand.clone()))
-                                  .all(|priority| priority.as_slice() == "important") {
+                                  .all(|priority| priority == "important") {
 
                 return "important".to_owned();
             }
@@ -196,10 +196,10 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         }
 
         // Step 2
-        let property = property.as_slice().to_ascii_lowercase();
+        let property = property.to_ascii_lowercase();
 
         // Step 3
-        if !is_supported_property(property.as_slice()) {
+        if !is_supported_property(&property) {
             return Ok(());
         }
 
@@ -209,20 +209,19 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         }
 
         // Step 5
-        let priority = priority.as_slice().to_ascii_lowercase();
-        if priority.as_slice() != "!important" && !priority.is_empty() {
+        let priority = priority.to_ascii_lowercase();
+        if priority != "!important" && !priority.is_empty() {
             return Ok(());
         }
 
         // Step 6
-        let mut synthesized_declaration = String::from_str(property.as_slice());
+        let mut synthesized_declaration = String::from_str(&property);
         synthesized_declaration.push_str(": ");
-        synthesized_declaration.push_str(value.as_slice());
+        synthesized_declaration.push_str(&value);
 
         let owner = self.owner.root();
         let window = window_from_node(owner.r()).root();
-        let decl_block = parse_style_attribute(synthesized_declaration.as_slice(),
-                                               &window.r().get_url());
+        let decl_block = parse_style_attribute(&synthesized_declaration, &window.r().get_url());
 
         // Step 7
         if decl_block.normal.len() == 0 {
@@ -253,23 +252,22 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         }
 
         // Step 2
-        let property = property.as_slice().to_ascii_lowercase();
+        let property = property.to_ascii_lowercase();
 
         // Step 3
-        if !is_supported_property(property.as_slice()) {
+        if !is_supported_property(&property) {
             return Ok(());
         }
 
         // Step 4
-        let priority = priority.as_slice().to_ascii_lowercase();
-        if priority.as_slice() != "important" && !priority.is_empty() {
+        let priority = priority.to_ascii_lowercase();
+        if priority != "important" && !priority.is_empty() {
             return Ok(());
         }
 
         let owner = self.owner.root();
         let window = window_from_node(owner.r()).root();
-        let decl_block = parse_style_attribute(property.as_slice(),
-                                               &window.r().get_url());
+        let decl_block = parse_style_attribute(&property, &window.r().get_url());
         let element: JSRef<Element> = ElementCast::from_ref(owner.r());
 
         // Step 5
@@ -298,12 +296,12 @@ impl<'a> CSSStyleDeclarationMethods for JSRef<'a, CSSStyleDeclaration> {
         }
 
         // Step 2
-        let property = property.as_slice().to_ascii_lowercase();
+        let property = property.to_ascii_lowercase();
 
         // Step 3
         let value = self.GetPropertyValue(property.clone());
 
-        let longhand_properties = longhands_from_shorthand(property.as_slice());
+        let longhand_properties = longhands_from_shorthand(&property);
         match longhand_properties {
             Some(longhands) => {
                 // Step 4

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -323,7 +323,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
             let node: JSRef<Node> = NodeCast::from_ref(element);
             node.is_in_doc()
         });
-        assert!(!id.as_slice().is_empty());
+        assert!(!id.is_empty());
 
         let mut idmap = self.idmap.borrow_mut();
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -53,7 +53,7 @@ impl DOMImplementation {
 impl<'a> DOMImplementationMethods for JSRef<'a, DOMImplementation> {
     // http://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype
     fn CreateDocumentType(self, qname: DOMString, pubid: DOMString, sysid: DOMString) -> Fallible<Temporary<DocumentType>> {
-        match xml_name_type(qname.as_slice()) {
+        match xml_name_type(&qname) {
             // Step 1.
             InvalidXMLName => Err(InvalidCharacter),
             // Step 2.

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -94,7 +94,7 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
 
     // http://dom.spec.whatwg.org/#dom-domtokenlist-contains
     fn Contains(self, token: DOMString) -> Fallible<bool> {
-        self.check_token_exceptions(token.as_slice()).map(|token| {
+        self.check_token_exceptions(&token).map(|token| {
             self.attribute().root().map(|attr| {
                 // FIXME(https://github.com/rust-lang/rust/issues/23338)
                 let attr = attr.r();
@@ -112,7 +112,7 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
         let element = self.element.root();
         let mut atoms = element.r().get_tokenlist_attribute(&self.local_name);
         for token in tokens.iter() {
-            let token = try!(self.check_token_exceptions(token.as_slice()));
+            let token = try!(self.check_token_exceptions(&token));
             if !atoms.iter().any(|atom| *atom == token) {
                 atoms.push(token);
             }
@@ -126,7 +126,7 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
         let element = self.element.root();
         let mut atoms = element.r().get_tokenlist_attribute(&self.local_name);
         for token in tokens.iter() {
-            let token = try!(self.check_token_exceptions(token.as_slice()));
+            let token = try!(self.check_token_exceptions(&token));
             atoms.iter().position(|atom| *atom == token).map(|index| {
                 atoms.remove(index)
             });
@@ -139,7 +139,7 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
     fn Toggle(self, token: DOMString, force: Option<bool>) -> Fallible<bool> {
         let element = self.element.root();
         let mut atoms = element.r().get_tokenlist_attribute(&self.local_name);
-        let token = try!(self.check_token_exceptions(token.as_slice()));
+        let token = try!(self.check_token_exceptions(&token));
         match atoms.iter().position(|atom| *atom == token) {
             Some(index) => match force {
                 Some(true) => Ok(true),

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -76,7 +76,7 @@ impl HTMLCollection {
 
     pub fn by_tag_name(window: JSRef<Window>, root: JSRef<Node>, tag: DOMString)
                        -> Temporary<HTMLCollection> {
-        if tag.as_slice() == "*" {
+        if tag == "*" {
             return HTMLCollection::all_elements(window, root, None);
         }
 
@@ -95,8 +95,8 @@ impl HTMLCollection {
             }
         }
         let filter = TagNameFilter {
-            tag: Atom::from_slice(tag.as_slice()),
-            ascii_lower_tag: Atom::from_slice(tag.as_slice().to_ascii_lowercase().as_slice()),
+            tag: Atom::from_slice(&tag),
+            ascii_lower_tag: Atom::from_slice(&tag.to_ascii_lowercase()),
         };
         HTMLCollection::create(window, root, box filter)
     }
@@ -104,11 +104,11 @@ impl HTMLCollection {
     pub fn by_tag_name_ns(window: JSRef<Window>, root: JSRef<Node>, tag: DOMString,
                           maybe_ns: Option<DOMString>) -> Temporary<HTMLCollection> {
         let namespace_filter = match maybe_ns {
-            Some(ref namespace) if namespace.as_slice() == "*" => None,
+            Some(ref namespace) if namespace == &"*" => None,
             ns => Some(namespace::from_domstring(ns)),
         };
 
-        if tag.as_slice() == "*" {
+        if tag == "*" {
             return HTMLCollection::all_elements(window, root, namespace_filter);
         }
         #[jstraceable]
@@ -128,7 +128,7 @@ impl HTMLCollection {
             }
         }
         let filter = TagNameNSFilter {
-            tag: Atom::from_slice(tag.as_slice()),
+            tag: Atom::from_slice(&tag),
             namespace_filter: namespace_filter
         };
         HTMLCollection::create(window, root, box filter)
@@ -146,7 +146,7 @@ impl HTMLCollection {
             }
         }
         let filter = ClassNameFilter {
-            classes: split_html_space_chars(classes.as_slice()).map(|class| {
+            classes: split_html_space_chars(&classes).map(|class| {
                          Atom::from_slice(class)
                      }).collect()
         };

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -146,7 +146,7 @@ pub trait HTMLElementCustomAttributeHelpers {
 
 fn to_snake_case(name: DOMString) -> DOMString {
     let mut attr_name = "data-".to_owned();
-    for ch in name.as_slice().chars() {
+    for ch in name.chars() {
         if ch.is_uppercase() {
             attr_name.push('\x2d');
             attr_name.push(ch.to_lowercase());
@@ -170,7 +170,7 @@ impl<'a> HTMLElementCustomAttributeHelpers for JSRef<'a, HTMLElement> {
 
     fn get_custom_attr(self, name: DOMString) -> Option<DOMString> {
         let element: JSRef<Element> = ElementCast::from_ref(self);
-        element.get_attribute(ns!(""), &Atom::from_slice(to_snake_case(name).as_slice())).map(|attr| {
+        element.get_attribute(ns!(""), &Atom::from_slice(&to_snake_case(name))).map(|attr| {
             let attr = attr.root();
             // FIXME(https://github.com/rust-lang/rust/issues/23338)
             let attr = attr.r();
@@ -181,7 +181,7 @@ impl<'a> HTMLElementCustomAttributeHelpers for JSRef<'a, HTMLElement> {
 
     fn delete_custom_attr(self, name: DOMString) {
         let element: JSRef<Element> = ElementCast::from_ref(self);
-        element.remove_attribute(ns!(""), to_snake_case(name).as_slice())
+        element.remove_attribute(ns!(""), &to_snake_case(name))
     }
 }
 
@@ -196,7 +196,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
             s.after_set_attr(attr);
         }
 
-        let name = attr.local_name().as_slice();
+        let name = attr.local_name();
         if name.starts_with("on") {
             let window = window_from_node(*self).root();
             let (cx, url, reflector) = (window.r().get_cx(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -218,8 +218,7 @@ impl Window {
 }
 
 // http://www.whatwg.org/html/#atob
-pub fn base64_btoa(btoa: DOMString) -> Fallible<DOMString> {
-    let input = btoa.as_slice();
+pub fn base64_btoa(input: DOMString) -> Fallible<DOMString> {
     // "The btoa() method must throw an InvalidCharacterError exception if
     //  the method's first argument contains any character whose code point
     //  is greater than U+00FF."
@@ -239,10 +238,7 @@ pub fn base64_btoa(btoa: DOMString) -> Fallible<DOMString> {
 }
 
 // http://www.whatwg.org/html/#atob
-pub fn base64_atob(atob: DOMString) -> Fallible<DOMString> {
-    // "Let input be the string being parsed."
-    let input = atob.as_slice();
-
+pub fn base64_atob(input: DOMString) -> Fallible<DOMString> {
     // "Remove all space characters from input."
     // serialize::base64::from_base64 ignores \r and \n,
     // but it treats the other space characters as

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1074,7 +1074,7 @@ impl ScriptTask {
             window: JS::from_rooted(window.r()),
         }));
 
-        let is_javascript = incomplete.url.scheme.as_slice() == "javascript";
+        let is_javascript = incomplete.url.scheme == "javascript";
         let parse_input = if is_javascript {
             let evalstr = incomplete.url.non_relative_scheme_data().unwrap();
             let jsval = window.r().evaluate_js_on_global_with_result(evalstr);
@@ -1305,7 +1305,7 @@ impl ScriptTask {
         let resource_task = self.resource_task.clone();
 
         spawn_named(format!("fetch for {:?}", load_data.url.serialize()), move || {
-            if load_data.url.scheme.as_slice() == "javascript" {
+            if load_data.url.scheme == "javascript" {
                 load_data.url = Url::parse("about:blank").unwrap();
             }
 

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -140,13 +140,13 @@ impl TextInput {
             let lines_suffix = &self.lines[end.line + 1..];
 
             let mut insert_lines = if self.multiline {
-                insert.as_slice().split('\n').map(|s| s.to_owned()).collect()
+                insert.split('\n').map(|s| s.to_owned()).collect()
             } else {
                 vec!(insert)
             };
 
             let mut new_line = prefix.to_owned();
-            new_line.push_str(insert_lines[0].as_slice());
+            new_line.push_str(&insert_lines[0]);
             insert_lines[0] = new_line;
 
             let last_insert_lines_index = insert_lines.len() - 1;
@@ -157,7 +157,7 @@ impl TextInput {
 
             let mut new_lines = vec!();
             new_lines.push_all(lines_prefix);
-            new_lines.push_all(insert_lines.as_slice());
+            new_lines.push_all(&insert_lines);
             new_lines.push_all(lines_suffix);
             new_lines
         };
@@ -341,7 +341,7 @@ impl TextInput {
     pub fn get_content(&self) -> DOMString {
         let mut content = "".to_owned();
         for (i, line) in self.lines.iter().enumerate() {
-            content.push_str(line.as_slice());
+            content.push_str(&line);
             if i < self.lines.len() - 1 {
                 content.push('\n');
             }
@@ -353,7 +353,7 @@ impl TextInput {
     /// any \n encountered will be stripped and force a new logical line.
     pub fn set_content(&mut self, content: DOMString) {
         self.lines = if self.multiline {
-            content.as_slice().split('\n').map(|s| s.to_owned()).collect()
+            content.split('\n').map(|s| s.to_owned()).collect()
         } else {
             vec!(content)
         };
@@ -367,14 +367,14 @@ fn test_textinput_delete_char() {
     let mut textinput = TextInput::new(Lines::Single, "abcdefg".to_owned());
     textinput.adjust_horizontal(2, Selection::NotSelected);
     textinput.delete_char(DeleteDir::Backward);
-    assert_eq!(textinput.get_content().as_slice(), "acdefg");
+    assert_eq!(textinput.get_content(), "acdefg");
 
     textinput.delete_char(DeleteDir::Forward);
-    assert_eq!(textinput.get_content().as_slice(), "adefg");
+    assert_eq!(textinput.get_content(), "adefg");
 
     textinput.adjust_horizontal(2, Selection::Selected);
     textinput.delete_char(DeleteDir::Forward);
-    assert_eq!(textinput.get_content().as_slice(), "afg");
+    assert_eq!(textinput.get_content(), "afg");
 }
 
 #[test]
@@ -382,11 +382,11 @@ fn test_textinput_insert_char() {
     let mut textinput = TextInput::new(Lines::Single, "abcdefg".to_owned());
     textinput.adjust_horizontal(2, Selection::NotSelected);
     textinput.insert_char('a');
-    assert_eq!(textinput.get_content().as_slice(), "abacdefg");
+    assert_eq!(textinput.get_content(), "abacdefg");
 
     textinput.adjust_horizontal(2, Selection::Selected);
     textinput.insert_char('b');
-    assert_eq!(textinput.get_content().as_slice(), "ababefg");
+    assert_eq!(textinput.get_content(), "ababefg");
 }
 
 #[test]
@@ -413,7 +413,7 @@ fn test_textinput_replace_selection() {
     textinput.adjust_horizontal(2, Selection::Selected);
 
     textinput.replace_selection("xyz".to_owned());
-    assert_eq!(textinput.get_content().as_slice(), "abxyzefg");
+    assert_eq!(textinput.get_content(), "abxyzefg");
 }
 
 #[test]
@@ -470,12 +470,12 @@ fn test_textinput_handle_return() {
     let mut single_line_textinput = TextInput::new(Lines::Single, "abcdef".to_owned());
     single_line_textinput.adjust_horizontal(3, Selection::NotSelected);
     single_line_textinput.handle_return();
-    assert_eq!(single_line_textinput.get_content().as_slice(), "abcdef");
+    assert_eq!(single_line_textinput.get_content(), "abcdef");
 
     let mut multi_line_textinput = TextInput::new(Lines::Multiple, "abcdef".to_owned());
     multi_line_textinput.adjust_horizontal(3, Selection::NotSelected);
     multi_line_textinput.handle_return();
-    assert_eq!(multi_line_textinput.get_content().as_slice(), "abc\ndef");
+    assert_eq!(multi_line_textinput.get_content(), "abc\ndef");
 }
 
 #[test]
@@ -492,19 +492,19 @@ fn test_textinput_select_all() {
 #[test]
 fn test_textinput_get_content() {
     let single_line_textinput = TextInput::new(Lines::Single, "abcdefg".to_owned());
-    assert_eq!(single_line_textinput.get_content().as_slice(), "abcdefg");
+    assert_eq!(single_line_textinput.get_content(), "abcdefg");
 
     let multi_line_textinput = TextInput::new(Lines::Multiple, "abc\nde\nf".to_owned());
-    assert_eq!(multi_line_textinput.get_content().as_slice(), "abc\nde\nf");
+    assert_eq!(multi_line_textinput.get_content(), "abc\nde\nf");
 }
 
 #[test]
 fn test_textinput_set_content() {
     let mut textinput = TextInput::new(Lines::Multiple, "abc\nde\nf".to_owned());
-    assert_eq!(textinput.get_content().as_slice(), "abc\nde\nf");
+    assert_eq!(textinput.get_content(), "abc\nde\nf");
 
     textinput.set_content("abc\nf".to_owned());
-    assert_eq!(textinput.get_content().as_slice(), "abc\nf");
+    assert_eq!(textinput.get_content(), "abc\nf");
 
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 0);
@@ -512,7 +512,7 @@ fn test_textinput_set_content() {
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 3);
     textinput.set_content("de".to_owned());
-    assert_eq!(textinput.get_content().as_slice(), "de");
+    assert_eq!(textinput.get_content(), "de");
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 2);
 }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -815,7 +815,7 @@ source = "git+https://github.com/servo/rust-stb-image#b683cc9e7ba52a1bb65361347d
 [[package]]
 name = "string_cache"
 version = "0.0.0"
-source = "git+https://github.com/servo/string-cache#8c05fdf456a0e4f884e85d7e3a7700b2e4ca91eb"
+source = "git+https://github.com/servo/string-cache#124cb555651bd7838c5c6dc4788bc4f5350947a9"
 dependencies = [
  "lazy_static 0.1.8 (git+https://github.com/Kimundi/lazy-static.rs)",
  "phf 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "string_cache_plugin"
 version = "0.0.0"
-source = "git+https://github.com/servo/string-cache#8c05fdf456a0e4f884e85d7e3a7700b2e4ca91eb"
+source = "git+https://github.com/servo/string-cache#124cb555651bd7838c5c6dc4788bc4f5350947a9"
 dependencies = [
  "lazy_static 0.1.8 (git+https://github.com/Kimundi/lazy-static.rs)",
  "mac 0.0.2 (git+https://github.com/reem/rust-mac)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -840,7 +840,7 @@ source = "git+https://github.com/servo/rust-stb-image#b683cc9e7ba52a1bb65361347d
 [[package]]
 name = "string_cache"
 version = "0.0.0"
-source = "git+https://github.com/servo/string-cache#8c05fdf456a0e4f884e85d7e3a7700b2e4ca91eb"
+source = "git+https://github.com/servo/string-cache#124cb555651bd7838c5c6dc4788bc4f5350947a9"
 dependencies = [
  "lazy_static 0.1.8 (git+https://github.com/Kimundi/lazy-static.rs)",
  "phf 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "string_cache_plugin"
 version = "0.0.0"
-source = "git+https://github.com/servo/string-cache#8c05fdf456a0e4f884e85d7e3a7700b2e4ca91eb"
+source = "git+https://github.com/servo/string-cache#124cb555651bd7838c5c6dc4788bc4f5350947a9"
 dependencies = [
  "lazy_static 0.1.8 (git+https://github.com/Kimundi/lazy-static.rs)",
  "mac 0.0.2 (git+https://github.com/reem/rust-mac)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",
+ "profile 0.0.1",
  "script 0.0.1",
  "servo 0.0.1",
  "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -763,7 +764,7 @@ source = "git+https://github.com/servo/rust-stb-image#b683cc9e7ba52a1bb65361347d
 [[package]]
 name = "string_cache"
 version = "0.0.0"
-source = "git+https://github.com/servo/string-cache#8c05fdf456a0e4f884e85d7e3a7700b2e4ca91eb"
+source = "git+https://github.com/servo/string-cache#124cb555651bd7838c5c6dc4788bc4f5350947a9"
 dependencies = [
  "lazy_static 0.1.8 (git+https://github.com/Kimundi/lazy-static.rs)",
  "phf 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -775,7 +776,7 @@ dependencies = [
 [[package]]
 name = "string_cache_plugin"
 version = "0.0.0"
-source = "git+https://github.com/servo/string-cache#8c05fdf456a0e4f884e85d7e3a7700b2e4ca91eb"
+source = "git+https://github.com/servo/string-cache#124cb555651bd7838c5c6dc4788bc4f5350947a9"
 dependencies = [
  "lazy_static 0.1.8 (git+https://github.com/Kimundi/lazy-static.rs)",
  "mac 0.0.2 (git+https://github.com/reem/rust-mac)",
@@ -838,6 +839,7 @@ dependencies = [
 name = "util"
 version = "0.0.1"
 dependencies = [
+ "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",


### PR DESCRIPTION
For the majority of these cases, `as_slice` can be removed due to
`Deref`. In particular, `Deref` for:
- `String` -> `str`
- `Atom` -> `str`

The latter of those two requires, a bump of the locked `string-cache`
library
