### PR TITLE
style: Disregard the `size` attribute for input elements other than text or password fields.

### DIFF
--- a/components/style/legacy.rs
+++ b/components/style/legacy.rs
@@ -167,25 +167,23 @@ impl PresentationalHintSynthesis for Stylist {
                     shareable);
             }
             name if *name == atom!("input") => {
-                match element.get_integer_attribute(IntegerAttribute::Size) {
-                    Some(value) if value != 0 => {
-                        // Per HTML 4.01 § 17.4, this value is in characters if `type` is `text` or
-                        // `password` and in pixels otherwise.
-                        //
-                        // FIXME(pcwalton): More use of atoms, please!
-                        let value = match element.get_attr(&ns!(""), &atom!("type")) {
-                            Some("text") | Some("password") => {
-                                specified::Length::ServoCharacterWidth(specified::CharacterWidth(value))
+                // FIXME(pcwalton): More use of atoms, please!
+                match element.get_attr(&ns!(""), &atom!("type")) {
+                    Some("text") | Some("password") => {
+                        match element.get_integer_attribute(IntegerAttribute::Size) {
+                            Some(value) if value != 0 => {
+                                let value = specified::Length::ServoCharacterWidth(
+                                    specified::CharacterWidth(value));
+                                matching_rules_list.vec_push(from_declaration(
+                                        PropertyDeclaration::Width(SpecifiedValue(
+                                            specified::LengthOrPercentageOrAuto::Length(value)))));
+                                *shareable = false
                             }
-                            _ => specified::Length::Absolute(Au::from_px(value as isize)),
-                        };
-                        matching_rules_list.vec_push(from_declaration(
-                                PropertyDeclaration::Width(SpecifiedValue(
-                                    specified::LengthOrPercentageOrAuto::Length(value)))));
-                        *shareable = false
+                            Some(_) | None => {}
+                        }
                     }
-                    Some(_) | None => {}
-                }
+                    _ => {}
+                };
             }
             name if *name == atom!("textarea") => {
                 match element.get_integer_attribute(IntegerAttribute::Cols) {

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -4,7 +4,7 @@ textarea                { background: white; min-height: 1.0em; padding: 0em; pa
 button,
 input[type="button"],
 input[type="submit"],
-input[type="reset"]     { background: lightgrey; border-top: solid 1px #EEEEEE; border-left: solid 1px #CCCCCC; border-right: solid 1px #999999; border-bottom: solid 1px #999999; text-align: center; vertical-align: middle; color: black; width: 100%; }
+input[type="reset"]     { background: lightgrey; border-top: solid 1px #EEEEEE; border-left: solid 1px #CCCCCC; border-right: solid 1px #999999; border-bottom: solid 1px #999999; text-align: center; vertical-align: middle; color: black; }
 input[type="hidden"]    { display: none !important }
 input[type="checkbox"],
 input[type="radio"]     { font-family: monospace !important; border: none !important; background: transparent; }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -179,6 +179,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 # inline_text_align_a.html inline_text_align_b.html
 == inline_whitespace_a.html inline_whitespace_ref.html
 == inline_whitespace_b.html inline_whitespace_ref.html
+== input_button_size_a.html input_button_size_ref.html
 != input_height_a.html input_height_ref.html
 == inset.html inset_ref.html
 != inset_blackborder.html blackborder_ref.html

--- a/tests/ref/input_button_size_a.html
+++ b/tests/ref/input_button_size_a.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<input type=submit size=100 value=sumbit>
+</body>
+</html>
+

--- a/tests/ref/input_button_size_ref.html
+++ b/tests/ref/input_button_size_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<input type=submit value=sumbit>
+</body>
+</html>
+


### PR DESCRIPTION
HTML5 § 4.10.5.3.2 doesn't explicitly say to do this, but all other
browser engines seem to do it.

Improves the Google home page.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5836)

<!-- Reviewable:end -->
