### PR TITLE
Change MutNullableJS<T> to MutNullableHeap<JS<T>>

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -6,7 +6,7 @@ use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::AttrBinding::{self, AttrMethods};
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{JSRef, MutNullableJS, Temporary};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
 use dom::bindings::js::{OptionalRootable, OptionalRootedRootable};
 use dom::bindings::js::RootedReference;
 use dom::bindings::utils::{Reflector, reflect_dom_object};
@@ -104,7 +104,7 @@ pub struct Attr {
     prefix: Option<DOMString>,
 
     /// the element that owns this attribute.
-    owner: MutNullableJS<Element>,
+    owner: MutNullableHeap<JS<Element>>,
 }
 
 impl Attr {
@@ -117,7 +117,7 @@ impl Attr {
             name: name,
             namespace: namespace,
             prefix: prefix,
-            owner: MutNullableJS::new(owner),
+            owner: MutNullableHeap::new(owner.map(JS::from_rooted)),
         }
     }
 
@@ -271,11 +271,11 @@ impl<'a> AttrHelpers<'a> for JSRef<'a, Attr> {
             }
             (old, new) => assert!(old == new)
         }
-        self.owner.assign(owner)
+        self.owner.set(owner.map(JS::from_rooted))
     }
 
     fn owner(self) -> Option<Temporary<Element>> {
-        self.owner.get()
+        self.owner.get().map(Temporary::new)
     }
 
     fn summarize(self) -> AttrInfo {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -27,8 +27,9 @@ use dom::bindings::codegen::UnionTypes::NodeOrString;
 use dom::bindings::error::{ErrorResult, Fallible};
 use dom::bindings::error::Error::{InvalidCharacter, Syntax};
 use dom::bindings::error::Error::NoModificationAllowed;
-use dom::bindings::js::{MutNullableJS, JS, JSRef, LayoutJS, Temporary, TemporaryPushable};
-use dom::bindings::js::{OptionalRootable, RootedReference};
+use dom::bindings::js::{JS, JSRef, LayoutJS, MutNullableHeap};
+use dom::bindings::js::{OptionalRootable, RootedReference, Temporary};
+use dom::bindings::js::TemporaryPushable;
 use dom::bindings::trace::RootedVec;
 use dom::bindings::utils::{xml_name_type, validate_and_extract};
 use dom::bindings::utils::XMLName::InvalidXMLName;
@@ -88,8 +89,8 @@ pub struct Element {
     prefix: Option<DOMString>,
     attrs: DOMRefCell<Vec<JS<Attr>>>,
     style_attribute: DOMRefCell<Option<PropertyDeclarationBlock>>,
-    attr_list: MutNullableJS<NamedNodeMap>,
-    class_list: MutNullableJS<DOMTokenList>,
+    attr_list: MutNullableHeap<JS<NamedNodeMap>>,
+    class_list: MutNullableHeap<JS<DOMTokenList>>,
 }
 
 impl ElementDerived for EventTarget {

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -13,7 +13,8 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLAnchorElementDerived, HTMLImageElementDerived};
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::codegen::InheritTypes::{MouseEventCast, NodeCast};
-use dom::bindings::js::{MutNullableJS, JSRef, Temporary, OptionalRootable};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
+use dom::bindings::js::OptionalRootable;
 use dom::document::{Document, DocumentHelpers};
 use dom::domtokenlist::DOMTokenList;
 use dom::element::{Element, AttributeHandlers, ElementTypeId};
@@ -32,7 +33,7 @@ use util::str::DOMString;
 #[dom_struct]
 pub struct HTMLAnchorElement {
     htmlelement: HTMLElement,
-    rel_list: MutNullableJS<DOMTokenList>,
+    rel_list: MutNullableHeap<JS<DOMTokenList>>,
 }
 
 impl HTMLAnchorElementDerived for EventTarget {

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLAreaElementBinding::HTMLAreaElementMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLAreaElementDerived, HTMLElementCast};
 use dom::bindings::codegen::InheritTypes::ElementCast;
-use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
 use dom::bindings::utils::Reflectable;
 use dom::document::Document;
 use dom::domtokenlist::DOMTokenList;
@@ -24,7 +24,7 @@ use util::str::DOMString;
 #[dom_struct]
 pub struct HTMLAreaElement {
     htmlelement: HTMLElement,
-    rel_list: MutNullableJS<DOMTokenList>,
+    rel_list: MutNullableHeap<JS<DOMTokenList>>,
 }
 
 impl HTMLAreaElementDerived for EventTarget {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -12,7 +12,7 @@ use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLFrameSetElementDerived};
 use dom::bindings::codegen::InheritTypes::{EventTargetCast, HTMLInputElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{HTMLElementDerived, HTMLBodyElementDerived};
-use dom::bindings::js::{JSRef, Temporary, MutNullableJS};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
 use dom::bindings::error::ErrorResult;
 use dom::bindings::error::Error::Syntax;
 use dom::bindings::utils::Reflectable;
@@ -39,8 +39,8 @@ use std::default::Default;
 #[dom_struct]
 pub struct HTMLElement {
     element: Element,
-    style_decl: MutNullableJS<CSSStyleDeclaration>,
-    dataset: MutNullableJS<DOMStringMap>,
+    style_decl: MutNullableHeap<JS<CSSStyleDeclaration>>,
+    dataset: MutNullableHeap<JS<DOMStringMap>>,
 }
 
 impl HTMLElementDerived for EventTarget {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -14,8 +14,9 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, HTMLInp
 use dom::bindings::codegen::InheritTypes::{HTMLInputElementDerived, HTMLFieldSetElementDerived, EventTargetCast};
 use dom::bindings::codegen::InheritTypes::KeyboardEventCast;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{Comparable, JSRef, LayoutJS, Root, Temporary, OptionalRootable};
-use dom::bindings::js::{ResultRootable, RootedReference, MutNullableJS};
+use dom::bindings::js::{Comparable, JS, JSRef, LayoutJS, MutNullableHeap};
+use dom::bindings::js::{OptionalRootable, OptionalRootedRootable};
+use dom::bindings::js::{ResultRootable, Root, RootedReference, Temporary};
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{AttributeHandlers, Element};
 use dom::element::{RawLayoutElementHelpers, ActivationElementHelpers};
@@ -80,7 +81,7 @@ struct InputActivationState {
     indeterminate: bool,
     checked: bool,
     checked_changed: bool,
-    checked_radio: MutNullableJS<HTMLInputElement>,
+    checked_radio: MutNullableHeap<JS<HTMLInputElement>>,
     // In case mutability changed
     was_mutable: bool,
     // In case the type changed
@@ -694,7 +695,7 @@ impl<'a> Activatable for JSRef<'a, HTMLInputElement> {
                                     r.r().Checked()
                                 })
                     };
-                    cache.checked_radio.assign(checked_member.r());
+                    cache.checked_radio.set(checked_member.r().map(JS::from_rooted));
                     cache.checked_changed = self.checked_changed.get();
                     self.SetChecked(true);
                 }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -8,7 +8,8 @@ use dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use dom::bindings::codegen::Bindings::HTMLLinkElementBinding::HTMLLinkElementMethods;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
-use dom::bindings::js::{MutNullableJS, JSRef, Temporary, OptionalRootable};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
+use dom::bindings::js::OptionalRootable;
 use dom::document::Document;
 use dom::domtokenlist::DOMTokenList;
 use dom::element::{AttributeHandlers, Element};
@@ -33,7 +34,7 @@ use string_cache::Atom;
 #[dom_struct]
 pub struct HTMLLinkElement {
     htmlelement: HTMLElement,
-    rel_list: MutNullableJS<DOMTokenList>,
+    rel_list: MutNullableHeap<JS<DOMTokenList>>,
 }
 
 impl HTMLLinkElementDerived for EventTarget {

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -8,7 +8,8 @@ use dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use dom::bindings::codegen::InheritTypes::{EventCast, UIEventCast, MouseEventDerived};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, RootedReference};
+use dom::bindings::js::Temporary;
 use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId, EventBubbles, EventCancelable};
 use dom::eventtarget::EventTarget;
