### PR TITLE
Add WebGLContextAttributes support

### DIFF
--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -19,5 +19,8 @@ git = "https://github.com/servo/rust-azure"
 [dependencies.layers]
 git = "https://github.com/servo/rust-layers"
 
+[dependencies.offscreen_gl_context]
+git = "https://github.com/ecoal95/rust-offscreen-rendering-context"
+
 [dependencies]
 cssparser = "0.3.1"

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -9,6 +9,7 @@ extern crate geom;
 extern crate cssparser;
 extern crate gfx_traits;
 extern crate layers;
+extern crate offscreen_gl_context;
 
 use azure::azure::AzFloat;
 use azure::azure_hl::{DrawTarget, Pattern, ColorPattern};
@@ -22,6 +23,7 @@ use geom::size::Size2D;
 use gfx_traits::color;
 use std::sync::mpsc::{Sender};
 use layers::platform::surface::NativeSurface;
+use offscreen_gl_context::GLContextAttributes;
 
 #[derive(Clone)]
 pub enum CanvasMsg {
@@ -66,6 +68,7 @@ pub enum Canvas2dMsg {
 
 #[derive(Clone)]
 pub enum CanvasWebGLMsg {
+    GetContextAttributes(Sender<GLContextAttributes>),
     AttachShader(u32, u32),
     BindBuffer(u32, u32),
     BufferData(u32, Vec<f32>, u32),

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -73,6 +73,9 @@ git = "https://github.com/servo/string-cache"
 version = "0.2.33"
 features = ["query_encoding"]
 
+[dependencies.offscreen_gl_context]
+git = "https://github.com/ecoal95/rust-offscreen-rendering-context"
+
 [dependencies]
 encoding = "0.2"
 time = "0.1.12"

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -214,7 +214,11 @@ impl CanvasRenderingContext2D {
         let msg = if self.canvas.root().r() == canvas {
             CanvasMsg::Canvas2d(Canvas2dMsg::DrawImageSelf(image_size, dest_rect, source_rect, smoothing_enabled))
         } else { // Source and target canvases are different
-            let context = canvas.get_2d_context().root();
+            let context = match canvas.get_or_init_2d_context() {
+                Some(context) => context.root(),
+                None => return Err(InvalidState),
+            };
+
             let renderer = context.r().get_renderer();
             let (sender, receiver) = channel::<Vec<u8>>();
             // Reads pixels from source image

--- a/components/script/dom/webidls/HTMLCanvasElement.webidl
+++ b/components/script/dom/webidls/HTMLCanvasElement.webidl
@@ -12,7 +12,7 @@ interface HTMLCanvasElement : HTMLElement {
   [Pure]
            attribute unsigned long height;
 
-  RenderingContext? getContext(DOMString contextId);
+  RenderingContext? getContext(DOMString contextId, any... arguments);
   //boolean probablySupportsContext(DOMString contextId, any... arguments);
 
   //void setContext(RenderingContext context);

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -481,7 +481,7 @@ interface WebGLRenderingContextBase
     //readonly attribute GLsizei drawingBufferWidth;
     //readonly attribute GLsizei drawingBufferHeight;
 
-    //[WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
+    [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     //[WebGLHandlesContextLoss] boolean isContextLost();
 
     //sequence<DOMString>? getSupportedExtensions();

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -53,6 +53,7 @@ extern crate url;
 extern crate uuid;
 extern crate string_cache;
 extern crate webdriver_traits;
+extern crate offscreen_gl_context;
 
 pub mod cors;
 pub mod document_loader;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx_traits 0.0.1",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "offscreen_gl_context 0.0.1 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
 ]
 
 [[package]]
@@ -479,6 +480,7 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
+ "net 0.0.1",
  "script_traits 0.0.1",
  "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,7 +848,7 @@ dependencies = [
 [[package]]
 name = "offscreen_gl_context"
 version = "0.0.1"
-source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#99cee719a811f28e70fe33fa71137663ac210487"
+source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#13c9f786c55266fa1594cb520fdbc74f45fda809"
 dependencies = [
  "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
@@ -1027,6 +1029,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "offscreen_gl_context 0.0.1 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile_traits 0.0.1",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx_traits 0.0.1",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "offscreen_gl_context 0.0.1 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
 ]
 
 [[package]]
@@ -837,7 +838,7 @@ dependencies = [
 [[package]]
 name = "offscreen_gl_context"
 version = "0.0.1"
-source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#99cee719a811f28e70fe33fa71137663ac210487"
+source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#13c9f786c55266fa1594cb520fdbc74f45fda809"
 dependencies = [
  "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
@@ -1018,6 +1019,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "offscreen_gl_context 0.0.1 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile_traits 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "geom 0.1.0 (git+https://github.com/servo/rust-geom)",
  "gfx_traits 0.0.1",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
+ "offscreen_gl_context 0.0.1 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
 ]
 
 [[package]]
@@ -727,7 +728,7 @@ dependencies = [
 [[package]]
 name = "offscreen_gl_context"
 version = "0.0.1"
-source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#99cee719a811f28e70fe33fa71137663ac210487"
+source = "git+https://github.com/ecoal95/rust-offscreen-rendering-context#13c9f786c55266fa1594cb520fdbc74f45fda809"
 dependencies = [
  "cgl 0.0.1 (git+https://github.com/servo/rust-cgl)",
  "core_foundation 0.1.0 (git+https://github.com/servo/rust-core-foundation)",
@@ -899,6 +900,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "offscreen_gl_context 0.0.1 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "profile_traits 0.0.1",

--- a/tests/html/test_webgl_context_attributes.html
+++ b/tests/html/test_webgl_context_attributes.html
@@ -1,0 +1,39 @@
+<meta charset="utf-8">
+<title>WebGL Context Attributes test</title>
+<script>
+(function () {
+    var canvas = document.createElement('canvas'),
+        closure = function() {},
+        gl, attributes;
+
+    closure.alpha = false;
+    closure.antialias = "";
+
+    gl = canvas.getContext("webgl", closure);
+
+    if ( ! gl ) {
+        console.log("Passing a closure to `getContext` didn't generate a context");
+        gl = canvas.getContext("webgl", { alpha: false, antialias: "" });
+    }
+
+    if ( ! gl ) {
+        console.error("Unable to generate a WebGL context");
+        return;
+    }
+
+    attributes = gl.getContextAttributes();
+    console.log("Got context attributes: ", JSON.stringify(attributes));
+
+    if ( attributes.alpha )
+        console.error("Alpha not expected");
+
+    if ( attributes.antialias )
+        console.error("Antialias not expected, should be casted to false");
+
+    gl = canvas.getContext("webgl", { alpha: true });
+    attributes = gl.getContextAttributes();
+
+    if ( attributes.alpha )
+        console.error("Should have returned the previous context attributes");
+})();
+</script>


### PR DESCRIPTION
r? @jdm

I couldn't add the `getContextAttributes` method since `CodegenRust`
doesn't know how to return a dictionary value, I'll take a look at it ASAP.

I think the helper functions can return directly the renderer, since they're used just for that, but I wanted to hear your opinions about this.

By the way I'm interested in adding more serious tests for WebGL, and I think the [khronos conformance suit](https://github.com/KhronosGroup/WebGL/tree/master/conformance-suites/1.0.3) should be the best option.

Should I try to integrate it in wpt, or making a `tests/webgl` directory (or similar) inside the servo tree? (Maybe this question should be for @Ms2ger)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6183)

<!-- Reviewable:end -->
