### PR TITLE
Support a system root with correct on-disk directory layout

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -167,12 +167,21 @@ class CommandBase(object):
         if not self.config["tools"]["system-rust"] \
                 or self.config["tools"]["rust-root"]:
             env["RUST_ROOT"] = self.config["tools"]["rust-root"]
+            # These paths are for when rust-root points to an unpacked installer
             extra_path += [path.join(self.config["tools"]["rust-root"], "rustc", "bin")]
             extra_lib += [path.join(self.config["tools"]["rust-root"], "rustc", "lib")]
+            # These paths are for when rust-root points to a rustc sysroot
+            extra_path += [path.join(self.config["tools"]["rust-root"], "bin")]
+            extra_lib += [path.join(self.config["tools"]["rust-root"], "lib")]
+
         if not self.config["tools"]["system-cargo"] \
                 or self.config["tools"]["cargo-root"]:
+            # This path is for when rust-root points to an unpacked installer
             extra_path += [
                 path.join(self.config["tools"]["cargo-root"], "cargo", "bin")]
+            # This path is for when rust-root points to a rustc sysroot
+            extra_path += [
+                path.join(self.config["tools"]["cargo-root"], "bin")]
 
         if extra_path:
             env["PATH"] = "%s%s%s" % (


### PR DESCRIPTION
The existing code for setting up the environment assumes that
the directory layout containing rust and cargo conforms to the
one used by rust-installer's tarballs. This makes overriding
the system root awkward for simple cases where I want to test
my own build directly from the rust build directory. This
patch just adds a second path to PATH and LD_LIBRARY_PATH
to accomodate both disk layouts.

Conflicts:
    python/servo/command_base.py

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6267)

<!-- Reviewable:end -->
