### PR TITLE
Fixes a number of race conditions and reliability issues with reftests and compositor.

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -11,14 +11,12 @@ use compositor;
 use headless;
 use windowing::{WindowEvent, WindowMethods};
 
-use azure::azure_hl::{SourceSurfaceMethods, Color};
 use geom::point::Point2D;
 use geom::rect::Rect;
-use geom::size::Size2D;
 use layers::platform::surface::{NativeCompositingGraphicsContext, NativeGraphicsMetadata};
 use layers::layers::LayerBufferSet;
-use msg::compositor_msg::{Epoch, LayerId, LayerMetadata, FrameTreeId, ReadyState};
-use msg::compositor_msg::{PaintListener, PaintState, ScriptListener, ScrollPolicy};
+use msg::compositor_msg::{Epoch, LayerId, LayerProperties, FrameTreeId};
+use msg::compositor_msg::{PaintListener, ScriptListener};
 use msg::constellation_msg::{AnimationState, ConstellationChan, PipelineId};
 use msg::constellation_msg::{Key, KeyState, KeyModifiers};
 use profile_traits::mem;
@@ -65,11 +63,6 @@ impl CompositorReceiver for Receiver<Msg> {
 
 /// Implementation of the abstract `ScriptListener` interface.
 impl ScriptListener for Box<CompositorProxy+'static+Send> {
-    fn set_ready_state(&mut self, pipeline_id: PipelineId, ready_state: ReadyState) {
-        let msg = Msg::ChangeReadyState(pipeline_id, ready_state);
-        self.send(msg);
-    }
-
     fn scroll_fragment_point(&mut self,
                              pipeline_id: PipelineId,
                              layer_id: LayerId,
@@ -96,33 +89,6 @@ impl ScriptListener for Box<CompositorProxy+'static+Send> {
     }
 }
 
-/// Information about each layer that the compositor keeps.
-#[derive(Clone, Copy)]
-pub struct LayerProperties {
-    pub pipeline_id: PipelineId,
-    pub epoch: Epoch,
-    pub id: LayerId,
-    pub rect: Rect<f32>,
-    pub background_color: Color,
-    pub scroll_policy: ScrollPolicy,
-}
-
-impl LayerProperties {
-    fn new(pipeline_id: PipelineId, epoch: Epoch, metadata: &LayerMetadata) -> LayerProperties {
-        LayerProperties {
-            pipeline_id: pipeline_id,
-            epoch: epoch,
-            id: metadata.id,
-            rect: Rect(Point2D(metadata.position.origin.x as f32,
-                               metadata.position.origin.y as f32),
-                       Size2D(metadata.position.size.width as f32,
-                              metadata.position.size.height as f32)),
-            background_color: metadata.background_color,
-            scroll_policy: metadata.scroll_policy,
-        }
-    }
-}
-
 /// Implementation of the abstract `PaintListener` interface.
 impl PaintListener for Box<CompositorProxy+'static+Send> {
     fn get_graphics_metadata(&mut self) -> Option<NativeGraphicsMetadata> {
@@ -141,29 +107,12 @@ impl PaintListener for Box<CompositorProxy+'static+Send> {
 
     fn initialize_layers_for_pipeline(&mut self,
                                       pipeline_id: PipelineId,
-                                      metadata: Vec<LayerMetadata>,
+                                      properties: Vec<LayerProperties>,
                                       epoch: Epoch) {
         // FIXME(#2004, pcwalton): This assumes that the first layer determines the page size, and
         // that all other layers are immediate children of it. This is sufficient to handle
         // `position: fixed` but will not be sufficient to handle `overflow: scroll` or transforms.
-        let mut first = true;
-        for metadata in metadata.iter() {
-            let layer_properties = LayerProperties::new(pipeline_id, epoch, metadata);
-            if first {
-                self.send(Msg::CreateOrUpdateBaseLayer(layer_properties));
-                first = false
-            } else {
-                self.send(Msg::CreateOrUpdateDescendantLayer(layer_properties));
-            }
-        }
-    }
-
-    fn paint_msg_discarded(&mut self) {
-        self.send(Msg::PaintMsgDiscarded);
-    }
-
-    fn set_paint_state(&mut self, pipeline_id: PipelineId, paint_state: PaintState) {
-        self.send(Msg::ChangePaintState(pipeline_id, paint_state))
+        self.send(Msg::InitializeLayersForPipeline(pipeline_id, epoch, properties));
     }
 }
 
