### PR TITLE
Only send unused buffers messages if there are actually any buffers

### DIFF
--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -227,7 +227,7 @@ impl CompositorLayer for Layer<CompositorData> {
             let _ = pipeline.paint_chan.send(PaintMsg::UnusedBuffer(unused_buffers));
         }
 
-        return true;
+        true
     }
 
     fn clear<Window>(&self, compositor: &IOCompositor<Window>) where Window: WindowMethods {

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -557,9 +557,8 @@ impl LayoutTask {
 
         {
             let mut rw_data = self.lock_rw_data(possibly_locked_rw_data);
-            match (&mut *rw_data).parallel_traversal {
-                None => {}
-                Some(ref mut traversal) => traversal.shutdown(),
+            if let Some(ref mut traversal) = (&mut *rw_data).parallel_traversal {
+                traversal.shutdown()
             }
             LayoutTask::return_rw_data(possibly_locked_rw_data, rw_data);
         }


### PR DESCRIPTION
Some debugging reveals that the send_back_unused_buffers() quite often sends empty vectors back to the paint task. This still incurs a communication overhead though. Instead check that the there actually are buffers to send back.
