### PR TITLE
Make LOCAL_CONTEXT_KEY safe and non-leaky.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -423,7 +423,7 @@ impl<'a> FlowConstructor<'a> {
         // for runs might collapse so much whitespace away that only hypothetical fragments
         // remain. In that case the inline flow will compute its ascent and descent to be zero.
         let scanned_fragments =
-            TextRunScanner::new().scan_for_runs(self.layout_context.font_context(),
+            TextRunScanner::new().scan_for_runs(&mut self.layout_context.font_context(),
                                                 fragments.fragments);
         let mut inline_flow_ref =
             FlowRef::new(box InlineFlow::from_fragments(scanned_fragments,
@@ -446,7 +446,7 @@ impl<'a> FlowConstructor<'a> {
 
 
             let (ascent, descent) =
-                inline_flow.compute_minimum_ascent_and_descent(self.layout_context.font_context(),
+                inline_flow.compute_minimum_ascent_and_descent(&mut self.layout_context.font_context(),
                                                                &**node.style());
             inline_flow.minimum_block_size_above_baseline = ascent;
             inline_flow.minimum_depth_below_baseline = descent;
@@ -1140,7 +1140,7 @@ impl<'a> FlowConstructor<'a> {
                             SpecificFragmentInfo::UnscannedText(
                                 UnscannedTextFragmentInfo::from_text(text))));
                         let marker_fragments = TextRunScanner::new().scan_for_runs(
-                            self.layout_context.font_context(),
+                            &mut self.layout_context.font_context(),
                             unscanned_marker_fragments);
                         debug_assert!(marker_fragments.len() == 1);
                         marker_fragments.fragments.into_iter().next()

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -856,7 +856,7 @@ impl Fragment {
                 self.border_box.size,
                 SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::from_text(
                         "…".to_owned()))));
-        let ellipsis_fragments = TextRunScanner::new().scan_for_runs(layout_context.font_context(),
+        let ellipsis_fragments = TextRunScanner::new().scan_for_runs(&mut layout_context.font_context(),
                                                                      unscanned_ellipsis_fragments);
         debug_assert!(ellipsis_fragments.len() == 1);
         ellipsis_fragments.fragments.into_iter().next().unwrap()
@@ -1005,7 +1005,7 @@ impl Fragment {
 
     pub fn calculate_line_height(&self, layout_context: &LayoutContext) -> Au {
         let font_style = self.style.get_font_arc();
-        let font_metrics = text::font_metrics_for_style(layout_context.font_context(), font_style);
+        let font_metrics = text::font_metrics_for_style(&mut layout_context.font_context(), font_style);
         text::line_height_from_style(&*self.style, &font_metrics)
     }
 
@@ -1819,7 +1819,7 @@ impl Fragment {
                 // See CSS 2.1 § 10.8.1.
                 let block_flow = info.flow_ref.as_immutable_block();
                 let font_style = self.style.get_font_arc();
-                let font_metrics = text::font_metrics_for_style(layout_context.font_context(),
+                let font_metrics = text::font_metrics_for_style(&mut layout_context.font_context(),
                                                                 font_style);
                 InlineMetrics::from_block_height(&font_metrics,
                                                  block_flow.base.position.size.block,

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -429,7 +429,7 @@ fn render_text(layout_context: &LayoutContext,
                                                              info));
     // FIXME(pcwalton): This should properly handle multiple marker fragments. This could happen
     // due to text run splitting.
-    let fragments = TextRunScanner::new().scan_for_runs(layout_context.font_context(), fragments);
+    let fragments = TextRunScanner::new().scan_for_runs(&mut layout_context.font_context(), fragments);
     debug_assert!(fragments.len() >= 1);
     fragments.fragments.into_iter().next().unwrap().specific
 }

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -312,7 +312,6 @@ impl LayoutTask {
         let reporter_name = format!("layout-reporter-{}", id.0);
         mem_profiler_chan.send(mem::ProfilerMsg::RegisterReporter(reporter_name.clone(), reporter));
 
-
         // Create the channel on which new animations can be sent.
         let (new_animations_sender, new_animations_receiver) = channel();
         let (image_cache_sender, image_cache_receiver) = channel();

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -106,7 +106,7 @@ impl Flow for ListItemFlow {
             marker.assign_replaced_block_size_if_necessary(containing_block_block_size);
 
             let font_metrics =
-                text::font_metrics_for_style(layout_context.font_context(),
+                text::font_metrics_for_style(&mut layout_context.font_context(),
                                              marker.style.get_font_arc());
             let line_height = text::line_height_from_style(&*marker.style, &font_metrics);
             let item_inline_metrics = InlineMetrics::from_font_metrics(&font_metrics, line_height);

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -154,7 +154,7 @@ impl<'a> PreorderDomTraversal for RecalcStyleForNode<'a> {
 
             // Check to see whether we can share a style with someone.
             let style_sharing_candidate_cache =
-                self.layout_context.style_sharing_candidate_cache();
+                &mut self.layout_context.style_sharing_candidate_cache();
             let sharing_result = unsafe {
                 node.share_style_if_possible(style_sharing_candidate_cache,
                                              parent_opt.clone())
@@ -181,7 +181,7 @@ impl<'a> PreorderDomTraversal for RecalcStyleForNode<'a> {
                         node.cascade_node(self.layout_context.shared,
                                           parent_opt,
                                           &applicable_declarations,
-                                          self.layout_context.applicable_declarations_cache(),
+                                          &mut self.layout_context.applicable_declarations_cache(),
                                           &self.layout_context.shared.new_animations_sender);
                     }
 


### PR DESCRIPTION
`LOCAL_CONTEXT_KEY` is currently a `Cell<*mut LocalLayoutContext>`. The use
of the raw pointer means that the `LocalLayoutContext` is not dropped when
the thread dies; this leaks FreeType instances and probably other
things. There are also some unsafe getter functions in `LayoutContext`
(`font_context`, `applicable_declarations_cache` and
`style_sharing_candidate_cache`) that @eddyb says involve undefined
behaviour.

This changeset changes `LOCAL_CONTEXT_KEY` to
`RefCell<Option<Rc<LocalLayoutContext>>>`. This fixes the leak and also
results in safe getters.

(Fixes #6282.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6289)

<!-- Reviewable:end -->