@@ -184,30 +133,21 @@ pub enum Msg {
     /// The headless compositor returns `None`.
     GetGraphicsMetadata(Sender<Option<NativeGraphicsMetadata>>),
 
-    /// Tells the compositor to create the root layer for a pipeline if necessary (i.e. if no layer
-    /// with that ID exists).
-    CreateOrUpdateBaseLayer(LayerProperties),
-    /// Tells the compositor to create a descendant layer for a pipeline if necessary (i.e. if no
-    /// layer with that ID exists).
-    CreateOrUpdateDescendantLayer(LayerProperties),
+    /// Tells the compositor to create or update the layers for a pipeline if necessary
+    /// (i.e. if no layer with that ID exists).
+    InitializeLayersForPipeline(PipelineId, Epoch, Vec<LayerProperties>),
     /// Alerts the compositor that the specified layer's rect has changed.
     SetLayerRect(PipelineId, LayerId, Rect<f32>),
     /// Scroll a page in a window
     ScrollFragmentPoint(PipelineId, LayerId, Point2D<f32>),
     /// Requests that the compositor assign the painted buffers to the given layers.
     AssignPaintedBuffers(PipelineId, Epoch, Vec<(LayerId, Box<LayerBufferSet>)>, FrameTreeId),
-    /// Alerts the compositor to the current status of page loading.
-    ChangeReadyState(PipelineId, ReadyState),
-    /// Alerts the compositor to the current status of painting.
-    ChangePaintState(PipelineId, PaintState),
     /// Alerts the compositor that the current page has changed its title.
     ChangePageTitle(PipelineId, Option<String>),
     /// Alerts the compositor that the current page has changed its URL.
     ChangePageUrl(PipelineId, Url),
     /// Alerts the compositor that the given pipeline has changed whether it is running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),
-    /// Alerts the compositor that a `PaintMsg` has been discarded.
-    PaintMsgDiscarded,
     /// Replaces the current frame tree, typically called during main frame navigation.
     SetFrameTree(SendableFrameTree, Sender<()>, ConstellationChan),
     /// The load of a page has completed.
@@ -226,6 +166,8 @@ pub enum Msg {
     PaintTaskExited(PipelineId),
     /// Alerts the compositor that the viewport has been constrained in some manner
     ViewportConstrained(PipelineId, ViewportConstraints),
+    /// A reply to the compositor asking if the output image is stable.
+    IsReadyToSaveImageReply(bool),
 }
 
 impl Debug for Msg {
@@ -234,17 +176,13 @@ impl Debug for Msg {
             Msg::Exit(..) => write!(f, "Exit"),
             Msg::ShutdownComplete(..) => write!(f, "ShutdownComplete"),
             Msg::GetGraphicsMetadata(..) => write!(f, "GetGraphicsMetadata"),
-            Msg::CreateOrUpdateBaseLayer(..) => write!(f, "CreateOrUpdateBaseLayer"),
-            Msg::CreateOrUpdateDescendantLayer(..) => write!(f, "CreateOrUpdateDescendantLayer"),
+            Msg::InitializeLayersForPipeline(..) => write!(f, "InitializeLayersForPipeline"),
             Msg::SetLayerRect(..) => write!(f, "SetLayerRect"),
             Msg::ScrollFragmentPoint(..) => write!(f, "ScrollFragmentPoint"),
             Msg::AssignPaintedBuffers(..) => write!(f, "AssignPaintedBuffers"),
-            Msg::ChangeReadyState(..) => write!(f, "ChangeReadyState"),
-            Msg::ChangePaintState(..) => write!(f, "ChangePaintState"),
             Msg::ChangeRunningAnimationsState(..) => write!(f, "ChangeRunningAnimationsState"),
             Msg::ChangePageTitle(..) => write!(f, "ChangePageTitle"),
             Msg::ChangePageUrl(..) => write!(f, "ChangePageUrl"),
-            Msg::PaintMsgDiscarded(..) => write!(f, "PaintMsgDiscarded"),
             Msg::SetFrameTree(..) => write!(f, "SetFrameTree"),
             Msg::LoadComplete => write!(f, "LoadComplete"),
             Msg::ScrollTimeout(..) => write!(f, "ScrollTimeout"),
@@ -254,6 +192,7 @@ impl Debug for Msg {
             Msg::CreatePng(..) => write!(f, "CreatePng"),
             Msg::PaintTaskExited(..) => write!(f, "PaintTaskExited"),
             Msg::ViewportConstrained(..) => write!(f, "ViewportConstrained"),
+            Msg::IsReadyToSaveImageReply(..) => write!(f, "IsReadyToSaveImageReply"),
         }
     }
 }

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -92,16 +92,12 @@ impl CompositorEventListener for NullCompositor {
             // we'll notice and think about whether it needs a response, like
             // SetFrameTree.
 
-            Msg::CreateOrUpdateBaseLayer(..) |
-            Msg::CreateOrUpdateDescendantLayer(..) |
+            Msg::InitializeLayersForPipeline(..) |
             Msg::SetLayerRect(..) |
             Msg::AssignPaintedBuffers(..) |
-            Msg::ChangeReadyState(..) |
-            Msg::ChangePaintState(..) |
             Msg::ChangeRunningAnimationsState(..) |
             Msg::ScrollFragmentPoint(..) |
             Msg::LoadComplete |
-            Msg::PaintMsgDiscarded(..) |
             Msg::ScrollTimeout(..) |
             Msg::RecompositeAfterScroll |
             Msg::ChangePageTitle(..) |
@@ -110,7 +106,8 @@ impl CompositorEventListener for NullCompositor {
             Msg::SetCursor(..) |
             Msg::ViewportConstrained(..) => {}
             Msg::CreatePng(..) |
-            Msg::PaintTaskExited(..) => {}
+            Msg::PaintTaskExited(..) |
+            Msg::IsReadyToSaveImageReply(..) => {}
         }
         true
     }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -11,7 +11,6 @@ use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeGraphicsMetadata;
-use msg::compositor_msg::{PaintState, ReadyState};
 use msg::constellation_msg::{Key, KeyState, KeyModifiers};
 use script_traits::MouseButton;
 use url::Url;
@@ -100,10 +99,6 @@ pub trait WindowMethods {
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self);
 
-    /// Sets the ready state of the current page.
-    fn set_ready_state(&self, ready_state: ReadyState);
-    /// Sets the paint state of the current page.
-    fn set_paint_state(&self, paint_state: PaintState);
     /// Sets the page title for the current page.
     fn set_page_title(&self, title: Option<String>);
     /// Sets the load data for the current page.

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -17,6 +17,7 @@ extern crate util;
 
 use gfx::font_cache_task::FontCacheTask;
 use gfx::paint_task::PaintChan;
+use msg::compositor_msg::Epoch;
 use msg::constellation_msg::{ConstellationChan, Failure, PipelineId, PipelineExitType};
 use profile_traits::mem;
 use profile_traits::time;
@@ -28,6 +29,7 @@ use std::sync::mpsc::{Sender, Receiver};
 /// Messages sent to the layout task from the constellation
 pub enum LayoutControlMsg {
     ExitNow(PipelineExitType),
+    GetCurrentEpoch(Sender<Epoch>),
     TickAnimations,
 }
 

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -5,6 +5,7 @@
 //! The high-level interface from script to constellation. Using this abstract interface helps
 //! reduce coupling between these two components.
 
+use compositor_msg::Epoch;
 use geom::rect::Rect;
 use geom::size::TypedSize2D;
 use geom::scale_factor::ScaleFactor;
@@ -14,6 +15,7 @@ use layers::geometry::DevicePixel;
 use png;
 use util::cursor::Cursor;
 use util::geometry::{PagePx, ViewportPx};
+use std::collections::HashMap;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use style::viewport::ViewportConstraints;
 use webdriver_traits::WebDriverScriptCommand;
@@ -239,7 +241,9 @@ pub enum Msg {
     /// Notifies the constellation that the viewport has been constrained in some manner
     ViewportConstrained(PipelineId, ViewportConstraints),
     /// Create a PNG of the window contents
-    CompositePng(Sender<Option<png::Image>>)
+    CompositePng(Sender<Option<png::Image>>),
+    /// Query the constellation to see if the current compositor output is stable
+    IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
 }
 
 #[derive(Clone, Eq, PartialEq)]

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -12,6 +12,7 @@ use geom::point::Point2D;
 use geom::rect::Rect;
 use libc::uintptr_t;
 use msg::constellation_msg::{PipelineExitType, WindowSizeData};
+use msg::compositor_msg::Epoch;
 use net_traits::PendingAsyncLoad;
 use profile_traits::mem::{Reporter, ReportsChan};
 use script_traits::{ScriptControlChan, OpaqueScriptLayoutChannel, UntrustedNodeAddress};
@@ -63,6 +64,9 @@ pub enum Msg {
     /// Requests that the layout task immediately shut down. There must be no more nodes left after
     /// this, or layout will crash.
     ExitNow(PipelineExitType),
+
+    /// Get the last epoch counter for this layout task.
+    GetCurrentEpoch(Sender<Epoch>)
 }
 
 /// Synchronous messages that script can send to layout.

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -58,9 +58,8 @@ use script_traits::CompositorEvent::{MouseDownEvent, MouseUpEvent};
 use script_traits::CompositorEvent::{MouseMoveEvent, KeyEvent};
 use script_traits::{NewLayoutInfo, OpaqueScriptLayoutChannel};
 use script_traits::{ConstellationControlMsg, ScriptControlChan};
-use script_traits::ScriptTaskFactory;
+use script_traits::{ScriptState, ScriptTaskFactory};
 use webdriver_traits::WebDriverScriptCommand;
-use msg::compositor_msg::ReadyState::{FinishedLoading, Loading, PerformingLayout};
 use msg::compositor_msg::{LayerId, ScriptListener};
 use msg::constellation_msg::{ConstellationChan, FocusType};
 use msg::constellation_msg::{LoadData, PipelineId, SubpageId, MozBrowserEvent, WorkerId};
@@ -735,6 +734,10 @@ impl ScriptTask {
                 responder.respond();
                 self.handle_resource_loaded(id, LoadType::Stylesheet(url));
             }
+            ConstellationControlMsg::GetCurrentState(sender, pipeline_id) => {
+                let state = self.handle_get_current_state(pipeline_id);
+                sender.send(state).unwrap();
+            }
         }
     }
 
