### PR TITLE
Switch Arc<Box<Image>> to Arc<Image> for perf boost.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -833,7 +833,7 @@ pub enum TextOrientation {
 #[derive(Clone)]
 pub struct ImageDisplayItem {
     pub base: BaseDisplayItem,
-    pub image: Arc<Box<Image>>,
+    pub image: Arc<Image>,
 
     /// The dimensions to which the image display item should be stretched. If this is smaller than
     /// the bounds of this display item, then the image will be repeated in the appropriate

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -129,7 +129,7 @@ impl<'a> PaintContext<'a> {
 
     pub fn draw_image(&self,
                       bounds: &Rect<Au>,
-                      image: Arc<Box<Image>>,
+                      image: Arc<Image>,
                       image_rendering: image_rendering::T) {
         let size = Size2D(image.width as i32, image.height as i32);
         let (pixel_width, pixels, source_format) = match image.pixels {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -414,7 +414,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
         // Use `background-size` to get the size.
         let mut bounds = *absolute_bounds;
-        let image_size = self.compute_background_image_size(style, &bounds, &**image);
+        let image_size = self.compute_background_image_size(style, &bounds, &*image);
 
         // Clip.
         //
@@ -1016,7 +1016,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                             &*self.style,
                                                                             Cursor::DefaultCursor),
                                                (*clip).clone()),
-                    image: Arc::new(box png::Image {
+                    image: Arc::new(png::Image {
                         width: width as u32,
                         height: height as u32,
                         pixels: PixelsByColorType::RGBA8(canvas_data),

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -110,7 +110,7 @@ enum ImageState {
     Prefetching(AfterPrefetch),
     Prefetched(Vec<u8>),
     Decoding,
-    Decoded(Arc<Box<Image>>),
+    Decoded(Arc<Image>),
     Failed
 }
 
@@ -303,7 +303,7 @@ impl ImageCache {
                         load_from_memory(&data)
                     });
 
-                    let image = image.map(|image| Arc::new(box image));
+                    let image = image.map(|image| Arc::new(image));
                     to_cache.send(Msg::StoreImage(url.clone(), image)).unwrap();
                     debug!("image_cache_task: ended image decode for {}", url.serialize());
                 });
@@ -317,7 +317,7 @@ impl ImageCache {
         }
     }
 
-    fn store_image(&mut self, url: Url, image: Option<Arc<Box<Image>>>) {
+    fn store_image(&mut self, url: Url, image: Option<Arc<Image>>) {
 
         match self.get_state(&url) {
           ImageState::Decoding => {

--- a/components/net/image_cache_task.rs
+++ b/components/net/image_cache_task.rs
@@ -303,7 +303,7 @@ impl ImageCache {
                         load_from_memory(&data)
                     });
 
-                    let image = image.map(|image| Arc::new(image));
+                    let image = image.map(Arc::new);
                     to_cache.send(Msg::StoreImage(url.clone(), image)).unwrap();
                     debug!("image_cache_task: ended image decode for {}", url.serialize());
                 });

--- a/components/net_traits/image/holder.rs
+++ b/components/net_traits/image/holder.rs
@@ -19,7 +19,7 @@ use url::Url;
 #[derive(Clone)]
 pub struct ImageHolder<NodeAddress> {
     url: Url,
-    image: Option<Arc<Box<Image>>>,
+    image: Option<Arc<Image>>,
     cached_size: Size2D<u32>,
     local_image_cache: Arc<Mutex<LocalImageCache<NodeAddress>>>,
 }
@@ -68,12 +68,12 @@ impl<NodeAddress: Send + 'static> ImageHolder<NodeAddress> {
         })
     }
 
-    pub fn get_image_if_present(&self) -> Option<Arc<Box<Image>>> {
+    pub fn get_image_if_present(&self) -> Option<Arc<Image>> {
         debug!("get_image_if_present() {}", self.url.serialize());
         self.image.clone()
     }
 
-    pub fn get_image(&mut self, node_address: NodeAddress) -> Option<Arc<Box<Image>>> {
+    pub fn get_image(&mut self, node_address: NodeAddress) -> Option<Arc<Image>> {
         debug!("get_image() {}", self.url.serialize());
 
         // If this is the first time we've called this function, load

--- a/components/net_traits/image_cache_task.rs
+++ b/components/net_traits/image_cache_task.rs
@@ -31,7 +31,7 @@ pub enum Msg {
     StorePrefetchedImageData(Url, Result<Vec<u8>, ()>),
 
     /// Used by the decoder tasks to post decoded images back to the cache
-    StoreImage(Url, Option<Arc<Box<Image>>>),
+    StoreImage(Url, Option<Arc<Image>>),
 
     /// For testing
     WaitForStore(Sender<()>),
@@ -42,7 +42,7 @@ pub enum Msg {
 
 #[derive(Clone)]
 pub enum ImageResponseMsg {
-    ImageReady(Arc<Box<Image>>),
+    ImageReady(Arc<Image>),
     ImageNotReady,
     ImageFailed
 }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -245,7 +245,7 @@ impl CanvasRenderingContext2D {
         return Some((image_data, image_size));
     }
 
-    fn request_image_from_cache(&self, url: Url) -> Option<Arc<Box<Image>>> {
+    fn request_image_from_cache(&self, url: Url) -> Option<Arc<Image>> {
         let canvas = self.canvas.root();
         let window = window_from_node(canvas.r()).root();
         let window = window.r();


### PR DESCRIPTION
Image used to be a trait, but no longer is, so boxing it is no longer
necessary. Fixes #5639.
