### PR TITLE
script: Make `PartialEq` on element type IDs generate a lot less code.

### DIFF
--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -36,6 +36,7 @@ use string_cache::Atom;
 
 use std::borrow::ToOwned;
 use std::default::Default;
+use std::intrinsics;
 
 #[dom_struct]
 pub struct HTMLElement {
@@ -303,7 +304,7 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLElement> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[jstraceable]
 pub enum HTMLElementTypeId {
     HTMLElement,
@@ -372,5 +373,27 @@ pub enum HTMLElementTypeId {
     HTMLTrackElement,
     HTMLUListElement,
     HTMLUnknownElement,
+}
+
+impl PartialEq for HTMLElementTypeId {
+    #[inline]
+    #[allow(unsafe_code)]
+    fn eq(&self, other: &HTMLElementTypeId) -> bool {
+        match (*self, *other) {
+            (HTMLElementTypeId::HTMLMediaElement(this_type),
+             HTMLElementTypeId::HTMLMediaElement(other_type)) => {
+                this_type == other_type
+            }
+            (HTMLElementTypeId::HTMLTableCellElement(this_type),
+             HTMLElementTypeId::HTMLTableCellElement(other_type)) => {
+                this_type == other_type
+            }
+            (_, _) => {
+                unsafe {
+                    intrinsics::discriminant_value(self) == intrinsics::discriminant_value(other)
+                }
+            }
+        }
+    }
 }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -42,10 +42,17 @@ impl HTMLMediaElement {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[jstraceable]
 pub enum HTMLMediaElementTypeId {
-    HTMLAudioElement,
-    HTMLVideoElement,
+    HTMLAudioElement = 0,
+    HTMLVideoElement = 1,
+}
+
+impl PartialEq for HTMLMediaElementTypeId {
+    #[inline]
+    fn eq(&self, other: &HTMLMediaElementTypeId) -> bool {
+        (*self as u8) == (*other as u8)
+    }
 }
 

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -23,11 +23,18 @@ use std::cmp::max;
 
 const DEFAULT_COLSPAN: u32 = 1;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[jstraceable]
 pub enum HTMLTableCellElementTypeId {
-    HTMLTableDataCellElement,
-    HTMLTableHeaderCellElement,
+    HTMLTableDataCellElement = 0,
+    HTMLTableHeaderCellElement = 1,
+}
+
+impl PartialEq for HTMLTableCellElementTypeId {
+    #[inline]
+    fn eq(&self, other: &HTMLTableCellElementTypeId) -> bool {
+        (*self as u8) == (*other as u8)
+    }
 }
 
 #[dom_struct]
@@ -143,3 +150,4 @@ impl<'a> VirtualMethods for JSRef<'a, HTMLTableCellElement> {
         }
     }
 }
+


### PR DESCRIPTION
This makes the difference between selector matching scaling on the ARM
Cortex-A9 and not, because the auto-derived `PartialEq` implementation
blows out the 32KB I-cache. With this change, there is a 2x improvement
in selector matching over sequential when using all 8 cores. (More work
needs to be done; this is a start.)

r? any DOM expert

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6308)

<!-- Reviewable:end -->
