### PR TITLE
Reduce the scope of the allowed unsafe code in context.rs.

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -4,7 +4,7 @@
 
 //! Data needed by the layout task.
 
-#![allow(unsafe_code)]
+#![deny(unsafe_code)]
 
 use css::matching::{ApplicableDeclarationsCache, StyleSharingCandidateCache};
 
@@ -138,6 +138,7 @@ pub struct SharedLayoutContext {
 // XXX UNSOUND!!! for stylist
 // XXX UNSOUND!!! for new_animations_sender
 // XXX UNSOUND!!! for canvas_layers_sender
+#[allow(unsafe_code)]
 unsafe impl Sync for SharedLayoutContext {}
 
 pub struct LayoutContext<'a> {


### PR DESCRIPTION
Since I made unsafe code opt-in in layout, the unsafe code in this module has
been reduced to a single unsafe impl, so there is no reason to allow it in
the entire module.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6576)

<!-- Reviewable:end -->
