### PR TITLE
Replace fill_color & stroke_color with fill_style & stroke_style in CanvasContextState.

### DIFF
--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -22,6 +22,7 @@ pub struct CanvasGradient {
 }
 
 #[jstraceable]
+#[derive(Clone)]
 pub enum CanvasGradientStyle {
     Linear(LinearGradientStyle),
     Radial(RadialGradientStyle),

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.stroke.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.stroke.html.ini
@@ -1,5 +1,0 @@
-[2d.gradient.interpolate.zerosize.stroke.html]
-  type: testharness
-  [Canvas test: 2d.gradient.interpolate.zerosize.stroke]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.strokeRect.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.strokeRect.html.ini
@@ -1,5 +1,0 @@
-[2d.gradient.interpolate.zerosize.strokeRect.html]
-  type: testharness
-  [Canvas test: 2d.gradient.interpolate.zerosize.strokeRect]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.compare.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.compare.html.ini
@@ -1,5 +1,0 @@
-[2d.gradient.object.compare.html]
-  type: testharness
-  [Canvas test: 2d.gradient.object.compare]
-    expected: FAIL
-


### PR DESCRIPTION
The fillStyle and strokeStyle attributes can be either strings(color), CanvasGradients, or CanvasPatterns.
The current implementation only considers strings(color).
r? @nox @jdm @pcwalton 
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6290)

<!-- Reviewable:end -->
