### PR TITLE
Ignore CollectReport messages when shutting down the LayoutTask.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -601,9 +601,11 @@ impl LayoutTask {
                     self.exit_now(possibly_locked_rw_data, exit_type);
                     break
                 }
+                Msg::CollectReports(_) => {
+                    // Just ignore these messages at this point.
+                }
                 _ => {
-                    panic!("layout: message that wasn't `ExitNow` received after \
-                           `PrepareToExitMsg`")
+                    panic!("layout: unexpected message received after `PrepareToExitMsg`")
                 }
             }
         }


### PR DESCRIPTION
Prior to this change, a panic would occur if a CollectReport message was
received while the LayoutTask was shutting down. Now it just gets
ignored.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6335)

<!-- Reviewable:end -->
