### PR TITLE
Use <base> in resolving url attributes (like "href").

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -10,6 +10,7 @@ use dom::attr::AttrValue;
 use dom::namednodemap::NamedNodeMap;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
+use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::ElementBinding;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -1061,6 +1062,9 @@ impl<'a> AttributeHandlers for JSRef<'a, Element> {
         let url = self.get_string_attribute(local_name);
         let doc = document_from_node(self).root();
         let base = doc.r().url();
+        let base = doc.r().QuerySelector("base".to_owned()).unwrap().map_or(base, |base| {
+            UrlParser::new().parse(&base.root().r().get_string_attribute(&atom!("href"))).unwrap()
+        });
         // https://html.spec.whatwg.org/multipage/#reflect
         // XXXManishearth this doesn't handle `javascript:` urls properly
         match UrlParser::new().base_url(&base).parse(&url) {


### PR DESCRIPTION
This allows polymer demos to load. For example, [paper-buttons](https://elements.polymer-project.org/bower_components/paper-button/demo/index.html):
![image](https://cloud.githubusercontent.com/assets/77424/8022084/f24e86e8-0cc5-11e5-81b7-23f7249bcf73.png)

Running the demo also requires the following userscript:

``` js
(function(window) {
    // Work around the fact that this userscript is inserted into
    // *every* single HTML <link rel="import"> document (fragment?).
    if(window.servoPolyfillLoaded)
        return;
    window.servoPolyfillLoaded = true;

    // Stubbed SVG "support".
    var Element = window.Element;

    function SVGElement() {
        Element.apply(this, arguments);
    }
    SVGElement.prototype = Object.create(Element.prototype);
    SVGElement.prototype.constructor = SVGElement;
    SVGElement.prototype.style = {};
    window.SVGElement = SVGElement;

    var createElementNS = document.createElementNS;
    document.createElementNS = function(ns, tag) {
        var e = createElementNS.apply(this, arguments);
        if(ns === 'http://www.w3.org/2000/svg') {
            e.__proto__ = SVGElement.prototype;
        }
        return e;
    };

    // Event bubbling from document to window.
    var dispatchEvent = window.dispatchEvent;
    var Event = window.Event;
    ['DOMContentLoaded', 'HTMLImportsLoaded', 'WebComponentsReady'].forEach(function(type) {
        document.addEventListener(type, function(ev) {
            dispatchEvent.call(window, new Event(type));
        });
    });

    // Hacky style info for ripples.
    window.getComputedStyle = function(e) {
        return {color: e.parentNode.classList.contains('colorful') ? '#4285F4' : 'black'};
    };

    // Servo shouldn't advertise <template> if it's not supported.
    window.HTMLTemplateElement = undefined;

    // Send "load" events to <style> elements as needed.
    addEventListener('DOMContentLoaded', function() {
        setInterval(function triggerLoad() {
            [].forEach.call(this.querySelectorAll('style'), function(e) {
                if(!e.servoStyleLoaded) {
                    e.servoStyleLoaded = true;
                    e.dispatchEvent(new Event('load'));
                }
            });
        }.bind(document), 100);
    });
})(this);
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6303)

<!-- Reviewable:end -->
