### PR TITLE
fixes 6111: WebSocket close event shouldn't be Cancelable

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -324,7 +324,7 @@ impl WebSocketTaskHandler {
         let close_event = CloseEvent::new(global.r(),
                                           "close".to_owned(),
                                           EventBubbles::DoesNotBubble,
-                                          EventCancelable::Cancelable,
+                                          EventCancelable::NotCancelable,
                                           ws.clean_close.get(),
                                           ws.code.get(),
                                           rsn_clone).root();


### PR DESCRIPTION
This fixes #6111 , @jdm said that I can work on this issue

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6170)

<!-- Reviewable:end -->
