### PR TITLE
Appease Github's Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/* linguist-vendored


### PR DESCRIPTION
According to #6332, Github's Linguist reported Servo as being
written in HTML instead of Rust. This fixes that by overriding
the linguist-vendored attribute for the tests directory.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6336)

<!-- Reviewable:end -->
