### PR TITLE
Remove trailing whitespace on Python files

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -148,7 +148,7 @@ class MachCommands(CommandBase):
             if self.config["build"]["mode"] == "dev":
                 dev = True
             elif self.config["build"]["mode"] == "release":
-                release = True 
+                release = True
             elif release_exists and not dev_exists:
                 release = True
             elif dev_exists and not release_exists:
@@ -320,7 +320,7 @@ class MachCommands(CommandBase):
     @CommandArgument('--verbose', '-v',
                      action='store_true',
                      help='Print verbose output')
-    
+
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
     def clean(self, manifest_path, params, verbose=False):

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -39,10 +39,10 @@ class MachCommands(CommandBase):
         'params', default=None, nargs='...',
         help='Command-line arguments to be passed through to cargo update')
     @CommandArgument(
-        '--package', '-p', default=None, 
+        '--package', '-p', default=None,
         help='Updates selected package')
     @CommandArgument(
-        '--all-packages','-a',action='store_true', 
+        '--all-packages','-a',action='store_true',
         help='Updates all packages')
     def cargo_update(self, params=None, package=None, all_packages=None):
         self.update_cargo(params, package, all_packages)
@@ -54,10 +54,10 @@ class MachCommands(CommandBase):
         'params', default=None, nargs='...',
         help='Command-line arguments to be passed through to cargo update')
     @CommandArgument(
-        '--package','-p',default=None, 
+        '--package','-p',default=None,
         help='Updates selected package')
     @CommandArgument(
-        '--all-packages','-a',action='store_true', 
+        '--all-packages','-a',action='store_true',
         help='Updates all packages')
     def update_cargo(self, params=None, package=None, all_packages=None):
         if not params:
@@ -68,7 +68,7 @@ class MachCommands(CommandBase):
         elif all_packages:
             params = []
         else:
-            print("Please choose package to update with the --package (-p) ") 
+            print("Please choose package to update with the --package (-p) ")
             print("flag or update all packages with --all-packages (-a) flag")
             sys.exit(1)
 


### PR DESCRIPTION
Trailing whitespace was found using flake8

This is working towards making flake8 part of the tidy process: #6236

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6260)

<!-- Reviewable:end -->
