### PR TITLE
Instead of panicking on broken url, break from the loop and return.

### DIFF
--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -274,7 +274,9 @@ pub fn parse_html(document: JSRef<Document>,
                     parser.parse_chunk(data);
                 }
                 ProgressMsg::Done(Err(err)) => {
-                    panic!("Failed to load page URL {}, error: {}", url.serialize(), err);
+                    debug!("Failed to load page URL {}, error: {}", url.serialize(), err);
+                    // TODO(Savago): we should send a notification to callers #5463.
+                    break;
                 }
                 ProgressMsg::Done(Ok(())) => break,
             }

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/security_location_0.sub.htm.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/security_location_0.sub.htm.ini
@@ -1,3 +1,4 @@
 [security_location_0.sub.htm]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT
+  disabled: Should fix behavior in servo.


### PR DESCRIPTION
Bug report on #5365.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5464)

<!-- Reviewable:end -->
