### PR TITLE
Support WebDriver takeScreenshot command.

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -23,6 +23,7 @@ use msg::constellation_msg::{AnimationState, ConstellationChan, PipelineId};
 use msg::constellation_msg::{Key, KeyState, KeyModifiers};
 use profile_traits::mem;
 use profile_traits::time;
+use png;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::fmt::{Error, Formatter, Debug};
 use std::rc::Rc;
@@ -218,6 +219,8 @@ pub enum Msg {
     KeyEvent(Key, KeyState, KeyModifiers),
     /// Changes the cursor.
     SetCursor(Cursor),
+    /// Composite to a PNG file and return the Image over a passed channel.
+    CreatePng(Sender<Option<png::Image>>),
     /// Informs the compositor that the paint task for the given pipeline has exited.
     PaintTaskExited(PipelineId),
     /// Alerts the compositor that the viewport has been constrained in some manner
@@ -247,6 +250,7 @@ impl Debug for Msg {
             Msg::RecompositeAfterScroll => write!(f, "RecompositeAfterScroll"),
             Msg::KeyEvent(..) => write!(f, "KeyEvent"),
             Msg::SetCursor(..) => write!(f, "SetCursor"),
+            Msg::CreatePng(..) => write!(f, "CreatePng"),
             Msg::PaintTaskExited(..) => write!(f, "PaintTaskExited"),
             Msg::ViewportConstrained(..) => write!(f, "ViewportConstrained"),
         }

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -413,6 +413,9 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 };
                 sender.send(result).unwrap();
             }
+            ConstellationMsg::CompositePng(reply) => {
+                self.compositor_proxy.send(CompositorMsg::CreatePng(reply));
+            }
             ConstellationMsg::WebDriverCommand(pipeline_id,
                                                command) => {
                 debug!("constellation got webdriver command message");

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -108,8 +108,9 @@ impl CompositorEventListener for NullCompositor {
             Msg::ChangePageUrl(..) |
             Msg::KeyEvent(..) |
             Msg::SetCursor(..) |
-            Msg::PaintTaskExited(..) |
             Msg::ViewportConstrained(..) => {}
+            Msg::CreatePng(..) |
+            Msg::PaintTaskExited(..) => {}
         }
         true
     }

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -32,6 +32,9 @@ git = "https://github.com/servo/rust-core-foundation"
 [dependencies.io_surface]
 git = "https://github.com/servo/rust-io-surface"
 
+[dependencies.png]
+git = "https://github.com/servo/rust-png"
+
 [dependencies]
 url = "0.2.16"
 bitflags = "*"

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -11,6 +11,7 @@ use geom::scale_factor::ScaleFactor;
 use hyper::header::Headers;
 use hyper::method::Method;
 use layers::geometry::DevicePixel;
+use png;
 use util::cursor::Cursor;
 use util::geometry::{PagePx, ViewportPx};
 use std::sync::mpsc::{channel, Sender, Receiver};
@@ -233,10 +234,12 @@ pub enum Msg {
     Focus(PipelineId),
     /// Requests that the constellation retrieve the current contents of the clipboard
     GetClipboardContents(Sender<String>),
-    // Dispatch a webdriver command
+    /// Dispatch a webdriver command
     WebDriverCommand(PipelineId, WebDriverScriptCommand),
     /// Notifies the constellation that the viewport has been constrained in some manner
     ViewportConstrained(PipelineId, ViewportConstraints),
+    /// Create a PNG of the window contents
+    CompositePng(Sender<Option<png::Image>>)
 }
 
 #[derive(Clone, Eq, PartialEq)]

--- a/components/msg/lib.rs
+++ b/components/msg/lib.rs
@@ -7,6 +7,7 @@ extern crate azure;
 extern crate geom;
 extern crate hyper;
 extern crate layers;
