### PR TITLE
script: Reflow 200 milliseconds after the `<body>` is parsed, like Gecko does.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -148,6 +148,8 @@ pub struct Document {
     loader: DOMRefCell<DocumentLoader>,
     /// The current active HTML parser, to allow resuming after interruptions.
     current_parser: MutNullableHeap<JS<ServoHTMLParser>>,
+    /// When we should kick off a reflow. This happens during parsing.
+    reflow_timeout: Cell<Option<u64>>,
 }
 
 impl DocumentDerived for EventTarget {
@@ -226,6 +228,9 @@ pub trait DocumentHelpers<'a> {
     fn set_encoding_name(self, name: DOMString);
     fn content_changed(self, node: JSRef<Node>, damage: NodeDamage);
     fn content_and_heritage_changed(self, node: JSRef<Node>, damage: NodeDamage);
+    fn reflow_if_reflow_timer_expired(self);
+    fn set_reflow_timeout(self, timeout: u64);
+    fn disarm_reflow_timeout(self);
     fn unregister_named_element(self, to_unregister: JSRef<Element>, id: Atom);
     fn register_named_element(self, element: JSRef<Element>, id: Atom);
     fn load_anchor_href(self, href: DOMString);
@@ -343,9 +348,40 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
     }
 
     fn content_and_heritage_changed(self, node: JSRef<Node>, damage: NodeDamage) {
-        debug!("content_and_heritage_changed on {}", node.debug_str());
         node.force_dirty_ancestors(damage);
         node.dirty(damage);
+    }
+
+    /// Reflows and disarms the timer if the reflow timer has expired.
+    fn reflow_if_reflow_timer_expired(self) {
+        if let Some(reflow_timeout) = self.reflow_timeout.get() {
+            if time::precise_time_ns() < reflow_timeout {
+                return
+            }
+
+            self.reflow_timeout.set(None);
+            let window = self.window.root();
+            window.r().reflow(ReflowGoal::ForDisplay,
+                              ReflowQueryType::NoQuery,
+                              ReflowReason::RefreshTick);
+        }
+    }
+
+    /// Schedules a reflow to be kicked off at the given `timeout` (in `time::precise_time_ns()`
+    /// units). This reflow happens even if the event loop is busy. This is used to display initial
+    /// page content during parsing.
+    fn set_reflow_timeout(self, timeout: u64) {
+        if let Some(existing_timeout) = self.reflow_timeout.get() {
+            if existing_timeout > timeout {
+                return
+            }
+        }
+        self.reflow_timeout.set(Some(timeout))
+    }
+
+    /// Disables any pending reflow timeouts.
+    fn disarm_reflow_timeout(self) {
+        self.reflow_timeout.set(None)
     }
 
     /// Remove any existing association between the provided id and any elements in this document.
