### PR TITLE
WebGLRenderingContext getters and `getParameter`

### DIFF
--- a/components/canvas/webgl_paint_task.rs
+++ b/components/canvas/webgl_paint_task.rs
@@ -32,9 +32,15 @@ impl WebGLPaintTask {
         let context = try!(
             GLContext::create_offscreen_with_color_attachment(
                 size, attrs, ColorAttachmentType::TextureWithSurface));
+
+        // NOTE: As of right now this is always equal to the size parameter,
+        // but this doesn't have to be true. Firefox after failing with
+        // the requested size, tries with the nearest powers of two, for example.
+        let real_size = context.borrow_draw_buffer().unwrap().size();
+
         Ok(WebGLPaintTask {
-            size: size,
-            original_context_size: size,
+            size: real_size,
+            original_context_size: real_size,
             gl_context: context
         })
     }
@@ -64,10 +70,11 @@ impl WebGLPaintTask {
             CanvasWebGLMsg::ShaderSource(shader_id, source) => self.shader_source(shader_id, source),
             CanvasWebGLMsg::Uniform4fv(uniform_id, data) => self.uniform_4fv(uniform_id, data),
             CanvasWebGLMsg::UseProgram(program_id) => self.use_program(program_id),
-            CanvasWebGLMsg::VertexAttribPointer2f(attrib_id, size, normalized, stride, offset) => {
-                self.vertex_attrib_pointer_f32(attrib_id, size, normalized, stride, offset);
-            },
+            CanvasWebGLMsg::VertexAttribPointer2f(attrib_id, size, normalized, stride, offset) =>
+                self.vertex_attrib_pointer_f32(attrib_id, size, normalized, stride, offset),
             CanvasWebGLMsg::Viewport(x, y, width, height) => self.viewport(x, y, width, height),
+            CanvasWebGLMsg::DrawingBufferWidth(sender) => self.send_drawing_buffer_width(sender),
+            CanvasWebGLMsg::DrawingBufferHeight(sender) => self.send_drawing_buffer_height(sender),
         }
     }
 