@@ -30,7 +31,7 @@ pub struct MouseEvent {
     alt_key: Cell<bool>,
     meta_key: Cell<bool>,
     button: Cell<i16>,
-    related_target: MutNullableJS<EventTarget>
+    related_target: MutNullableHeap<JS<EventTarget>>,
 }
 
 impl MouseEventDerived for Event {
@@ -142,7 +143,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
     }
 
     fn GetRelatedTarget(self) -> Option<Temporary<EventTarget>> {
-        self.related_target.get()
+        self.related_target.get().map(Temporary::new)
     }
 
     fn InitMouseEvent(self,
@@ -177,7 +178,7 @@ impl<'a> MouseEventMethods for JSRef<'a, MouseEvent> {
         self.shift_key.set(shiftKeyArg);
         self.meta_key.set(metaKeyArg);
         self.button.set(buttonArg);
-        self.related_target.assign(relatedTargetArg);
+        self.related_target.set(relatedTargetArg.map(JS::from_rooted));
     }
 }
 

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -10,7 +10,8 @@ use dom::bindings::codegen::Bindings::StorageEventBinding::{StorageEventMethods}
 use dom::bindings::codegen::InheritTypes::{EventCast};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, RootedReference};
+use dom::bindings::js::Temporary;
 use dom::bindings::utils::{reflect_dom_object};
 use dom::event::{Event, EventTypeId, EventBubbles, EventCancelable};
 use dom::storage::Storage;
