### PR TITLE
Use an atomic bool for EXPERIMENTAL_ENABLED.

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -21,6 +21,7 @@ use std::mem;
 use std::path::Path;
 use std::process;
 use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use url::{self, Url};
 
 /// Global flags for Servo, currently set on the command line.
@@ -422,21 +423,17 @@ pub fn from_cmdline_args(args: &[String]) {
     set(opts);
 }
 
-static mut EXPERIMENTAL_ENABLED: bool = false;
+static EXPERIMENTAL_ENABLED: AtomicBool = ATOMIC_BOOL_INIT;
 
 /// Turn on experimental features globally. Normally this is done
 /// during initialization by `set` or `from_cmdline_args`, but
 /// tests that require experimental features will also set it.
 pub fn set_experimental_enabled(new_value: bool) {
-    unsafe {
-        EXPERIMENTAL_ENABLED = new_value;
-    }
+    EXPERIMENTAL_ENABLED.store(new_value, Ordering::SeqCst);
 }
 
 pub fn experimental_enabled() -> bool {
-    unsafe {
-        EXPERIMENTAL_ENABLED
-    }
+    EXPERIMENTAL_ENABLED.load(Ordering::SeqCst)
 }
 
 // Make Opts available globally. This saves having to clone and pass


### PR DESCRIPTION
static mut smells, especially as it can be set and read from multiple threads
(for example in unit tests).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6494)

<!-- Reviewable:end -->