@@ -100,6 +107,14 @@ impl WebGLPaintTask {
 
     fn get_context_attributes(&self, sender: Sender<GLContextAttributes>) {
         sender.send(*self.gl_context.borrow_attributes()).unwrap()
+    }
+
+    fn send_drawing_buffer_width(&self, sender: Sender<i32>) {
+        sender.send(self.size.width).unwrap()
+    }
+
+    fn send_drawing_buffer_height(&self, sender: Sender<i32>) {
+        sender.send(self.size.height).unwrap()
     }
 
     fn attach_shader(&self, program_id: u32, shader_id: u32) {
@@ -229,7 +244,7 @@ impl WebGLPaintTask {
         if size.width > self.original_context_size.width ||
            size.height > self.original_context_size.height {
             try!(self.gl_context.resize(size));
-            self.size = size;
+            self.size = self.gl_context.borrow_draw_buffer().unwrap().size();
         } else {
             self.size = size;
             unsafe { gl::Scissor(0, 0, size.width, size.height); }

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -90,6 +90,8 @@ pub enum CanvasWebGLMsg {
     UseProgram(u32),
     VertexAttribPointer2f(u32, i32, bool, i32, i64),
     Viewport(i32, i32, i32, i32),
+    DrawingBufferWidth(Sender<i32>),
+    DrawingBufferHeight(Sender<i32>),
 }
 
 #[derive(Clone)]

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -10,6 +10,7 @@ use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::{
 use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JS, JSRef, LayoutJS, Temporary};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
+use dom::bindings::conversions::ToJSValConvertible;
 use dom::htmlcanvaselement::{HTMLCanvasElement};
 use dom::webglbuffer::{WebGLBuffer, WebGLBufferHelpers};
 use dom::webglshader::{WebGLShader, WebGLShaderHelpers};
@@ -73,6 +74,38 @@ impl Drop for WebGLRenderingContext {
 }
 
 impl<'a> WebGLRenderingContextMethods for JSRef<'a, WebGLRenderingContext> {
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1
+    fn Canvas(self) -> Temporary<HTMLCanvasElement> {
+        Temporary::from_rooted(self.canvas)
+    }
+
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1
+    fn DrawingBufferWidth(self) -> i32 {
+        let (sender, receiver) = channel();
+        self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::DrawingBufferWidth(sender))).unwrap();
+        receiver.recv().unwrap()
+    }
+
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1
+    fn DrawingBufferHeight(self) -> i32 {
+        let (sender, receiver) = channel();
+        self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::DrawingBufferHeight(sender))).unwrap();
+        receiver.recv().unwrap()
+    }
+
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    fn GetParameter(self, cx: *mut JSContext, parameter: u32) -> JSVal {
+        // TODO(ecoal95): Implement the missing parameters from the spec
+        match parameter {
+            WebGLRenderingContextConstants::VERSION =>
+                DOMString::from_str("WebGL 1.0").to_jsval(cx),
+            WebGLRenderingContextConstants::RENDERER |
+            WebGLRenderingContextConstants::VENDOR =>
+                DOMString::from_str("Mozilla/Servo").to_jsval(cx),
+            _ => NullValue(),
+        }
+    }
+
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.2
     fn GetContextAttributes(self) -> Option<WebGLContextAttributes> {
         let (sender, receiver) = channel();

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -307,9 +307,9 @@ interface WebGLRenderingContextBase
     //const GLenum DECR_WRAP                      = 0x8508;
 
     /* StringName */
-    //const GLenum VENDOR                         = 0x1F00;
-    //const GLenum RENDERER                       = 0x1F01;
-    //const GLenum VERSION                        = 0x1F02;
+    const GLenum VENDOR                         = 0x1F00;
+    const GLenum RENDERER                       = 0x1F01;
+    const GLenum VERSION                        = 0x1F02;
 
     /* TextureMagFilter */
     //const GLenum NEAREST                        = 0x2600;
@@ -477,9 +477,9 @@ interface WebGLRenderingContextBase
     //const GLenum UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243;
     //const GLenum BROWSER_DEFAULT_WEBGL          = 0x9244;
 
-    //readonly attribute HTMLCanvasElement canvas;
-    //readonly attribute GLsizei drawingBufferWidth;
-    //readonly attribute GLsizei drawingBufferHeight;
+    readonly attribute HTMLCanvasElement canvas;
+    readonly attribute GLsizei drawingBufferWidth;
+    readonly attribute GLsizei drawingBufferHeight;
 
     [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     //[WebGLHandlesContextLoss] boolean isContextLost();
@@ -577,7 +577,7 @@ interface WebGLRenderingContextBase
     [WebGLHandlesContextLoss] GLint getAttribLocation(WebGLProgram? program, DOMString name);
 
     //any getBufferParameter(GLenum target, GLenum pname);
-    //any getParameter(GLenum pname);
+    any getParameter(GLenum pname);
 
     //[WebGLHandlesContextLoss] GLenum getError();
 

--- a/tests/html/test_webgl_context_get_parameter.html
+++ b/tests/html/test_webgl_context_get_parameter.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>WebGLRenderingContext getParameter test</title>
+<script>
+  var gl = document.createElement("canvas").getContext("webgl");
+
+  if ( typeof gl.getParameter !== "function" )
+      console.error("getParameter should be a function");
+
+  if ( gl.getParameter(gl.VERSION).indexOf("WebGL 1.0") !== 0 )
+      console.error("getParameter(VERSION) should return a string beginning with \"WebGL 1.0\"");
+</script>

--- a/tests/html/test_webgl_context_getters.html
+++ b/tests/html/test_webgl_context_getters.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>WebGLRenderingContext attributes test</title>
+<script>
+  var canvas = document.createElement('canvas'),
+      gl = canvas.getContext('webgl');
+
+  if ( gl.canvas !== canvas )
+      console.error("Expected a canvas getter");
+
+  if ( typeof gl.drawingBufferWidth !== "number" ||
+       typeof gl.drawingBufferHeight !== "number" )
+      console.error("drawingBuffer{Height/Width} should be numbers");
+</script>


### PR DESCRIPTION
This implements the `canvas`, `drawingBufferHeight` and `drawingBufferWidth` getters to `WebGLRenderingContext`, and an initial version of `getParameter`.

r? @jdm or @nox?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6240)

<!-- Reviewable:end -->
