### PR TITLE
Remove unused ScriptDevtoolControlMsg enum

### DIFF
--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -119,13 +119,6 @@ pub enum DevtoolScriptControlMsg {
     DropTimelineMarkers(PipelineId, Vec<TimelineMarkerType>),
 }
 
-/// Messages to instruct devtools server to update its state relating to a particular
-/// tab.
-pub enum ScriptDevtoolControlMsg {
-    /// Report a new JS error message
-    ReportConsoleMsg(String),
-}
-
 #[derive(RustcEncodable)]
 pub struct Modification{
     pub attributeName: String,


### PR DESCRIPTION
Simple patch to remove unused enum, ScriptDevtoolControlMsg.

r? @jdm
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5818)

<!-- Reviewable:end -->
