### PR TITLE
Remove null_str_as_empty and null_str_as_empty_ref functions.

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -53,7 +53,7 @@ use parse::html::parse_html_fragment;
 use script_traits::UntrustedNodeAddress;
 use util::geometry::Au;
 use util::namespace;
-use util::str::{DOMString, null_str_as_empty};
+use util::str::DOMString;
 use selectors::parser::{Selector, AttrSelector, NamespaceConstraint};
 use selectors::parser::parse_author_origin_selector_list_from_str;
 use selectors::matching::matches;
@@ -2078,7 +2078,7 @@ impl<'a> NodeMethods for JSRef<'a, Node> {
 
     // https://dom.spec.whatwg.org/#dom-node-textcontent
     fn SetTextContent(self, value: Option<DOMString>) {
-        let value = null_str_as_empty(&value);
+        let value = value.unwrap_or(String::new());
         match self.type_id {
             NodeTypeId::DocumentFragment |
             NodeTypeId::Element(..) => {

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -19,22 +19,6 @@ pub type DOMString = String;
 pub type StaticCharVec = &'static [char];
 pub type StaticStringVec = &'static [&'static str];
 
-pub fn null_str_as_empty(s: &Option<DOMString>) -> DOMString {
-    // We don't use map_default because it would allocate "".to_owned() even
-    // for Some.
-    match *s {
-        Some(ref s) => s.clone(),
-        None => "".to_owned()
-    }
-}
-
-pub fn null_str_as_empty_ref<'a>(s: &'a Option<DOMString>) -> &'a str {
-    match *s {
-        Some(ref s) => s,
-        None => ""
-    }
-}
-
 /// Whitespace as defined by HTML5 § 2.4.1.
 // TODO(SimonSapin) Maybe a custom Pattern can be more efficient?
 const WHITESPACE: &'static [char] = &[' ', '\t', '\x0a', '\x0c', '\x0d'];


### PR DESCRIPTION
With just one caller between the two functions, there doesn't seem to be
much point in having the abstraction.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6320)

<!-- Reviewable:end -->
