### PR TITLE
Make NodeTypeId include CharacterData variant

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -47,6 +47,7 @@ use text::TextRunScanner;
 use wrapper::{PostorderNodeMutTraversal, PseudoElementType, TLayoutNode, ThreadSafeLayoutNode};
 
 use gfx::display_list::OpaqueNode;
+use script::dom::characterdata::CharacterDataTypeId;
 use script::dom::element::ElementTypeId;
 use script::dom::htmlelement::HTMLElementTypeId;
 use script::dom::htmlobjectelement::is_image_data;
@@ -789,7 +790,7 @@ impl<'a> FlowConstructor<'a> {
         // fragment that needs to be generated for this inline node.
         let mut fragments = LinkedList::new();
         match (node.get_pseudo_element_type(), node.type_id()) {
-            (_, Some(NodeTypeId::Text)) => {
+            (_, Some(NodeTypeId::CharacterData(CharacterDataTypeId::Text))) => {
                 self.create_fragments_for_node_text_content(&mut fragments, node, &style)
             }
             (PseudoElementType::Normal, _) => {
@@ -1239,12 +1240,12 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
                 };
                 (munged_display, style.get_box().float, style.get_box().position)
             }
-            Some(NodeTypeId::Text) => (display::T::inline, float::T::none, position::T::static_),
-            Some(NodeTypeId::Comment) |
+            Some(NodeTypeId::CharacterData(CharacterDataTypeId::Text)) => (display::T::inline, float::T::none, position::T::static_),
+            Some(NodeTypeId::CharacterData(CharacterDataTypeId::Comment)) |
+            Some(NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction)) |
             Some(NodeTypeId::DocumentType) |
             Some(NodeTypeId::DocumentFragment) |
-            Some(NodeTypeId::Document) |
-            Some(NodeTypeId::ProcessingInstruction) => {
+            Some(NodeTypeId::Document) => {
                 (display::T::none, float::T::none, position::T::static_)
             }
         };
@@ -1382,9 +1383,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
     fn is_replaced_content(&self) -> bool {
         match self.type_id() {
             None |
-            Some(NodeTypeId::Text) |
-            Some(NodeTypeId::ProcessingInstruction) |
-            Some(NodeTypeId::Comment) |
+            Some(NodeTypeId::CharacterData(_)) |
             Some(NodeTypeId::DocumentType) |
             Some(NodeTypeId::DocumentFragment) |
             Some(NodeTypeId::Document) |

--- a/components/layout/css/matching.rs
+++ b/components/layout/css/matching.rs
@@ -14,6 +14,7 @@ use incremental::{self, RestyleDamage};
 use opaque_node::OpaqueNodeMethods;
 use wrapper::{LayoutElement, LayoutNode, TLayoutNode};
 
+use script::dom::characterdata::CharacterDataTypeId;
 use script::dom::node::NodeTypeId;
 use script::layout_interface::Animation;
 use selectors::bloom::BloomFilter;
@@ -676,7 +677,7 @@ impl<'ln> MatchMethods for LayoutNode<'ln> {
             &mut None => panic!("no layout data"),
             &mut Some(ref mut layout_data) => {
                 match self.type_id() {
-                    Some(NodeTypeId::Text) => {
+                    Some(NodeTypeId::CharacterData(CharacterDataTypeId::Text)) => {
                         // Text nodes get a copy of the parent style. This ensures
                         // that during fragment construction any non-inherited
                         // CSS properties (such as vertical-align) are correctly

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -45,7 +45,7 @@ use script::dom::bindings::codegen::InheritTypes::{HTMLIFrameElementCast, HTMLCa
 use script::dom::bindings::codegen::InheritTypes::{HTMLImageElementCast, HTMLInputElementCast};
 use script::dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementCast, NodeCast, TextCast};
 use script::dom::bindings::js::LayoutJS;
-use script::dom::characterdata::LayoutCharacterDataHelpers;
+use script::dom::characterdata::{CharacterDataTypeId, LayoutCharacterDataHelpers};
 use script::dom::element::{Element, ElementTypeId};
 use script::dom::element::{LayoutElementHelpers, RawLayoutElementHelpers};
 use script::dom::htmlelement::HTMLElementTypeId;
@@ -1048,7 +1048,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
     /// `empty_cells` per CSS 2.1 § 17.6.1.1.
     pub fn is_content(&self) -> bool {
         match self.type_id() {
-            Some(NodeTypeId::Element(..)) | Some(NodeTypeId::Text(..)) => true,
+            Some(NodeTypeId::Element(..)) | Some(NodeTypeId::CharacterData(CharacterDataTypeId::Text(..))) => true,
             _ => false
         }
     }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -33,18 +33,16 @@ pub struct CharacterData {
 impl CharacterDataDerived for EventTarget {
     fn is_characterdata(&self) -> bool {
         match *self.type_id() {
-            EventTargetTypeId::Node(NodeTypeId::Text) |
-            EventTargetTypeId::Node(NodeTypeId::Comment) |
-            EventTargetTypeId::Node(NodeTypeId::ProcessingInstruction) => true,
+            EventTargetTypeId::Node(NodeTypeId::CharacterData(_)) => true,
             _ => false
         }
     }
 }
 
 impl CharacterData {
-    pub fn new_inherited(id: NodeTypeId, data: DOMString, document: JSRef<Document>) -> CharacterData {
+    pub fn new_inherited(id: CharacterDataTypeId, data: DOMString, document: JSRef<Document>) -> CharacterData {
         CharacterData {
-            node: Node::new_inherited(id, document),
+            node: Node::new_inherited(NodeTypeId::CharacterData(id), document),
             data: DOMRefCell::new(data),
         }
     }
@@ -151,6 +149,15 @@ impl<'a> CharacterDataMethods for JSRef<'a, CharacterData> {
         NodeCast::from_ref(self).following_siblings()
                                 .filter_map(ElementCast::to_temporary).next()
     }
+}
+
+/// The different types of CharacterData.
+#[derive(Copy, Clone, PartialEq, Debug)]
+#[jstraceable]
+pub enum CharacterDataTypeId {
+    Comment,
+    Text,
+    ProcessingInstruction,
 }
 
 pub trait CharacterDataHelpers<'a> {

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -8,7 +8,7 @@ use dom::bindings::codegen::InheritTypes::CommentDerived;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, Rootable, Temporary};
-use dom::characterdata::CharacterData;
+use dom::characterdata::{CharacterData, CharacterDataTypeId};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::node::{Node, NodeTypeId};
@@ -22,14 +22,14 @@ pub struct Comment {
 
 impl CommentDerived for EventTarget {
     fn is_comment(&self) -> bool {
-        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::Comment)
+        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::CharacterData(CharacterDataTypeId::Comment))
     }
 }
 
 impl Comment {
     fn new_inherited(text: DOMString, document: JSRef<Document>) -> Comment {
         Comment {
-            characterdata: CharacterData::new_inherited(NodeTypeId::Comment, text, document)
+            characterdata: CharacterData::new_inherited(CharacterDataTypeId::Comment, text, document)
         }
     }
 

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::ProcessingInstructionBinding;
 use dom::bindings::codegen::Bindings::ProcessingInstructionBinding::ProcessingInstructionMethods;
 use dom::bindings::codegen::InheritTypes::ProcessingInstructionDerived;
 use dom::bindings::js::{JSRef, Temporary};
-use dom::characterdata::CharacterData;
+use dom::characterdata::{CharacterData, CharacterDataTypeId};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::node::{Node, NodeTypeId};
@@ -21,14 +21,14 @@ pub struct ProcessingInstruction {
 
 impl ProcessingInstructionDerived for EventTarget {
     fn is_processinginstruction(&self) -> bool {
-        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::ProcessingInstruction)
+        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction))
     }
 }
 
 impl ProcessingInstruction {
     fn new_inherited(target: DOMString, data: DOMString, document: JSRef<Document>) -> ProcessingInstruction {
         ProcessingInstruction {
-            characterdata: CharacterData::new_inherited(NodeTypeId::ProcessingInstruction, data, document),
+            characterdata: CharacterData::new_inherited(CharacterDataTypeId::ProcessingInstruction, data, document),
             target: target
         }
     }

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -13,7 +13,7 @@ use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JSRef, OptionalRootable, Rootable, RootedReference};
 use dom::bindings::js::Temporary;
-use dom::characterdata::{CharacterData, CharacterDataHelpers};
+use dom::characterdata::{CharacterData, CharacterDataHelpers, CharacterDataTypeId};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::node::{Node, NodeHelpers, NodeTypeId};
@@ -27,14 +27,14 @@ pub struct Text {
 
 impl TextDerived for EventTarget {
     fn is_text(&self) -> bool {
-        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::Text)
+        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::CharacterData(CharacterDataTypeId::Text))
     }
 }
 
 impl Text {
     fn new_inherited(text: DOMString, document: JSRef<Document>) -> Text {
         Text {
-            characterdata: CharacterData::new_inherited(NodeTypeId::Text, text, document)
+            characterdata: CharacterData::new_inherited(CharacterDataTypeId::Text, text, document)
         }
     }
 

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -14,7 +14,7 @@ use dom::bindings::codegen::InheritTypes::ProcessingInstructionCast;
 use dom::bindings::js::{JS, JSRef, OptionalRootable, Root, Rootable};
 use dom::bindings::js::{RootedReference, Temporary};
 use dom::bindings::trace::RootedVec;
-use dom::characterdata::CharacterDataHelpers;
+use dom::characterdata::{CharacterDataHelpers, CharacterDataTypeId};
 use dom::comment::Comment;
 use dom::document::{Document, DocumentHelpers};
 use dom::document::{DocumentSource, IsHTMLDocument};
@@ -247,17 +247,17 @@ impl<'a> Serializable for JSRef<'a, Node> {
                 serializer.write_doctype(&doctype.name())
             },
 
-            (IncludeNode, NodeTypeId::Text) => {
+            (IncludeNode, NodeTypeId::CharacterData(CharacterDataTypeId::Text)) => {
                 let cdata = CharacterDataCast::to_ref(node).unwrap();
                 serializer.write_text(&cdata.data())
             },
 
-            (IncludeNode, NodeTypeId::Comment) => {
+            (IncludeNode, NodeTypeId::CharacterData(CharacterDataTypeId::Comment)) => {
                 let cdata = CharacterDataCast::to_ref(node).unwrap();
                 serializer.write_comment(&cdata.data())
             },
 
-            (IncludeNode, NodeTypeId::ProcessingInstruction) => {
+            (IncludeNode, NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction)) => {
                 let pi: JSRef<ProcessingInstruction> = ProcessingInstructionCast::to_ref(node).unwrap();
                 let data = CharacterDataCast::from_ref(pi).data();
                 serializer.write_processing_instruction(&pi.target(), &data)


### PR DESCRIPTION
NodeTypeId is supposed to reflect the WebIDL inheritance hierarchy.
All of Text/ProcessingInstruction/Comment inherit from CharacterData,
which inherits from Node. There should be a CharacterDataTypeId value
that differentiates between those, instead.

r? @jdm 
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5879)

<!-- Reviewable:end -->
