### PR TITLE
Canvas: arc throws IndexSizeError on negative radius.

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -460,15 +460,21 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
                                                     Point2D(x as f32, y as f32))).unwrap();
     }
 
-    fn Arc(self, x: Finite<f64>, y: Finite<f64>, r: Finite<f64>, start: Finite<f64>, end: Finite<f64>, ccw: bool) {
+    fn Arc(self, x: Finite<f64>, y: Finite<f64>, r: Finite<f64>,
+           start: Finite<f64>, end: Finite<f64>, ccw: bool) -> Fallible<()> {
         let x = *x;
         let y = *y;
         let r = *r;
         let start = *start;
         let end = *end;
 
+        if r < 0.0 {
+            return Err(IndexSize);
+        }
+
         self.renderer.send(CanvasMsg::Arc(Point2D(x as f32, y as f32), r as f32,
                                           start as f32, end as f32, ccw)).unwrap();
+        Ok(())
     }
 
     // https://html.spec.whatwg.org/#dom-context-2d-imagesmoothingenabled

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -150,6 +150,7 @@ interface CanvasPathMethods {
 
   //void rect(double x, double y, double w, double h);
 
+  [Throws]
   void arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false);
 // NOT IMPLEMENTED  [LenientFloat] void ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, boolean anticlockwise);
 };

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.negative.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.negative.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arc.negative.html]
-  type: testharness
-  [arc() with negative radius throws INDEX_SIZE_ERR]
-    expected: FAIL
-


### PR DESCRIPTION
"Negative values for radius must cause the implementation to throw an IndexSizeError exception."
