### PR TITLE
Various fixes to getClientBoundingRect()

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -64,7 +64,7 @@ pub static BLUR_INFLATION_FACTOR: i32 = 3;
 /// Because the script task's GC does not trace layout, node data cannot be safely stored in layout
 /// data structures. Also, layout code tends to be faster when the DOM is not being accessed, for
 /// locality reasons. Using `OpaqueNode` enforces this invariant.
-#[derive(Clone, PartialEq, Copy)]
+#[derive(Clone, PartialEq, Copy, Debug)]
 pub struct OpaqueNode(pub uintptr_t);
 
 impl OpaqueNode {

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1914,7 +1914,7 @@ impl Flow for BlockFlow {
                                                             self.base
                                                                 .absolute_position_info
                                                                 .relative_containing_block_mode,
-                                                            CoordinateSystem::Parent)
+                                                            CoordinateSystem::Own)
                               .translate(stacking_context_position));
     }
 

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -15,7 +15,7 @@ use gfx::font_context::FontContext;
 use msg::constellation_msg::ConstellationChan;
 use net_traits::image::base::Image;
 use net_traits::image_cache_task::{ImageCacheChan, ImageCacheTask, ImageState};
-use script::layout_interface::{Animation, LayoutChan};
+use script::layout_interface::{Animation, LayoutChan, ReflowGoal};
 use std::boxed;
 use std::cell::Cell;
 use std::ptr;
@@ -98,6 +98,9 @@ pub struct SharedLayoutContext {
     /// A channel on which new animations that have been triggered by style recalculation can be
     /// sent.
     pub new_animations_sender: Sender<Animation>,
+
+    /// Why is this reflow occurring
+    pub goal: ReflowGoal,
 }
 
 pub struct SharedLayoutContextWrapper(pub *const SharedLayoutContext);

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -867,30 +867,30 @@ impl FragmentDisplayListBuilding for Fragment {
 
             // Add shadows, background, borders, and outlines, if applicable.
             if let Some(ref inline_context) = self.inline_context {
-                for style in inline_context.styles.iter().rev() {
+                for node in inline_context.nodes.iter().rev() {
                     self.build_display_list_for_box_shadow_if_applicable(
-                        &**style,
+                        &*node.style,
                         display_list,
                         layout_context,
                         level,
                         &stacking_relative_border_box,
                         &clip);
                     self.build_display_list_for_background_if_applicable(
-                        &**style,
+                        &*node.style,
                         display_list,
                         layout_context,
                         level,
                         &stacking_relative_border_box,
                         &clip);
                     self.build_display_list_for_borders_if_applicable(
-                        &**style,
+                        &*node.style,
                         border_painting_mode,
                         display_list,
                         &stacking_relative_border_box,
                         level,
                         &clip);
                     self.build_display_list_for_outline_if_applicable(
-                        &**style,
+                        &*node.style,
                         display_list,
                         &stacking_relative_border_box,
                         &clip);

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -172,7 +172,7 @@ impl Flow for ListItemFlow {
                                                              .base
                                                              .absolute_position_info
                                                              .relative_containing_block_mode,
-                                                         CoordinateSystem::Parent)
+                                                         CoordinateSystem::Own)
                            .translate(stacking_context_position));
             }
         }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -14,6 +14,7 @@ use flow::{Flow, MutableFlowUtils};
 use flow::{PreorderFlowTraversal, PostorderFlowTraversal};
 use flow;
 use incremental::{self, BUBBLE_ISIZES, REFLOW, REFLOW_OUT_OF_FLOW, RestyleDamage};
+use script::layout_interface::ReflowGoal;
 use wrapper::{layout_node_to_unsafe_layout_node, LayoutNode};
 use wrapper::{PostorderNodeMutTraversal, ThreadSafeLayoutNode, UnsafeLayoutNode};
 use wrapper::{PreorderDomTraversal, PostorderDomTraversal};
@@ -378,5 +379,9 @@ impl<'a> PostorderFlowTraversal for BuildDisplayList<'a> {
     fn process(&self, flow: &mut Flow) {
         flow.build_display_list(self.layout_context);
     }
-}
 
+    #[inline]
+    fn should_process(&self, _: &mut Flow) -> bool {
+        self.layout_context.shared.goal == ReflowGoal::ForDisplay
+    }
+}

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -88,7 +88,7 @@ pub struct HitTestResponse(pub UntrustedNodeAddress);
 pub struct MouseOverResponse(pub Vec<UntrustedNodeAddress>);
 
 /// Why we're doing reflow.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Copy, Debug)]
 pub enum ReflowGoal {
     /// We're reflowing in order to send a display list to the screen.
     ForDisplay,

--- a/tests/wpt/mozilla/tests/mozilla/getBoundingClientRect.html
+++ b/tests/wpt/mozilla/tests/mozilla/getBoundingClientRect.html
@@ -3,18 +3,68 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
-div {
+@font-face {
+    font-family: 'ahem';
+    src: url(../css/fonts/ahem/ahem.ttf);
+}
+#rel-div {
     position: relative;
     top:  100px;
     left: 100px;
     width: 100px;
     height: 100px;
 }
+#abs1 {
+    position: absolute;
+    background-color: red;
+    top: 45px;
+    left: 55px;
+    width: 100px;
+    height: 120px;
+}
+#abs2 {
+    position: absolute;
+    background-color: green;
+    top: 5px;
+    left: 5px;
+    width: 80px;
+    height: 80px;
+}
+#abs3 {
+    position: absolute;
+    background-color: blue;
+    top: 12px;
+    left: 14px;
+    width: 48px;
+    height: 40px;
+}
+#span1 {
+    font-family: 'ahem';
+    font-size: 20px;
+    line-height: 1;
+}
 </style>
 </head>
 <body>
-    <div>my div</div>
+    <div id="rel-div">my div</div>
+    <div id="abs1">
+        <div id="abs2">
+            <div id="abs3">
+                <span id="span1">X</span>
+            </div>
+        </div>
+    </div>
     <script>
+    test_rect = function(name, left, top, bottom, right) {
+      var div = document.getElementById(name);
+      var rect = div.getBoundingClientRect();
+
+      assert_equals(rect.left, left);
+      assert_equals(rect.top, top);
+      assert_equals(rect.bottom, bottom);
+      assert_equals(rect.right, right);
+    }
+
     test(function() {
       assert_equals(String(DOMRect).indexOf("function DOMRect("), 0);
 
@@ -31,6 +81,13 @@ div {
       assert_equals(rect.height, 100);
       assert_equals(rect.width,  rect.right  - rect.left);
       assert_equals(rect.height, rect.bottom - rect.top);
+    });
+
+    test(function() {
+        test_rect('abs1', 55, 45, 165, 155);
+        test_rect('abs2', 60, 50, 130, 140);
+        test_rect('abs3', 74, 62, 102, 122);
+        test_rect('span1', 74, 62, 82, 94);
     });
     </script>
 </body>


### PR DESCRIPTION
- Fix queries involving stacking contexts
  - The code was double accumulating stacking context origins.
- Handle queries of inline elements.
  - The node addresses being compared were incorrect (CharacterData vs. Span)
- Handle ScriptQuery reflows correctly.
  - The layout task was skipping the compute absolute positions traversal, so failed before window.onload.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5913)

<!-- Reviewable:end -->
