### PR TITLE
Fix for #6542 - <img> top-padding adds margin

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1352,7 +1352,7 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
             }
         };
 
-        debug!("building flow for node: {:?} {:?} {:?}", display, float, node.type_id());
+        debug!("building flow for node: {:?} {:?} {:?} {:?}", display, float, positioning, node.type_id());
 
         // Switch on display and floatedness.
         match (display, float, positioning) {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1802,7 +1802,7 @@ impl Fragment {
                     block_size_above_baseline: computed_block_size +
                                                    self.border_padding.block_start_end(),
                     depth_below_baseline: Au(0),
-                    ascent: computed_block_size + self.border_padding.block_end,
+                    ascent: computed_block_size + self.border_padding.block_start_end(),
                 }
             }
             SpecificFragmentInfo::ScannedText(ref text_fragment) => {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -133,6 +133,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 == img_block_maxwidth_a.html img_block_maxwidth_ref.html
 == img_block_maxwidth_b.html img_block_maxwidth_ref.html
 == img_dynamic_remove.html img_dynamic_remove_ref.html
+== img_padding_a.html img_padding_b.html
 != img_simple.html img_simple_ref.html
 == img_size_a.html img_size_b.html
 == img_width_attribute_intrinsic_width_a.html img_width_attribute_intrinsic_width_ref.html

--- a/tests/ref/img_padding_a.html
+++ b/tests/ref/img_padding_a.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <img src="../html/rust-0.png" style='padding-top: 100px; border: 1px solid black; position:relative; height: 206px; width: 206px; left:0px; top: 0px;'>
+    </body>
+</html>

--- a/tests/ref/img_padding_b.html
+++ b/tests/ref/img_padding_b.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <img src="../html/rust-0.png" style='padding-top: 100px; border: 1px solid black;'>
+    </body>
+</html>

--- a/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-max-height-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-max-height-003.htm.ini
@@ -1,3 +1,0 @@
-[absolute-non-replaced-max-height-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-max-height-011.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-max-height-011.htm.ini
@@ -1,3 +1,0 @@
-[absolute-non-replaced-max-height-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/floats-040.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/floats-040.htm.ini
@@ -1,3 +1,0 @@
-[floats-040.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-111.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-111.htm.ini
@@ -1,3 +1,0 @@
-[min-height-111.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-112.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-112.htm.ini
@@ -1,3 +1,0 @@
-[min-height-112.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-absolute-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-absolute-002.htm.ini
@@ -1,3 +1,0 @@
-[position-absolute-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/top-offset-percentage-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/top-offset-percentage-001.htm.ini
@@ -1,3 +1,0 @@
-[top-offset-percentage-001.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
I wrote this patch that makes the test from #6542 render as expected but I am not confident it is actually the right fix.  Should the padding be included in the 'ascent' metric for images, or am I just introducing a bug that happens to offset the one I'm trying to fix?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6565)

<!-- Reviewable:end -->
