### PR TITLE
Switch from let to var in mozilla wpt tests

### DIFF
--- a/tests/wpt/mozilla/tests/mozilla/DOMParser.html
+++ b/tests/wpt/mozilla/tests/mozilla/DOMParser.html
@@ -5,7 +5,7 @@
 <script>
 test(function() {
   assert_equals(String(DOMParser).indexOf("function DOMParser("), 0);
-  let parser = new DOMParser();
+  var parser = new DOMParser();
   assert_true(parser instanceof DOMParser, "Should be DOMParser");
   assert_true(parser.parseFromString("", "text/html") instanceof Document, "Should be Document");
 });

--- a/tests/wpt/mozilla/tests/mozilla/Event.html
+++ b/tests/wpt/mozilla/tests/mozilla/Event.html
@@ -6,7 +6,7 @@
 test(function() {
   assert_equals(String(Event).indexOf("function Event("), 0);
 
-  let ev = new Event("foopy", {cancelable: true});
+  var ev = new Event("foopy", {cancelable: true});
   assert_true(ev instanceof Event, "Should be Event");
 
   assert_equals(ev.type, 'foopy');

--- a/tests/wpt/mozilla/tests/mozilla/MouseEvent.html
+++ b/tests/wpt/mozilla/tests/mozilla/MouseEvent.html
@@ -6,7 +6,7 @@
 test(function() {
   assert_equals(String(MouseEvent).indexOf("function MouseEvent("), 0);
 
-  let ev = new MouseEvent("press", {bubbles: true, screenX: 150, detail: 100});
+  var ev = new MouseEvent("press", {bubbles: true, screenX: 150, detail: 100});
 
   assert_true(ev instanceof Event, "Should be Event");
   assert_true(ev instanceof UIEvent, "Should be UIEvent");

--- a/tests/wpt/mozilla/tests/mozilla/document_body.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_body.html
@@ -12,23 +12,23 @@
             }, "existing document's body");
 
             test(function() {
-                let new_body = document.createElement("body");
+                var new_body = document.createElement("body");
                 assert_not_equals(new_body, null, "test2-0, replace document's body with new body");
                 document.body = new_body;
                 assert_equals(new_body, document.body, "test2-1, replace document's body with new body");
             }, "replace document's body with new body");
 
             test(function() {
-                let new_frameset = document.createElement("frameset");
+                var new_frameset = document.createElement("frameset");
                 assert_not_equals(new_frameset, null, "test2-0, replace document's body with new frameset");
                 document.body = new_frameset;
                 assert_equals(new_frameset, document.body, "test2-1, replace document's body with new frameset");
             }, "replace document's body with new frameset");
 
             test(function() {
-                let new_document = new Document();
+                var new_document = new Document();
                 new_document.appendChild(new_document.createElement("html"));
-                let new_div = new_document.createElement("div");
+                var new_div = new_document.createElement("div");
 
                 assert_not_equals(new_div, null, "test4-0, append an invalid element to a new document");
 
@@ -39,8 +39,8 @@
             }, "append an invalid element to a new document");
 
             test(function() {
-                let new_document = document.implementation.createHTMLDocument();
-                let new_body = new_document.createElement("body");
+                var new_document = document.implementation.createHTMLDocument();
+                var new_body = new_document.createElement("body");
 
                 assert_not_equals(new_body, null, "test5-0, append body to a new document");
                 assert_true(new_body instanceof HTMLBodyElement, "test5-1, append body to a new document: should be HTMLBodyElement");
@@ -51,8 +51,8 @@
             }, "append body to a new document");
 
             test(function() {
-                let new_document = document.implementation.createHTMLDocument();
-                let new_frameset = new_document.createElement("frameset");
+                var new_document = document.implementation.createHTMLDocument();
+                var new_frameset = new_document.createElement("frameset");
 
                 assert_not_equals(new_frameset, null, "test6-0, append frameset to a new document");
                 assert_true(new_frameset instanceof HTMLFrameSetElement, "test6-1, append frameset to a new document: should be HTMLFrameSetElement");

--- a/tests/wpt/mozilla/tests/mozilla/document_getElementById.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_getElementById.html
@@ -8,17 +8,17 @@
   <div id="bar"></div>
   <script>
   test(function() {
-    let gBody = document.getElementsByTagName("body")[0];
+    var gBody = document.getElementsByTagName("body")[0];
 
     // Test the assertion with inserting node with child having id into the document (mozilla#2630)
     // This need not to port to WPF-test because this tests servo's internally flags.
     {
-      let TEST_ID = "test-9";
-      let a = document.createElement("a");
-      let b = document.createElement("b");
+      var TEST_ID = "test-9";
+      var a = document.createElement("a");
+      var b = document.createElement("b");
       a.appendChild(b).id = TEST_ID;
       gBody.appendChild(a);
-      let result = document.getElementById(TEST_ID);
+      var result = document.getElementById(TEST_ID);
       assert_equals(result, b, "test 9-0");
     }
   });

--- a/tests/wpt/mozilla/tests/mozilla/document_getElementsByName.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_getElementsByName.html
@@ -8,7 +8,7 @@
   <div name="foo"></div>
   <script>
   test(function() {
-    let nameList = document.getElementsByName("foo");
+    var nameList = document.getElementsByName("foo");
     assert_true(nameList instanceof NodeList, "Should be NodeList");
     assert_false(nameList instanceof HTMLCollection, "Should not be HTMLCollection");
   });

--- a/tests/wpt/mozilla/tests/mozilla/document_head.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_head.html
@@ -12,9 +12,9 @@
             }, "existing document's head");
 
             test(function() {
-                let new_document = new Document();
+                var new_document = new Document();
                 new_document.appendChild(new_document.createElement("html"));
-                let new_head = new_document.createElement("head");
+                var new_head = new_document.createElement("head");
 
                 assert_not_equals(new_head, null, "test2-0, append head to a new document");
                 assert_true(new_head instanceof HTMLHeadElement, "test2-1, append head to a new document: should be HTMLHeadElement");
@@ -29,10 +29,10 @@
             }, "append head to a new document");
 
             test(function() {
-                let new_document = new Document();
-                let html = new_document.createElement("html");
-                let foo = new_document.createElement("foo");
-                let head = new_document.createElement("head");
+                var new_document = new Document();
+                var html = new_document.createElement("html");
+                var foo = new_document.createElement("foo");
+                var head = new_document.createElement("head");
                 new_document.appendChild(html);
                 html.appendChild(foo);
                 foo.appendChild(head);

--- a/tests/wpt/mozilla/tests/mozilla/element_attribute.html
+++ b/tests/wpt/mozilla/tests/mozilla/element_attribute.html
@@ -7,28 +7,28 @@
 <body>
   <div id="test" foo="bar"></div>
   <script>
-    let element = document.getElementById("test");
+    var element = document.getElementById("test");
 
     test(function() {
-      let r1 = element.getAttribute("id");
+      var r1 = element.getAttribute("id");
       assert_equals(r1, "test", "test1-0, Element.getAttribute().");
-      let r2 = element.getAttribute("foo");
+      var r2 = element.getAttribute("foo");
       assert_equals(r2, "bar", "test1-1, Element.getAttribute().");
     });
 
     test(function() {
-      let NAME  = "hoge";
-      let VALUE = "fuga";
+      var NAME  = "hoge";
+      var VALUE = "fuga";
       element.setAttribute(NAME, VALUE);
-      let r = element.getAttribute(NAME);
+      var r = element.getAttribute(NAME);
       assert_equals(r, VALUE, "test2. Element.setAttribute().");
     });
 
     test(function() {
-      let NAME = "foo";
-      let VALUE = "mozilla";
+      var NAME = "foo";
+      var VALUE = "mozilla";
       element.setAttribute(NAME, VALUE);
-      let r = element.getAttribute(NAME);
+      var r = element.getAttribute(NAME);
       assert_equals(r, VALUE, "test3, attribute update by Element.setAttribute().")
     });
 
@@ -36,18 +36,18 @@
       element.setAttribute("id", "bar");
       element.removeAttribute("id");
 
-      let r1 = element.hasAttribute("id");
+      var r1 = element.hasAttribute("id");
       assert_equals(r1, false, "test4-0, Element.removeAttribute().");
-      let r2 = element.getAttribute("id");
+      var r2 = element.getAttribute("id");
       assert_equals(r2, null, "test4-1, Element.removeAttribute().");
     });
 
     test(function() {
       element.setAttribute("xml:lang", "en");
 
-      let r1 = element.hasAttribute("xml:lang");
+      var r1 = element.hasAttribute("xml:lang");
       assert_equals(r1, true, "test5-0, Element.setAttribute('xml:lang').");
-      let r2 = element.getAttribute("xml:lang");
+      var r2 = element.getAttribute("xml:lang");
       assert_not_equals(r2, null, "test5-1, Element.setAttribute('xml:lang').");
     });
 

--- a/tests/wpt/mozilla/tests/mozilla/element_classList.html
+++ b/tests/wpt/mozilla/tests/mozilla/element_classList.html
@@ -6,10 +6,10 @@
         <script src="/resources/testharnessreport.js"></script>
         <script>
           test(function() {
-            let div = document.createElement("div");
+            var div = document.createElement("div");
             div.className = "foo bar";
 
-            let classList = div.classList;
+            var classList = div.classList;
             div.className = "";
 
             assert_equals(classList.item(0), null, "classList.item(0) must return null when all classes have been removed");

--- a/tests/wpt/mozilla/tests/mozilla/element_className.html
+++ b/tests/wpt/mozilla/tests/mozilla/element_className.html
@@ -9,19 +9,19 @@
         <div id="foo-2" class="baz"></div>
         <script>
           test(function() {
-            let foo1 = document.getElementById("foo-1");
-            let foo2 = document.getElementById("foo-2");
+            var foo1 = document.getElementById("foo-1");
+            var foo2 = document.getElementById("foo-2");
 
             foo1.className += " bar";
             assert_equals(foo1.className, "foo bar");
 
-            let foo3 = document.createElement("div");
+            var foo3 = document.createElement("div");
             foo3.id = "foo-3";
             foo3.className = "foo";
             document.body.appendChild(foo3);
             assert_equals(foo3, document.getElementById("foo-3"));
 
-            let collection = document.getElementsByClassName("foo");
+            var collection = document.getElementsByClassName("foo");
             assert_equals(collection.length, 2);
             assert_equals(collection[0].id, foo1.id);
             assert_equals(collection[1].id, foo3.id);

--- a/tests/wpt/mozilla/tests/mozilla/element_matches.html
+++ b/tests/wpt/mozilla/tests/mozilla/element_matches.html
@@ -9,7 +9,7 @@
 
   <script>
   test(function() {
-    let test = document.getElementById("foo");
+    var test = document.getElementById("foo");
 
     assert_equals(test.matches("#foo"), true, "test-1");
     assert_equals(test.matches("#not-foo"), false, "test-2");

--- a/tests/wpt/mozilla/tests/mozilla/htmlcollection.html
+++ b/tests/wpt/mozilla/tests/mozilla/htmlcollection.html
@@ -15,16 +15,16 @@
             <p id="p3" class="bbb ccc"/>
         </div>
         <script>
-            let foo1 = document.getElementById("foo-1");
-            let foo2 = document.getElementById("foo-2");
-            let bar = document.getElementById("bar");
-            let live = document.getElementById("live");
-            let child = document.createElement("p");
-            let p1 = document.getElementById("p1");
-            let p2 = document.getElementById("p2");
-            let p3 = document.getElementById("p3");
+            var foo1 = document.getElementById("foo-1");
+            var foo2 = document.getElementById("foo-2");
+            var bar = document.getElementById("bar");
+            var live = document.getElementById("live");
+            var child = document.createElement("p");
+            var p1 = document.getElementById("p1");
+            var p2 = document.getElementById("p2");
+            var p3 = document.getElementById("p3");
 
-            let htmlcollection = null;
+            var htmlcollection = null;
 
             test(function() {
                 htmlcollection = document.getElementsByClassName("foo");
@@ -50,7 +50,7 @@
                 assert_equals(htmlcollection.length, 1);
                 assert_equals(htmlcollection.item(0), live);
 
-                let new_live = document.createElement("div");
+                var new_live = document.createElement("div");
                 new_live.className = "live";
                 document.body.appendChild(new_live);
                 assert_equals(htmlcollection.length, 2);
@@ -74,7 +74,7 @@
                 htmlcollection = document.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "div");
                 assert_equals(htmlcollection.length, 5);
 
-                let from_element = document.documentElement.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "div");
+                var from_element = document.documentElement.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "div");
                 assert_equals(htmlcollection.length, from_element.length);
 
                 htmlcollection = document.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "DIV");
@@ -103,7 +103,7 @@
                 htmlcollection = document.getElementsByClassName("aaa,bbb");
                 assert_equals(htmlcollection.length, 0);
 
-                let from_element = document.getElementById("class-example").getElementsByClassName("bbb");
+                var from_element = document.getElementById("class-example").getElementsByClassName("bbb");
                 assert_equals(from_element.length, 2);
                 assert_equals(from_element.item(0), p1);
                 assert_equals(from_element.item(1), p3);

--- a/tests/wpt/mozilla/tests/mozilla/parentNode_querySelector.html
+++ b/tests/wpt/mozilla/tests/mozilla/parentNode_querySelector.html
@@ -11,7 +11,7 @@
         <div id="bar" class="myClass"></p>
         <script>
             test(function() {
-                let div = document.getElementById("foo");
+                var div = document.getElementById("foo");
                 assert_equals(document.querySelector("#foo"), div);
 
                 div = document.getElementById("foo\\bar");
@@ -26,8 +26,8 @@
             }, "Document");
 
             test(function() {
-                let body = document.body;
-                let div = document.getElementById("foo");
+                var body = document.body;
+                var div = document.getElementById("foo");
                 assert_equals(body.querySelector("#foo"), div);
 
                 div = document.getElementById("foo\\bar");
@@ -42,17 +42,17 @@
             }, "Element");
 
             test(function() {
-                let docfrag = document.createDocumentFragment();
+                var docfrag = document.createDocumentFragment();
 
-                let div = document.createElement("div");
+                var div = document.createElement("div");
                 div.id = "foo";
                 div.className = "myClass";
 
-                let child = document.createElement("div");
+                var child = document.createElement("div");
                 div.appendChild(child);
                 docfrag.appendChild(div);
 
-                let p = document.createElement("p");
+                var p = document.createElement("p");
                 p.id = "bar";
                 p.className = "myClass";
                 docfrag.appendChild(p);

--- a/tests/wpt/mozilla/tests/mozilla/parentNode_querySelectorAll.html
+++ b/tests/wpt/mozilla/tests/mozilla/parentNode_querySelectorAll.html
@@ -11,12 +11,12 @@
             <div id="baz" class="test"></div>
         </div>
         <script>
-            let foo = document.getElementById("foo");
-            let bar = document.getElementById("bar");
-            let baz = document.getElementById("baz");
+            var foo = document.getElementById("foo");
+            var bar = document.getElementById("bar");
+            var baz = document.getElementById("baz");
 
             test(function() {
-                let nodelist = document.querySelectorAll(".test");
+                var nodelist = document.querySelectorAll(".test");
                 assert_true(nodelist instanceof NodeList, "Should be NodeList");
                 assert_equals(nodelist.length, 3);
                 assert_equals(nodelist.item(0), foo);
@@ -28,8 +28,8 @@
             }, "Document");
 
             test(function() {
-                let div = document.getElementById("parent");
-                let nodelist = div.querySelectorAll(".test");
+                var div = document.getElementById("parent");
+                var nodelist = div.querySelectorAll(".test");
                 assert_equals(nodelist.length, 3);
 
                 nodelist = div.querySelectorAll("div:nth-of-type(1)");
@@ -37,17 +37,17 @@
             }, "Element");
 
             test(function() {
-                let docfrag = document.createDocumentFragment();
+                var docfrag = document.createDocumentFragment();
 
-                let div = document.createElement("div");
+                var div = document.createElement("div");
                 div.id = "foo";
                 div.className = "myClass";
 
-                let child = document.createElement("div");
+                var child = document.createElement("div");
                 div.appendChild(child);
                 docfrag.appendChild(div);
 
-                let nodelist = docfrag.querySelectorAll("#foo");
+                var nodelist = docfrag.querySelectorAll("#foo");
                 assert_equals(nodelist.item(0), div);
 
                 nodelist = docfrag.querySelectorAll("#foo:nth-child(1)");


### PR DESCRIPTION
let can't be used without specifying a newer JS version at the moment.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6339)

<!-- Reviewable:end -->
