### PR TITLE
Fix useless assert in script::dom::element

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -798,7 +798,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
     }
 
     fn set_atomic_attribute(self, name: &Atom, value: DOMString) {
-        assert!(name.eq_ignore_ascii_case(name));
+        assert!(name.as_slice() == name.to_ascii_lowercase());
         let value = AttrValue::from_atomic(value);
         self.set_attribute(name, value);
     }


### PR DESCRIPTION
We should ensure the parameter is lowercased. Right now, the assert will
always return true.

Discussed in #5445

Introduced in ee2ccc4f872ba33a86057d87a99d1015b3c41cf1
