### PR TITLE
Remove the unsafe impl Send for ConstellationControlMsg.

### DIFF
--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -76,9 +76,6 @@ pub enum ConstellationControlMsg {
     UpdateSubpageId(PipelineId, SubpageId, SubpageId),
 }
 
-unsafe impl Send for ConstellationControlMsg {
-}
-
 /// The mouse button involved in the event.
 #[derive(Clone, Debug)]
 pub enum MouseButton {

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#f3cffb2c37cf1a4dac06a02eb00a882626039a0c"
+source = "git+https://github.com/servo/rust-selectors#12d3ce84a12ded4cf1def63651ccab06e1cfa80e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#f3cffb2c37cf1a4dac06a02eb00a882626039a0c"
+source = "git+https://github.com/servo/rust-selectors#12d3ce84a12ded4cf1def63651ccab06e1cfa80e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#f3cffb2c37cf1a4dac06a02eb00a882626039a0c"
+source = "git+https://github.com/servo/rust-selectors#12d3ce84a12ded4cf1def63651ccab06e1cfa80e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.2.0 (git+https://github.com/servo/rust-cssparser)",


### PR DESCRIPTION
This impl made it possible to put raw pointers in ConstellationControlMsg and
send them across threads without considering the consequences.

This required making SmallVec1<T> Send if T is Send.
