### PR TITLE
Fix positioning of RTL blocks with margins.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1572,11 +1572,8 @@ impl Flow for BlockFlow {
 
         // Distance from the inline-end margin edge to the inline-end content edge.
         let inline_end_content_edge =
-            self.base.block_container_inline_size -
-            self.fragment.margin.inline_end -
-            self.fragment.border_box.size.inline -
-            self.fragment.border_box.start.i -
-            padding_and_borders;
+            self.fragment.margin.inline_end +
+            self.fragment.border_padding.inline_end;
 
         let content_inline_size = self.fragment.border_box.size.inline - padding_and_borders;
 
@@ -1747,7 +1744,7 @@ impl Flow for BlockFlow {
                                                     .contains(LAYERS_NEEDED_FOR_DESCENDANTS),
         };
         let container_size_for_children =
-            self.fragment.content_box().size.to_physical(self.base.writing_mode);
+            self.base.position.size.to_physical(self.base.writing_mode);
 
         // Compute the origin and clipping rectangle for children.
         let relative_offset = relative_offset.to_physical(self.base.writing_mode);
@@ -1786,8 +1783,6 @@ impl Flow for BlockFlow {
             if flow::base(kid).flags.contains(INLINE_POSITION_IS_STATIC) ||
                     flow::base(kid).flags.contains(BLOCK_POSITION_IS_STATIC) {
                 let kid_base = flow::mut_base(kid);
-                // FIXME (mbrubeck): `position.size` is inflated by the inline margin size, making
-                // this incorrect for RTL blocks (see `set_inline_size_constraint_solutions`).
                 let physical_position = kid_base.position.to_physical(kid_base.writing_mode,
                                                                       container_size_for_children);
 
@@ -2097,9 +2092,6 @@ pub trait ISizeAndMarginsComputer {
         // We also resize the block itself, to ensure that overflow is not calculated
         // as the inline-size of our parent. We might be smaller and we might be larger if we
         // overflow.
-        //
-        // FIXME (mbrubeck): The margin is included in position.size but not position.start, which
-        // throws off position.to_physical results (especially for RTL blocks).
         flow::mut_base(block).position.size.inline = inline_size + extra_inline_size_from_margin;
     }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -264,6 +264,7 @@ experimental != overconstrained_block.html overconstrained_block_ref.html
 == root_margin_collapse_a.html root_margin_collapse_b.html
 == root_pseudo_a.html root_pseudo_b.html
 experimental == rtl_body.html rtl_body_ref.html
+experimental == rtl_margin_a.html rtl_margin_ref.html
 experimental == rtl_simple.html rtl_simple_ref.html
 == servo_center_a.html servo_center_ref.html
 == setattribute_id_restyle_a.html setattribute_id_restyle_b.html

--- a/tests/ref/rtl_margin_a.html
+++ b/tests/ref/rtl_margin_a.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>RTL margin test</title>
+    <style>
+      body {
+        margin: 8px;
+      }
+      #a {
+        direction: rtl;
+      }
+      #b {
+        border: 1px solid red;
+        width: 100px;
+        height: 100px;
+      }
+      #c {
+        border: 1px solid blue;
+        margin: 10px;
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="a">
+      <div id="b">
+        <div id="c">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+

--- a/tests/ref/rtl_margin_ref.html
+++ b/tests/ref/rtl_margin_ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>RTL margin test</title>
+    <style>
+      #b {
+        border: 1px solid red;
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 8px;
+        right: 8px;
+      }
+      #c {
+        border: 1px solid blue;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="a">
+      <div id="b">
+        <div id="c">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+


### PR DESCRIPTION
`BaseFlow::position` is relative to the parent flow's margin box in the inline direction.  We need to use the parent's `position` as the container size when translating it to physical coordinates, or we get incorrect results for non-LTR content.

r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6049)

<!-- Reviewable:end -->
