### PR TITLE
TextEncoder::Constructor should not trim whitespaces or lowercase labels...

### DIFF
--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -14,7 +14,6 @@ use dom::bindings::utils::{Reflector, reflect_dom_object};
 use util::str::DOMString;
 
 use std::borrow::ToOwned;
-use std::ascii::AsciiExt;
 use std::ptr;
 
 use encoding::types::EncodingRef;
@@ -50,7 +49,7 @@ impl TextEncoder {
     // https://encoding.spec.whatwg.org/#dom-textencoder
     pub fn Constructor(global: GlobalRef,
                        label: DOMString) -> Fallible<Temporary<TextEncoder>> {
-        let encoding = match encoding_from_whatwg_label(&label.trim().to_ascii_lowercase()) {
+        let encoding = match encoding_from_whatwg_label(&label) {
             Some(enc) => enc,
             None => {
                 debug!("Encoding Label Not Supported");

--- a/tests/wpt/metadata/encoding/api-invalid-label.html.ini
+++ b/tests/wpt/metadata/encoding/api-invalid-label.html.ini
@@ -1,218 +1,0 @@
-[api-invalid-label.html]
-  type: testharness
-  [Invalid label "\\vunicode-1-1-utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "unicode-1-1-utf-8\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vunicode-1-1-utf-8\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " unicode-1-1-utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "unicode-1-1-utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " unicode-1-1-utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " unicode-1-1-utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "unicode-1-1-utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " unicode-1-1-utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " unicode-1-1-utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "unicode-1-1-utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " unicode-1-1-utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-8\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-8\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf8\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf8\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf8" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf8 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-16be" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16be\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-16be\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16be" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16be " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16be " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16be" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16be " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16be " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16be" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16be " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16be " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-16" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-16\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16 " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-16le" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16le\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "\\vutf-16le\\v" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16le" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16le " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16le " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16le" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16le " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16le " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16le" should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label "utf-16le " should be rejected by TextEncoder.]
-    expected: FAIL
-
-  [Invalid label " utf-16le " should be rejected by TextEncoder.]
-    expected: FAIL
-


### PR DESCRIPTION
... #5900

Fixes #5900

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5903)

<!-- Reviewable:end -->