@@ -857,6 +860,40 @@ impl ScriptTask {
         let page = get_page(&self.root_page(), pipeline);
         let doc = page.document().root();
         doc.r().finish_load(load);
+    }
+
+    /// Get the current state of a given pipeline.
+    fn handle_get_current_state(&self, pipeline_id: PipelineId) -> ScriptState {
+        // Check if the main page load is still pending
+        let loads = self.incomplete_loads.borrow();
+        if let Some(_) = loads.iter().find(|load| load.pipeline_id == pipeline_id) {
+            return ScriptState::DocumentLoading;
+        }
+
+        // If not in pending loads, the page should exist by now.
+        let page = self.root_page();
+        let page = page.find(pipeline_id).expect("GetCurrentState sent to nonexistent pipeline");
+        let doc = page.document().root();
+
+        // Check if document load event has fired. If the document load
+        // event has fired, this also guarantees that the first reflow
+        // has been kicked off. Since the script task does a join with
+        // layout, this ensures there are no race conditions that can occur
+        // between load completing and the first layout completing.
+        let load_pending = doc.r().ReadyState() != DocumentReadyState::Complete;
+        if load_pending {
+            return ScriptState::DocumentLoading;
+        }
+
+        // Checks if the html element has reftest-wait attribute present.
+        // See http://testthewebforward.org/docs/reftests.html
+        let html_element = doc.r().GetDocumentElement().root();
+        let reftest_wait = html_element.r().map_or(false, |elem| elem.has_class(&Atom::from_slice("reftest-wait")));
+        if reftest_wait {
+            return ScriptState::DocumentLoading;
+        }
+
+        return ScriptState::DocumentLoaded;
     }
 
     fn handle_new_layout(&self, new_layout_info: NewLayoutInfo) {
@@ -993,14 +1030,6 @@ impl ScriptTask {
              with this script task. This is a bug.");
         let window = page.window().root();
         window.r().handle_reflow_complete_msg(reflow_id);
-
-        let doc = page.document().root();
-        let html_element = doc.r().GetDocumentElement().root();
-        let reftest_wait = html_element.r().map_or(false, |elem| elem.has_class(&Atom::from_slice("reftest-wait")));
-
-        if !reftest_wait {
-            self.compositor.borrow_mut().set_ready_state(pipeline_id, FinishedLoading);
-        }
     }
 
     /// Window was resized, but this script was not active, so don't reflow yet
@@ -1101,8 +1130,6 @@ impl ScriptTask {
                 })
             })
         }).root();
