### PR TITLE
Avoid casting in the callers

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2165,11 +2165,11 @@ assert!(((*JS_GetClass(global)).flags & JSCLASS_DOM_GLOBAL) != 0);
 
 /* Check to see whether the interface objects are already installed */
 let proto_or_iface_array = get_proto_or_iface_array(global);
-let cached_object: *mut JSObject = *proto_or_iface_array.offset(%s as isize);
+let cached_object: *mut JSObject = (*proto_or_iface_array)[%s as usize];
 if cached_object.is_null() {
     let tmp: *mut JSObject = CreateInterfaceObjects(cx, global, receiver);
     assert!(!tmp.is_null());
-    *proto_or_iface_array.offset(%s as isize) = tmp;
+    (*proto_or_iface_array)[%s as usize] = tmp;
     tmp
 } else {
     cached_object

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -156,10 +156,10 @@ unsafe impl Sync for DOMJSClass {}
 
 /// Returns the ProtoOrIfaceArray for the given global object.
 /// Fails if `global` is not a DOM global object.
-pub fn get_proto_or_iface_array(global: *mut JSObject) -> *mut *mut JSObject {
+pub fn get_proto_or_iface_array(global: *mut JSObject) -> *mut ProtoOrIfaceArray {
     unsafe {
         assert!(((*JS_GetClass(global)).flags & JSCLASS_DOM_GLOBAL) != 0);
-        JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT).to_private() as *mut *mut JSObject
+        JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT).to_private() as *mut ProtoOrIfaceArray
     }
 }
 
@@ -330,7 +330,8 @@ pub unsafe extern fn throwing_constructor(cx: *mut JSContext, _argc: c_uint,
     return 0;
 }
 
-type ProtoOrIfaceArray = [*mut JSObject; PrototypeList::ID::Count as usize];
+/// An array of *mut JSObject of size PrototypeList::ID::Count
+pub type ProtoOrIfaceArray = [*mut JSObject; PrototypeList::ID::Count as usize];
 
 /// Construct and cache the ProtoOrIfaceArray for the given global.
 /// Fails if the argument is not a DOM global.
@@ -594,12 +595,12 @@ pub fn create_dom_global(cx: *mut JSContext, class: *const JSClass)
 /// Drop the resources held by reserved slots of a global object
 pub unsafe fn finalize_global(obj: *mut JSObject) {
     let _: Box<ProtoOrIfaceArray> =
-        Box::from_raw(get_proto_or_iface_array(obj) as *mut ProtoOrIfaceArray);
+        Box::from_raw(get_proto_or_iface_array(obj));
 }
 
 /// Trace the resources held by reserved slots of a global object
 pub unsafe fn trace_global(tracer: *mut JSTracer, obj: *mut JSObject) {
-    let array = get_proto_or_iface_array(obj) as *mut ProtoOrIfaceArray;
+    let array = get_proto_or_iface_array(obj);
     for &proto in (*array).iter() {
         if !proto.is_null() {
             trace_object(tracer, "prototype", proto);


### PR DESCRIPTION
get_proto_or_iface_array now returns *mut ProtoOrIfaceArray

Fix #6271

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6299)

<!-- Reviewable:end -->
