### PR TITLE
Use canonical Servo GitHub URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ pull requests. Each pull request will be reviewed by a core contributor
 given feedback for changes that would be required. All contributions should
 follow this format, even those from core contributors.
 
-If you're looking for easy bugs, have a look at the [E-Easy issue tag](https://github.com/mozilla/servo/issues?labels=E-easy&page=1&state=open) on GitHub.
+If you're looking for easy bugs, have a look at the [E-Easy issue tag](https://github.com/servo/servo/labels/E-easy) on GitHub.
 
 ## Pull Request Checklist
 
@@ -29,9 +29,9 @@ If you're looking for easy bugs, have a look at the [E-Easy issue tag](https://g
 
 - Add tests relevant to the fixed bug or new feature.  For a DOM change this
   will usually be a web platform test; for layout, a reftest.  See our [testing
-  guide](https://github.com/mozilla/servo/wiki/Testing) for more information.
+  guide](https://github.com/servo/servo/wiki/Testing) for more information.
 
-For specific git instructions, see [GitHub & Critic PR handling 101](https://github.com/mozilla/servo/wiki/Github-&-Critic-PR-handling-101).
+For specific git instructions, see [GitHub & Critic PR handling 101](https://github.com/servo/servo/wiki/Github-&-Critic-PR-handling-101).
 
 ## Conduct
 


### PR DESCRIPTION
Three URLs have changed from `github.com/mozilla/servo` to `github.com/servo/servo`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5908)

<!-- Reviewable:end -->