@@ -23,7 +24,7 @@ pub struct StorageEvent {
     oldValue: DOMRefCell<Option<DOMString>>,
     newValue: DOMRefCell<Option<DOMString>>,
     url: DOMRefCell<DOMString>,
-    storageArea: MutNullableJS<Storage>
+    storageArea: MutNullableHeap<JS<Storage>>
 }
 
 
@@ -40,7 +41,7 @@ impl StorageEvent {
             oldValue: DOMRefCell::new(oldValue),
             newValue: DOMRefCell::new(newValue),
             url: DOMRefCell::new(url),
-            storageArea: MutNullableJS::new(storageArea)
+            storageArea: MutNullableHeap::new(storageArea.map(JS::from_rooted))
         }
     }
 
@@ -107,7 +108,7 @@ impl<'a> StorageEventMethods for JSRef<'a, StorageEvent> {
     }
 
     fn GetStorageArea(self) -> Option<Temporary<Storage>> {
-        self.storageArea.get()
+        self.storageArea.get().map(Temporary::new)
     }
 
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -8,7 +8,8 @@ use dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use dom::bindings::codegen::InheritTypes::{EventCast, UIEventDerived};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{MutNullableJS, JSRef, RootedReference, Temporary};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, RootedReference};
+use dom::bindings::js::Temporary;
 
 use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventTypeId, EventBubbles, EventCancelable};
@@ -22,7 +23,7 @@ use std::default::Default;
 #[dom_struct]
 pub struct UIEvent {
     event: Event,
-    view: MutNullableJS<Window>,
+    view: MutNullableHeap<JS<Window>>,
     detail: Cell<i32>
 }
 
@@ -73,7 +74,7 @@ impl UIEvent {
 impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
     // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#widl-UIEvent-view
     fn GetView(self) -> Option<Temporary<Window>> {
-        self.view.get()
+        self.view.get().map(Temporary::new)
     }
 
     // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#widl-UIEvent-detail
@@ -93,7 +94,7 @@ impl<'a> UIEventMethods for JSRef<'a, UIEvent> {
         }
 
         event.InitEvent(type_, can_bubble, cancelable);
-        self.view.assign(view);
+        self.view.set(view.map(JS::from_rooted));
         self.detail.set(detail);
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -13,7 +13,8 @@ use dom::bindings::global::global_object_for_js_object;
 use dom::bindings::error::{report_pending_exception, Fallible};
 use dom::bindings::error::Error::InvalidCharacter;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{MutNullableJS, JSRef, Temporary, OptionalRootable, RootedReference};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, OptionalRootable};
+use dom::bindings::js::{RootedReference, Temporary};
 use dom::bindings::utils::{GlobalStaticData, Reflectable, WindowProxyHandler};
 use dom::browsercontext::BrowserContext;
 use dom::console::Console;
