### PR TITLE
Make external script sources load asynchronously, yet still block furthe...

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -100,6 +100,7 @@ impl DocumentLoader {
     }
 
     pub fn is_blocked(&self) -> bool {
+        //TODO: Ensure that we report blocked if parsing is still ongoing.
         !self.blocking_loads.is_empty()
     }
 

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -7,13 +7,12 @@
 
 use script_task::{ScriptMsg, ScriptChan};
 use msg::constellation_msg::{PipelineId};
-use net_traits::{LoadResponse, Metadata, load_whole_resource, ResourceTask, PendingAsyncLoad};
+use net_traits::{Metadata, load_whole_resource, ResourceTask, PendingAsyncLoad};
+use net_traits::AsyncResponseTarget;
 use url::Url;
 
-use std::sync::mpsc::Receiver;
-
 #[jstraceable]
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum LoadType {
     Image(Url),
     Script(Url),
@@ -75,9 +74,9 @@ impl DocumentLoader {
     }
 
     /// Create and initiate a new network request.
-    pub fn load_async(&mut self, load: LoadType) -> Receiver<LoadResponse> {
+    pub fn load_async(&mut self, load: LoadType, listener: Box<AsyncResponseTarget + Send>) {
         let pending = self.prepare_async_load(load);
-        pending.load()
+        pending.load_async(listener)
     }
 
     /// Create, initiate, and await the response for a new network request.
@@ -91,7 +90,7 @@ impl DocumentLoader {
     /// Mark an in-progress network request complete.
     pub fn finish_load(&mut self, load: LoadType) {
         let idx = self.blocking_loads.iter().position(|unfinished| *unfinished == load);
-        self.blocking_loads.remove(idx.expect("unknown completed load"));
+        self.blocking_loads.remove(idx.expect(&format!("unknown completed load {:?}", load)));
 
         if let Some(NotifierData { ref script_chan, pipeline }) = self.notifier_data {
             if !self.is_blocked() {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -15,7 +15,7 @@ use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::document::{Document, DocumentHelpers, IsHTMLDocument};
 use dom::document::DocumentSource;
 use dom::window::{Window, WindowHelpers};
-use parse::html::{HTMLInput, parse_html};
+use parse::html::{ParseContext, parse_html};
 use util::str::DOMString;
 
 use std::borrow::ToOwned;
@@ -64,7 +64,7 @@ impl<'a> DOMParserMethods for JSRef<'a, DOMParser> {
                                              None,
                                              DocumentSource::FromParser,
                                              loader).root();
-                parse_html(document.r(), HTMLInput::InputString(s), &url, None);
+                parse_html(document.r(), s, &url, ParseContext::Owner(None));
                 document.r().set_ready_state(DocumentReadyState::Complete);
                 Ok(Temporary::from_rooted(document.r()))
             }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -28,17 +28,21 @@ use dom::event::{Event, EventBubbles, EventCancelable, EventHelpers};
 use dom::element::ElementTypeId;
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
 use dom::node::{Node, NodeHelpers, NodeTypeId, document_from_node, window_from_node, CloneChildrenFlag};
+use dom::servohtmlparser::ServoHTMLParserHelpers;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::{WindowHelpers, ScriptHelpers};
-use script_task::{ScriptMsg, Runnable};
+use network_listener::{NetworkListener, PreInvoke};
+use script_task::{ScriptChan, ScriptMsg, Runnable};
 
 use encoding::all::UTF_8;
 use encoding::label::encoding_from_whatwg_label;
 use encoding::types::{Encoding, EncodingRef, DecoderTrap};
-use net_traits::Metadata;
+use net_traits::{Metadata, AsyncResponseListener};
 use util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
-use std::borrow::ToOwned;
-use std::cell::Cell;
+use html5ever::tree_builder::NextParserState;
+use std::cell::{RefCell, Cell};
+use std::mem;
+use std::sync::{Arc, Mutex};
 use string_cache::Atom;
 use url::{Url, UrlParser};
 
@@ -99,7 +103,7 @@ impl HTMLScriptElement {
 
 pub trait HTMLScriptElementHelpers {
     /// Prepare a script (<https://www.whatwg.org/html/#prepare-a-script>)
-    fn prepare(self);
+    fn prepare(self) -> NextParserState;
 
     /// [Execute a script block]
     /// (https://html.spec.whatwg.org/multipage/#execute-the-script-block)
@@ -153,12 +157,52 @@ pub enum ScriptOrigin {
     External(Result<(Metadata, Vec<u8>), String>),
 }
 
+/// The context required for asynchronously loading an external script source.
+struct ScriptContext {
+    /// The element that initiated the request.
+    elem: Trusted<HTMLScriptElement>,
+    /// The response body received to date.
+    data: RefCell<Vec<u8>>,
+    /// The response metadata received to date.
+    metadata: RefCell<Option<Metadata>>,
+    /// Whether the owning document's parser should resume once the response completes.
+    resume_on_completion: bool,
+}
+
+impl AsyncResponseListener for ScriptContext {
+    fn headers_available(&self, metadata: Metadata) {
+        *self.metadata.borrow_mut() = Some(metadata);
+    }
+
+    fn data_available(&self, payload: Vec<u8>) {
+        self.data.borrow_mut().extend(payload.into_iter());
+    }
+
+    fn response_complete(&self, status: Result<(), String>) {
+        let load = status.map(|_| {
+            let data = mem::replace(&mut *self.data.borrow_mut(), vec!());
+            let metadata = self.metadata.borrow_mut().take().unwrap();
+            (metadata, data)
+        });
+        let elem = self.elem.to_temporary().root();
+
+        elem.r().execute(ScriptOrigin::External(load));
+
+        if self.resume_on_completion {
+            let document = document_from_node(elem.r()).root();
+            document.r().get_current_parser().unwrap().root().r().resume();
+        }
+    }
+}
+
+impl PreInvoke for ScriptContext {}
+
 impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
-    fn prepare(self) {
+    fn prepare(self) -> NextParserState {
         // https://html.spec.whatwg.org/multipage/#prepare-a-script
         // Step 1.
         if self.already_started.get() {
-            return;
+            return NextParserState::Continue;
         }
         // Step 2.
         let was_parser_inserted = self.parser_inserted.get();
@@ -172,16 +216,16 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
         // Step 4.
         let text = self.Text();
         if text.len() == 0 && !element.has_attribute(&atom!("src")) {
-            return;
+            return NextParserState::Continue;
         }
         // Step 5.
         let node: JSRef<Node> = NodeCast::from_ref(self);
         if !node.is_in_doc() {
-            return;
+            return NextParserState::Continue;
         }
         // Step 6, 7.
         if !self.is_javascript() {
-            return;
+            return NextParserState::Continue;
         }
         // Step 8.
         if was_parser_inserted {
@@ -195,12 +239,12 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
         let document_from_node_ref = document_from_node(self).root();
         let document_from_node_ref = document_from_node_ref.r();
         if self.parser_inserted.get() && self.parser_document.root().r() != document_from_node_ref {
-            return;
+            return NextParserState::Continue;
         }
 
         // Step 11.
         if !document_from_node_ref.is_scripting_enabled() {
-            return;
+            return NextParserState::Continue;
         }
 
         // Step 12.
@@ -212,13 +256,13 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
                                              .to_ascii_lowercase();
                 let for_value = for_value.trim_matches(HTML_SPACE_CHARACTERS);
                 if for_value != "window" {
-                    return;
+                    return NextParserState::Continue;
                 }
 
                 let event_value = event_attribute.Value().to_ascii_lowercase();
                 let event_value = event_value.trim_matches(HTML_SPACE_CHARACTERS);
                 if event_value != "onload" && event_value != "onload()" {
-                    return;
+                    return NextParserState::Continue;
                 }
             },
             (_, _) => (),
@@ -245,7 +289,7 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
                 // Step 14.2
                 if src.is_empty() {
                     self.queue_error_event();
-                    return;
+                    return NextParserState::Continue;
                 }
 
                 // Step 14.3
@@ -254,7 +298,7 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
                         // Step 14.4
                         error!("error parsing URL for script {}", src);
                         self.queue_error_event();
-                        return;
+                        return NextParserState::Continue;
                     }
                     Ok(url) => {
                         // Step 14.5
@@ -263,8 +307,28 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
                         // the origin of the script element's node document, and the default origin
                         // behaviour set to taint.
                         let doc = document_from_node(self).root();
-                        let contents = doc.r().load_sync(LoadType::Script(url));
-                        ScriptOrigin::External(contents)
+
+                        let script_chan = window.script_chan();
+                        let elem = Trusted::new(window.get_cx(), self, script_chan.clone());
+
+                        let context = Arc::new(Mutex::new(ScriptContext {
+                            elem: elem,
+                            data: RefCell::new(vec!()),
+                            metadata: RefCell::new(None),
+                            resume_on_completion: self.parser_inserted.get(),
+                        }));
+
+                        let listener = box NetworkListener {
+                            context: context,
+                            script_chan: script_chan,
+                        };
+
+                        doc.r().load_async(LoadType::Script(url), listener);
+
+                        if self.parser_inserted.get() {
+                            doc.r().get_current_parser().unwrap().root().r().suspend();
+                        }
+                        return NextParserState::Suspend;
                     }
                 }
             },
@@ -275,6 +339,7 @@ impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
         // TODO: Add support for the `defer` and `async` attributes.  (For now, we fetch all
         // scripts synchronously and execute them immediately.)
         self.execute(load);
+        NextParserState::Continue
     }
 
     fn execute(self, load: ScriptOrigin) {

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -5,24 +5,35 @@
 //! The bulk of the HTML parser integration is in `script::parse::html`.
 //! This module is mostly about its interaction with DOM memory management.
 
+use document_loader::LoadType;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::ServoHTMLParserBinding;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::trace::JSTraceable;
 use dom::bindings::js::{JS, JSRef, Rootable, Temporary};
+use dom::bindings::refcounted::Trusted;
 use dom::bindings::utils::{Reflectable, Reflector, reflect_dom_object};
 use dom::document::{Document, DocumentHelpers};
-use dom::node::Node;
+use dom::node::{window_from_node, Node};
+use dom::window::Window;
+use network_listener::PreInvoke;
 use parse::Parser;
+use script_task::{ScriptTask, ScriptChan};
 
-use util::task_state;
+use msg::constellation_msg::{PipelineId, SubpageId};
+use net_traits::{Metadata, AsyncResponseListener};
 
+use encoding::all::UTF_8;
+use encoding::types::{Encoding, DecoderTrap};
+use std::cell::{Cell, RefCell};
 use std::default::Default;
 use url::Url;
 use js::jsapi::JSTracer;
 use html5ever::tokenizer;
 use html5ever::tree_builder;
 use html5ever::tree_builder::{TreeBuilder, TreeBuilderOpts};
+use hyper::header::ContentType;
+use hyper::mime::{Mime, TopLevel, SubLevel};
 
 #[must_root]
 #[jstraceable]
@@ -41,6 +52,110 @@ pub struct FragmentContext<'a> {
 
 pub type Tokenizer = tokenizer::Tokenizer<TreeBuilder<JS<Node>, Sink>>;
 
+/// The context required for asynchronously fetching a document and parsing it progressively.
+pub struct ParserContext {
+    /// The parser that initiated the request.
+    parser: RefCell<Option<Trusted<ServoHTMLParser>>>,
+    /// Is this document a synthesized document for a single image?
+    is_image_document: Cell<bool>,
+    /// The pipeline associated with this document.
+    id: PipelineId,
+    /// The subpage associated with this document.
+    subpage: Option<SubpageId>,
+    /// The target event loop for the response notifications.
+    script_chan: Box<ScriptChan+Send>,
+    /// The URL for this document.
+    url: Url,
+}
+
+impl ParserContext {
+    pub fn new(id: PipelineId, subpage: Option<SubpageId>, script_chan: Box<ScriptChan+Send>,
+               url: Url) -> ParserContext {
+        ParserContext {
+            parser: RefCell::new(None),
+            is_image_document: Cell::new(false),
+            id: id,
+            subpage: subpage,
+            script_chan: script_chan,
+            url: url,
+        }
+    }
+}
+
+impl AsyncResponseListener for ParserContext {
+    fn headers_available(&self, metadata: Metadata) {
+        let content_type = metadata.content_type.clone();
+
+        let parser = ScriptTask::page_fetch_complete(self.id.clone(), self.subpage.clone(),
+                                                     metadata);
+        let parser = match parser {
+            Some(parser) => parser,
+            None => return,
+        }.root();
+
+        let parser = parser.r();
+        let win = parser.window().root();
+        *self.parser.borrow_mut() = Some(Trusted::new(win.r().get_cx(), parser,
+                                                      self.script_chan.clone()));
+
+        match content_type {
+            Some(ContentType(Mime(TopLevel::Image, _, _))) => {
+                self.is_image_document.set(true);
+                let page = format!("<html><body><img src='{}' /></body></html>",
+                                   self.url.serialize());
+                parser.pending_input.borrow_mut().push(page);
+                parser.parse_sync();
+            }
+            Some(ContentType(Mime(TopLevel::Text, SubLevel::Plain, _))) => {
+                // FIXME: When servo/html5ever#109 is fixed remove <plaintext> usage and
+                // replace with fix from that issue.
+
+                // text/plain documents require setting the tokenizer into PLAINTEXT mode.
+                // This is done by using a <plaintext> element as the html5ever tokenizer
+                // provides no other way to change to that state.
+                // Spec for text/plain handling is:
+                // https://html.spec.whatwg.org/multipage/#read-text
+                let page = format!("<pre>\u{000A}<plaintext>");
+                parser.pending_input.borrow_mut().push(page);
+                parser.parse_sync();
+            },
+            _ => {}
+        }
+    }
+
+    fn data_available(&self, payload: Vec<u8>) {
+        if !self.is_image_document.get() {
+            // FIXME: use Vec<u8> (html5ever #34)
+            let data = UTF_8.decode(&payload, DecoderTrap::Replace).unwrap();
+            let parser = match self.parser.borrow().as_ref() {
+                Some(parser) => parser.to_temporary(),
+                None => return,
+            }.root();
+            parser.r().parse_chunk(data);
+        }
+    }
+
+    fn response_complete(&self, status: Result<(), String>) {
+        let parser = match self.parser.borrow().as_ref() {
+            Some(parser) => parser.to_temporary(),
+            None => return,
+        }.root();
+        let doc = parser.r().document.root();
+        doc.r().finish_load(LoadType::PageSource(self.url.clone()));
+
+        if let Err(err) = status {
+            debug!("Failed to load page URL {}, error: {}", self.url.serialize(), err);
+            // TODO(Savago): we should send a notification to callers #5463.
+        }
+
+        parser.r().last_chunk_received.set(true);
+        parser.r().parse_sync();
+    }
+}
+
+impl PreInvoke for ParserContext {
+}
+
 // NB: JSTraceable is *not* auto-derived.
 // You must edit the impl below if you add fields!
 #[must_root]
@@ -48,20 +163,46 @@ pub type Tokenizer = tokenizer::Tokenizer<TreeBuilder<JS<Node>, Sink>>;
 pub struct ServoHTMLParser {
     reflector_: Reflector,
     tokenizer: DOMRefCell<Tokenizer>,
+    /// Input chunks received but not yet passed to the parser.
+    pending_input: DOMRefCell<Vec<String>>,
+    /// The document associated with this parser.
+    document: JS<Document>,
+    /// True if this parser should avoid passing any further data to the tokenizer.
+    suspended: Cell<bool>,
+    /// Whether to expect any further input from the associated network request.
+    last_chunk_received: Cell<bool>,
+    /// The pipeline associated with this parse, unavailable if this parse does not
+    /// correspond to a page load.
+    pipeline: Option<PipelineId>,
 }
 
-impl Parser for ServoHTMLParser{
-    fn parse_chunk(&self, input: String) {
-        self.tokenizer().borrow_mut().feed(input);
+impl<'a> Parser for JSRef<'a, ServoHTMLParser> {
+    fn parse_chunk(self, input: String) {
+        self.document.root().r().set_current_parser(Some(self));
+        self.pending_input.borrow_mut().push(input);
+        self.parse_sync();
     }
-    fn finish(&self){
+
+    fn finish(self) {
+        assert!(!self.suspended.get());
+        assert!(self.pending_input.borrow().is_empty());
+
         self.tokenizer().borrow_mut().end();
+        debug!("finished parsing");
+
+        let document = self.document.root();
+        document.r().set_current_parser(None);
+
+        if let Some(pipeline) = self.pipeline {
+            ScriptTask::parsing_complete(pipeline);
+        }
     }
 }
 
 impl ServoHTMLParser {
     #[allow(unrooted_must_root)]
-    pub fn new(base_url: Option<Url>, document: JSRef<Document>) -> Temporary<ServoHTMLParser> {
+    pub fn new(base_url: Option<Url>, document: JSRef<Document>, pipeline: Option<PipelineId>)
+               -> Temporary<ServoHTMLParser> {
         let window = document.window().root();
         let sink = Sink {
             base_url: base_url,
@@ -78,6 +219,11 @@ impl ServoHTMLParser {
         let parser = ServoHTMLParser {
             reflector_: Reflector::new(),
             tokenizer: DOMRefCell::new(tok),
+            pending_input: DOMRefCell::new(vec!()),
+            document: JS::from_rooted(document),
+            suspended: Cell::new(false),
+            last_chunk_received: Cell::new(false),
+            pipeline: pipeline,
         };
 
         reflect_dom_object(box parser, GlobalRef::Window(window.r()),
@@ -111,6 +257,11 @@ impl ServoHTMLParser {
         let parser = ServoHTMLParser {
             reflector_: Reflector::new(),
             tokenizer: DOMRefCell::new(tok),
+            pending_input: DOMRefCell::new(vec!()),
+            document: JS::from_rooted(document),
+            suspended: Cell::new(false),
+            last_chunk_received: Cell::new(true),
+            pipeline: None,
         };
 
         reflect_dom_object(box parser, GlobalRef::Window(window.r()),
@@ -126,6 +277,73 @@ impl ServoHTMLParser {
 impl Reflectable for ServoHTMLParser {
     fn reflector<'a>(&'a self) -> &'a Reflector {
         &self.reflector_
+    }
+}
+
+trait PrivateServoHTMLParserHelpers {
+    /// Synchronously run the tokenizer parse loop until explicitly suspended or
+    /// the tokenizer runs out of input.
+    fn parse_sync(self);
+    /// Retrieve the window object associated with this parser.
+    fn window(self) -> Temporary<Window>;
+}
+
+impl<'a> PrivateServoHTMLParserHelpers for JSRef<'a, ServoHTMLParser> {
+    fn parse_sync(self) {
+        let mut first = true;
+
+        // This parser will continue to parse while there is either pending input or
+        // the parser remains unsuspended.
+        loop {
+            if self.suspended.get() {
+                return;
+            }
+
+            if self.pending_input.borrow().is_empty() && !first {
+                break;
+            }
+
+            let mut pending_input = self.pending_input.borrow_mut();
+            if !pending_input.is_empty() {
+                let chunk = pending_input.remove(0);
+                self.tokenizer.borrow_mut().feed(chunk);
+            } else {
+                self.tokenizer.borrow_mut().run();
+            }
+
+            first = false;
+        }
+
+        if self.last_chunk_received.get() {
+            self.finish();
+        }
+    }
+
+    fn window(self) -> Temporary<Window> {
+        let doc = self.document.root();
+        window_from_node(doc.r())
+    }
+}
+
+pub trait ServoHTMLParserHelpers {
+    /// Cause the parser to interrupt next time the tokenizer reaches a quiescent state.
+    /// No further parsing will occur after that point until the `resume` method is called.
+    /// Panics if the parser is already suspended.
+    fn suspend(self);
+    /// Immediately resume a suspended parser. Panics if the parser is not suspended.
+    fn resume(self);
+}
+
+impl<'a> ServoHTMLParserHelpers for JSRef<'a, ServoHTMLParser> {
+    fn suspend(self) {
+        assert!(!self.suspended.get());
+        self.suspended.set(true);
+    }
+
+    fn resume(self) {
+        assert!(self.suspended.get());
+        self.suspended.set(false);
+        self.parse_sync();
     }
 }
 
@@ -152,11 +370,6 @@ impl JSTraceable for ServoHTMLParser {
         let tracer = &tracer as &tree_builder::Tracer<Handle=JS<Node>>;
 
         unsafe {
-            // Assertion: If the parser is mutably borrowed, we're in the
-            // parsing code paths.
-            debug_assert!(task_state::get().contains(task_state::IN_HTML_PARSER)
-                || !self.tokenizer.is_mutably_borrowed());
-
             let tokenizer = self.tokenizer.borrow_for_gc_trace();
             let tree_builder = tokenizer.sink();
             tree_builder.trace_handles(tracer);

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -4,7 +4,7 @@
 
 #![allow(unsafe_code, unrooted_must_root)]
 
-use document_loader::{DocumentLoader, LoadType};
+use document_loader::DocumentLoader;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -32,13 +32,10 @@ use dom::servohtmlparser::{ServoHTMLParser, FragmentContext};
 use dom::text::Text;
 use parse::Parser;
 
-use encoding::all::UTF_8;
-use encoding::types::{Encoding, DecoderTrap};
+use encoding::types::Encoding;
 
-use net_traits::{ProgressMsg, LoadResponse};
+use msg::constellation_msg::PipelineId;
 use util::str::DOMString;
-use util::task_state;
-use util::task_state::IN_HTML_PARSER;
 use std::borrow::Cow;
 use std::io::{self, Write};
 use url::Url;
@@ -48,14 +45,6 @@ use html5ever::serialize::TraversalScope;
 use html5ever::serialize::TraversalScope::{IncludeNode, ChildrenOnly};
 use html5ever::tree_builder::{TreeSink, QuirksMode, NodeOrText, AppendNode, AppendText, NextParserState};
 use string_cache::QualName;
-
-use hyper::header::ContentType;
-use hyper::mime::{Mime, TopLevel, SubLevel};
-
-pub enum HTMLInput {
-    InputString(String),
-    InputUrl(LoadResponse),
-}
 
 trait SinkHelpers {
     fn get_or_create(&self, child: NodeOrText<JS<Node>>) -> Temporary<Node>;
@@ -183,7 +172,9 @@ impl<'a> TreeSink for servohtmlparser::Sink {
     fn complete_script(&mut self, node: JS<Node>) -> NextParserState {
         let node: Root<Node> = node.root();
         let script: Option<JSRef<HTMLScriptElement>> = HTMLScriptElementCast::to_ref(node.r());
-        script.map(|script| script.prepare());
+        if let Some(script) = script {
+            return script.prepare();
+        }
         NextParserState::Continue
     }
 
@@ -272,80 +263,22 @@ impl<'a> Serializable for JSRef<'a, Node> {
     }
 }
 
+pub enum ParseContext<'a> {
+    Fragment(FragmentContext<'a>),
+    Owner(Option<PipelineId>),
+}
+
 pub fn parse_html(document: JSRef<Document>,
-                  input: HTMLInput,
+                  input: String,
                   url: &Url,
-                  fragment_context: Option<FragmentContext>) {
-    let parser = match fragment_context {
-        None => ServoHTMLParser::new(Some(url.clone()), document).root(),
-        Some(fc) => ServoHTMLParser::new_for_fragment(Some(url.clone()), document, fc).root(),
-    };
-    let parser: JSRef<ServoHTMLParser> = parser.r();
-
-    let nested_parse = task_state::get().contains(task_state::IN_HTML_PARSER);
-    if !nested_parse {
-        task_state::enter(IN_HTML_PARSER);
-    }
-
-    fn parse_progress(document: JSRef<Document>, parser: JSRef<ServoHTMLParser>, url: &Url, load_response: &LoadResponse) {
-        for msg in load_response.progress_port.iter() {
-            match msg {
-                ProgressMsg::Payload(data) => {
-                    // FIXME: use Vec<u8> (html5ever #34)
-                    let data = UTF_8.decode(&data, DecoderTrap::Replace).unwrap();
-                    parser.parse_chunk(data);
-                }
-                ProgressMsg::Done(Err(err)) => {
-                    debug!("Failed to load page URL {}, error: {}", url.serialize(), err);
-                    // TODO(Savago): we should send a notification to callers #5463.
-                    break;
-                }
-                ProgressMsg::Done(Ok(())) => {
-                    document.finish_load(LoadType::PageSource(url.clone()));
-                    break;
-                }
-            }
-        }
-    };
-
-    match input {
-        HTMLInput::InputString(s) => {
-            parser.parse_chunk(s);
-        }
-        HTMLInput::InputUrl(load_response) => {
-            match load_response.metadata.content_type {
-                Some(ContentType(Mime(TopLevel::Image, _, _))) => {
-                    let page = format!("<html><body><img src='{}' /></body></html>", url.serialize());
-                    parser.parse_chunk(page);
-                    document.finish_load(LoadType::PageSource(url.clone()));
-                },
-                Some(ContentType(Mime(TopLevel::Text, SubLevel::Plain, _))) => {
-                    // FIXME: When servo/html5ever#109 is fixed remove <plaintext> usage and
-                    // replace with fix from that issue.
-
-                    // text/plain documents require setting the tokenizer into PLAINTEXT mode.
-                    // This is done by using a <plaintext> element as the html5ever tokenizer
-                    // provides no other way to change to that state.
-                    // Spec for text/plain handling is:
-                    // https://html.spec.whatwg.org/multipage/#read-text
-                    let page = format!("<pre>\u{000A}<plaintext>");
-                    parser.parse_chunk(page);
-                    parse_progress(document, parser, url, &load_response);
-                },
-                _ => {
-                    parse_progress(document, parser, url, &load_response);
-                }
-            }
-        }
-    }
-
-    parser.finish();
-
-    if !nested_parse {
-        task_state::exit(IN_HTML_PARSER);
-    }
-
-    debug!("finished parsing");
+                  context: ParseContext) {
+    let parser = match context {
+        ParseContext::Owner(owner) =>
+            ServoHTMLParser::new(Some(url.clone()), document, owner),
+        ParseContext::Fragment(fc) =>
+            ServoHTMLParser::new_for_fragment(Some(url.clone()), document, fc),
+    }.root();
+    parser.r().parse_chunk(input);
 }
 
 // https://html.spec.whatwg.org/multipage/#parsing-html-fragments
@@ -376,7 +309,7 @@ pub fn parse_html_fragment(context_node: JSRef<Node>,
         context_elem: context_node,
         form_elem: form.r(),
     };
-    parse_html(document.r(), HTMLInput::InputString(input), &url, Some(fragment_context));
+    parse_html(document.r(), input, &url, ParseContext::Fragment(fragment_context));
 
     // Step 14.
     let root_element = document.r().GetDocumentElement().expect("no document element").root();

--- a/components/script/parse/mod.rs
+++ b/components/script/parse/mod.rs
@@ -5,6 +5,6 @@
 pub mod html;
 
 pub trait Parser {
-    fn parse_chunk(&self,input: String);
-    fn finish(&self);
+    fn parse_chunk(self, input: String);
+    fn finish(self);
 }

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/async_006.htm.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/async_006.htm.ini
@@ -1,5 +1,0 @@
-[async_006.htm]
-  type: testharness
-  [dynamically created external script executes asynchronously]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/async_008.htm.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/async_008.htm.ini
@@ -1,5 +1,0 @@
-[async_008.htm]
-  type: testharness
-  [Async script element execution delays the window's load event]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/015.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/015.html.ini
@@ -1,5 +1,0 @@
-[015.html]
-  type: testharness
-  [ scheduler: DOM added inline+external+inline script earlier in document]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/015a.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/015a.html.ini
@@ -1,5 +1,0 @@
-[015a.html]
-  type: testharness
-  [ scheduler: DOM added inline+external+inline script earlier in document]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/017.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/017.html.ini
@@ -1,5 +1,0 @@
-[017.html]
-  type: testharness
-  [ scheduler: multiple DOM added scripts later in document]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/020.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/020.html.ini
@@ -1,5 +1,0 @@
-[020.html]
-  type: testharness
-  [ scheduler: DOM added script with data: URL ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/022.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/022.html.ini
@@ -1,5 +1,0 @@
-[022.html]
-  type: testharness
-  [ scheduler: DOM added script, late .src ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/023.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/023.html.ini
@@ -1,6 +1,0 @@
-[023.html]
-  type: testharness
-  expected: TIMEOUT
-  [ scheduler: DOM added script, even later .src ]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/024.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/024.html.ini
@@ -1,5 +1,0 @@
-[024.html]
-  type: testharness
-  [ scheduler: DOM added script, .src set twice]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/038.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/038.html.ini
@@ -1,5 +1,0 @@
-[038.html]
-  type: testharness
-  [ scheduler: DOM movement with appendChild, external]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/046.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/046.html.ini
@@ -1,5 +1,0 @@
-[046.html]
-  type: testharness
-  [ scheduler: no readystatechange events when adding external scripts ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/047.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/047.html.ini
@@ -1,5 +1,0 @@
-[047.html]
-  type: testharness
-  [ scheduler: adding and removing external script ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/049.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/049.html.ini
@@ -1,5 +1,0 @@
-[049.html]
-  type: testharness
-  [ scheduler: adding external script but removeAttribute( src ) before it runs]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/050.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/050.html.ini
@@ -1,5 +1,0 @@
-[050.html]
-  type: testharness
-  [ scheduler: adding external script that removes all scripts from document]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/051.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/051.html.ini
@@ -1,5 +1,0 @@
-[051.html]
-  type: testharness
-  [ scheduler: interaction of parsing and script execution - script added through DOM]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/053.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/053.html.ini
@@ -1,5 +1,0 @@
-[053.html]
-  type: testharness
-  [ scheduler: adding external script that removes itself from document when loading]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/069.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/069.html.ini
@@ -1,5 +1,0 @@
-[069.html]
-  type: testharness
-  [scheduler: external files added through DOM should not block further parsing while loading]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/076.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/076.html.ini
@@ -1,5 +1,0 @@
-[076.html]
-  type: testharness
-  [ scheduler: adding and removing external and inline scripts ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/078.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/078.html.ini
@@ -1,5 +1,0 @@
-[078.html]
-  type: testharness
-  [ adding several types of scripts through the DOM and removing some of them confuses scheduler (slow-loading scripts) ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/081.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/081.html.ini
@@ -1,5 +1,0 @@
-[081.html]
-  type: testharness
-  [ scheduler: slow loading external script added with DOM (appendChild)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/082.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/082.html.ini
@@ -1,5 +1,0 @@
-[082.html]
-  type: testharness
-  [ scheduler: multiple slow loading external scripts added with DOM (appendChild)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/092.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/092.html.ini
@@ -1,5 +1,0 @@
-[092.html]
-  type: testharness
-  [ scheduler: defer script and slow-loading non-async external script]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/095.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/095.html.ini
@@ -1,0 +1,4 @@
+[095.html]
+  type: testharness
+  [ scheduler: slow-loading script added from defer blocking load event]
+    expected: FAIL

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/095.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/095.html.ini
@@ -1,4 +1,0 @@
-[095.html]
-  type: testharness
-  [ scheduler: slow-loading script added from defer blocking load event]
-    expected: FAIL

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/105.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/105.html.ini
@@ -1,0 +1,4 @@
+[105.html]
+  type: testharness
+  [ scheduler: adding async attribute at runtime]
+    expected: FAIL

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/122.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/122.html.ini
@@ -1,8 +1,5 @@
 [122.html]
   type: testharness
-  [scheduler: altering the type attribute and adding/removing external script ]
-    expected: FAIL
-
   [Reinserted script async IDL attribute]
     expected: FAIL
 

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/123.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/123.html.ini
@@ -1,0 +1,4 @@
+[123.html]
+  type: testharness
+  [scheduler: altering the type attribute and adding/removing external script with async=false ]
+    expected: FAIL

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/125.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/125.html.ini
@@ -1,5 +1,0 @@
-[125.html]
-  type: testharness
-  [scheduler: altering the type attribute and changing script data external script ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/126.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/126.html.ini
@@ -1,0 +1,4 @@
+[126.html]
+  type: testharness
+  [scheduler: altering the type attribute and changing script data external script async=false ]
+    expected: FAIL

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/130.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/130.html.ini
@@ -1,5 +1,0 @@
-[130.html]
-  type: testharness
-  [scheduler: appending external script element to script ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/134.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/134.html.ini
@@ -1,5 +1,0 @@
-[134.html]
-  type: testharness
-  [scheduler: external HTML script added by SVG script ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/134.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/134.html.ini
@@ -1,5 +1,5 @@
 [134.html]
   type: testharness
-  [scheduler: external HTML script added by SVG script]
+  [scheduler: external HTML script added by SVG script ]
     expected: FAIL
 

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/134.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/134.html.ini
@@ -1,0 +1,5 @@
+[134.html]
+  type: testharness
+  [scheduler: external HTML script added by SVG script]
+    expected: FAIL
+


### PR DESCRIPTION
...r parsing. Hook up document loading to async networking events.

Relies on https://github.com/servo/html5ever/pull/107, so we'll likely need to backport it rather than wait for the next rustc upgrade.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5727)

<!-- Reviewable:end -->