-
-        self.compositor.borrow_mut().set_ready_state(incomplete.pipeline_id, Loading);
 
         // Create a new frame tree entry.
         let page = Rc::new(Page::new(incomplete.pipeline_id, final_url.clone()));
@@ -1462,7 +1489,6 @@ impl ScriptTask {
         let final_url = document.r().url();
 
         document.r().set_ready_state(DocumentReadyState::Interactive);
-        self.compositor.borrow_mut().set_ready_state(id, PerformingLayout);
 
         // Kick off the initial reflow of the page.
         debug!("kicking off initial reflow of {:?}", final_url);

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -60,6 +60,13 @@ pub trait StylesheetLoadResponder {
     fn respond(self: Box<Self>);
 }
 
+/// Used to determine if a script has any pending asynchronous activity.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ScriptState {
+    DocumentLoaded,
+    DocumentLoading,
+}
+
 /// Messages sent from the constellation to the script task
 pub enum ConstellationControlMsg {
     /// Gives a channel and ID to a layout task, as well as the ID of that layout's parent
@@ -96,6 +103,8 @@ pub enum ConstellationControlMsg {
     TickAllAnimations(PipelineId),
     /// Notifies script that a stylesheet has finished loading.
     StylesheetLoadComplete(PipelineId, Url, Box<StylesheetLoadResponder+Send>),
+    /// Get the current state of the script task for a given pipeline.
+    GetCurrentState(Sender<ScriptState>, PipelineId),
 }
 
 /// The mouse button involved in the event.

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -22,7 +22,6 @@ use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeGraphicsMetadata;
 use libc::{c_char, c_void};
 use msg::constellation_msg::{Key, KeyModifiers};
-use msg::compositor_msg::{ReadyState, PaintState};
 use std::ptr;
 use std_url::Url;
 use util::cursor::Cursor;
@@ -210,26 +209,6 @@ impl WindowMethods for Window {
                 browser.get_host().get_client().get_render_handler().on_present(browser.clone());
             }
         }
