### PR TITLE
doc/howto install: Fedora replaces yum with dnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo apt-get install curl freeglut3-dev \
 On Fedora:
 
 ``` sh
-sudo yum install curl freeglut-devel libtool gcc-c++ libXi-devel \
+sudo dnf install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv expat-devel \
     rpm-build openssl-devel cmake bzip2-devel libXcursor-devel libXmu-devel mesa-libOSMesa-devel


### PR DESCRIPTION
According to the official change set [1] for Fedora 22 which will be released in some days [2] yum will be replaced by dnf. The syntax is basically the same (in these simple cases here it is exactly the same, tested with dnf). After that only Fedora 21 and 22 will be supported, both come with dnf shipped by default.

[1] https://fedoraproject.org/wiki/Releases/22/ChangeSet#Replace_Yum_With_DNF
[2] https://fedoraproject.org/wiki/Releases/22/Schedule?rd=Releases/22

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6163)

<!-- Reviewable:end -->
