### PR TITLE
Ensure installed git version is above 1.8.1 [Bug #5637]

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -170,6 +170,13 @@ class MachCommands(CommandBase):
              description='Update submodules',
              category='bootstrap')
     def update_submodules(self):
+        # Ensure that the installed git version is >= 1.8.1 
+        gitversion = subprocess.check_output(["git", "--version"])
+        gitversion = gitversion.split(" ")[-1]
+        majv, minv, patchv, = [int(i) for i in gitversion.split(".")]
+        if not (majv >=1 and minv >= 8 and patchv >= 1):
+            print("Git version 1.8.1 or above required. Current version is", gitversion)
+            sys.exit(1)
         submodules = subprocess.check_output(["git", "submodule", "status"])
         for line in submodules.split('\n'):
             components = line.strip().split(' ')


### PR DESCRIPTION
Versions of git before 1.8.1 do not support git submodule --recursive sync
This commit makes update_submodules() exit with an error message if the version is <1.8.1

https://github.com/servo/servo/issues/5637

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5648)

<!-- Reviewable:end -->
