### PR TITLE
Basic support for bidirectional text

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -106,7 +106,9 @@ bitflags! {
         #[doc="Set if we are to ignore ligatures."]
         const IGNORE_LIGATURES_SHAPING_FLAG = 0x02,
         #[doc="Set if we are to disable kerning."]
-        const DISABLE_KERNING_SHAPING_FLAG = 0x04
+        const DISABLE_KERNING_SHAPING_FLAG = 0x04,
+        #[doc="Text direction is right-to-left."]
+        const RTL_FLAG = 0x08,
     }
 }
 

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -1294,7 +1294,7 @@ impl ScaledFontExtensionMethods for ScaledFont {
         let mut azglyphs = vec!();
         azglyphs.reserve(range.length().to_usize());
 
-        for slice in run.natural_word_slices_in_range(range) {
+        for slice in run.natural_word_slices_in_visual_order(range) {
             for (_i, glyph) in slice.glyphs.iter_glyphs_for_char_range(&slice.range) {
                 let glyph_advance = glyph.advance();
                 let glyph_offset = glyph.offset().unwrap_or(Point2D::zero());

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -5,14 +5,14 @@
 extern crate harfbuzz;
 
 use font::{DISABLE_KERNING_SHAPING_FLAG, Font, FontHandleMethods, FontTableMethods, FontTableTag};
-use font::{IGNORE_LIGATURES_SHAPING_FLAG, ShapingOptions};
+use font::{IGNORE_LIGATURES_SHAPING_FLAG, RTL_FLAG, ShapingOptions};
 use platform::font::FontTable;
 use text::glyph::{CharIndex, GlyphStore, GlyphId, GlyphData};
 use text::shaping::ShaperMethods;
 use text::util::{float_to_fixed, fixed_to_float};
 
 use euclid::Point2D;
-use harfbuzz::{HB_MEMORY_MODE_READONLY, HB_DIRECTION_LTR};
+use harfbuzz::{HB_MEMORY_MODE_READONLY, HB_DIRECTION_LTR, HB_DIRECTION_RTL};
 use harfbuzz::{RUST_hb_blob_create, RUST_hb_face_create_for_tables};
 use harfbuzz::{hb_blob_t};
 use harfbuzz::{hb_bool_t};
@@ -229,7 +229,11 @@ impl ShaperMethods for Shaper {
     fn shape_text(&self, text: &str, options: &ShapingOptions, glyphs: &mut GlyphStore) {
         unsafe {
             let hb_buffer: *mut hb_buffer_t = RUST_hb_buffer_create();
-            RUST_hb_buffer_set_direction(hb_buffer, HB_DIRECTION_LTR);
+            RUST_hb_buffer_set_direction(hb_buffer, if options.flags.contains(RTL_FLAG) {
+                HB_DIRECTION_RTL
+            } else {
+                HB_DIRECTION_LTR
+            });
 
             RUST_hb_buffer_add_utf8(hb_buffer,
                                     text.as_ptr() as *const c_char,

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -73,4 +73,4 @@ string_cache_plugin = "0.1"
 euclid = "0.1"
 serde = "0.4"
 serde_macros = "0.4"
-
+unicode-bidi = "0.2"

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -28,10 +28,11 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::mem;
 use std::sync::Arc;
-use std::u16;
+use std::isize;
 use style::computed_values::{display, overflow_x, position, text_align, text_justify};
 use style::computed_values::{text_overflow, vertical_align, white_space};
 use style::properties::ComputedValues;
+use unicode_bidi;
 use util::geometry::{Au, MAX_AU, ZERO_RECT};
 use util::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
 use util::range::{Range, RangeIndex};
@@ -66,7 +67,7 @@ static FONT_SUPERSCRIPT_OFFSET_RATIO: f32 = 0.34;
 /// with a float or a horizontal wall of the containing block. The block-start
 /// inline-start corner of the green zone is the same as that of the line, but
 /// the green zone can be taller and wider than the line itself.
-#[derive(RustcEncodable, Debug, Copy, Clone)]
+#[derive(RustcEncodable, Debug, Clone)]
 pub struct Line {
     /// A range of line indices that describe line breaks.
     ///
@@ -94,6 +95,11 @@ pub struct Line {
     /// |----------|-------------|-------------|----------|
     /// | 'I like' | 'truffles,' | '<img> yes' | 'I do.'  |
     pub range: Range<FragmentIndex>,
+
+    /// The bidirectional embedding level runs for this line, in visual order.
+    ///
+    /// Can be set to `None` if the line is 100% left-to-right.
+    pub visual_runs: Option<Vec<(Range<FragmentIndex>, u8)>>,
 
     /// The bounds are the exact position and extents of the line with respect
     /// to the parent box.
@@ -153,6 +159,23 @@ pub struct Line {
     pub inline_metrics: InlineMetrics,
 }
 
+impl Line {
+    fn new(writing_mode: WritingMode,
+           minimum_block_size_above_baseline: Au,
+           minimum_depth_below_baseline: Au)
+           -> Line {
+        Line {
+            range: Range::empty(),
+            visual_runs: None,
+            bounds: LogicalRect::zero(writing_mode),
+            green_zone: LogicalSize::zero(writing_mode),
+            inline_metrics: InlineMetrics::new(minimum_block_size_above_baseline,
+                                               minimum_depth_below_baseline,
+                                               minimum_block_size_above_baseline),
+        }
+    }
+}
+
 int_range_index! {
     #[derive(RustcEncodable)]
     #[doc = "The index of a fragment in a flattened vector of DOM elements."]
@@ -202,14 +225,9 @@ impl LineBreaker {
         LineBreaker {
             new_fragments: Vec::new(),
             work_list: VecDeque::new(),
-            pending_line: Line {
-                range: Range::empty(),
-                bounds: LogicalRect::zero(float_context.writing_mode),
-                green_zone: LogicalSize::zero(float_context.writing_mode),
-                inline_metrics: InlineMetrics::new(minimum_block_size_above_baseline,
-                                                   minimum_depth_below_baseline,
-                                                   minimum_block_size_above_baseline),
-            },
+            pending_line: Line::new(float_context.writing_mode,
+                                    minimum_block_size_above_baseline,
+                                    minimum_depth_below_baseline),
             floats: float_context,
             lines: Vec::new(),
             cur_b: Au(0),
@@ -228,18 +246,10 @@ impl LineBreaker {
     }
 
     /// Reinitializes the pending line to blank data.
-    fn reset_line(&mut self) {
-        self.pending_line.range.reset(FragmentIndex(0), FragmentIndex(0));
-        self.pending_line.bounds = LogicalRect::new(self.floats.writing_mode,
-                                                    Au(0),
-                                                    self.cur_b,
-                                                    Au(0),
-                                                    Au(0));
-        self.pending_line.green_zone = LogicalSize::zero(self.floats.writing_mode);
-        self.pending_line.inline_metrics =
-            InlineMetrics::new(self.minimum_block_size_above_baseline,
-                               self.minimum_depth_below_baseline,
-                               self.minimum_block_size_above_baseline)
+    fn reset_line(&mut self) -> Line {
+        mem::replace(&mut self.pending_line, Line::new(self.floats.writing_mode,
+                                                       self.minimum_block_size_above_baseline,
+                                                       self.minimum_depth_below_baseline))
     }
 
     /// Reflows fragments for the given inline flow.
@@ -260,10 +270,40 @@ impl LineBreaker {
         // Do the reflow.
         self.reflow_fragments(old_fragment_iter, flow, layout_context);
 
+        // Perform unicode bidirectional layout.
+
+        let para_level = flow.base.writing_mode.to_bidi_level();
+
+        // The text within a fragment is at a single bidi embedding level (because we split
+        // fragments on level run boundaries during flow construction), so we can build a level
+        // array with just one entry per fragment.
+        let levels: Vec<u8> = self.new_fragments.iter().map(|fragment| match fragment.specific {
+            SpecificFragmentInfo::ScannedText(ref info) => info.run.bidi_level,
+            _ => para_level
+        }).collect();
+
+        let mut lines = mem::replace(&mut self.lines, Vec::new());
+
+        // If everything is LTR, don't bother with reordering.
+        let has_rtl = levels.iter().cloned().any(unicode_bidi::is_rtl);
+
+        if has_rtl {
+            // Compute and store the visual ordering of the fragments within the line.
+            for line in &mut lines {
+                let range = line.range.begin().to_usize()..line.range.end().to_usize();
+                let runs = unicode_bidi::visual_runs(range, &levels);
+                line.visual_runs = Some(runs.iter().map(|run| {
+                    let start = FragmentIndex(run.start as isize);
+                    let len = FragmentIndex(run.len() as isize);
+                    (Range::new(start, len), levels[run.start])
+                }).collect());
+            }
+        }
+
         // Place the fragments back into the flow.
         old_fragments.fragments = mem::replace(&mut self.new_fragments, vec![]);
         flow.fragments = old_fragments;
-        flow.lines = mem::replace(&mut self.lines, Vec::new());
+        flow.lines = lines;
     }
 
     /// Reflows the given fragments, which have been plucked out of the inline flow.
@@ -350,7 +390,7 @@ impl LineBreaker {
     fn flush_current_line(&mut self) {
         debug!("LineBreaker: flushing line {}: {:?}", self.lines.len(), self.pending_line);
         self.strip_trailing_whitespace_from_pending_line_if_necessary();
-        self.lines.push(self.pending_line);
+        self.lines.push(self.pending_line.clone());
         self.cur_b = self.pending_line.bounds.start.b + self.pending_line.bounds.size.block;
         self.reset_line();
     }
@@ -612,7 +652,7 @@ impl LineBreaker {
                              line_flush_mode: LineFlushMode) {
         let indentation = self.indentation_for_pending_fragment();
         if self.pending_line_is_empty() {
-            assert!(self.new_fragments.len() <= (u16::MAX as usize));
+            debug_assert!(self.new_fragments.len() <= (isize::MAX as usize));
             self.pending_line.range.reset(FragmentIndex(self.new_fragments.len() as isize),
                                           FragmentIndex(0));
         }
@@ -922,18 +962,47 @@ impl InlineFlow {
             text_align::T::left | text_align::T::right => unreachable!()
         }
 
-        for fragment_index in line.range.each_index() {
-            let fragment = fragments.get_mut(fragment_index.to_usize());
-            inline_start_position_for_fragment = inline_start_position_for_fragment +
-                fragment.margin.inline_start;
-            fragment.border_box = LogicalRect::new(fragment.style.writing_mode,
-                                                   inline_start_position_for_fragment,
-                                                   fragment.border_box.start.b,
-                                                   fragment.border_box.size.inline,
-                                                   fragment.border_box.size.block);
-            fragment.update_late_computed_inline_position_if_necessary();
-            inline_start_position_for_fragment = inline_start_position_for_fragment +
-                fragment.border_box.size.inline + fragment.margin.inline_end;
+        // Lay out the fragments in visual order.
+        let run_count = match line.visual_runs {
+            Some(ref runs) => runs.len(),
+            None => 1
+        };
+        for run_idx in 0..run_count {
+            let (range, level) = match line.visual_runs {
+                Some(ref runs) if is_ltr => runs[run_idx],
+                Some(ref runs) => runs[run_count - run_idx - 1], // reverse order for RTL runs
+                None => (line.range, 0)
+            };
+            // If the bidi embedding direction is opposite the layout direction, lay out this
+            // run in reverse order.
+            let reverse = unicode_bidi::is_ltr(level) != is_ltr;
+            let fragment_indices = if reverse {
+                (range.end().get() - 1..range.begin().get() - 1).step_by(-1)
+            } else {
+                (range.begin().get()..range.end().get()).step_by(1)
+            };
+
+            for fragment_index in fragment_indices {
+                let fragment = fragments.get_mut(fragment_index as usize);
+                inline_start_position_for_fragment = inline_start_position_for_fragment +
+                    fragment.margin.inline_start;
+
+                let border_start = if fragment.style.writing_mode.is_bidi_ltr() == is_ltr {
+                    inline_start_position_for_fragment
+                } else {
+                    line.green_zone.inline - inline_start_position_for_fragment
+                                           - fragment.margin.inline_end
+                                           - fragment.border_box.size.inline
+                };
+                fragment.border_box = LogicalRect::new(fragment.style.writing_mode,
+                                                       border_start,
+                                                       fragment.border_box.start.b,
+                                                       fragment.border_box.size.inline,
+                                                       fragment.border_box.size.block);
+                fragment.update_late_computed_inline_position_if_necessary();
+                inline_start_position_for_fragment = inline_start_position_for_fragment +
+                    fragment.border_box.size.inline + fragment.margin.inline_end;
+            }
         }
     }
 
@@ -1302,6 +1371,7 @@ impl Flow for InlineFlow {
                                            self.minimum_block_size_above_baseline,
                                            self.minimum_depth_below_baseline);
         scanner.scan_for_lines(self, layout_context);
+
 
         // Now, go through each line and lay out the fragments inside.
         let mut line_distance_from_flow_block_start = Au(0);

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -14,6 +14,7 @@
 #![feature(plugin)]
 #![feature(raw)]
 #![feature(slice_chars)]
+#![feature(step_by)]
 #![feature(str_char)]
 #![feature(unsafe_no_drop_flag)]
 
@@ -59,6 +60,7 @@ extern crate serde;
 extern crate smallvec;
 extern crate string_cache;
 extern crate style;
+extern crate unicode_bidi;
 extern crate url;
 
 // Listed first because of macro definitions

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
+ "unicode-bidi 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1400,6 +1401,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicase"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"

--- a/components/util/logical_geometry.rs
+++ b/components/util/logical_geometry.rs
@@ -85,6 +85,14 @@ impl WritingMode {
             (true, false) => PhysicalSide::Left,
         }
     }
+
+    #[inline]
+    /// The default bidirectional embedding level for this writing mode.
+    ///
+    /// Returns 0 if the mode is LTR, or 1 otherwise.
+    pub fn to_bidi_level(&self) -> u8 {
+        !self.is_bidi_ltr() as u8
+    }
 }
 
 impl fmt::Display for WritingMode {

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
+ "unicode-bidi 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1383,6 +1384,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicase"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
  "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
+ "unicode-bidi 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1281,6 +1282,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicase"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"

--- a/tests/wpt/metadata-css/css21_dev/html4/bidi-box-model-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/bidi-box-model-002.htm.ini
@@ -1,3 +1,0 @@
-[bidi-box-model-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/bidi-box-model-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/bidi-box-model-005.htm.ini
@@ -1,3 +1,0 @@
-[bidi-box-model-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/bidi-breaking-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/bidi-breaking-002.htm.ini
@@ -1,3 +1,0 @@
-[bidi-breaking-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/bidi-breaking-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/bidi-breaking-003.htm.ini
@@ -1,3 +1,3 @@
 [bidi-breaking-003.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/bidi-glyph-mirroring-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/bidi-glyph-mirroring-002.htm.ini
@@ -1,3 +1,5 @@
 [bidi-glyph-mirroring-002.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL
+    PASS

--- a/tests/wpt/metadata-css/css21_dev/html4/first-letter-dynamic-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/first-letter-dynamic-002.htm.ini
@@ -1,3 +1,3 @@
-[bidi-box-model-001.htm]
+[first-letter-dynamic-002.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/metadata/html/semantics/grouping-content/the-pre-element/grouping-pre-reftest-001.html.ini
+++ b/tests/wpt/metadata/html/semantics/grouping-content/the-pre-element/grouping-pre-reftest-001.html.ini
@@ -1,5 +1,0 @@
-[grouping-pre-reftest-001.html]
-  type: reftest
-  reftype: ==
-  refurl: /html/semantics/grouping-content/the-pre-element/grouping-pre-reftest-001-ref.html
-  expected: FAIL

--- a/tests/wpt/metadata/html/semantics/text-level-semantics/the-bdo-element/bdo-override.html.ini
+++ b/tests/wpt/metadata/html/semantics/text-level-semantics/the-bdo-element/bdo-override.html.ini
@@ -1,3 +1,3 @@
-[bidi-box-model-004.htm]
+[bdo-override.html]
   type: reftest
   expected: FAIL


### PR DESCRIPTION
This re-orders text according to the Unicode bidirectional layout algorithm, using the [unicode-bidi](https://github.com/mbrubeck/unicode-bidi) crate.  It uses the natural order of the text based on Unicode character properties and the CSS `direction` property.

This does not yet support the CSS `unicode-bidi` property or the HTML `dir` attribute, but these should be straightforward to add.

r? @pcwalton.  Also depends on servo/unicode-bidi#4.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6471)

<!-- Reviewable:end -->
