### PR TITLE
Added mesa-libOSMesa-devel as a dependency for Fedora compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On Fedora:
 sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
-    rpm-build openssl-devel cmake bzip2-devel libXcursor-devel libXmu-devel
+    rpm-build openssl-devel cmake bzip2-devel libXcursor-devel libXmu-devel mesa-libOSMesa-devel
 pushd /tmp
 wget http://corefonts.sourceforge.net/msttcorefonts-2.5-1.spec
 rpmbuild -bb msttcorefonts-2.5-1.spec


### PR DESCRIPTION
Hello !

I've noticed that master does not compile on the fresh Fedora 21 install, after following the README.
It turned out that one more library, namely `mesa-libOSMesa-devel` is needed to do so.

hope this helps !

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5924)

<!-- Reviewable:end -->
