### PR TITLE
Replace 'tests/wpt/mozilla/tests' with '_mozilla' in testing_commands.py

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -207,6 +207,9 @@ class MachCommands(CommandBase):
         hosts_file_path = path.join('tests', 'wpt', 'hosts')
 
         os.environ["hosts_file_path"] = hosts_file_path
+        # Replace "test/wpt/mozilla/tests" with "_mozilla" in test paths. This
+        # allows for tab-completing of mozilla wpt tests.
+        kwargs["test_list"] = [x.replace("tests/wpt/mozilla/tests", "_mozilla") for x in kwargs["test_list"]]
 
         run_file = path.abspath(path.join("tests", "wpt", "run_wpt.py"))
         run_globals = {"__file__": run_file}


### PR DESCRIPTION
This PR replaces instances of 'tests/wpt/mozilla/tests' with '_mozilla' in the 'test-wpt' command, making it possible to tab-complete mozilla wpt tests.

Fixes #5791

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5797)

<!-- Reviewable:end -->
