### PR TITLE
Drop support for `box-sizing: padding-box`

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -347,10 +347,8 @@ impl CandidateBSizeIterator {
         };
 
         // If the style includes `box-sizing: border-box`, subtract the border and padding.
-        // If the style includes `box-sizing: padding-box`, subtract the border.
         let adjustment_for_box_sizing = match fragment.style.get_box().box_sizing {
             box_sizing::T::border_box => fragment.border_padding.block_start_end(),
-            box_sizing::T::padding_box => fragment.padding_width().block_start_end(),
             box_sizing::T::content_box => Au(0),
         };
 
@@ -2060,12 +2058,7 @@ pub trait ISizeAndMarginsComputer {
                 computed_inline_size =
                     MaybeAuto::Specified(size - block.fragment.border_padding.inline_start_end())
             }
-            (MaybeAuto::Specified(size), box_sizing::T::padding_box) => {
-                computed_inline_size =
-                    MaybeAuto::Specified(size - block.fragment.padding_width().inline_start_end())
-            }
             (MaybeAuto::Auto, box_sizing::T::border_box) |
-            (MaybeAuto::Auto, box_sizing::T::padding_box) |
             (_, box_sizing::T::content_box) => {}
         }
 

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -49,7 +49,7 @@ fn create_or_get_local_context(shared_layout_context: &SharedLayoutContext)
                 applicable_declarations_cache: ApplicableDeclarationsCache::new(),
                 style_sharing_candidate_cache: StyleSharingCandidateCache::new(),
             };
-            r.set(unsafe { boxed::into_raw(context) });
+            r.set(boxed::into_raw(context));
         } else if shared_layout_context.screen_size_changed {
             unsafe {
                 (*r.get()).applicable_declarations_cache.evict_all();

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1029,10 +1029,6 @@ impl Fragment {
         }
     }
 
-    pub fn padding_width(&self) -> LogicalMargin<Au> {
-        self.border_padding - self.border_width()
-    }
-
     /// Computes the margins in the inline direction from the containing block inline-size and the
     /// style. After this call, the inline direction of the `margin` field will be correct.
     ///

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -2176,7 +2176,7 @@ pub mod longhands {
     // http://dev.w3.org/csswg/css-ui/
     ${switch_to_style_struct("Box")}
 
-    ${single_keyword("box-sizing", "content-box padding-box border-box")}
+    ${single_keyword("box-sizing", "content-box border-box")}
 
     ${new_style_struct("Pointing", is_inherited=True)}
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -70,7 +70,6 @@ flaky_cpu == append_style_a.html append_style_b.html
 == box_shadow_paint_order_a.html box_shadow_paint_order_ref.html
 == box_shadow_spread_a.html box_shadow_spread_ref.html
 == box_sizing_border_box_a.html box_sizing_border_box_ref.html
-== box_sizing_padding_box_a.html box_sizing_padding_box_ref.html
 == box_sizing_sanity_check_a.html box_sizing_sanity_check_ref.html
 == br.html br-ref.html
 == canvas_as_block_element_a.html canvas_as_block_element_ref.html

--- a/tests/ref/box_sizing_padding_box_a.html
+++ b/tests/ref/box_sizing_padding_box_a.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-<div style="width: 256px; height: 256px; background: purple; border: 8px solid blue; padding: 10px; box-sizing: padding-box;"></div>
-<div style="width: 236px; height: 236px; background: purple; border: 8px solid blue; padding: 10px;"></div>
-</body>
-</html>

--- a/tests/ref/box_sizing_padding_box_ref.html
+++ b/tests/ref/box_sizing_padding_box_ref.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-<div style="width: 236px; height: 236px; background: purple; border: 8px solid blue; padding: 10px;"></div>
-<div style="width: 236px; height: 236px; background: purple; border: 8px solid blue; padding: 10px;"></div>
-</body>
-</html>


### PR DESCRIPTION
This reverts commit 945adab /  PR #6033.

The CSS Working Group resolved to drop this value from the spec:
http://log.csswg.org/irc.w3.org/css/2015-05-20/#e555680

The group was unable to come up with even a theoretical use case. Gecko only implemented this value for completeness. Other browsers vendors have clearly expressed they have no interest in implementing this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6258)

<!-- Reviewable:end -->
