### PR TITLE
Switched Element::Get_attributes to use a RootedVec

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -664,8 +664,7 @@ pub trait AttributeHandlers {
     /// Returns the first attribute with any namespace and given case-sensitive
     /// name, if any.
     fn get_attribute_by_name(self, name: DOMString) -> Option<Temporary<Attr>>;
-    fn get_attributes(self, local_name: &Atom)
-                      -> Vec<Temporary<Attr>>;
+    fn get_attributes(self, local_name: &Atom, attributes: &mut RootedVec<JS<Attr>>);
     fn set_attribute_from_parser(self,
                                  name: QualName,
                                  value: DOMString,
@@ -709,9 +708,9 @@ pub trait AttributeHandlers {
 
 impl<'a> AttributeHandlers for JSRef<'a, Element> {
     fn get_attribute(self, namespace: &Namespace, local_name: &Atom) -> Option<Temporary<Attr>> {
-        self.get_attributes(local_name).into_iter().map(|attr| attr.root())
-            .find(|attr| attr.r().namespace() == namespace)
-            .map(|x| Temporary::from_rooted(x.r()))
+        let mut attributes = RootedVec::new();
+        self.get_attributes(local_name, &mut attributes);
+        attributes.iter().map(|attr| attr.root()).find(|attr| attr.r().namespace() == namespace).map(|x| Temporary::from_rooted(x.r()))
     }
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
@@ -724,19 +723,18 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
              .map(|x| Temporary::from_rooted(x.r()))
     }
 
-    fn get_attributes(self, local_name: &Atom) -> Vec<Temporary<Attr>> {
+    // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
+    fn get_attributes(self, local_name: &Atom, attributes: &mut RootedVec<JS<Attr>>) {
         // FIXME(https://github.com/rust-lang/rust/issues/23338)
         let attrs = self.attrs.borrow();
-        attrs.iter().map(|attr| attr.root()).filter_map(|attr| {
+        for attr in attrs.iter().map(|attr| attr.root()) {
             // FIXME(https://github.com/rust-lang/rust/issues/23338)
             let attr = attr.r();
             let attr_local_name = attr.local_name();
             if attr_local_name == local_name {
-                Some(Temporary::from_rooted(attr))
-            } else {
-                None
+                attributes.push(JS::from_rooted(attr));
             }
-        }).collect()
+        }
     }
 
     fn set_attribute_from_parser(self,
@@ -1502,7 +1500,9 @@ impl<'a> style::node::TElement<'a> for JSRef<'a, Element> {
     }
     #[allow(unsafe_code)]
     fn get_attrs(self, local_name: &Atom) -> Vec<&'a str> {
-        self.get_attributes(local_name).into_iter().map(|attr| attr.root()).map(|attr| {
+        let mut attributes = RootedVec::new();
+        self.get_attributes(local_name, &mut attributes);
+        attributes.iter().map(|attr| attr.root()).map(|attr| {
             // FIXME(https://github.com/rust-lang/rust/issues/23338)
             let attr = attr.r();
             let value = attr.value();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2524,9 +2524,9 @@ impl<'a> style::node::TNode<'a> for JSRef<'a, Node> {
                     })
             },
             NamespaceConstraint::Any => {
-                self.as_element().get_attributes(local_name).into_iter()
-                    .map(|attr| attr.root())
-                    .any(|attr| {
+                let mut attributes: RootedVec<JS<Attr>> = RootedVec::new();
+                self.as_element().get_attributes(local_name, &mut attributes);
+                attributes.iter().map(|attr| attr.root()).any(|attr| {
                         // FIXME(https://github.com/rust-lang/rust/issues/23338)
                         let attr = attr.r();
                         let value = attr.value();


### PR DESCRIPTION
Changes Element::get_attributes to use a `&mut Rooted<JS<Attr>>` param instead of returning a `Vec<Temporary<Attr>>`, fixes  #5684.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5692)

<!-- Reviewable:end -->