@@ -87,19 +88,19 @@ pub struct Window {
     eventtarget: EventTarget,
     script_chan: Box<ScriptChan+Send>,
     control_chan: ScriptControlChan,
-    console: MutNullableJS<Console>,
-    navigator: MutNullableJS<Navigator>,
+    console: MutNullableHeap<JS<Console>>,
+    navigator: MutNullableHeap<JS<Navigator>>,
     image_cache_task: ImageCacheTask,
     image_cache_chan: ImageCacheChan,
     compositor: DOMRefCell<Box<ScriptListener+'static>>,
     browser_context: DOMRefCell<Option<BrowserContext>>,
     page: Rc<Page>,
-    performance: MutNullableJS<Performance>,
+    performance: MutNullableHeap<JS<Performance>>,
     navigation_start: u64,
     navigation_start_precise: f64,
-    screen: MutNullableJS<Screen>,
-    session_storage: MutNullableJS<Storage>,
-    local_storage: MutNullableJS<Storage>,
+    screen: MutNullableHeap<JS<Screen>>,
+    session_storage: MutNullableHeap<JS<Storage>>,
+    local_storage: MutNullableHeap<JS<Storage>>,
     timers: TimerManager,
 
     next_worker_id: Cell<WorkerId>,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::InheritTypes::DedicatedWorkerGlobalScopeCast;
 use dom::bindings::error::{ErrorResult, Fallible};
 use dom::bindings::error::Error::{Syntax, Network, JSFailed};
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{MutNullableJS, JSRef, Temporary};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
 use dom::bindings::utils::Reflectable;
 use dom::console::Console;
 use dom::dedicatedworkerglobalscope::{DedicatedWorkerGlobalScope, DedicatedWorkerGlobalScopeHelpers};
@@ -48,9 +48,9 @@ pub struct WorkerGlobalScope {
     js_context: Rc<Cx>,
     next_worker_id: Cell<WorkerId>,
     resource_task: ResourceTask,
-    location: MutNullableJS<WorkerLocation>,
-    navigator: MutNullableJS<WorkerNavigator>,
-    console: MutNullableJS<Console>,
+    location: MutNullableHeap<JS<WorkerLocation>>,
+    navigator: MutNullableHeap<JS<WorkerNavigator>>,
+    console: MutNullableHeap<JS<Console>>,
     timers: TimerManager,
     devtools_chan: Option<DevtoolsControlChan>,
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -14,7 +14,8 @@ use dom::bindings::error::{Error, ErrorResult, Fallible};
 use dom::bindings::error::Error::{InvalidState, InvalidAccess};
 use dom::bindings::error::Error::{Network, Syntax, Security, Abort, Timeout};
 use dom::bindings::global::{GlobalField, GlobalRef, GlobalRoot};
-use dom::bindings::js::{MutNullableJS, JS, JSRef, Temporary, OptionalRootedRootable};
+use dom::bindings::js::{JS, JSRef, MutNullableHeap, Temporary};
+use dom::bindings::js::OptionalRootedRootable;
 use dom::bindings::refcounted::Trusted;
 use dom::bindings::str::ByteString;
 use dom::bindings::utils::{Reflectable, reflect_dom_object};
@@ -125,7 +126,7 @@ pub struct XMLHttpRequest {
     status_text: DOMRefCell<ByteString>,
     response: DOMRefCell<ByteString>,
     response_type: Cell<XMLHttpRequestResponseType>,
-    response_xml: MutNullableJS<Document>,
+    response_xml: MutNullableHeap<JS<Document>>,
     response_headers: DOMRefCell<Headers>,
 
     // Associated concepts
@@ -710,7 +711,7 @@ impl<'a> XMLHttpRequestMethods for JSRef<'a, XMLHttpRequest> {
 
     // https://xhr.spec.whatwg.org/#the-responsexml-attribute
     fn GetResponseXML(self) -> Option<Temporary<Document>> {
-        self.response_xml.get()
+        self.response_xml.get().map(Temporary::new)
     }
 }
 


### PR DESCRIPTION
This is useful for union types, in cases where we need MutNullableHeap&lt;NodeOrString&gt;.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5862)

<!-- Reviewable:end -->
