### PR TITLE
Wire up the JS engine's memory reporting.

### DIFF
--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -318,6 +318,7 @@ impl PipelineContent {
                                   self.resource_task,
                                   self.storage_task.clone(),
                                   self.image_cache_task.clone(),
+                                  self.mem_profiler_chan.clone(),
                                   self.devtools_chan,
                                   self.window_size,
                                   self.load_data.clone());

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -19,6 +19,7 @@ use script_task::{ScriptChan, ScriptPort, ScriptMsg, ScriptTask};
 
 use msg::constellation_msg::{PipelineId, WorkerId};
 use net_traits::ResourceTask;
+use profile_traits::mem;
 
 use js::{JSCLASS_IS_GLOBAL, JSCLASS_IS_DOMJSCLASS};
 use js::jsapi::{GetGlobalForObjectCrossCompartment};
@@ -82,7 +83,15 @@ impl<'a> GlobalRef<'a> {
         }
     }
 
-    /// Get `DevtoolsControlChan` to send messages to Devtools
+    /// Get a `mem::ProfilerChan` to send messages to the memory profiler task.
+    pub fn mem_profiler_chan(&self) -> mem::ProfilerChan {
+        match *self {
+            GlobalRef::Window(window) => window.mem_profiler_chan(),
+            GlobalRef::Worker(worker) => worker.mem_profiler_chan(),
+        }
+    }
+
+    /// Get a `DevtoolsControlChan` to send messages to Devtools
     /// task when available.
     pub fn devtools_chan(&self) -> Option<DevtoolsControlChan> {
         match *self {

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -60,6 +60,7 @@ use smallvec::SmallVec1;
 use msg::compositor_msg::ScriptListener;
 use msg::constellation_msg::ConstellationChan;
 use net_traits::image::base::Image;
+use profile_traits::mem::ProfilerChan;
 use util::str::{LengthOrPercentageOrAuto};
 use std::cell::{Cell, UnsafeCell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -299,6 +300,7 @@ no_jsmanaged_fields!(CanvasGradientStop, LinearGradientStyle, RadialGradientStyl
 no_jsmanaged_fields!(LineCapStyle, LineJoinStyle, CompositionOrBlending);
 no_jsmanaged_fields!(RepetitionStyle);
 no_jsmanaged_fields!(WebGLError);
+no_jsmanaged_fields!(ProfilerChan);
 
 impl JSTraceable for Box<ScriptChan+Send> {
     #[inline]

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -90,8 +90,8 @@ impl Worker {
         }
 
         DedicatedWorkerGlobalScope::run_worker_scope(
-            worker_url, global.pipeline(), global.devtools_chan(), worker_ref, resource_task, global.script_chan(),
-            sender, receiver);
+            worker_url, global.pipeline(), global.mem_profiler_chan(), global.devtools_chan(),
+            worker_ref, resource_task, global.script_chan(), sender, receiver);
 
         Ok(worker)
     }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -23,6 +23,7 @@ use timers::{IsInterval, TimerId, TimerManager, TimerCallback};
 use devtools_traits::DevtoolsControlChan;
 
 use msg::constellation_msg::{PipelineId, WorkerId};
+use profile_traits::mem;
 use net_traits::{load_whole_resource, ResourceTask};
 use util::str::DOMString;
 
@@ -52,6 +53,7 @@ pub struct WorkerGlobalScope {
     console: MutNullableHeap<JS<Console>>,
     crypto: MutNullableHeap<JS<Crypto>>,
     timers: TimerManager,
+    mem_profiler_chan: mem::ProfilerChan,
     devtools_chan: Option<DevtoolsControlChan>,
 }
 
@@ -60,6 +62,7 @@ impl WorkerGlobalScope {
                          worker_url: Url,
                          runtime: Rc<Runtime>,
                          resource_task: ResourceTask,
+                         mem_profiler_chan: mem::ProfilerChan,
                          devtools_chan: Option<DevtoolsControlChan>) -> WorkerGlobalScope {
         WorkerGlobalScope {
             eventtarget: EventTarget::new_inherited(EventTargetTypeId::WorkerGlobalScope(type_id)),
@@ -72,8 +75,13 @@ impl WorkerGlobalScope {
             console: Default::default(),
             crypto: Default::default(),
             timers: TimerManager::new(),
+            mem_profiler_chan: mem_profiler_chan,
             devtools_chan: devtools_chan,
         }
+    }
+
+    pub fn mem_profiler_chan(&self) -> mem::ProfilerChan {
+        self.mem_profiler_chan.clone()
     }
 
     pub fn devtools_chan(&self) -> Option<DevtoolsControlChan> {

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -57,6 +57,7 @@ extern crate time;
 extern crate canvas;
 extern crate canvas_traits;
 extern crate rand;
+#[macro_use]
 extern crate profile_traits;
 extern crate script_traits;
 extern crate selectors;

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -13,6 +13,9 @@ path = "../msg"
 [dependencies.net_traits]
 path = "../net_traits"
 
+[dependencies.profile_traits]
+path = "../profile_traits"
+
 [dependencies.util]
 path = "../util"
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -16,6 +16,7 @@ extern crate ipc_channel;
 extern crate libc;
 extern crate msg;
 extern crate net_traits;
+extern crate profile_traits;
 extern crate serde;
 extern crate util;
 extern crate url;
@@ -32,6 +33,7 @@ use msg::webdriver_msg::WebDriverScriptCommand;
 use net_traits::ResourceTask;
 use net_traits::image_cache_task::ImageCacheTask;
 use net_traits::storage_task::StorageTask;
+use profile_traits::mem;
 use std::any::Any;
 use std::sync::mpsc::{Sender, Receiver};
 use url::Url;
@@ -190,6 +192,7 @@ pub trait ScriptTaskFactory {
               resource_task: ResourceTask,
               storage_task: StorageTask,
               image_cache_task: ImageCacheTask,
+              mem_profiler_chan: mem::ProfilerChan,
               devtools_chan: Option<DevtoolsControlChan>,
               window_size: Option<WindowSizeData>,
               load_data: LoadData);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#f59c04795c84b82e00fdbd694bed90c56fa6567a"
+source = "git+https://github.com/servo/rust-mozjs#9509978ed1e767c6cbf3da1886ab618f3fa58585"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#2c918d1fb803673f5e5aca230034f77e85455448"
+source = "git+https://github.com/servo/mozjs#065c9a4268ae51288e946b9dbf1c233f1dcf5ca3"
 
 [[package]]
 name = "msg"
@@ -1178,6 +1178,7 @@ dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
+ "profile_traits 0.0.1",
  "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -111,8 +111,8 @@ impl Browser {
         let constellation_chan = create_constellation(opts.clone(),
                                                       compositor_proxy.clone_compositor_proxy(),
                                                       time_profiler_chan.clone(),
-                                                      devtools_chan,
                                                       mem_profiler_chan.clone(),
+                                                      devtools_chan,
                                                       supports_clipboard);
 
         if let Some(port) = opts.webdriver_port {
@@ -157,8 +157,8 @@ impl Browser {
 fn create_constellation(opts: opts::Opts,
                         compositor_proxy: Box<CompositorProxy+Send>,
                         time_profiler_chan: time::ProfilerChan,
-                        devtools_chan: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
                         mem_profiler_chan: mem::ProfilerChan,
+                        devtools_chan: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
                         supports_clipboard: bool) -> ConstellationChan {
     let resource_task = new_resource_task(opts.user_agent.clone(), devtools_chan.clone());
 

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#f59c04795c84b82e00fdbd694bed90c56fa6567a"
+source = "git+https://github.com/servo/rust-mozjs#9509978ed1e767c6cbf3da1886ab618f3fa58585"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#2c918d1fb803673f5e5aca230034f77e85455448"
+source = "git+https://github.com/servo/mozjs#065c9a4268ae51288e946b9dbf1c233f1dcf5ca3"
 
 [[package]]
 name = "msg"
@@ -1150,6 +1150,7 @@ dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
+ "profile_traits 0.0.1",
  "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#f59c04795c84b82e00fdbd694bed90c56fa6567a"
+source = "git+https://github.com/servo/rust-mozjs#9509978ed1e767c6cbf3da1886ab618f3fa58585"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,7 +739,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#2c918d1fb803673f5e5aca230034f77e85455448"
+source = "git+https://github.com/servo/mozjs#065c9a4268ae51288e946b9dbf1c233f1dcf5ca3"
 
 [[package]]
 name = "msg"
@@ -1058,6 +1058,7 @@ dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
+ "profile_traits 0.0.1",
  "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
SpiderMonkey provides an extremely fine-grained breakdown of memory
usage, but for Servo we aggregate the measurements into a small number
of coarse buckets, which seems appropriate for the current level of
detail provided by Servo's memory profiler. Sample output:

```
|      17.41 MiB -- url(file:///home/njn/moz/servo/../servo-static-suite/wikipedia/Guardians%20of%20the%20Galaxy%20(film)%20-%20Wikipedia,%20the%20free%20encyclopedia.html)
|          7.32 MiB -- js
|             3.07 MiB -- malloc-heap
|             3.00 MiB -- gc-heap
|                2.48 MiB -- used
|                0.34 MiB -- decommitted
|                0.09 MiB -- unused
|                0.09 MiB -- admin
|             1.25 MiB -- non-heap
```

Most of the changes are plumbing to get the script task communicating
with the memory profiler task.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6572)

<!-- Reviewable:end -->
