### PR TITLE
Remove "experimental" from direction:rtl reftests

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -225,7 +225,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == outset.html outset_ref.html
 != outset_blackborder.html blackborder_ref.html
 # Should be == with expected failure. See #2797
-experimental != overconstrained_block.html overconstrained_block_ref.html
+!= overconstrained_block.html overconstrained_block_ref.html
 == overflow_auto.html overflow_simple_b.html
 == overflow_scroll.html overflow_simple_b.html
 == overflow_simple_a.html overflow_simple_b.html
@@ -265,11 +265,11 @@ experimental != overconstrained_block.html overconstrained_block_ref.html
 == root_height_a.html root_height_b.html
 == root_margin_collapse_a.html root_margin_collapse_b.html
 == root_pseudo_a.html root_pseudo_b.html
-experimental == rtl_body.html rtl_body_ref.html
-experimental == rtl_float_a.html rtl_float_ref.html
-experimental == rtl_margin_a.html rtl_margin_ref.html
-experimental == rtl_simple.html rtl_simple_ref.html
-experimental == rtl_table_a.html rtl_table_ref.html
+== rtl_body.html rtl_body_ref.html
+== rtl_float_a.html rtl_float_ref.html
+== rtl_margin_a.html rtl_margin_ref.html
+== rtl_simple.html rtl_simple_ref.html
+== rtl_table_a.html rtl_table_ref.html
 == servo_center_a.html servo_center_ref.html
 == setattribute_id_restyle_a.html setattribute_id_restyle_b.html
 == stacking_context_overflow_a.html stacking_context_overflow_ref.html
@@ -288,12 +288,12 @@ experimental == rtl_table_a.html rtl_table_ref.html
 == table_padding_a.html table_padding_ref.html
 == table_percentage_capping_a.html table_percentage_capping_ref.html
 == table_percentage_width_a.html table_percentage_width_ref.html
-experimental == table_row_direction_a.html table_row_direction_ref.html
+== table_row_direction_a.html table_row_direction_ref.html
 == table_width_attribute_a.html table_width_attribute_ref.html
 == text_align_complex_a.html text_align_complex_ref.html
 == text_align_justify_a.html text_align_justify_ref.html
-experimental == text_align_rtl.html text_align_rtl_ref.html
-experimental == text_align_start_end.html text_align_start_end_ref.html
+== text_align_rtl.html text_align_rtl_ref.html
+== text_align_start_end.html text_align_start_end_ref.html
 == text_decoration_cached.html text_decoration_cached_ref.html
 # text_decoration_propagation_a.html text_decoration_propagation_b.html
 != text_decoration_smoke_a.html text_decoration_smoke_ref.html


### PR DESCRIPTION
No longer needed after #6138.  r? @SimonSapin

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6147)

<!-- Reviewable:end -->
