### PR TITLE
Remove Deref and DerefMut implementations from WeakFlowRef.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1393,7 +1393,7 @@ impl ContainingBlockLink {
                 panic!("Link to containing block not established; perhaps you forgot to call \
                         `set_absolute_descendants`?")
             }
-            Some(ref mut link) => link.generated_containing_block_size(for_flow),
+            Some(ref link) => link.upgrade().unwrap().generated_containing_block_size(for_flow),
         }
     }
 }


### PR DESCRIPTION
By definition of a weak pointer, these implementations cannot be safe.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6498)

<!-- Reviewable:end -->
