### PR TITLE
layout: When a table is too large for its explicitly-specified inline width, ignore the latter.

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -174,19 +174,6 @@ impl TableFlow {
         }
     }
 
-    /// Returns the effective spacing per cell, taking the value of `border-collapse` into account.
-    fn spacing(&self) -> border_spacing::T {
-        let style = self.block_flow.fragment.style();
-        match style.get_inheritedtable().border_collapse {
-            border_collapse::T::separate => style.get_inheritedtable().border_spacing,
-            border_collapse::T::collapse => {
-                border_spacing::T {
-                    horizontal: Au(0),
-                    vertical: Au(0),
-                }
-            }
-        }
-    }
 }
 
 impl Flow for TableFlow {
@@ -204,6 +191,10 @@ impl Flow for TableFlow {
 
     fn as_block<'a>(&'a mut self) -> &'a mut BlockFlow {
         &mut self.block_flow
+    }
+
+    fn as_immutable_block<'a>(&'a self) -> &'a BlockFlow {
+        &self.block_flow
     }
 
     fn column_intrinsic_inline_sizes<'a>(&'a mut self) -> &'a mut Vec<ColumnIntrinsicInlineSize> {
@@ -641,4 +632,22 @@ impl<'a> ChildInlineSizeInfo<'a> {
         }
     }
 }
+
+pub trait TableAndTableWrapperMethods : Flow {
+    /// Returns the effective spacing per cell, taking the value of `border-collapse` into account.
+    fn spacing(&self) -> border_spacing::T {
+        let style = self.as_immutable_block().fragment.style();
+        match style.get_inheritedtable().border_collapse {
+            border_collapse::T::separate => style.get_inheritedtable().border_spacing,
+            border_collapse::T::collapse => {
+                border_spacing::T {
+                    horizontal: Au(0),
+                    vertical: Au(0),
+                }
+            }
+        }
+    }
+}
+
+impl TableAndTableWrapperMethods for TableFlow {}
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -286,6 +286,7 @@ experimental == rtl_simple.html rtl_simple_ref.html
 == table_colspan_simple_a.html table_colspan_simple_ref.html
 == table_containing_block_a.html table_containing_block_ref.html
 == table_expansion_to_fit_a.html table_expansion_to_fit_ref.html
+== table_explicit_width_a.html table_explicit_width_ref.html
 == table_float_translation_a.html table_float_translation_ref.html
 == table_padding_a.html table_padding_ref.html
 == table_percentage_capping_a.html table_percentage_capping_ref.html

--- a/tests/ref/table_explicit_width_a.html
+++ b/tests/ref/table_explicit_width_a.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+    width: 0;
+}
+</style>
+</head>
+<body>
+<table><tr><td>Hello beautiful</td><td>world</td></tr></table>
+</body>
+</html>
+

--- a/tests/ref/table_explicit_width_ref.html
+++ b/tests/ref/table_explicit_width_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<table><tr><td>Hello beautiful</td><td>world</td></tr></table>
+</body>
+</html>
+


### PR DESCRIPTION
r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5549)

<!-- Reviewable:end -->
