### PR TITLE
Implement the :focus pseudo-class selector and element.focus/blur

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -582,6 +582,14 @@ impl<'le> TElement<'le> for LayoutElement<'le> {
     }
 
     #[inline]
+    fn get_focus_state(self) -> bool {
+        unsafe {
+            let node: &Node = NodeCast::from_actual(self.element);
+            node.get_focus_state_for_layout()
+        }
+    }
+
+    #[inline]
     fn get_id(self) -> Option<Atom> {
         unsafe {
             self.element.get_attr_atom_for_layout(&ns!(""), &atom!("id"))

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -454,7 +454,20 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
     /// transaction, or none if no elements requested it.
     fn commit_focus_transaction(self) {
         //TODO: dispatch blur, focus, focusout, and focusin events
+
+        if let Some(ref elem) = self.focused.get().root() {
+            let node: JSRef<Node> = NodeCast::from_ref(elem.r());
+            node.set_focus_state(false);
+        }
+
         self.focused.assign(self.possibly_focused.get());
+
+        if let Some(ref elem) = self.focused.get().root() {
+            let node: JSRef<Node> = NodeCast::from_ref(elem.r());
+            node.set_focus_state(true);
+        }
+        // TODO: Update the focus state for all elements in the focus chain.
+        // https://html.spec.whatwg.org/multipage/interaction.html#focus-chain
     }
 
     /// Handles any updates when the document's title has changed.

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1461,6 +1461,13 @@ impl<'a> style::node::TElement<'a> for JSRef<'a, Element> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         node.get_hover_state()
     }
+    fn get_focus_state(self) -> bool {
+        // TODO: Also check whether the top-level browsing context has the system focus,
+        // and whether this element is a browsing context container.
+        // https://html.spec.whatwg.org/multipage/scripting.html#selector-focus
+        let node: JSRef<Node> = NodeCast::from_ref(self);
+        node.get_focus_state()
+    }
     fn get_id(self) -> Option<Atom> {
         self.get_attribute(ns!(""), &atom!("id")).map(|attr| {
             let attr = attr.root();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -152,6 +152,8 @@ bitflags! {
         #[doc = "Specifies whether or not there is an authentic click in progress on \
                  this element."]
         const CLICK_IN_PROGRESS = 0x100,
+        #[doc = "Specifies whether this node has the focus."]
+        const IN_FOCUS_STATE = 0x200,
     }
 }
 
@@ -440,6 +442,9 @@ pub trait NodeHelpers<'a> {
     fn get_hover_state(self) -> bool;
     fn set_hover_state(self, state: bool);
 
+    fn get_focus_state(self) -> bool;
+    fn set_focus_state(self, state: bool);
+
     fn get_disabled_state(self) -> bool;
     fn set_disabled_state(self, state: bool);
 
@@ -616,6 +621,14 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
 
     fn set_hover_state(self, state: bool) {
         self.set_flag(IN_HOVER_STATE, state)
+    }
+
+    fn get_focus_state(self) -> bool {
+        self.get_flag(IN_FOCUS_STATE)
+    }
+
+    fn set_focus_state(self, state: bool) {
+        self.set_flag(IN_FOCUS_STATE, state)
     }
 
     fn get_disabled_state(self) -> bool {
@@ -1036,6 +1049,8 @@ pub trait RawLayoutNodeHelpers {
     #[allow(unsafe_code)]
     unsafe fn get_hover_state_for_layout(&self) -> bool;
     #[allow(unsafe_code)]
+    unsafe fn get_focus_state_for_layout(&self) -> bool;
+    #[allow(unsafe_code)]
     unsafe fn get_disabled_state_for_layout(&self) -> bool;
     #[allow(unsafe_code)]
     unsafe fn get_enabled_state_for_layout(&self) -> bool;
@@ -1047,6 +1062,11 @@ impl RawLayoutNodeHelpers for Node {
     #[allow(unsafe_code)]
     unsafe fn get_hover_state_for_layout(&self) -> bool {
         self.flags.get().contains(IN_HOVER_STATE)
+    }
+    #[inline]
+    #[allow(unsafe_code)]
+    unsafe fn get_focus_state_for_layout(&self) -> bool {
+        self.flags.get().contains(IN_FOCUS_STATE)
     }
     #[inline]
     #[allow(unsafe_code)]

--- a/components/script/dom/webidls/HTMLElement.webidl
+++ b/components/script/dom/webidls/HTMLElement.webidl
@@ -25,8 +25,8 @@ interface HTMLElement : Element {
            attribute boolean hidden;
   void click();
   //         attribute long tabIndex;
-  //void focus();
-  //void blur();
+  void focus();
+  void blur();
   //         attribute DOMString accessKey;
   //readonly attribute DOMString accessKeyLabel;
   //         attribute boolean draggable;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#12d3ce84a12ded4cf1def63651ccab06e1cfa80e"
+source = "git+https://github.com/servo/rust-selectors#0d7d846090c21d71ebb1bc17921806933a38f52b"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",
+ "net_traits 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile 0.0.1",
  "script_traits 0.0.1",
@@ -327,7 +328,7 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "net 0.0.1",
+ "net_traits 0.0.1",
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile 0.0.1",
@@ -533,7 +534,7 @@ dependencies = [
  "layout_traits 0.0.1",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "net 0.0.1",
+ "net_traits 0.0.1",
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile 0.0.1",
@@ -554,7 +555,7 @@ version = "0.0.1"
 dependencies = [
  "gfx 0.0.1",
  "msg 0.0.1",
- "net 0.0.1",
+ "net_traits 0.0.1",
  "profile 0.0.1",
  "script_traits 0.0.1",
  "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,14 +646,27 @@ dependencies = [
  "flate2 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "hyper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net_traits 0.0.1",
  "openssl 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile 0.0.1",
  "regex 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "util 0.0.1",
+]
+
+[[package]]
+name = "net_traits"
+version = "0.0.1"
+dependencies = [
+ "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
+ "hyper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
+ "profile 0.0.1",
+ "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -791,7 +805,7 @@ dependencies = [
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "net 0.0.1",
+ "net_traits 0.0.1",
  "plugins 0.0.1",
  "profile 0.0.1",
  "rustc-serialize 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -814,7 +828,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "net 0.0.1",
+ "net_traits 0.0.1",
  "url 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -822,7 +836,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#12d3ce84a12ded4cf1def63651ccab06e1cfa80e"
+source = "git+https://github.com/servo/rust-selectors#0d7d846090c21d71ebb1bc17921806933a38f52b"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",
@@ -843,6 +857,7 @@ dependencies = [
  "layout 0.0.1",
  "msg 0.0.1",
  "net 0.0.1",
+ "net_traits 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile 0.0.1",
  "script 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#12d3ce84a12ded4cf1def63651ccab06e1cfa80e"
+source = "git+https://github.com/servo/rust-selectors#0d7d846090c21d71ebb1bc17921806933a38f52b"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/tests/content/test_document_activeElement.html
+++ b/tests/content/test_document_activeElement.html
@@ -10,10 +10,9 @@
             is_not(document.activeElement, null, "test_1.1, document.activeElement");
             is(document.activeElement, document.body, "test_1.2, document.activeElement");
 
-            //TODO: uncomment following lines when focus() method will be available
-            //document.getElementById('foo').focus();
+            document.getElementById('foo').focus();
             is_not(document.activeElement, null, "test_2.1, document.activeElement");
-            //is(document.activeElement, document.getElementById("foo"), "test_2.2, document.activeElement");
+            is(document.activeElement, document.getElementById("foo"), "test_2.2, document.activeElement");
         </script>
     </body>
 </html>

--- a/tests/content/test_focus_blur.html
+++ b/tests/content/test_focus_blur.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <script src="harness.js"></script>
+</head>
+<body>
+  <input id="a">
+  <input id="b">
+  <script>
+    var a = document.getElementById("a");
+    var b = document.getElementById("b");
+
+    is(document.activeElement, document.body);
+    a.focus();
+    is(document.activeElement, a);
+    b.focus();
+    is(document.activeElement, b);
+    a.blur();
+    is(document.activeElement, b);
+    b.blur();
+    is(document.activeElement, document.body);
+  </script>
+</body>
+</html>

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -102,6 +102,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == floated_generated_content_a.html floated_generated_content_b.html
 == floated_list_item_a.html floated_list_item_ref.html
 == floated_table_with_margin_a.html floated_table_with_margin_ref.html
+== focus_selector.html focus_selector_ref.html
 == font_advance.html font_advance_ref.html
 == font_size.html font_size_ref.html
 == font_style.html font_style_ref.html

--- a/tests/ref/focus_selector.html
+++ b/tests/ref/focus_selector.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <style>
+      input:focus {
+        outline: 2px solid orange;
+      }
+    </style>
+  </head>
+  <body>
+    <input id="a">
+    <input id="b">
+    <script>
+      document.getElementById("a").focus();
+    </script>
+  </body>
+</html>

--- a/tests/ref/focus_selector_ref.html
+++ b/tests/ref/focus_selector_ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <style>
+      #a {
+        outline: 2px solid orange;
+      }
+    </style>
+  </head>
+  <body>
+    <input id="a">
+    <input id="b">
+  </body>
+</html>

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -1704,12 +1704,6 @@
   [HTMLElement interface: attribute tabIndex]
     expected: FAIL
 
-  [HTMLElement interface: operation focus()]
-    expected: FAIL
-
-  [HTMLElement interface: operation blur()]
-    expected: FAIL
-
   [HTMLElement interface: attribute accessKey]
     expected: FAIL
 
@@ -1957,12 +1951,6 @@
     expected: FAIL
 
   [HTMLElement interface: document.createElement("noscript") must inherit property "tabIndex" with the proper type (14)]
-    expected: FAIL
-
-  [HTMLElement interface: document.createElement("noscript") must inherit property "focus" with the proper type (15)]
-    expected: FAIL
-
-  [HTMLElement interface: document.createElement("noscript") must inherit property "blur" with the proper type (16)]
     expected: FAIL
 
   [HTMLElement interface: document.createElement("noscript") must inherit property "accessKey" with the proper type (17)]

--- a/tests/wpt/metadata/html/semantics/disabled-elements/disabledElement.html.ini
+++ b/tests/wpt/metadata/html/semantics/disabled-elements/disabledElement.html.ini
@@ -20,10 +20,3 @@
 
   [A disabled <input[type=radio\]> should not be focusable]
     expected: FAIL
-
-  [A disabled <a> should be focusable]
-    expected: FAIL
-
-  [A disabled <span> should be focusable]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes #5460. This supports for simple focusable elements that are their own DOM anchors, like text `input` fields.

Requires servo/rust-selectors#20.  r? @SimonSapin

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5461)

<!-- Reviewable:end -->
