### PR TITLE
layout: Disable parallel display list building by default.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -821,17 +821,17 @@ impl LayoutTask {
             flow::mut_base(&mut **layout_root).clip =
                 ClippingRegion::from_rect(&data.page_clip_rect);
 
-            match rw_data.parallel_traversal {
-                None => {
-                    sequential::build_display_list_for_subtree(layout_root,
-                                                               shared_layout_context);
-                }
-                Some(ref mut traversal) => {
+            match (&mut rw_data.parallel_traversal, opts::get().parallel_display_list_building) {
+                (&mut Some(ref mut traversal), true) => {
                     parallel::build_display_list_for_subtree(layout_root,
                                                              self.profiler_metadata(),
                                                              self.time_profiler_chan.clone(),
                                                              shared_layout_context,
                                                              traversal);
+                }
+                _ => {
+                    sequential::build_display_list_for_subtree(layout_root,
+                                                               shared_layout_context);
                 }
             }
 

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -152,6 +152,9 @@ pub struct Opts {
 
     /// Whether Style Sharing Cache is used
     pub disable_share_style_cache: bool,
+
+    /// Whether to run absolute position calculation and display list construction in parallel.
+    pub parallel_display_list_building: bool,
 }
 
 fn print_usage(app: &str, opts: &[getopts::OptGroup]) {
@@ -183,6 +186,7 @@ pub fn print_debug_usage(app: &str)  {
                  "Display an error when display list geometry escapes overflow region.");
     print_option("disable-share-style-cache",
                  "Disable the style sharing cache.");
+    print_option("parallel-display-list-building", "Build display lists in parallel.");
 
     println!("");
 }
@@ -241,6 +245,7 @@ pub fn default_opts() -> Opts {
         resources_path: None,
         sniff_mime_types: false,
         disable_share_style_cache: false,
+        parallel_display_list_building: false,
     }
 }
 
@@ -420,6 +425,7 @@ pub fn from_cmdline_args(args: &[String]) -> bool {
         resources_path: opt_match.opt_str("resources-path"),
         sniff_mime_types: opt_match.opt_present("sniff-mime-types"),
         disable_share_style_cache: debug_options.contains(&"disable-share-style-cache"),
+        parallel_display_list_building: debug_options.contains(&"parallel-display-list-building"),
     };
 
     set(opts);


### PR DESCRIPTION
I've never see it result in a speedup. Actually, I don't think I've seen
it result in anything better than a 50% slowdown. The arithmetic
intensity is just too low, at least with the current algorithm.

Parallel DL building can still be enabled with a debug flag if the
algorithm is improved.

r? @metajack

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6365)

<!-- Reviewable:end -->
