### PR TITLE
Remove *Cast::from_actual.

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -411,7 +411,7 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
 
     fn is_link(&self) -> bool {
         // FIXME: This is HTML only.
-        let node: &Node = NodeCast::from_actual(self.element);
+        let node: &Node = NodeCast::from_ref(self.element);
         match node.type_id_for_layout() {
             // https://html.spec.whatwg.org/multipage/#selector-link
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLAnchorElement)) |
@@ -438,7 +438,7 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
     #[inline]
     fn get_hover_state(&self) -> bool {
         unsafe {
-            let node: &Node = NodeCast::from_actual(self.element);
+            let node: &Node = NodeCast::from_ref(self.element);
             node.get_hover_state_for_layout()
         }
     }
@@ -446,7 +446,7 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
     #[inline]
     fn get_focus_state(&self) -> bool {
         unsafe {
-            let node: &Node = NodeCast::from_actual(self.element);
+            let node: &Node = NodeCast::from_ref(self.element);
             node.get_focus_state_for_layout()
         }
     }
@@ -461,7 +461,7 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
     #[inline]
     fn get_disabled_state(&self) -> bool {
         unsafe {
-            let node: &Node = NodeCast::from_actual(self.element);
+            let node: &Node = NodeCast::from_ref(self.element);
             node.get_disabled_state_for_layout()
         }
     }
@@ -469,7 +469,7 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
     #[inline]
     fn get_enabled_state(&self) -> bool {
         unsafe {
-            let node: &Node = NodeCast::from_actual(self.element);
+            let node: &Node = NodeCast::from_ref(self.element);
             node.get_enabled_state_for_layout()
         }
     }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5736,7 +5736,7 @@ class GlobalGenRoots():
 impl ${selfName} for ${baseName} {
     #[inline]
     fn ${fname}(&self) -> bool {
-        let base: &${parentName} = ${parentName}Cast::from_actual(self);
+        let base: &${parentName} = ${parentName}Cast::from_ref(self);
         base.${fname}()
     }
 }
@@ -5803,11 +5803,6 @@ impl ${name}Cast {
 
     #[inline]
     pub fn from_root<T: ${fromBound}+Reflectable>(derived: Root<T>) -> Root<${name}> {
-        unsafe { mem::transmute(derived) }
-    }
-
-    #[inline]
-    pub fn from_actual<'a, T: ${fromBound}+Reflectable>(derived: &'a T) -> &'a ${name} {
         unsafe { mem::transmute(derived) }
     }
 }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -180,7 +180,7 @@ impl RawHTMLIFrameElementHelpers for HTMLIFrameElement {
     #[allow(unsafe_code)]
     fn get_width(&self) -> LengthOrPercentageOrAuto {
         unsafe {
-            element::get_attr_for_layout(ElementCast::from_actual(&*self),
+            element::get_attr_for_layout(ElementCast::from_ref(&*self),
                                          &ns!(""),
                                          &atom!("width")).map(|attribute| {
                 str::parse_length(&**attribute.value_for_layout())
@@ -191,7 +191,7 @@ impl RawHTMLIFrameElementHelpers for HTMLIFrameElement {
     #[allow(unsafe_code)]
     fn get_height(&self) -> LengthOrPercentageOrAuto {
         unsafe {
-            element::get_attr_for_layout(ElementCast::from_actual(&*self),
+            element::get_attr_for_layout(ElementCast::from_ref(&*self),
                                          &ns!(""),
                                          &atom!("height")).map(|attribute| {
                 str::parse_length(&**attribute.value_for_layout())


### PR DESCRIPTION
Since JSRef was removed, from_actual duplicates from_ref.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6549)

<!-- Reviewable:end -->
