### PR TITLE
Allow dumping the optimized display list (DL).

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -34,6 +34,7 @@ use libc::uintptr_t;
 use paint_task::PaintLayer;
 use msg::compositor_msg::LayerId;
 use net_traits::image::base::Image;
+use util::opts;
 use util::cursor::Cursor;
 use util::linked_list::prepend_from;
 use util::geometry::{self, Au, MAX_RECT, ZERO_RECT};
@@ -279,6 +280,11 @@ impl StackingContext {
             // Optimize the display list to throw out out-of-bounds display items and so forth.
             let display_list =
                 DisplayListOptimizer::new(tile_bounds).optimize(&*self.display_list);
+
+            if opts::get().dump_display_list_optimized {
+                println!("**** optimized display list. Tile bounds: {:?}", tile_bounds);
+                display_list.print_items(String::from_str("*"));
+            }
 
             // Sort positioned children according to z-index.
             let mut positioned_children = SmallVec8::new();

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -121,8 +121,11 @@ pub struct Opts {
     /// Dumps the flow tree after a layout.
     pub dump_flow_tree: bool,
 
-    /// Dumps the flow tree after a layout.
+    /// Dumps the display list after a layout.
     pub dump_display_list: bool,
+
+    /// Dumps the display list after optimization (post layout, at painting time).
+    pub dump_display_list_optimized: bool,
 
     /// Emits notifications when there is a relayout.
     pub relayout_event: bool,
@@ -156,6 +159,7 @@ pub fn print_debug_usage(app: &str)  {
     print_option("disable-text-aa", "Disable antialiasing of rendered text.");
     print_option("dump-flow-tree", "Print the flow tree after each layout.");
     print_option("dump-display-list", "Print the display list after each layout.");
+    print_option("dump-display-list-optimized", "Print optimized display list (at paint time).");
     print_option("relayout-event", "Print notifications when there is a relayout.");
     print_option("profile-tasks", "Instrument each task, writing the output to a file.");
     print_option("show-compositor-borders", "Paint borders along layer and tile boundaries.");
@@ -216,6 +220,7 @@ pub fn default_opts() -> Opts {
         user_agent: None,
         dump_flow_tree: false,
         dump_display_list: false,
+        dump_display_list_optimized: false,
         relayout_event: false,
         validate_display_list_geometry: false,
         profile_tasks: false,
@@ -379,6 +384,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         enable_text_antialiasing: !debug_options.contains(&"disable-text-aa"),
         dump_flow_tree: debug_options.contains(&"dump-flow-tree"),
         dump_display_list: debug_options.contains(&"dump-display-list"),
+        dump_display_list_optimized: debug_options.contains(&"dump-display-list-optimized"),
         relayout_event: debug_options.contains(&"relayout-event"),
         validate_display_list_geometry: debug_options.contains(&"validate-display-list-geometry"),
         resources_path: opt_match.opt_str("resources-path"),


### PR DESCRIPTION
This DL is created at paint time, per tile. To dump, pass -Z dump-display-list-optimized at startup.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5728)

<!-- Reviewable:end -->
