### PR TITLE
Measure paint task buffer maps in the memory profiler.

### DIFF
--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -136,12 +136,15 @@ impl Pipeline {
         };
 
         PaintTask::create(id,
+                          load_data.url.clone(),
+                          paint_chan.clone(),
                           paint_port,
                           compositor_proxy,
                           constellation_chan.clone(),
                           font_cache_task.clone(),
                           failure.clone(),
                           time_profiler_chan.clone(),
+                          mem_profiler_chan.clone(),
                           paint_shutdown_chan);
 
         LayoutTaskFactory::create(None::<&mut LTF>,

--- a/components/gfx/buffer_map.rs
+++ b/components/gfx/buffer_map.rs
@@ -160,4 +160,8 @@ impl BufferMap {
         }
         self.mem = 0
     }
+
+    pub fn mem(&self) -> usize {
+        self.mem
+    }
 }

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -24,6 +24,7 @@ extern crate layers;
 extern crate libc;
 extern crate stb_image;
 extern crate png;
+#[macro_use]
 extern crate profile_traits;
 extern crate script_traits;
 extern crate rustc_serialize;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
+ "net 0.0.1",
  "script_traits 0.0.1",
  "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Example output from the memory profiler:

```
|       1.04 MiB -- url(http://en.wikipedia.org/wiki/Main_Page)
|          0.26 MiB -- display-list
|          0.78 MiB -- paint-task       # new output line
|             0.78 MiB -- buffer-map    # new output line
```

The buffer maps aren't huge, but they're worth measuring, and it's good
to get the memory profiler plumbing into PaintTask.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6199)

<!-- Reviewable:end -->
