### PR TITLE
Implement TextEncoder (fixes #4768).

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -312,6 +312,7 @@ pub mod servohtmlparser;
 pub mod storage;
 pub mod storageevent;
 pub mod text;
+pub mod textencoder;
 pub mod treewalker;
 pub mod uievent;
 pub mod urlhelper;

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::Bindings::TextEncoderBinding;
+use dom::bindings::codegen::Bindings::TextEncoderBinding::TextEncoderMethods;
+use dom::bindings::global::GlobalRef;
+use dom::bindings::error::Fallible;
+use dom::bindings::error::Error::IndexSize;
+use dom::bindings::js::{JSRef, Temporary};
+use dom::bindings::str::USVString;
+use dom::bindings::utils::{Reflector, reflect_dom_object};
+
+use util::str::DOMString;
+
+use std::borrow::ToOwned;
+use std::ascii::AsciiExt;
+use std::ptr;
+
+use encoding::types::EncodingRef;
+use encoding::{Encoding, EncoderTrap};
+use encoding::label::encoding_from_whatwg_label;
+
+use libc::uint8_t;
+use js::jsapi::{JSContext, JSObject};
+use js::jsfriendapi::bindgen::{JS_NewUint8Array, JS_GetUint8ArrayData};
+
+#[dom_struct]
+pub struct TextEncoder {
+    reflector_: Reflector,
+    encoding: DOMString,
+    encoder: EncodingRef,
+}
+
+impl TextEncoder {
+    fn new_inherited(encoding: DOMString, encoder: EncodingRef) -> TextEncoder {
+        TextEncoder {
+            reflector_: Reflector::new(),
+            encoding: encoding,
+            encoder: encoder,
+        }
+    }
+
+    pub fn new(global: GlobalRef, encoding: DOMString, encoder: EncodingRef) -> Temporary<TextEncoder> {
+        reflect_dom_object(box TextEncoder::new_inherited(encoding, encoder),
+                           global,
+                           TextEncoderBinding::Wrap)
+    }
+
+    // https://encoding.spec.whatwg.org/#dom-textencoder
+    pub fn Constructor(global: GlobalRef,
+                       label: DOMString) -> Fallible<Temporary<TextEncoder>> {
+        let encoding = match encoding_from_whatwg_label(label.trim().as_slice().to_ascii_lowercase().as_slice()) {
+            Some(enc) => enc,
+            None => {
+                debug!("Encoding Label Not Supported");
+                // TODO: should throw RangeError
+                return Err(IndexSize)
+            }
+        };
+
+        match encoding.name() {
+            "utf-8" | "utf-16be" | "utf-16le" => {
+                Ok(TextEncoder::new(global, encoding.name().to_owned(), encoding))
+            }
+            _ => {
+                debug!("Encoding Not UTF");
+                // TODO: should throw RangeError
+                Err(IndexSize)
+            }
+        }
+    }
+}
+
+impl<'a> TextEncoderMethods for JSRef<'a, TextEncoder> {
+    // https://encoding.spec.whatwg.org/#dom-textencoder-encoding
+    fn Encoding(self) -> DOMString {
+        self.encoding.clone()
+    }
+
+    // https://encoding.spec.whatwg.org/#dom-textencoder-encode
+    #[allow(unsafe_code)]
+    fn Encode(self, cx: *mut JSContext, input: USVString) -> *mut JSObject {
+        unsafe {
+            let output = self.encoder.encode(input.0.as_slice(), EncoderTrap::Strict).unwrap();
+            let length = output.len() as u32;
+            let js_object: *mut JSObject = JS_NewUint8Array(cx, length);
+
+            let js_object_data: *mut uint8_t = JS_GetUint8ArrayData(js_object, cx);
+            ptr::copy_nonoverlapping(js_object_data, output.as_ptr(), length as usize);
+            return js_object;
+        }
+    }
+}

--- a/components/script/dom/webidls/TextEncoder.webidl
+++ b/components/script/dom/webidls/TextEncoder.webidl
@@ -1,0 +1,12 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* https://encoding.spec.whatwg.org/#interface-textencoder */
+[Constructor(optional DOMString utfLabel = "utf-8")/*, Exposed=Window,Worker */]
+interface TextEncoder {
+   readonly attribute DOMString encoding;
+   [NewObject]
+   Uint8Array encode(optional USVString input = "");
+};

--- a/tests/content/test_interfaces.html
+++ b/tests/content/test_interfaces.html
@@ -166,6 +166,7 @@ var interfaceNamesInGlobalScope = [
   "StorageEvent",
   "TestBinding", // XXX
   "Text",
+  "TextEncoder",
   "TreeWalker",
   "UIEvent",
   "URLSearchParams",

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -95,3 +95,5 @@ skip: true
   skip: true
 [webstorage]
   skip: false
+[encoding]
+  skip: false

--- a/tests/wpt/metadata/encoding/api-basics.html.ini
+++ b/tests/wpt/metadata/encoding/api-basics.html.ini
@@ -1,0 +1,20 @@
+[api-basics.html]
+  type: testharness
+  [Default encodings]
+    expected: FAIL
+
+  [Default inputs]
+    expected: FAIL
+
+  [Encode/decode round trip: utf-8]
+    expected: FAIL
+
+  [Encode/decode round trip: utf-16le]
+    expected: FAIL
+
+  [Encode/decode round trip: utf-16be]
+    expected: FAIL
+
+  [Encode/decode round trip: utf-16]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/api-replacement-encodings.html.ini
+++ b/tests/wpt/metadata/encoding/api-replacement-encodings.html.ini
@@ -1,0 +1,20 @@
+[api-replacement-encodings.html]
+  type: testharness
+  [The "replacement" label should not be a known encoding.]
+    expected: FAIL
+
+  [Label for "replacement" should be rejected by API: csiso2022kr]
+    expected: FAIL
+
+  [Label for "replacement" should be rejected by API: hz-gb-2312]
+    expected: FAIL
+
+  [Label for "replacement" should be rejected by API: iso-2022-cn]
+    expected: FAIL
+
+  [Label for "replacement" should be rejected by API: iso-2022-cn-ext]
+    expected: FAIL
+
+  [Label for "replacement" should be rejected by API: iso-2022-kr]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/api-surrogates-utf8.html.ini
+++ b/tests/wpt/metadata/encoding/api-surrogates-utf8.html.ini
@@ -1,0 +1,20 @@
+[api-surrogates-utf8.html]
+  type: testharness
+  [Invalid surrogates encoded into UTF-8: Sanity check]
+    expected: FAIL
+
+  [Invalid surrogates encoded into UTF-8: Surrogate half (low)]
+    expected: FAIL
+
+  [Invalid surrogates encoded into UTF-8: Surrogate half (high)]
+    expected: FAIL
+
+  [Invalid surrogates encoded into UTF-8: Surrogate half (low), in a string]
+    expected: FAIL
+
+  [Invalid surrogates encoded into UTF-8: Surrogate half (high), in a string]
+    expected: FAIL
+
+  [Invalid surrogates encoded into UTF-8: Wrong order]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/gb18030-encoder.html.ini
+++ b/tests/wpt/metadata/encoding/gb18030-encoder.html.ini
@@ -1,0 +1,20 @@
+[gb18030-encoder.html]
+  type: testharness
+  [gb18030 encoder: very basic]
+    expected: FAIL
+
+  [gb18030 encoder: Euro]
+    expected: FAIL
+
+  [gb18030 encoder: character]
+    expected: FAIL
+
+  [gb18030 encoder: PUA]
+    expected: FAIL
+
+  [gb18030 encoder: PUA #2]
+    expected: FAIL
+
+  [gb18030 encoder: poo]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/gbk-encoder.html.ini
+++ b/tests/wpt/metadata/encoding/gbk-encoder.html.ini
@@ -1,0 +1,20 @@
+[gbk-encoder.html]
+  type: testharness
+  [gbk encoder: very basic]
+    expected: FAIL
+
+  [gbk encoder: Euro]
+    expected: FAIL
+
+  [gbk encoder: character]
+    expected: FAIL
+
+  [gbk encoder: PUA]
+    expected: FAIL
+
+  [gbk encoder: PUA #2]
+    expected: FAIL
+
+  [gbk encoder: poo]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/idlharness.html.ini
+++ b/tests/wpt/metadata/encoding/idlharness.html.ini
@@ -1,0 +1,52 @@
+[idlharness.html]
+  type: testharness
+  [TextDecoder interface: existence and properties of interface object]
+    expected: FAIL
+
+  [TextDecoder interface object length]
+    expected: FAIL
+
+  [TextDecoder interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [TextDecoder interface: existence and properties of interface prototype object\'s "constructor" property]
+    expected: FAIL
+
+  [TextDecoder interface: attribute encoding]
+    expected: FAIL
+
+  [TextDecoder interface: attribute fatal]
+    expected: FAIL
+
+  [TextDecoder interface: attribute ignoreBOM]
+    expected: FAIL
+
+  [TextDecoder interface: operation decode(BufferSource,TextDecodeOptions)]
+    expected: FAIL
+
+  [TextDecoder must be primary interface of new TextDecoder()]
+    expected: FAIL
+
+  [Stringification of new TextDecoder()]
+    expected: FAIL
+
+  [TextDecoder interface: new TextDecoder() must inherit property "encoding" with the proper type (0)]
+    expected: FAIL
+
+  [TextDecoder interface: new TextDecoder() must inherit property "fatal" with the proper type (1)]
+    expected: FAIL
+
+  [TextDecoder interface: new TextDecoder() must inherit property "ignoreBOM" with the proper type (2)]
+    expected: FAIL
+
+  [TextDecoder interface: new TextDecoder() must inherit property "decode" with the proper type (3)]
+    expected: FAIL
+
+  [TextDecoder interface: calling decode(BufferSource,TextDecodeOptions) on new TextDecoder() with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TextEncoder interface object length]
+    expected: FAIL
+
+  [TextEncoder interface: operation encode(USVString)]
+    expected: FAIL

--- a/tests/wpt/metadata/encoding/iso-2022-jp-decoder.html.ini
+++ b/tests/wpt/metadata/encoding/iso-2022-jp-decoder.html.ini
@@ -1,0 +1,104 @@
+[iso-2022-jp-decoder.html]
+  type: testharness
+  [iso-2022-jp decoder: Error ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Error ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: ASCII ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Double ASCII ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, ASCII ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: characters]
+    expected: FAIL
+
+  [iso-2022-jp decoder: SO / SI]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Roman ESC, characters]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Roman ESC, SO / SI]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Roman ESC, error ESC, Katakana ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Katakana ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Katakana ESC, multibyte ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Katakana ESC, error ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Katakana ESC, error ESC #2, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Katakana ESC, character, Katakana ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Katakana ESC, SO / SI]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC #2, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC, error ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Double multibyte ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Double multibyte ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Double multibyte ESC #2, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC, error ESC #2, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC, single byte, multibyte ESC, character]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC, lead error byte]
+    expected: FAIL
+
+  [iso-2022-jp decoder: Multibyte ESC, trail error byte]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, error ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, error ESC #2]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, error ESC #3]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, ASCII ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, Roman ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, Katakana ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, Multibyte ESC]
+    expected: FAIL
+
+  [iso-2022-jp decoder: character, Multibyte ESC #2]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/iso-2022-jp-encoder.html.ini
+++ b/tests/wpt/metadata/encoding/iso-2022-jp-encoder.html.ini
@@ -1,0 +1,11 @@
+[iso-2022-jp-encoder.html]
+  type: testharness
+  [iso-2022-jp encoder: very basic]
+    expected: FAIL
+
+  [iso-2022-jp encoder: basics]
+    expected: FAIL
+
+  [iso-2022-jp encoder: SO/SI ESC]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/single-byte-decoder.html.ini
+++ b/tests/wpt/metadata/encoding/single-byte-decoder.html.ini
@@ -1,0 +1,3 @@
+[single-byte-decoder.html]
+  type: testharness
+  disabled: iframe thread issue 5247

--- a/tests/wpt/metadata/encoding/textdecoder-byte-order-marks.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-byte-order-marks.html.ini
@@ -1,0 +1,11 @@
+[textdecoder-byte-order-marks.html]
+  type: testharness
+  [Byte-order marks: utf-8]
+    expected: FAIL
+
+  [Byte-order marks: utf-16le]
+    expected: FAIL
+
+  [Byte-order marks: utf-16be]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textdecoder-fatal-streaming.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-fatal-streaming.html.ini
@@ -1,0 +1,8 @@
+[textdecoder-fatal-streaming.html]
+  type: testharness
+  [Fatal flag, non-streaming cases]
+    expected: FAIL
+
+  [Fatal flag, streaming cases]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textdecoder-fatal.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-fatal.html.ini
@@ -1,0 +1,107 @@
+[textdecoder-fatal.html]
+  type: testharness
+  [Fatal flag: utf-8 - invalid code]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - ends early]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - ends early 2]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - invalid trail]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - invalid trail 2]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - invalid trail 3]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - invalid trail 4]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - invalid trail 5]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - invalid trail 6]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - > 0x10FFFF]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - obsolete lead byte]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+0000 - 2 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+0000 - 3 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+0000 - 4 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+0000 - 5 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+0000 - 6 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+007F - 2 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+007F - 3 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+007F - 4 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+007F - 5 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+007F - 6 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+07FF - 3 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+07FF - 4 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+07FF - 5 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+07FF - 6 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+FFFF - 4 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+FFFF - 5 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+FFFF - 6 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+10FFFF - 5 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - overlong U+10FFFF - 6 bytes]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - lead surrogate]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - trail surrogate]
+    expected: FAIL
+
+  [Fatal flag: utf-8 - surrogate pair]
+    expected: FAIL
+
+  [Fatal flag: utf-16le - truncated code unit]
+    expected: FAIL
+
+  [The fatal attribute of TextDecoder]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textdecoder-ignorebom.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-ignorebom.html.ini
@@ -1,0 +1,14 @@
+[textdecoder-ignorebom.html]
+  type: testharness
+  [BOM is ignored if ignoreBOM option is specified: utf-8]
+    expected: FAIL
+
+  [BOM is ignored if ignoreBOM option is specified: utf-16le]
+    expected: FAIL
+
+  [BOM is ignored if ignoreBOM option is specified: utf-16be]
+    expected: FAIL
+
+  [The ignoreBOM attribute of TextDecoder]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textdecoder-labels.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-labels.html.ini
@@ -1,0 +1,635 @@
+[textdecoder-labels.html]
+  type: testharness
+  [name=utf-8 label=unicode-1-1-utf-8]
+    expected: FAIL
+
+  [name=utf-8 label=utf-8]
+    expected: FAIL
+
+  [name=utf-8 label=utf8]
+    expected: FAIL
+
+  [name=ibm866 label=866]
+    expected: FAIL
+
+  [name=ibm866 label=cp866]
+    expected: FAIL
+
+  [name=ibm866 label=csibm866]
+    expected: FAIL
+
+  [name=ibm866 label=ibm866]
+    expected: FAIL
+
+  [name=iso-8859-2 label=csisolatin2]
+    expected: FAIL
+
+  [name=iso-8859-2 label=iso-8859-2]
+    expected: FAIL
+
+  [name=iso-8859-2 label=iso-ir-101]
+    expected: FAIL
+
+  [name=iso-8859-2 label=iso8859-2]
+    expected: FAIL
+
+  [name=iso-8859-2 label=iso88592]
+    expected: FAIL
+
+  [name=iso-8859-2 label=iso_8859-2]
+    expected: FAIL
+
+  [name=iso-8859-2 label=iso_8859-2:1987]
+    expected: FAIL
+
+  [name=iso-8859-2 label=l2]
+    expected: FAIL
+
+  [name=iso-8859-2 label=latin2]
+    expected: FAIL
+
+  [name=iso-8859-3 label=csisolatin3]
+    expected: FAIL
+
+  [name=iso-8859-3 label=iso-8859-3]
+    expected: FAIL
+
+  [name=iso-8859-3 label=iso-ir-109]
+    expected: FAIL
+
+  [name=iso-8859-3 label=iso8859-3]
+    expected: FAIL
+
+  [name=iso-8859-3 label=iso88593]
+    expected: FAIL
+
+  [name=iso-8859-3 label=iso_8859-3]
+    expected: FAIL
+
+  [name=iso-8859-3 label=iso_8859-3:1988]
+    expected: FAIL
+
+  [name=iso-8859-3 label=l3]
+    expected: FAIL
+
+  [name=iso-8859-3 label=latin3]
+    expected: FAIL
+
+  [name=iso-8859-4 label=csisolatin4]
+    expected: FAIL
+
+  [name=iso-8859-4 label=iso-8859-4]
+    expected: FAIL
+
+  [name=iso-8859-4 label=iso-ir-110]
+    expected: FAIL
+
+  [name=iso-8859-4 label=iso8859-4]
+    expected: FAIL
+
+  [name=iso-8859-4 label=iso88594]
+    expected: FAIL
+
+  [name=iso-8859-4 label=iso_8859-4]
+    expected: FAIL
+
+  [name=iso-8859-4 label=iso_8859-4:1988]
+    expected: FAIL
+
+  [name=iso-8859-4 label=l4]
+    expected: FAIL
+
+  [name=iso-8859-4 label=latin4]
+    expected: FAIL
+
+  [name=iso-8859-5 label=csisolatincyrillic]
+    expected: FAIL
+
+  [name=iso-8859-5 label=cyrillic]
+    expected: FAIL
+
+  [name=iso-8859-5 label=iso-8859-5]
+    expected: FAIL
+
+  [name=iso-8859-5 label=iso-ir-144]
+    expected: FAIL
+
+  [name=iso-8859-5 label=iso8859-5]
+    expected: FAIL
+
+  [name=iso-8859-5 label=iso88595]
+    expected: FAIL
+
+  [name=iso-8859-5 label=iso_8859-5]
+    expected: FAIL
+
+  [name=iso-8859-5 label=iso_8859-5:1988]
+    expected: FAIL
+
+  [name=iso-8859-6 label=arabic]
+    expected: FAIL
+
+  [name=iso-8859-6 label=asmo-708]
+    expected: FAIL
+
+  [name=iso-8859-6 label=csiso88596e]
+    expected: FAIL
+
+  [name=iso-8859-6 label=csiso88596i]
+    expected: FAIL
+
+  [name=iso-8859-6 label=csisolatinarabic]
+    expected: FAIL
+
+  [name=iso-8859-6 label=ecma-114]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso-8859-6]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso-8859-6-e]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso-8859-6-i]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso-ir-127]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso8859-6]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso88596]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso_8859-6]
+    expected: FAIL
+
+  [name=iso-8859-6 label=iso_8859-6:1987]
+    expected: FAIL
+
+  [name=iso-8859-7 label=csisolatingreek]
+    expected: FAIL
+
+  [name=iso-8859-7 label=ecma-118]
+    expected: FAIL
+
+  [name=iso-8859-7 label=elot_928]
+    expected: FAIL
+
+  [name=iso-8859-7 label=greek]
+    expected: FAIL
+
+  [name=iso-8859-7 label=greek8]
+    expected: FAIL
+
+  [name=iso-8859-7 label=iso-8859-7]
+    expected: FAIL
+
+  [name=iso-8859-7 label=iso-ir-126]
+    expected: FAIL
+
+  [name=iso-8859-7 label=iso8859-7]
+    expected: FAIL
+
+  [name=iso-8859-7 label=iso88597]
+    expected: FAIL
+
+  [name=iso-8859-7 label=iso_8859-7]
+    expected: FAIL
+
+  [name=iso-8859-7 label=iso_8859-7:1987]
+    expected: FAIL
+
+  [name=iso-8859-7 label=sun_eu_greek]
+    expected: FAIL
+
+  [name=iso-8859-8 label=csiso88598e]
+    expected: FAIL
+
+  [name=iso-8859-8 label=csisolatinhebrew]
+    expected: FAIL
+
+  [name=iso-8859-8 label=hebrew]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso-8859-8]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso-8859-8-e]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso-ir-138]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso8859-8]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso88598]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso_8859-8]
+    expected: FAIL
+
+  [name=iso-8859-8 label=iso_8859-8:1988]
+    expected: FAIL
+
+  [name=iso-8859-8 label=visual]
+    expected: FAIL
+
+  [name=iso-8859-8-i label=csiso88598i]
+    expected: FAIL
+
+  [name=iso-8859-8-i label=iso-8859-8-i]
+    expected: FAIL
+
+  [name=iso-8859-8-i label=logical]
+    expected: FAIL
+
+  [name=iso-8859-10 label=csisolatin6]
+    expected: FAIL
+
+  [name=iso-8859-10 label=iso-8859-10]
+    expected: FAIL
+
+  [name=iso-8859-10 label=iso-ir-157]
+    expected: FAIL
+
+  [name=iso-8859-10 label=iso8859-10]
+    expected: FAIL
+
+  [name=iso-8859-10 label=iso885910]
+    expected: FAIL
+
+  [name=iso-8859-10 label=l6]
+    expected: FAIL
+
+  [name=iso-8859-10 label=latin6]
+    expected: FAIL
+
+  [name=iso-8859-13 label=iso-8859-13]
+    expected: FAIL
+
+  [name=iso-8859-13 label=iso8859-13]
+    expected: FAIL
+
+  [name=iso-8859-13 label=iso885913]
+    expected: FAIL
+
+  [name=iso-8859-14 label=iso-8859-14]
+    expected: FAIL
+
+  [name=iso-8859-14 label=iso8859-14]
+    expected: FAIL
+
+  [name=iso-8859-14 label=iso885914]
+    expected: FAIL
+
+  [name=iso-8859-15 label=csisolatin9]
+    expected: FAIL
+
+  [name=iso-8859-15 label=iso-8859-15]
+    expected: FAIL
+
+  [name=iso-8859-15 label=iso8859-15]
+    expected: FAIL
+
+  [name=iso-8859-15 label=iso885915]
+    expected: FAIL
+
+  [name=iso-8859-15 label=iso_8859-15]
+    expected: FAIL
+
+  [name=iso-8859-15 label=l9]
+    expected: FAIL
+
+  [name=iso-8859-16 label=iso-8859-16]
+    expected: FAIL
+
+  [name=koi8-r label=cskoi8r]
+    expected: FAIL
+
+  [name=koi8-r label=koi]
+    expected: FAIL
+
+  [name=koi8-r label=koi8]
+    expected: FAIL
+
+  [name=koi8-r label=koi8-r]
+    expected: FAIL
+
+  [name=koi8-r label=koi8_r]
+    expected: FAIL
+
+  [name=koi8-u label=koi8-u]
+    expected: FAIL
+
+  [name=macintosh label=csmacintosh]
+    expected: FAIL
+
+  [name=macintosh label=mac]
+    expected: FAIL
+
+  [name=macintosh label=macintosh]
+    expected: FAIL
+
+  [name=macintosh label=x-mac-roman]
+    expected: FAIL
+
+  [name=windows-874 label=dos-874]
+    expected: FAIL
+
+  [name=windows-874 label=iso-8859-11]
+    expected: FAIL
+
+  [name=windows-874 label=iso8859-11]
+    expected: FAIL
+
+  [name=windows-874 label=iso885911]
+    expected: FAIL
+
+  [name=windows-874 label=tis-620]
+    expected: FAIL
+
+  [name=windows-874 label=windows-874]
+    expected: FAIL
+
+  [name=windows-1250 label=cp1250]
+    expected: FAIL
+
+  [name=windows-1250 label=windows-1250]
+    expected: FAIL
+
+  [name=windows-1250 label=x-cp1250]
+    expected: FAIL
+
+  [name=windows-1251 label=cp1251]
+    expected: FAIL
+
+  [name=windows-1251 label=windows-1251]
+    expected: FAIL
+
+  [name=windows-1251 label=x-cp1251]
+    expected: FAIL
+
+  [name=windows-1252 label=ansi_x3.4-1968]
+    expected: FAIL
+
+  [name=windows-1252 label=ascii]
+    expected: FAIL
+
+  [name=windows-1252 label=cp1252]
+    expected: FAIL
+
+  [name=windows-1252 label=cp819]
+    expected: FAIL
+
+  [name=windows-1252 label=csisolatin1]
+    expected: FAIL
+
+  [name=windows-1252 label=ibm819]
+    expected: FAIL
+
+  [name=windows-1252 label=iso-8859-1]
+    expected: FAIL
+
+  [name=windows-1252 label=iso-ir-100]
+    expected: FAIL
+
+  [name=windows-1252 label=iso8859-1]
+    expected: FAIL
+
+  [name=windows-1252 label=iso88591]
+    expected: FAIL
+
+  [name=windows-1252 label=iso_8859-1]
+    expected: FAIL
+
+  [name=windows-1252 label=iso_8859-1:1987]
+    expected: FAIL
+
+  [name=windows-1252 label=l1]
+    expected: FAIL
+
+  [name=windows-1252 label=latin1]
+    expected: FAIL
+
+  [name=windows-1252 label=us-ascii]
+    expected: FAIL
+
+  [name=windows-1252 label=windows-1252]
+    expected: FAIL
+
+  [name=windows-1252 label=x-cp1252]
+    expected: FAIL
+
+  [name=windows-1253 label=cp1253]
+    expected: FAIL
+
+  [name=windows-1253 label=windows-1253]
+    expected: FAIL
+
+  [name=windows-1253 label=x-cp1253]
+    expected: FAIL
+
+  [name=windows-1254 label=cp1254]
+    expected: FAIL
+
+  [name=windows-1254 label=csisolatin5]
+    expected: FAIL
+
+  [name=windows-1254 label=iso-8859-9]
+    expected: FAIL
+
+  [name=windows-1254 label=iso-ir-148]
+    expected: FAIL
+
+  [name=windows-1254 label=iso8859-9]
+    expected: FAIL
+
+  [name=windows-1254 label=iso88599]
+    expected: FAIL
+
+  [name=windows-1254 label=iso_8859-9]
+    expected: FAIL
+
+  [name=windows-1254 label=iso_8859-9:1989]
+    expected: FAIL
+
+  [name=windows-1254 label=l5]
+    expected: FAIL
+
+  [name=windows-1254 label=latin5]
+    expected: FAIL
+
+  [name=windows-1254 label=windows-1254]
+    expected: FAIL
+
+  [name=windows-1254 label=x-cp1254]
+    expected: FAIL
+
+  [name=windows-1255 label=cp1255]
+    expected: FAIL
+
+  [name=windows-1255 label=windows-1255]
+    expected: FAIL
+
+  [name=windows-1255 label=x-cp1255]
+    expected: FAIL
+
+  [name=windows-1256 label=cp1256]
+    expected: FAIL
+
+  [name=windows-1256 label=windows-1256]
+    expected: FAIL
+
+  [name=windows-1256 label=x-cp1256]
+    expected: FAIL
+
+  [name=windows-1257 label=cp1257]
+    expected: FAIL
+
+  [name=windows-1257 label=windows-1257]
+    expected: FAIL
+
+  [name=windows-1257 label=x-cp1257]
+    expected: FAIL
+
+  [name=windows-1258 label=cp1258]
+    expected: FAIL
+
+  [name=windows-1258 label=windows-1258]
+    expected: FAIL
+
+  [name=windows-1258 label=x-cp1258]
+    expected: FAIL
+
+  [name=x-mac-cyrillic label=x-mac-cyrillic]
+    expected: FAIL
+
+  [name=x-mac-cyrillic label=x-mac-ukrainian]
+    expected: FAIL
+
+  [name=gbk label=chinese]
+    expected: FAIL
+
+  [name=gbk label=csgb2312]
+    expected: FAIL
+
+  [name=gbk label=csiso58gb231280]
+    expected: FAIL
+
+  [name=gbk label=gb2312]
+    expected: FAIL
+
+  [name=gbk label=gb_2312]
+    expected: FAIL
+
+  [name=gbk label=gb_2312-80]
+    expected: FAIL
+
+  [name=gbk label=gbk]
+    expected: FAIL
+
+  [name=gbk label=iso-ir-58]
+    expected: FAIL
+
+  [name=gbk label=x-gbk]
+    expected: FAIL
+
+  [name=gb18030 label=gb18030]
+    expected: FAIL
+
+  [name=big5 label=big5]
+    expected: FAIL
+
+  [name=big5 label=big5-hkscs]
+    expected: FAIL
+
+  [name=big5 label=cn-big5]
+    expected: FAIL
+
+  [name=big5 label=csbig5]
+    expected: FAIL
+
+  [name=big5 label=x-x-big5]
+    expected: FAIL
+
+  [name=euc-jp label=cseucpkdfmtjapanese]
+    expected: FAIL
+
+  [name=euc-jp label=euc-jp]
+    expected: FAIL
+
+  [name=euc-jp label=x-euc-jp]
+    expected: FAIL
+
+  [name=iso-2022-jp label=csiso2022jp]
+    expected: FAIL
+
+  [name=iso-2022-jp label=iso-2022-jp]
+    expected: FAIL
+
+  [name=shift_jis label=csshiftjis]
+    expected: FAIL
+
+  [name=shift_jis label=ms_kanji]
+    expected: FAIL
+
+  [name=shift_jis label=shift-jis]
+    expected: FAIL
+
+  [name=shift_jis label=shift_jis]
+    expected: FAIL
+
+  [name=shift_jis label=sjis]
+    expected: FAIL
+
+  [name=shift_jis label=windows-31j]
+    expected: FAIL
+
+  [name=shift_jis label=x-sjis]
+    expected: FAIL
+
+  [name=euc-kr label=cseuckr]
+    expected: FAIL
+
+  [name=euc-kr label=csksc56011987]
+    expected: FAIL
+
+  [name=euc-kr label=euc-kr]
+    expected: FAIL
+
+  [name=euc-kr label=iso-ir-149]
+    expected: FAIL
+
+  [name=euc-kr label=korean]
+    expected: FAIL
+
+  [name=euc-kr label=ks_c_5601-1987]
+    expected: FAIL
+
+  [name=euc-kr label=ks_c_5601-1989]
+    expected: FAIL
+
+  [name=euc-kr label=ksc5601]
+    expected: FAIL
+
+  [name=euc-kr label=ksc_5601]
+    expected: FAIL
+
+  [name=euc-kr label=windows-949]
+    expected: FAIL
+
+  [name=utf-16be label=utf-16be]
+    expected: FAIL
+
+  [name=utf-16le label=utf-16]
+    expected: FAIL
+
+  [name=utf-16le label=utf-16le]
+    expected: FAIL
+
+  [name=x-user-defined label=x-user-defined]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textdecoder-streaming.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-streaming.html.ini
@@ -1,0 +1,47 @@
+[textdecoder-streaming.html]
+  type: testharness
+  [Streaming decode: utf-8, 1 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-8, 2 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-8, 3 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-8, 4 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-8, 5 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16le, 1 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16le, 2 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16le, 3 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16le, 4 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16le, 5 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16be, 1 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16be, 2 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16be, 3 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16be, 4 byte window]
+    expected: FAIL
+
+  [Streaming decode: utf-16be, 5 byte window]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textdecoder-utf16-surrogates.html.ini
+++ b/tests/wpt/metadata/encoding/textdecoder-utf16-surrogates.html.ini
@@ -1,0 +1,32 @@
+[textdecoder-utf16-surrogates.html]
+  type: testharness
+  [utf-16le - lone surrogate lead]
+    expected: FAIL
+
+  [utf-16le - lone surrogate lead (fatal flag set)]
+    expected: FAIL
+
+  [utf-16le - lone surrogate trail]
+    expected: FAIL
+
+  [utf-16le - lone surrogate trail (fatal flag set)]
+    expected: FAIL
+
+  [utf-16le - unmatched surrogate lead]
+    expected: FAIL
+
+  [utf-16le - unmatched surrogate lead (fatal flag set)]
+    expected: FAIL
+
+  [utf-16le - unmatched surrogate trail]
+    expected: FAIL
+
+  [utf-16le - unmatched surrogate trail (fatal flag set)]
+    expected: FAIL
+
+  [utf-16le - swapped surrogate pair]
+    expected: FAIL
+
+  [utf-16le - swapped surrogate pair (fatal flag set)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textencoder-constructor-non-utf.html.ini
+++ b/tests/wpt/metadata/encoding/textencoder-constructor-non-utf.html.ini
@@ -1,0 +1,119 @@
+[textencoder-constructor-non-utf.html]
+  type: testharness
+  [UTF encodings are supported for encode and decode: utf-8]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: ibm866]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-2]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-3]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-4]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-5]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-6]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-7]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-8]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-8-i]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-10]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-13]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-14]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-15]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-8859-16]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: koi8-r]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: koi8-u]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: macintosh]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-874]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1250]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1251]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1252]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1253]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1254]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1255]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1256]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1257]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: windows-1258]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: x-mac-cyrillic]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: gbk]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: gb18030]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: big5]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: euc-jp]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: iso-2022-jp]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: shift_jis]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: euc-kr]
+    expected: FAIL
+
+  [UTF encodings are supported for encode and decode: utf-16be]
+    expected: FAIL
+
+  [UTF encodings are supported for encode and decode: utf-16le]
+    expected: FAIL
+
+  [Non-UTF encodings supported only for decode, not encode: x-user-defined]
+    expected: FAIL
+

