### PR TITLE
Fixed definition of Close and Send in WebSocket.webidl and updated im…

### DIFF
--- a/components/script/dom/webidls/WebSocket.webidl
+++ b/components/script/dom/webidls/WebSocket.webidl
@@ -21,13 +21,13 @@ interface WebSocket : EventTarget {
     attribute EventHandler onclose;
     //readonly attribute DOMString extensions;
     //readonly attribute DOMString protocol;
-    //[Throws] void close([Clamp] optional unsigned short code, optional DOMString reason); //Clamp doesn't work
-    [Throws] void close(optional unsigned short code, optional DOMString reason); //No clamp version - works
+    //[Throws] void close([Clamp] optional unsigned short code, optional USVString reason); //Clamp doesn't work
+    [Throws] void close(optional unsigned short code, optional USVString reason); //No clamp version - works
 
     //messaging
     //attribute EventHandler onmessage;
     //attribute BinaryType binaryType;
-    [Throws] void send(optional DOMString data);
+    [Throws] void send(optional USVString data);
     //void send(Blob data);
     //void send(ArrayBuffer data);
     //void send(ArrayBufferView data);

--- a/tests/wpt/metadata/websockets/Close-reason-unpaired-surrogates.htm.ini
+++ b/tests/wpt/metadata/websockets/Close-reason-unpaired-surrogates.htm.ini
@@ -1,3 +1,5 @@
 [Close-reason-unpaired-surrogates.htm]
   type: testharness
   expected: TIMEOUT
+  [W3C WebSocket API - Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed]
+    expected: NOTRUN

--- a/tests/wpt/metadata/websockets/Send-Unpaired-Surrogates.htm.ini
+++ b/tests/wpt/metadata/websockets/Send-Unpaired-Surrogates.htm.ini
@@ -1,3 +1,7 @@
 [Send-Unpaired-Surrogates.htm]
   type: testharness
   expected: TIMEOUT
+  [W3C WebSocket API - Send unpaired surrogates on a WebSocket - Message should be received]
+    expected: NOTRUN
+  [W3C WebSocket API - Send unpaired surrogates on a WebSocket - Connection should be closed]
+    expected: NOTRUN

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/send/006.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/send/006.html.ini
@@ -1,3 +1,5 @@
 [006.html]
   type: testharness
   expected: TIMEOUT
+  [WebSockets: send() with unpaired surrogate when readyState is OPEN]
+    expected: TIMEOUT


### PR DESCRIPTION
Fix #6063
Fix #6062
Fixed definition of Close and Send in WebSocket.webidl and updated implementation in websocket.rs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6094)

<!-- Reviewable:end -->
