### PR TITLE
Remove unused import.

### DIFF
--- a/components/util/workqueue.rs
+++ b/components/util/workqueue.rs
@@ -13,7 +13,6 @@ use task_state;
 
 use libc::funcs::posix88::unistd::usleep;
 use rand::{Rng, weak_rng, XorShiftRng};
-use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Sender, Receiver};
 


### PR DESCRIPTION
Remove an unused import. This prevents a compiler warning in `util`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6567)

<!-- Reviewable:end -->
