### PR TITLE
Make "mach run -d" an alias for "mach run --dev"

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -75,7 +75,7 @@ class MachCommands(CommandBase):
              category='post-build')
     @CommandArgument('--release', '-r', action='store_true',
                      help='Run the release build')
-    @CommandArgument('--dev', action='store_true',
+    @CommandArgument('--dev', '-d', action='store_true',
                      help='Run the dev build')
     @CommandArgument('--debug', action='store_true',
                      help='Enable the debugger. Not specifying a '
@@ -127,7 +127,7 @@ class MachCommands(CommandBase):
              category='post-build')
     @CommandArgument('--release', '-r', action='store_true',
                      help='Use release build')
-    @CommandArgument('--dev', action='store_true',
+    @CommandArgument('--dev', '-d', action='store_true',
                      help='Use dev build')
     @CommandArgument(
         'params', nargs='...',


### PR DESCRIPTION
(And the same for `rr-record`.) For consistency with `mach build`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6068)

<!-- Reviewable:end -->
