### PR TITLE
Show tabs in pre elements

### DIFF
--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -521,6 +521,9 @@ impl Shaper {
         // We elect to only space the two required code points.
         if character == ' ' || character == '\u{a0}' {
             advance = advance + options.word_spacing
+        } else if character == '\t' {
+            let tab_size = 8f64;
+            advance = Au::from_frac_px(tab_size * glyph_space_advance(self.font_and_shaping_options.font));
         }
 
         advance
@@ -561,6 +564,19 @@ extern fn glyph_h_advance_func(_: *mut hb_font_t,
         let advance = (*font).glyph_h_advance(glyph as GlyphId);
         Shaper::float_to_fixed(advance)
     }
+}
+
+fn glyph_space_advance(font: *mut Font) -> f64 {
+    let space_unicode = ' ';
+    let space_glyph: hb_codepoint_t;
+    match unsafe {(*font).glyph_index(space_unicode)} {
+        Some(g) => {
+            space_glyph = g as hb_codepoint_t;
+        }
+        None => panic!("No space info")
+    }
+    let space_advance = unsafe {(*font).glyph_h_advance(space_glyph as GlyphId)};
+    space_advance
 }
 
 extern fn glyph_h_kerning_func(_: *mut hb_font_t,

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -245,6 +245,7 @@ experimental != overconstrained_block.html overconstrained_block_ref.html
 == position_relative_a.html position_relative_b.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html
+== pre_with_tab.html pre_with_tab_ref.html
 == pseudo_element_a.html pseudo_element_b.html
 == pseudo_inherit.html pseudo_inherit_ref.html
 == quotes_simple_a.html quotes_simple_ref.html

--- a/tests/ref/pre_with_tab.html
+++ b/tests/ref/pre_with_tab.html
@@ -1,0 +1,1 @@
+<html><body><pre>	tab</pre></body></html>

--- a/tests/ref/pre_with_tab_ref.html
+++ b/tests/ref/pre_with_tab_ref.html
@@ -1,0 +1,1 @@
+<html><body><pre>        tab</pre></body></html>


### PR DESCRIPTION
Display tab characters as 4 spaces for pre and other elements that don't
compress whitespace.

Fixes https://github.com/servo/servo/issues/4651

@pcwalton r?
