### PR TITLE
Update some URLs.

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -29,7 +29,7 @@ pub trait Activatable : Copy {
     // https://html.spec.whatwg.org/multipage/interaction.html#run-post-click-activation-steps
     fn activation_behavior(&self, event: JSRef<Event>, target: JSRef<EventTarget>);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#implicit-submission
+    // https://html.spec.whatwg.org/multipage/#implicit-submission
     fn implicit_submission(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool);
 
     // https://html.spec.whatwg.org/multipage/interaction.html#run-synthetic-click-activation-steps
@@ -45,7 +45,7 @@ pub trait Activatable : Copy {
         self.pre_click_activation();
 
         // Step 4
-        // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-synthetic-mouse-event
+        // https://html.spec.whatwg.org/multipage/#fire-a-synthetic-mouse-event
         let win = window_from_node(element.r()).root();
         let target: JSRef<EventTarget> = EventTargetCast::from_ref(element.r());
         let mouse = MouseEvent::new(win.r(), "click".to_owned(),

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -481,7 +481,7 @@ pub fn find_enum_string_index(cx: *mut JSContext,
 }
 
 /// Returns wether `obj` is a platform object
-/// http://heycam.github.io/webidl/#dfn-platform-object
+/// https://heycam.github.io/webidl/#dfn-platform-object
 pub fn is_platform_object(obj: *mut JSObject) -> bool {
     unsafe {
         // Fast-path the common case

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -124,7 +124,7 @@ pub struct Document {
     focused: MutNullableJS<Element>,
     /// The script element that is currently executing.
     current_script: MutNullableJS<HTMLScriptElement>,
-    /// https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript
+    /// https://html.spec.whatwg.org/multipage/#concept-n-noscript
     /// True if scripting is enabled for all scripts in this document
     scripting_enabled: Cell<bool>,
 }
@@ -249,7 +249,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         self.is_html_document
     }
 
-    // https://html.spec.whatwg.org/multipage/browsers.html#fully-active
+    // https://html.spec.whatwg.org/multipage/#fully-active
     fn is_fully_active(self) -> bool {
         let window = self.window.root();
         let window = window.r();
@@ -418,7 +418,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+    // https://html.spec.whatwg.org/multipage/#current-document-readiness
     fn set_ready_state(self, state: DocumentReadyState) {
         self.ready_state.set(state);
 
@@ -1388,17 +1388,17 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         root.query_selector_all(selectors)
     }
 
-    // https://html.spec.whatwg.org/multipage/dom.html#dom-document-readystate
+    // https://html.spec.whatwg.org/multipage/#dom-document-readystate
     fn ReadyState(self) -> DocumentReadyState {
         self.ready_state.get()
     }
 
-    // https://html.spec.whatwg.org/multipage/browsers.html#dom-document-defaultview
+    // https://html.spec.whatwg.org/multipage/#dom-document-defaultview
     fn DefaultView(self) -> Temporary<Window> {
         Temporary::new(self.window)
     }
 
-    // https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie
+    // https://html.spec.whatwg.org/multipage/#dom-document-cookie
     fn GetCookie(self) -> Fallible<DOMString> {
         //TODO: return empty string for cookie-averse Document
         let url = self.url();
@@ -1412,7 +1412,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         Ok(cookies.unwrap_or("".to_owned()))
     }
 
-    // https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie
+    // https://html.spec.whatwg.org/multipage/#dom-document-cookie
     fn SetCookie(self, cookie: DOMString) -> ErrorResult {
         //TODO: ignore for cookie-averse Document
         let url = self.url();

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -60,21 +60,21 @@ impl DOMException {
 }
 
 impl<'a> DOMExceptionMethods for JSRef<'a, DOMException> {
-    // http://heycam.github.io/webidl/#dfn-DOMException
+    // https://heycam.github.io/webidl/#dfn-DOMException
     fn Code(self) -> u16 {
         match self.code {
-            // http://heycam.github.io/webidl/#dfn-throw
+            // https://heycam.github.io/webidl/#dfn-throw
             DOMErrorName::EncodingError => 0,
             code => code as u16
         }
     }
 
-    // http://heycam.github.io/webidl/#idl-DOMException-error-names
+    // https://heycam.github.io/webidl/#idl-DOMException-error-names
     fn Name(self) -> DOMString {
         format!("{:?}", self.code)
     }
 
-    // http://heycam.github.io/webidl/#error-names
+    // https://heycam.github.io/webidl/#error-names
     fn Message(self) -> DOMString {
         let message = match self.code {
             DOMErrorName::IndexSizeError => "The index is not in the allowed range.",

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -591,7 +591,7 @@ impl<'a> ElementHelpers<'a> for JSRef<'a, Element> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/infrastructure.html#root-element
+    // https://html.spec.whatwg.org/multipage/#root-element
     fn get_root_element(self) -> Option<Temporary<Element>> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         match node.ancestors().last().map(ElementCast::to_temporary) {
@@ -759,7 +759,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
             ns!(""), None, |attr| attr.local_name() == name);
     }
 
-    // https://html.spec.whatwg.org/multipage/dom.html#attr-data-*
+    // https://html.spec.whatwg.org/multipage/#attr-data-*
     fn set_custom_attribute(self, name: DOMString, value: DOMString) -> ErrorResult {
         // Step 1.
         match xml_name_type(&name) {
@@ -907,7 +907,7 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
         let url = self.get_string_attribute(local_name);
         let doc = document_from_node(self).root();
         let base = doc.r().url();
-        // https://html.spec.whatwg.org/multipage/infrastructure.html#reflect
+        // https://html.spec.whatwg.org/multipage/#reflect
         // XXXManishearth this doesn't handle `javascript:` urls properly
         match UrlParser::new().base_url(&base).parse(&url) {
             Ok(parsed) => parsed.serialize(),

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -270,7 +270,7 @@ impl<'a> EventHelpers for JSRef<'a, Event> {
         self.trusted.set(trusted);
     }
 
-    // https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event
+    // https://html.spec.whatwg.org/multipage/#fire-a-simple-event
     fn fire(self, target: JSRef<EventTarget>) -> bool {
         self.set_trusted(true);
         target.dispatch_event(self)

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -78,21 +78,21 @@ impl<'a> HTMLButtonElementMethods for JSRef<'a, HTMLButtonElement> {
     // https://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-button-type
+    // https://html.spec.whatwg.org/multipage/#dom-button-type
     fn Type(self) -> DOMString {
         let elem: JSRef<Element> = ElementCast::from_ref(self);
         let ty = elem.get_string_attribute(&atom!("type")).into_ascii_lowercase();
-        // https://html.spec.whatwg.org/multipage/forms.html#attr-button-type
+        // https://html.spec.whatwg.org/multipage/#attr-button-type
         match ty.as_slice() {
             "reset" | "button" | "menu" => ty,
             _ => "submit".to_owned()
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-button-type
+    // https://html.spec.whatwg.org/multipage/#dom-button-type
     make_setter!(SetType, "type");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement
+    // https://html.spec.whatwg.org/multipage/#htmlbuttonelement
     make_url_or_base_getter!(FormAction);
 
     make_setter!(SetFormAction, "formaction");
@@ -182,13 +182,13 @@ impl<'a> Activatable for JSRef<'a, HTMLButtonElement> {
     }
 
     fn is_instance_activatable(&self) -> bool {
-        //https://html.spec.whatwg.org/multipage/forms.html#the-button-element
+        //https://html.spec.whatwg.org/multipage/#the-button-element
         let node: JSRef<Node> = NodeCast::from_ref(*self);
         !(node.get_disabled_state())
     }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#run-pre-click-activation-steps
-    // https://html.spec.whatwg.org/multipage/forms.html#the-button-element:activation-behavior
+    // https://html.spec.whatwg.org/multipage/#the-button-element:activation-behavior
     fn pre_click_activation(&self) {
     }
 
@@ -200,7 +200,7 @@ impl<'a> Activatable for JSRef<'a, HTMLButtonElement> {
     fn activation_behavior(&self, _event: JSRef<Event>, _target: JSRef<EventTarget>) {
         let ty = self.button_type.get();
         match ty {
-            //https://html.spec.whatwg.org/multipage/forms.html#attr-button-type-submit-state
+            //https://html.spec.whatwg.org/multipage/#attr-button-type-submit-state
             ButtonType::ButtonSubmit => {
                 self.form_owner().map(|o| {
                     o.root().r().submit(SubmittedFrom::NotFromFormSubmitMethod,
@@ -211,7 +211,7 @@ impl<'a> Activatable for JSRef<'a, HTMLButtonElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#implicit-submission
+    // https://html.spec.whatwg.org/multipage/#implicit-submission
     #[allow(unsafe_code)]
     fn implicit_submission(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool) {
         let doc = document_from_node(*self).root();

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -98,7 +98,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
 
     global_event_handlers!(NoOnload);
 
-    // https://html.spec.whatwg.org/multipage/dom.html#dom-dataset
+    // https://html.spec.whatwg.org/multipage/#dom-dataset
     fn Dataset(self) -> Temporary<DOMStringMap> {
         self.dataset.or_init(|| DOMStringMap::new(self))
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -64,70 +64,70 @@ impl HTMLFormElement {
 }
 
 impl<'a> HTMLFormElementMethods for JSRef<'a, HTMLFormElement> {
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-acceptcharset
+    // https://html.spec.whatwg.org/multipage/#dom-form-acceptcharset
     make_getter!(AcceptCharset, "accept-charset");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-acceptcharset
+    // https://html.spec.whatwg.org/multipage/#dom-form-acceptcharset
     make_setter!(SetAcceptCharset, "accept-charset");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-action
+    // https://html.spec.whatwg.org/multipage/#dom-fs-action
     make_url_or_base_getter!(Action);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-action
+    // https://html.spec.whatwg.org/multipage/#dom-fs-action
     make_setter!(SetAction, "action");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-autocomplete
+    // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
     make_enumerated_getter!(Autocomplete, "on", ("off"));
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-autocomplete
+    // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
     make_setter!(SetAutocomplete, "autocomplete");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-enctype
+    // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
     make_enumerated_getter!(Enctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-enctype
+    // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
     make_setter!(SetEnctype, "enctype");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-encoding
+    // https://html.spec.whatwg.org/multipage/#dom-fs-encoding
     fn Encoding(self) -> DOMString {
         self.Enctype()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-encoding
+    // https://html.spec.whatwg.org/multipage/#dom-fs-encoding
     fn SetEncoding(self, value: DOMString) {
         self.SetEnctype(value)
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-method
+    // https://html.spec.whatwg.org/multipage/#dom-fs-method
     make_enumerated_getter!(Method, "get", ("post") | ("dialog"));
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-method
+    // https://html.spec.whatwg.org/multipage/#dom-fs-method
     make_setter!(SetMethod, "method");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-name
+    // https://html.spec.whatwg.org/multipage/#dom-form-name
     make_getter!(Name);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-name
+    // https://html.spec.whatwg.org/multipage/#dom-form-name
     make_setter!(SetName, "name");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-novalidate
+    // https://html.spec.whatwg.org/multipage/#dom-fs-novalidate
     make_bool_getter!(NoValidate);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-novalidate
+    // https://html.spec.whatwg.org/multipage/#dom-fs-novalidate
     make_bool_setter!(SetNoValidate, "novalidate");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-target
+    // https://html.spec.whatwg.org/multipage/#dom-fs-target
     make_getter!(Target);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-fs-target
+    // https://html.spec.whatwg.org/multipage/#dom-fs-target
     make_setter!(SetTarget, "target");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#the-form-element:concept-form-submit
+    // https://html.spec.whatwg.org/multipage/#the-form-element:concept-form-submit
     fn Submit(self) {
         self.submit(SubmittedFrom::FromFormSubmitMethod, FormSubmitter::FormElement(self));
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-reset
+    // https://html.spec.whatwg.org/multipage/#dom-form-reset
     fn Reset(self) {
         self.reset(ResetFrom::FromFormResetMethod);
     }
@@ -146,11 +146,11 @@ pub enum ResetFrom {
 }
 
 pub trait HTMLFormElementHelpers {
-    // https://html.spec.whatwg.org/multipage/forms.html#concept-form-submit
+    // https://html.spec.whatwg.org/multipage/#concept-form-submit
     fn submit(self, submit_method_flag: SubmittedFrom, submitter: FormSubmitter);
-    // https://html.spec.whatwg.org/multipage/forms.html#constructing-the-form-data-set
+    // https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
     fn get_form_dataset(self, submitter: Option<FormSubmitter>) -> Vec<FormDatum>;
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-form-reset
+    // https://html.spec.whatwg.org/multipage/#dom-form-reset
     fn reset(self, submit_method_flag: ResetFrom);
 }
 
@@ -209,18 +209,18 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
                 load_data.method = Method::Post;
                 load_data.data = Some(parsed_data.into_bytes());
             },
-            // https://html.spec.whatwg.org/multipage/forms.html#submit-get-action
+            // https://html.spec.whatwg.org/multipage/#submit-get-action
             ("ftp", _) | ("javascript", _) | ("data", FormMethod::FormGet) => (),
             _ => return // Unimplemented (data and mailto)
         }
 
-        // This is wrong. https://html.spec.whatwg.org/multipage/forms.html#planned-navigation
+        // This is wrong. https://html.spec.whatwg.org/multipage/#planned-navigation
         win.r().script_chan().send(ScriptMsg::Navigate(win.r().pipeline(), load_data)).unwrap();
     }
 
     fn get_form_dataset<'b>(self, submitter: Option<FormSubmitter<'b>>) -> Vec<FormDatum> {
         fn clean_crlf(s: &str) -> DOMString {
-            // https://html.spec.whatwg.org/multipage/forms.html#constructing-the-form-data-set
+            // https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
             // Step 4
             let mut buf = "".to_owned();
             let mut prev = ' ';
@@ -332,7 +332,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
             }
         });
         // TODO: Handle `dirnames` (needs directionality support)
-        //       https://html.spec.whatwg.org/multipage/dom.html#the-directionality
+        //       https://html.spec.whatwg.org/multipage/#the-directionality
         let mut ret: Vec<FormDatum> = data_set.collect();
         for datum in ret.iter_mut() {
             match datum.ty.as_slice() {
@@ -347,7 +347,7 @@ impl<'a> HTMLFormElementHelpers for JSRef<'a, HTMLFormElement> {
     }
 
     fn reset(self, _reset_method_flag: ResetFrom) {
-        // https://html.spec.whatwg.org/multipage/forms.html#locked-for-reset
+        // https://html.spec.whatwg.org/multipage/#locked-for-reset
         if self.marked_for_reset.get() {
             return;
         } else {
@@ -465,7 +465,7 @@ impl<'a> FormSubmitter<'a> {
         match attr.as_slice() {
             "multipart/form-data" => FormEncType::FormDataEncoded,
             "text/plain" => FormEncType::TextPlainEncoded,
-            // https://html.spec.whatwg.org/multipage/forms.html#attr-fs-enctype
+            // https://html.spec.whatwg.org/multipage/#attr-fs-enctype
             // urlencoded is the default
             _ => FormEncType::UrlEncoded
         }
@@ -515,7 +515,7 @@ pub trait FormControl<'a> : Copy + Sized {
     // FIXME: This is wrong (https://github.com/servo/servo/issues/3553)
     //        but we need html5ever to do it correctly
     fn form_owner(self) -> Option<Temporary<HTMLFormElement>> {
-        // https://html.spec.whatwg.org/multipage/forms.html#reset-the-form-owner
+        // https://html.spec.whatwg.org/multipage/#reset-the-form-owner
         let elem = self.to_element();
         let owner = elem.get_string_attribute(&atom!("form"));
         if !owner.is_empty() {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -215,35 +215,35 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
     // https://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-defaultchecked
+    // https://html.spec.whatwg.org/multipage/#dom-input-defaultchecked
     make_bool_getter!(DefaultChecked, "checked");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-defaultchecked
+    // https://html.spec.whatwg.org/multipage/#dom-input-defaultchecked
     make_bool_setter!(SetDefaultChecked, "checked");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-checked
+    // https://html.spec.whatwg.org/multipage/#dom-input-checked
     fn Checked(self) -> bool {
         self.checked.get()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-checked
+    // https://html.spec.whatwg.org/multipage/#dom-input-checked
     fn SetChecked(self, checked: bool) {
         self.update_checked_state(checked, true);
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-readonly
+    // https://html.spec.whatwg.org/multipage/#dom-input-readonly
     make_bool_getter!(ReadOnly);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-readonly
+    // https://html.spec.whatwg.org/multipage/#dom-input-readonly
     make_bool_setter!(SetReadOnly, "readonly");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-size
+    // https://html.spec.whatwg.org/multipage/#dom-input-size
     make_uint_getter!(Size);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-size
+    // https://html.spec.whatwg.org/multipage/#dom-input-size
     make_uint_setter!(SetSize, "size");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-type
+    // https://html.spec.whatwg.org/multipage/#dom-input-type
     make_enumerated_getter!(Type, "text", ("hidden") | ("search") | ("tel") |
                                   ("url") | ("email") | ("password") |
                                   ("datetime") | ("date") | ("month") |
@@ -252,71 +252,71 @@ impl<'a> HTMLInputElementMethods for JSRef<'a, HTMLInputElement> {
                                   ("checkbox") | ("radio") | ("file") |
                                   ("submit") | ("image") | ("reset") | ("button"));
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-type
+    // https://html.spec.whatwg.org/multipage/#dom-input-type
     make_setter!(SetType, "type");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-value
+    // https://html.spec.whatwg.org/multipage/#dom-input-value
     fn Value(self) -> DOMString {
         // FIXME(https://github.com/rust-lang/rust/issues/23338)
         let textinput = self.textinput.borrow();
         textinput.get_content()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-value
+    // https://html.spec.whatwg.org/multipage/#dom-input-value
     fn SetValue(self, value: DOMString) {
         self.textinput.borrow_mut().set_content(value);
         self.value_changed.set(true);
         self.force_relayout();
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-defaultvalue
+    // https://html.spec.whatwg.org/multipage/#dom-input-defaultvalue
     make_getter!(DefaultValue, "value");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-defaultvalue
+    // https://html.spec.whatwg.org/multipage/#dom-input-defaultvalue
     make_setter!(SetDefaultValue, "value");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name
+    // https://html.spec.whatwg.org/multipage/#attr-fe-name
     make_getter!(Name);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name
+    // https://html.spec.whatwg.org/multipage/#attr-fe-name
     make_setter!(SetName, "name");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-input-placeholder
+    // https://html.spec.whatwg.org/multipage/#attr-input-placeholder
     make_getter!(Placeholder);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-input-placeholder
+    // https://html.spec.whatwg.org/multipage/#attr-input-placeholder
     make_setter!(SetPlaceholder, "placeholder");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formaction
+    // https://html.spec.whatwg.org/multipage/#dom-input-formaction
     make_url_or_base_getter!(FormAction);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formaction
+    // https://html.spec.whatwg.org/multipage/#dom-input-formaction
     make_setter!(SetFormAction, "formaction");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formenctype
+    // https://html.spec.whatwg.org/multipage/#dom-input-formenctype
     make_enumerated_getter!(FormEnctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formenctype
+    // https://html.spec.whatwg.org/multipage/#dom-input-formenctype
     make_setter!(SetFormEnctype, "formenctype");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formmethod
+    // https://html.spec.whatwg.org/multipage/#dom-input-formmethod
     make_enumerated_getter!(FormMethod, "get", ("post") | ("dialog"));
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formmethod
+    // https://html.spec.whatwg.org/multipage/#dom-input-formmethod
     make_setter!(SetFormMethod, "formmethod");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formtarget
+    // https://html.spec.whatwg.org/multipage/#dom-input-formtarget
     make_getter!(FormTarget);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-formtarget
+    // https://html.spec.whatwg.org/multipage/#dom-input-formtarget
     make_setter!(SetFormTarget, "formtarget");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-indeterminate
+    // https://html.spec.whatwg.org/multipage/#dom-input-indeterminate
     fn Indeterminate(self) -> bool {
         self.indeterminate.get()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-input-indeterminate
+    // https://html.spec.whatwg.org/multipage/#dom-input-indeterminate
     fn SetIndeterminate(self, val: bool) {
         self.indeterminate.set(val)
     }
@@ -421,15 +421,15 @@ impl<'a> HTMLInputElementHelpers for JSRef<'a, HTMLInputElement> {
         self.indeterminate.get()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#concept-fe-mutable
+    // https://html.spec.whatwg.org/multipage/#concept-fe-mutable
     fn mutable(self) -> bool {
-        // https://html.spec.whatwg.org/multipage/forms.html#the-input-element:concept-fe-mutable
-        // https://html.spec.whatwg.org/multipage/forms.html#the-readonly-attribute:concept-fe-mutable
+        // https://html.spec.whatwg.org/multipage/#the-input-element:concept-fe-mutable
+        // https://html.spec.whatwg.org/multipage/#the-readonly-attribute:concept-fe-mutable
         let node: JSRef<Node> = NodeCast::from_ref(self);
         !(node.get_disabled_state() || self.ReadOnly())
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#the-input-element:concept-form-reset-control
+    // https://html.spec.whatwg.org/multipage/#the-input-element:concept-form-reset-control
     fn reset(self) {
         match self.input_type.get() {
             InputType::InputRadio | InputType::InputCheckbox => {
@@ -464,7 +464,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                 node.set_enabled_state(false);
             }
             &atom!("checked") => {
-                // https://html.spec.whatwg.org/multipage/forms.html#the-input-element:concept-input-checked-dirty
+                // https://html.spec.whatwg.org/multipage/#the-input-element:concept-input-checked-dirty
                 if !self.checked_changed.get() {
                     self.update_checked_state(true, false);
                 }
@@ -528,7 +528,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
                 node.check_ancestors_disabled_state_for_form_control();
             }
             &atom!("checked") => {
-                // https://html.spec.whatwg.org/multipage/forms.html#the-input-element:concept-input-checked-dirty
+                // https://html.spec.whatwg.org/multipage/#the-input-element:concept-input-checked-dirty
                 if !self.checked_changed.get() {
                     self.update_checked_state(false, false);
                 }
@@ -603,7 +603,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLInputElement> {
             }
 
             // TODO: Dispatch events for non activatable inputs
-            // https://html.spec.whatwg.org/multipage/forms.html#common-input-element-events
+            // https://html.spec.whatwg.org/multipage/#common-input-element-events
 
             //TODO: set the editing position for text inputs
 
@@ -641,10 +641,10 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
 
     fn is_instance_activatable(&self) -> bool {
         match self.input_type.get() {
-            // https://html.spec.whatwg.org/multipage/forms.html#submit-button-state-%28type=submit%29:activation-behaviour-2
-            // https://html.spec.whatwg.org/multipage/forms.html#reset-button-state-%28type=reset%29:activation-behaviour-2
-            // https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-%28type=checkbox%29:activation-behaviour-2
-            // https://html.spec.whatwg.org/multipage/forms.html#radio-button-state-%28type=radio%29:activation-behaviour-2
+            // https://html.spec.whatwg.org/multipage/#submit-button-state-%28type=submit%29:activation-behaviour-2
+            // https://html.spec.whatwg.org/multipage/#reset-button-state-%28type=reset%29:activation-behaviour-2
+            // https://html.spec.whatwg.org/multipage/#checkbox-state-%28type=checkbox%29:activation-behaviour-2
+            // https://html.spec.whatwg.org/multipage/#radio-button-state-%28type=radio%29:activation-behaviour-2
             InputType::InputSubmit | InputType::InputReset
             | InputType::InputCheckbox | InputType::InputRadio => self.mutable(),
             _ => false
@@ -660,12 +660,12 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         cache.was_mutable = self.mutable();
         if cache.was_mutable {
             match ty {
-                // https://html.spec.whatwg.org/multipage/forms.html#submit-button-state-(type=submit):activation-behavior
+                // https://html.spec.whatwg.org/multipage/#submit-button-state-(type=submit):activation-behavior
                 // InputType::InputSubmit => (), // No behavior defined
-                // https://html.spec.whatwg.org/multipage/forms.html#reset-button-state-(type=reset):activation-behavior
+                // https://html.spec.whatwg.org/multipage/#reset-button-state-(type=reset):activation-behavior
                 // InputType::InputSubmit => (), // No behavior defined
                 InputType::InputCheckbox => {
-                    // https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-(type=checkbox):pre-click-activation-steps
+                    // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):pre-click-activation-steps
                     // cache current values of `checked` and `indeterminate`
                     // we may need to restore them later
                     cache.indeterminate = self.Indeterminate();
@@ -674,7 +674,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                     self.SetIndeterminate(false);
                     self.SetChecked(!cache.checked);
                 },
-                // https://html.spec.whatwg.org/multipage/forms.html#radio-button-state-(type=radio):pre-click-activation-steps
+                // https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):pre-click-activation-steps
                 InputType::InputRadio => {
                     //TODO: if not in document, use root ancestor instead of document
                     let owner = self.form_owner().root();
@@ -711,11 +711,11 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
             return;
         }
         match ty {
-            // https://html.spec.whatwg.org/multipage/forms.html#submit-button-state-(type=submit):activation-behavior
+            // https://html.spec.whatwg.org/multipage/#submit-button-state-(type=submit):activation-behavior
             // InputType::InputSubmit => (), // No behavior defined
-            // https://html.spec.whatwg.org/multipage/forms.html#reset-button-state-(type=reset):activation-behavior
+            // https://html.spec.whatwg.org/multipage/#reset-button-state-(type=reset):activation-behavior
             // InputType::InputReset => (), // No behavior defined
-            // https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-(type=checkbox):canceled-activation-steps
+            // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):canceled-activation-steps
             InputType::InputCheckbox => {
                 // We want to restore state only if the element had been changed in the first place
                 if cache.was_mutable {
@@ -724,7 +724,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                     self.checked_changed.set(cache.checked_changed);
                 }
             },
-            // https://html.spec.whatwg.org/multipage/forms.html#radio-button-state-(type=radio):canceled-activation-steps
+            // https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):canceled-activation-steps
             InputType::InputRadio => {
                 // We want to restore state only if the element had been changed in the first place
                 if cache.was_mutable {
@@ -762,7 +762,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         }
         match ty {
             InputType::InputSubmit => {
-                // https://html.spec.whatwg.org/multipage/forms.html#submit-button-state-(type=submit):activation-behavior
+                // https://html.spec.whatwg.org/multipage/#submit-button-state-(type=submit):activation-behavior
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 if self.mutable() /* and document owner is fully active */ {
                     self.form_owner().map(|o| {
@@ -772,7 +772,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                 }
             },
             InputType::InputReset => {
-                // https://html.spec.whatwg.org/multipage/forms.html#reset-button-state-(type=reset):activation-behavior
+                // https://html.spec.whatwg.org/multipage/#reset-button-state-(type=reset):activation-behavior
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 if self.mutable() /* and document owner is fully active */ {
                     self.form_owner().map(|o| {
@@ -781,8 +781,8 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                 }
             },
             InputType::InputCheckbox | InputType::InputRadio => {
-                // https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-(type=checkbox):activation-behavior
-                // https://html.spec.whatwg.org/multipage/forms.html#radio-button-state-(type=radio):activation-behavior
+                // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):activation-behavior
+                // https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):activation-behavior
                 if self.mutable() {
                     let win = window_from_node(*self).root();
                     let event = Event::new(GlobalRef::Window(win.r()),
@@ -804,7 +804,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#implicit-submission
+    // https://html.spec.whatwg.org/multipage/#implicit-submission
     #[allow(unsafe_code)]
     fn implicit_submission(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool) {
         let doc = document_from_node(*self).root();

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -93,7 +93,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         node.SetTextContent(Some(value))
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-option-value
+    // https://html.spec.whatwg.org/multipage/#attr-option-value
     fn Value(self) -> DOMString {
         let element: JSRef<Element> = ElementCast::from_ref(self);
         let attr = &atom!("value");
@@ -104,10 +104,10 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-option-value
+    // https://html.spec.whatwg.org/multipage/#attr-option-value
     make_setter!(SetValue, "value");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-option-label
+    // https://html.spec.whatwg.org/multipage/#attr-option-label
     fn Label(self) -> DOMString {
         let element: JSRef<Element> = ElementCast::from_ref(self);
         let attr = &atom!("label");
@@ -118,7 +118,7 @@ impl<'a> HTMLOptionElementMethods for JSRef<'a, HTMLOptionElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-option-label
+    // https://html.spec.whatwg.org/multipage/#attr-option-label
     make_setter!(SetLabel, "label");
 
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -66,7 +66,7 @@ impl<'a> HTMLSelectElementMethods for JSRef<'a, HTMLSelectElement> {
     // https://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-select-type
+    // https://html.spec.whatwg.org/multipage/#dom-select-type
     fn Type(self) -> DOMString {
         let elem: JSRef<Element> = ElementCast::from_ref(self);
         if elem.has_attribute(&atom!("multiple")) {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -41,7 +41,7 @@ pub struct HTMLTextAreaElement {
     textinput: DOMRefCell<TextInput>,
     cols: Cell<u32>,
     rows: Cell<u32>,
-    // https://html.spec.whatwg.org/multipage/forms.html#concept-textarea-dirty
+    // https://html.spec.whatwg.org/multipage/#concept-textarea-dirty
     value_changed: Cell<bool>,
 }
 
@@ -110,10 +110,10 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
     // TODO A few of these attributes have default values and additional
     // constraints
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-cols
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-cols
     make_uint_getter!(Cols);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-cols
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-cols
     make_uint_setter!(SetCols, "cols");
 
     // https://www.whatwg.org/html/#dom-fe-disabled
@@ -122,54 +122,54 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
     // https://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name
+    // https://html.spec.whatwg.org/multipage/#attr-fe-name
     make_getter!(Name);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name
+    // https://html.spec.whatwg.org/multipage/#attr-fe-name
     make_setter!(SetName, "name");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-placeholder
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-placeholder
     make_getter!(Placeholder);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-placeholder
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-placeholder
     make_setter!(SetPlaceholder, "placeholder");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-textarea-readonly
+    // https://html.spec.whatwg.org/multipage/#attr-textarea-readonly
     make_bool_getter!(ReadOnly);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#attr-textarea-readonly
+    // https://html.spec.whatwg.org/multipage/#attr-textarea-readonly
     make_bool_setter!(SetReadOnly, "readonly");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-required
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-required
     make_bool_getter!(Required);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-required
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-required
     make_bool_setter!(SetRequired, "required");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-rows
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-rows
     make_uint_getter!(Rows);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-rows
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-rows
     make_uint_setter!(SetRows, "rows");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-wrap
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-wrap
     make_getter!(Wrap);
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-wrap
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-wrap
     make_setter!(SetWrap, "wrap");
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-type
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-type
     fn Type(self) -> DOMString {
         "textarea".to_owned()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-defaultvalue
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-defaultvalue
     fn DefaultValue(self) -> DOMString {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         node.GetTextContent().unwrap()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-defaultvalue
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-defaultvalue
     fn SetDefaultValue(self, value: DOMString) {
         let node: JSRef<Node> = NodeCast::from_ref(self);
         node.SetTextContent(Some(value));
@@ -181,14 +181,14 @@ impl<'a> HTMLTextAreaElementMethods for JSRef<'a, HTMLTextAreaElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-value
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-value
     fn Value(self) -> DOMString {
         // FIXME(https://github.com/rust-lang/rust/issues/23338)
         let textinput = self.textinput.borrow();
         textinput.get_content()
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#dom-textarea-value
+    // https://html.spec.whatwg.org/multipage/#dom-textarea-value
     fn SetValue(self, value: DOMString) {
         // TODO move the cursor to the end of the field
         self.textinput.borrow_mut().set_content(value);
@@ -204,13 +204,13 @@ pub trait HTMLTextAreaElementHelpers {
 }
 
 impl<'a> HTMLTextAreaElementHelpers for JSRef<'a, HTMLTextAreaElement> {
-    // https://html.spec.whatwg.org/multipage/forms.html#concept-fe-mutable
+    // https://html.spec.whatwg.org/multipage/#concept-fe-mutable
     fn mutable(self) -> bool {
-        // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-fe-mutable
+        // https://html.spec.whatwg.org/multipage/#the-textarea-element:concept-fe-mutable
         !(self.Disabled() || self.ReadOnly())
     }
     fn reset(self) {
-        // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-form-reset-control
+        // https://html.spec.whatwg.org/multipage/#the-textarea-element:concept-form-reset-control
         self.SetValue(self.DefaultValue());
         self.value_changed.set(false);
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -37,7 +37,7 @@ impl Location {
 }
 
 impl<'a> LocationMethods for JSRef<'a, Location> {
-    // https://html.spec.whatwg.org/multipage/browsers.html#dom-location-assign
+    // https://html.spec.whatwg.org/multipage/#dom-location-assign
     fn Assign(self, url: DOMString) {
         self.window.root().r().load_url(url);
     }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -111,7 +111,7 @@ macro_rules! make_enumerated_getter(
             let element: JSRef<Element> = ElementCast::from_ref(self);
             let val = element.get_string_attribute(&Atom::from_slice($htmlname))
                              .into_ascii_lowercase();
-            // https://html.spec.whatwg.org/multipage/forms.html#attr-fs-method
+            // https://html.spec.whatwg.org/multipage/#attr-fs-method
             match val.as_slice() {
                 $($choices)|+ => val,
                 _ => $default.to_owned()
@@ -214,7 +214,7 @@ macro_rules! error_event_handler(
     )
 );
 
-// https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+// https://html.spec.whatwg.org/multipage/#globaleventhandlers
 // see webidls/EventHandler.webidl
 // As more methods get added, just update them here.
 macro_rules! global_event_handlers(

--- a/components/script/dom/urlhelper.rs
+++ b/components/script/dom/urlhelper.rs
@@ -40,7 +40,7 @@ impl UrlHelper {
         })
     }
 
-    /// https://html.spec.whatwg.org/multipage/browsers.html#same-origin
+    /// https://html.spec.whatwg.org/multipage/#same-origin
     pub fn SameOrigin(urlA: &Url, urlB: &Url) -> bool {
         if urlA.host() != urlB.host() {
             return false

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -402,7 +402,7 @@ impl<'a> WindowMethods for JSRef<'a, Window> {
         self.Window()
     }
 
-    // https://html.spec.whatwg.org/multipage/browsers.html#dom-parent
+    // https://html.spec.whatwg.org/multipage/#dom-parent
     fn Parent(self) -> Temporary<Window> {
         let browser_context = self.browser_context();
         let browser_context = browser_context.as_ref().unwrap();
@@ -779,7 +779,7 @@ impl<'a> WindowHelpers for JSRef<'a, Window> {
        self.devtools_wants_updates.set(value);
    }
 
-    // https://html.spec.whatwg.org/multipage/browsers.html#accessing-other-browsing-contexts
+    // https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts
     fn IndexedGetter(self, _index: u32, _found: &mut bool) -> Option<Temporary<Window>> {
         None
     }

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -310,7 +310,7 @@ pub fn parse_html(document: JSRef<Document>,
                     // This is done by using a <plaintext> element as the html5ever tokenizer
                     // provides no other way to change to that state.
                     // Spec for text/plain handling is:
-                    // https://html.spec.whatwg.org/multipage/browsers.html#read-text
+                    // https://html.spec.whatwg.org/multipage/#read-text
                     let page = format!("<pre>\u{000A}<plaintext>");
                     parser.parse_chunk(page);
                     parse_progress(&parser, url, &load_response);
@@ -331,7 +331,7 @@ pub fn parse_html(document: JSRef<Document>,
     debug!("finished parsing");
 }
 
-// https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
+// https://html.spec.whatwg.org/multipage/#parsing-html-fragments
 pub fn parse_html_fragment(context_node: JSRef<Node>,
                            input: DOMString,
                            output: &mut RootedVec<JS<Node>>) {

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1233,7 +1233,7 @@ impl ScriptTask {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/browsers.html#navigating-across-documents
+    /// https://html.spec.whatwg.org/multipage/#navigating-across-documents
     /// The entry point for content to notify that a new load has been requested
     /// for the given pipeline (specifically the "navigate" algorithm).
     fn handle_navigate(&self, pipeline_id: PipelineId, subpage_id: Option<SubpageId>, load_data: LoadData) {


### PR DESCRIPTION
The HTML spec's division into pages is not stable, so it is safer to use the
URL without a specific page (which will redirect).