--- a/tests/wpt/metadata/encoding/textencoder-utf16-surrogates.html.ini
+++ b/tests/wpt/metadata/encoding/textencoder-utf16-surrogates.html.ini
@@ -1,0 +1,19 @@
+[textencoder-utf16-surrogates.html]
+  type: testharness
+  [USVString handling: lone surrogate lead]
+    expected: FAIL
+
+  [USVString handling: lone surrogate trail]
+    expected: FAIL
+
+  [USVString handling: unmatched surrogate lead]
+    expected: FAIL
+
+  [USVString handling: unmatched surrogate trail]
+    expected: FAIL
+
+  [USVString handling: swapped surrogate pair]
+    expected: FAIL
+
+  [USVString handling: properly encoded MUSICAL SYMBOL G CLEF (U+1D11E)]
+    expected: FAIL


### PR DESCRIPTION
This is a series of already-reviewed changes by @yodalee from #5025, rebased onto current servo master, with some fixups applied:
- Fixed build errors/warnings from the latest rust upgrade.
- Marked `tests/wpt/web-platform-tests/encoding/single-byte-decoder.html` as expecting CRASH.

I could not verify locally that the new test annotation is correct, since the test appears to hang rather than crash on my Linux box.  (Or maybe I just didn't wait long enough.)  If this crash isn't consistent, or if it takes a long time, maybe we should skip this test instead?

r? @jdm 