-    }
-
-    fn set_ready_state(&self, ready_state: ReadyState) {
-        let browser = self.cef_browser.borrow();
-        let browser = match *browser {
-            None => return,
-            Some(ref browser) => browser,
-        };
-        let is_loading = match ready_state {
-            ReadyState::Blank | ReadyState::FinishedLoading => 0,
-            ReadyState::Loading | ReadyState::PerformingLayout => 1,
-        };
-        browser.get_host()
-               .get_client()
-               .get_load_handler()
-               .on_loading_state_change(browser.clone(), is_loading, 1, 1);
-    }
-
-    fn set_paint_state(&self, _: PaintState) {
-        // TODO(pcwalton)
     }
 
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx,DevicePixel,f32> {

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -14,7 +14,6 @@ use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeGraphicsMetadata;
 use msg::constellation_msg;
 use msg::constellation_msg::Key;
-use msg::compositor_msg::{PaintState, ReadyState};
 use NestedEventLoopListener;
 use std::rc::Rc;
 use std::sync::mpsc::{channel, Sender};
@@ -64,8 +63,6 @@ pub struct Window {
     event_queue: RefCell<Vec<WindowEvent>>,
 
     mouse_pos: Cell<Point2D<i32>>,
-    ready_state: Cell<ReadyState>,
-    paint_state: Cell<PaintState>,
     key_modifiers: Cell<KeyModifiers>,
 }
 
@@ -92,8 +89,6 @@ impl Window {
             mouse_down_point: Cell::new(Point2D(0, 0)),
 
             mouse_pos: Cell::new(Point2D(0, 0)),
-            ready_state: Cell::new(ReadyState::Blank),
-            paint_state: Cell::new(PaintState::Idle),
             key_modifiers: Cell::new(KeyModifiers::empty()),
         };
 
@@ -475,16 +470,6 @@ impl WindowMethods for Window {
          box receiver as Box<CompositorReceiver>)
     }
 
