### PR TITLE
Don't consume self when calling root on a Temporary<T>.

### DIFF
--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -173,7 +173,7 @@ impl<T: Reflectable> Temporary<T> {
     }
 
     /// Create a stack-bounded root for this value.
-    pub fn root(self) -> Root<T> {
+    pub fn root(&self) -> Root<T> {
         STACK_ROOTS.with(|ref collection| {
             let RootCollectionPtr(collection) = collection.get().unwrap();
             unsafe {


### PR DESCRIPTION
Fixes issue #5540.

As far as I can tell this is all that's necessary, but I'm new to Rust, so let me know if I missed something!
