### PR TITLE
WebSocket constructor should not panic

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -141,7 +141,16 @@ impl WebSocket {
 
         // TODO Client::connect does not conform to RFC 6455
         // see https://github.com/cyderize/rust-websocket/issues/38
-        let request = Client::connect(parsed_url).unwrap();
+        let request = match Client::connect(parsed_url) {
+            Ok(request) => request,
+            Err(_) => {
+                let global_root = ws_root.global.root();
+                let address = Trusted::new(global_root.r().get_cx(), ws_root, global_root.r().script_chan().clone());
+                let task = box WebSocketTaskHandler::new(address, WebSocketTask::Close);
+                global_root.r().script_chan().send(ScriptMsg::RunnableMsg(task)).unwrap();
+                return Ok(Temporary::from_rooted(ws_root));
+            }
+        };
         let response = request.send().unwrap();
         response.validate().unwrap();
         ws_root.ready_state.set(WebSocketRequestState::Open);

--- a/tests/wpt/metadata/FileAPI/progress.html.ini
+++ b/tests/wpt/metadata/FileAPI/progress.html.ini
@@ -1,3 +1,6 @@
 [progress.html]
   type: testharness
   expected: TIMEOUT
+  [W3C WebSocket API - Create WebSocket - Pass a URL with a non ws/wss scheme - SYNTAX_ERR is thrown]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/Create-Secure-blocked-port.htm.ini
+++ b/tests/wpt/metadata/websockets/Create-Secure-blocked-port.htm.ini
@@ -1,3 +1,5 @@
 [Create-Secure-blocked-port.htm]
   type: testharness
-  expected: CRASH
+  [W3C WebSocket API - Create Secure WebSocket - Pass a URL with a blocked port - SECURITY_ERR should be thrown]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/constructor/008.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/008.html.ini
@@ -1,3 +1,0 @@
-[008.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/constructor/017.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/017.html.ini
@@ -1,3 +1,0 @@
-[017.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/constructor/021.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/021.html.ini
@@ -1,3 +1,5 @@
 [021.html]
   type: testharness
-  expected: CRASH
+  [WebSockets: Same sub protocol twice]
+    expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-getter.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-getter.html.ini
@@ -1,3 +1,0 @@
-[bufferedAmount-defineProperty-getter.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-setter.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-defineProperty-setter.html.ini
@@ -1,3 +1,0 @@
-[bufferedAmount-defineProperty-setter.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/020.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/020.html.ini
@@ -1,3 +1,6 @@
 [020.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT
+  [WebSockets: error events]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/004.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/004.html.ini
@@ -1,3 +1,0 @@
-[004.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/005.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/readyState/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/url/005.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/url/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/url/006.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/url/006.html.ini
@@ -1,3 +1,0 @@
-[006.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -539,6 +539,12 @@
             "url": "/_mozilla/mozilla/union.html"
           }
         ],
+        "mozilla/websocket_connection_fail.html": [
+          {
+            "path": "mozilla/websocket_connection_fail.html",
+            "url": "/_mozilla/mozilla/websocket_connection_fail.html"
+          }
+        ],
         "mozilla/window.html": [
           {
             "path": "mozilla/window.html",

--- a/tests/wpt/mozilla/tests/mozilla/websocket_connection_fail.html
+++ b/tests/wpt/mozilla/tests/mozilla/websocket_connection_fail.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async_test(function() {
+  var onclose = 0;
+  var ws = new WebSocket("ws://wrong_url");
+
+  ws.onclose = this.step_func_done(function(ev) {
+      onclose++;
+      assert_equals(onclose, 1);
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Make an early return when the WebSocket connection fails in the constructor.
Also let the WebSocket connection to be closed when the connection could
not be established.

Fixes #6082.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6397)

<!-- Reviewable:end -->
