### PR TITLE
Enable antialiasing for the canvas.

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -14,6 +14,7 @@ use geom::size::Size2D;
 use layers::platform::surface::NativeSurface;
 use gfx_traits::color;
 use num::ToPrimitive;
+use util::opts;
 use util::task::spawn_named;
 use util::vec::byte_swap;
 
@@ -174,8 +175,14 @@ struct CanvasPaintState<'a> {
 
 impl<'a> CanvasPaintState<'a> {
     fn new() -> CanvasPaintState<'a> {
+        let antialias = if opts::get().enable_canvas_antialiasing {
+            AntialiasMode::Default
+        } else {
+            AntialiasMode::None
+        };
+
         CanvasPaintState {
-            draw_options: DrawOptions::default(),
+            draw_options: DrawOptions::new(1.0, CompositionOp::Over, antialias),
             fill_style: Pattern::Color(ColorPattern::new(color::black())),
             stroke_style: Pattern::Color(ColorPattern::new(color::black())),
             stroke_opts: StrokeOptions::new(1.0, JoinStyle::MiterOrBevel, CapStyle::Butt, 10.0, &[]),

--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -79,7 +79,7 @@ impl<'a> CanvasPaintTask<'a> {
             image_size, image_size.width * 4, SurfaceFormat::B8G8R8A8);
 
         let draw_surface_options = DrawSurfaceOptions::new(filter, true);
-        let draw_options = DrawOptions::new(self.state.draw_options.alpha, 0);
+        let draw_options = DrawOptions::new(self.state.draw_options.alpha, CompositionOp::Over, AntialiasMode::Default);
 
         self.drawtarget.draw_surface(source_surface,
                                      dest_rect.to_azfloat(),
@@ -175,7 +175,7 @@ struct CanvasPaintState<'a> {
 impl<'a> CanvasPaintState<'a> {
     fn new() -> CanvasPaintState<'a> {
         CanvasPaintState {
-            draw_options: DrawOptions::new(1.0, 0),
+            draw_options: DrawOptions::default(),
             fill_style: Pattern::Color(ColorPattern::new(color::black())),
             stroke_style: Pattern::Color(ColorPattern::new(color::black())),
             stroke_opts: StrokeOptions::new(1.0, JoinStyle::MiterOrBevel, CapStyle::Butt, 10.0, &[]),

--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -5,7 +5,7 @@
 use azure::azure::AzFloat;
 use azure::azure_hl::{DrawTarget, SurfaceFormat, BackendType, StrokeOptions, DrawOptions, Pattern};
 use azure::azure_hl::{ColorPattern, PathBuilder, DrawSurfaceOptions, Filter};
-use azure::azure_hl::{JoinStyle, CapStyle};
+use azure::azure_hl::{JoinStyle, CapStyle, CompositionOp, AntialiasMode};
 use canvas_traits::*;
 use geom::matrix2d::Matrix2D;
 use geom::point::Point2D;
@@ -80,7 +80,7 @@ impl<'a> CanvasPaintTask<'a> {
             image_size, image_size.width * 4, SurfaceFormat::B8G8R8A8);
 
         let draw_surface_options = DrawSurfaceOptions::new(filter, true);
-        let draw_options = DrawOptions::new(self.state.draw_options.alpha, CompositionOp::Over, AntialiasMode::Default);
+        let draw_options = DrawOptions::new(self.state.draw_options.alpha, CompositionOp::Over, AntialiasMode::None);
 
         self.drawtarget.draw_surface(source_surface,
                                      dest_rect.to_azfloat(),

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -19,7 +19,7 @@ use azure::azure_hl::{DrawOptions, DrawSurfaceOptions, DrawTarget, ExtendMode, F
 use azure::azure_hl::{GaussianBlurAttribute, StrokeOptions, SurfaceFormat};
 use azure::azure_hl::{GaussianBlurInput, GradientStop, Filter, FilterNode, LinearGradientPattern};
 use azure::azure_hl::{JoinStyle, CapStyle};
-use azure::azure_hl::{PatternRef, Path, PathBuilder, CompositionOp};
+use azure::azure_hl::{PatternRef, Path, PathBuilder, CompositionOp, AntialiasMode};
 use azure::scaled_font::ScaledFont;
 use azure::{AzFloat, struct__AzDrawOptions, struct__AzGlyph};
 use azure::{struct__AzGlyphBuffer, struct__AzPoint, AzDrawTargetFillGlyphs};
@@ -28,7 +28,7 @@ use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::side_offsets::SideOffsets2D;
 use geom::size::Size2D;
-use libc::types::common::c99::{uint16_t, uint32_t};
+use libc::types::common::c99::uint32_t;
 use net_traits::image::base::Image;
 use png::PixelsByColorType;
 use std::default::Default;
@@ -159,7 +159,7 @@ impl<'a> PaintContext<'a> {
             }
         };
 
-        let draw_options = DrawOptions::new(1.0, 0);
+        let draw_options = DrawOptions::default();
         draw_target_ref.draw_surface(azure_surface,
                                      dest_rect,
                                      source_rect,
@@ -173,7 +173,7 @@ impl<'a> PaintContext<'a> {
                                 self.page_rect.origin.y as AzFloat),
                         Size2D(self.screen_rect.size.width as AzFloat,
                                self.screen_rect.size.height as AzFloat));
-        let mut draw_options = DrawOptions::new(1.0, 0);
+        let mut draw_options = DrawOptions::default();
         draw_options.set_composition_op(CompositionOp::Source);
         self.draw_target.make_current();
         self.draw_target.fill_rect(&rect, PatternRef::Color(&pattern), Some(&draw_options));
@@ -290,7 +290,7 @@ impl<'a> PaintContext<'a> {
                         color: Color) {
         let mut path_builder = self.draw_target.create_path_builder();
         self.create_border_path_segment(&mut path_builder, bounds, direction, border, radii);
-        let draw_options = DrawOptions::new(1.0, 0);
+        let draw_options = DrawOptions::default();
         self.draw_target.fill(&path_builder.finish(), &ColorPattern::new(color), &draw_options);
     }
 
@@ -617,7 +617,7 @@ impl<'a> PaintContext<'a> {
                                   color: Color,
                                   dash_size: DashSize) {
         let rect = bounds.to_nearest_azure_rect();
-        let draw_opts = DrawOptions::new(1 as AzFloat, 0 as uint16_t);
+        let draw_opts = DrawOptions::default();
         let border_width = match direction {
             Direction::Top => border.top,
             Direction::Left => border.left,
@@ -960,7 +960,7 @@ impl<'a> PaintContext<'a> {
                                                              &mut accum_blur);
 
         // Perform the blit operation.
-        let mut draw_options = DrawOptions::new(opacity, 0);
+        let mut draw_options = DrawOptions::new(opacity, CompositionOp::Over, AntialiasMode::Default);
         draw_options.set_composition_op(blend_mode.to_azure_composition_op());
 
        // If there is a blur expansion, shift the transform and update the size.
@@ -1024,7 +1024,7 @@ impl<'a> PaintContext<'a> {
         // Draw the shadow, and blur if we need to.
         temporary_draw_target.draw_target.fill(&path,
                                                &ColorPattern::new(color),
-                                               &DrawOptions::new(1.0, 0));
+                                               &DrawOptions::default());
         self.blur_if_necessary(temporary_draw_target, blur_radius);
 
         // Undo the draw target's clip if we need to, and push back the stacking context clip.
@@ -1221,15 +1221,11 @@ impl ScaledFontExtensionMethods for ScaledFont {
         let azure_pattern = pattern.azure_color_pattern;
         assert!(!azure_pattern.is_null());
 
-        let fields = if antialias {
-            0x0200
-        } else {
-            0
-        };
-
         let mut options = struct__AzDrawOptions {
             mAlpha: 1f64 as AzFloat,
-            fields: fields,
+            mCompositionOp: CompositionOp::Over as u8,
+            mAntialiasMode: if antialias { AntialiasMode::Subpixel as u8 }
+                            else { AntialiasMode::None as u8 }
         };
 
         let mut origin = baseline_origin.clone();
@@ -1418,7 +1414,7 @@ impl TemporaryDrawTarget {
         main_draw_target.draw_filter(&filter,
                                      &Rect(Point2D(0.0, 0.0), temporary_draw_target_size),
                                      &self.offset,
-                                     DrawOptions::new(1.0, 0));
+                                     DrawOptions::default());
         main_draw_target.set_transform(&main_draw_target_transform);
 
     }

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -159,7 +159,7 @@ impl<'a> PaintContext<'a> {
             }
         };
 
-        let draw_options = DrawOptions::default();
+        let draw_options = DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None);
         draw_target_ref.draw_surface(azure_surface,
                                      dest_rect,
                                      source_rect,
@@ -173,7 +173,7 @@ impl<'a> PaintContext<'a> {
                                 self.page_rect.origin.y as AzFloat),
                         Size2D(self.screen_rect.size.width as AzFloat,
                                self.screen_rect.size.height as AzFloat));
-        let mut draw_options = DrawOptions::default();
+        let mut draw_options = DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None);
         draw_options.set_composition_op(CompositionOp::Source);
         self.draw_target.make_current();
         self.draw_target.fill_rect(&rect, PatternRef::Color(&pattern), Some(&draw_options));
@@ -290,7 +290,7 @@ impl<'a> PaintContext<'a> {
                         color: Color) {
         let mut path_builder = self.draw_target.create_path_builder();
         self.create_border_path_segment(&mut path_builder, bounds, direction, border, radii);
-        let draw_options = DrawOptions::default();
+        let draw_options = DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None);
         self.draw_target.fill(&path_builder.finish(), &ColorPattern::new(color), &draw_options);
     }
 
@@ -617,7 +617,7 @@ impl<'a> PaintContext<'a> {
                                   color: Color,
                                   dash_size: DashSize) {
         let rect = bounds.to_nearest_azure_rect();
-        let draw_opts = DrawOptions::default();
+        let draw_opts = DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None);
         let border_width = match direction {
             Direction::Top => border.top,
             Direction::Left => border.left,
@@ -960,7 +960,7 @@ impl<'a> PaintContext<'a> {
                                                              &mut accum_blur);
 
         // Perform the blit operation.
-        let mut draw_options = DrawOptions::new(opacity, CompositionOp::Over, AntialiasMode::Default);
+        let mut draw_options = DrawOptions::new(opacity, CompositionOp::Over, AntialiasMode::None);
         draw_options.set_composition_op(blend_mode.to_azure_composition_op());
 
        // If there is a blur expansion, shift the transform and update the size.
@@ -1024,7 +1024,7 @@ impl<'a> PaintContext<'a> {
         // Draw the shadow, and blur if we need to.
         temporary_draw_target.draw_target.fill(&path,
                                                &ColorPattern::new(color),
-                                               &DrawOptions::default());
+                                               &DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None));
         self.blur_if_necessary(temporary_draw_target, blur_radius);
 
         // Undo the draw target's clip if we need to, and push back the stacking context clip.
@@ -1414,7 +1414,7 @@ impl TemporaryDrawTarget {
         main_draw_target.draw_filter(&filter,
                                      &Rect(Point2D(0.0, 0.0), temporary_draw_target_size),
                                      &self.offset,
-                                     DrawOptions::default());
+                                     DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None));
         main_draw_target.set_transform(&main_draw_target_transform);
 
     }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#f1c5e98201e4c2d7684a388596979ce862788a9e"
+source = "git+https://github.com/servo/rust-azure#5b9f2dbe7517196a82ea3c9c4dc4cf9fbd7d0867"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -52,7 +52,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
- "xlib 0.1.0 (git+https://github.com/servo/rust-xlib)",
+ "x11 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -479,6 +479,7 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
+ "net 0.0.1",
  "script_traits 0.0.1",
  "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -99,6 +99,10 @@ pub struct Opts {
     /// font for layout tests.
     pub enable_text_antialiasing: bool,
 
+    /// If set with --disable-canvas-aa, disable antialiasing on the HTML canvas element.
+    /// Like --disable-text-aa, this is useful for reftests where pixel perfect results are required.
+    pub enable_canvas_antialiasing: bool,
+
     /// True if each step of layout is traced to an external JSON file
     /// for debugging purposes. Settings this implies sequential layout
     /// and paint.
@@ -220,6 +224,7 @@ pub fn default_opts() -> Opts {
         show_debug_parallel_layout: false,
         paint_flashing: false,
         enable_text_antialiasing: false,
+        enable_canvas_antialiasing: false,
         trace_layout: false,
         devtools_port: None,
         webdriver_port: None,
@@ -398,6 +403,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         show_debug_parallel_layout: debug_options.contains(&"show-parallel-layout"),
         paint_flashing: debug_options.contains(&"paint-flashing"),
         enable_text_antialiasing: !debug_options.contains(&"disable-text-aa"),
+        enable_canvas_antialiasing: !debug_options.contains(&"disable-canvas-aa"),
         dump_flow_tree: debug_options.contains(&"dump-flow-tree"),
         dump_display_list: debug_options.contains(&"dump-display-list"),
         dump_display_list_optimized: debug_options.contains(&"dump-display-list-optimized"),

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#f1c5e98201e4c2d7684a388596979ce862788a9e"
+source = "git+https://github.com/servo/rust-azure#5b9f2dbe7517196a82ea3c9c4dc4cf9fbd7d0867"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -51,7 +51,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
- "xlib 0.1.0 (git+https://github.com/servo/rust-xlib)",
+ "x11 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -73,6 +73,7 @@ pub extern "C" fn cef_initialize(args: *const cef_main_args_t,
     temp_opts.headless = false;
     temp_opts.hard_fail = false;
     temp_opts.enable_text_antialiasing = true;
+    temp_opts.enable_canvas_antialiasing = true;
     temp_opts.resources_path = None;
     temp_opts.url = None;
     opts::set(temp_opts);

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#f1c5e98201e4c2d7684a388596979ce862788a9e"
+source = "git+https://github.com/servo/rust-azure#5b9f2dbe7517196a82ea3c9c4dc4cf9fbd7d0867"
 dependencies = [
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
  "core_graphics 0.1.0 (git+https://github.com/servo/rust-core-graphics)",
@@ -38,7 +38,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
- "xlib 0.1.0 (git+https://github.com/servo/rust-xlib)",
+ "x11 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -250,9 +250,9 @@ fn capture(reftest: &Reftest, side: usize) -> (u32, u32, Vec<u8>) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .args(&reftest.servo_args[..])
-        // Allows pixel perfect rendering of Ahem font for reftests.
+        // Allows pixel perfect rendering of Ahem font and the HTML canvas for reftests.
         .arg("-Z")
-        .arg("disable-text-aa")
+        .arg("disable-text-aa,disable-canvas-aa")
         .args(&["-f", "-o"])
         .arg(&png_filename)
         .arg(&{

--- a/tests/wpt/harness/wptrunner/executors/executorservo.py
+++ b/tests/wpt/harness/wptrunner/executors/executorservo.py
@@ -186,7 +186,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
 
         with TempFilename(self.tempdir) as output_path:
             self.command = [self.binary, "--cpu", "--hard-fail", "--exit",
-                            "-Z", "disable-text-aa", "--output=%s" % output_path,
+                            "-Z", "disable-text-aa,disable-canvas-aa", "--output=%s" % output_path,
                             full_url]
 
             env = os.environ.copy()

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.curve1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.curve1.html.ini
@@ -1,0 +1,6 @@
+[2d.path.arcTo.shape.curve1.html]
+  type: testharness
+  [arcTo() curves in the right kind of shape]
+    expected:
+      FAIL
+

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.curve2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.curve2.html.ini
@@ -1,0 +1,6 @@
+[2d.path.arcTo.shape.curve2.html]
+  type: testharness
+  [arcTo() curves in the right kind of shape]
+    expected:
+      FAIL
+


### PR DESCRIPTION
This patch turns on antialiasing for the canvas, and updates the painting code to use the updated Azure DrawOptions defined in servo/rust-azure#158.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6065)

<!-- Reviewable:end -->
