### PR TITLE
layout: Remove the bogus `assign_block_size_for_inorder_child_if_necessary` logic from table wrapper flows.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1416,6 +1416,8 @@ impl BlockFlow {
         match style.get_box().display {
             display::T::table_cell |
             display::T::table_caption |
+            display::T::table_row_group |
+            display::T::table |
             display::T::inline_block => {
                 FormattingContextType::Other
             }
@@ -1692,7 +1694,7 @@ impl Flow for BlockFlow {
     fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
         if self.is_replaced_content() {
             let _scope = layout_debug_scope!("assign_replaced_block_size_if_necessary {:x}",
-                                                self.base.debug_id());
+                                             self.base.debug_id());
 
             // Assign block-size for fragment if it is an image fragment.
             let containing_block_block_size =
@@ -1703,10 +1705,12 @@ impl Flow for BlockFlow {
             }
         } else if self.is_root() || self.base.flags.is_float() || self.is_inline_block() {
             // Root element margins should never be collapsed according to CSS § 8.3.1.
-            debug!("assign_block_size: assigning block_size for root flow {:?}", flow::base(self).debug_id());
+            debug!("assign_block_size: assigning block_size for root flow {:?}",
+                   flow::base(self).debug_id());
             self.assign_block_size_block_base(ctx, MarginsMayCollapseFlag::MarginsMayNotCollapse);
         } else {
-            debug!("assign_block_size: assigning block_size for block {:?}", flow::base(self).debug_id());
+            debug!("assign_block_size: assigning block_size for block {:?}",
+                   flow::base(self).debug_id());
             self.assign_block_size_block_base(ctx, MarginsMayCollapseFlag::MarginsMayCollapse);
         }
     }

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -336,9 +336,11 @@ impl Flow for TableWrapperFlow {
 
     }
 
-    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
+    fn assign_block_size<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
         debug!("assign_block_size: assigning block_size for table_wrapper");
-        self.block_flow.assign_block_size_block_base(ctx, MarginsMayCollapseFlag::MarginsMayNotCollapse);
+        self.block_flow
+            .assign_block_size_block_base(layout_context,
+                                          MarginsMayCollapseFlag::MarginsMayNotCollapse);
     }
 
     fn compute_absolute_position(&mut self) {
@@ -353,17 +355,8 @@ impl Flow for TableWrapperFlow {
                                                             layout_context: &'a LayoutContext<'a>,
                                                             parent_thread_id: u8)
                                                             -> bool {
-        if self.block_flow.base.flags.is_float() {
-            self.block_flow.place_float();
-            return true
-        }
-
-        let impacted = self.block_flow.base.flags.impacted_by_floats();
-        if impacted {
-            self.block_flow.base.thread_id = parent_thread_id;
-            self.assign_block_size(layout_context);
-        }
-        impacted
+        self.block_flow.assign_block_size_for_inorder_child_if_necessary(layout_context,
+                                                                         parent_thread_id)
     }
 
     fn update_late_computed_inline_position_if_necessary(&mut self, inline_position: Au) {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -264,6 +264,7 @@ experimental == rtl_simple.html rtl_simple_ref.html
 == table_colspan_simple_a.html table_colspan_simple_ref.html
 == table_containing_block_a.html table_containing_block_ref.html
 == table_expansion_to_fit_a.html table_expansion_to_fit_ref.html
+== table_float_translation_a.html table_float_translation_ref.html
 == table_padding_a.html table_padding_ref.html
 == table_percentage_capping_a.html table_percentage_capping_ref.html
 == table_percentage_width_a.html table_percentage_width_ref.html

--- a/tests/ref/table_float_translation_a.html
+++ b/tests/ref/table_float_translation_a.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#float {
+    width: 33%;
+    float: right;
+}
+#table {
+    width: 50%;
+    display: table;
+}
+* {
+    border-spacing: 0;
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<div id=float>
+    Ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+</div>
+<div id=table>
+    Bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+</div>
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu turpis eu elit fermentum molestie ut et nibh. Cras a sapien purus. Proin ac libero felis. Mauris sed nisi et dolor commodo blandit. Sed diam lacus, volutpat sit amet vulputate ac, sollicitudin nec massa. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin feugiat convallis leo, eu condimentum dolor gravida quis. Pellentesque iaculis lobortis ligula at gravida. Praesent quis sagittis elit. Curabitur mollis, lacus at vulputate eleifend, sem urna congue eros, a fringilla lacus ante ut elit. Fusce pharetra sollicitudin mi, sed interdum augue luctus a. Mauris congue convallis massa, nec dignissim ex molestie ut. Proin volutpat egestas urna, at blandit lectus congue at. Suspendisse tempus cursus dui a varius.
+</p>
+</body>
+</html>
+

--- a/tests/ref/table_float_translation_ref.html
+++ b/tests/ref/table_float_translation_ref.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#float {
+    width: 33%;
+    float: right;
+}
+#table {
+    width: 50%;
+    display: block;
+}
+* {
+    border-spacing: 0;
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+</style>
+</head>
+<body>
+<div id=float>
+    Ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+    ketchup ketchup ketchup ketchup
+</div>
+<div id=table>
+    Bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+    bloobity bloobity bloobity bloobity
+</div>
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu turpis eu elit fermentum molestie ut et nibh. Cras a sapien purus. Proin ac libero felis. Mauris sed nisi et dolor commodo blandit. Sed diam lacus, volutpat sit amet vulputate ac, sollicitudin nec massa. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin feugiat convallis leo, eu condimentum dolor gravida quis. Pellentesque iaculis lobortis ligula at gravida. Praesent quis sagittis elit. Curabitur mollis, lacus at vulputate eleifend, sem urna congue eros, a fringilla lacus ante ut elit. Fusce pharetra sollicitudin mi, sed interdum augue luctus a. Mauris congue convallis massa, nec dignissim ex molestie ut. Proin volutpat egestas urna, at blandit lectus congue at. Suspendisse tempus cursus dui a varius.
+</p>
+</body>
+</html>
+


### PR DESCRIPTION
As far as I can tell, this is a cut-and-paste of old buggy code from
block flows. Delegating to the correct block flow code fixes the sidebar
float placement on Guardians of the Galaxy.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5498)

<!-- Reviewable:end -->
