### PR TITLE
notify_darwin should trap import errors.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -64,21 +64,24 @@ def notify_win(title, text):
 
 
 def notify_darwin(title, text):
-    import Foundation
-    import objc
+    try:
+        import Foundation
+        import objc
 
-    NSUserNotification = objc.lookUpClass("NSUserNotification")
-    NSUserNotificationCenter = objc.lookUpClass("NSUserNotificationCenter")
+        NSUserNotification = objc.lookUpClass("NSUserNotification")
+        NSUserNotificationCenter = objc.lookUpClass("NSUserNotificationCenter")
 
-    note = NSUserNotification.alloc().init()
-    note.setTitle_(title)
-    note.setInformativeText_(text)
+        note = NSUserNotification.alloc().init()
+        note.setTitle_(title)
+        note.setInformativeText_(text)
 
-    now = Foundation.NSDate.dateWithTimeInterval_sinceDate_(0, Foundation.NSDate.date())
-    note.setDeliveryDate_(now)
+        now = Foundation.NSDate.dateWithTimeInterval_sinceDate_(0, Foundation.NSDate.date())
+        note.setDeliveryDate_(now)
 
-    centre = NSUserNotificationCenter.defaultUserNotificationCenter()
-    centre.scheduleNotification_(note)
+        centre = NSUserNotificationCenter.defaultUserNotificationCenter()
+        centre.scheduleNotification_(note)
+    except ImportError:
+        raise Exception("Please make sure that the Python pyobjc module is installed!")
 
 
 def notify_build_done(elapsed):


### PR DESCRIPTION
notify_darwin should trap import errors and should provide the useful package name for the user to install. Fix for issue #6479.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6506)

<!-- Reviewable:end -->
