### PR TITLE
First step to have all ref tests using the same Rust logo.

### DIFF
--- a/tests/ref/background_ref.html
+++ b/tests/ref/background_ref.html
@@ -4,6 +4,6 @@
 <title></title>
 </head>
 <body>
-<img class="test" src="rust-0.png" style="width:206px; height:206px;" />
+<img class="test" src="rust.png" style="width:128px; height:128px;" />
 </body>
 </html>

--- a/tests/ref/background_style_attr.html
+++ b/tests/ref/background_style_attr.html
@@ -4,6 +4,6 @@
 <title></title>
 </head>
 <body>
-<div class="test" style="background: url(rust-0.png); width:206px; height:206px;"></div>
+<div class="test" style="background: url(rust.png); width:128px; height:128px;"></div>
 </body>
 </html>


### PR DESCRIPTION
Currently we have 3 variants of Rust logo (2 being opaque white and 1 transparent). It would be nice to have a single logo to avoid duplication, this patch is the first step on doing this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5832)

<!-- Reviewable:end -->
