### PR TITLE
Don't generate pyc files.

### DIFF
--- a/components/script/makefile.cargo
+++ b/components/script/makefile.cargo
@@ -28,7 +28,7 @@ $(CACHE_DIR)/.done:
 	touch $@
 
 $(OUT_DIR)/ParserResults.pkl: $(globalgen_dependencies) $(WEBIDLS)
-	$(PYTHON) $(BINDINGS_SRC)/pythonpath.py \
+	$(PYTHON) -B $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(OUT_DIR) \
 	  $(BINDINGS_SRC)/GlobalGen.py $(BINDINGS_SRC)/Bindings.conf . \
@@ -37,7 +37,7 @@ $(OUT_DIR)/ParserResults.pkl: $(globalgen_dependencies) $(WEBIDLS)
 
 $(AUTOGEN_SRC): $(OUT_DIR)/Bindings/%Binding.rs: $(bindinggen_dependencies) \
 						 $(addprefix $(WEBIDLS_SRC)/,%.webidl)
-	$(PYTHON) $(BINDINGS_SRC)/pythonpath.py \
+	$(PYTHON) -B $(BINDINGS_SRC)/pythonpath.py \
 	  -I$(BINDINGS_SRC)/parser -I$(BINDINGS_SRC)/ply \
 	  -D$(OUT_DIR) \
 	  $(BINDINGS_SRC)/BindingGen.py \


### PR DESCRIPTION
This eliminates the last bit of script crate generating in-tree
files. This now allows cargo target dir sharing to fully work.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6411)

<!-- Reviewable:end -->
