### PR TITLE
Various fixes for cleaning up iframes, compositor layers, pipelines and threads.

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -114,6 +114,10 @@ impl PaintListener for Box<CompositorProxy+'static+Send> {
         // `position: fixed` but will not be sufficient to handle `overflow: scroll` or transforms.
         self.send(Msg::InitializeLayersForPipeline(pipeline_id, epoch, properties));
     }
+
+    fn notify_paint_task_exiting(&mut self, pipeline_id: PipelineId) {
+        self.send(Msg::PaintTaskExited(pipeline_id))
+    }
 }
 
 /// Messages from the painting task and the constellation task to the compositor task.

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(box_syntax)]
+#![feature(collections)]
 #![feature(core)]
 #![feature(rustc_private)]
 

--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -253,6 +253,11 @@ impl Pipeline {
         self.children.push(frame_id);
     }
 
+    pub fn remove_child(&mut self, frame_id: FrameId) {
+        let index = self.children.iter().position(|id| *id == frame_id).unwrap();
+        self.children.remove(index);
+    }
+
     pub fn trigger_mozbrowser_event(&self,
                                      subpage_id: SubpageId,
                                      event: MozBrowserEvent) {

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -93,6 +93,8 @@ pub trait PaintListener {
                               replies: Vec<(LayerId, Box<LayerBufferSet>)>,
                               frame_tree_id: FrameTreeId);
 
+    // Notification that the paint task wants to exit.
+    fn notify_paint_task_exiting(&mut self, pipeline_id: PipelineId);
 }
 
 /// The interface used by the script task to tell the compositor to update its ready state,

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -244,6 +244,8 @@ pub enum Msg {
     CompositePng(Sender<Option<png::Image>>),
     /// Query the constellation to see if the current compositor output is stable
     IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
+    /// Notification that this iframe should be removed.
+    RemoveIFrame(PipelineId, SubpageId),
 }
 
 #[derive(Clone, Eq, PartialEq)]


### PR DESCRIPTION
This allows most of the jquery test suite to run without exhausting thread resources.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5890)

<!-- Reviewable:end -->
