### PR TITLE
Properly generate proxy stringifiers

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4089,25 +4089,6 @@ class CGDOMJSProxyHandler_obj_toString(CGAbstractExternMethod):
         CGAbstractExternMethod.__init__(self, descriptor, "obj_toString", "*mut JSString", args)
         self.descriptor = descriptor
     def getBody(self):
-        stringifier = self.descriptor.operations['Stringifier']
-        if stringifier:
-            name = self.descriptor.binaryNameFor(stringifier.identifier.name)
-            nativeName = MakeNativeName(name)
-            signature = stringifier.signatures()[0]
-            returnType = signature[0]
-            extendedAttributes = self.descriptor.getExtendedAttributes(stringifier)
-            infallible = 'infallible' in extendedAttributes
-            if not infallible:
-                error = CGGeneric(
-                    ('ThrowMethodFailedWithDetails(cx, rv, "%s", "toString");\n' +
-                     "return NULL;") % self.descriptor.interface.identifier.name)
-            else:
-                error = None
-            call = CGCallGenerator(error, [], "", returnType, extendedAttributes, self.descriptor, nativeName, False, object="UnwrapProxy(proxy)")
-            return call.define() + """\
-JSString* jsresult;
-return xpc_qsStringToJsstring(cx, result, &jsresult) ? jsresult : NULL;"""
-
         return """proxyhandler::object_to_string(cx, "%s")""" % self.descriptor.name
 
     def definition_body(self):
@@ -4247,7 +4228,7 @@ class CGInterfaceTrait(CGThing):
 
             if descriptor.proxy:
                 for name, operation in descriptor.operations.iteritems():
-                    if not operation:
+                    if not operation or operation.isStringifier():
                         continue
 
                     assert len(operation.signatures()) == 1

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -254,7 +254,7 @@ class Descriptor(DescriptorProvider):
 
         self._binaryNames = desc.get('binaryNames', {})
         self._binaryNames.setdefault('__legacycaller', 'LegacyCall')
-        self._binaryNames.setdefault('__stringifier', 'Stringify')
+        self._binaryNames.setdefault('__stringifier', 'Stringifier')
 
         for member in self.interface.members:
             if not member.isAttr() and not member.isMethod():

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -159,4 +159,9 @@ impl<'a> DOMTokenListMethods for JSRef<'a, DOMTokenList> {
             }
         }
     }
+
+    // https://dom.spec.whatwg.org/#stringification-behavior
+    fn Stringifier(self) -> DOMString {
+        self.element.root().r().get_string_attribute(&self.local_name)
+    }
 }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -53,7 +53,7 @@ impl<'a> LocationMethods for JSRef<'a, Location> {
     }
 
     // https://url.spec.whatwg.org/#URLUtils-stringification-behavior
-    fn Stringify(self) -> DOMString {
+    fn Stringifier(self) -> DOMString {
         self.Href().0
     }
 

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -106,6 +106,11 @@ impl<'a> URLSearchParamsMethods for JSRef<'a, URLSearchParams> {
         self.data.borrow_mut().insert(name, vec!(value));
         self.update_steps();
     }
+
+    // https://url.spec.whatwg.org/#stringification-behavior
+    fn Stringifier(self) -> DOMString {
+        DOMString::from_utf8(self.serialize(None)).unwrap()
+    }
 }
 
 pub trait URLSearchParamsHelpers {

--- a/components/script/dom/webidls/DOMTokenList.webidl
+++ b/components/script/dom/webidls/DOMTokenList.webidl
@@ -17,5 +17,5 @@ interface DOMTokenList {
   [Throws]
   boolean toggle(DOMString token, optional boolean force);
 
-  //stringifier;
+  stringifier;
 };

--- a/components/script/dom/webidls/URLSearchParams.webidl
+++ b/components/script/dom/webidls/URLSearchParams.webidl
@@ -15,5 +15,5 @@ interface URLSearchParams {
   // sequence<DOMString> getAll(DOMString name);
   boolean has(DOMString name);
   void set(DOMString name, DOMString value);
-  //stringifier;
+  stringifier;
 };

--- a/tests/wpt/metadata/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/dom/interfaces.html.ini
@@ -825,9 +825,6 @@
   [DOMTokenList interface: operation toggle(DOMString,boolean)]
     expected: FAIL
 
-  [DOMTokenList interface: stringifier]
-    expected: FAIL
-
   [DOMTokenList interface: calling add(DOMString) on document.body.classList with too few arguments must throw TypeError]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/Element-classlist.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-classlist.html.ini
@@ -12,42 +12,12 @@
   [classList.add must not cause the CSS selector to stop matching]
     expected: FAIL
 
-  [classList must stringify correctly when items have been added]
-    expected: FAIL
-
-  [classList.add should not add a token if it already exists]
-    expected: FAIL
-
-  [classList.remove removes arguments passed, if they are present.]
-    expected: FAIL
-
-  [classList.remove must remove existing tokens]
-    expected: FAIL
-
   [classList.remove must not break case-sensitive CSS selector matching]
-    expected: FAIL
-
-  [classList.remove must collapse whitespace around removed tokens]
-    expected: FAIL
-
-  [classList.remove must collapse whitespaces around each token]
-    expected: FAIL
-
-  [classList.remove must collapse whitespaces around each token and remove duplicates]
-    expected: FAIL
-
-  [classList.remove must collapse whitespace when removing duplicate tokens]
-    expected: FAIL
-
-  [classList.add must collapse whitespaces and remove duplicates when adding a token that already exists]
     expected: FAIL
 
   [classList.toggle must not break case-sensitive CSS selector matching]
     expected: FAIL
 
   [CSS class selectors must stop matching when all classes have been removed]
-    expected: FAIL
-
-  [classList must stringify to an empty string when all classes have been removed]
     expected: FAIL
 


### PR DESCRIPTION
The proxy stringifiers called through {}.toString.call() (obj_toString) shouldn't use the stringifier.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5896)

<!-- Reviewable:end -->
