### PR TITLE
Canvas: added miterLimit support.

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -39,6 +39,7 @@ pub enum CanvasMsg {
     SetFillStyle(FillOrStrokeStyle),
     SetStrokeStyle(FillOrStrokeStyle),
     SetLineWidth(f32),
+    SetMiterLimit(f32),
     SetTransform(Matrix2D<f32>),
     SetGlobalAlpha(f32),
     Recreate(Size2D<i32>),
@@ -202,7 +203,7 @@ impl<'a> CanvasPaintTask<'a> {
             draw_options: DrawOptions::new(1.0, 0),
             fill_style: Pattern::Color(ColorPattern::new(color::black())),
             stroke_style: Pattern::Color(ColorPattern::new(color::black())),
-            stroke_opts: StrokeOptions::new(1.0, JoinStyle::MiterOrBevel, CapStyle::Butt, 1.0, &[]),
+            stroke_opts: StrokeOptions::new(1.0, JoinStyle::MiterOrBevel, CapStyle::Butt, 10.0, &[]),
             path_builder: path_builder,
             transform: Matrix2D::identity(),
         }
@@ -245,6 +246,7 @@ impl<'a> CanvasPaintTask<'a> {
                     CanvasMsg::SetFillStyle(style) => painter.set_fill_style(style),
                     CanvasMsg::SetStrokeStyle(style) => painter.set_stroke_style(style),
                     CanvasMsg::SetLineWidth(width) => painter.set_line_width(width),
+                    CanvasMsg::SetMiterLimit(limit) => painter.set_miter_limit(limit),
                     CanvasMsg::SetTransform(ref matrix) => painter.set_transform(matrix),
                     CanvasMsg::SetGlobalAlpha(alpha) => painter.set_global_alpha(alpha),
                     CanvasMsg::Recreate(size) => painter.recreate(size),
@@ -423,6 +425,10 @@ impl<'a> CanvasPaintTask<'a> {
 
     fn set_line_width(&mut self, width: f32) {
         self.stroke_opts.line_width = width;
+    }
+
+    fn set_miter_limit(&mut self, limit: f32) {
+        self.stroke_opts.miter_limit = limit;
     }
 
     fn set_transform(&mut self, transform: &Matrix2D<f32>) {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -53,6 +53,7 @@ pub struct CanvasRenderingContext2D {
     image_smoothing_enabled: Cell<bool>,
     stroke_color: Cell<RGBA>,
     line_width: Cell<f64>,
+    miter_limit: Cell<f64>,
     fill_color: Cell<RGBA>,
     transform: Cell<Matrix2D<f32>>,
 }
@@ -75,6 +76,7 @@ impl CanvasRenderingContext2D {
             image_smoothing_enabled: Cell::new(true),
             stroke_color: Cell::new(black),
             line_width: Cell::new(1.0),
+            miter_limit: Cell::new(10.0),
             fill_color: Cell::new(black),
             transform: Cell::new(Matrix2D::identity()),
         }
@@ -815,6 +817,19 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
 
         self.line_width.set(width);
         self.renderer.send(CanvasMsg::SetLineWidth(width as f32)).unwrap()
+    }
+
+    fn MiterLimit(self) -> f64 {
+        self.miter_limit.get()
+    }
+
+    fn SetMiterLimit(self, limit: f64) {
+        if !limit.is_finite() || limit <= 0.0 {
+            return;
+        }
+
+        self.miter_limit.set(limit);
+        self.renderer.send(CanvasMsg::SetMiterLimit(limit as f32)).unwrap()
     }
 }
 

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -136,7 +136,7 @@ interface CanvasDrawingStyles {
   attribute unrestricted double lineWidth; // (default 1)
   //attribute DOMString lineCap; // "butt", "round", "square" (default "butt")
   //attribute DOMString lineJoin; // "round", "bevel", "miter" (default "miter")
-  //attribute unrestricted double miterLimit; // (default 10)
+  attribute unrestricted double miterLimit; // (default 10)
 
   // dashed lines
   //void setLineDash(sequence<unrestricted double> segments); // default empty

--- a/tests/wpt/metadata/2dcontext/drawing-rectangles-to-the-canvas/2d.strokeRect.zero.4.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-rectangles-to-the-canvas/2d.strokeRect.zero.4.html.ini
@@ -1,0 +1,5 @@
+[2d.strokeRect.zero.4.html]
+  type: testharness
+  [strokeRect of Nx0 pixels draws a closed line with no caps]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/drawing-rectangles-to-the-canvas/2d.strokeRect.zero.5.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-rectangles-to-the-canvas/2d.strokeRect.zero.5.html.ini
@@ -1,5 +1,0 @@
-[2d.strokeRect.zero.5.html]
-  type: testharness
-  [strokeRect of Nx0 pixels draws a closed line with joins]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.cap.closed.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.cap.closed.html.ini
@@ -1,0 +1,5 @@
+[2d.line.cap.closed.html]
+  type: testharness
+  [Line caps are not drawn at the corners of an unclosed rectangle]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.join.bevel.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.join.bevel.html.ini
@@ -1,0 +1,5 @@
+[2d.line.join.bevel.html]
+  type: testharness
+  [lineJoin \'bevel\' is rendered correctly]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.join.closed.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.join.closed.html.ini
@@ -1,5 +1,0 @@
-[2d.line.join.closed.html]
-  type: testharness
-  [Line joins are drawn at the corner of a closed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.join.miter.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.join.miter.html.ini
@@ -1,5 +1,0 @@
-[2d.line.join.miter.html]
-  type: testharness
-  [lineJoin \'miter\' is rendered correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.acute.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.acute.html.ini
@@ -1,5 +1,0 @@
-[2d.line.miter.acute.html]
-  type: testharness
-  [Miter joins are drawn correctly with acute angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.invalid.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.invalid.html.ini
@@ -1,5 +1,0 @@
-[2d.line.miter.invalid.html]
-  type: testharness
-  [Setting miterLimit to invalid values is ignored]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.obtuse.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.obtuse.html.ini
@@ -1,5 +1,0 @@
-[2d.line.miter.obtuse.html]
-  type: testharness
-  [Miter joins are drawn correctly with obtuse angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.valid.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.valid.html.ini
@@ -1,5 +1,0 @@
-[2d.line.miter.valid.html]
-  type: testharness
-  [Setting miterLimit to valid values works]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.within.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.miter.within.html.ini
@@ -1,5 +1,0 @@
-[2d.line.miter.within.html]
-  type: testharness
-  [Miter joins are drawn when the miter limit is not quite exceeded]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -7005,9 +7005,6 @@
   [CanvasRenderingContext2D interface: attribute lineJoin]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: attribute miterLimit]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation setLineDash([object Object\])]
     expected: FAIL
 
@@ -7213,9 +7210,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "lineJoin" with the proper type (61)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "miterLimit" with the proper type (62)]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "setLineDash" with the proper type (63)]


### PR DESCRIPTION
This exposes some other canvas tests which were marked as PASS before. Two strokeRect related tests are fixed by #5612, and lineCap/lineJoin will have an implementation soon.
