### PR TITLE
Remove compositor dependency on net crate.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -20,9 +20,8 @@ use msg::constellation_msg::{IFrameSandboxState, MozBrowserEvent, NavigationDire
 use msg::constellation_msg::{Key, KeyState, KeyModifiers, LoadData};
 use msg::constellation_msg::{SubpageId, WindowSizeData};
 use msg::constellation_msg::{self, ConstellationChan, Failure};
-use net::image_cache_task::ImageCacheTaskClient;
 use net_traits::{self, ResourceTask};
-use net_traits::image_cache_task::ImageCacheTask;
+use net_traits::image_cache_task::{ImageCacheTask, ImageCacheTaskClient};
 use net_traits::storage_task::{StorageTask, StorageTaskMsg};
 use profile::mem;
 use profile::time;

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -395,18 +395,6 @@ impl ImageCache {
     }
 }
 
-pub trait ImageCacheTaskClient {
-    fn exit(&self);
-}
-
-impl ImageCacheTaskClient for ImageCacheTask {
-    fn exit(&self) {
-        let (response_chan, response_port) = channel();
-        self.send(Msg::Exit(response_chan));
-        response_port.recv().unwrap();
-    }
-}
-
 pub fn spawn_listener<F, A>(f: F) -> Sender<A>
     where F: FnOnce(Receiver<A>) + Send + 'static,
           A: Send + 'static

--- a/components/net_traits/image_cache_task.rs
+++ b/components/net_traits/image_cache_task.rs
@@ -70,6 +70,18 @@ impl ImageCacheTask {
     }
 }
 
+pub trait ImageCacheTaskClient {
+    fn exit(&self);
+}
+
+impl ImageCacheTaskClient for ImageCacheTask {
+    fn exit(&self) {
+        let (response_chan, response_port) = channel();
+        self.send(Msg::Exit(response_chan));
+        response_port.recv().unwrap();
+    }
+}
+
 pub fn load_image_data(url: Url, resource_task: ResourceTask, placeholder: &[u8]) -> Result<Vec<u8>, ()> {
     let (response_chan, response_port) = channel();
     resource_task.send(ControlMsg::Load(LoadData::new(url.clone(), response_chan))).unwrap();

--- a/tests/unit/net/image_cache_task.rs
+++ b/tests/unit/net/image_cache_task.rs
@@ -8,7 +8,7 @@ use net_traits::image_cache_task::Msg::*;
 
 use net::resource_task::start_sending;
 use net_traits::{ControlMsg, Metadata, ProgressMsg, ResourceTask};
-use net_traits::image_cache_task::{ImageCacheTask, ImageResponseMsg, Msg};
+use net_traits::image_cache_task::{ImageCacheTask, ImageCacheTaskClient, ImageResponseMsg, Msg};
 use net_traits::ProgressMsg::{Payload, Done};
 use profile::time;
 use std::sync::mpsc::{Sender, channel, Receiver};


### PR DESCRIPTION
Move the ImageCacheTaskClient trait and impl to net_traits. Fixes #5551.
