### PR TITLE
Only make a elements activatable when they have an href attribute.

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -101,7 +101,12 @@ impl<'a> Activatable for &'a HTMLAnchorElement {
     }
 
     fn is_instance_activatable(&self) -> bool {
-        true
+        // https://html.spec.whatwg.org/multipage/#hyperlink
+        // "a [...] element[s] with an href attribute [...] must [..] create a
+        // hyperlink"
+        // https://html.spec.whatwg.org/multipage/#the-a-element
+        // "The activation behaviour of a elements *that create hyperlinks*"
+        ElementCast::from_ref(*self).has_attribute(&atom!("href"))
     }
 
 
@@ -141,14 +146,13 @@ impl<'a> Activatable for &'a HTMLAnchorElement {
 
         //TODO: Step 4. Download the link is `download` attribute is set.
 
-        if let Some(ref href) = element.get_attribute(&ns!(""), &atom!("href")) {
-            let mut value = href.r().Value();
-            if let Some(suffix) = ismap_suffix {
-                value.push_str(&suffix);
-            }
-            debug!("clicked on link to {}", value);
-            doc.r().load_anchor_href(value);
+        let href = element.get_attribute(&ns!(""), &atom!("href")).unwrap();
+        let mut value = href.r().Value();
+        if let Some(suffix) = ismap_suffix {
+            value.push_str(&suffix);
         }
+        debug!("clicked on link to {}", value);
+        doc.r().load_anchor_href(value);
     }
 
     //TODO:https://html.spec.whatwg.org/multipage/#the-a-element


### PR DESCRIPTION
I've tested this manually, by clicking on the "baz" in code like

``` js
var a = document.body.appendChild(document.createElement("a"));
a.textContent = "bar ";
a.setAttribute("href", "http://www.yahoo.com");
var b = a.appendChild(document.createElement("a"));
b.textContent = "baz";
```

but I've not found a way to write an automated test.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6543)

<!-- Reviewable:end -->
