### PR TITLE
Android refixup

### DIFF
--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -173,7 +173,9 @@ mod android {
 
     pub fn setup_logging() {
         use self::libc::consts::os::posix88::{STDERR_FILENO, STDOUT_FILENO};
-        //os::setenv("RUST_LOG", "servo,gfx,msg,util,layers,js,std,rt,extra");
+        //use std::env;
+
+        //env::set_var("RUST_LOG", "servo,gfx,msg,util,layers,js,std,rt,extra");
         redirect_output(STDERR_FILENO);
         redirect_output(STDOUT_FILENO);
     }


### PR DESCRIPTION
It appears that https://github.com/servo/servo/pull/6012 reverted our attempts to update the android submodule - probably a bad rebase. This re-fixes it and also updates the debugging code to modern Rust.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6054)

<!-- Reviewable:end -->
