### PR TITLE
Factor in z-index value while defining if an element establishes a stacking context.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1496,9 +1496,7 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
                                                              self.fragments.fragments[0].node);
         }
 
-        // FIXME(Savago): fix Fragment::establishes_stacking_context() for absolute positioned item
-        // and remove the check for filter presence. Further details on #5812.
-        if has_stacking_context && !self.fragments.fragments[0].style().get_effects().filter.is_empty() {
+        if has_stacking_context {
             self.base.display_list_building_result =
                 DisplayListBuildingResult::StackingContext(self.fragments.fragments[0].create_stacking_context(&self.base, display_list, None));
         } else {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1918,14 +1918,10 @@ impl Fragment {
         }
         match self.style().get_box().position {
             position::T::absolute | position::T::fixed => {
-                // FIXME(pcwalton): This should only establish a new stacking context when
-                // `z-index` is not `auto`. But this matches what we did before.
-                true
+                self.style().get_box().z_index.is_number()
             }
             position::T::relative | position::T::static_ => {
-                // FIXME(pcwalton): `position: relative` establishes a new stacking context if
-                // `z-index` is not `auto`. But this matches what we did before.
-                false
+                self.style().get_box().z_index.is_number()
             }
         }
     }

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -408,6 +408,13 @@ pub mod longhands {
                         T::Number(value) => value,
                     }
                 }
+
+                pub fn is_number(self) -> bool {
+                    match self {
+                        T::Auto => false,
+                        T::Number(_) => true,
+                    }
+                }
             }
         }
         #[inline]

--- a/tests/ref/absolute_img_stacking_a.html
+++ b/tests/ref/absolute_img_stacking_a.html
@@ -1,0 +1,11 @@
+<style>
+body {
+   margin: 0px;
+}
+
+img {
+   position: absolute;
+   margin: 0px;
+}
+</style>
+<img src="rust.png"/>

--- a/tests/ref/absolute_img_stacking_ref.html
+++ b/tests/ref/absolute_img_stacking_ref.html
@@ -1,0 +1,6 @@
+<style>
+body {
+   margin: 0px;
+}
+</style>
+<img src="rust.png"/>

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -38,6 +38,7 @@ fragment=top != ../html/acid2.html acid2_ref.html
 == 2dcontext/lineto_a.html 2dcontext/lineto_ref.html
 == 2dcontext/transform_a.html 2dcontext/transform_ref.html
 
+== absolute_img_stacking_a.html absolute_img_stacking_ref.html
 == acid1_a.html acid1_b.html
 == acid2_noscroll.html acid2_ref_broken.html
 == after_block_iteration.html after_block_iteration_ref.html


### PR DESCRIPTION
We added a new method in z-index type to return  if an element has a numeric value defined for that property.

Thanks to this change, there is no longer the need to test for an inline element filter presence to create an associated StackingContext.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5909)

<!-- Reviewable:end -->
