### PR TITLE
Firefox timeline integration #4957

### DIFF
--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -1,0 +1,77 @@
+use rustc_serialize::json;
+use std::cell::RefCell;
+use std::mem;
+use std::net::TcpStream;
+use time::precise_time_ns;
+
+use actor::{Actor, ActorRegistry};
+use protocol::JsonPacketStream;
+
+pub struct FramerateActor {
+    name: String,
+    startTime: RefCell<Option<u64>>,
+    isRecording: RefCell<bool>,
+    ticks: RefCell<Vec<u64>>,
+}
+
+impl Actor for FramerateActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+
+    fn handle_message(&self,
+                      registry: &ActorRegistry,
+                      msg_type: &str,
+                      msg: &json::Object,
+                      stream: &mut TcpStream) -> Result<bool, ()> {
+        Ok(true)
+    }
+}
+
+impl FramerateActor {
+    pub fn new(registry: &ActorRegistry) -> FramerateActor {
+        FramerateActor {
+            name: registry.new_name("framerate"),
+            startTime: RefCell::new(None),
+            isRecording: RefCell::new(false),
+            ticks: RefCell::new(Vec::new()),
+        }
+    }
+
+    pub fn startRecording(&self) {
+        let currentTime = precise_time_ns();
+        *self.isRecording.borrow_mut() = true;
+        *self.startTime.borrow_mut() = Some(currentTime);
+
+        //TODO: request animation frame
+    }
+
+    pub fn stopRecording(&self) {
+        if !self.isRecording() {
+            return;
+        }
+        *self.isRecording.borrow_mut() = false;
+        *self.startTime.borrow_mut() = None;
+    }
+
+    pub fn isRecording(&self) -> bool {
+        *self.isRecording.borrow()
+    }
+
+    // callback on request animation frame
+    pub fn on_refresh_driver_tick(&self) {
+        if !self.isRecording() {
+            return;
+        }
+        //TODO: request animation frame
+
+        let startTime = self.startTime.borrow().unwrap();
+        self.ticks.borrow_mut().push(startTime - precise_time_ns());
+    }
+
+    pub fn get_pending_ticks(&self) -> Vec<u64> {
+        let mut ticks = self.ticks.borrow_mut();
+        mem::replace(&mut *ticks, Vec::new())
+    }
+}

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use rustc_serialize::json;
 use std::cell::RefCell;
 use std::mem;

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use rustc_serialize::json;
 use std::net::TcpStream;
 

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -1,0 +1,58 @@
+use rustc_serialize::json;
+use std::net::TcpStream;
+
+use actor::{Actor, ActorRegistry};
+
+#[derive(RustcEncodable)]
+pub struct TimelineMemoryReply {
+    jsObjectSize: u64,
+    jsStringSize: u64,
+    jsOtherSize: u64,
+    domSize: u64,
+    styleSize: u64,
+    otherSize: u64,
+    totalSize: u64,
+    jsMilliseconds: f64,
+    nonJSMilliseconds: f64,
+}
+
+pub struct MemoryActor {
+    pub name: String,
+}
+
+impl Actor for MemoryActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(&self,
+                      registry: &ActorRegistry,
+                      msg_type: &str,
+                      msg: &json::Object,
+                      stream: &mut TcpStream) -> Result<bool, ()> {
+        Ok(true)
+    }
+}
+
+impl MemoryActor {
+    pub fn new(registry: &ActorRegistry) -> MemoryActor {
+        MemoryActor {
+            name: registry.new_name("memory")
+        }
+    }
+
+    pub fn measure(&self) -> TimelineMemoryReply {
+        //TODO:
+        TimelineMemoryReply {
+            jsObjectSize: 1,
+            jsStringSize: 1,
+            jsOtherSize: 1,
+            domSize: 1,
+            styleSize: 1,
+            otherSize: 1,
+            totalSize: 1,
+            jsMilliseconds: 1.1,
+            nonJSMilliseconds: 1.1,
+        }
+    }
+}

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -60,6 +60,7 @@ pub struct TabActorMsg {
     outerWindowID: uint,
     consoleActor: String,
     inspectorActor: String,
+    timelineActor: String,
 }
 
 pub struct TabActor {
@@ -68,6 +69,7 @@ pub struct TabActor {
     pub url: String,
     pub console: String,
     pub inspector: String,
+    pub timeline: String,
 }
 
 impl Actor for TabActor {
@@ -143,6 +145,7 @@ impl TabActor {
             outerWindowID: 0, //FIXME: this should probably be the pipeline id
             consoleActor: self.console.clone(),
             inspectorActor: self.inspector.clone(),
+            timelineActor: self.timeline.clone(),
         }
     }
 }

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use msg::constellation_msg::PipelineId;
 use rustc_serialize::json;
 use std::cell::RefCell;

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -1,0 +1,339 @@
+use msg::constellation_msg::PipelineId;
+use rustc_serialize::json;
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+use std::net::TcpStream;
+use std::old_io::timer::sleep;
+use std::sync::Arc;
+use std::thread;
+use std::time::duration::Duration;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Sender, Receiver, TryRecvError};
+use time::precise_time_ns;
+
+use actor::{Actor, ActorRegistry};
+use actors::memory::{MemoryActor, TimelineMemoryReply};
+use actors::framerate::FramerateActor;
+use devtools_traits::DevtoolScriptControlMsg;
+use devtools_traits::DevtoolScriptControlMsg::{SetTimelineMarker, DropTimelineMarker};
+use devtools_traits::{TimelineMarker, TracingMetadata, TimelineMarkerType};
+use protocol::JsonPacketStream;
+
+pub struct TimelineActor {
+    name: String,
+    script_sender: Sender<DevtoolScriptControlMsg>,
+    marker_types: Vec<TimelineMarkerType>,
+    pipeline: PipelineId,
+    isRecording: Arc<AtomicBool>,
+    stream: RefCell<Option<TcpStream>>,
+}
+
+struct Emitter {
+    from: String,
+    stream: RefCell<TcpStream>,
+    framerateActor: RefCell<Option<FramerateActor>>,
+    markers: RefCell<Vec<TimelineMarkerReply>>,
+    memoryActor: RefCell<Option<MemoryActor>>,
+}
+
+#[derive(RustcEncodable)]
+struct IsRecordingReply {
+    from: String,
+    value: bool
+}
+
+#[derive(RustcEncodable)]
+struct StartReply {
+    from: String,
+    value: u64
+}
+
+#[derive(RustcEncodable)]
+struct StopReply {
+    from: String,
+    value: u64
+}
+
+#[derive(RustcEncodable)]
+struct TimelineMarkerReply {
+    name: String,
+    start: u64,
+    end: u64,
+    stack: Option<Vec<uint>>,
+    endStack: Option<Vec<uint>>,
+}
+
+#[derive(RustcEncodable)]
+struct MarkersEmitterReply {
+    __type__: String,
+    markers: RefCell<Vec<TimelineMarkerReply>>,
+    from: String,
+    endTime: u64,
+}
+
+#[derive(RustcEncodable)]
+struct MemoryEmitterReply {
+    __type__: String,
+    from: String,
+    delta: u64,
+    measurement: TimelineMemoryReply,
+}
+
+#[derive(RustcEncodable)]
+struct FramerateEmitterReply {
+    __type__: String,
+    from: String,
+    delta: u64,
+    timestamps: Vec<u64>,
+}
+
+static DEFAULT_TIMELINE_DATA_PULL_TIMEOUT: uint = 200; //ms
+
+impl TimelineActor {
+    pub fn new(name: String,
+               pipeline: PipelineId,
+               script_sender: Sender<DevtoolScriptControlMsg>) -> TimelineActor {
+
+        let mut marker_types = vec!(TimelineMarkerType::Reflow,
+                                    TimelineMarkerType::DOMEvent);
+
+        TimelineActor {
+            name: name,
+            pipeline: pipeline,
+            marker_types: marker_types,
+            script_sender: script_sender,
+            isRecording: Arc::new(AtomicBool::new(false)),
+            stream: RefCell::new(None),
+        }
+    }
+
+    fn pullTimelineData(&self, receiver: Receiver<TimelineMarker>, emitter: Emitter) {
+        let isRecording = self.isRecording.clone();
+
+        if !isRecording.load(Ordering::Relaxed) {
+            return;
+        }
+
+        /// Select root(with depth 0) TimelineMarker pair (IntervalStart + IntervalEnd)
+        /// from queue and add marker to emitter
+        /// Return true if closed (IntervalStart + IntervalEnd) pair was founded
+        fn group(queue: &mut VecDeque<TimelineMarker>, depth: uint,
+                        start_payload: Option<TimelineMarker>, emitter: &Emitter) -> bool {
+
+            match start_payload {
+                Some(start_payload) => {
+                    if start_payload.metadata != TracingMetadata::IntervalStart {
+                        panic!("Start payload doesn't have metadata IntervalStart");
+                    }
+                    match queue.pop_front() {
+                        Some(end_payload) => {
+                            match end_payload.metadata {
+                                TracingMetadata::IntervalEnd => {
+                                    if depth == 0 {
+                                        // Emit TimelineMarkerReply, pair was founded
+                                        emitter.add_marker(start_payload, end_payload);
+                                    }
+                                    return true;
+                                }
+                                TracingMetadata::IntervalStart => {
+                                    if group(queue, depth + 1, Some(end_payload), emitter) {
+                                        return group(queue, depth, Some(start_payload), emitter);
+                                    } else {
+                                        queue.push_front(start_payload);
+                                    }
+                                }
+                                _ => panic!("Unknown tracingMetadata")
+                            }
+                        },
+                        None => {
+                            queue.push_front(start_payload);
+                        },
+                    }
+                },
+                None => (),
+            };
+            false
+        }
+
+        thread::spawn(move || {
+            let mut queues = HashMap::new();
+            queues.insert("Reflow".to_string(), VecDeque::new());
+            queues.insert("DOMEvent".to_string(), VecDeque::new());
+
+            loop {
+                if !isRecording.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                // Creating queues by marker.name
+                loop {
+                    match receiver.try_recv() {
+                        Ok(marker) => {
+                            match queues.get_mut(&marker.name) {
+                                Some(list) => list.push_back(marker),
+                                None => ()
+                            }
+                        }
+
+                        Err(TryRecvError) => break
+                    }
+                }
+
+                // Emit all markers
+                for (name, queue) in queues.iter_mut() {
+                    let start_payload = queue.pop_front();
+                    group(queue, 0, start_payload, &emitter);
+                }
+                emitter.send();
+
+                sleep(Duration::milliseconds(DEFAULT_TIMELINE_DATA_PULL_TIMEOUT as i64));
+            }
+        });
+    }
+}
+
+impl Actor for TimelineActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(&self,
+                      registry: &ActorRegistry,
+                      msg_type: &str,
+                      msg: &json::Object,
+                      stream: &mut TcpStream) -> Result<bool, ()> {
+        Ok(match msg_type {
+            "start" => {
+                self.isRecording.store(true, Ordering::Relaxed);
+
+                let (tx, rx) = channel::<TimelineMarker>();
+                for marker_type in self.marker_types.iter() {
+                    self.script_sender.send(SetTimelineMarker(self.pipeline, marker_type.clone(), tx.clone()));
+                }
+
+                *self.stream.borrow_mut() = stream.try_clone().ok();
+                let emitter = Emitter {
+                    from: self.name(),
+                    stream: RefCell::new(stream.try_clone().ok().unwrap()),
+                    framerateActor: RefCell::new(None),
+                    markers: RefCell::new(Vec::new()),
+                    memoryActor: RefCell::new(None),
+                };
+
+                // init memoryActor
+                if msg.contains_key("withMemory") {
+                    *emitter.memoryActor.borrow_mut() = Some(MemoryActor::new(registry));
+                }
+
+                // init framerateActor
+                if msg.contains_key("withTicks") {
+                    let framerateActor = FramerateActor::new(registry);
+                    framerateActor.startRecording();
+                    *emitter.framerateActor.borrow_mut() = Some(framerateActor);
+                }
+
+                self.pullTimelineData(rx, emitter);
+
+                let msg = StartReply {
+                    from: self.name(),
+                    value: precise_time_ns(),
+                };
+                stream.write_json_packet(&msg);
+                true
+            }
+
+            "stop" => {
+                let msg = StopReply {
+                    from: self.name(),
+                    value: precise_time_ns()
+                };
+
+                stream.write_json_packet(&msg);
+                for marker_type in self.marker_types.iter() {
+                    self.script_sender.send(DropTimelineMarker(self.pipeline, marker_type.clone()));
+                }
+
+                self.isRecording.store(false, Ordering::Relaxed);
+                *self.stream.borrow_mut() = None;
+                true
+            }
+
+            "isRecording" => {
+                let msg = IsRecordingReply {
+                    from: self.name(),
+                    value: self.isRecording.load(Ordering::Relaxed)
+                };
+
+                stream.write_json_packet(&msg);
+                true
+            }
+
+            _ => {
+                false
+            }
+        })
+    }
+}
+
+impl Emitter {
+    fn add_marker(&self, start_payload: TimelineMarker, end_payload: TimelineMarker) -> () {
+        self.markers.borrow_mut().push(TimelineMarkerReply {
+            name: start_payload.name,
+            start: start_payload.time,
+            end: end_payload.time,
+            stack: start_payload.stack,
+            endStack: end_payload.stack,
+        });
+    }
+
+    fn send(&self) -> () {
+        let endTime = precise_time_ns();
+        let reply = MarkersEmitterReply {
+            __type__: "markers".to_string(),
+            markers: RefCell::new(Vec::new()),
+            from: self.from.clone(),
+            endTime: endTime,
+        };
+
+        let mut markers = self.markers.borrow_mut();
+        for marker in markers.drain() {
+            reply.markers.borrow_mut().push(marker);
+        }
+        self.stream.borrow_mut().write_json_packet(&reply);
+
+        match *self.framerateActor.borrow() {
+            Some(ref framerateActor) => {
+                let framerateReply = FramerateEmitterReply {
+                    __type__: "framerate".to_string(),
+                    from: self.from.clone(),
+                    delta: endTime,
+                    timestamps: framerateActor.get_pending_ticks(),
+                };
+                self.stream.borrow_mut().write_json_packet(&framerateReply);
+            }
+            None => ()
+        }
+
+        match *self.memoryActor.borrow() {
+            Some(ref memoryActor) => {
+                let memoryReply = MemoryEmitterReply {
+                    __type__: "memory".to_string(),
+                    from: self.from.clone(),
+                    delta: endTime,
+                    measurement: memoryActor.measure(),
+                };
+                self.stream.borrow_mut().write_json_packet(&memoryReply);
+            }
+            None => ()
+        }
+    }
+}
+
+impl Drop for Emitter {
+    fn drop(&mut self) {
+        match *self.framerateActor.borrow() {
+            Some(ref framerateActor) =>  framerateActor.stopRecording(),
+            None => ()
+        }
+    }
+}

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -84,6 +84,30 @@ pub struct NodeInfo {
     pub incompleteValue: bool,
 }
 
