### PR TITLE
layout: Simplify and improve the correctness of whitespace stripping in text layout, and unify the inline layout paths for pre- and normally-formatted text.

### DIFF
--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -16,6 +16,7 @@ use text::glyph::{CharIndex, GlyphStore};
 /// A single "paragraph" of text in one font size and style.
 #[derive(Clone)]
 pub struct TextRun {
+    /// The UTF-8 string represented by this text run.
     pub text: Arc<String>,
     pub font_template: Arc<FontTemplateData>,
     pub actual_pt_size: Au,
@@ -310,7 +311,8 @@ impl<'a> TextRun {
                         self.font_metrics.descent)
     }
 
-    pub fn metrics_for_slice(&self, glyphs: &GlyphStore, slice_range: &Range<CharIndex>) -> RunMetrics {
+    pub fn metrics_for_slice(&self, glyphs: &GlyphStore, slice_range: &Range<CharIndex>)
+                             -> RunMetrics {
         RunMetrics::new(glyphs.advance_for_char_range(slice_range),
                         self.font_metrics.ascent,
                         self.font_metrics.descent)

--- a/components/gfx/text/util.rs
+++ b/components/gfx/text/util.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use text::glyph::CharIndex;
-
 #[derive(PartialEq, Eq, Copy)]
 pub enum CompressionMode {
     CompressNone,
@@ -25,12 +23,10 @@ pub enum CompressionMode {
 pub fn transform_text(text: &str,
                       mode: CompressionMode,
                       incoming_whitespace: bool,
-                      output_text: &mut String,
-                      new_line_pos: &mut Vec<CharIndex>)
+                      output_text: &mut String)
                       -> bool {
     let out_whitespace = match mode {
         CompressionMode::CompressNone | CompressionMode::DiscardNewline => {
-            let mut new_line_index = CharIndex(0);
             for ch in text.chars() {
                 if is_discardable_char(ch, mode) {
                     // TODO: record skipped char
@@ -38,15 +34,6 @@ pub fn transform_text(text: &str,
                     // TODO: record kept char
                     if ch == '\t' {
                         // TODO: set "has tab" flag
-                    } else if ch == '\n' {
-                        // Save new-line's position for line-break
-                        // This value is relative(not absolute)
-                        new_line_pos.push(new_line_index);
-                        new_line_index = CharIndex(0);
-                    }
-
-                    if ch != '\n' {
-                        new_line_index = new_line_index + CharIndex(1);
                     }
                     output_text.push(ch);
                 }
@@ -124,6 +111,6 @@ pub fn fixed_to_rounded_int(before: isize, f: i32) -> isize {
     if f > 0i32 {
         ((half + f) >> before) as isize
     } else {
-       -((half - f) >> before) as isize
+       -((half - f) >> before as usize) as isize
     }
 }

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -39,7 +39,12 @@ pub fn null_str_as_empty_ref<'a>(s: &'a Option<DOMString>) -> &'a str {
 const WHITESPACE: &'static [char] = &[' ', '\t', '\x0a', '\x0c', '\x0d'];
 
 pub fn is_whitespace(s: &str) -> bool {
-    s.chars().all(|c| WHITESPACE.contains(&c))
+    s.chars().all(char_is_whitespace)
+}
+
+#[inline]
+pub fn char_is_whitespace(c: char) -> bool {
+    WHITESPACE.contains(&c)
 }
 
 /// A "space character" according to:

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -151,6 +151,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 != img_simple.html img_simple_ref.html
 == img_size_a.html img_size_b.html
 == incremental_float_a.html incremental_float_ref.html
+== incremental_inline_layout_a.html incremental_inline_layout_ref.html
 != inline_background_a.html inline_background_ref.html
 == inline_block_baseline_a.html inline_block_baseline_ref.html
 == inline_block_border_a.html inline_block_border_ref.html
@@ -184,6 +185,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == legacy_td_bgcolor_attribute_a.html legacy_td_bgcolor_attribute_ref.html
 == legacy_td_width_attribute_a.html legacy_td_width_attribute_ref.html
 == letter_spacing_a.html letter_spacing_ref.html
+== line_breaking_whitespace_collapse_a.html line_breaking_whitespace_collapse_ref.html
 == line_height_a.html line_height_ref.html
 != linear_gradients_corners_a.html linear_gradients_corners_ref.html
 == linear_gradients_lengths_a.html linear_gradients_lengths_ref.html

--- a/tests/ref/incremental_inline_layout_a.html
+++ b/tests/ref/incremental_inline_layout_a.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+h1 {
+    font-size: 72px;
+}
+</style>
+</head>
+<body>
+<h1 id=h1>
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+</h1>
+<script>
+document.getElementById('h1').getBoundingClientRect();  // Trigger one layout.
+document.getElementById('h1').getBoundingClientRect();  // Trigger another layout.
+</script>
+</body>
+</html>
+

--- a/tests/ref/incremental_inline_layout_ref.html
+++ b/tests/ref/incremental_inline_layout_ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+h1 {
+    font-size: 72px;
+}
+</style>
+</head>
+<body>
+<h1 id=h1>
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+Incremental Inline Layout
+</h1>
+</body>
+</html>
+

--- a/tests/ref/line_breaking_whitespace_collapse_a.html
+++ b/tests/ref/line_breaking_whitespace_collapse_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+p {
+    font-size: 10px;
+    font-family: Ahem, monospace;
+    width: 300px;
+}
+a {
+    color: blue;
+}
+</style>
+</head>
+<body>
+<p>xxxxx xxxxx <a>xxxxx xxx xxxxx</a> xxxxxxxxxxx</p>
+</body>
+

--- a/tests/ref/line_breaking_whitespace_collapse_ref.html
+++ b/tests/ref/line_breaking_whitespace_collapse_ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+p {
+    font-size: 10px;
+    font-family: Ahem, monospace;
+    width: 300px;
+}
+a {
+    color: blue;
+}
+</style>
+</head>
+<body>
+<p>xxxxx xxxxx <a>xxxxx xxx xxxxx</a><br>xxxxxxxxxxx</p>
+</body>
+

--- a/tests/unit/gfx/text_util.rs
+++ b/tests/unit/gfx/text_util.rs
@@ -18,9 +18,8 @@ fn test_transform_compress_none() {
 
     let mode = CompressionMode::CompressNone;
     for &test in test_strs.iter() {
-        let mut new_line_pos = vec![];
         let mut trimmed_str = String::new();
-        transform_text(test, mode, true, &mut trimmed_str, &mut new_line_pos);
+        transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(trimmed_str, test)
     }
 }
@@ -52,9 +51,8 @@ fn test_transform_discard_newline() {
 
     let mode = CompressionMode::DiscardNewline;
     for &(test, oracle) in test_strs.iter() {
-        let mut new_line_pos = vec![];
         let mut trimmed_str = String::new();
-        transform_text(test, mode, true, &mut trimmed_str, &mut new_line_pos);
+        transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(trimmed_str, oracle)
     }
 }
@@ -86,9 +84,8 @@ fn test_transform_compress_whitespace() {
 
     let mode = CompressionMode::CompressWhitespace;
     for &(test, oracle) in test_strs.iter() {
-        let mut new_line_pos = vec![];
         let mut trimmed_str = String::new();
-        transform_text(test, mode, true, &mut trimmed_str, &mut new_line_pos);
+        transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(&*trimmed_str, oracle)
     }
 }
@@ -120,9 +117,8 @@ fn test_transform_compress_whitespace_newline() {
 
     let mode = CompressionMode::CompressWhitespaceNewline;
     for &(test, oracle) in test_strs.iter() {
-        let mut new_line_pos = vec![];
         let mut trimmed_str = String::new();
-        transform_text(test, mode, true, &mut trimmed_str, &mut new_line_pos);
+        transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(&*trimmed_str, oracle)
     }
 }
@@ -157,9 +153,8 @@ fn test_transform_compress_whitespace_newline_no_incoming() {
 
     let mode = CompressionMode::CompressWhitespaceNewline;
     for &(test, oracle) in test_strs.iter() {
-        let mut new_line_pos = vec![];
         let mut trimmed_str = String::new();
-        transform_text(test, mode, false, &mut trimmed_str, &mut new_line_pos);
+        transform_text(test, mode, false, &mut trimmed_str);
         assert_eq!(trimmed_str, oracle)
     }
 }


### PR DESCRIPTION
This fixes a lot of "jumpiness" and removes the `new_line_pos` stuff.

Closes #2260.

r? @mbrubeck
cc @metajack
