### PR TITLE
Fixes for layout of RTL floats

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1049,7 +1049,8 @@ impl BlockFlow {
         let float_offset = self.base.floats.last_float_pos().unwrap()
                                            .convert(self.base.floats.writing_mode,
                                                     self.base.writing_mode,
-                                                    container_size);
+                                                    container_size)
+                                           .start;
         let margin_offset = LogicalPoint::new(self.base.writing_mode,
                                               Au(0),
                                               self.fragment.margin.block_start);

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -771,8 +771,9 @@ impl BlockFlow {
             }
 
             let mut margin_collapse_info = MarginCollapseInfo::new();
+            let writing_mode = self.base.floats.writing_mode;
             self.base.floats.translate(LogicalSize::new(
-                self.fragment.style.writing_mode, -self.fragment.inline_start_offset(), Au(0)));
+                writing_mode, -self.fragment.inline_start_offset(), Au(0)));
 
             // The sum of our block-start border and block-start padding.
             let block_start_offset = self.fragment.border_padding.block_start;
@@ -1029,7 +1030,8 @@ impl BlockFlow {
             size: LogicalSize::new(
                 self.fragment.style.writing_mode,
                 self.base.position.size.inline,
-                block_size + self.fragment.margin.block_start_end()),
+                block_size + self.fragment.margin.block_start_end())
+                      .convert(self.fragment.style.writing_mode, self.base.floats.writing_mode),
             ceiling: clearance + float_info.float_ceiling,
             max_inline_size: float_info.containing_inline_size,
             kind: float_info.float_kind,
@@ -1039,11 +1041,16 @@ impl BlockFlow {
         // After, grab the position and use that to set our position.
         self.base.floats.add_float(&info);
 
+        // FIXME (mbrubeck) Get the correct container size for self.base.floats;
+        let container_size = Size2D(self.base.block_container_inline_size, Au(0));
+
         // Move in from the margin edge, as per CSS 2.1 § 9.5, floats may not overlap anything on
         // their margin edges.
-        let float_offset = self.base.floats.last_float_pos().unwrap();
-        let writing_mode = self.base.floats.writing_mode;
-        let margin_offset = LogicalPoint::new(writing_mode,
+        let float_offset = self.base.floats.last_float_pos().unwrap()
+                                           .convert(self.base.floats.writing_mode,
+                                                    self.base.writing_mode,
+                                                    container_size);
+        let margin_offset = LogicalPoint::new(self.base.writing_mode,
                                               Au(0),
                                               self.fragment.margin.block_start);
 
@@ -1379,7 +1386,8 @@ impl BlockFlow {
         }
 
         let info = PlacementInfo {
-            size: self.fragment.border_box.size,
+            size: self.fragment.border_box.size.convert(self.fragment.style.writing_mode,
+                                                        self.base.floats.writing_mode),
             ceiling: self.base.position.start.b,
             max_inline_size: MAX_AU,
             kind: FloatKind::Left,

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -4,7 +4,7 @@
 
 use util::geometry::Au;
 use util::logical_geometry::WritingMode;
-use util::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize};
+use util::logical_geometry::{LogicalRect, LogicalSize};
 use util::persistent_list::PersistentList;
 use std::cmp::{max, min};
 use std::i32;
@@ -146,10 +146,10 @@ impl Floats {
     }
 
     /// Returns the position of the last float in flow coordinates.
-    pub fn last_float_pos(&self) -> Option<LogicalPoint<Au>> {
+    pub fn last_float_pos(&self) -> Option<LogicalRect<Au>> {
         match self.list.floats.front() {
             None => None,
-            Some(float) => Some(float.bounds.start + self.offset),
+            Some(float) => Some(float.bounds.translate_by_size(self.offset)),
         }
     }
 

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1455,7 +1455,8 @@ impl Flow for InlineFlow {
         };
 
         self.base.floats = scanner.floats.clone();
-        self.base.floats.translate(LogicalSize::new(self.base.writing_mode,
+        let writing_mode = self.base.floats.writing_mode;
+        self.base.floats.translate(LogicalSize::new(writing_mode,
                                                     Au(0),
                                                     -self.base.position.size.block));
 

--- a/components/util/logical_geometry.rs
+++ b/components/util/logical_geometry.rs
@@ -919,6 +919,13 @@ impl<T: Copy + Add<T, Output=T> + Sub<T, Output=T>> LogicalRect<T> {
         }
     }
 
+    pub fn translate_by_size(&self, offset: LogicalSize<T>) -> LogicalRect<T> {
+        LogicalRect {
+            start: self.start + offset,
+            ..*self
+        }
+    }
+
     pub fn translate(&self, offset: &LogicalPoint<T>) -> LogicalRect<T> {
         LogicalRect {
             start: self.start + LogicalSize {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -264,6 +264,7 @@ experimental != overconstrained_block.html overconstrained_block_ref.html
 == root_margin_collapse_a.html root_margin_collapse_b.html
 == root_pseudo_a.html root_pseudo_b.html
 experimental == rtl_body.html rtl_body_ref.html
+experimental == rtl_float_a.html rtl_float_ref.html
 experimental == rtl_margin_a.html rtl_margin_ref.html
 experimental == rtl_simple.html rtl_simple_ref.html
 experimental == rtl_table_a.html rtl_table_ref.html

--- a/tests/ref/rtl_float_a.html
+++ b/tests/ref/rtl_float_a.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>RTL float test</title>
+    <style>
+      div {
+        direction: rtl;
+        float: left;
+        background: green;
+        width: 100px;
+        height: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="a"></div>
+  </body>
+</html>
+

--- a/tests/ref/rtl_float_ref.html
+++ b/tests/ref/rtl_float_ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>RTL float reference</title>
+    <style>
+      div {
+        float: left;
+        background: green;
+        width: 100px;
+        height: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="a"></div>
+  </body>
+</html>
+


### PR DESCRIPTION
This fixes panics in RTL pages with floats (#6113) and partially fixes the positioning of RTL floats.  There are some remaining issues with the layout of floats in RTL flows, which I'll file follow-up issues for.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6130)

<!-- Reviewable:end -->
