### PR TITLE
layout: Fix a couple of issues relating to intrinsic widths of inline blocks.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -822,7 +822,7 @@ impl<'a> FlowConstructor<'a> {
                 block_flow));
         let fragment = Fragment::new(node, fragment_info);
 
-        let mut fragment_accumulator = InlineFragmentsAccumulator::from_inline_node(node);
+        let mut fragment_accumulator = InlineFragmentsAccumulator::new();
         fragment_accumulator.fragments.push_back(fragment);
 
         let construction_item =

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -882,8 +882,7 @@ impl Fragment {
             SpecificFragmentInfo::Generic |
             SpecificFragmentInfo::GeneratedContent(_) |
             SpecificFragmentInfo::Iframe(_) |
-            SpecificFragmentInfo::Image(_) |
-            SpecificFragmentInfo::InlineBlock(_) => {
+            SpecificFragmentInfo::Image(_) => {
                 QuantitiesIncludedInIntrinsicInlineSizes::all()
             }
             SpecificFragmentInfo::Table | SpecificFragmentInfo::TableCell => {
@@ -918,7 +917,8 @@ impl Fragment {
             SpecificFragmentInfo::ScannedText(_) |
             SpecificFragmentInfo::TableColumn(_) |
             SpecificFragmentInfo::UnscannedText(_) |
-            SpecificFragmentInfo::InlineAbsoluteHypothetical(_) => {
+            SpecificFragmentInfo::InlineAbsoluteHypothetical(_) |
+            SpecificFragmentInfo::InlineBlock(_) => {
                 QuantitiesIncludedInIntrinsicInlineSizes::empty()
             }
         }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -115,6 +115,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == first_of_type_pseudo_a.html first_of_type_pseudo_b.html
 == fixed_width_overrides_child_intrinsic_width_a.html fixed_width_overrides_child_intrinsic_width_ref.html
 == float_clearance_a.html float_clearance_ref.html
+== float_clearance_intrinsic_width_a.html float_clearance_intrinsic_width_ref.html
 == float_intrinsic_height.html float_intrinsic_height_ref.html
 == float_intrinsic_width_a.html float_intrinsic_width_ref.html
 == float_right_intrinsic_width_a.html float_right_intrinsic_width_ref.html
@@ -161,6 +162,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 != inline_background_a.html inline_background_ref.html
 == inline_block_baseline_a.html inline_block_baseline_ref.html
 == inline_block_border_a.html inline_block_border_ref.html
+== inline_block_border_intrinsic_size_a.html inline_block_border_intrinsic_size_ref.html
 == inline_block_img_a.html inline_block_img_ref.html
 == inline_block_margin_a.html inline_block_margin_ref.html
 == inline_block_min_width.html inline_block_min_width_ref.html

--- a/tests/ref/float_clearance_intrinsic_width_a.html
+++ b/tests/ref/float_clearance_intrinsic_width_a.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#nav-your-account {
+	background: lightblue;
+	display: inline-block;
+}
+.nav-button-title {
+	float: left;
+	clear: both;
+}
+</style>
+</head>
+<body>
+	<a id="nav-your-account">
+		<div class="nav-button-title">Hello.</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+	</a>
+</body>
+</html>

--- a/tests/ref/float_clearance_intrinsic_width_ref.html
+++ b/tests/ref/float_clearance_intrinsic_width_ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#nav-your-account {
+	background: lightblue;
+	display: inline-block;
+}
+</style>
+</head>
+<body>
+	<a id="nav-your-account">
+		<div class="nav-button-title">Hello.</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+		<div class="nav-button-title">Account</div>
+	</a>
+</body>
+</html>

--- a/tests/ref/inline_block_border_intrinsic_size_a.html
+++ b/tests/ref/inline_block_border_intrinsic_size_a.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html, body {
+    margin: 0;
+    font-size: 0;
+    line-height: 0;
+}
+.nav-button-outer {
+	background: red;
+	display: inline-block;
+}
+.nav-down-arrow {
+	display: inline-block;
+	border-style: solid;
+	border-color: black;
+	border-width: 10px 200px 0 0;
+}
+</style>
+</head>
+
+<body>
+	<a class="nav-button-outer"><span class="nav-down-arrow"></span></a>
+</body>
+</html>

--- a/tests/ref/inline_block_border_intrinsic_size_ref.html
+++ b/tests/ref/inline_block_border_intrinsic_size_ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html, body {
+    margin: 0;
+    font-size: 0;
+    line-height: 0;
+}
+.nav-button-outer {
+	display: inline-block;
+}
+.nav-down-arrow {
+	display: inline-block;
+	border-style: solid;
+	border-color: black;
+	border-width: 10px 200px 0 0;
+}
+</style>
+</head>
+
+<body>
+	<a class="nav-button-outer"><span class="nav-down-arrow"></span></a>
+</body>
+</html>


### PR DESCRIPTION
- Stop double-counting border and padding for inline-block fragments.
  (Test case: `inline_block_border_intrinsic_size_a.html`.)
- Take clearance into account when determining intrinsic widths of
  blocks containing floats.

Improves the Amazon headers.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5919)

<!-- Reviewable:end -->
