### PR TITLE
CSS 'transformation: skew()' should take <angle> type as parameters

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -313,6 +313,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == text_transform_none_a.html text_transform_none_ref.html
 == text_transform_uppercase_a.html text_transform_uppercase_ref.html
 == transform_simple_a.html transform_simple_ref.html
+== transform_skew_a.html transform_skew_ref.html
 == transform_stacking_context_a.html transform_stacking_context_ref.html
 == upper_id_attr.html upper_id_attr_ref.html
 flaky_cpu,experimental == vertical-lr-blocks.html vertical-lr-blocks_ref.html

--- a/tests/ref/transform_skew_a.html
+++ b/tests/ref/transform_skew_a.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+div {
+    height: 150px;
+    width: 150px;
+}
+
+div>div {
+    background-color: blue;
+}
+
+.container {
+    border: 1px solid black;
+    margin: 20px;
+}
+
+.transformed1 {
+    transform: skewX(0.3rad);
+}
+
+.transformed2 {
+    transform: skewY(0.5rad);
+}
+
+.transformed3 {
+    transform: skew(0.3rad, 0.5rad);
+}
+</style>
+</head>
+<body>
+<p>
+<div class="container">
+    <div class="transformed1"></div>
+</div>
+</p>
+
+<p>
+<div class="container">
+    <div class="transformed2"></div>
+</div>
+</p>
+
+<p>
+<div class="container">
+    <div class="transformed3"></div>
+</div>
+</p>
+</body>
+</html>

--- a/tests/ref/transform_skew_ref.html
+++ b/tests/ref/transform_skew_ref.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+div {
+    height: 150px;
+    width: 150px;
+}
+
+div>div {
+    background-color: blue;
+}
+
+.container {
+    border: 1px solid black;
+    margin: 20px;
+}
+
+.transformed1_ref {
+    transform: matrix(1, 0, 0.3, 1, 0, 0);
+}
+
+.transformed2_ref {
+    transform: matrix(1, 0.5, 0, 1, 0, 0);
+}
+
+.transformed3_ref {
+    transform: matrix(1, 0.5, 0.3, 1, 0, 0);
+}
+
+</style>
+</head>
+<body>
+<p>
+<div class="container">
+    <div class="transformed1_ref"></div>
+</div>
+</p>
+
+<p>
+<div class="container">
+    <div class="transformed2_ref"></div>
+</div>
+</p>
+
+<p>
+<div class="container">
+    <div class="transformed3_ref"></div>
+</div>
+</p>
+</body>
+</html>


### PR DESCRIPTION
Current implementation is taking <number> type as parameter so skew()
does not work properly. Let the skew() to get <angle> as specification
described.

Fixes #6237.

r? @pcwalton 
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6238)

<!-- Reviewable:end -->
