### PR TITLE
Instead of panicking on broken url, break from the loop and return.

### DIFF
--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -274,7 +274,9 @@ pub fn parse_html(document: JSRef<Document>,
                     parser.parse_chunk(data);
                 }
                 ProgressMsg::Done(Err(err)) => {
-                    panic!("Failed to load page URL {}, error: {}", url.serialize(), err);
+                    debug!("Failed to load page URL {}, error: {}", url.serialize(), err);
+                    // TODO(Savago): we should send a notification to callers #5463.
+                    break;
                 }
                 ProgressMsg::Done(Ok(())) => break,
             }

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/security_location_0.sub.htm.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/security_location_0.sub.htm.ini
@@ -1,3 +1,6 @@
 [security_location_0.sub.htm]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT
+  [Accessing location object from different origins doesn\'t raise SECURITY_ERR exception]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/browsers/the-window-object/security-window/window-security.sub.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/security-window/window-security.sub.html.ini
@@ -1,3 +1,6 @@
 [window-security.sub.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT
+  [Window Security testing]
+    expected: NOTRUN
+


### PR DESCRIPTION
Fixes #5365.
