### PR TITLE
compositing: Fix scrolling timeout. There are 1,000,000 nanoseconds in a millisecond.

### DIFF
--- a/components/compositing/scrolling.rs
+++ b/components/compositing/scrolling.rs
@@ -60,7 +60,7 @@ impl ScrollingTimer {
                 Ok(ToScrollingTimerMsg::ScrollEventProcessedMsg(timestamp)) => {
                     let target = timestamp as i64 + TIMEOUT;
                     let delta_ns = target - (time::precise_time_ns() as i64);
-                    sleep_ms((delta_ns / 1000) as u32);
+                    sleep_ms((delta_ns / 1000000) as u32);
                     self.compositor_proxy.send(Msg::ScrollTimeout(timestamp));
                 }
                 Ok(ToScrollingTimerMsg::ExitMsg) | Err(_) => break,


### PR DESCRIPTION
r? @jdm (or whoever)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6011)

<!-- Reviewable:end -->
