### PR TITLE
Correct the calculation of rects for drawimage.

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -140,8 +140,8 @@ impl CanvasRenderingContext2D {
 
         // The source rectangle is the rectangle whose corners are the four points (sx, sy),
         // (sx+sw, sy), (sx+sw, sy+sh), (sx, sy+sh).
-        let source_rect = Rect(Point2D(sx, sy),
-                               Size2D(sw, sh));
+        let source_rect = Rect(Point2D(sx.min(sx+sw), sy.min(sy+sh)),
+                               Size2D(sw.abs(), sh.abs()));
 
         // When the source rectangle is outside the source image,
         // the source rectangle must be clipped to the source image
@@ -158,8 +158,8 @@ impl CanvasRenderingContext2D {
 
         // The destination rectangle is the rectangle whose corners are the four points (dx, dy),
         // (dx+dw, dy), (dx+dw, dy+dh), (dx, dy+dh).
-        let dest_rect = Rect(Point2D(dx, dy),
-                             Size2D(dest_rect_width_scaled, dest_rect_height_scaled));
+        let dest_rect = Rect(Point2D(dx.min(dx+dest_rect_width_scaled), dy.min(dy+dest_rect_height_scaled)),
+                             Size2D(dest_rect_width_scaled.abs(), dest_rect_height_scaled.abs()));
 
         let source_rect = Rect(Point2D(source_rect_clipped.origin.x,
                                      source_rect_clipped.origin.y),

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.negativedest.html]
-  type: testharness
-  [Negative destination width/height represents the correct rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.negativedir.html]
-  type: testharness
-  [Negative dimensions do not affect the direction of the image]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.negativesource.html]
-  type: testharness
-  [Negative source width/height represents the correct rectangle]
-    expected: FAIL
-


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
The source and destination rectangles have four points (x, y), (x+w, y), (x+w, y+h), (x, y+h), which doesn't mean rect(x, y, w, h).
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6239)

<!-- Reviewable:end -->
