### PR TITLE
Only count outline width in overflow calculation if outline style is active.

### DIFF
--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -294,13 +294,38 @@ pub mod longhands {
     </%self:longhand>
 
     <%self:longhand name="outline-width">
-        pub use super::border_top_width::get_initial_value;
-        pub type SpecifiedValue = specified::Length;
-        pub mod computed_value {
-            pub use util::geometry::Au as T;
+        use values::computed::{ToComputedValue, Context};
+        use util::geometry::Au;
+        use cssparser::ToCss;
+        use std::fmt;
+
+        impl ToCss for SpecifiedValue {
+            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+                self.0.to_css(dest)
+            }
         }
+
         pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-            specified::parse_border_width(input)
+            specified::parse_border_width(input).map(SpecifiedValue)
+        }
+        #[derive(Clone, PartialEq)]
+        pub struct SpecifiedValue(pub specified::Length);
+        pub mod computed_value {
+            use util::geometry::Au;
+            pub type T = Au;
+        }
+        pub use super::border_top_width::get_initial_value;
+        impl ToComputedValue for SpecifiedValue {
+            type ComputedValue = computed_value::T;
+
+            #[inline]
+            fn to_computed_value(&self, context: &Context) -> computed_value::T {
+                if !context.outline_style_present {
+                    Au(0)
+                } else {
+                    self.0.to_computed_value(context)
+                }
+            }
         }
     </%self:longhand>
 
@@ -4475,6 +4500,7 @@ pub mod shorthands {
 
     <%self:shorthand name="outline" sub_properties="outline-color outline-style outline-width">
         use values::specified;
+        use properties::longhands::outline_width;
 
         let _unused = context;
         let mut color = None;
@@ -4497,7 +4523,7 @@ pub mod shorthands {
                 }
             }
             if width.is_none() {
-                if let Ok(value) = input.try(specified::parse_border_width) {
+                if let Ok(value) = input.try(|input| outline_width::parse(context, input)) {
                     width = Some(value);
                     any = true;
                     continue
@@ -5499,6 +5525,7 @@ pub fn cascade(viewport_size: Size2D<Au>,
             border_right_present: false,
             border_bottom_present: false,
             border_left_present: false,
+            outline_style_present: false,
         }
     };
 
@@ -5569,13 +5596,20 @@ pub fn cascade(viewport_size: Size2D<Au>,
                 PropertyDeclaration::TextDecoration(ref value) => {
                     context.text_decoration = get_specified!(get_text, text_decoration, value);
                 }
+                PropertyDeclaration::OutlineStyle(ref value) => {
+                    context.outline_style_present =
+                        match get_specified!(get_outline, outline_style, value) {
+                            BorderStyle::none => false,
+                            _ => true,
+                        };
+                }
                 % for side in ["top", "right", "bottom", "left"]:
                     PropertyDeclaration::Border${side.capitalize()}Style(ref value) => {
                         context.border_${side}_present =
-                        match get_specified!(get_border, border_${side}_style, value) {
-                            BorderStyle::none | BorderStyle::hidden => false,
-                            _ => true,
-                        };
+                            match get_specified!(get_border, border_${side}_style, value) {
+                                BorderStyle::none | BorderStyle::hidden => false,
+                                _ => true,
+                            };
                     }
                 % endfor
                 _ => {}

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -920,7 +920,8 @@ pub mod computed {
         pub border_bottom_present: bool,
         pub border_left_present: bool,
         pub is_root_element: bool,
-        pub viewport_size: Size2D<Au>
+        pub viewport_size: Size2D<Au>,
+        pub outline_style_present: bool,
         // TODO, as needed: viewport size, etc.
     }
 

--- a/tests/ref/inline_block_stacking_context_a.html
+++ b/tests/ref/inline_block_stacking_context_a.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <link rel="stylesheet" type="text/css" href="css/ahem.css">
         <style type="text/css">
             * {
                 margin: 0;

--- a/tests/ref/inline_block_stacking_context_ref.html
+++ b/tests/ref/inline_block_stacking_context_ref.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <link rel="stylesheet" type="text/css" href="css/ahem.css">
         <style type="text/css">
             * {
                 margin: 0;


### PR DESCRIPTION
This fixes layers being created with a 3x3 overflow that's not needed.

This exposes https://github.com/servo/servo/issues/6250, so update the affected reftest to use ahem font until it is fixed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6251)

<!-- Reviewable:end -->
