### PR TITLE
Remove #[jstraceable] annotation for the RootedVec type [Issue #5849]

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -401,7 +401,6 @@ impl VecRootableType for *mut JSObject {
 /// A vector of items that are rooted for the lifetime
 /// of this struct
 #[allow(unrooted_must_root)]
-#[jstraceable]
 pub struct RootedVec<T> {
     v: Vec<T>
 }


### PR DESCRIPTION
This PR solves Issue #5849.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5860)

<!-- Reviewable:end -->
