### PR TITLE
Convert inline(always) to inline in CodegenRust and jstraceable.

### DIFF
--- a/components/plugins/jstraceable.rs
+++ b/components/plugins/jstraceable.rs
@@ -50,7 +50,7 @@ pub fn expand_jstraceable(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, item: 
                 args: vec!(ty::Ptr(box ty::Literal(ty::Path::new(vec!("js","jsapi","JSTracer"))),
                                    ty::Raw(ast::MutMutable))),
                 ret_ty: ty::nil_ty(),
-                attributes: vec![quote_attr!(cx, #[inline(always)])],
+                attributes: vec![quote_attr!(cx, #[inline])],
                 is_unsafe: false,
                 combine_substructure: combine_substructure(box jstraceable_substructure)
             }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1887,7 +1887,7 @@ class CGAbstractMethod(CGThing):
     def _decorators(self):
         decorators = []
         if self.alwaysInline:
-            decorators.append('#[inline(always)]')
+            decorators.append('#[inline]')
 
         if self.extern:
             decorators.append('unsafe')
@@ -5478,7 +5478,7 @@ impl ${selfName} for ${baseName} {
             cast = [CGGeneric(string.Template("""\
 pub struct ${name}Cast;
 impl ${name}Cast {
-    #[inline(always)]
+    #[inline]
     pub fn to_ref<'a, T: ${toBound}+Reflectable>(base: JSRef<'a, T>) -> Option<JSRef<'a, ${name}>> {
         match base.${checkFn}() {
             true => Some(unsafe { mem::transmute(base) }),
@@ -5486,7 +5486,7 @@ impl ${name}Cast {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn to_borrowed_ref<'a, 'b, T: ${toBound}+Reflectable>(base: &'a JSRef<'b, T>) -> Option<&'a JSRef<'b, ${name}>> {
         match base.${checkFn}() {
             true => Some(unsafe { mem::transmute(base) }),
@@ -5494,7 +5494,7 @@ impl ${name}Cast {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     #[allow(unrooted_must_root)]
     pub fn to_layout_js<T: ${toBound}+Reflectable>(base: &LayoutJS<T>) -> Option<LayoutJS<${name}>> {
         unsafe {
@@ -5505,7 +5505,7 @@ impl ${name}Cast {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn to_temporary<T: ${toBound}+Reflectable>(base: Temporary<T>) -> Option<Temporary<${name}>> {
         match base.root().r().${checkFn}() {
             true => Some(unsafe { mem::transmute(base) }),
@@ -5513,28 +5513,28 @@ impl ${name}Cast {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn from_ref<'a, T: ${fromBound}+Reflectable>(derived: JSRef<'a, T>) -> JSRef<'a, ${name}> {
         unsafe { mem::transmute(derived) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn from_borrowed_ref<'a, 'b, T: ${fromBound}+Reflectable>(derived: &'a JSRef<'b, T>) -> &'a JSRef<'b, ${name}> {
         unsafe { mem::transmute(derived) }
     }
 
-    #[inline(always)]
+    #[inline]
     #[allow(unrooted_must_root)]
     pub fn from_layout_js<T: ${fromBound}+Reflectable>(derived: &LayoutJS<T>) -> LayoutJS<${name}> {
         unsafe { mem::transmute_copy(derived) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn from_temporary<T: ${fromBound}+Reflectable>(derived: Temporary<T>) -> Temporary<${name}> {
         unsafe { mem::transmute(derived) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn from_actual<'a, T: ${fromBound}+Reflectable>(derived: &'a T) -> &'a ${name} {
         unsafe { mem::transmute(derived) }
     }


### PR DESCRIPTION
This results in a 14% compile time improvement.

See https://gist.github.com/brson/b48dd03b06c406be68e6

I'm not suggesting you merge this as-is, but you might consider whether removing some of these is worth pursuing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6297)

<!-- Reviewable:end -->
