### PR TITLE
Refactor #[jstraceable] to #[derive(JSTraceable)]

### DIFF
--- a/components/plugins/jstraceable.rs
+++ b/components/plugins/jstraceable.rs
@@ -16,7 +16,7 @@ pub fn expand_dom_struct(cx: &mut ExtCtxt, sp: Span, _: &MetaItem, anno: Annotat
         let mut item2 = (*item).clone();
         item2.attrs.push(quote_attr!(cx, #[must_root]));
         item2.attrs.push(quote_attr!(cx, #[privatize]));
-        item2.attrs.push(quote_attr!(cx, #[jstraceable]));
+        item2.attrs.push(quote_attr!(cx, #[derive(JSTraceable)]));
 
         // The following attributes are only for internal usage
         item2.attrs.push(quote_attr!(cx, #[_generate_reflector]));
@@ -30,7 +30,7 @@ pub fn expand_dom_struct(cx: &mut ExtCtxt, sp: Span, _: &MetaItem, anno: Annotat
     }
 }
 
-/// Provides the hook to expand `#[jstraceable]` into an implementation of `JSTraceable`
+/// Provides the hook to expand `#[derive(JSTraceable)]` into an implementation of `JSTraceable`
 ///
 /// The expansion basically calls `trace()` on all of the fields of the struct/enum, erroring if they do not
 /// implement the method.

--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -7,10 +7,10 @@
 //! Attributes this crate provides:
 //!
 //!  - `#[privatize]` : Forces all fields in a struct/enum to be private
-//!  - `#[jstraceable]` : Auto-derives an implementation of `JSTraceable` for a struct in the script crate
+//!  - `#[derive(JSTraceable)]` : Auto-derives an implementation of `JSTraceable` for a struct in the script crate
 //!  - `#[must_root]` : Prevents data of the marked type from being used on the stack.
 //!                     See the lints module for more details
-//!  - `#[dom_struct]` : Implies `#[privatize]`,`#[jstraceable]`, and `#[must_root]`.
+//!  - `#[dom_struct]` : Implies `#[privatize]`,`#[derive(JSTraceable)]`, and `#[must_root]`.
 //!                       Use this for structs that correspond to a DOM type
 
 #![feature(plugin_registrar, quote, plugin, box_syntax, rustc_private)]
@@ -29,7 +29,7 @@ use syntax::ext::base::*;
 use syntax::parse::token::intern;
 
 // Public for documentation to show up
-/// Handles the auto-deriving for `#[jstraceable]`
+/// Handles the auto-deriving for `#[derive(JSTraceable)]`
 pub mod jstraceable;
 /// Handles the auto-deriving for `#[derive(HeapSizeOf)]`
 pub mod heap_size;
@@ -43,7 +43,7 @@ pub mod casing;
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(intern("dom_struct"), MultiModifier(box jstraceable::expand_dom_struct));
-    reg.register_syntax_extension(intern("jstraceable"), MultiDecorator(box jstraceable::expand_jstraceable));
+    reg.register_syntax_extension(intern("derive_JSTraceable"), MultiDecorator(box jstraceable::expand_jstraceable));
     reg.register_syntax_extension(intern("_generate_reflector"), MultiDecorator(box reflector::expand_reflector));
     reg.register_syntax_extension(intern("derive_HeapSizeOf"), MultiDecorator(box heap_size::expand_heap_size));
     reg.register_macro("to_lower", casing::expand_lower);

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -11,8 +11,7 @@ use net_traits::{Metadata, load_whole_resource, ResourceTask, PendingAsyncLoad};
 use net_traits::AsyncResponseTarget;
 use url::Url;
 
-#[jstraceable]
-#[derive(PartialEq, Clone, Debug)]
+#[derive(JSTraceable, PartialEq, Clone, Debug)]
 pub enum LoadType {
     Image(Url),
     Script(Url),
@@ -33,14 +32,14 @@ impl LoadType {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct DocumentLoader {
     pub resource_task: ResourceTask,
     notifier_data: Option<NotifierData>,
     blocking_loads: Vec<LoadType>,
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct NotifierData {
     pub script_chan: Box<ScriptChan + Send>,
     pub pipeline: PipelineId,

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -28,8 +28,7 @@ pub enum AttrSettingType {
     ReplacedAttr,
 }
 
-#[derive(PartialEq, Clone)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq, Clone)]
 pub enum AttrValue {
     String(DOMString),
     TokenList(DOMString, Vec<Atom>),

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -33,8 +33,7 @@ pub enum ExceptionHandling {
 }
 
 /// A common base class for representing IDL callback function types.
-#[derive(PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq)]
 pub struct CallbackFunction {
     object: CallbackObject
 }
@@ -57,8 +56,7 @@ impl CallbackFunction {
 }
 
 /// A common base class for representing IDL callback interface types.
-#[derive(PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq)]
 pub struct CallbackInterface {
     object: CallbackObject
 }
@@ -66,7 +64,7 @@ pub struct CallbackInterface {
 /// A common base class for representing IDL callback function and
 /// callback interface types.
 #[allow(raw_pointer_derive)]
-#[jstraceable]
+#[derive(JSTraceable)]
 struct CallbackObject {
     /// The underlying `JSObject`.
     callback: Heap<*mut JSObject>,

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3189,8 +3189,7 @@ class CGEnum(CGThing):
 
         decl = """\
 #[repr(usize)]
-#[derive(PartialEq, Copy, Clone)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq, Copy, Clone)]
 pub enum %s {
     %s
 }
@@ -5181,7 +5180,7 @@ class CGCallback(CGClass):
                          bases=[ClassBase(baseName)],
                          constructors=self.getConstructors(),
                          methods=realMethods+getters+setters,
-                         decorators="#[derive(PartialEq)]#[jstraceable]")
+                         decorators="#[derive(JSTraceable, PartialEq)]")
 
     def getConstructors(self):
         return [ClassConstructor(

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -46,7 +46,7 @@ pub enum GlobalRoot {
 
 /// A traced reference to a global object, for use in fields of traced Rust
 /// structures.
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 pub enum GlobalField {
     /// A field for a `Window` object.

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -164,7 +164,7 @@ impl<T: Reflectable> HeapGCValue for JS<T> {
 /// Must be used in place of traditional interior mutability to ensure proper
 /// GC barriers are enforced.
 #[must_root]
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct MutHeapJSVal {
     val: UnsafeCell<Heap<JSVal>>,
 }
@@ -196,7 +196,7 @@ impl MutHeapJSVal {
 /// A holder that provides interior mutability for GC-managed values such as
 /// `JS<T>`.
 #[must_root]
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct MutHeap<T: HeapGCValue+Copy> {
     val: Cell<T>,
 }
@@ -225,7 +225,7 @@ impl<T: HeapGCValue+Copy> MutHeap<T> {
 /// place of traditional internal mutability to ensure that the proper GC
 /// barriers are enforced.
 #[must_root]
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct MutNullableHeap<T: HeapGCValue+Copy> {
     ptr: Cell<Option<T>>
 }

--- a/components/script/dom/bindings/num.rs
+++ b/components/script/dom/bindings/num.rs
@@ -9,8 +9,7 @@ use num::Float;
 use std::ops::Deref;
 
 /// Encapsulates the IDL restricted float type.
-#[derive(Clone,Eq,PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable,Clone,Eq,PartialEq)]
 pub struct Finite<T: Float>(T);
 
 unsafe impl<T: Float> Zeroable for Finite<T> {}

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -12,8 +12,7 @@ use std::str;
 use std::str::FromStr;
 
 /// Encapsulates the IDL `ByteString` type.
-#[derive(Clone,Eq,PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable,Clone,Eq,PartialEq)]
 pub struct ByteString(Vec<u8>);
 
 impl ByteString {

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -12,7 +12,7 @@
 //!    phase. (This happens through `JSClass.trace` for non-proxy bindings, and
 //!    through `ProxyTraps.trace` otherwise.)
 //! 2. `_trace` calls `Foo::trace()` (an implementation of `JSTraceable`).
-//!    This is typically derived via a `#[dom_struct]` (implies `#[jstraceable]`) annotation.
+//!    This is typically derived via a `#[dom_struct]` (implies `#[derive(JSTraceable)]`) annotation.
 //!    Non-JS-managed types have an empty inline `trace()` method,
 //!    achieved via `no_jsmanaged_fields!` or similar.
 //! 3. For all fields, `Foo::trace()`
@@ -410,7 +410,7 @@ impl RootedTraceableSet {
 /// If you have GC things like *mut JSObject or JSVal, use jsapi::Rooted.
 /// If you have an arbitrary number of Reflectables to root, use RootedVec<JS<T>>
 /// If you know what you're doing, use this.
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct RootedTraceable<'a, T: 'a + JSTraceable> {
     ptr: &'a T
 }
@@ -434,7 +434,7 @@ impl<'a, T: JSTraceable> Drop for RootedTraceable<'a, T> {
 /// Must be a reflectable
 #[allow(unrooted_must_root)]
 #[no_move]
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct RootedVec<T: JSTraceable + Reflectable> {
     v: Vec<T>
 }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -65,7 +65,7 @@ use string_cache::{Atom, Namespace};
 pub struct WindowProxyHandler(pub *const libc::c_void);
 
 #[allow(raw_pointer_derive)]
-#[jstraceable]
+#[derive(JSTraceable)]
 /// Static data associated with a global object.
 pub struct GlobalStaticData {
     /// The WindowProxy proxy handler for this global.

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -17,7 +17,7 @@ use std::ascii::AsciiExt;
 use std::borrow::ToOwned;
 use std::cmp::{min, max};
 
-#[jstraceable]
+#[derive(JSTraceable)]
 pub enum BlobTypeId {
     Blob,
     File,

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -27,7 +27,7 @@ use js::{JSTrue, JSFalse};
 use std::ptr;
 use std::default::Default;
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[privatize]
 #[allow(raw_pointer_derive)]
 pub struct BrowserContext {
@@ -87,7 +87,7 @@ impl BrowserContext {
 // without a reflector, so we don't mark this as #[dom_struct]
 #[must_root]
 #[privatize]
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct SessionHistoryEntry {
     document: JS<Document>,
     children: Vec<BrowserContext>

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -21,8 +21,7 @@ pub struct CanvasGradient {
     stops: DOMRefCell<Vec<CanvasGradientStop>>,
 }
 
-#[jstraceable]
-#[derive(Clone)]
+#[derive(JSTraceable, Clone)]
 pub enum CanvasGradientStyle {
     Linear(LinearGradientStyle),
     Radial(RadialGradientStyle),

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -48,8 +48,7 @@ use url::Url;
 use util::vec::byte_swap;
 
 #[must_root]
-#[jstraceable]
-#[derive(Clone)]
+#[derive(JSTraceable, Clone)]
 pub enum CanvasFillOrStrokeStyle {
     Color(RGBA),
     Gradient(JS<CanvasGradient>),
@@ -68,8 +67,7 @@ pub struct CanvasRenderingContext2D {
 }
 
 #[must_root]
-#[jstraceable]
-#[derive(Clone)]
+#[derive(JSTraceable, Clone)]
 struct CanvasContextState {
     global_alpha: f64,
     global_composition: CompositionOrBlending,

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -154,8 +154,7 @@ impl<'a> CharacterDataMethods for &'a CharacterData {
 }
 
 /// The different types of CharacterData.
-#[derive(Copy, Clone, PartialEq, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, PartialEq, Debug)]
 pub enum CharacterDataTypeId {
     Comment,
     Text,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -45,8 +45,7 @@ use std::sync::mpsc::{Sender, Receiver, channel};
 /// A ScriptChan that can be cloned freely and will silently send a TrustedWorkerAddress with
 /// every message. While this SendableWorkerScriptChan is alive, the associated Worker object
 /// will remain alive.
-#[derive(Clone)]
-#[jstraceable]
+#[derive(JSTraceable, Clone)]
 pub struct SendableWorkerScriptChan {
     sender: Sender<(TrustedWorkerAddress, ScriptMsg)>,
     worker: TrustedWorkerAddress,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -100,8 +100,7 @@ use std::sync::mpsc::channel;
 use std::rc::Rc;
 use time;
 
-#[derive(PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq)]
 pub enum IsHTMLDocument {
     HTMLDocument,
     NonHTMLDocument,
@@ -164,7 +163,7 @@ impl DocumentDerived for EventTarget {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct ImagesFilter;
 impl CollectionFilter for ImagesFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -172,7 +171,7 @@ impl CollectionFilter for ImagesFilter {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct EmbedsFilter;
 impl CollectionFilter for EmbedsFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -180,7 +179,7 @@ impl CollectionFilter for EmbedsFilter {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct LinksFilter;
 impl CollectionFilter for LinksFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -189,7 +188,7 @@ impl CollectionFilter for LinksFilter {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct FormsFilter;
 impl CollectionFilter for FormsFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -197,7 +196,7 @@ impl CollectionFilter for FormsFilter {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct ScriptsFilter;
 impl CollectionFilter for ScriptsFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -205,7 +204,7 @@ impl CollectionFilter for ScriptsFilter {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct AnchorsFilter;
 impl CollectionFilter for AnchorsFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -213,7 +212,7 @@ impl CollectionFilter for AnchorsFilter {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 struct AppletsFilter;
 impl CollectionFilter for AppletsFilter {
     fn filter(&self, elem: &Element, _root: &Node) -> bool {
@@ -1748,7 +1747,7 @@ impl<'a> DocumentMethods for &'a Document {
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
     fn NamedGetter(self, _cx: *mut JSContext, name: DOMString, found: &mut bool)
                    -> *mut JSObject {
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct NamedElementFilter {
             name: Atom,
         }

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -13,8 +13,7 @@ use util::str::DOMString;
 use std::borrow::ToOwned;
 
 #[repr(u16)]
-#[derive(Copy, Clone, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, Debug)]
 pub enum DOMErrorName {
     IndexSizeError = DOMExceptionConstants::INDEX_SIZE_ERR,
     HierarchyRequestError = DOMExceptionConstants::HIERARCHY_REQUEST_ERR,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -117,8 +117,7 @@ impl PartialEq for Element {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, PartialEq, Debug)]
 pub enum ElementTypeId {
     HTMLElement(HTMLElementTypeId),
     Element,

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -18,8 +18,7 @@ use std::default::Default;
 
 use time;
 
-#[jstraceable]
-#[derive(Copy, Clone)]
+#[derive(JSTraceable, Copy, Clone)]
 #[repr(u16)]
 pub enum EventPhase {
     None      = EventConstants::NONE,
@@ -28,8 +27,7 @@ pub enum EventPhase {
     Bubbling  = EventConstants::BUBBLING_PHASE,
 }
 
-#[derive(PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq)]
 pub enum EventTypeId {
     CustomEvent,
     HTMLEvent,

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -36,15 +36,13 @@ use url::Url;
 
 use std::collections::HashMap;
 
-#[derive(Copy, Clone, PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, PartialEq)]
 pub enum ListenerPhase {
     Capturing,
     Bubbling,
 }
 
-#[derive(Copy, Clone)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone)]
 pub enum EventTargetTypeId {
     Node(NodeTypeId),
     WebSocket,
@@ -90,8 +88,7 @@ impl EventTargetTypeId {
     }
 }
 
-#[derive(Clone, PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, Clone, PartialEq)]
 pub enum EventListenerType {
     Additive(Rc<EventListener>),
     Inline(Rc<EventListener>),
@@ -106,8 +103,7 @@ impl EventListenerType {
     }
 }
 
-#[derive(Clone, PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, Clone, PartialEq)]
 #[privatize]
 pub struct EventListenerEntry {
     phase: ListenerPhase,

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -21,8 +21,7 @@ use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 
-#[derive(Clone)]
-#[jstraceable]
+#[derive(JSTraceable, Clone)]
 #[must_root]
 pub enum FormDatum {
     StringData(DOMString),

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -27,8 +27,7 @@ use std::borrow::ToOwned;
 use util::str::DOMString;
 use std::cell::Cell;
 
-#[jstraceable]
-#[derive(PartialEq, Copy, Clone)]
+#[derive(JSTraceable, PartialEq, Copy, Clone)]
 #[allow(dead_code)]
 enum ButtonType {
     ButtonSubmit,

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -37,9 +37,8 @@ use std::sync::mpsc::Sender;
 const DEFAULT_WIDTH: u32 = 300;
 const DEFAULT_HEIGHT: u32 = 150;
 
-#[jstraceable]
 #[must_root]
-#[derive(Clone, Copy)]
+#[derive(JSTraceable, Clone, Copy)]
 pub enum CanvasContext {
     Context2d(JS<CanvasRenderingContext2D>),
     WebGL(JS<WebGLRenderingContext>),

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -23,7 +23,7 @@ pub trait CollectionFilter : JSTraceable {
     fn filter<'a>(&self, elem: &'a Element, root: &'a Node) -> bool;
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 pub enum CollectionTypeId {
     Static(Vec<JS<Element>>),
@@ -58,7 +58,7 @@ impl HTMLCollection {
 
     fn all_elements(window: &Window, root: &Node,
                     namespace_filter: Option<Namespace>) -> Root<HTMLCollection> {
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct AllElementFilter {
             namespace_filter: Option<Namespace>
         }
@@ -80,7 +80,7 @@ impl HTMLCollection {
             return HTMLCollection::all_elements(window, root, None);
         }
 
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct TagNameFilter {
             tag: Atom,
             ascii_lower_tag: Atom,
@@ -111,7 +111,7 @@ impl HTMLCollection {
         if tag == "*" {
             return HTMLCollection::all_elements(window, root, namespace_filter);
         }
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct TagNameNSFilter {
             tag: Atom,
             namespace_filter: Option<Namespace>
@@ -136,7 +136,7 @@ impl HTMLCollection {
 
     pub fn by_class_name(window: &Window, root: &Node, classes: DOMString)
                          -> Root<HTMLCollection> {
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct ClassNameFilter {
             classes: Vec<Atom>
         }
@@ -154,7 +154,7 @@ impl HTMLCollection {
     }
 
     pub fn children(window: &Window, root: &Node) -> Root<HTMLCollection> {
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct ElementChildFilter;
         impl CollectionFilter for ElementChildFilter {
             fn filter(&self, elem: &Element, root: &Node) -> bool {

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -50,7 +50,7 @@ impl HTMLDataListElement {
 
 impl<'a> HTMLDataListElementMethods for &'a HTMLDataListElement {
     fn Options(self) -> Root<HTMLCollection> {
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct HTMLDataListOptionsFilter;
         impl CollectionFilter for HTMLDataListOptionsFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -309,8 +309,7 @@ impl<'a> VirtualMethods for &'a HTMLElement {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, Debug)]
 pub enum HTMLElementTypeId {
     HTMLElement,
 

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -56,7 +56,7 @@ impl HTMLFieldSetElement {
 impl<'a> HTMLFieldSetElementMethods for &'a HTMLFieldSetElement {
     // https://www.whatwg.org/html/#dom-fieldset-elements
     fn Elements(self) -> Root<HTMLCollection> {
-        #[jstraceable]
+        #[derive(JSTraceable)]
         struct ElementsFilter;
         impl CollectionFilter for ElementsFilter {
             fn filter<'a>(&self, elem: &'a Element, _root: &'a Node) -> bool {

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -12,7 +12,7 @@ use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
 use dom::node::{Node, NodeTypeId};
 use util::str::DOMString;
 
-#[jstraceable]
+#[derive(JSTraceable)]
 pub enum HeadingLevel {
     Heading1,
     Heading2,

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -45,8 +45,7 @@ use std::cell::Cell;
 const DEFAULT_SUBMIT_VALUE: &'static str = "Submit";
 const DEFAULT_RESET_VALUE: &'static str = "Reset";
 
-#[jstraceable]
-#[derive(PartialEq, Copy, Clone)]
+#[derive(JSTraceable, PartialEq, Copy, Clone)]
 #[allow(dead_code)]
 enum InputType {
     InputSubmit,
@@ -80,7 +79,7 @@ impl PartialEq for HTMLInputElement {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 struct InputActivationState {
     indeterminate: bool,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -41,8 +41,7 @@ impl HTMLMediaElement {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, Debug)]
 pub enum HTMLMediaElementTypeId {
     HTMLAudioElement = 0,
     HTMLVideoElement = 1,

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -22,8 +22,7 @@ use std::cmp::max;
 
 const DEFAULT_COLSPAN: u32 = 1;
 
-#[derive(Copy, Clone, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, Debug)]
 pub enum HTMLTableCellElementTypeId {
     HTMLTableDataCellElement = 0,
     HTMLTableHeaderCellElement = 1,

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -214,7 +214,7 @@ macro_rules! make_atomic_setter(
 );
 
 /// For use on non-jsmanaged types
-/// Use #[jstraceable] on JS managed types
+/// Use #[derive(JSTraceable)] on JS managed types
 macro_rules! no_jsmanaged_fields(
     ($($ty:ident),+) => (
         $(

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -135,7 +135,7 @@ impl NodeDerived for EventTarget {
 
 bitflags! {
     #[doc = "Flags for node items."]
-    #[jstraceable]
+    #[derive(JSTraceable)]
     flags NodeFlags: u16 {
         #[doc = "Specifies whether this node is in a document."]
         const IS_IN_DOC = 0x01,
@@ -279,8 +279,7 @@ impl LayoutDataRef {
 }
 
 /// The different types of nodes.
-#[derive(Copy, Clone, PartialEq, Debug)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, PartialEq, Debug)]
 pub enum NodeTypeId {
     CharacterData(CharacterDataTypeId),
     DocumentType,

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -217,7 +217,7 @@ impl<'a> PrivateNodeIteratorHelpers for &'a NodeIterator {
 }
 
 
-#[jstraceable]
+#[derive(JSTraceable)]
 pub enum Filter {
     None,
     Native(fn (node: &Node) -> u16),

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -10,7 +10,7 @@ use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::node::{Node, NodeHelpers};
 use dom::window::Window;
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 pub enum NodeListType {
     Simple(Vec<JS<Node>>),

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -290,7 +290,7 @@ impl<'a> RangeMethods for &'a Range {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 #[privatize]
 pub struct RangeInner {
@@ -424,7 +424,7 @@ impl RangeInner {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 #[privatize]
 pub struct BoundaryPoint {

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -36,7 +36,7 @@ use hyper::header::ContentType;
 use hyper::mime::{Mime, TopLevel, SubLevel};
 
 #[must_root]
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct Sink {
     pub base_url: Option<Url>,
     pub document: JS<Document>,

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -502,7 +502,7 @@ impl<'a> Iterator for &'a TreeWalker {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 pub enum Filter {
     None,
     Native(fn (node: &Node) -> u16),

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -33,8 +33,7 @@ use websocket::stream::WebSocketStream;
 use websocket::client::request::Url;
 use websocket::Client;
 
-#[derive(PartialEq, Copy, Clone)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq, Copy, Clone)]
 enum WebSocketRequestState {
     Connecting = 0,
     Open = 1,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -70,8 +70,7 @@ use std::sync::mpsc::TryRecvError::{Empty, Disconnected};
 use time;
 
 /// Current state of the window object
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, Debug, PartialEq)]
 enum WindowState {
     Alive,
     Zombie,     // Pipeline is closed, but the window hasn't been GCed yet.

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -33,8 +33,7 @@ use std::default::Default;
 use std::cell::Cell;
 use std::rc::Rc;
 
-#[derive(Copy, Clone, PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, PartialEq)]
 pub enum WorkerGlobalScopeTypeId {
     DedicatedGlobalScope,
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -67,8 +67,7 @@ use dom::bindings::codegen::UnionTypes::StringOrURLSearchParams::{eString, eURLS
 
 pub type SendParam = StringOrURLSearchParams;
 
-#[derive(PartialEq, Copy, Clone)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq, Copy, Clone)]
 enum XMLHttpRequestState {
     Unsent = 0,
     Opened = 1,
@@ -77,8 +76,7 @@ enum XMLHttpRequestState {
     Done = 4,
 }
 
-#[derive(PartialEq, Clone, Copy)]
-#[jstraceable]
+#[derive(JSTraceable, PartialEq, Clone, Copy)]
 pub struct GenerationId(u32);
 
 /// Closure of required data for each async network event that comprises the

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -8,8 +8,7 @@ use dom::bindings::codegen::InheritTypes::EventTargetCast;
 use dom::bindings::codegen::InheritTypes::XMLHttpRequestEventTargetDerived;
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 
-#[derive(Copy, Clone, PartialEq)]
-#[jstraceable]
+#[derive(JSTraceable, Copy, Clone, PartialEq)]
 pub enum XMLHttpRequestEventTargetTypeId {
     XMLHttpRequest,
     XMLHttpRequestUpload,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -11,6 +11,7 @@
 #![feature(core)]
 #![feature(core_intrinsics)]
 #![feature(custom_attribute)]
+#![feature(custom_derive)]
 #![feature(drain)]
 #![feature(hashmap_hasher)]
 #![feature(mpsc_select)]

--- a/components/script/page.rs
+++ b/components/script/page.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use url::Url;
 
 /// Encapsulates a handle to a frame in a frame tree.
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct Page {
     /// Pipeline id associated with this page.
     id: PipelineId,
@@ -133,7 +133,7 @@ impl Page {
 }
 
 /// Information for one frame in the browsing context.
-#[jstraceable]
+#[derive(JSTraceable)]
 #[must_root]
 pub struct Frame {
     /// The document for this frame.

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -121,7 +121,7 @@ unsafe extern fn trace_rust_roots(tr: *mut JSTracer, _data: *mut libc::c_void) {
 /// data that will need to be present when the document and frame tree entry are created,
 /// but is only easily available at initiation of the load and on a push basis (so some
 /// data will be updated according to future resize events, viewport changes, etc.)
-#[jstraceable]
+#[derive(JSTraceable)]
 struct InProgressLoad {
     /// The pipeline which requested this load.
     pipeline_id: PipelineId,
@@ -226,7 +226,7 @@ impl ScriptPort for Receiver<(TrustedWorkerAddress, ScriptMsg)> {
 }
 
 /// Encapsulates internal communication within the script task.
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct NonWorkerScriptChan(pub Sender<ScriptMsg>);
 
 impl ScriptChan for NonWorkerScriptChan {
@@ -269,7 +269,7 @@ impl Drop for StackRootTLS {
 
 /// Information for an entire page. Pages are top-level browsing contexts and can contain multiple
 /// frames.
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct ScriptTask {
     /// A handle to the information pertaining to page layout
     page: DOMRefCell<Option<Rc<Page>>>,

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -21,8 +21,7 @@ pub enum Selection {
     NotSelected
 }
 
-#[jstraceable]
-#[derive(Copy, Clone)]
+#[derive(JSTraceable, Copy, Clone)]
 pub struct TextPoint {
     /// 0-based line number
     pub line: usize,
@@ -31,7 +30,7 @@ pub struct TextPoint {
 }
 
 /// Encapsulated state for handling keyboard input in a single or multiline text input control.
-#[jstraceable]
+#[derive(JSTraceable)]
 pub struct TextInput<T: ClipboardProvider> {
     /// Current text input content, split across lines without trailing '\n'
     lines: Vec<DOMString>,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -29,12 +29,10 @@ use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::default::Default;
 
-#[derive(PartialEq, Eq)]
-#[jstraceable]
-#[derive(Copy, Clone)]
+#[derive(JSTraceable, PartialEq, Eq, Copy, Clone)]
 pub struct TimerId(i32);
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[privatize]
 struct TimerHandle {
     handle: TimerId,
@@ -42,8 +40,7 @@ struct TimerHandle {
     control_chan: Option<Sender<TimerControlMsg>>,
 }
 
-#[jstraceable]
-#[derive(Clone)]
+#[derive(JSTraceable, Clone)]
 pub enum TimerCallback {
     StringTimerCallback(DOMString),
     FunctionTimerCallback(Rc<Function>)
@@ -68,7 +65,7 @@ impl TimerHandle {
     }
 }
 
-#[jstraceable]
+#[derive(JSTraceable)]
 #[privatize]
 pub struct TimerManager {
     active_timers: DOMRefCell<HashMap<TimerId, TimerHandle>>,
@@ -85,16 +82,14 @@ impl Drop for TimerManager {
 }
 
 // Enum allowing more descriptive values for the is_interval field
-#[jstraceable]
-#[derive(PartialEq, Copy, Clone)]
+#[derive(JSTraceable, PartialEq, Copy, Clone)]
 pub enum IsInterval {
     Interval,
     NonInterval,
 }
 
 // Messages sent control timers from script task
-#[jstraceable]
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(JSTraceable, PartialEq, Copy, Clone, Debug)]
 pub enum TimerControlMsg {
     Cancel,
     Suspend,
@@ -105,7 +100,7 @@ pub enum TimerControlMsg {
 // (ie. function value to invoke and all arguments to pass
 //      to the function when calling it)
 // TODO: Handle rooting during fire_timer when movable GC is turned on
-#[jstraceable]
+#[derive(JSTraceable)]
 #[privatize]
 struct TimerData {
     is_interval: IsInterval,


### PR DESCRIPTION
fixes #6524.  I had to make an additional change not mentioned in the ticket - adding the `#[feature]` to enable deriving custom traits but I assume that's expected at this time.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6529)

<!-- Reviewable:end -->
