### PR TITLE
Fix direction of columns in mixed LTR/RTL tables.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1207,6 +1207,7 @@ impl BlockFlow {
                                                                         usize,
                                                                         Au,
                                                                         WritingMode,
+                                                                        &mut Au,
                                                                         &mut Au) {
         // Keep track of whether floats could impact each child.
         let mut inline_start_floats_impact_child =
@@ -1259,6 +1260,7 @@ impl BlockFlow {
 
         // This value is used only for table cells.
         let mut inline_start_margin_edge = inline_start_content_edge;
+        let mut inline_end_margin_edge = inline_end_content_edge;
 
         let mut iterator = self.base.child_iter().enumerate().peekable();
         while let Some((i, kid)) = iterator.next() {
@@ -1332,7 +1334,8 @@ impl BlockFlow {
                      i,
                      content_inline_size,
                      containing_block_mode,
-                     &mut inline_start_margin_edge);
+                     &mut inline_start_margin_edge,
+                     &mut inline_end_margin_edge);
 
             // Per CSS 2.1 § 16.3.1, text alignment propagates to all children in flow.
             //
@@ -1602,7 +1605,7 @@ impl Flow for BlockFlow {
                                                         inline_start_content_edge,
                                                         inline_end_content_edge,
                                                         content_inline_size,
-                                                        |_, _, _, _, _| {});
+                                                        |_, _, _, _, _, _| {});
     }
 
     fn place_float_if_applicable<'a>(&mut self, _: &'a LayoutContext<'a>) {

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -473,19 +473,16 @@ impl Flow for TableFlow {
                                                                    inline_end_content_edge,
                                                                    content_inline_size,
                                                                    |child_flow,
-                                                                    child_index,
-                                                                    content_inline_size,
+                                                                    _child_index,
+                                                                    _content_inline_size,
                                                                     writing_mode,
-                                                                    inline_start_margin_edge| {
+                                                                    _inline_start_margin_edge,
+                                                                    _inline_end_margin_edge| {
             table_row::propagate_column_inline_sizes_to_child(
                 child_flow,
-                child_index,
-                content_inline_size,
                 writing_mode,
                 column_computed_inline_sizes,
-                &spacing_per_cell,
-                &None,
-                inline_start_margin_edge);
+                &spacing_per_cell);
             if child_flow.is_table_row() {
                 let child_table_row = child_flow.as_table_row();
                 child_table_row.populate_collapsed_border_spacing(

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -157,7 +157,7 @@ impl Flow for TableCellFlow {
                                                                    inline_start_content_edge,
                                                                    inline_end_content_edge,
                                                                    content_inline_size,
-                                                                   |_, _, _, _, _| {});
+                                                                   |_, _, _, _, _, _| {});
     }
 
     fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -341,7 +341,7 @@ impl Flow for TableWrapperFlow {
                                                                 inline_start_content_edge,
                                                                 inline_end_content_edge,
                                                                 content_inline_size,
-                                                                |_, _, _, _, _| {})
+                                                                |_, _, _, _, _, _| {})
             }
             Some(ref assigned_column_inline_sizes) => {
                 self.block_flow
@@ -350,19 +350,16 @@ impl Flow for TableWrapperFlow {
                                                                 inline_end_content_edge,
                                                                 content_inline_size,
                                                                 |child_flow,
-                                                                 child_index,
-                                                                 content_inline_size,
+                                                                 _child_index,
+                                                                 _content_inline_size,
                                                                  writing_mode,
-                                                                 inline_start_margin_edge| {
+                                                                 _inline_start_margin_edge,
+                                                                 _inline_end_margin_edge| {
                     table_row::propagate_column_inline_sizes_to_child(
                         child_flow,
-                        child_index,
-                        content_inline_size,
                         writing_mode,
                         assigned_column_inline_sizes,
-                        &border_spacing,
-                        &None,
-                        inline_start_margin_edge)
+                        &border_spacing);
                 })
             }
         }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -277,6 +277,7 @@ experimental == rtl_simple.html rtl_simple_ref.html
 == table_padding_a.html table_padding_ref.html
 == table_percentage_capping_a.html table_percentage_capping_ref.html
 == table_percentage_width_a.html table_percentage_width_ref.html
+experimental == table_row_direction_a.html table_row_direction_ref.html
 == text_align_complex_a.html text_align_complex_ref.html
 == text_align_justify_a.html text_align_justify_ref.html
 experimental == text_align_rtl.html text_align_rtl_ref.html

--- a/tests/ref/table_row_direction_a.html
+++ b/tests/ref/table_row_direction_a.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="css/ahem.css">
+    <style>
+      * { margin: 0; padding: 0; border-spacing: 0; }
+      tr { direction: rtl; }
+      .r { color: red; }
+      .o { color: orange; }
+      .y { color: yellow; }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td class="r">R</td>
+        <td class="o">O</td>
+        <td class="y">Y</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/tests/ref/table_row_direction_ref.html
+++ b/tests/ref/table_row_direction_ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="css/ahem.css">
+    <style>
+      * { margin: 0; padding: 0; border-spacing: 0; }
+      .r { color: red; }
+      .o { color: orange; }
+      .y { color: yellow; }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td class="r">R</td>
+        <td class="o">O</td>
+        <td class="y">Y</td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Table columns should be layed out according to the 'direction' property of the
table flow, regardless of the 'direction' property of any table-row,
table-rowgroup, etc. flows.

This fixes a number of the `direction-applies-to-*` tests in the CSS2.1 test
suite.

This also simplifies `propagate_column_inline_sizes_to_child` by separating
the code used for table cells from the code for non-cell flows.

r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/5997)

<!-- Reviewable:end -->
