### PR TITLE
Better command-line error handling

### DIFF
--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -8,7 +8,7 @@
 #![feature(core)]
 #![feature(exit_status)]
 #![feature(optin_builtin_traits)]
-#![cfg_attr(not(target_os = "android"), feature(path_ext))]
+#![feature(path_ext)]
 #![feature(plugin)]
 #![feature(rustc_private)]
 #![feature(step_by)]

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -16,7 +16,9 @@ use std::collections::HashSet;
 use std::cmp;
 use std::env;
 use std::io::{self, Write};
+use std::fs::PathExt;
 use std::mem;
+use std::path::Path;
 use std::ptr;
 use url::{self, Url};
 
@@ -310,8 +312,14 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         let cwd = env::current_dir().unwrap();
         match Url::parse(url) {
             Ok(url) => url,
-            Err(url::ParseError::RelativeUrlWithoutBase)
-                => Url::from_file_path(&*cwd.join(url)).unwrap(),
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                if Path::new(url).exists() {
+                    Url::from_file_path(&*cwd.join(url)).unwrap()
+                } else {
+                    args_fail(&format!("File not found: {}", url));
+                    return false;
+                }
+            }
             Err(_) => panic!("URL parsing failed"),
         }
     };

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -80,6 +80,9 @@ class MachCommands(CommandBase):
 
         try:
             subprocess.check_call(args, env=env)
+        except subprocess.CalledProcessError as e:
+            print("Servo exited with return value %d" % e.returncode)
+            return e.returncode
         except OSError as e:
             if e.errno == 2:
                 print("Servo Binary can't be found! Run './mach build'"


### PR DESCRIPTION
- Don't hang silently when passed a non-existant file.
- Fix uncaught exception in `mach run` when Servo fails.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6285)

<!-- Reviewable:end -->
