### PR TITLE
Add a no-op --dev option to the mach build command.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -70,6 +70,9 @@ class MachCommands(CommandBase):
     @CommandArgument('--release', '-r',
                      action='store_true',
                      help='Build in release mode')
+    @CommandArgument('--dev', '-d',
+                     action='store_true',
+                     help='Build in development mode')
     @CommandArgument('--jobs', '-j',
                      default=None,
                      help='Number of jobs to run in parallel')
@@ -86,8 +89,8 @@ class MachCommands(CommandBase):
                      help='Print verbose output')
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
-    def build(self, target=None, release=False, jobs=None, android=None,
-              verbose=False, debug_mozjs=False, params=None):
+    def build(self, target=None, release=False, dev=False, jobs=None,
+              android=None, verbose=False, debug_mozjs=False, params=None):
         self.ensure_bootstrapped()
 
         if android is None:


### PR DESCRIPTION
This is part of #5965.  It needs to land before the rest of that PR, so we can land servo/saltfs#28 without breaking automated builds for other PRs. r? @larsbergstrom

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6023)

<!-- Reviewable:end -->
