### PR TITLE
forces user to update cargo packages individually or enable flag to update all packages

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -40,7 +40,7 @@ class MachCommands(CommandBase):
         help='Command-line arguments to be passed through to cargo update')
     @CommandArgument(
         '--package', '-p', default=None, 
-        help='Updates select packages')
+        help='Updates selected package')
     @CommandArgument(
         '--all-packages','-a',action='store_true', 
         help='Updates all packages')
@@ -55,7 +55,7 @@ class MachCommands(CommandBase):
         help='Command-line arguments to be passed through to cargo update')
     @CommandArgument(
         '--package','-p',default=None, 
-        help='Updates select packages')
+        help='Updates selected package')
     @CommandArgument(
         '--all-packages','-a',action='store_true', 
         help='Updates all packages')

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -2,6 +2,7 @@ from __future__ import print_function, unicode_literals
 from os import path, getcwd, listdir
 
 import subprocess
+import sys
 
 from mach.decorators import (
     CommandArgument,
@@ -37,8 +38,14 @@ class MachCommands(CommandBase):
     @CommandArgument(
         'params', default=None, nargs='...',
         help='Command-line arguments to be passed through to cargo update')
-    def cargo_update(self, params=None):
-        self.update_cargo(params)
+    @CommandArgument(
+        '--package', '-p', default=None, 
+        help='Updates select packages')
+    @CommandArgument(
+        '--all-packages','-a',action='store_true', 
+        help='Updates all packages')
+    def cargo_update(self, params=None, package=None, all_packages=None):
+        self.update_cargo(params, package, all_packages)
 
     @Command('update-cargo',
              description='Update Cargo dependencies',
@@ -46,9 +53,24 @@ class MachCommands(CommandBase):
     @CommandArgument(
         'params', default=None, nargs='...',
         help='Command-line arguments to be passed through to cargo update')
-    def update_cargo(self, params=None):
+    @CommandArgument(
+        '--package','-p',default=None, 
+        help='Updates select packages')
+    @CommandArgument(
+        '--all-packages','-a',action='store_true', 
+        help='Updates all packages')
+    def update_cargo(self, params=None, package=None, all_packages=None):
         if not params:
             params = []
+
+        if package:
+            params += ["-p", package]
+        elif all_packages:
+            params = []
+        else:
+            print("Please choose package to update with the --package (-p) ") 
+            print("flag or update all packages with --all-packages (-a) flag")
+            sys.exit(1)
 
         cargo_paths = [path.join('components', 'servo'),
                        path.join('ports', 'cef'),


### PR DESCRIPTION
Fixes issue #6112 
update-cargo and cargo-update both require that the user specifies the "-p" flag along with a specified package OR specify the "-a" flag to update all packages.

Let me know if this is not the right functionality.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6136)

<!-- Reviewable:end -->
