### PR TITLE
fixes #5603, added support for tabindex field

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -51,7 +51,7 @@ use dom::htmltablecellelement::{HTMLTableCellElement, HTMLTableCellElementHelper
 use dom::htmltablerowelement::{HTMLTableRowElement, HTMLTableRowElementHelpers};
 use dom::htmltablesectionelement::{HTMLTableSectionElement, HTMLTableSectionElementHelpers};
 use dom::htmltextareaelement::{HTMLTextAreaElement, RawLayoutHTMLTextAreaElementHelpers};
-use dom::node::{CLICK_IN_PROGRESS, LayoutNodeHelpers, Node, NodeHelpers, NodeTypeId};
+use dom::node::{CLICK_IN_PROGRESS, LayoutNodeHelpers, Node, NodeHelpers, NodeTypeId, SEQUENTIALLY_FOCUSABLE};
 use dom::node::{document_from_node, NodeDamage};
 use dom::node::{window_from_node};
 use dom::nodelist::NodeList;
@@ -712,9 +712,11 @@ impl<'a> FocusElementHelpers for JSRef<'a, Element> {
             return false;
         }
         // TODO: Check whether the element is being rendered (i.e. not hidden).
-        // TODO: Check the tabindex focus flag.
-        // https://html.spec.whatwg.org/multipage/#specially-focusable
         let node: JSRef<Node> = NodeCast::from_ref(self);
+        if node.get_flag(SEQUENTIALLY_FOCUSABLE) {
+            return true;
+        }
+        // https://html.spec.whatwg.org/multipage/#specially-focusable
         match node.type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLAnchorElement)) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLInputElement)) |
@@ -934,6 +936,9 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
 
             self.attrs.borrow_mut().remove(idx);
             attr.r().set_owner(None);
+            if attr.r().namespace() == &ns!("") {
+                vtable_for(&NodeCast::from_ref(self)).after_remove_attr(attr.r().name());
+            }
 
             let node: JSRef<Node> = NodeCast::from_ref(self);
             if node.is_in_doc() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -158,6 +158,9 @@ bitflags! {
         const CLICK_IN_PROGRESS = 0x100,
         #[doc = "Specifies whether this node has the focus."]
         const IN_FOCUS_STATE = 0x200,
+        #[doc = "Specifies whether this node is focusable and whether it is supposed \
+                 to be reachable with using sequential focus navigation."]
+        const SEQUENTIALLY_FOCUSABLE = 0x400,
     }
 }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -88,6 +88,14 @@ pub trait VirtualMethods {
         }
     }
 
+    /// Called when changing or removing attributes, after all modification
+    /// has taken place.
+    fn after_remove_attr(&self, name: &Atom) {
+        if let Some(ref s) = self.super_type() {
+            s.after_remove_attr(name);
+        }
+    }
+
     /// Returns the right AttrValue variant for the attribute with name `name`
     /// on this element.
     fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {

--- a/tests/wpt/metadata/html/semantics/disabled-elements/disabledElement.html.ini
+++ b/tests/wpt/metadata/html/semantics/disabled-elements/disabledElement.html.ini
@@ -1,5 +1,0 @@
-[disabledElement.html]
-  type: testharness
-  [A disabled <span> should be focusable]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/selectors/pseudo-classes/focus.html.ini
+++ b/tests/wpt/metadata/html/semantics/selectors/pseudo-classes/focus.html.ini
@@ -3,12 +3,5 @@
   [input3 has the attribute autofocus]
     expected: FAIL
 
-  [tabindex attribute makes the element focusable]
-    expected: FAIL
-
   [editable elements are focusable]
     expected: FAIL
-
-  [':focus' matches focussed body with tabindex]
-    expected: FAIL
-


### PR DESCRIPTION
Added support for the tabindex field, also added its correct defaults (-2 TODOs for things not supported in Servo yet).  Also added tabindex logic into Element::is_focusable_area.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5858)

<!-- Reviewable:end -->
