### PR TITLE
Restrict output of getElementsByName to HTML elements

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1540,6 +1540,9 @@ impl<'a> DocumentMethods for JSRef<'a, Document> {
                 Some(element) => element,
                 None => return false,
             };
+            if element.namespace() != &ns!(HTML) {
+                return false;
+            }
             element.get_attribute(&ns!(""), &atom!("name")).root().map_or(false, |attr| {
                 // FIXME(https://github.com/rust-lang/rust/issues/23338)
                 let attr = attr.r();

--- a/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.html.ini
+++ b/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.html.ini
@@ -1,5 +1,0 @@
-[document.getElementsByName-namespace.html]
-  type: testharness
-  [getElementsByName and foreign namespaces]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.xhtml.ini
+++ b/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.xhtml.ini
@@ -1,5 +1,0 @@
-[document.getElementsByName-namespace.xhtml]
-  type: testharness
-  [getElementsByName and foreign namespaces]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes #1745 
Should I adjust the expected result of the corresponding wpt test cases?

html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.html
html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace.xhtml

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6231)

<!-- Reviewable:end -->
