### PR TITLE
Remove an unused import.

### DIFF
--- a/ports/gonk/build.rs
+++ b/ports/gonk/build.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::env;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();


### PR DESCRIPTION
I accidentally left it in after removing the calls to stdout/stderr in
d926b8342b492cfa442a72b4d4da01e7e23d9cba.
