### PR TITLE
Run tidy everything in the tree, remove directory whitelist

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -15,7 +15,6 @@ import itertools
 import re
 from licenseck import licenses
 
-directories_to_check = ["ports", "components", "tests", "python"]
 filetypes_to_check = [".rs", ".rc", ".cpp", ".c", ".h", ".py"]
 reftest_directories = ["tests/ref"]
 reftest_filetype = ".list"
@@ -40,10 +39,15 @@ ignored_files = [
 
     # MIT license
     "components/util/deque/mod.rs",
+
+    # Hidden files/directories
+    ".*",
 ]
 
 
-def collect_file_names(top_directories):
+def collect_file_names(top_directories=None):
+    if top_directories is None:
+        top_directories = os.listdir(".")
     for top_directory in top_directories:
         for dirname, dirs, files in os.walk(top_directory):
             for basename in files:
@@ -142,7 +146,7 @@ def get_reftest_names(line):
 
 
 def scan():
-    all_files = collect_file_names(directories_to_check)
+    all_files = collect_file_names()
     files_to_check = filter(should_check, all_files)
 
     checking_functions = [check_license, check_by_line]


### PR DESCRIPTION
After #6268 merged, I found out that everything in the tree currently
passes the tidy checker.

---

It is worth pointing out that I personally do not know if this is a feature wanted by others. Once I noticed everything was already tidy, I decided to open this PR to start the conversation (if any). I am not convinced this is really a Good Thing, so my feelings would not get hurt if this was closed immediately.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6274)

<!-- Reviewable:end -->
