### PR TITLE
Disable Document-createElement-namespace.html.

### DIFF
--- a/tests/wpt/metadata/dom/nodes/Document-createElement-namespace.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createElement-namespace.html.ini
@@ -1,5 +1,3 @@
 [Document-createElement-namespace.html]
   type: testharness
-  expected:
-    if os == "mac": TIMEOUT
-    if os == "linux": CRASH
+  disabled: Issue 6386


### PR DESCRIPTION
It crashes, but that's not always detected properly.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6387)

<!-- Reviewable:end -->
