### PR TITLE
Set dirty flag on hover or focus change

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -623,7 +623,8 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     fn set_hover_state(self, state: bool) {
-        self.set_flag(IN_HOVER_STATE, state)
+        self.set_flag(IN_HOVER_STATE, state);
+        self.dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn get_focus_state(self) -> bool {
@@ -631,7 +632,8 @@ impl<'a> NodeHelpers<'a> for JSRef<'a, Node> {
     }
 
     fn set_focus_state(self, state: bool) {
-        self.set_flag(IN_FOCUS_STATE, state)
+        self.set_flag(IN_FOCUS_STATE, state);
+        self.dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn get_disabled_state(self) -> bool {


### PR DESCRIPTION
This fixes a bug where styles are not recalculated immediately when an element's hover or focus state changes.  I'm not sure how to write an automated test for this.  r? @glennw or @pcwalton