-    /// Sets the ready state.
-    fn set_ready_state(&self, ready_state: ReadyState) {
-        self.ready_state.set(ready_state);
-    }
-
-    /// Sets the paint state.
-    fn set_paint_state(&self, paint_state: PaintState) {
-        self.paint_state.set(paint_state);
-    }
-
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32> {
         ScaleFactor::new(self.window.hidpi_factor())
     }
@@ -667,14 +652,6 @@ impl WindowMethods for Window {
              window_proxy: None,
          } as Box<CompositorProxy+Send>,
          box receiver as Box<CompositorReceiver>)
-    }
-
-    /// Sets the ready state.
-    fn set_ready_state(&self, _: ReadyState) {
-    }
-
-    /// Sets the paint state.
-    fn set_paint_state(&self, _: PaintState) {
     }
 
     fn hidpi_factor(&self) -> ScaleFactor<ScreenPx, DevicePixel, f32> {

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -11,9 +11,7 @@ use geom::size::TypedSize2D;
 use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeGraphicsMetadata;
 use libc::c_int;
-use msg::compositor_msg::{ReadyState, PaintState};
 use msg::constellation_msg::{Key, KeyModifiers};
-use std::cell::Cell;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::rc::Rc;
 use std::mem::transmute;
@@ -622,9 +620,6 @@ pub struct Window {
     dpy: EGLDisplay,
     ctx: EGLContext,
     surf: EGLSurface,
-
-    ready_state: Cell<ReadyState>,
-    paint_state: Cell<PaintState>,
 }
 
 impl Window {
@@ -750,9 +745,6 @@ impl Window {
             dpy: dpy,
             ctx: ctx,
             surf: eglwindow,
-
-            ready_state: Cell::new(ReadyState::Blank),
-            paint_state: Cell::new(PaintState::Idle),
         };
 
         Rc::new(window)
@@ -785,16 +777,6 @@ impl WindowMethods for Window {
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self) {
         let _ = egl::SwapBuffers(self.dpy, self.surf);
-    }
-
-    /// Sets the ready state.
-    fn set_ready_state(&self, ready_state: ReadyState) {
-        self.ready_state.set(ready_state);
-    }
-
-    /// Sets the paint state.
-    fn set_paint_state(&self, paint_state: PaintState) {
-        self.paint_state.set(paint_state);
     }
 
     fn set_page_title(&self, _: Option<String>) {


### PR DESCRIPTION
The basic idea is it's safe to output an image for reftest by testing:
- That the compositor doesn't have any animations active.
- That the compositor is not waiting on any outstanding paint messages to arrive.
- That the script tasks are "idle" and therefore won't cause reflow.
  - This currently means page loaded, onload fired, reftest-wait not active, first reflow triggered.
  - It could easily be expanded to handle pending timers etc.
- That the "epoch" that the layout tasks have last laid out after script went idle, is reflected by the compositor in all visible layers for that pipeline.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6031)

<!-- Reviewable:end -->
