### PR TITLE
gfx: Make display lists serializable using `serde`.

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -57,6 +57,8 @@ harfbuzz = "0.1"
 smallvec = "0.1"
 string_cache = "0.1"
 euclid = "0.1"
+serde = "*"
+serde_macros = "*"
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "*"

--- a/components/gfx/display_list/optimizer.rs
+++ b/components/gfx/display_list/optimizer.rs
@@ -37,7 +37,8 @@ impl DisplayListOptimizer {
         self.add_in_bounds_display_items(&mut result.content, display_list.content.iter());
         self.add_in_bounds_display_items(&mut result.positioned_content,
                                          display_list.positioned_content.iter());
-        self.add_in_bounds_display_items(&mut result.outlines, display_list.outlines.iter());
+        self.add_in_bounds_display_items(&mut result.outlines,
+                                         display_list.outlines.iter());
         self.add_in_bounds_stacking_contexts(&mut result.children, display_list.children.iter());
         result
     }

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -69,7 +69,7 @@ pub trait FontTableMethods {
     fn with_buffer<F>(&self, F) where F: FnOnce(*const u8, usize);
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FontMetrics {
     pub underline_size:   Au,
     pub underline_offset: Au,

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -14,9 +14,11 @@
 #![feature(vec_push_all)]
 
 #![plugin(plugins)]
+#![plugin(serde_macros)]
 
 #[macro_use]
 extern crate log;
+extern crate serde;
 
 extern crate azure;
 #[macro_use] extern crate bitflags;

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -40,7 +40,7 @@ use util::task_state;
 use util::task::spawn_named;
 
 /// Information about a hardware graphics layer that layout sends to the painting task.
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct PaintLayer {
     /// A per-pipeline ID describing this layer that should be stable across reflows.
     pub id: LayerId,
@@ -353,18 +353,23 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
             let transform = transform.mul(&stacking_context.transform);
             let perspective = perspective.mul(&stacking_context.perspective);
 
-            let (next_parent_id, page_position, transform, perspective) = match stacking_context.layer {
+            let (next_parent_id, page_position, transform, perspective) =
+                match stacking_context.layer {
                 Some(ref paint_layer) => {
-                    // Layers start at the top left of their overflow rect, as far as the info we give to
-                    // the compositor is concerned.
+                    // Layers start at the top left of their overflow rect, as far as the info we
+                    // give to the compositor is concerned.
                     let overflow_relative_page_position = *page_position +
                                                           stacking_context.bounds.origin +
                                                           stacking_context.overflow.origin;
                     let layer_position =
-                        Rect::new(Point2D::new(overflow_relative_page_position.x.to_nearest_px() as f32,
-                                               overflow_relative_page_position.y.to_nearest_px() as f32),
-                                  Size2D::new(stacking_context.overflow.size.width.to_nearest_px() as f32,
-                                              stacking_context.overflow.size.height.to_nearest_px() as f32));
+                        Rect::new(Point2D::new(overflow_relative_page_position.x.to_nearest_px() as
+                                               f32,
+                                               overflow_relative_page_position.y.to_nearest_px() as
+                                               f32),
+                                  Size2D::new(stacking_context.overflow.size.width.to_nearest_px()
+                                              as f32,
+                                              stacking_context.overflow.size.height.to_nearest_px()
+                                              as f32));
 
                     let establishes_3d_context = stacking_context.establishes_3d_context;
 
@@ -395,12 +400,7 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
             };
 
             for kid in stacking_context.display_list.children.iter() {
-                build(properties,
-                      &**kid,
-                      &page_position,
-                      &transform,
-                      &perspective,
-                      next_parent_id);
+                build(properties, &**kid, &page_position, &transform, &perspective, next_parent_id)
             }
         }
     }

--- a/components/gfx/platform/freetype/font_template.rs
+++ b/components/gfx/platform/freetype/font_template.rs
@@ -10,6 +10,7 @@ use string_cache::Atom;
 /// The identifier is an absolute path, and the bytes
 /// field is the loaded data that can be passed to
 /// freetype and azure directly.
+#[derive(Deserialize, Serialize)]
 pub struct FontTemplateData {
     pub bytes: Vec<u8>,
     pub identifier: Atom,

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -64,7 +64,7 @@ impl FontHandleMethods for FontHandle {
             Some(s) => s.to_f64_px(),
             None => 0.0
         };
-        match template.ctfont {
+        match *template.ctfont {
             Some(ref ctfont) => {
                 Ok(FontHandle {
                     font_data: template.clone(),

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -7,14 +7,27 @@ use core_graphics::font::CGFont;
 use core_text::font::CTFont;
 use core_text;
 
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::ToOwned;
+use std::ops::Deref;
 use string_cache::Atom;
 
 /// Platform specific font representation for mac.
 /// The identifier is a PostScript font name. The
 /// CTFont object is cached here for use by the
 /// paint functions that create CGFont references.
+#[derive(Deserialize, Serialize)]
 pub struct FontTemplateData {
-    pub ctfont: Option<CTFont>,
+    /// The `CTFont` object, if present. This is cached here so that we don't have to keep creating
+    /// `CTFont` instances over and over. It can always be recreated from the `identifier` and/or
+    /// `font_data` fields.
+    ///
+    /// When sending a `FontTemplateData` instance across processes, this will be set to `None` on
+    /// the other side, because `CTFont` instances cannot be sent across processes. This is
+    /// harmless, however, because it can always be recreated.
+    pub ctfont: CachedCTFont,
+
     pub identifier: Atom,
     pub font_data: Option<Vec<u8>>
 }
@@ -39,9 +52,43 @@ impl FontTemplateData {
         };
 
         FontTemplateData {
-            ctfont: ctfont,
+            ctfont: CachedCTFont(ctfont),
             identifier: identifier.to_owned(),
             font_data: font_data
         }
     }
 }
+
+pub struct CachedCTFont(Option<CTFont>);
+
+impl Deref for CachedCTFont {
+    type Target = Option<CTFont>;
+    fn deref(&self) -> &Option<CTFont> {
+        &self.0
+    }
+}
+
+impl Serialize for CachedCTFont {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+        serializer.visit_none()
+    }
+}
+
+impl Deserialize for CachedCTFont {
+    fn deserialize<D>(deserializer: &mut D) -> Result<CachedCTFont, D::Error>
+                      where D: Deserializer {
+        struct NoneOptionVisitor;
+
+        impl Visitor for NoneOptionVisitor {
+            type Value = CachedCTFont;
+
+            #[inline]
+            fn visit_none<E>(&mut self) -> Result<CachedCTFont,E> where E: Error {
+                Ok(CachedCTFont(None))
+            }
+        }
+
+        deserializer.visit_option(NoneOptionVisitor)
+    }
+}
+

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -19,7 +19,7 @@ use util::vec::*;
 /// In the uncommon case (multiple glyphs per unicode character, large glyph index/advance, or
 /// glyph offsets), we pack the glyph count into GlyphEntry, and store the other glyph information
 /// in DetailedGlyphStore.
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, Deserialize, Serialize)]
 struct GlyphEntry {
     value: u32,
 }
@@ -250,7 +250,7 @@ impl GlyphEntry {
 
 // Stores data for a detailed glyph, in the case that several glyphs
 // correspond to one character, or the glyph's data couldn't be packed.
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, Deserialize, Serialize)]
 struct DetailedGlyph {
     id: GlyphId,
     // glyph's advance, in the text's direction (LTR or RTL)
@@ -269,7 +269,7 @@ impl DetailedGlyph {
     }
 }
 
-#[derive(PartialEq, Clone, Eq, Debug, Copy)]
+#[derive(PartialEq, Clone, Eq, Debug, Copy, Deserialize, Serialize)]
 struct DetailedGlyphRecord {
     // source string offset/GlyphEntry offset in the TextRun
     entry_offset: CharIndex,
@@ -293,7 +293,7 @@ impl Ord for DetailedGlyphRecord {
 // until a lookup is actually performed; this matches the expected
 // usage pattern of setting/appending all the detailed glyphs, and
 // then querying without setting.
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 struct DetailedGlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
@@ -500,7 +500,7 @@ impl<'a> GlyphInfo<'a> {
 /// |               +---+---+                     |
 /// +---------------------------------------------+
 /// ~~~
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
@@ -515,7 +515,7 @@ pub struct GlyphStore {
 }
 
 int_range_index! {
-    #[derive(RustcEncodable)]
+    #[derive(Deserialize, Serialize, RustcEncodable)]
     #[doc = "An index that refers to a character in a text run. This could \
              point to the middle of a glyph."]
     #[derive(HeapSizeOf)]

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use text::glyph::{CharIndex, GlyphStore};
 
 /// A single "paragraph" of text in one font size and style.
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct TextRun {
     /// The UTF-8 string represented by this text run.
     pub text: Arc<String>,
@@ -26,7 +26,7 @@ pub struct TextRun {
 }
 
 /// A single series of glyphs within a text run.
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GlyphRun {
     /// The glyphs.
     pub glyph_store: Arc<GlyphStore>,

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -71,3 +71,6 @@ smallvec = "0.1"
 string_cache = "0.1"
 string_cache_plugin = "0.1"
 euclid = "0.1"
+serde = "*"
+serde_macros = "*"
+

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -829,7 +829,9 @@ impl FragmentDisplayListBuilding for Fragment {
 
         let line_display_item = box LineDisplayItem {
             base: BaseDisplayItem::new(baseline,
-                                       DisplayItemMetadata::new(self.node, style, Cursor::DefaultCursor),
+                                       DisplayItemMetadata::new(self.node,
+                                                                style,
+                                                                Cursor::DefaultCursor),
                                        (*clip).clone()),
             color: color::rgb(0, 200, 0),
             style: border_style::T::dashed,

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -58,6 +58,7 @@ use script::layout_interface::{NewLayoutTaskInfo, Msg, Reflow, ReflowGoal, Reflo
 use script::layout_interface::{ScriptLayoutChan, ScriptReflow, TrustedNodeAddress};
 use script_traits::{ConstellationControlMsg, LayoutControlMsg, OpaqueScriptLayoutChannel};
 use script_traits::{ScriptControlChan, StylesheetLoadResponder};
+use serde::json;
 use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -906,6 +907,9 @@ impl LayoutTask {
                 if opts::get().dump_display_list {
                     println!("#### start printing display list.");
                     stacking_context.print("#".to_owned());
+                }
+                if opts::get().dump_display_list_json {
+                    println!("{}", json::to_string_pretty(&stacking_context).unwrap());
                 }
 
                 rw_data.stacking_context = Some(stacking_context.clone());

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -5,6 +5,7 @@
 #![feature(append)]
 #![feature(arc_unique)]
 #![feature(box_syntax)]
+#![feature(custom_derive)]
 #![feature(filling_drop)]
 #![feature(hashmap_hasher)]
 #![feature(heap_api)]
@@ -36,7 +37,6 @@ extern crate profile_traits;
 #[macro_use]
 extern crate util;
 
-extern crate rustc_serialize;
 extern crate azure;
 extern crate canvas_traits;
 extern crate clock_ticks;
@@ -50,9 +50,11 @@ extern crate ipc_channel;
 extern crate layout_traits;
 extern crate libc;
 extern crate msg;
+extern crate rustc_serialize;
 extern crate script;
 extern crate script_traits;
 extern crate selectors;
+extern crate serde;
 extern crate smallvec;
 extern crate string_cache;
 extern crate style;

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -60,7 +60,7 @@ pub enum LayerKind {
 }
 
 /// The scrolling policy of a layer.
-#[derive(Clone, PartialEq, Eq, Copy)]
+#[derive(Clone, PartialEq, Eq, Copy, Deserialize, Serialize)]
 pub enum ScrollPolicy {
     /// These layers scroll when the parent receives a scrolling message.
     Scrollable,

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -24,4 +24,6 @@ log = "*"
 url = "0.2.35"
 hyper = "0.6"
 euclid = "0.1"
+serde = "*"
+serde_macros = "*"
 

--- a/components/net_traits/image/base.rs
+++ b/components/net_traits/image/base.rs
@@ -10,6 +10,7 @@ use util::vec::byte_swap;
 // FIXME: Images must not be copied every frame. Instead we should atomically
 // reference count them.
 
+#[derive(Deserialize, Serialize)]
 pub enum PixelFormat {
     K8,         // Luminance channel only
     KA8,        // Luminance + alpha
@@ -17,6 +18,7 @@ pub enum PixelFormat {
     RGBA8,      // RGB + alpha, 8 bits per channel
 }
 
+#[derive(Deserialize, Serialize)]
 pub struct Image {
     pub width: u32,
     pub height: u32,

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -3,15 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(box_syntax)]
+#![feature(custom_derive)]
+#![feature(plugin)]
 #![feature(slice_patterns)]
 #![feature(step_by)]
 #![feature(vec_push_all)]
+#![plugin(serde_macros)]
 
 extern crate euclid;
 extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate png;
+extern crate serde;
 extern crate stb_image;
 extern crate url;
 extern crate util;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -445,9 +445,11 @@ dependencies = [
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -579,7 +581,7 @@ dependencies = [
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,8 +722,10 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -883,6 +887,8 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1142,7 +1148,7 @@ dependencies = [
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "tendril 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1189,7 +1195,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicksort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1269,13 +1275,14 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1311,8 +1318,10 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1325,7 +1334,7 @@ dependencies = [
  "cssparser 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -34,3 +34,6 @@ smallvec = "0.1"
 string_cache = "0.1"
 string_cache_plugin = "0.1"
 euclid = "0.1"
+serde = "*"
+serde_macros = "*"
+

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -10,9 +10,9 @@
 #![feature(hasher_write)]
 #![feature(plugin)]
 #![feature(vec_push_all)]
-#![feature(vec_push_all)]
 
 #![plugin(string_cache_plugin)]
+#![plugin(serde_macros)]
 #![plugin(plugins)]
 
 #[macro_use] extern crate log;
@@ -20,6 +20,7 @@
 
 extern crate fnv;
 extern crate euclid;
+extern crate serde;
 extern crate smallvec;
 extern crate url;
 

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -3050,7 +3050,7 @@ pub mod longhands {
             use values::CSSFloat;
             use values::specified::{Angle};
 
-            #[derive(Clone, PartialEq, Debug, HeapSizeOf)]
+            #[derive(Clone, PartialEq, Debug, HeapSizeOf, Deserialize, Serialize)]
             pub enum Filter {
                 Blur(Au),
                 Brightness(CSSFloat),
@@ -3063,7 +3063,7 @@ pub mod longhands {
                 Sepia(CSSFloat),
             }
 
-            #[derive(Clone, PartialEq, Debug, HeapSizeOf)]
+            #[derive(Clone, PartialEq, Debug, HeapSizeOf, Deserialize, Serialize)]
             pub struct T { pub filters: Vec<Filter> }
 
             impl T {
@@ -3857,7 +3857,7 @@ pub mod longhands {
             use cssparser::ToCss;
             use std::fmt;
 
-            #[derive(Copy, Clone, Debug, PartialEq, HeapSizeOf)]
+            #[derive(Copy, Clone, Debug, PartialEq, HeapSizeOf, Deserialize, Serialize)]
             pub enum T {
                 Auto,
                 CrispEdges,

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -13,6 +13,7 @@ macro_rules! define_css_keyword_enum {
     ($name: ident: $( $css: expr => $variant: ident ),+) => {
         #[allow(non_camel_case_types)]
         #[derive(Clone, Eq, PartialEq, Copy, Hash, RustcEncodable, Debug, HeapSizeOf)]
+        #[derive(Deserialize, Serialize)]
         pub enum $name {
             $( $variant ),+
         }
@@ -44,6 +45,7 @@ macro_rules! define_numbered_css_keyword_enum {
     ($name: ident: $( $css: expr => $variant: ident = $value: expr ),+) => {
         #[allow(non_camel_case_types)]
         #[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Copy, RustcEncodable, Debug, HeapSizeOf)]
+        #[derive(Deserialize, Serialize)]
         pub enum $name {
             $( $variant = $value ),+
         }
@@ -645,7 +647,7 @@ pub mod specified {
         }
     }
 
-    #[derive(Clone, PartialEq, PartialOrd, Copy, Debug, HeapSizeOf)]
+    #[derive(Clone, PartialEq, PartialOrd, Copy, Debug, HeapSizeOf, Deserialize, Serialize)]
     pub struct Angle(pub CSSFloat);
 
     impl ToCss for Angle {

--- a/components/util/cursor.rs
+++ b/components/util/cursor.rs
@@ -9,7 +9,7 @@ use std::ascii::AsciiExt;
 
 macro_rules! define_cursor {
     ($( $css: expr => $variant: ident = $value: expr, )+) => {
-        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        #[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize, Serialize)]
         #[repr(u8)]
         pub enum Cursor {
             $( $variant = $value ),+

--- a/components/util/linked_list.rs
+++ b/components/util/linked_list.rs
@@ -4,8 +4,81 @@
 
 //! Utility functions for doubly-linked lists.
 
+use mem::HeapSizeOf;
+
+use serde::de::{Error, SeqVisitor, Visitor};
+use serde::ser::impls::SeqIteratorVisitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::LinkedList;
+use std::marker::PhantomData;
 use std::mem;
+use std::ops::{Deref, DerefMut};
+
+pub struct SerializableLinkedList<T>(LinkedList<T>);
+
+impl<T> SerializableLinkedList<T> {
+    pub fn new(linked_list: LinkedList<T>) -> SerializableLinkedList<T> {
+        SerializableLinkedList(linked_list)
+    }
+}
+
+impl<T> Deref for SerializableLinkedList<T> {
+    type Target = LinkedList<T>;
+
+    fn deref(&self) -> &LinkedList<T> {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for SerializableLinkedList<T> {
+    fn deref_mut(&mut self) -> &mut LinkedList<T> {
+        &mut self.0
+    }
+}
+
+impl<T: HeapSizeOf> HeapSizeOf for SerializableLinkedList<T> {
+    fn heap_size_of_children(&self) -> usize {
+        self.0.heap_size_of_children()
+    }
+}
+
+impl<T> Serialize for SerializableLinkedList<T> where T: Serialize {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+        serializer.visit_seq(SeqIteratorVisitor::new(self.0.iter(), Some(self.0.len())))
+    }
+}
+
+impl<T> Deserialize for SerializableLinkedList<T> where T: Deserialize {
+    fn deserialize<D>(deserializer: &mut D) -> Result<SerializableLinkedList<T>, D::Error>
+                      where D: Deserializer {
+        struct SerializableLinkedListVisitor<T> {
+            marker: PhantomData<T>,
+        }
+
+        impl<T> Visitor for SerializableLinkedListVisitor<T> where T: Deserialize {
+            type Value = SerializableLinkedList<T>;
+
+            #[inline]
+            fn visit_seq<V>(&mut self, mut visitor: V)
+                            -> Result<SerializableLinkedList<T>, V::Error>
+                            where V: SeqVisitor {
+                let mut list = LinkedList::new();
+                for _ in 0..visitor.size_hint().0 {
+                    match try!(visitor.visit()) {
+                        Some(element) => list.push_back(element),
+                        None => return Err(Error::end_of_stream_error()),
+                    }
+                }
+                try!(visitor.end());
+                Ok(SerializableLinkedList(list))
+            }
+        }
+
+        deserializer.visit_seq(SerializableLinkedListVisitor {
+            marker: PhantomData,
+        })
+    }
+}
 
 /// Splits the head off a list in O(1) time, and returns the head.
 pub fn split_off_head<T>(list: &mut LinkedList<T>) -> LinkedList<T> {

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -140,6 +140,9 @@ pub struct Opts {
     /// Dumps the display list after a layout.
     pub dump_display_list: bool,
 
+    /// Dumps the display list in JSON form after a layout.
+    pub dump_display_list_json: bool,
+
     /// Dumps the display list after optimization (post layout, at painting time).
     pub dump_display_list_optimized: bool,
 
@@ -178,6 +181,7 @@ pub fn print_debug_usage(app: &str) -> ! {
     print_option("disable-text-aa", "Disable antialiasing of rendered text.");
     print_option("dump-flow-tree", "Print the flow tree after each layout.");
     print_option("dump-display-list", "Print the display list after each layout.");
+    print_option("dump-display-list-json", "Print the display list in JSON form.");
     print_option("dump-display-list-optimized", "Print optimized display list (at paint time).");
     print_option("relayout-event", "Print notifications when there is a relayout.");
     print_option("profile-tasks", "Instrument each task, writing the output to a file.");
@@ -248,6 +252,7 @@ pub fn default_opts() -> Opts {
         user_agent: None,
         dump_flow_tree: false,
         dump_display_list: false,
+        dump_display_list_json: false,
         dump_display_list_optimized: false,
         relayout_event: false,
         validate_display_list_geometry: false,
@@ -424,6 +429,7 @@ pub fn from_cmdline_args(args: &[String]) {
         enable_canvas_antialiasing: !debug_options.contains(&"disable-canvas-aa"),
         dump_flow_tree: debug_options.contains(&"dump-flow-tree"),
         dump_display_list: debug_options.contains(&"dump-display-list"),
+        dump_display_list_json: debug_options.contains(&"dump-display-list-json"),
         dump_display_list_optimized: debug_options.contains(&"dump-display-list-optimized"),
         relayout_event: debug_options.contains(&"relayout-event"),
         validate_display_list_geometry: debug_options.contains(&"validate-display-list-geometry"),

--- a/components/util/range.rs
+++ b/components/util/range.rs
@@ -124,7 +124,7 @@ macro_rules! int_range_index {
 }
 
 /// A range of indices
-#[derive(Clone, RustcEncodable, Copy)]
+#[derive(Clone, RustcEncodable, Copy, Deserialize, Serialize)]
 pub struct Range<I> {
     begin: I,
     length: I,

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -444,9 +444,11 @@ dependencies = [
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -571,7 +573,7 @@ dependencies = [
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,8 +714,10 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -863,6 +867,8 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1108,6 +1114,7 @@ dependencies = [
  "hyper 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
+ "layout_traits 0.0.1",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1121,7 +1128,7 @@ dependencies = [
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "tendril 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1139,9 +1146,12 @@ version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1157,7 +1167,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicksort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1263,13 +1273,14 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1305,8 +1316,10 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -423,9 +423,11 @@ dependencies = [
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -505,7 +507,7 @@ dependencies = [
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -646,8 +648,10 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,6 +793,8 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1016,6 +1022,7 @@ dependencies = [
  "hyper 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "js 0.1.0 (git+https://github.com/servo/rust-mozjs)",
+ "layout_traits 0.0.1",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1029,7 +1036,7 @@ dependencies = [
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "tendril 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,9 +1054,12 @@ version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1065,7 +1075,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicksort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1161,13 +1171,14 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1203,8 +1214,10 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
+ "serde 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",


### PR DESCRIPTION
This commit introduces the `serde` dependency, which we will use to
serialize messages going between processes in multiprocess Servo.

This also adds a new debugging flag, `-Z print-display-list-json`,
allowing the output of display list serialization to be visualized.
This will be useful for our experiments with alternate rasterizers.

r? @metajack

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6583)

<!-- Reviewable:end -->
