### PR TITLE
layout: Remove `absolute_static_i_offset` and `fixed_static_i_offset`.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1227,19 +1227,6 @@ impl BlockFlow {
         let mut inline_end_floats_impact_child =
             self.base.flags.contains(IMPACTED_BY_RIGHT_FLOATS);
 
-        let absolute_static_i_offset = if self.is_positioned() {
-            // This flow is the containing block. The static inline offset will be the inline-start
-            // padding edge.
-            self.fragment.border_padding.inline_start
-                - self.fragment.style().logical_border_width().inline_start
-        } else {
-            // For kids, the inline-start margin edge will be at our inline-start content edge. The
-            // current static offset is at our inline-start margin edge. So move in to the
-            // inline-start content edge.
-            self.base.absolute_static_i_offset + inline_start_content_edge
-        };
-
-        let fixed_static_i_offset = self.base.fixed_static_i_offset + inline_start_content_edge;
         let flags = self.base.flags.clone();
 
         // Remember the inline-sizes of the last left and right floats, if there were any. These
@@ -1291,8 +1278,6 @@ impl BlockFlow {
             {
                 let kid_base = flow::mut_base(kid);
                 kid_base.block_container_explicit_block_size = explicit_content_size;
-                kid_base.absolute_static_i_offset = absolute_static_i_offset;
-                kid_base.fixed_static_i_offset = fixed_static_i_offset;
             }
 
             // Determine float impaction, and update the inline size speculations if necessary.

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -790,20 +790,11 @@ pub struct BaseFlow {
     /// depend on content heights).  Used for computing percentage values for `height`.
     pub block_container_explicit_block_size: Option<Au>,
 
-    /// Offset wrt the nearest positioned ancestor - aka the Containing Block
-    /// for any absolutely positioned elements.
-    pub absolute_static_i_offset: Au,
-
-    /// Offset wrt the Initial Containing Block.
-    pub fixed_static_i_offset: Au,
-
     /// Reference to the Containing Block, if this flow is absolutely positioned.
     pub absolute_cb: ContainingBlockLink,
 
     /// Information needed to compute absolute (i.e. viewport-relative) flow positions (not to be
     /// confused with absolutely-positioned flows).
-    ///
-    /// FIXME(pcwalton): Merge with `absolute_static_i_offset` and `fixed_static_i_offset` above?
     pub absolute_position_info: AbsolutePositionInfo,
 
     /// The clipping region for this flow and its descendants, in layer coordinates.
@@ -968,8 +959,6 @@ impl BaseFlow {
             collapsible_margins: CollapsibleMargins::new(),
             stacking_relative_position: Point2D::zero(),
             abs_descendants: Descendants::new(),
-            absolute_static_i_offset: Au(0),
-            fixed_static_i_offset: Au(0),
             block_container_inline_size: Au(0),
             block_container_writing_mode: writing_mode,
             block_container_explicit_block_size: None,


### PR DESCRIPTION
They haven't been used for hypothetical box calculation in quite some
time.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5889)

<!-- Reviewable:end -->
