### PR TITLE
Allow Window implementations to indicate that they don't support a clipboard.

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -135,4 +135,7 @@ pub trait WindowMethods {
 
     /// Process a key event.
     fn handle_key(&self, key: Key, mods: KeyModifiers);
+
+    /// Does this window support a clipboard
+    fn supports_clipboard(&self) -> bool;
 }

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -451,6 +451,10 @@ impl WindowMethods for Window {
             }
         }
     }
+
+    fn supports_clipboard(&self) -> bool {
+        true
+    }
 }
 
 struct CefCompositorProxy {

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -614,6 +614,10 @@ impl WindowMethods for Window {
             _ => {}
         }
     }
+
+    fn supports_clipboard(&self) -> bool {
+        true
+    }
 }
 
 /// The type of a window.
@@ -717,6 +721,10 @@ impl WindowMethods for Window {
 
     /// Helper function to handle keyboard events.
     fn handle_key(&self, _: Key, _: constellation_msg::KeyModifiers) {
+    }
+
+    fn supports_clipboard(&self) -> bool {
+        false
     }
 }
 

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -841,6 +841,10 @@ impl WindowMethods for Window {
     fn prepare_for_composite(&self, _width: usize, _height: usize) -> bool {
         true
     }
+
+    fn supports_clipboard(&self) -> bool {
+        true
+    }
 }
 
 struct GonkCompositorProxy {


### PR DESCRIPTION
This is important for the SERVO_HEADLESS configuration, because
creating a clipboard on linux creates an X context which then causes
reftest instability.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6248)

<!-- Reviewable:end -->
