### PR TITLE
layout: During inline layout, make `place_between_floats` use the same line height computation logic as final block size assignment.

### DIFF
--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -333,7 +333,9 @@ impl Floats {
             let maybe_location = self.available_rect(float_b,
                                                      info.size.block,
                                                      info.max_inline_size);
-            debug!("place_float: Got available rect: {:?} for y-pos: {:?}", maybe_location, float_b);
+            debug!("place_float: got available rect: {:?} for block-pos: {:?}",
+                   maybe_location,
+                   float_b);
             match maybe_location {
                 // If there are no floats blocking us, return the current location
                 // TODO(eatkinson): integrate with overflow
@@ -364,8 +366,8 @@ impl Floats {
                     // Place here if there is enough room
                     if rect.size.inline >= info.size.inline {
                         let block_size = self.max_block_size_for_bounds(rect.start.i,
-                                                                rect.start.b,
-                                                                rect.size.inline);
+                                                                        rect.start.b,
+                                                                        rect.size.inline);
                         let block_size = block_size.unwrap_or(Au(i32::MAX));
                         return match info.kind {
                             FloatKind::Left => {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1313,37 +1313,6 @@ impl Fragment {
         }
     }
 
-    /// Returns, and computes, the block-size of this fragment.
-    pub fn content_block_size(&self, layout_context: &LayoutContext) -> Au {
-        match self.specific {
-            SpecificFragmentInfo::Generic |
-            SpecificFragmentInfo::GeneratedContent(_) |
-            SpecificFragmentInfo::Iframe(_) |
-            SpecificFragmentInfo::Table |
-            SpecificFragmentInfo::TableCell |
-            SpecificFragmentInfo::TableRow |
-            SpecificFragmentInfo::TableWrapper |
-            SpecificFragmentInfo::InlineBlock(_) |
-            SpecificFragmentInfo::InlineAbsoluteHypothetical(_) => Au(0),
-            SpecificFragmentInfo::Image(ref image_fragment_info) => {
-                image_fragment_info.replaced_image_fragment_info.computed_block_size()
-            }
-            SpecificFragmentInfo::Canvas(ref canvas_fragment_info) => {
-                canvas_fragment_info.replaced_image_fragment_info.computed_block_size()
-            }
-            SpecificFragmentInfo::ScannedText(_) => {
-                // Compute the block-size based on the line-block-size and font size.
-                self.calculate_line_height(layout_context)
-            }
-            SpecificFragmentInfo::TableColumn(_) => {
-                panic!("Table column fragments do not have block size")
-            }
-            SpecificFragmentInfo::UnscannedText(_) => {
-                panic!("Unscanned text fragments should have been scanned by now!")
-            }
-        }
-    }
-
     /// Returns the dimensions of the content box.
     ///
     /// This is marked `#[inline]` because it is frequently called when only one or two of the

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -169,6 +169,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == legacy_td_width_attribute_a.html legacy_td_width_attribute_ref.html
 == letter_spacing_a.html letter_spacing_ref.html
 == line_height_a.html line_height_ref.html
+== line_height_float_placement_a.html line_height_float_placement_ref.html
 != linear_gradients_corners_a.html linear_gradients_corners_ref.html
 == linear_gradients_lengths_a.html linear_gradients_lengths_ref.html
 == linear_gradients_parsing_a.html linear_gradients_parsing_ref.html

--- a/tests/ref/line_height_float_placement_a.html
+++ b/tests/ref/line_height_float_placement_a.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+body {
+    font-size: 16px;
+    font-family: Ahem, monospace;
+    padding-top: 5px;
+}
+#floaty {
+    float: left;
+    height: 20px;
+    width: 100px;
+}
+#pre {
+    line-height: 32px;
+    white-space: pre;
+}
+</style>
+</head>
+<body>
+<div id=floaty></div>
+<div id=pre>x
+x</div>
+</body>
+</html>
+

--- a/tests/ref/line_height_float_placement_ref.html
+++ b/tests/ref/line_height_float_placement_ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+body {
+    font-size: 16px;
+    font-family: Ahem, monospace;
+}
+#floaty {
+    float: left;
+    height: 20px;
+    width: 100px;
+}
+#pre {
+    white-space: pre;
+}
+.spacer {
+    color: transparent;
+    font-size: 32px;
+}
+</style>
+</head>
+<body>
+<div id=floaty></div>
+<div id=pre>x<span class=spacer>x</span>
+x<span class=spacer>x</span></div>
+</body>
+</html>
+


### PR DESCRIPTION
Improves Wikipedia.

r? @glennw
