### PR TITLE
`vertical-align` can take negative lengths and percentages.

### DIFF
--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -608,7 +608,7 @@ pub mod longhands {
         /// baseline | sub | super | top | text-top | middle | bottom | text-bottom
         /// | <percentage> | <length>
         pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-            input.try(specified::LengthOrPercentage::parse_non_negative)
+            input.try(specified::LengthOrPercentage::parse)
             .map(SpecifiedValue::LengthOrPercentage)
             .or_else(|()| {
                 match_ignore_ascii_case! { try!(input.expect_ident()),


### PR DESCRIPTION
http://dev.w3.org/csswg/css2/visudet.html#propdef-vertical-align

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5794)

<!-- Reviewable:end -->
