### PR TITLE
Use a dedicated type for the opaque type parameter to WorkQueue in layout.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -19,7 +19,7 @@ use fragment::{Fragment, FragmentBorderBoxIterator};
 use incremental::{LayoutDamageComputation, REFLOW, REFLOW_ENTIRE_DOCUMENT, REPAINT};
 use layout_debug;
 use opaque_node::OpaqueNodeMethods;
-use parallel::{self, UnsafeFlow};
+use parallel::{self, WorkQueueData};
 use sequential;
 use wrapper::LayoutNode;
 
@@ -109,7 +109,7 @@ pub struct LayoutTaskData {
     pub stylist: Box<Stylist>,
 
     /// The workers that we use for parallel operation.
-    pub parallel_traversal: Option<WorkQueue<SharedLayoutContextWrapper, UnsafeFlow>>,
+    pub parallel_traversal: Option<WorkQueue<SharedLayoutContextWrapper, WorkQueueData>>,
 
     /// The dirty rect. Used during display list construction.
     pub dirty: Rect<Au>,

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -29,6 +29,8 @@ use util::workqueue::{WorkQueue, WorkUnit, WorkerProxy};
 
 const CHUNK_SIZE: usize = 64;
 
+pub struct WorkQueueData(usize, usize);
+
 #[allow(dead_code)]
 fn static_assertion(node: UnsafeLayoutNode) {
     unsafe {
@@ -447,7 +449,7 @@ fn build_display_list(unsafe_flow: UnsafeFlow,
 }
 
 fn run_queue_with_custom_work_data_type<To,F>(
-        queue: &mut WorkQueue<SharedLayoutContextWrapper,UnsafeLayoutNode>,
+        queue: &mut WorkQueue<SharedLayoutContextWrapper, WorkQueueData>,
         callback: F)
         where To: 'static + Send, F: FnOnce(&mut WorkQueue<SharedLayoutContextWrapper,To>) {
     unsafe {
@@ -459,7 +461,7 @@ fn run_queue_with_custom_work_data_type<To,F>(
 
 pub fn traverse_dom_preorder(root: LayoutNode,
                              shared_layout_context: &SharedLayoutContext,
-                             queue: &mut WorkQueue<SharedLayoutContextWrapper, UnsafeLayoutNode>) {
+                             queue: &mut WorkQueue<SharedLayoutContextWrapper, WorkQueueData>) {
     queue.data = SharedLayoutContextWrapper(shared_layout_context as *const _);
 
     run_queue_with_custom_work_data_type(queue, |queue| {
@@ -477,7 +479,7 @@ pub fn traverse_flow_tree_preorder(
         profiler_metadata: ProfilerMetadata,
         time_profiler_chan: time::ProfilerChan,
         shared_layout_context: &SharedLayoutContext,
-        queue: &mut WorkQueue<SharedLayoutContextWrapper,UnsafeLayoutNode>) {
+        queue: &mut WorkQueue<SharedLayoutContextWrapper, WorkQueueData>) {
     if opts::get().bubble_inline_sizes_separately {
         let layout_context = LayoutContext::new(shared_layout_context);
         let bubble_inline_sizes = BubbleISizes { layout_context: &layout_context };
@@ -504,7 +506,7 @@ pub fn build_display_list_for_subtree(
         profiler_metadata: ProfilerMetadata,
         time_profiler_chan: time::ProfilerChan,
         shared_layout_context: &SharedLayoutContext,
-        queue: &mut WorkQueue<SharedLayoutContextWrapper,UnsafeLayoutNode>) {
+        queue: &mut WorkQueue<SharedLayoutContextWrapper, WorkQueueData>) {
     queue.data = SharedLayoutContextWrapper(shared_layout_context as *const _);
 
     run_queue_with_custom_work_data_type(queue, |queue| {


### PR DESCRIPTION
Currently, we use UnsafeFlow and UnsafeLayoutNode, both of which are aliases
for (usize, usize) and thus interconvertible. This change should make it
clearer that the WorkQueue is not limited to one particular type.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6461)

<!-- Reviewable:end -->