@@ -1004,6 +1040,7 @@ impl Document {
             animation_frame_list: RefCell::new(HashMap::new()),
             loader: DOMRefCell::new(doc_loader),
             current_parser: Default::default(),
+            reflow_timeout: Cell::new(None),
         }
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -372,7 +372,7 @@ impl<'a> DocumentHelpers<'a> for JSRef<'a, Document> {
     /// page content during parsing.
     fn set_reflow_timeout(self, timeout: u64) {
         if let Some(existing_timeout) = self.reflow_timeout.get() {
-            if existing_timeout > timeout {
+            if existing_timeout < timeout {
                 return
             }
         }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -100,6 +100,10 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
             s.bind_to_tree(tree_in_doc);
         }
 
+        if !tree_in_doc {
+            return
+        }
+
         let window = window_from_node(*self).root();
         let document = window.r().Document().root();
         document.r().set_reflow_timeout(time::precise_time_ns() + INITIAL_REFLOW_DELAY);

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -6,11 +6,11 @@ use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::HTMLBodyElementBinding::{self, HTMLBodyElementMethods};
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use dom::bindings::codegen::InheritTypes::EventTargetCast;
+use dom::bindings::codegen::InheritTypes::{EventTargetCast};
 use dom::bindings::codegen::InheritTypes::{HTMLBodyElementDerived, HTMLElementCast};
 use dom::bindings::js::{JSRef, Rootable, Temporary};
 use dom::bindings::utils::Reflectable;
-use dom::document::Document;
+use dom::document::{Document, DocumentHelpers};
 use dom::element::ElementTypeId;
 use dom::eventtarget::{EventTarget, EventTargetTypeId, EventTargetHelpers};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
@@ -23,6 +23,11 @@ use util::str::{self, DOMString};
 
 use std::borrow::ToOwned;
 use std::cell::Cell;
+use time;
+
+/// How long we should wait before performing the initial reflow after `<body>` is parsed, in
+/// nanoseconds.
+const INITIAL_REFLOW_DELAY: u64 = 200_000_000;
 
 #[dom_struct]
 pub struct HTMLBodyElement {
@@ -32,9 +37,8 @@ pub struct HTMLBodyElement {
 
 impl HTMLBodyElementDerived for EventTarget {
     fn is_htmlbodyelement(&self) -> bool {
-        *self.type_id() ==
-            EventTargetTypeId::Node(
-                NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement)))
+        *self.type_id() == EventTargetTypeId::Node(NodeTypeId::Element(ElementTypeId::HTMLElement(
+                    HTMLElementTypeId::HTMLBodyElement)))
     }
 }
 
@@ -89,6 +93,16 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLBodyElement> {
     fn super_type<'b>(&'b self) -> Option<&'b VirtualMethods> {
         let element: &JSRef<HTMLElement> = HTMLElementCast::from_borrowed_ref(self);
         Some(element as &VirtualMethods)
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
+        }
+
+        let window = window_from_node(*self).root();
+        let document = window.r().Document().root();
+        document.r().set_reflow_timeout(time::precise_time_ns() + INITIAL_REFLOW_DELAY);
     }
 
     fn after_set_attr(&self, attr: JSRef<Attr>) {

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -303,6 +303,11 @@ impl<'a> PrivateServoHTMLParserHelpers for JSRef<'a, ServoHTMLParser> {
                 break;
             }
 
+            {
+                let document = self.document.root();
+                document.r().reflow_if_reflow_timer_expired();
+            }
+
             let mut pending_input = self.pending_input.borrow_mut();
             if !pending_input.is_empty() {
                 let chunk = pending_input.remove(0);

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -303,10 +303,8 @@ impl<'a> PrivateServoHTMLParserHelpers for JSRef<'a, ServoHTMLParser> {
                 break;
             }
 
-            {
-                let document = self.document.root();
-                document.r().reflow_if_reflow_timer_expired();
-            }
+            let document = self.document.root();
+            document.r().reflow_if_reflow_timer_expired();
 
             let mut pending_input = self.pending_input.borrow_mut();
             if !pending_input.is_empty() {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -81,6 +81,7 @@ enum WindowState {
 #[derive(Debug)]
 pub enum ReflowReason {
     CachedPageNeededReflow,
+    RefreshTick,
     FirstLoad,
     KeyEvent,
     MouseEvent,
@@ -1046,6 +1047,7 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
 
     debug_msg.push_str(match *reason {
         ReflowReason::CachedPageNeededReflow => "\tCachedPageNeededReflow",
+        ReflowReason::RefreshTick => "\tRefreshTick",
         ReflowReason::FirstLoad => "\tFirstLoad",
         ReflowReason::KeyEvent => "\tKeyEvent",
         ReflowReason::MouseEvent => "\tMouseEvent",

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1565,7 +1565,7 @@ impl ScriptTask {
 
         // Kick off the initial reflow of the page.
         debug!("kicking off initial reflow of {:?}", final_url);
-
+        document.r().disarm_reflow_timeout();
         document.r().content_changed(NodeCast::from_ref(document.r()),
                                      NodeDamage::OtherNodeDamage);
         let window = window_from_node(document.r()).root();


### PR DESCRIPTION
It would be nice if HTML parsing didn't have to hog the event loop, so I didn't have to do this polling in `content_changed()`, but maybe the way we do it is unavoidable.

r? @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6028)

<!-- Reviewable:end -->
