### PR TITLE
Use FT_Done_Library instead of FT_Done_Freetype

### DIFF
--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -4,7 +4,7 @@
 
 use freetype::freetype::FTErrorMethods;
 use freetype::freetype::FT_Add_Default_Modules;
-use freetype::freetype::FT_Done_FreeType;
+use freetype::freetype::FT_Done_Library;
 use freetype::freetype::FT_Library;
 use freetype::freetype::FT_Memory;
 use freetype::freetype::FT_New_Library;
@@ -50,7 +50,7 @@ pub struct FontContextHandle {
 impl Drop for FreeTypeLibraryHandle {
     fn drop(&mut self) {
         assert!(!self.ctx.is_null());
-        unsafe { FT_Done_FreeType(self.ctx) };
+        unsafe { FT_Done_Library(self.ctx) };
     }
 }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "freetype"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-freetype#f256a9ac84893f0a183b8966de2a3a03d7552b8b"
+source = "git+https://github.com/servo/rust-freetype#34db81810ae8be3bef57094c8a378dbe98d2d2c7"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "freetype"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-freetype#f256a9ac84893f0a183b8966de2a3a03d7552b8b"
+source = "git+https://github.com/servo/rust-freetype#34db81810ae8be3bef57094c8a378dbe98d2d2c7"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "freetype"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-freetype#f256a9ac84893f0a183b8966de2a3a03d7552b8b"
+source = "git+https://github.com/servo/rust-freetype#34db81810ae8be3bef57094c8a378dbe98d2d2c7"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
It is recommended to use FT_Done_Library with FT_New_Library
from freetype document.

Fixes #6191.

r? @jdm @nnethercote 
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6198)

<!-- Reviewable:end -->
