### PR TITLE
Remove unnecessary clone in Document constructor

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -794,7 +794,7 @@ impl Document {
             implementation: Default::default(),
             location: Default::default(),
             content_type: match content_type {
-                Some(string) => string.clone(),
+                Some(string) => string,
                 None => match is_html_document {
                     // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
                     IsHTMLDocument::HTMLDocument => "text/html".to_owned(),


### PR DESCRIPTION
This closes issue https://github.com/servo/servo/issues/5719.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5733)

<!-- Reviewable:end -->
