### PR TITLE
Don't allow disabled fields to be focused

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -36,7 +36,7 @@ use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
 use dom::domimplementation::DOMImplementation;
 use dom::element::{Element, ElementCreator, AttributeHandlers};
-use dom::element::{ElementTypeId, ActivationElementHelpers};
+use dom::element::{ElementTypeId, ActivationElementHelpers, FocusElementHelpers};
 use dom::event::{Event, EventBubbles, EventCancelable, EventHelpers};
 use dom::eventtarget::{EventTarget, EventTargetTypeId, EventTargetHelpers};
 use dom::htmlanchorelement::HTMLAnchorElement;
@@ -448,7 +448,9 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
 
     /// Request that the given element receive focus once the current transaction is complete.
     fn request_focus(self, elem: JSRef<Element>) {
-        self.possibly_focused.assign(Some(elem))
+        if elem.is_focusable_area() {
+            self.possibly_focused.assign(Some(elem))
+        }
     }
 
     /// Reassign the focus context to the element that last requested focus during this

--- a/tests/wpt/metadata/html/semantics/disabled-elements/disabledElement.html.ini
+++ b/tests/wpt/metadata/html/semantics/disabled-elements/disabledElement.html.ini
@@ -1,23 +1,5 @@
 [disabledElement.html]
   type: testharness
-  [A disabled <button> should not be focusable]
-    expected: FAIL
-
-  [A disabled <input> should not be focusable]
-    expected: FAIL
-
-  [A disabled <select> should not be focusable]
-    expected: FAIL
-
-  [A disabled <optgroup> should not be focusable]
-    expected: FAIL
-
-  [A disabled <option> should not be focusable]
-    expected: FAIL
-
-  [A disabled <textarea> should not be focusable]
-    expected: FAIL
-
-  [A disabled <input[type=radio\]> should not be focusable]
+  [A disabled <span> should be focusable]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/selectors/pseudo-classes/focus.html.ini
+++ b/tests/wpt/metadata/html/semantics/selectors/pseudo-classes/focus.html.ini
@@ -2,4 +2,10 @@
   type: testharness
   [input3 has the attribute autofocus]
     expected: FAIL
+  [tabindex attribute makes the element focusable]
+    expected: FAIL
+  [editable elements are focusable]
+    expected: FAIL
+  [':focus' matches focussed body with tabindex]
+    expected: FAIL
 


### PR DESCRIPTION
This begins implementing parts of the [focusing steps](https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps) algorithm. r? @jdm or @Ms2ger
