### PR TITLE
Remove gfx_traits from the dependencies of [script].

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -268,7 +268,7 @@ impl<'a> CanvasPaintTask<'a> {
                             Canvas2dMsg::SetShadowOffsetX(value) => painter.set_shadow_offset_x(value),
                             Canvas2dMsg::SetShadowOffsetY(value) => painter.set_shadow_offset_y(value),
                             Canvas2dMsg::SetShadowBlur(value) => painter.set_shadow_blur(value),
-                            Canvas2dMsg::SetShadowColor(rgba) => painter.set_shadow_color(rgba),
+                            Canvas2dMsg::SetShadowColor(ref color) => painter.set_shadow_color(color.to_azcolor()),
                         }
                     },
                     CanvasMsg::Common(message) => {

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -70,7 +70,7 @@ pub enum Canvas2dMsg {
     SetShadowOffsetX(f64),
     SetShadowOffsetY(f64),
     SetShadowBlur(f64),
-    SetShadowColor(AzColor),
+    SetShadowColor(RGBA),
 }
 
 #[derive(Clone)]
@@ -453,5 +453,18 @@ impl CompositionOrBlending {
         }
 
         None
+    }
+}
+
+pub trait ToAzColor {
+    fn to_azcolor(&self) -> AzColor;
+}
+
+impl ToAzColor for RGBA {
+    fn to_azcolor(&self) -> AzColor {
+        color::rgba(self.red as AzFloat,
+                    self.green as AzFloat,
+                    self.blue as AzFloat,
+                    self.alpha as AzFloat)
     }
 }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -39,9 +39,6 @@ path = "../style"
 [dependencies.gfx]
 path = "../gfx"
 
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
 [dependencies.canvas]
 path = "../canvas"
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -27,7 +27,6 @@ use geom::matrix2d::Matrix2D;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
-use gfx_traits::color;
 
 use canvas_traits::{CanvasMsg, Canvas2dMsg, CanvasCommonMsg};
 use canvas_traits::{FillOrStrokeStyle, LinearGradientStyle, RadialGradientStyle};
@@ -1108,16 +1107,9 @@ impl<'a> CanvasRenderingContext2DMethods for JSRef<'a, CanvasRenderingContext2D>
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn SetShadowColor(self, value: DOMString) {
-        match parse_color(&value) {
-            Ok(rgba) => {
-                self.state.borrow_mut().shadow_color = rgba;
-                self.renderer.send(CanvasMsg::Canvas2d(Canvas2dMsg::SetShadowColor(
-                                                            color::rgba(rgba.red,
-                                                                        rgba.green,
-                                                                        rgba.blue,
-                                                                        rgba.alpha)))).unwrap()
-            },
-            _ => {}
+        if let Ok(color) = parse_color(&value) {
+            self.state.borrow_mut().shadow_color = color;
+            self.renderer.send(CanvasMsg::Canvas2d(Canvas2dMsg::SetShadowColor(color))).unwrap()
         }
     }
 }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -26,7 +26,6 @@ extern crate core;
 extern crate devtools_traits;
 extern crate cssparser;
 extern crate geom;
-extern crate gfx_traits;
 extern crate html5ever;
 extern crate encoding;
 extern crate fnv;


### PR DESCRIPTION
It seems @hyowon uploaded her canvas shadow patch faster than me; I've handled the color dependency a bit different, this way `gfx_traits` is not required by the script module.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6354)

<!-- Reviewable:end -->
