### PR TITLE
Add support for debugmozjs in components/servo

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "gfx 0.0.1",
  "gfx_tests 0.0.1",
  "glutin_app 0.0.1",
+ "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
  "layout 0.0.1",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -43,6 +43,7 @@ git = "https://github.com/servo/rust-png"
 default = ["glutin_app", "window"]
 window = ["glutin_app/window"]
 headless = ["glutin_app/headless"]
+debugmozjs = ['js/debugmozjs']
 
 # Uncomment to profile on Linux:
 #
@@ -75,6 +76,9 @@ path = "../util"
 
 [dependencies.script]
 path = "../script"
+
+[dependencies.js]
+git = "https://github.com/servo/rust-mozjs"
 
 [dependencies.layout]
 path = "../layout"


### PR DESCRIPTION
This lets you do `./mach build -d --features debugmozjs` which builds SM with all the assertions that are necessary to quickly debug crashes in SM.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6517)

<!-- Reviewable:end -->
