### PR TITLE
Fix implementation of Element::get_root_element

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -510,7 +510,7 @@ pub trait ElementHelpers<'a> {
     fn get_inline_style_declaration(self, property: &Atom) -> Option<PropertyDeclaration>;
     fn get_important_inline_style_declaration(self, property: &Atom) -> Option<PropertyDeclaration>;
     fn serialize(self, traversal_scope: TraversalScope) -> Fallible<DOMString>;
-    fn get_root_element(self) -> Option<Temporary<Element>>;
+    fn get_root_element(self) -> Temporary<Element>;
     fn lookup_prefix(self, namespace: Option<DOMString>) -> Option<DOMString>;
 }
 
@@ -663,12 +663,12 @@ impl<'a> ElementHelpers<'a> for JSRef<'a, Element> {
     }
 
     // https://html.spec.whatwg.org/multipage/#root-element
-    fn get_root_element(self) -> Option<Temporary<Element>> {
+    fn get_root_element(self) -> Temporary<Element> {
         let node: JSRef<Node> = NodeCast::from_ref(self);
-        match node.ancestors().last().map(ElementCast::to_temporary) {
-            Some(n) => n,
-            None => Some(self).map(Temporary::from_rooted),
-        }
+        node.inclusive_ancestors()
+            .filter_map(ElementCast::to_temporary)
+            .last()
+            .expect("We know inclusive_ancestors will return `self` which is an element")
     }
 
     // https://dom.spec.whatwg.org/#locate-a-namespace-prefix


### PR DESCRIPTION
The [current implementation](http://mxr.mozilla.org/servo/source/components/script/dom/element.rs#666) is wrong as it always tries to cast the furthest ancestor into an element.
When the method is invoked on an element that is in the document tree, this will be the `Document` node, which is not an element. The `last().map(ElementCast::to_temporary)` returns Some(None) hence the method will return `None`, while the correct behaviour is to return the `html` node.

This PR interprets the line `"furthest ancestor element node of whatever node is being discussed"` in the spec to mean `"find the furthest ancestor that is an element node"`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6043)

<!-- Reviewable:end -->
