### PR TITLE
Unit test for util::str::split_html_space_chars

### DIFF
--- a/tests/unit/util/lib.rs
+++ b/tests/unit/util/lib.rs
@@ -13,3 +13,4 @@ extern crate euclid;
 #[cfg(test)] mod task;
 #[cfg(test)] mod vec;
 #[cfg(test)] mod mem;
+#[cfg(test)] mod str;

--- a/tests/unit/util/str.rs
+++ b/tests/unit/util/str.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use util::str::split_html_space_chars;
+
+
+#[test]
+pub fn split_html_space_chars_whitespace() {
+    assert!(split_html_space_chars("").collect::<Vec<_>>().is_empty());
+    assert!(split_html_space_chars("\u{0020}\u{0009}\u{000a}\u{000c}\u{000d}").collect::<Vec<_>>().is_empty());
+}


### PR DESCRIPTION
I was concerned for a little bit that passing just whitespace to the
split_html_space_chars function would result in len > 0, so I wrote this
small unit test to make sure it does the right thing. Even though it
does do the right thing, I think there's still value in committing the
unit test.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6553)

<!-- Reviewable:end -->
