### PR TITLE
Add keyboard shortcuts to glutin browser

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -851,6 +851,10 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.on_zoom_window_event(magnification);
             }
 
+            WindowEvent::ResetZoom => {
+                self.on_zoom_reset_window_event();
+            }
+
             WindowEvent::PinchZoom(magnification) => {
                 self.on_pinch_zoom_window_event(magnification);
             }
@@ -1064,6 +1068,12 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         // We need to set the size of the root layer again, since the window size
         // has changed in unscaled layer pixels.
         self.scene.set_root_layer_size(self.window_size.as_f32());
+    }
+
+    fn on_zoom_reset_window_event(&mut self) {
+        self.page_zoom = ScaleFactor::new(1.0);
+        self.update_zoom_transform();
+        self.send_window_size();
     }
 
     fn on_zoom_window_event(&mut self, magnification: f32) {

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -64,6 +64,8 @@ pub enum WindowEvent {
     Zoom(f32),
     /// Simulated "pinch zoom" gesture for non-touch platforms (e.g. ctrl-scrollwheel).
     PinchZoom(f32),
+    /// Sent when the user resets zoom to default.
+    ResetZoom,
     /// Sent when the user uses chrome navigation (i.e. backspace or shift-backspace).
     Navigation(WindowNavigateMsg),
     /// Sent when the user quits the application
@@ -86,6 +88,7 @@ impl Debug for WindowEvent {
             WindowEvent::Scroll(..) => write!(f, "Scroll"),
             WindowEvent::Zoom(..) => write!(f, "Zoom"),
             WindowEvent::PinchZoom(..) => write!(f, "PinchZoom"),
+            WindowEvent::ResetZoom => write!(f, "ResetZoom"),
             WindowEvent::Navigation(..) => write!(f, "Navigation"),
             WindowEvent::Quit => write!(f, "Quit"),
         }

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -192,6 +192,7 @@ pub enum Key {
 
 bitflags! {
     flags KeyModifiers: u8 {
+        const NONE = 0x00,
         const SHIFT = 0x01,
         const CONTROL = 0x02,
         const ALT = 0x04,


### PR DESCRIPTION
New shortcuts:
- Reset zoom (Cmd+0)
- Spacebar scrolling
- Line scrolling
- More shortcuts for back and forward (⌘[, ⌘], ⌘←, ⌘→)

Other changes:
- Page scrolling now leaves a few lines of overlap, like Firefox.
- Mouse line scrolling reduced to match the line height I see on most pages. (Is this change desired?)
- All shortcuts now check for exact sets of modifiers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6488)

<!-- Reviewable:end -->
