### PR TITLE
Move LayerBuffer cache to the compositor

### DIFF
--- a/components/compositing/buffer_map.rs
+++ b/components/compositing/buffer_map.rs
@@ -8,7 +8,6 @@ use euclid::size::Size2D;
 use layers::platform::surface::NativeDisplay;
 use layers::layers::LayerBuffer;
 use std::hash::{Hash, Hasher};
-use std::mem;
 
 /// This is a struct used to store buffers when they are not in use.
 /// The paint task can quickly query for a particular size of buffer when it
@@ -67,6 +66,13 @@ impl BufferMap {
             mem: 0,
             max_mem: max_mem,
             counter: 0,
+        }
+    }
+
+    pub fn insert_buffers(&mut self, display: &NativeDisplay, buffers: Vec<Box<LayerBuffer>>) {
+        for mut buffer in buffers.into_iter() {
+            buffer.mark_wont_leak();
+            self.insert(display, buffer)
         }
     }
 
@@ -148,17 +154,6 @@ impl BufferMap {
         }
 
         ret
-    }
-
-    /// Destroys all buffers.
-    pub fn clear(&mut self, display: &NativeDisplay) {
-        let map = mem::replace(&mut self.map, HashMap::new());
-        for (_, value) in map.into_iter() {
-            for tile in value.buffers.into_iter() {
-                tile.destroy(display)
-            }
-        }
-        self.mem = 0
     }
 
     pub fn mem(&self) -> usize {

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -111,6 +111,7 @@ impl CompositorEventListener for NullCompositor {
             Msg::IsReadyToSaveImageReply(..) => {}
             Msg::NewFavicon(..) => {}
             Msg::HeadParsed => {}
+            Msg::ReturnUnusedLayerBuffers(..) => {}
         }
         true
     }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(box_syntax)]
+#![feature(iter_cmp)]
 #![feature(slice_bytes)]
 #![feature(vec_push_all)]
 
@@ -43,6 +44,7 @@ pub use constellation::Constellation;
 
 pub mod compositor_task;
 
+mod buffer_map;
 mod compositor_layer;
 mod compositor;
 mod headless;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -9,7 +9,6 @@
 #![feature(custom_derive)]
 #![feature(hashmap_hasher)]
 #![cfg_attr(any(target_os="linux", target_os = "android"), feature(heap_api))]
-#![feature(iter_cmp)]
 #![feature(plugin)]
 #![feature(str_char)]
 #![feature(vec_push_all)]
@@ -78,7 +77,6 @@ pub mod font_cache_task;
 pub mod font_template;
 
 // Misc.
-mod buffer_map;
 mod filters;
 
 // Platform-specific implementations.

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -8,7 +8,7 @@ use euclid::point::Point2D;
 use euclid::rect::Rect;
 use euclid::Matrix4;
 use layers::platform::surface::NativeDisplay;
-use layers::layers::LayerBufferSet;
+use layers::layers::{BufferRequest, LayerBufferSet};
 use std::fmt::{Formatter, Debug};
 use std::fmt;
 
@@ -107,6 +107,9 @@ pub trait PaintListener {
                               epoch: Epoch,
                               replies: Vec<(LayerId, Box<LayerBufferSet>)>,
                               frame_tree_id: FrameTreeId);
+
+    /// Inform the compositor that these buffer requests will be ignored.
+    fn ignore_buffer_requests(&mut self, buffer_requests: Vec<BufferRequest>);
 
     // Notification that the paint task wants to exit.
     fn notify_paint_task_exiting(&mut self, pipeline_id: PipelineId);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -642,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#01bfc9fbb0748af62d89720f67a84e9542fad1d1"
+source = "git+https://github.com/servo/rust-layers#fff80972a75b5c4bce731de2ee2452bb8ef96430"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -634,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#01bfc9fbb0748af62d89720f67a84e9542fad1d1"
+source = "git+https://github.com/servo/rust-layers#fff80972a75b5c4bce731de2ee2452bb8ef96430"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -568,7 +568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#01bfc9fbb0748af62d89720f67a84e9542fad1d1"
+source = "git+https://github.com/servo/rust-layers#fff80972a75b5c4bce731de2ee2452bb8ef96430"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Now that NativeDisplay can be shared between the compositor and the
paint task, we can move the LayerBuffer cache to the compositor. This
allows surfaces to be potentially reused between different paint tasks
and will eventually allow OpenGL contexts to be preserved between
instances of GL rasterization.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6530)

<!-- Reviewable:end -->
