### PR TITLE
Implement Worker.prototype.terminate()

### DIFF
--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -198,11 +198,9 @@ impl GlobalUnrooted {
     }
 }
 
-/// Returns the global object of the realm that the given JS object was created in.
-#[allow(unrooted_must_root)]
-pub fn global_object_for_js_object(obj: *mut JSObject) -> GlobalUnrooted {
+/// Return the global object for a global JSObject
+fn global_object_for_js_global(global: *mut JSObject) -> GlobalUnrooted {
     unsafe {
-        let global = GetGlobalForObjectCrossCompartment(obj);
         let clasp = JS_GetClass(global);
         assert!(((*clasp).flags & (JSCLASS_IS_DOMJSCLASS | JSCLASS_IS_GLOBAL)) != 0);
         match native_from_reflector_jsmanaged(global) {
@@ -219,24 +217,22 @@ pub fn global_object_for_js_object(obj: *mut JSObject) -> GlobalUnrooted {
     }
 }
 
+/// Returns the global object of the realm that the given JS object was created in.
+#[allow(unrooted_must_root)]
+pub fn global_object_for_js_object(obj: *mut JSObject) -> GlobalUnrooted {
+    unsafe {
+        let global = GetGlobalForObjectCrossCompartment(obj);
+        global_object_for_js_global(global)
+    }
+}
+
 /// Returns the global object for the given JSContext
 #[allow(unrooted_must_root)]
 pub fn global_object_for_js_context(cx: *mut JSContext) -> GlobalUnrooted {
     unsafe {
         let rt = JS_GetRuntime(cx);
         let global = JS_GetRuntimePrivate(rt) as *mut JSObject;
-        let clasp = JS_GetClass(global);
-        assert!(((*clasp).flags & (JSCLASS_IS_DOMJSCLASS | JSCLASS_IS_GLOBAL)) != 0);
-        match native_from_reflector_jsmanaged(global) {
-            Ok(window) => return GlobalUnrooted::Window(window),
-            Err(_) => (),
-        }
-
-        match native_from_reflector_jsmanaged(global) {
-            Ok(worker) => return GlobalUnrooted::Worker(worker),
-            Err(_) => (),
-        }
-
-        panic!("found DOM global that doesn't unwrap to Window or WorkerGlobalScope")
+        assert!(!global.is_null());
+        global_object_for_js_global(global)
     }
 }

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -21,7 +21,7 @@ use net_traits::ResourceTask;
 use js::{JSCLASS_IS_GLOBAL, JSCLASS_IS_DOMJSCLASS};
 use js::glue::{GetGlobalForObjectCrossCompartment};
 use js::jsapi::{JSContext, JSObject};
-use js::jsapi::{JS_GetClass, JS_GetGlobalObject};
+use js::jsapi::{JS_GetClass, JS_GetRuntime, JS_GetRuntimePrivate};
 use url::Url;
 
 /// A freely-copyable reference to a rooted global object.
@@ -223,7 +223,8 @@ pub fn global_object_for_js_object(obj: *mut JSObject) -> GlobalUnrooted {
 #[allow(unrooted_must_root)]
 pub fn global_object_for_js_context(cx: *mut JSContext) -> GlobalUnrooted {
     unsafe {
-        let global = JS_GetGlobalObject(cx);
+        let rt = JS_GetRuntime(cx);
+        let global = JS_GetRuntimePrivate(rt) as *mut JSObject;
         let clasp = JS_GetClass(global);
         assert!(((*clasp).flags & (JSCLASS_IS_DOMJSCLASS | JSCLASS_IS_GLOBAL)) != 0);
         match native_from_reflector_jsmanaged(global) {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-#![allow(unsafe_code)]
 
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DedicatedWorkerGlobalScopeBinding;

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -35,7 +35,7 @@ use util::task::spawn_named;
 use util::task_state;
 use util::task_state::{SCRIPT, IN_WORKER};
 
-use js::jsapi::{JSContext, JS_SetOperationCallback, JSBool};
+use js::jsapi::{JSContext, JS_SetOperationCallback, JSBool, JS_SetRuntimePrivate};
 use js::jsval::JSVal;
 use js::rust::Cx;
 
@@ -44,6 +44,8 @@ use std::collections::LinkedList;
 use std::rc::Rc;
 use std::sync::mpsc::{Sender, Receiver, channel};
 use url::Url;
+
+use libc::c_void;
 
 /// A ScriptChan that can be cloned freely and will silently send a TrustedWorkerAddress with
 /// every message. While this SendableWorkerScriptChan is alive, the associated Worker object
@@ -147,6 +149,7 @@ impl DedicatedWorkerGlobalScope {
 }
 
 impl DedicatedWorkerGlobalScope {
+    #[allow(unsafe_code)]
     pub fn run_worker_scope(worker_url: Url,
                             id: PipelineId,
                             devtools_chan: Option<DevtoolsControlChan>,
@@ -179,15 +182,19 @@ impl DedicatedWorkerGlobalScope {
             // Send JSRuntime ref to main thread for interrupt scheduling
             rt_sender.send(SharedRt::new(runtime.rt())).unwrap();
 
-            // Handle interrupt requests
-            unsafe {
-                JS_SetOperationCallback(runtime.cx.ptr,
-                    Some(interrupt_callback as unsafe extern "C" fn(*mut JSContext) -> JSBool));
-            }
-
             let global = DedicatedWorkerGlobalScope::new(
                 worker_url, id, devtools_chan, runtime.cx.clone(), resource_task,
                 parent_sender, own_sender, receiver).root();
+
+            unsafe {
+                // Worker's global scope is stored in the JSRuntime private
+                JS_SetRuntimePrivate(runtime.rt(),
+                    global.r().reflector().get_jsobject() as *mut c_void);
+
+                // Handle interrupt requests
+                JS_SetOperationCallback(runtime.cx.ptr,
+                    Some(interrupt_callback as unsafe extern "C" fn(*mut JSContext) -> JSBool));
+            }
 
             {
                 let _ar = AutoWorkerReset::new(global.r(), worker);
@@ -206,22 +213,26 @@ impl DedicatedWorkerGlobalScope {
                 }
             }
 
-            loop {
+            'process_events : loop {
                 // Process any pending events
                 while let Some((linked_worker, msg)) = global.r().take_event() {
                     let _ar = AutoWorkerReset::new(global.r(), linked_worker);
                     global.r().handle_event(msg);
 
-                    if global.r().is_closing() { break }
+                    if global.r().is_closing() {
+                        break 'process_events
+                    }
                 }
 
-                // Wait for new events
+                // Wait for a new event
                 match global.r().receiver.recv() {
                     Ok((linked_worker, msg)) => {
                         let _ar = AutoWorkerReset::new(global.r(), linked_worker);
                         global.r().handle_event(msg);
 
-                        if global.r().is_closing() { break }
+                        if global.r().is_closing() {
+                            break
+                        }
                     }
                     Err(_) => break,
                 }
@@ -233,6 +244,7 @@ impl DedicatedWorkerGlobalScope {
     }
 }
 
+#[allow(unsafe_code)]
 unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> JSBool {
     // get global for context
     let global = global_object_for_js_context(cx);

--- a/components/script/dom/webidls/Worker.webidl
+++ b/components/script/dom/webidls/Worker.webidl
@@ -12,7 +12,7 @@ interface AbstractWorker {
 // https://www.whatwg.org/html/#worker
 [Constructor(DOMString scriptURL)/*, Exposed=Window,Worker*/]
 interface Worker : EventTarget {
-  //void terminate();
+  void terminate();
 
   [Throws]
   void postMessage(any message/*, optional sequence<Transferable> transfer*/);

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -20,7 +20,7 @@ use dom::errorevent::ErrorEvent;
 use dom::event::{Event, EventBubbles, EventCancelable, EventHelpers};
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 use dom::messageevent::MessageEvent;
-use script_task::{ScriptChan, ScriptMsg, Runnable};
+use script_task::{ScriptTask, ScriptChan, ScriptMsg, Runnable};
 
 use devtools_traits::{DevtoolsControlMsg, DevtoolsPageInfo};
 
@@ -28,6 +28,7 @@ use util::str::DOMString;
 
 use js::jsapi::JSContext;
 use js::jsval::{JSVal, UndefinedValue};
+use js::rust::Runtime;
 use url::UrlParser;
 
 use std::borrow::ToOwned;

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-#![allow(unsafe_code)]
 
 use dom::bindings::codegen::Bindings::WorkerBinding;
 use dom::bindings::codegen::Bindings::WorkerBinding::WorkerMethods;
@@ -169,6 +168,7 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
 
 
     // https://html.spec.whatwg.org/multipage/#terminate-a-worker
+    #[allow(unsafe_code)]
     fn Terminate(self) {
         if self.closing.get() { return; }
         self.closing.set(true);
@@ -178,10 +178,10 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
         self.sender.send((address, ScriptMsg::Terminate)).unwrap();
 
         let rt = self.get_rt();
-        if !rt.is_null() {
-            unsafe {
-                JS_TriggerOperationCallback(rt.rt());
-            }
+        assert!(!rt.is_null());
+
+        unsafe {
+            JS_TriggerOperationCallback(rt.rt());
         }
     }
 
@@ -308,6 +308,7 @@ impl Clone for SharedRt {
     fn clone(&self) -> SharedRt { *self }
 }
 
+#[allow(unsafe_code)]
 unsafe impl Send for SharedRt {
 
 }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -170,7 +170,10 @@ impl<'a> WorkerMethods for JSRef<'a, Worker> {
     // https://html.spec.whatwg.org/multipage/#terminate-a-worker
     #[allow(unsafe_code)]
     fn Terminate(self) {
-        if self.closing.get() { return; }
+        if self.closing.get() {
+            return;
+        }
+
         self.closing.set(true);
 
         let address = Trusted::new(self.global.root().r().get_cx(), self,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -45,6 +45,7 @@ pub enum WorkerGlobalScopeTypeId {
 pub struct WorkerGlobalScope {
     eventtarget: EventTarget,
     worker_url: Url,
+    closing: Cell<bool>,
     js_context: Rc<Cx>,
     next_worker_id: Cell<WorkerId>,
     resource_task: ResourceTask,
@@ -65,6 +66,7 @@ impl WorkerGlobalScope {
             eventtarget: EventTarget::new_inherited(EventTargetTypeId::WorkerGlobalScope(type_id)),
             next_worker_id: Cell::new(WorkerId(0)),
             worker_url: worker_url,
+            closing: Cell::new(false),
             js_context: cx,
             resource_task: resource_task,
             location: Default::default(),
@@ -101,6 +103,16 @@ impl WorkerGlobalScope {
         let WorkerId(id_num) = worker_id;
         self.next_worker_id.set(WorkerId(id_num + 1));
         worker_id
+    }
+
+    // set_closing and get_closing should only be used from self and
+    // DedicatedWorkerGlobalScope.
+    pub fn get_closing(&self) -> bool {
+        self.closing.get()
+    }
+
+    pub fn set_closing(&self, closing: bool) {
+        self.closing.set(closing);
     }
 }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -105,15 +105,6 @@ impl WorkerGlobalScope {
         worker_id
     }
 
-    // set_closing and get_closing should only be used from self and
-    // DedicatedWorkerGlobalScope.
-    pub fn get_closing(&self) -> bool {
-        self.closing.get()
-    }
-
-    pub fn set_closing(&self, closing: bool) {
-        self.closing.set(closing);
-    }
 }
 
 impl<'a> WorkerGlobalScopeMethods for JSRef<'a, WorkerGlobalScope> {
@@ -231,6 +222,9 @@ pub trait WorkerGlobalScopeHelpers {
     fn new_script_pair(self) -> (Box<ScriptChan+Send>, Box<ScriptPort+Send>);
     fn process_event(self, msg: ScriptMsg);
     fn get_cx(self) -> *mut JSContext;
+    fn get_closing(self) -> bool;
+    fn set_closing(self, closing: bool);
+
 }
 
 impl<'a> WorkerGlobalScopeHelpers for JSRef<'a, WorkerGlobalScope> {
@@ -276,6 +270,16 @@ impl<'a> WorkerGlobalScopeHelpers for JSRef<'a, WorkerGlobalScope> {
 
     fn get_cx(self) -> *mut JSContext {
         self.js_context.ptr
+    }
+
+    // set_closing and get_closing should only be used from self and
+    // DedicatedWorkerGlobalScope.
+    fn get_closing(self) -> bool {
+        self.closing.get()
+    }
+
+    fn set_closing(self, closing: bool) {
+        self.closing.set(closing);
     }
 }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -224,7 +224,7 @@ pub trait WorkerGlobalScopeHelpers {
     fn get_cx(self) -> *mut JSContext;
     fn get_closing(self) -> bool;
     fn set_closing(self, closing: bool);
-
+    fn clear_timers(self);
 }
 
 impl<'a> WorkerGlobalScopeHelpers for JSRef<'a, WorkerGlobalScope> {
@@ -280,6 +280,10 @@ impl<'a> WorkerGlobalScopeHelpers for JSRef<'a, WorkerGlobalScope> {
 
     fn set_closing(self, closing: bool) {
         self.closing.set(closing);
+    }
+
+    fn clear_timers(self) {
+        self.timers.clear()
     }
 }
 

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -184,6 +184,9 @@ pub enum ScriptMsg {
     /// Message sent through Worker.postMessage (only dispatched to
     /// DedicatedWorkerGlobalScope).
     DOMMessage(StructuredCloneData),
+    /// Message sent by Worker.terminate (dispatched to either
+    /// WorkerGlobalScope or DedicatedGlobalScope)
+    Terminate,
     /// Generic message that encapsulates event handling.
     RunnableMsg(Box<Runnable+Send>),
     /// Generic message for running tasks in the ScriptTask
@@ -747,8 +750,6 @@ impl ScriptTask {
                 panic!("Worker timeouts must not be sent to script task"),
             ScriptMsg::ExitWindow(id) =>
                 self.handle_exit_window_msg(id),
-            ScriptMsg::DOMMessage(..) =>
-                panic!("unexpected message"),
             ScriptMsg::RunnableMsg(runnable) =>
                 runnable.handler(),
             ScriptMsg::MainThreadRunnableMsg(runnable) =>
@@ -757,6 +758,7 @@ impl ScriptTask {
                 LiveDOMReferences::cleanup(self.get_cx(), addr),
             ScriptMsg::PageFetchComplete(id, subpage, response) =>
                 self.handle_page_fetch_complete(id, subpage, response),
+            _ => panic!("unexpected message"),
         }
     }
 

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -184,8 +184,7 @@ pub enum ScriptMsg {
     /// Message sent through Worker.postMessage (only dispatched to
     /// DedicatedWorkerGlobalScope).
     DOMMessage(StructuredCloneData),
-    /// Message sent by Worker.terminate (dispatched to either
-    /// WorkerGlobalScope or DedicatedGlobalScope)
+    /// Message sent by Worker.terminate (dispatched to DedicatedGlobalScope)
     Terminate,
     /// Generic message that encapsulates event handling.
     RunnableMsg(Box<Runnable+Send>),

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -184,7 +184,7 @@ pub enum ScriptMsg {
     /// Message sent through Worker.postMessage (only dispatched to
     /// DedicatedWorkerGlobalScope).
     DOMMessage(StructuredCloneData),
-    /// Message sent by Worker.terminate (dispatched to DedicatedGlobalScope)
+    /// Message sent by Worker.terminate (dispatched to  DedicatedGlobalScope)
     Terminate,
     /// Generic message that encapsulates event handling.
     RunnableMsg(Box<Runnable+Send>),

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -131,6 +131,11 @@ impl TimerManager {
             timer_handle.resume();
         }
     }
+    pub fn clear(&self) {
+        for (_, timer_handle) in self.active_timers.borrow_mut().iter_mut() {
+            timer_handle.cancel();
+        }
+    }
 
     #[allow(unsafe_code)]
     pub fn set_timeout_or_interval(&self,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -77,9 +77,7 @@ pub struct TimerManager {
 #[unsafe_destructor]
 impl Drop for TimerManager {
     fn drop(&mut self) {
-        for (_, timer_handle) in self.active_timers.borrow_mut().iter_mut() {
-            timer_handle.cancel();
-        }
+        self.clear();
     }
 }
 

--- a/tests/html/worker/worker_post_block.js
+++ b/tests/html/worker/worker_post_block.js
@@ -1,0 +1,9 @@
+var prev = Date.now()
+for (var i=0; true; i++) {
+
+  if (i % 100000000 == 0) {
+    var now = Date.now();
+    postMessage(now - prev);
+    prev = now;
+  }
+}

--- a/tests/html/worker/worker_post_interval.js
+++ b/tests/html/worker/worker_post_interval.js
@@ -1,0 +1,6 @@
+var prev = Date.now()
+setInterval(function () {
+  var now = Date.now();
+  postMessage(now - prev);
+  prev = now;
+}, 500);

--- a/tests/html/worker/worker_terminate.html
+++ b/tests/html/worker/worker_terminate.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Worker Test</title>
+</head>
+<body>
+<script>
+var workerPath = (function () {
+  var workerType;
+  switch (window.location.search.match(/worker=(\w+)/)[1]) {
+    case 'block':
+      workerType = 'block';
+      break;
+    default:
+      workerType = 'interval';
+      break;
+  }
+
+  return './worker_post_' + workerType + '.js';
+})();
+
+function startWorker() {
+  window.w = new Worker(workerPath);
+  w.onmessage = function(m) {
+    var p = document.createElement('p');
+    p.innerHTML = JSON.stringify(m.data);
+    document.body.appendChild(p);
+  };
+
+  var ps = document.getElementsByTagName('p');
+  while (ps.length) {
+    document.body.removeChild(ps[0]);
+  }
+}
+
+function stopWorker() {
+  if (w) {
+    w.terminate();
+  }
+
+  window.w = null;
+}
+</script>
+  <button onclick="startWorker()">Start Worker</button>
+  <button onclick="stopWorker()">Stop Worker</button>
+</body>
+</html>

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -9069,9 +9069,6 @@
   [Worker interface object length]
     expected: FAIL
 
-  [Worker interface: operation terminate()]
-    expected: FAIL
-
   [Worker interface: attribute onerror]
     expected: FAIL
 

--- a/tests/wpt/metadata/workers/Worker_terminate_event_queue.htm.ini
+++ b/tests/wpt/metadata/workers/Worker_terminate_event_queue.htm.ini
@@ -1,3 +1,2 @@
 [Worker_terminate_event_queue.htm]
   type: testharness
-  disabled: too much output

--- a/tests/wpt/metadata/workers/Worker_terminate_event_queue.htm.ini
+++ b/tests/wpt/metadata/workers/Worker_terminate_event_queue.htm.ini
@@ -1,2 +1,0 @@
-[Worker_terminate_event_queue.htm]
-  type: testharness

--- a/tests/wpt/metadata/workers/constructors/Worker/terminate.html.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/terminate.html.ini
@@ -1,5 +1,5 @@
 [terminate.html]
   type: testharness
   [terminate()]
-    expected: FAIL
+    expected: PASS
 

--- a/tests/wpt/metadata/workers/constructors/Worker/terminate.html.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/terminate.html.ini
@@ -1,5 +1,0 @@
-[terminate.html]
-  type: testharness
-  [terminate()]
-    expected: PASS
-

--- a/tests/wpt/metadata/workers/nested_worker.worker.js.ini
+++ b/tests/wpt/metadata/workers/nested_worker.worker.js.ini
@@ -1,6 +1,3 @@
 [nested_worker.worker]
   type: testharness
-  expected: TIMEOUT
-  [Nested worker]
-    expected: FAIL
 

--- a/tests/wpt/metadata/workers/nested_worker.worker.js.ini
+++ b/tests/wpt/metadata/workers/nested_worker.worker.js.ini
@@ -1,3 +1,0 @@
-[nested_worker.worker]
-  type: testharness
-

--- a/tests/wpt/web-platform-tests/workers/support/WorkerTerminate.js
+++ b/tests/wpt/web-platform-tests/workers/support/WorkerTerminate.js
@@ -2,7 +2,7 @@ onmessage = function(evt)
 {
     for (var i=0; true; i++)
     {
-        if (i%1000 == 1)
+        if (i%1000 == 0)
         {
             postMessage(i);
         }


### PR DESCRIPTION
Adds support for terminating DOM workers. `ScriptMsg::Terminate` was added to notify the WorkerGlobalScope/DedicatedWorkerGlobalScope to stop processing events and shut down. A closing flag was added to WorkerGlobalScope per the spec.

Additionally, a closing flag was added to `dom::worker::Worker` to ensure no further events are dispatched to the `onmessage` handler.

The change to the wpt WorkerTerminate.js is a patch for the broken Worker_terminate_event_queue test (asserts 10001 == 10000).

Resolves #4427

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5846)

<!-- Reviewable:end -->
