### PR TITLE
layout: Don't panic in border collapse when a row has fewer cells than its previous sibling.

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -754,7 +754,9 @@ fn perform_border_collapse_for_row(child_table_row: &mut TableRowFlow,
         let next_block = next_block.push_or_mutate(i, *this_block_border);
         match next_block_borders {
             NextBlockCollapsedBorders::FromNextRow(next_block_borders) => {
-                next_block.combine(&next_block_borders[i]);
+                if next_block_borders.len() > i {
+                    next_block.combine(&next_block_borders[i])
+                }
             }
             NextBlockCollapsedBorders::FromTable(ref next_block_borders) => {
                 next_block.combine(next_block_borders);

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -81,6 +81,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 != border_black_ridge.html border_black_groove.html
 != border_black_ridge.html border_black_solid.html
 == border_code_tag.html border_code_tag_ref.html
+== border_collapse_missing_cell_a.html border_collapse_missing_cell_ref.html
 == border_collapse_simple_a.html border_collapse_simple_ref.html
 == border_radius_clip_a.html border_radius_clip_ref.html
 == border_radius_overlapping_a.html border_radius_overlapping_ref.html

--- a/tests/ref/border_collapse_missing_cell_a.html
+++ b/tests/ref/border_collapse_missing_cell_a.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that missing cells don't cause a crash in border collapse code. -->
+<style>
+table {
+    border-collapse: collapse;
+}
+</style>
+</head>
+<body>
+    <table>
+        <tr>
+            <td>United States</td>
+            <td>40404</td>
+            <td>(any)</td>
+        </tr>
+        <tr>
+            <td>3424486444</td>
+            <td>Vodafone</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/tests/ref/border_collapse_missing_cell_ref.html
+++ b/tests/ref/border_collapse_missing_cell_ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that missing cells don't cause a crash in border collapse code. -->
+<style>
+table {
+    border-collapse: collapse;
+}
+</style>
+</head>
+<body>
+    <table>
+        <tr>
+            <td>United States</td>
+            <td>40404</td>
+            <td>(any)</td>
+        </tr>
+        <tr>
+            <td>3424486444</td>
+            <td>Vodafone</td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
This was seen in Twitter and the Google SERPs (sometimes).

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5887)

<!-- Reviewable:end -->