+extern crate png;
 extern crate util;
 extern crate url;
 extern crate style;

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -724,9 +724,8 @@ impl ScriptTask {
                 self.handle_update_subpage_id(containing_pipeline_id, old_subpage_id, new_subpage_id),
             ConstellationControlMsg::FocusIFrame(containing_pipeline_id, subpage_id) =>
                 self.handle_focus_iframe_msg(containing_pipeline_id, subpage_id),
-            ConstellationControlMsg::WebDriverCommand(pipeline_id, msg) => {
-                self.handle_webdriver_msg(pipeline_id, msg);
-            }
+            ConstellationControlMsg::WebDriverCommand(pipeline_id, msg) =>
+                self.handle_webdriver_msg(pipeline_id, msg),
             ConstellationControlMsg::TickAllAnimations(pipeline_id) =>
                 self.handle_tick_all_animations(pipeline_id),
         }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -751,6 +751,7 @@ dependencies = [
  "hyper 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "io_surface 0.1.0 (git+https://github.com/servo/rust-io-surface)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "style 0.0.1",
  "url 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1251,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "webdriver"
 version = "0.1.0"
-source = "git+https://github.com/jgraham/webdriver-rust.git#66547888f47bae7e938a92af4586276479343216"
+source = "git+https://github.com/jgraham/webdriver-rust.git#c2038b4195ee8cd982079cc48d6a9d039f59f1fb"
 dependencies = [
  "hyper 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1265,6 +1266,7 @@ name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
  "msg 0.0.1",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -19,6 +19,9 @@ path = "../webdriver_traits"
 [dependencies.webdriver]
 git = "https://github.com/jgraham/webdriver-rust.git"
 
+[dependencies.png]
+git = "https://github.com/servo/rust-png"
+
 [dependencies]
 rustc-serialize = "0.3.4"
 url = "0.2.16"

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -12,6 +12,7 @@ extern crate log;
 
 extern crate webdriver;
 extern crate msg;
+extern crate png;
 extern crate url;
 extern crate util;
 extern crate rustc_serialize;
@@ -35,8 +36,11 @@ use uuid::Uuid;
 
 use std::borrow::ToOwned;
 use rustc_serialize::json::{Json, ToJson};
+use rustc_serialize::base64::{Config, ToBase64, CharacterSet, Newline};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
+
+use std::thread::sleep_ms;
 
 pub fn start_server(port: u16, constellation_chan: ConstellationChan) {
     let handler = Handler::new(constellation_chan);
@@ -171,6 +175,46 @@ impl Handler {
                                               "Unsupported return type"))
         }
     }
+
+
+    fn handle_take_screenshot(&self) -> WebDriverResult<WebDriverResponse> {
+        let mut img = None;
+
+        let interval = 20;
+        let iterations = 30_000 / interval;
+
+        for _ in 0..iterations {
+            let (sender, reciever) = channel();
+            let ConstellationChan(ref const_chan) = self.constellation_chan;
+            const_chan.send(ConstellationMsg::CompositePng(sender)).unwrap();
+
+            if let Some(x) = reciever.recv().unwrap() {
+                img = Some(x);
+                break;
+            };
+
+            sleep_ms(interval)
+        }
+
+        if img.is_none() {
+            return Err(WebDriverError::new(ErrorStatus::Timeout,
+                                           "Taking screenshot timed out"));
+        }
+
+        let img_vec = match png::to_vec(&mut img.unwrap()) {
+           Ok(x) => x,
+           Err(_) => return Err(WebDriverError::new(ErrorStatus::UnknownError,
+                                                    "Taking screenshot failed"))
+        };
+        let config = Config {
+            char_set:CharacterSet::Standard,
+            newline: Newline::LF,
+            pad: true,
+            line_length: None
+        };
+        let encoded = img_vec.to_base64(config);
+        Ok(WebDriverResponse::Generic(ValueResponse::new(encoded.to_json())))
+    }
 }
 
 impl WebDriverHandler for Handler {
@@ -185,6 +229,7 @@ impl WebDriverHandler for Handler {
             WebDriverCommand::GetWindowHandle => self.handle_get_window_handle(),
             WebDriverCommand::GetWindowHandles => self.handle_get_window_handles(),
             WebDriverCommand::ExecuteScript(ref x) => self.handle_execute_script(x),
+            WebDriverCommand::TakeScreenshot => self.handle_take_screenshot(),
             _ => Err(WebDriverError::new(ErrorStatus::UnsupportedOperation,
                                          "Command not implemented"))
         }

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
  "hyper 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "io_surface 0.1.0 (git+https://github.com/servo/rust-io-surface)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "style 0.0.1",
  "url 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1235,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "webdriver"
 version = "0.1.0"
-source = "git+https://github.com/jgraham/webdriver-rust.git#66547888f47bae7e938a92af4586276479343216"
+source = "git+https://github.com/jgraham/webdriver-rust.git#c2038b4195ee8cd982079cc48d6a9d039f59f1fb"
 dependencies = [
  "hyper 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1249,6 +1250,7 @@ name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
  "msg 0.0.1",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "hyper 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "io_surface 0.1.0 (git+https://github.com/servo/rust-io-surface)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "style 0.0.1",
  "url 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1207,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "webdriver"
 version = "0.1.0"
-source = "git+https://github.com/jgraham/webdriver-rust.git#66547888f47bae7e938a92af4586276479343216"
+source = "git+https://github.com/jgraham/webdriver-rust.git#c2038b4195ee8cd982079cc48d6a9d039f59f1fb"
 dependencies = [
  "hyper 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1221,6 +1222,7 @@ name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
  "msg 0.0.1",
+ "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",


### PR DESCRIPTION
This adds support for compositing to a PNG without actually quiting
the browser.

Cargo bits need to be updated after the upstream changes to rust-png land.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5884)

<!-- Reviewable:end -->
