### PR TITLE
layout: Don't strip trailing newlines from fragments, since we use their presence to determine the line flush mode.

### DIFF
--- a/tests/html/incremental_inline_line_flush_mode.html
+++ b/tests/html/incremental_inline_line_flush_mode.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<!-- This will become "jumpy" when mousing over "Bar" if trailing newlines are stripped from
+     fragments during inline layout. -->
+<table><td><div style="white-space: pre">
+Foo</div></td><td><a href="/">Bar</a></td></table>
+


### PR DESCRIPTION
Fixes the "jumpiness" seen on the Google home page, Wikipedia, and many
other places.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5816)

<!-- Reviewable:end -->
