### PR TITLE
net: Don't load the placeholder image for background images, only for image fragments.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -37,6 +37,7 @@ use msg::compositor_msg::ScrollPolicy;
 use msg::constellation_msg::Msg as ConstellationMsg;
 use msg::constellation_msg::ConstellationChan;
 use net_traits::image::holder::ImageHolder;
+use net_traits::image_cache_task::UsePlaceholder;
 use util::cursor::Cursor;
 use util::geometry::{self, Au, ZERO_POINT, to_px, to_frac_px};
 use util::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize, WritingMode};
@@ -399,6 +400,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                image_url: &Url) {
         let background = style.get_background();
         let mut holder = ImageHolder::new(image_url.clone(),
+                                          UsePlaceholder::No,
                                           layout_context.shared.image_cache.clone());
         let image = match holder.get_image(self.node.to_untrusted_node_address()) {
             None => {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -31,6 +31,7 @@ use script_traits::UntrustedNodeAddress;
 use rustc_serialize::{Encodable, Encoder};
 use msg::constellation_msg::{ConstellationChan, Msg, PipelineId, SubpageId};
 use net_traits::image::holder::ImageHolder;
+use net_traits::image_cache_task::UsePlaceholder;
 use net_traits::local_image_cache::LocalImageCache;
 use util::geometry::{self, Au, ZERO_POINT};
 use util::logical_geometry::{LogicalRect, LogicalSize, LogicalMargin, WritingMode};
@@ -320,7 +321,7 @@ impl ImageFragmentInfo {
             replaced_image_fragment_info: ReplacedImageFragmentInfo::new(node,
                 convert_length(node, &atom!("width")),
                 convert_length(node, &atom!("height"))),
-            image: ImageHolder::new(image_url, local_image_cache)
+            image: ImageHolder::new(image_url, UsePlaceholder::Yes, local_image_cache)
         }
     }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -195,6 +195,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == negative_margin_uncle_a.html negative_margin_uncle_b.html
 == negative_margins_a.html negative_margins_b.html
 == no-image.html no-image-ref.html
+== no_image_background_a.html no_image_background_ref.html
 == noscript.html noscript_ref.html
 != noteq_attr_exists_selector.html attr_exists_selector_ref.html
 == nth_child_pseudo_a.html nth_child_pseudo_b.html

--- a/tests/ref/no_image_background_a.html
+++ b/tests/ref/no_image_background_a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    background: peachpuff;
+}
+section {
+    display: block;
+    width: 256px;
+    height: 256px;
+    border: solid black 1px;
+    background: url(bogusybogusbogus.jpg);
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+</html>
+

--- a/tests/ref/no_image_background_ref.html
+++ b/tests/ref/no_image_background_ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    background: peachpuff;
+}
+section {
+    display: block;
+    width: 256px;
+    height: 256px;
+    border: solid black 1px;
+}
+</style>
+</head>
+<body>
+<section></section>
+</body>
+</html>
+


### PR DESCRIPTION
This also changes the way the placeholder is handled in the image cache
task to decode it up front instead of each time an image fails to load,
both because it was more convenient to implement that way and because
it saves CPU cycles to do so.

This matches the behavior of Gecko and WebKit. It improves the look of
our cached copy of Wikipedia.

r? @jdm
cc @Adenilson

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5516)

<!-- Reviewable:end -->
