### PR TITLE
Preserve UserAgent header on redirect.

### DIFF
--- a/components/net/resource_task.rs
+++ b/components/net/resource_task.rs
@@ -259,7 +259,9 @@ impl ResourceManager {
             }
         }
 
-        self.user_agent.as_ref().map(|ua| load_data.headers.set(UserAgent(ua.clone())));
+        self.user_agent.as_ref().map(|ua| {
+            load_data.preserved_headers.set(UserAgent(ua.clone()));
+        });
 
         fn from_factory(factory: fn(LoadData, LoadConsumer, Arc<MIMEClassifier>))
                         -> Box<FnBox(LoadData, LoadConsumer, Arc<MIMEClassifier>) + Send> {

--- a/tests/wpt/harness/wptrunner/executors/executorservo.py
+++ b/tests/wpt/harness/wptrunner/executors/executorservo.py
@@ -62,7 +62,9 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
         self.result_data = None
         self.result_flag = threading.Event()
 
-        debug_args, command = browser_command(self.binary, ["--cpu", "--hard-fail", "-z", self.test_url(test)],
+        debug_args, command = browser_command(self.binary, ["--cpu", "--hard-fail", "-z",
+                                                            "-u", "Servo/wptrunner",
+                                                            self.test_url(test)],
                                               self.debug_info)
 
         self.command = command

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -25117,7 +25117,16 @@
   },
   "local_changes": {
     "deleted": [],
-    "items": {},
+    "items": {
+      "testharness": {
+        "XMLHttpRequest/preserve-ua-header-on-redirect.htm": [
+          {
+            "path": "XMLHttpRequest/preserve-ua-header-on-redirect.htm",
+            "url": "/XMLHttpRequest/preserve-ua-header-on-redirect.htm"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/preserve-ua-header-on-redirect.htm
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/preserve-ua-header-on-redirect.htm
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: User-Agent header is preserved on redirect</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var ua = "Servo/wptrunner";
+      var test = async_test()
+      test.step(function() {
+        var client = new XMLHttpRequest()
+          client.onreadystatechange = function() {
+            test.step(function() {
+              if(client.readyState == 4) {
+                assert_equals(client.responseText, "user-agent,")
+                test.done()
+              }
+            })
+          }
+        client.open("POST", "resources/redirect.py?location="+encodeURIComponent("inspect-headers.py?filter_value="+ua))
+        client.send(null)
+      })
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This unblocks facebook.com's feed, after a few months of it being accidentally broken.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6302)

<!-- Reviewable:end -->
