### PR TITLE
Set the OPENSSL_STATIC env var for Android builds

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -139,6 +139,7 @@ class MachCommands(CommandBase):
             openssl_dir = path.join(self.android_support_dir(), "openssl-1.0.1k")
             env['OPENSSL_LIB_DIR'] = openssl_dir
             env['OPENSSL_INCLUDE_DIR'] = path.join(openssl_dir, "include")
+            env['OPENSSL_STATIC'] = 'TRUE'
 
         status = subprocess.call(
             ["cargo", "build"] + opts,


### PR DESCRIPTION
Required by the latest version of the openssl-sys build script. Fixes #5145.

r? @larsbergstrom or @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5784)

<!-- Reviewable:end -->
