### PR TITLE
Add warning for building without --release

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -149,6 +149,10 @@ class MachCommands(CommandBase):
         # Generate Desktop Notification if elapsed-time > some threshold value
         notify(elapsed)
 
+        # Print warning if release flag is not used
+        if release is False:
+            print("[Warning] This is an un-optimized debug build. For performance testing, use ./mach build --release to enable compiler optimizations.")
+        
         print("Build completed in %0.2fs" % elapsed)
         return status
 
@@ -252,7 +256,7 @@ class MachCommands(CommandBase):
     @CommandArgument('--verbose', '-v',
                      action='store_true',
                      help='Print verbose output')
-    
+
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
     def clean(self, manifest_path, params, verbose=False):


### PR DESCRIPTION
Fixes issue #5933, adds warning to python build script when built without release flag:

> [Warning] This is an un-optimized debug build. For performance testing, use ./mach build --release to enable compiler optimizations.

![no-release-flag](https://cloud.githubusercontent.com/assets/3682072/7465981/d063f2b6-f28f-11e4-8045-0fcf1148271a.png)

Followed debug warning conventions in rest of file, and omitted colon.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5941)

<!-- Reviewable:end -->
