### PR TITLE
layout: Implement per-glyph font fallback.

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -19,7 +19,7 @@ use platform::font::{FontHandle, FontTable};
 use util::geometry::Au;
 use text::glyph::{GlyphStore, GlyphId};
 use text::shaping::ShaperMethods;
-use text::{Shaper, TextRun};
+use text::Shaper;
 use font_template::FontTemplateDescriptor;
 use platform::font_template::FontTemplateData;
 
@@ -183,6 +183,7 @@ impl Font {
         return result;
     }
 
+    #[inline]
     pub fn glyph_index(&self, codepoint: char) -> Option<GlyphId> {
         let codepoint = match self.variant {
             font_variant::T::small_caps => codepoint.to_uppercase().next().unwrap(), //FIXME: #5938
@@ -216,14 +217,6 @@ impl FontGroup {
         FontGroup {
             fonts: fonts,
         }
-    }
-
-    pub fn create_textrun(&self, text: String, options: &ShapingOptions) -> TextRun {
-        assert!(self.fonts.len() > 0);
-
-        // TODO(Issue #177): Actually fall back through the FontGroup when a font is unsuitable.
-        let mut font_borrow = self.fonts[0].borrow_mut();
-        TextRun::new(&mut *font_borrow, text.clone(), options)
     }
 }
 

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -427,8 +427,10 @@ fn render_text(layout_context: &LayoutContext,
                                                              style,
                                                              incremental::rebuild_and_reflow(),
                                                              info));
+    // FIXME(pcwalton): This should properly handle multiple marker fragments. This could happen
+    // due to text run splitting.
     let fragments = TextRunScanner::new().scan_for_runs(layout_context.font_context(), fragments);
-    debug_assert!(fragments.len() == 1);
+    debug_assert!(fragments.len() >= 1);
     fragments.fragments.into_iter().next().unwrap().specific
 }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -234,6 +234,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == overflow_simple_a.html overflow_simple_b.html
 == overflow_wrap_a.html overflow_wrap_ref.html
 == overflow_xy_a.html overflow_xy_ref.html
+== per_glyph_font_fallback_a.html per_glyph_font_fallback_ref.html
 == percent_height.html percent_height_ref.html
 == percentage_height_float_a.html percentage_height_float_ref.html
 == percentage_height_root.html percentage_height_root_ref.html

--- a/tests/ref/line_height_float_placement_a.html
+++ b/tests/ref/line_height_float_placement_a.html
@@ -9,7 +9,7 @@
 }
 body {
     font-size: 16px;
-    font-family: Ahem, monospace;
+    font-family: Ahem;
     padding-top: 5px;
 }
 #floaty {

--- a/tests/ref/per_glyph_font_fallback_a.html
+++ b/tests/ref/per_glyph_font_fallback_a.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that font fallback occurs on a per-glyph basis. -->
+<style>
+@font-face {
+    font-family: 'ahem';
+    src: url(fonts/ahem/ahem.ttf);
+}
+
+body {
+    font-family: Ahem, sans-serif;
+    font-size: 24px;
+    line-height: 24px;
+}
+</style>
+</head>
+<body>
+<section>x&larr;</section>
+<section>&rarr;x</section>
+<section>&rarr;x&larr;</section>
+</body>
+</html>
+

--- a/tests/ref/per_glyph_font_fallback_ref.html
+++ b/tests/ref/per_glyph_font_fallback_ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that font fallback occurs on a per-glyph basis. -->
+<style>
+@font-face {
+    font-family: 'ahem';
+    src: url(fonts/ahem/ahem.ttf);
+}
+
+body {
+    font-family: Ahem, sans-serif;
+    font-size: 24px;
+    line-height: 24px;
+}
+
+.arrow {
+    font-family: sans-serif;
+}
+</style>
+</head>
+<body>
+<section>x<span class=arrow>&larr;</span></section>
+<section><span class=arrow>&rarr;</span>x</section>
+<section><span class=arrow>&rarr;</span>x<span class=arrow>&larr;</span></section>
+</body>
+</html>
+

--- a/tests/ref/text_align_complex_a.html
+++ b/tests/ref/text_align_complex_a.html
@@ -9,7 +9,7 @@
 	div {
 		width: 100px;
 		font-size: 10px;
-		font-family: Ahem, monospace;
+		font-family: Ahem;
 		padding: 10px !important;
 	}
 	

--- a/tests/ref/text_align_complex_ref.html
+++ b/tests/ref/text_align_complex_ref.html
@@ -9,7 +9,7 @@
 	div {
 		width: 100px;
 		font-size: 10px;
-		font-family: Ahem, monospace;
+		font-family: Ahem;
 		padding: 10px !important;
 	}
 	


### PR DESCRIPTION
This improves numerous pages, for example Wikipedia and Ars Technica.

Built on #5493.

Closes #177.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5607)

<!-- Reviewable:end -->
