### PR TITLE
Add --dev option to mach build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,18 @@ Mach tools to orchestrate the build and other tasks.
 
 ### Normal build
 
+
+To build Servo in development mode.  This is useful for development, but
+the resulting binary is very slow.
+
 ``` sh
 git clone https://github.com/servo/servo
 cd servo
-./mach build
+./mach build --dev
 ./mach run tests/html/about-mozilla.html
 ```
 
-By default, Servo builds in debug mode.  This is useful for development, but
-the resulting binary is very slow.  For benchmarking, performance testing, or
+For benchmarking, performance testing, or
 real-world use, add the `--release` flag to create an optimized build:
 
 ``` sh

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -106,6 +106,20 @@ class MachCommands(CommandBase):
         opts = params or []
         features = []
 
+        if not (release or dev):
+            if self.config["build"]["mode"] == "dev":
+                dev = True
+            elif self.config["build"]["mode"] == "release":
+                release = True 
+            else:
+                print("Please specify either --dev (-d) for a development")
+                print("  build, or --release (-r) for an optimized build.")
+                sys.exit(1)
+
+        if release and dev:
+            print("Please specify either --dev or --release.")
+            sys.exit(1)
+
         if release:
             opts += ["--release"]
         if target:

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -93,7 +93,7 @@ class CommandBase(object):
 
         self.config.setdefault("build", {})
         self.config["build"].setdefault("android", False)
-
+        self.config["build"].setdefault("mode", "")
         self.config["build"].setdefault("debug-mozjs", False)
 
         self.config.setdefault("android", {})

--- a/servobuild.example
+++ b/servobuild.example
@@ -23,6 +23,9 @@ system-cargo = false
 cargo-root = "/path/to/cargo"
 
 [build]
+# Set "mode = dev" or use `mach build --dev` to build the project with warning.
+# or Set "mode = release" or use `mach build --release` for optimized build.
+mode = "dev"
 # Set "android = true" or use `mach build --android` to build the Android app.
 android = false
 # Set "debug-mozjs" or use `mach build --debug-mozjs` to build a debug spidermonkey.


### PR DESCRIPTION
Require either `--dev` or `--release`, unless a default build.mode is set in `.servobuild`.  This is @jinankjain's patch from #5965, rebased onto master.  It is already reviewed, and only waiting for servo/saltfs#28 to be deployed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6038)

<!-- Reviewable:end -->
