### PR TITLE
First step towards 3d transforms.

### DIFF
--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -12,7 +12,8 @@ use paint_context::PaintContext;
 
 use azure::azure_hl::{SurfaceFormat, Color, DrawTarget, BackendType};
 use azure::AzFloat;
-use geom::matrix2d::Matrix2D;
+use geom::Matrix4;
+use geom::matrix::identity;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
@@ -579,10 +580,11 @@ impl WorkerThread {
                          stacking_context.overflow.origin.y.to_f32_px()));
 
             // Apply the translation to paint the tile we want.
-            let matrix: Matrix2D<AzFloat> = Matrix2D::identity();
-            let matrix = matrix.scale(scale as AzFloat, scale as AzFloat);
+            let matrix: Matrix4<AzFloat> = identity();
+            let matrix = matrix.scale(scale as AzFloat, scale as AzFloat, 1.0);
             let matrix = matrix.translate(-tile_bounds.origin.x as AzFloat,
-                                          -tile_bounds.origin.y as AzFloat);
+                                          -tile_bounds.origin.y as AzFloat,
+                                          0.0);
 
             // Clear the buffer.
             paint_context.clear();

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -27,7 +27,7 @@ use azure::azure::AzColor;
 use canvas_traits::CanvasMsg;
 use encoding::EncodingRef;
 use encoding::all::UTF_8;
-use geom::matrix2d::Matrix2D;
+use geom::matrix;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::scale_factor::ScaleFactor;
@@ -854,7 +854,7 @@ impl LayoutTask {
                                                                      &origin,
                                                                      &origin,
                                                                      0,
-                                                                     &Matrix2D::identity(),
+                                                                     &matrix::identity(),
                                                                      filter::T::new(Vec::new()),
                                                                      mix_blend_mode::T::normal,
                                                                      Some(paint_layer)));

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -8,7 +8,7 @@
 
 use fragment::Fragment;
 
-use geom::{Matrix2D, SideOffsets2D, Size2D};
+use geom::{Matrix4, SideOffsets2D, Size2D};
 use std::cmp::{max, min};
 use std::fmt;
 use style::computed_values::transform::ComputedMatrix;
