### PR TITLE
Canvas: implement context state save/restore.

### DIFF
--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -26,8 +26,8 @@ interface CanvasRenderingContext2D {
   //void commit(); // push the image to the output bitmap
 
   // state
-  //void save(); // push state on state stack
-  //void restore(); // pop state stack and restore state
+  void save(); // push state on state stack
+  void restore(); // pop state stack and restore state
 
   // transformations (default transform is the identity matrix)
   //         attribute SVGMatrix currentTransform;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -35,7 +35,7 @@ source = "git+https://github.com/tomaka/android-rs-glue#5a68056599fb498b0cf3715f
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#358fc5da081cf7d0618fae2d9d5582951beb791f"
+source = "git+https://github.com/servo/rust-azure#3e5daf667a62f702dc16285e923464458bef785f"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -37,7 +37,7 @@ source = "git+https://github.com/tomaka/android-rs-glue#5a68056599fb498b0cf3715f
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#358fc5da081cf7d0618fae2d9d5582951beb791f"
+source = "git+https://github.com/servo/rust-azure#3e5daf667a62f702dc16285e923464458bef785f"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -855,6 +855,7 @@ dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "compositing 0.0.1",
  "devtools 0.0.1",
+ "devtools_traits 0.0.1",
  "gfx 0.0.1",
  "glutin_app 0.0.1",
  "layout 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#358fc5da081cf7d0618fae2d9d5582951beb791f"
+source = "git+https://github.com/servo/rust-azure#3e5daf667a62f702dc16285e923464458bef785f"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -780,6 +780,7 @@ dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "compositing 0.0.1",
  "devtools 0.0.1",
+ "devtools_traits 0.0.1",
  "gfx 0.0.1",
  "layout 0.0.1",
  "msg 0.0.1",

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.width.transformed.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.width.transformed.html.ini
@@ -1,5 +1,0 @@
-[2d.line.width.transformed.html]
-  type: testharness
-  [Line stroke widths are affected by scale transformations]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.bitmap.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.bitmap.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.bitmap.html]
-  type: testharness
-  [save()/restore() does not affect the current bitmap]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.fillStyle.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.fillStyle.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.fillStyle.html]
-  type: testharness
-  [save()/restore() works for fillStyle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.globalAlpha.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.globalAlpha.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.globalAlpha.html]
-  type: testharness
-  [save()/restore() works for globalAlpha]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.lineCap.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.lineCap.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.lineCap.html]
-  type: testharness
-  [save()/restore() works for lineCap]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.lineJoin.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.lineJoin.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.lineJoin.html]
-  type: testharness
-  [save()/restore() works for lineJoin]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.lineWidth.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.lineWidth.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.lineWidth.html]
-  type: testharness
-  [save()/restore() works for lineWidth]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.miterLimit.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.miterLimit.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.miterLimit.html]
-  type: testharness
-  [save()/restore() works for miterLimit]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.stack.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.stack.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.stack.html]
-  type: testharness
-  [save()/restore() can be nested as a stack]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.stackdepth.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.stackdepth.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.stackdepth.html]
-  type: testharness
-  [save()/restore() stack depth is not unreasonably limited]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.strokeStyle.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.strokeStyle.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.strokeStyle.html]
-  type: testharness
-  [save()/restore() works for strokeStyle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.transformation.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.transformation.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.transformation.html]
-  type: testharness
-  [save()/restore() affects the current transformation matrix]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.underflow.html.ini
+++ b/tests/wpt/metadata/2dcontext/the-canvas-state/2d.state.saverestore.underflow.html.ini
@@ -1,5 +1,0 @@
-[2d.state.saverestore.underflow.html]
-  type: testharness
-  [restore() with an empty stack has no effect]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/transformations/2d.transformation.scale.negative.html.ini
+++ b/tests/wpt/metadata/2dcontext/transformations/2d.transformation.scale.negative.html.ini
@@ -1,5 +1,0 @@
-[2d.transformation.scale.negative.html]
-  type: testharness
-  [scale() with negative scale factors works]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -6870,12 +6870,6 @@
   [CanvasRenderingContext2D interface: operation commit()]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation save()]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: operation restore()]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: attribute currentTransform]
     expected: FAIL
 
@@ -7015,12 +7009,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "commit" with the proper type (3)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "save" with the proper type (4)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "restore" with the proper type (5)]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "currentTransform" with the proper type (6)]


### PR DESCRIPTION
This patch enables the use of `save()` and `restore()` for the canvas context, which is used by _a lot_ of sites and scripts.

Depends on servo/rust-azure#153.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5731)

<!-- Reviewable:end -->
