### PR TITLE
Parse attributes according to the specification in AttrValue::from_u32.

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -16,7 +16,7 @@ use dom::window::Window;
 use dom::virtualmethods::vtable_for;
 
 use devtools_traits::AttrInfo;
-use util::str::{DOMString, split_html_space_chars};
+use util::str::{DOMString, parse_unsigned_integer, split_html_space_chars};
 
 use string_cache::{Atom, Namespace};
 
@@ -55,8 +55,7 @@ impl AttrValue {
     }
 
     pub fn from_u32(string: DOMString, default: u32) -> AttrValue {
-        // XXX Is parse() correct?
-        let result: u32 = string.parse().unwrap_or(default);
+        let result = parse_unsigned_integer(string.chars()).unwrap_or(default);
         AttrValue::UInt(string, result)
     }
 

--- a/tests/wpt/metadata/html/dom/reflection-embedded.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-embedded.html.ini
@@ -1131,24 +1131,6 @@
   [img.hspace: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
-  [img.hspace: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [img.hspace: setAttribute() to "\\f7" followed by IDL get]
-    expected: FAIL
-
-  [img.hspace: setAttribute() to " 7" followed by IDL get]
-    expected: FAIL
-
-  [img.hspace: setAttribute() to "\\n7" followed by IDL get]
-    expected: FAIL
-
-  [img.hspace: setAttribute() to "\\r7" followed by IDL get]
-    expected: FAIL
-
-  [img.hspace: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
   [img.hspace: setAttribute() to object "3" followed by getAttribute()]
     expected: FAIL
 
@@ -1159,24 +1141,6 @@
     expected: FAIL
 
   [img.vspace: setAttribute() to 4294967295 followed by IDL get]
-    expected: FAIL
-
-  [img.vspace: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [img.vspace: setAttribute() to "\\f7" followed by IDL get]
-    expected: FAIL
-
-  [img.vspace: setAttribute() to " 7" followed by IDL get]
-    expected: FAIL
-
-  [img.vspace: setAttribute() to "\\n7" followed by IDL get]
-    expected: FAIL
-
-  [img.vspace: setAttribute() to "\\r7" followed by IDL get]
-    expected: FAIL
-
-  [img.vspace: setAttribute() to 1.5 followed by IDL get]
     expected: FAIL
 
   [img.vspace: setAttribute() to object "3" followed by getAttribute()]

--- a/tests/wpt/metadata/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-forms.html.ini
@@ -5778,25 +5778,10 @@
   [input.size: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
+  [input.size: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
   [input.size: setAttribute() to "0" followed by IDL get]
-    expected: FAIL
-
-  [input.size: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [input.size: setAttribute() to "\\f7" followed by IDL get]
-    expected: FAIL
-
-  [input.size: setAttribute() to " 7" followed by IDL get]
-    expected: FAIL
-
-  [input.size: setAttribute() to "\\n7" followed by IDL get]
-    expected: FAIL
-
-  [input.size: setAttribute() to "\\r7" followed by IDL get]
-    expected: FAIL
-
-  [input.size: setAttribute() to 1.5 followed by IDL get]
     expected: FAIL
 
   [input.size: setAttribute() to object "3" followed by getAttribute()]
@@ -12228,25 +12213,10 @@
   [textarea.cols: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
+  [textarea.cols: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
   [textarea.cols: setAttribute() to "0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\\f7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to " 7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\\n7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to "\\r7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.cols: setAttribute() to 1.5 followed by IDL get]
     expected: FAIL
 
   [textarea.cols: setAttribute() to object "3" followed by getAttribute()]
@@ -13179,25 +13149,10 @@
   [textarea.rows: setAttribute() to 4294967295 followed by IDL get]
     expected: FAIL
 
+  [textarea.rows: setAttribute() to "-0" followed by IDL get]
+    expected: FAIL
+
   [textarea.rows: setAttribute() to "0" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\\t7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\\f7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to " 7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\\n7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to "\\r7" followed by IDL get]
-    expected: FAIL
-
-  [textarea.rows: setAttribute() to 1.5 followed by IDL get]
     expected: FAIL
 
   [textarea.rows: setAttribute() to object "3" followed by getAttribute()]


### PR DESCRIPTION
This exposes another bug: "-0" failed to parse with str.parse(), and is now
successfully parsed into 0. However, input.size and textarea.{rows, cols} are
supposed to be "limited to only non-negative numbers greater than zero", so 0
is not actually supposed to be accepted.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5750)

<!-- Reviewable:end -->
