### PR TITLE
layout: Outline the individual property cascading functions to reduce I-cache footprint.

### DIFF
--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -22,8 +22,10 @@ fn main() {
         .env("PYTHONPATH", &mako)
         .env("TEMPLATE", &template)
         .arg("-c")
-        .arg("from os import environ; from mako.template import Template;\
-             print(Template(filename=environ['TEMPLATE']).render())")
+        .arg("from os import environ; from mako.template import Template; \
+              from mako import exceptions; \n\
+              try:\n    print(Template(filename=environ['TEMPLATE']).render());\n\
+              except:\n    print exceptions.html_error_template().render()")
         .stderr(Stdio::inherit())
         .output()
         .unwrap();


### PR DESCRIPTION
Reduces the size of `properties::cascade` from over 100K of code to
under 5K. Due to the improved I-cache utilization, improves ARM scaling
on 4 cores by 15%.

r? @SimonSapin (feel free to punt to someone else if you like)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6364)

<!-- Reviewable:end -->
