### PR TITLE
Don't link to specific WHATWG multipage page

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -92,7 +92,7 @@ impl<'a> CanvasPaintTask<'a> {
                     source_rect: Rect<f64>,
                     dest_rect: Rect<f64>,
                     smoothing_enabled: bool) {
-        // From spec https://html.spec.whatwg.org/multipage/scripting.html#dom-context-2d-drawimage
+        // From spec https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
         // When scaling up, if the imageSmoothingEnabled attribute is set to true, the user agent should attempt
         // to apply a smoothing algorithm to the image data when it is scaled.
         // Otherwise, the image must be rendered using nearest-neighbor interpolation.

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -721,7 +721,7 @@ impl BlockFlow {
     /// Return true if this has a replaced fragment.
     ///
     /// Text, Images, Inline Block and
-    //  Canvas (https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements)
+    //  Canvas (https://html.spec.whatwg.org/multipage/#replaced-elements)
     //  fragments are considered as replaced fragments
     fn is_replaced_content(&self) -> bool {
         match self.fragment.specific {

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -20,19 +20,19 @@ pub trait Activatable : Copy {
     // Is this particular instance of the element activatable?
     fn is_instance_activatable(&self) -> bool;
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-pre-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-pre-click-activation-steps
     fn pre_click_activation(&self);
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-canceled-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-canceled-activation-steps
     fn canceled_activation(&self);
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-post-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
     fn activation_behavior(&self, event: JSRef<Event>, target: JSRef<EventTarget>);
 
     // https://html.spec.whatwg.org/multipage/#implicit-submission
     fn implicit_submission(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool);
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-synthetic-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-synthetic-click-activation-steps
     fn synthetic_click_activation(&self, ctrlKey: bool, shiftKey: bool, altKey: bool, metaKey: bool) {
         let element = self.as_element().root();
         // Step 1

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -475,7 +475,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
             node.set_focus_state(true);
         }
         // TODO: Update the focus state for all elements in the focus chain.
-        // https://html.spec.whatwg.org/multipage/interaction.html#focus-chain
+        // https://html.spec.whatwg.org/multipage/#focus-chain
     }
 
     /// Handles any updates when the document's title has changed.
@@ -552,7 +552,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
 
         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#trusted-events
         event.set_trusted(true);
-        // https://html.spec.whatwg.org/multipage/interaction.html#run-authentic-click-activation-steps
+        // https://html.spec.whatwg.org/multipage/#run-authentic-click-activation-steps
         el.r().authentic_click_activation(event);
 
         self.commit_focus_transaction();
@@ -908,7 +908,7 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
         self.url().serialize()
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#dom-document-activeelement
+    // https://html.spec.whatwg.org/multipage/#dom-document-activeelement
     fn GetActiveElement(self) -> Option<Temporary<Element>> {
         // TODO: Step 2.
 

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -107,16 +107,16 @@ impl<'a> Activatable for JSRef<'a, HTMLAnchorElement> {
     }
 
 
-    //TODO:https://html.spec.whatwg.org/multipage/semantics.html#the-a-element
+    //TODO:https://html.spec.whatwg.org/multipage/#the-a-element
     fn pre_click_activation(&self) {
     }
 
-    //TODO:https://html.spec.whatwg.org/multipage/semantics.html#the-a-element
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-canceled-activation-steps
+    //TODO:https://html.spec.whatwg.org/multipage/#the-a-element
+    // https://html.spec.whatwg.org/multipage/#run-canceled-activation-steps
     fn canceled_activation(&self) {
     }
 
-    //https://html.spec.whatwg.org/multipage/semantics.html#the-a-element:activation-behaviour
+    //https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour
     fn activation_behavior(&self, event: JSRef<Event>, target: JSRef<EventTarget>) {
         //Step 1. If the node document is not fully active, abort.
         let doc = document_from_node(*self).root();
@@ -153,7 +153,7 @@ impl<'a> Activatable for JSRef<'a, HTMLAnchorElement> {
         }
     }
 
-    //TODO:https://html.spec.whatwg.org/multipage/semantics.html#the-a-element
+    //TODO:https://html.spec.whatwg.org/multipage/#the-a-element
     fn implicit_submission(&self, _ctrlKey: bool, _shiftKey: bool, _altKey: bool, _metaKey: bool) {
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -187,16 +187,16 @@ impl<'a> Activatable for JSRef<'a, HTMLButtonElement> {
         !(node.get_disabled_state())
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-pre-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-pre-click-activation-steps
     // https://html.spec.whatwg.org/multipage/#the-button-element:activation-behavior
     fn pre_click_activation(&self) {
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-canceled-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-canceled-activation-steps
     fn canceled_activation(&self) {
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-post-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
     fn activation_behavior(&self, _event: JSRef<Event>, _target: JSRef<EventTarget>) {
         let ty = self.button_type.get();
         match ty {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -123,7 +123,7 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#dom-click
+    // https://html.spec.whatwg.org/multipage/#dom-click
     fn Click(self) {
         let maybe_input: Option<JSRef<HTMLInputElement>> = HTMLInputElementCast::to_ref(self);
         if let Some(i) = maybe_input {
@@ -136,10 +136,10 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
         element.as_maybe_activatable().map(|a| a.synthetic_click_activation(false, false, false, false));
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#dom-focus
+    // https://html.spec.whatwg.org/multipage/#dom-focus
     fn Focus(self) {
         // TODO: Mark the element as locked for focus and run the focusing steps.
-        // https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps
+        // https://html.spec.whatwg.org/multipage/#focusing-steps
         let element: JSRef<Element> = ElementCast::from_ref(self);
         let document = document_from_node(self).root();
         let document = document.r();
@@ -148,14 +148,14 @@ impl<'a> HTMLElementMethods for JSRef<'a, HTMLElement> {
         document.commit_focus_transaction();
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#dom-blur
+    // https://html.spec.whatwg.org/multipage/#dom-blur
     fn Blur(self) {
         // TODO: Run the unfocusing steps.
         let node: JSRef<Node> = NodeCast::from_ref(self);
         if !node.get_focus_state() {
             return;
         }
-        // https://html.spec.whatwg.org/multipage/interaction.html#unfocusing-steps
+        // https://html.spec.whatwg.org/multipage/#unfocusing-steps
         let document = document_from_node(self).root();
         document.r().begin_focus_transaction();
         // If `request_focus` is not called, focus will be set to None.

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -651,7 +651,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-pre-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-pre-click-activation-steps
     #[allow(unsafe_code)]
     fn pre_click_activation(&self) {
         let mut cache = self.activation_state.borrow_mut();
@@ -701,7 +701,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-canceled-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-canceled-activation-steps
     fn canceled_activation(&self) {
         let cache = self.activation_state.borrow();
         let ty = self.input_type.get();
@@ -752,7 +752,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/interaction.html#run-post-click-activation-steps
+    // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
     fn activation_behavior(&self, _event: JSRef<Event>, _target: JSRef<EventTarget>) {
         let ty = self.input_type.get();
         if self.activation_state.borrow().old_type != ty {

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -87,10 +87,10 @@ impl<'a> HTMLObjectElementMethods for JSRef<'a, HTMLObjectElement> {
         ValidityState::new(window.r())
     }
 
-    // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-object-type
+    // https://html.spec.whatwg.org/multipage/#dom-object-type
     make_getter!(Type);
 
-    // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-object-type
+    // https://html.spec.whatwg.org/multipage/#dom-object-type
     make_setter!(SetType, "type");
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -44,18 +44,18 @@ use url::{Url, UrlParser};
 pub struct HTMLScriptElement {
     htmlelement: HTMLElement,
 
-    /// https://html.spec.whatwg.org/multipage/scripting.html#already-started
+    /// https://html.spec.whatwg.org/multipage/#already-started
     already_started: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/scripting.html#parser-inserted
+    /// https://html.spec.whatwg.org/multipage/#parser-inserted
     parser_inserted: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/scripting.html#non-blocking
+    /// https://html.spec.whatwg.org/multipage/#non-blocking
     ///
     /// (currently unused)
     non_blocking: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/scripting.html#ready-to-be-parser-executed
+    /// https://html.spec.whatwg.org/multipage/#ready-to-be-parser-executed
     ///
     /// (currently unused)
     ready_to_be_parser_executed: Cell<bool>,
@@ -63,7 +63,7 @@ pub struct HTMLScriptElement {
     /// Document of the parser that created this element
     parser_document: JS<Document>,
 
-    /// https://html.spec.whatwg.org/multipage/scripting.html#concept-script-encoding
+    /// https://html.spec.whatwg.org/multipage/#concept-script-encoding
     block_character_encoding: DOMRefCell<EncodingRef>,
 }
 
@@ -153,7 +153,7 @@ pub enum ScriptOrigin {
 
 impl<'a> HTMLScriptElementHelpers for JSRef<'a, HTMLScriptElement> {
     fn prepare(self) {
-        // https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script
+        // https://html.spec.whatwg.org/multipage/#prepare-a-script
         // Step 1.
         if self.already_started.get() {
             return;

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -133,7 +133,7 @@ trait PrivateStorageHelpers {
 }
 
 impl<'a> PrivateStorageHelpers for JSRef<'a, Storage> {
-    /// https://html.spec.whatwg.org/multipage/webstorage.html#send-a-storage-notification
+    /// https://html.spec.whatwg.org/multipage/#send-a-storage-notification
     fn broadcast_change_notification(self, key: Option<DOMString>, old_value: Option<DOMString>,
                                      new_value: Option<DOMString>){
         let global_root = self.global.root();

--- a/components/script/dom/webidls/Storage.webidl
+++ b/components/script/dom/webidls/Storage.webidl
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * The origin of this IDL file is
- * https://html.spec.whatwg.org/multipage/webstorage.html#webstorage
+ * https://html.spec.whatwg.org/multipage/#webstorage
  *
  */
 

--- a/components/script/dom/webidls/StorageEvent.webidl
+++ b/components/script/dom/webidls/StorageEvent.webidl
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * Interface for a client side storage. See
- * https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface
+ * https://html.spec.whatwg.org/multipage/#the-storageevent-interface
  * for more information.
  *
  * Event sent to a window when a storage area changes.

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -128,14 +128,14 @@ partial interface Window {
 };
 Window implements OnErrorEventHandlerForWindow;
 
-// https://html.spec.whatwg.org/multipage/webstorage.html#dom-sessionstorage
+// https://html.spec.whatwg.org/multipage/#dom-sessionstorage
 [NoInterfaceObject]
 interface WindowSessionStorage {
   readonly attribute Storage sessionStorage;
 };
 Window implements WindowSessionStorage;
 
-// https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage
+// https://html.spec.whatwg.org/multipage/#dom-localstorage
 [NoInterfaceObject]
 interface WindowLocalStorage {
   readonly attribute Storage localStorage;

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -35,7 +35,7 @@ use std::sync::mpsc::{channel, Sender};
 
 pub type TrustedWorkerAddress = Trusted<Worker>;
 
-// https://html.spec.whatwg.org/multipage/workers.html#worker
+// https://html.spec.whatwg.org/multipage/#worker
 #[dom_struct]
 pub struct Worker {
     eventtarget: EventTarget,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -40,7 +40,7 @@ pub enum WorkerGlobalScopeTypeId {
     DedicatedGlobalScope,
 }
 
-// https://html.spec.whatwg.org/multipage/workers.html#the-workerglobalscope-common-interface
+// https://html.spec.whatwg.org/multipage/#the-workerglobalscope-common-interface
 #[dom_struct]
 pub struct WorkerGlobalScope {
     eventtarget: EventTarget,
@@ -105,19 +105,19 @@ impl WorkerGlobalScope {
 }
 
 impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
-    // https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-self
+    // https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-self
     fn Self_(self) -> Temporary<WorkerGlobalScope> {
         Temporary::from_rooted(self)
     }
 
-    // https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-location
+    // https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-location
     fn Location(self) -> Temporary<WorkerLocation> {
         self.location.or_init(|| {
             WorkerLocation::new(self, self.worker_url.clone())
         })
     }
 
-    // https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts
+    // https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-importscripts
     fn ImportScripts(self, url_strings: Vec<DOMString>) -> ErrorResult {
         let mut urls = Vec::with_capacity(url_strings.len());
         for url in url_strings.into_iter() {
@@ -150,7 +150,7 @@ impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
         Ok(())
     }
 
-    // https://html.spec.whatwg.org/multipage/workers.html#dom-worker-navigator
+    // https://html.spec.whatwg.org/multipage/#dom-worker-navigator
     fn Navigator(self) -> Temporary<WorkerNavigator> {
         self.navigator.or_init(|| WorkerNavigator::new(self))
     }

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -13,7 +13,7 @@ use dom::workerglobalscope::WorkerGlobalScope;
 
 use url::Url;
 
-// https://html.spec.whatwg.org/multipage/workers.html#worker-locations
+// https://html.spec.whatwg.org/multipage/#worker-locations
 #[dom_struct]
 pub struct WorkerLocation {
     reflector_: Reflector,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -11,7 +11,7 @@ use dom::navigatorinfo;
 use dom::workerglobalscope::WorkerGlobalScope;
 use util::str::DOMString;
 
-// https://html.spec.whatwg.org/multipage/workers.html#workernavigator
+// https://html.spec.whatwg.org/multipage/#workernavigator
 #[dom_struct]
 pub struct WorkerNavigator {
     reflector_: Reflector,

--- a/components/style/legacy.rs
+++ b/components/style/legacy.rs
@@ -194,7 +194,7 @@ impl PresentationalHintSynthesis for Stylist {
                         // the math for <textarea> is a little different since we need to take
                         // scrollbar size into consideration (but we don't have a scrollbar yet!)
                         //
-                        // https://html.spec.whatwg.org/multipage/rendering.html#textarea-effective-width
+                        // https://html.spec.whatwg.org/multipage/#textarea-effective-width
                         let value = specified::Length::ServoCharacterWidth(specified::CharacterWidth(value));
                         matching_rules_list.vec_push(from_declaration(
                                 PropertyDeclaration::Width(SpecifiedValue(
@@ -207,7 +207,7 @@ impl PresentationalHintSynthesis for Stylist {
                     Some(value) if value != 0 => {
                         // TODO(mttr) This should take scrollbar size into consideration.
                         //
-                        // https://html.spec.whatwg.org/multipage/rendering.html#textarea-effective-height
+                        // https://html.spec.whatwg.org/multipage/#textarea-effective-height
                         let value = specified::Length::FontRelative(specified::FontRelativeLength::Em(value as CSSFloat));
                         matching_rules_list.vec_push(from_declaration(
                                 PropertyDeclaration::Height(SpecifiedValue(

--- a/resources/iso-8859-8.css
+++ b/resources/iso-8859-8.css
@@ -1,6 +1,6 @@
 /*
 
-https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering
+https://html.spec.whatwg.org/multipage/#bidi-rendering
 
 > When the document's character encoding is ISO-8859-8,
 > the following rules are additionally expected to apply, following [user-agent.css]

--- a/resources/presentational-hints.css
+++ b/resources/presentational-hints.css
@@ -1,5 +1,5 @@
 /*
-https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints
+https://html.spec.whatwg.org/multipage/#presentational-hints
 */
 
 @namespace url(http://www.w3.org/1999/xhtml);
@@ -9,7 +9,7 @@ pre[wrap] { white-space: pre-wrap; }
 
 /*
 FIXME: also "align descendants"
-https://html.spec.whatwg.org/multipage/rendering.html#align-descendants
+https://html.spec.whatwg.org/multipage/#align-descendants
 */
 center, div[align=center i], div[align=middle i] { text-align: center; }
 div[align=left i] { text-align: left; }
@@ -240,7 +240,7 @@ applet, embed, iframe, img, input[type=image i], object, video
 
 Extra
   ol > li
-    https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value
+    https://html.spec.whatwg.org/multipage/#ordinal-value
   col
     span
   colgroup (if not col child)
@@ -253,7 +253,7 @@ Extra
     text-align: center;
   }
 
-  https://html.spec.whatwg.org/multipage/rendering.html#rendered-legend
+  https://html.spec.whatwg.org/multipage/#rendered-legend
 
 */
 

--- a/resources/quirks-mode.css
+++ b/resources/quirks-mode.css
@@ -1,6 +1,6 @@
 /*
 
-https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3
+https://html.spec.whatwg.org/multipage/#flow-content-3
 
 > In quirks mode, the following rules are also expected to apply:
 
@@ -23,7 +23,7 @@ table {
 }
 
 
-/* FIXME: https://html.spec.whatwg.org/multipage/rendering.html#margin-collapsing-quirks */
+/* FIXME: https://html.spec.whatwg.org/multipage/#margin-collapsing-quirks */
 
 
 input:not([type=image]), textarea { box-sizing: border-box; }

--- a/resources/quotes.css
+++ b/resources/quotes.css
@@ -1,6 +1,6 @@
 /*
 
-https://html.spec.whatwg.org/multipage/rendering.html#quotes
+https://html.spec.whatwg.org/multipage/#quotes
 
 > This block is automatically generated from the Unicode Common Locale Data Repository.
 > http://cldr.unicode.org/

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -1,5 +1,5 @@
 /*
-https://html.spec.whatwg.org/multipage/rendering.html#form-controls
+https://html.spec.whatwg.org/multipage/#form-controls
 */
 
 @namespace url(http://www.w3.org/1999/xhtml);


### PR DESCRIPTION
"Links to the multipage version of the specification are unfortunately
likely to break over time."
-- https://html.spec.whatwg.org/multipage/asefij.html

This commit removes all references to the specific pages when viewing
WHATWG using multipage mode. I went through all these links and they
redirect fine.

Regex used to generate this commit:

`s_whatwg.org/multipage/.*#_whatwg.org/multipage/#_g`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5729)

<!-- Reviewable:end -->
