### PR TITLE
Disregard variadic args when trying to pass not enough args

### DIFF
--- a/tests/wpt/web-platform-tests/resources/idlharness.js
+++ b/tests/wpt/web-platform-tests/resources/idlharness.js
@@ -1463,7 +1463,7 @@ IdlInterface.prototype.test_interface_of = function(desc, obj, exception, expect
                 var args = [];
                 for (var i = 0; i < member.arguments.length; i++)
                 {
-                    if (member.arguments[i].optional)
+                    if (member.arguments[i].optional || member.arguments[i].variadic)
                     {
                         break;
                     }


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5937)

<!-- Reviewable:end -->
