### PR TITLE
Prevent Python KeyErrors when setting test defaults

### DIFF
--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -29,22 +29,22 @@ def run_tests(paths=None, **kwargs):
     return 0 if success else 1
 
 def set_defaults(paths, kwargs):
-    if kwargs["product"] is None:
+    if kwargs.get("product") is None:
         kwargs["product"] = "servo"
 
-    if kwargs["config"] is None and "config" in paths:
+    if kwargs.get("config") is None and "config" in paths:
         kwargs["config"] = paths["config"]
 
-    if kwargs["include_manifest"] is None and "include_manifest" in paths:
+    if kwargs.get("include_manifest") is None and "include_manifest" in paths:
         kwargs["include_manifest"] = paths["include_manifest"]
 
-    if kwargs["binary"] is None:
-        bin_dir = "release" if kwargs["release"] else "debug"
+    if kwargs.get("binary") is None:
+        bin_dir = "release" if kwargs.get("release") else "debug"
         bin_path = servo_path("target", bin_dir, "servo")
 
         kwargs["binary"] = bin_path
 
-    if kwargs["processes"] is None:
+    if kwargs.get("processes") is None:
         kwargs["processes"] = multiprocessing.cpu_count()
 
     wptcommandline.check_args(kwargs)


### PR DESCRIPTION
I'm not sure how it got into this state, but while running the test suite, the `kwargs` param here had no entries, so I changed all the indexes to not fail if the key doesn't exist

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6511)

<!-- Reviewable:end -->
