### PR TITLE
layout: Correctly take the inline size of cleared floats into account when estimating the inline size of block formatting contexts.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1313,6 +1313,17 @@ impl BlockFlow {
                 kid_base.fixed_static_i_offset = fixed_static_i_offset;
             }
 
+            // Determine float impaction, and update the inline size speculations if necessary.
+            if flow::base(kid).flags.contains(CLEARS_LEFT) {
+                inline_start_floats_impact_child = false;
+                inline_size_of_preceding_left_floats = Au(0);
+            }
+            if flow::base(kid).flags.contains(CLEARS_RIGHT) {
+                inline_end_floats_impact_child = false;
+                inline_size_of_preceding_right_floats = Au(0);
+            }
+
+            // Update the speculated inline size if this child is floated.
             match flow::base(kid).flags.float_kind() {
                 float::T::none => {}
                 float::T::left => {
@@ -1351,16 +1362,6 @@ impl BlockFlow {
                         // The kid's inline 'start' is at the parent's 'end'
                         inline_end_content_edge
                     }
-            }
-
-            // Determine float impaction.
-            if flow::base(kid).flags.contains(CLEARS_LEFT) {
-                inline_start_floats_impact_child = false;
-                inline_size_of_preceding_left_floats = Au(0);
-            }
-            if flow::base(kid).flags.contains(CLEARS_RIGHT) {
-                inline_end_floats_impact_child = false;
-                inline_size_of_preceding_right_floats = Au(0);
             }
 
             {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -50,6 +50,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == background_style_attr.html background_ref.html
 == basic_width_px.html basic_width_em.html
 == block_formatting_context_a.html block_formatting_context_ref.html
+== block_formatting_context_cleared_float_a.html block_formatting_context_cleared_float_ref.html
 == block_formatting_context_complex_a.html block_formatting_context_complex_ref.html
 == block_formatting_context_containing_floats_a.html block_formatting_context_containing_floats_ref.html
 == block_formatting_context_relative_a.html block_formatting_context_ref.html

--- a/tests/ref/block_formatting_context_cleared_float_a.html
+++ b/tests/ref/block_formatting_context_cleared_float_a.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!--
+    Tests that block formatting context inline-size speculation works when the floats that impact
+    the block formatting context are cleared.
+-->
+<style>
+#a {
+    background: silver;
+    height: 150px;
+    width: 150px;
+    float: right;
+    clear: right;
+}
+#b {
+    background: goldenrod;
+    height: 300px;
+    overflow: hidden;
+}
+</style>
+</head>
+<body>
+<div id=a></div>
+<div id=b></div>
+</body>
+</html>
+

--- a/tests/ref/block_formatting_context_cleared_float_ref.html
+++ b/tests/ref/block_formatting_context_cleared_float_ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!--
+    Tests that block formatting context inline-size speculation works when the floats that impact
+    the block formatting context are cleared.
+-->
+<style>
+#a {
+    background: silver;
+    height: 150px;
+    width: 150px;
+    float: right;
+}
+#b {
+    background: goldenrod;
+    height: 300px;
+    overflow: hidden;
+}
+</style>
+</head>
+<body>
+<div id=a></div>
+<div id=b></div>
+</body>
+</html>
+


### PR DESCRIPTION
The speculated inline-size of the preceding floats was forced to zero at
the wrong time if the float was itself cleared, causing it to overwrite
the speculated value. Shuffling the code around a bit fixes the problem.

r? @glennw