+#[derive(PartialEq, Eq)]
+pub enum TracingMetadata {
+    Default,
+    IntervalStart,
+    IntervalEnd,
+    Event,
+    EventBacktrace,
+}
+
+pub struct TimelineMarker {
+    pub name: String,
+    pub metadata: TracingMetadata,
+    pub time: u64,
+    pub stack: Option<Vec<uint>>,
+}
+
+#[derive(PartialEq, Eq)]
+#[derive(Hash)]
+#[derive(Clone)]
+pub enum TimelineMarkerType {
+    Reflow,
+    DOMEvent,
+}
+
 /// Messages to process in a particular script task, as instructed by a devtools client.
 pub enum DevtoolScriptControlMsg {
     EvaluateJS(PipelineId, String, Sender<EvaluateJSReply>),
@@ -93,6 +117,8 @@ pub enum DevtoolScriptControlMsg {
     GetLayout(PipelineId, String, Sender<(f32, f32)>),
     ModifyAttribute(PipelineId, String, Vec<Modification>),
     WantsLiveNotifications(PipelineId, bool),
+    SetTimelineMarker(PipelineId, TimelineMarkerType, Sender<TimelineMarker>),
+    DropTimelineMarker(PipelineId, TimelineMarkerType),
 }
 
 /// Messages to instruct devtools server to update its state relating to a particular

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use devtools_traits::{EvaluateJSReply, NodeInfo, Modification};
+use devtools_traits::{EvaluateJSReply, NodeInfo, Modification, TimelineMarker, TimelineMarkerType};
 use dom::bindings::conversions::FromJSValConvertible;
 use dom::bindings::conversions::StringificationBehavior;
 use dom::bindings::js::{JSRef, Temporary, OptionalRootable};
@@ -16,7 +16,7 @@ use dom::element::Element;
 use dom::document::DocumentHelpers;
 use page::Page;
 use msg::constellation_msg::PipelineId;
-use script_task::get_page;
+use script_task::{get_page, ScriptTask};
 
 use std::sync::mpsc::Sender;
 use std::rc::Rc;
@@ -110,4 +110,34 @@ pub fn handle_wants_live_notifications(page: &Rc<Page>, pipeline_id: PipelineId,
     let page = get_page(&*page, pipeline_id);
     let window = page.window().root();
     window.r().set_devtools_wants_updates(send_notifications);
+}
+
+pub fn handle_set_timeline_marker(page: &Rc<Page>,
+                                  script_task: &ScriptTask,
+                                  marker_type: TimelineMarkerType,
+                                  reply: Sender<TimelineMarker>) {
+    let window = page.window().root();
+    match marker_type {
+        TimelineMarkerType::Reflow => {
+            window.r().set_devtools_timeline_marker(TimelineMarkerType::Reflow, reply.clone());
+        }
+        TimelineMarkerType::DOMEvent => {
+            (*script_task).set_devtools_timeline_marker(TimelineMarkerType::DOMEvent, reply.clone());
+        }
+    }
+}
+
+pub fn handle_drop_timeline_marker(page: &Rc<Page>,
+                                   script_task: &ScriptTask,
+                                   marker_type: TimelineMarkerType) {
+    let window = page.window().root();
+    //TODO: drop by one
+    match marker_type {
+        TimelineMarkerType::Reflow => {
+            window.r().drop_devtools_timeline_markers();
+        }
+        TimelineMarkerType::DOMEvent => {
+            (*script_task).drop_devtools_timeline_markers();
+        }
+    }
 }

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -241,6 +241,7 @@ no_jsmanaged_fields!(ImageCacheTask, ScriptControlChan);
 no_jsmanaged_fields!(Atom, Namespace, Timer);
 no_jsmanaged_fields!(Trusted<T>);
 no_jsmanaged_fields!(PropertyDeclarationBlock);
+no_jsmanaged_fields!(HashSet<T>);
 // These three are interdependent, if you plan to put jsmanaged data
 // in one of these make sure it is propagated properly to containing structs
 no_jsmanaged_fields!(SubpageId, WindowSizeData, PipelineId);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -32,9 +32,10 @@ use page::Page;
 use script_task::{TimerSource, ScriptChan};
 use script_task::ScriptMsg;
 use script_traits::ScriptControlChan;
+use time::precise_time_ns;
 use timers::{IsInterval, TimerId, TimerManager, TimerCallback};
 
-use devtools_traits::DevtoolsControlChan;
+use devtools_traits::{DevtoolsControlChan, TimelineMarker, TimelineMarkerType, TracingMetadata};
 use msg::compositor_msg::ScriptListener;
 use msg::constellation_msg::{LoadData, PipelineId, SubpageId, ConstellationChan, WindowSizeData, WorkerId};
 use net::image_cache_task::ImageCacheTask;
@@ -54,13 +55,14 @@ use url::{Url, UrlParser};
 
 use libc;
 use rustc_serialize::base64::{FromBase64, ToBase64, STANDARD};
-use std::cell::{Cell, Ref, RefMut};
+use std::cell::{Cell, Ref, RefMut, RefCell};
+use std::collections::HashSet;
 use std::default::Default;
 use std::ffi::CString;
 use std::mem;
 use std::num::Float;
 use std::rc::Rc;
-use std::sync::mpsc::{channel, Receiver};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::mpsc::TryRecvError::{Empty, Disconnected};
 use time;
 
@@ -102,6 +104,10 @@ pub struct Window {
 
     /// For providing instructions to an optional devtools server.
     devtools_chan: Option<DevtoolsControlChan>,
+    /// For sending timeline markers. Will be ignored if
+    /// no devtools server
+    devtools_markers: RefCell<HashSet<TimelineMarkerType>>,
+    devtools_marker_sender: RefCell<Option<Sender<TimelineMarker>>>,
 
     /// A flag to indicate whether the developer tools have requested live updates of
     /// page changes.
@@ -477,6 +483,9 @@ pub trait WindowHelpers {
     fn IndexedGetter(self, _index: u32, _found: &mut bool) -> Option<Temporary<Window>>;
     fn thaw(self);
     fn freeze(self);
+    fn emit_timeline_marker(&self, timeline_type: TimelineMarkerType, marker: TimelineMarker);
+    fn set_devtools_timeline_marker(&self, marker: TimelineMarkerType, reply: Sender<TimelineMarker>);
+    fn drop_devtools_timeline_markers(&self);
 }
 
 pub trait ScriptHelpers {
@@ -547,6 +556,15 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
             None => return,
         };
 
+        self.emit_timeline_marker(
+            TimelineMarkerType::Reflow,
+            TimelineMarker {
+                name: String::from_str("Reflow"),
+                metadata: TracingMetadata::IntervalStart,
+                time: precise_time_ns(),
+                stack: None,
+        });
+
         // Layout will let us know when it's done.
         let (join_chan, join_port) = channel();
 
@@ -585,6 +603,15 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
         debug!("script: layout forked");
 
         self.join_layout();
+        // Emit Reflow marker to devtools
+        self.emit_timeline_marker(
+            TimelineMarkerType::Reflow,
+            TimelineMarker {
+                name: String::from_str("Reflow"),
+                metadata: TracingMetadata::IntervalEnd,
+                time: precise_time_ns(),
+                stack: None,
+        });
     }
 
     // FIXME(cgaebel): join_layout is racey. What if the compositor triggers a
@@ -778,6 +805,28 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
     fn freeze(self) {
         self.timers.suspend();
     }
+
+    fn emit_timeline_marker(&self, timeline_type: TimelineMarkerType, marker: TimelineMarker) {
+        if self.devtools_markers.borrow().contains(&timeline_type) {
+            match self.devtools_marker_sender.borrow().clone() {
+                Some(sender) => {
+                    sender.send(marker);
+                }
+                None => panic!("There is no marker sender")
+            }
+        }
+    }
+
+    fn set_devtools_timeline_marker(&self, marker: TimelineMarkerType, reply: Sender<TimelineMarker>) {
+        // Notice, overhead: each time on adding timeline marker Sender is copied and replaced
+        *self.devtools_marker_sender.borrow_mut() = Some(reply);
+        self.devtools_markers.borrow_mut().insert(marker);
+    }
+
+    fn drop_devtools_timeline_markers(&self) {
+        *self.devtools_marker_sender.borrow_mut() = None;
+        *self.devtools_markers.borrow_mut() = HashSet::new();
+    }
 }
 
 impl Window {
@@ -838,11 +887,15 @@ impl Window {
             layout_rpc: layout_rpc,
             layout_join_port: DOMRefCell::new(None),
             window_size: Cell::new(window_size),
+
+            devtools_marker_sender: RefCell::new(None),
+            devtools_markers: RefCell::new(HashSet::new()),
             devtools_wants_updates: Cell::new(false),
         };
 
         WindowBinding::Wrap(js_context.ptr, win)
     }
+
 }
 
 fn should_move_clip_rect(clip_rect: Rect<Au>, new_viewport: Rect<f32>) -> bool{


### PR DESCRIPTION
Available markers  only:
- Reflow
- DOMEvent

Also need to implement:
- Style marker
- Paint marker
- Javascript marker
- frames reply, depends on getting javascript stack

I decided to make pull request before implemented another markers for getting feedback.
mb it would be better to create separated tasks. 

Notices:
Marker doesn't fill `stack` and `stackEnd`
MemoryActor sends fake data because there is no memory profiler per tab
FramerateActor sends empty Vec, need implement http://mxr.mozilla.org/mozilla-central/source/dom/base/nsGlobalWindow.cpp#5240

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5485)

<!-- Reviewable:end -->
