### PR TITLE
Fix ARM linker

### DIFF
--- a/components/servo/.cargo/config
+++ b/components/servo/.cargo/config
@@ -3,3 +3,7 @@ paths = ["../../support/android-rs-glue"]
 [target.arm-linux-androideabi]
 linker = "../../target/debug/apk-builder"
 ar = "arm-linux-androideabi-ar"
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+ar = "arm-linux-gnueabihf-ar"


### PR DESCRIPTION
By default, `cc` is used for the final linking of servo, which points to the host's compiler. This patch ensures that the correct linker is used for cross-compiling to ARM.

Part of #6327

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6421)

<!-- Reviewable:end -->
