### PR TITLE
Generate code into OUT_DIR.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,11 @@
+/.servo
 /.cargo
-/Cargo.lock
+/.servobuild
 /target
-/components/servo/target
-/ports/gonk/target
-/ports/cef/target
 /ports/android/bin
 /ports/android/libs
 /ports/android/local.properties
 /ports/android/obj
-/components/script/dom/bindings/codegen/*.rs
-/components/script/dom/bindings/codegen/_cache
-/components/script/dom/bindings/codegen/Bindings
-/components/script/dom/bindings/codegen/test/*.rs
-/.servobuild
-/.servo
 /tests/wpt/_virtualenv
 *~
 *#
@@ -34,4 +26,3 @@ Servo.app
 .config.mk.last
 parser.out
 /glfw
-

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -155,11 +155,30 @@ pub mod codegen {
     // FIXME(#5853) we shouldn't need to
     // allow moved_no_move here
     #[allow(unrooted_must_root, moved_no_move)]
-    pub mod Bindings;
-    pub mod InterfaceTypes;
-    pub mod InheritTypes;
-    pub mod PrototypeList;
-    pub mod RegisterBindings;
-    pub mod UnionTypes;
+    pub mod Bindings {
+        include!(concat!(env!("OUT_DIR"), "/Bindings/mod.rs"));
+    }
+    pub mod InterfaceTypes {
+        include!(concat!(env!("OUT_DIR"), "/InterfaceTypes.rs"));
+    }
+    #[allow(unused_imports)]
+    pub mod InheritTypes {
+        include!(concat!(env!("OUT_DIR"), "/InheritTypes.rs"));
+    }
+    pub mod PrototypeList {
+        include!(concat!(env!("OUT_DIR"), "/PrototypeList.rs"));
+    }
+    #[allow(unreachable_code, non_camel_case_types, non_upper_case_globals, unused_parens,
+            unused_imports, unused_variables, unused_unsafe, unused_mut, unused_assignments,
+            dead_code)]
+    pub mod RegisterBindings {
+        include!(concat!(env!("OUT_DIR"), "/RegisterBindings.rs"));
+    }
+    #[allow(unreachable_code, non_camel_case_types, non_upper_case_globals, unused_parens,
+            unused_imports, unused_variables, unused_unsafe, unused_mut, unused_assignments,
+            dead_code)]
+    pub mod UnionTypes {
+        include!(concat!(env!("OUT_DIR"), "/UnionTypes.rs"));
+    }
 }
 

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -190,8 +190,9 @@ pub mod macros;
 
 pub mod bindings;
 
-#[path="bindings/codegen/InterfaceTypes.rs"]
-pub mod types;
+pub mod types {
+    include!(concat!(env!("OUT_DIR"), "/InterfaceTypes.rs"));
+}
 
 pub mod activation;
 pub mod attr;

--- a/components/script/makefile.cargo
+++ b/components/script/makefile.cargo
@@ -8,38 +8,38 @@ BINDINGS_SRC = $(shell pwd)/dom/bindings/codegen
 WEBIDLS_SRC = $(shell pwd)/dom/webidls
 WEBIDLS = $(call rwildcard,$(WEBIDLS_SRC),*.webidl)
 BINDINGS = $(patsubst %.webidl,%Binding.rs,$(WEBIDLS))
-AUTOGEN_SRC = $(foreach var,$(BINDINGS),$(subst $(WEBIDLS_SRC),$(BINDINGS_SRC)/Bindings,$(var)))
+AUTOGEN_SRC = $(foreach var,$(BINDINGS),$(subst $(WEBIDLS_SRC),$(OUT_DIR)/Bindings,$(var)))
 
-CACHE_DIR = $(BINDINGS_SRC)/_cache
+CACHE_DIR = $(OUT_DIR)/_cache
 
-bindinggen_dependencies := $(addprefix $(BINDINGS_SRC)/,BindingGen.py Bindings.conf Configuration.py CodegenRust.py parser/WebIDL.py ParserResults.pkl Bindings/.done)
+bindinggen_dependencies := $(addprefix $(BINDINGS_SRC)/,BindingGen.py Bindings.conf Configuration.py CodegenRust.py parser/WebIDL.py) $(OUT_DIR)/ParserResults.pkl $(OUT_DIR)/Bindings/.done
 
-globalgen_dependencies := $(addprefix $(BINDINGS_SRC)/,GlobalGen.py Bindings.conf Configuration.py CodegenRust.py parser/WebIDL.py) $(CACHE_DIR)/.done $(BINDINGS_SRC)/Bindings/.done
+globalgen_dependencies := $(addprefix $(BINDINGS_SRC)/,GlobalGen.py Bindings.conf Configuration.py CodegenRust.py parser/WebIDL.py) $(CACHE_DIR)/.done $(OUT_DIR)/Bindings/.done
 
 .PHONY: all
 all: $(AUTOGEN_SRC)
 
-$(BINDINGS_SRC)/Bindings/.done:
-	mkdir -p $(BINDINGS_SRC)/Bindings
+$(OUT_DIR)/Bindings/.done:
+	mkdir -p $(OUT_DIR)/Bindings
 	touch $@
 
 $(CACHE_DIR)/.done:
 	mkdir -p $(CACHE_DIR)
 	touch $@
 
-$(BINDINGS_SRC)/ParserResults.pkl: $(globalgen_dependencies) $(WEBIDLS)
+$(OUT_DIR)/ParserResults.pkl: $(globalgen_dependencies) $(WEBIDLS)
 	$(PYTHON) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
-	  -D$(BINDINGS_SRC) \
+	  -D$(OUT_DIR) \
 	  $(BINDINGS_SRC)/GlobalGen.py $(BINDINGS_SRC)/Bindings.conf . \
 	  --cachedir=$(CACHE_DIR) \
 	  $(WEBIDLS)
 
-$(AUTOGEN_SRC): $(BINDINGS_SRC)/Bindings/%Binding.rs: $(bindinggen_dependencies) \
-						$(addprefix $(WEBIDLS_SRC)/,%.webidl)
+$(AUTOGEN_SRC): $(OUT_DIR)/Bindings/%Binding.rs: $(bindinggen_dependencies) \
+						 $(addprefix $(WEBIDLS_SRC)/,%.webidl)
 	$(PYTHON) $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
-	  -D$(BINDINGS_SRC) \
+	  -D$(OUT_DIR) \
 	  $(BINDINGS_SRC)/BindingGen.py \
 	  $(BINDINGS_SRC)/Bindings.conf Bindings/$*Binding $(addprefix $(WEBIDLS_SRC)/,$*.webidl)
 	touch $@


### PR DESCRIPTION
This is necessary to ensure Cargo knows when to rebuild. Normally
.gitignore would be enough to exclude these from Cargo's freshness
calculation, but https://github.com/rust-lang/cargo/issues/1729 prevents
this currently. This is the new, correct way to do these thigns, just
like the style crate does.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6408)

<!-- Reviewable:end -->
