### PR TITLE
WebSocket constructor should not panic

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -141,7 +141,16 @@ impl WebSocket {
 
         // TODO Client::connect does not conform to RFC 6455
         // see https://github.com/cyderize/rust-websocket/issues/38
-        let request = Client::connect(parsed_url).unwrap();
+        let request = match Client::connect(parsed_url) {
+            Ok(request) => request,
+            Err(_) => {
+                let global_root = ws_root.global.root();
+                let address = Trusted::new(global_root.r().get_cx(), ws_root, global_root.r().script_chan().clone());
+                let task = box WebSocketTaskHandler::new(address, WebSocketTask::Close);
+                global_root.r().script_chan().send(ScriptMsg::RunnableMsg(task)).unwrap();
+                return Ok(Temporary::from_rooted(ws_root));
+            }
+        };
         let response = request.send().unwrap();
         response.validate().unwrap();
         ws_root.ready_state.set(WebSocketRequestState::Open);

--- a/tests/wpt/metadata/FileAPI/progress.html.ini
+++ b/tests/wpt/metadata/FileAPI/progress.html.ini
@@ -1,3 +1,6 @@
 [progress.html]
   type: testharness
   expected: TIMEOUT
+  [W3C WebSocket API - Create WebSocket - Pass a URL with a non ws/wss scheme - SYNTAX_ERR is thrown]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/Create-Secure-blocked-port.htm.ini
+++ b/tests/wpt/metadata/websockets/Create-Secure-blocked-port.htm.ini
@@ -1,3 +1,5 @@
 [Create-Secure-blocked-port.htm]
   type: testharness
-  expected: TIMEOUT
+  [W3C WebSocket API - Create Secure WebSocket - Pass a URL with a blocked port - SECURITY_ERR should be thrown]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/constructor/004.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/004.html.ini
@@ -1,3 +1,485 @@
 [004.html]
   type: testharness
-  expected: TIMEOUT
+  [WebSockets: new WebSocket(url, invalid protocol)]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 1]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 2]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 3]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 4]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 5]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 6]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 7]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 8]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 9]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 10]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 11]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 12]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 13]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 14]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 15]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 16]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 17]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 18]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 19]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 20]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 21]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 22]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 23]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 24]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 25]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 26]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 27]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 28]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 29]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 30]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 31]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 32]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 33]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 34]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 35]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 36]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 37]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 38]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 39]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 40]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 41]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 42]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 43]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 44]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 45]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 46]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 47]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 48]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 49]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 50]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 51]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 52]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 53]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 54]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 55]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 56]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 57]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 58]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 59]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 60]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 61]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 62]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 63]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 64]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 65]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 66]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 67]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 68]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 69]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 70]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 71]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 72]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 73]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 74]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 75]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 76]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 77]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 78]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 79]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 80]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 81]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 82]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 83]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 84]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 85]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 86]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 87]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 88]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 89]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 90]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 91]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 92]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 93]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 94]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 95]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 96]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 97]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 98]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 99]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 100]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 101]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 102]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 103]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 104]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 105]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 106]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 107]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 108]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 109]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 110]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 111]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 112]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 113]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 114]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 115]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 116]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 117]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 118]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 119]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 120]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 121]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 122]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 123]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 124]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 125]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 126]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 127]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 128]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 129]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 130]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 131]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 132]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 133]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 134]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 135]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 136]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 137]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 138]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 139]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 140]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 141]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 142]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 143]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 144]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 145]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 146]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 147]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 148]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 149]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 150]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 151]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 152]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 153]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 154]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 155]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 156]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 157]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 158]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 159]
+    expected: FAIL
+
+  [WebSockets: new WebSocket(url, invalid protocol) 160]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/constructor/005.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/constructor/007.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/007.html.ini
@@ -1,3 +1,5 @@
 [007.html]
   type: testharness
-  expected: TIMEOUT
+  [WebSockets: new WebSocket(url, null char)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/constructor/008.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/008.html.ini
@@ -1,3 +1,0 @@
-[008.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/constructor/017.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/017.html.ini
@@ -1,3 +1,0 @@
-[017.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/constructor/021.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/021.html.ini
@@ -1,3 +1,5 @@
 [021.html]
   type: testharness
-  expected: TIMEOUT
+  [WebSockets: Same sub protocol twice]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-getter.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-getter.html.ini
@@ -1,3 +1,0 @@
-[bufferedAmount-defineProperty-getter.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-setter.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-setter.html.ini
@@ -1,3 +1,0 @@
-[bufferedAmount-defineProperty-setter.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/010.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/010.html.ini
@@ -1,3 +1,5 @@
 [010.html]
   type: testharness
-  expected: TIMEOUT
+  [WebSockets: setting event handlers to undefined 3]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/011.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/011.html.ini
@@ -1,3 +1,5 @@
 [011.html]
   type: testharness
-  expected: TIMEOUT
+  [onmessage]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/012.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/012.html.ini
@@ -1,3 +1,5 @@
 [012.html]
   type: testharness
-  expected: TIMEOUT
+  [onmessage]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/013.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/013.html.ini
@@ -1,3 +1,11 @@
 [013.html]
   type: testharness
-  expected: TIMEOUT
+  [onclose]
+    expected: FAIL
+
+  [onopen]
+    expected: FAIL
+
+  [onerror]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/014.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/014.html.ini
@@ -1,3 +1,0 @@
-[014.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/020.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/020.html.ini
@@ -1,3 +1,6 @@
 [020.html]
   type: testharness
   expected: TIMEOUT
+  [WebSockets: error events]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/extensions/001.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/extensions/001.html.ini
@@ -1,3 +1,5 @@
 [001.html]
   type: testharness
-  expected: TIMEOUT
+  [WebSockets: getting extensions in connecting]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/protocol/protocol-initial.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/protocol/protocol-initial.html.ini
@@ -1,3 +1,5 @@
 [protocol-initial.html]
   type: testharness
-  expected: TIMEOUT
+  [WebSockets: getting protocol in connecting]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/004.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/004.html.ini
@@ -1,3 +1,0 @@
-[004.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/005.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/url/005.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/url/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/url/006.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/url/006.html.ini
@@ -1,3 +1,0 @@
-[006.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -539,6 +539,12 @@
             "url": "/_mozilla/mozilla/union.html"
           }
         ],
+        "mozilla/websocket_connection_fail.html": [
+          {
+            "path": "mozilla/websocket_connection_fail.html",
+            "url": "/_mozilla/mozilla/websocket_connection_fail.html"
+          }
+        ],
         "mozilla/window.html": [
           {
             "path": "mozilla/window.html",

--- a/tests/wpt/mozilla/tests/mozilla/websocket_connection_fail.html
+++ b/tests/wpt/mozilla/tests/mozilla/websocket_connection_fail.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async_test(function() {
+  var onclose = 0;
+  var ws = new WebSocket("ws://wrong_url");
+
+  ws.onclose = this.step_func_done(function(ev) {
+      onclose++;
+      assert_equals(onclose, 1);
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Make an early return when the WebSocket connection fails in the constructor.
Also let the WebSockect connection to be closed when the connection could
not be established.

Fixes #6082.
Fixes #6086.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6338)

<!-- Reviewable:end -->
