### PR TITLE
layout: Don't take collapsible top margin into account when determining the float ceiling.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1990,7 +1990,8 @@ pub struct ISizeConstraintSolution {
 }
 
 impl ISizeConstraintSolution {
-    pub fn new(inline_size: Au, margin_inline_start: Au, margin_inline_end: Au) -> ISizeConstraintSolution {
+    pub fn new(inline_size: Au, margin_inline_start: Au, margin_inline_end: Au)
+               -> ISizeConstraintSolution {
         ISizeConstraintSolution {
             inline_start: Au(0),
             inline_end: Au(0),

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -100,6 +100,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == float_intrinsic_width_a.html float_intrinsic_width_ref.html
 == float_right_intrinsic_width_a.html float_right_intrinsic_width_ref.html
 == float_table_a.html float_table_ref.html
+== float_under_top_margin_a.html float_under_top_margin_ref.html
 == floated_generated_content_a.html floated_generated_content_b.html
 == floated_list_item_a.html floated_list_item_ref.html
 == floated_table_with_margin_a.html floated_table_with_margin_ref.html

--- a/tests/ref/float_intrinsic_height.html
+++ b/tests/ref/float_intrinsic_height.html
@@ -19,6 +19,6 @@
 		<div class="otherprojects">
 			<div class="otherprojects-item">
 			</div>
-		</div>
+		</div>&nbsp;
 	</body>
 </html>

--- a/tests/ref/float_under_top_margin_a.html
+++ b/tests/ref/float_under_top_margin_a.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+body {
+    margin-top: 64px;
+}
+#foo, #bar {
+    height: 35px;
+    width: 35px;
+}
+#foo {
+    background: blue;
+    float: right;
+}
+#bar {
+    background: gold;
+}
+</style>
+</head>
+<body>
+<div id=foo></div><div id=bar></div>
+</body>
+</html>
+

--- a/tests/ref/float_under_top_margin_ref.html
+++ b/tests/ref/float_under_top_margin_ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+body {
+    padding-top: 64px;
+}
+#foo, #bar {
+    height: 35px;
+    width: 35px;
+}
+#foo {
+    background: blue;
+    float: right;
+}
+#bar {
+    background: gold;
+}
+</style>
+</head>
+<body>
+<div id=foo></div><div id=bar></div>
+</body>
+</html>
+

--- a/tests/ref/margins_inside_floats_a.html
+++ b/tests/ref/margins_inside_floats_a.html
@@ -4,7 +4,7 @@
 <div style="float: left;">
     <div style="margin-bottom: 64px;">Must be this tall</div>
     <div style="margin-top: 64px;">to write multi-threaded code.</div>
-</div>
+</div>&nbsp;
 </body>
 </html>
 


### PR DESCRIPTION
As the float ceiling is relative to the border box, not the margin box,
of the parent flow, top margin must not be included.

This exposed a pre-existing bug whereby margins are discarded if a block
contains only floats and no content, affecting the tests
`float_intrinsic_height.html` and `margins_inside_floats_a.html`. As a
workaround, some invisible content has been added to the bodies of both
tests.

r? @mbrubeck
