### PR TITLE
Implement onsubmit and onfocusin event handlers

### DIFF
--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -227,5 +227,7 @@ macro_rules! global_event_handlers(
         event_handler!(click, GetOnclick, SetOnclick);
         event_handler!(input, GetOninput, SetOninput);
         event_handler!(change, GetOnchange, SetOnchange);
+        event_handler!(submit, GetOnsubmit, SetOnsubmit);
+        event_handler!(focusin, GetOnfocusin, SetOnfocusin);
     )
 );

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -228,6 +228,5 @@ macro_rules! global_event_handlers(
         event_handler!(input, GetOninput, SetOninput);
         event_handler!(change, GetOnchange, SetOnchange);
         event_handler!(submit, GetOnsubmit, SetOnsubmit);
-        event_handler!(focusin, GetOnfocusin, SetOnfocusin);
     )
 );

--- a/components/script/dom/webidls/EventHandler.webidl
+++ b/components/script/dom/webidls/EventHandler.webidl
@@ -26,7 +26,6 @@ interface GlobalEventHandlers {
            attribute EventHandler oninput;
            attribute EventHandler onchange;
            attribute EventHandler onsubmit;
-           attribute EventHandler onfocusin;
 };
 
 [NoInterfaceObject]

--- a/components/script/dom/webidls/EventHandler.webidl
+++ b/components/script/dom/webidls/EventHandler.webidl
@@ -25,6 +25,8 @@ interface GlobalEventHandlers {
            attribute EventHandler onload;
            attribute EventHandler oninput;
            attribute EventHandler onchange;
+           attribute EventHandler onsubmit;
+           attribute EventHandler onfocusin;
 };
 
 [NoInterfaceObject]

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -246,9 +246,6 @@
   [Document interface: attribute onstalled]
     expected: FAIL
 
-  [Document interface: attribute onsubmit]
-    expected: FAIL
-
   [Document interface: attribute onsuspend]
     expected: FAIL
 
@@ -262,9 +259,6 @@
     expected: FAIL
 
   [Document interface: attribute onwaiting]
-    expected: FAIL
-
-  [Document interface: attributon onsubmit]
     expected: FAIL
 
   [Stringification of iframe.contentDocument]
@@ -820,9 +814,6 @@
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "onstalled" with the proper type (149)]
-    expected: FAIL
-
-  [Document interface: iframe.contentDocument must inherit property "onsubmit" with the proper type (150)]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "onsuspend" with the proper type (151)]
@@ -1389,9 +1380,6 @@
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onstalled" with the proper type (149)]
     expected: FAIL
 
-  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onsubmit" with the proper type (150)]
-    expected: FAIL
-
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onsuspend" with the proper type (151)]
     expected: FAIL
 
@@ -1405,9 +1393,6 @@
     expected: FAIL
 
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onwaiting" with the proper type (155)]
-    expected: FAIL
-
-  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onsubmit" with the proper type (156)]
     expected: FAIL
 
   [MouseEvent interface: attribute region]
@@ -1926,9 +1911,6 @@
   [HTMLElement interface: attribute onstalled]
     expected: FAIL
 
-  [HTMLElement interface: attribute onsubmit]
-    expected: FAIL
-
   [HTMLElement interface: attribute onsuspend]
     expected: FAIL
 
@@ -1942,9 +1924,6 @@
     expected: FAIL
 
   [HTMLElement interface: attribute onwaiting]
-    expected: FAIL
-
-  [HTMLElement interface: attribute onsubmit]
     expected: FAIL
 
   [HTMLElement interface: document.createElement("noscript") must inherit property "translate" with the proper type (2)]
@@ -2187,9 +2166,6 @@
   [HTMLElement interface: document.createElement("noscript") must inherit property "onstalled" with the proper type (88)]
     expected: FAIL
 
-  [HTMLElement interface: document.createElement("noscript") must inherit property "onsubmit" with the proper type (89)]
-    expected: FAIL
-
   [HTMLElement interface: document.createElement("noscript") must inherit property "onsuspend" with the proper type (90)]
     expected: FAIL
 
@@ -2203,9 +2179,6 @@
     expected: FAIL
 
   [HTMLElement interface: document.createElement("noscript") must inherit property "onwaiting" with the proper type (94)]
-    expected: FAIL
-
-  [HTMLElement interface: document.createElement("noscript") must inherit property "onsubmit" with the proper type (95)]
     expected: FAIL
 
   [Element interface: document.createElement("noscript") must inherit property "hasAttributes" with the proper type (7)]
@@ -7896,9 +7869,6 @@
   [Window interface: attribute onstalled]
     expected: FAIL
 
-  [Window interface: attribute onsubmit]
-    expected: FAIL
-
   [Window interface: attribute onsuspend]
     expected: FAIL
 
@@ -8253,9 +8223,6 @@
   [Window interface: window must inherit property "onstalled" with the proper type (94)]
     expected: FAIL
 
-  [Window interface: window must inherit property "onsubmit" with the proper type (95)]
-    expected: FAIL
-
   [Window interface: window must inherit property "onsuspend" with the proper type (96)]
     expected: FAIL
 
@@ -8305,9 +8272,6 @@
     expected: FAIL
 
   [Window interface: window must inherit property "onstorage" with the proper type (112)]
-    expected: FAIL
-
-  [Window interface: window must inherit property "onsubmit" with the proper type (113)]
     expected: FAIL
 
   [Window interface: window must inherit property "createImageBitmap" with the proper type (122)]

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -264,6 +264,9 @@
   [Document interface: attribute onwaiting]
     expected: FAIL
 
+  [Document interface: attributon onsubmit]
+    expected: FAIL
+
   [Stringification of iframe.contentDocument]
     expected: FAIL
 
@@ -1404,6 +1407,9 @@
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onwaiting" with the proper type (155)]
     expected: FAIL
 
+  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "onsubmit" with the proper type (156)]
+    expected: FAIL
+
   [MouseEvent interface: attribute region]
     expected: FAIL
 
@@ -1938,6 +1944,9 @@
   [HTMLElement interface: attribute onwaiting]
     expected: FAIL
 
+  [HTMLElement interface: attribute onsubmit]
+    expected: FAIL
+
   [HTMLElement interface: document.createElement("noscript") must inherit property "translate" with the proper type (2)]
     expected: FAIL
 
@@ -2194,6 +2203,9 @@
     expected: FAIL
 
   [HTMLElement interface: document.createElement("noscript") must inherit property "onwaiting" with the proper type (94)]
+    expected: FAIL
+
+  [HTMLElement interface: document.createElement("noscript") must inherit property "onsubmit" with the proper type (95)]
     expected: FAIL
 
   [Element interface: document.createElement("noscript") must inherit property "hasAttributes" with the proper type (7)]
@@ -8293,6 +8305,9 @@
     expected: FAIL
 
   [Window interface: window must inherit property "onstorage" with the proper type (112)]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onsubmit" with the proper type (113)]
     expected: FAIL
 
   [Window interface: window must inherit property "createImageBitmap" with the proper type (122)]


### PR DESCRIPTION
fixes #5396 

jquery test suite is still broken with the following errors:

```
ERROR:js::rust: Error at http://localhost:8000/test/jquery.js:6: TypeError: window.location.pathname is undefined

ERROR:js::rust: Error at http://localhost:8000/test/data/testrunner.js:11: TypeError: jQuery is undefined
```
