### PR TITLE
Change notification threshold from 300s to 30s.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -19,7 +19,7 @@ def is_headless_build():
 
 # Function to generate desktop notification once build is completed & limit exceeded!
 def notify(elapsed):
-    if elapsed < 300:
+    if elapsed < 30:
         return
 
     if sys.platform.startswith('linux'):


### PR DESCRIPTION
The 300 second threshold was originally from the Gecko/Firefox build system. It doesn't fit Servo builds, which are shorter, and often hover right around the 300 second mark (making the notification unpredictable).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5819)

<!-- Reviewable:end -->
