### PR TITLE
Fill and stroke for all pattern types and check the zero size gradient.

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -19,7 +19,7 @@ use azure::azure_hl::{DrawOptions, DrawSurfaceOptions, DrawTarget, ExtendMode, F
 use azure::azure_hl::{GaussianBlurAttribute, StrokeOptions, SurfaceFormat};
 use azure::azure_hl::{GaussianBlurInput, GradientStop, Filter, FilterNode, LinearGradientPattern};
 use azure::azure_hl::{JoinStyle, CapStyle};
-use azure::azure_hl::{PatternRef, Path, PathBuilder, CompositionOp, AntialiasMode};
+use azure::azure_hl::{Pattern, PatternRef, Path, PathBuilder, CompositionOp, AntialiasMode};
 use azure::scaled_font::ScaledFont;
 use azure::{AzFloat, struct__AzDrawOptions, struct__AzGlyph};
 use azure::{struct__AzGlyphBuffer, struct__AzPoint, AzDrawTargetFillGlyphs};
@@ -291,7 +291,9 @@ impl<'a> PaintContext<'a> {
         let mut path_builder = self.draw_target.create_path_builder();
         self.create_border_path_segment(&mut path_builder, bounds, direction, border, radii);
         let draw_options = DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None);
-        self.draw_target.fill(&path_builder.finish(), &ColorPattern::new(color), &draw_options);
+        self.draw_target.fill(&path_builder.finish(),
+                              Pattern::Color(ColorPattern::new(color)).to_pattern_ref(),
+                              &draw_options);
     }
 
     fn push_rounded_rect_clip(&self, bounds: &Rect<f32>, radii: &BorderRadii<AzFloat>) {
@@ -1023,7 +1025,7 @@ impl<'a> PaintContext<'a> {
 
         // Draw the shadow, and blur if we need to.
         temporary_draw_target.draw_target.fill(&path,
-                                               &ColorPattern::new(color),
+                                               Pattern::Color(ColorPattern::new(color)).to_pattern_ref(),
                                                &DrawOptions::new(1.0, CompositionOp::Over, AntialiasMode::None));
         self.blur_if_necessary(temporary_draw_target, blur_radius);
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -42,7 +42,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#b9bb83c733507f3f57e2c334499f38432056e26c"
+source = "git+https://github.com/servo/rust-azure#0e864697513c9e31bbe2213957d5713fd6139e69"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#b9bb83c733507f3f57e2c334499f38432056e26c"
+source = "git+https://github.com/servo/rust-azure#0e864697513c9e31bbe2213957d5713fd6139e69"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#b9bb83c733507f3f57e2c334499f38432056e26c"
+source = "git+https://github.com/servo/rust-azure#0e864697513c9e31bbe2213957d5713fd6139e69"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fillRect.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fillRect.html.ini
@@ -1,5 +1,0 @@
-[2d.gradient.interpolate.zerosize.fillRect.html]
-  type: testharness
-  [Canvas test: 2d.gradient.interpolate.zerosize.fillRect]
-    expected: FAIL
-


### PR DESCRIPTION
Depends on servo/rust-azure#170 which has been already merged.
So this patch contains the update of rust-azure.
r? @nox
cc @yichoi

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6402)

<!-- Reviewable:end -->