@@ -426,21 +426,24 @@ pub fn padding_from_style(style: &ComputedValues, containing_block_inline_size: 
 }
 
 pub trait ToGfxMatrix {
-    fn to_gfx_matrix(&self, containing_size: &Size2D<Au>) -> Matrix2D<f32>;
+    fn to_gfx_matrix(&self, containing_size: &Size2D<Au>) -> Matrix4<f32>;
 }
 
 impl ToGfxMatrix for ComputedMatrix {
-    fn to_gfx_matrix(&self, containing_size: &Size2D<Au>) -> Matrix2D<f32> {
-        Matrix2D::new(self.m11 as f32,
-                      self.m12 as f32,
-                      self.m21 as f32,
-                      self.m22 as f32,
-                      self.m31.to_au(containing_size.width).to_f32_px(),
-                      self.m32.to_au(containing_size.height).to_f32_px())
+    fn to_gfx_matrix(&self, containing_size: &Size2D<Au>) -> Matrix4<f32> {
+        Matrix4 {
+            m11: self.m11 as f32, m12: self.m12 as f32, m13: self.m13 as f32, m14: self.m14 as f32,
+            m21: self.m21 as f32, m22: self.m22 as f32, m23: self.m23 as f32, m24: self.m24 as f32,
+            m31: self.m31 as f32, m32: self.m32 as f32, m33: self.m33 as f32, m34: self.m34 as f32,
+            m41: self.m41.to_au(containing_size.width).to_f32_px(),
+            m42: self.m42.to_au(containing_size.height).to_f32_px(),
+            m43: self.m43 as f32,
+            m44: self.m44 as f32
+        }
     }
 }
 
-trait ToAu {
+pub trait ToAu {
     fn to_au(&self, containing_size: Au) -> Au;
 }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#c4bdb1ef8f4915ae636eb752b103f69246b50304"
+source = "git+https://github.com/servo/rust-geom#270d0246b79fbf86fc2938c4952cae74e4025fcf"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#c4bdb1ef8f4915ae636eb752b103f69246b50304"
+source = "git+https://github.com/servo/rust-geom#270d0246b79fbf86fc2938c4952cae74e4025fcf"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "geom"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-geom#c4bdb1ef8f4915ae636eb752b103f69246b50304"
+source = "git+https://github.com/servo/rust-geom#270d0246b79fbf86fc2938c4952cae74e4025fcf"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -312,6 +312,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == text_transform_lowercase_a.html text_transform_lowercase_ref.html
 == text_transform_none_a.html text_transform_none_ref.html
 == text_transform_uppercase_a.html text_transform_uppercase_ref.html
+== transform_3d.html transform_3d_ref.html
 == transform_simple_a.html transform_simple_ref.html
 == transform_stacking_context_a.html transform_stacking_context_ref.html
 == upper_id_attr.html upper_id_attr_ref.html

--- a/tests/ref/transform_3d.html
+++ b/tests/ref/transform_3d.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            #div_t3d_1 {
+                position: absolute;
+                background-color: red;
+                top: 10px;
+                left: 10px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_t3d_2 {
+                position: absolute;
+                background-color: green;
+                top: 10px;
+                left: 10px;
+                width: 20px;
+                height: 20px;
+                transform: translate3d(50%, 50%, 0);
+            }
+
+            #div_t3d_3 {
+                position: absolute;
+                background-color: red;
+                top: 10px;
+                left: 60px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_t3d_4 {
+                position: absolute;
+                background-color: green;
+                top: 10px;
+                left: 10px;
+                width: 20px;
+                height: 20px;
+                transform: translate3d(-5px, 10px, 0);
+            }
+
+            #div_s3d_1 {
+                position: absolute;
+                background-color: red;
+                top: 10px;
+                left: 110px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_s3d_2 {
+                position: absolute;
+                background-color: green;
+                top: 10px;
+                left: 10px;
+                width: 20px;
+                height: 20px;
+                transform: scale3d(0.5, 2, 1);
+            }
+
+            #div_r3d_1 {
+                position: absolute;
+                background-color: red;
+                top: 60px;
+                left: 10px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_r3d_2 {
+                position: absolute;
+                background-color: green;
+                top: 10px;
+                left: 10px;
+                width: 10px;
+                height: 20px;
+                transform: rotateZ(90deg);
+            }
+
+            #div_r3d_3 {
+                position: absolute;
+                background-color: red;
+                top: 60px;
+                left: 60px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_r3d_4 {
+                position: absolute;
+                background-color: green;
+                top: 10px;
+                left: 10px;
+                width: 10px;
+                height: 20px;
+                transform: rotate3d(0, 0, 1, 90deg);
+            }
+        </style>
+    </head>
+    <body>
+        <div id="div_t3d_1">
+            <div id="div_t3d_2">
+            </div>
+        </div>
+
+        <div id="div_t3d_3">
+            <div id="div_t3d_4">
+            </div>
+        </div>
+
+        <div id="div_s3d_1">
+            <div id="div_s3d_2">
+            </div>
+        </div>
+
+        <div id="div_r3d_1">
+            <div id="div_r3d_2">
+            </div>
+        </div>
+
+        <div id="div_r3d_3">
+            <div id="div_r3d_4">
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/ref/transform_3d_ref.html
+++ b/tests/ref/transform_3d_ref.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+            #div_t3d_1 {
+                position: absolute;
+                background-color: red;
+                top: 10px;
+                left: 10px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_t3d_2 {
+                position: absolute;
+                background-color: green;
+                top: 20px;
+                left: 20px;
+                width: 20px;
+                height: 20px;
+            }
+
+            #div_t3d_3 {
+                position: absolute;
+                background-color: red;
+                top: 10px;
+                left: 60px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_t3d_4 {
+                position: absolute;
+                background-color: green;
+                top: 20px;
+                left: 5px;
+                width: 20px;
+                height: 20px;
+            }
+
+            #div_s3d_1 {
+                position: absolute;
+                background-color: red;
+                top: 10px;
+                left: 110px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_s3d_2 {
+                position: absolute;
+                background-color: green;
+                top: 0;
+                left: 15px;
+                width: 10px;
+                height: 40px;
+            }
+
+            #div_r3d_1 {
+                position: absolute;
+                background-color: red;
+                top: 60px;
+                left: 10px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_r3d_2 {
+                position: absolute;
+                background-color: green;
+                top: 15px;
+                left: 5px;
+                width: 20px;
+                height: 10px;
+            }
+
+            #div_r3d_3 {
+                position: absolute;
+                background-color: red;
+                top: 60px;
+                left: 60px;
+                width: 40px;
+                height: 40px;
+            }
+
+            #div_r3d_4 {
+                position: absolute;
+                background-color: green;
+                top: 15px;
+                left: 5px;
+                width: 20px;
+                height: 10px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="div_t3d_1">
+            <div id="div_t3d_2">
+            </div>
+        </div>
+
+        <div id="div_t3d_3">
+            <div id="div_t3d_4">
+            </div>
+        </div>
+
+        <div id="div_s3d_1">
+            <div id="div_s3d_2">
+            </div>
+        </div>
+
+        <div id="div_r3d_1">
+            <div id="div_r3d_2">
+            </div>
+        </div>
+
+        <div id="div_r3d_3">
+            <div id="div_r3d_4">
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
- Add parser support for 3d transforms.
- Change ComputedMatrix to a representation that suits interpolation.
- Switch stacking contexts to use 4x4 matrices.

The transforms themselves are still converted to 2d and handled by azure for now, but this is a small standalone part that can be landed now to make it easier to review.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6214)

<!-- Reviewable:end -->
