### PR TITLE
layout: Take the `width` attribute of `<img>` into account when computing the intrinsic widths of the associated fragment.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1248,11 +1248,15 @@ impl Fragment {
                 result.union_block(&block_flow.base.intrinsic_inline_sizes)
             }
             SpecificFragmentInfo::Image(ref mut image_fragment_info) => {
-                let image_inline_size = image_fragment_info.image_inline_size();
+                let image_inline_size = match image_fragment_info.replaced_image_fragment_info
+                                                                 .dom_inline_size {
+                    None => image_fragment_info.image_inline_size(),
+                    Some(dom_inline_size) => dom_inline_size,
+                };
                 result.union_block(&IntrinsicISizes {
                     minimum_inline_size: image_inline_size,
                     preferred_inline_size: image_inline_size,
-                })
+                });
             }
             SpecificFragmentInfo::Canvas(ref mut canvas_fragment_info) => {
                 let canvas_inline_size = canvas_fragment_info.canvas_inline_size();

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -131,6 +131,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == img_dynamic_remove.html img_dynamic_remove_ref.html
 != img_simple.html img_simple_ref.html
 == img_size_a.html img_size_b.html
+== img_width_attribute_intrinsic_width_a.html img_width_attribute_intrinsic_width_ref.html
 == incremental_float_a.html incremental_float_ref.html
 == incremental_inline_layout_a.html incremental_inline_layout_ref.html
 != inline_background_a.html inline_background_ref.html

--- a/tests/ref/img_width_attribute_intrinsic_width_a.html
+++ b/tests/ref/img_width_attribute_intrinsic_width_a.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<table>
+    <tr>
+        <td><img src=smiling.png width=300></td>
+        <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus molestie orci euismod metus sodales, at varius odio luctus. Nunc vehicula sagittis interdum. Aenean fringilla ipsum et fermentum commodo. Sed dui orci, egestas sit amet augue quis, rutrum imperdiet tortor. Aenean congue ac odio in semper. Nullam sit amet libero at tortor feugiat mollis. Vivamus semper lacus ac erat luctus, ac ullamcorper metus scelerisque. Ut molestie libero nec tortor auctor consectetur. Nullam sagittis ipsum ut tellus tempor venenatis id sit amet augue.</td>
+    </tr>
+</table>
+</body>
+</html>
+

--- a/tests/ref/img_width_attribute_intrinsic_width_ref.html
+++ b/tests/ref/img_width_attribute_intrinsic_width_ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<table>
+    <tr>
+        <td><img src=smiling.png style="width: 300px"></td>
+        <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus molestie orci euismod metus sodales, at varius odio luctus. Nunc vehicula sagittis interdum. Aenean fringilla ipsum et fermentum commodo. Sed dui orci, egestas sit amet augue quis, rutrum imperdiet tortor. Aenean congue ac odio in semper. Nullam sit amet libero at tortor feugiat mollis. Vivamus semper lacus ac erat luctus, ac ullamcorper metus scelerisque. Ut molestie libero nec tortor auctor consectetur. Nullam sagittis ipsum ut tellus tempor venenatis id sit amet augue.</td>
+    </tr>
+</table>
+</body>
+</html>
+


### PR DESCRIPTION
Fixes sites that use spacer gifs for table layout, such as the comments
page on Hacker News.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5990)

<!-- Reviewable:end -->
