### PR TITLE
Use NotImplementedError for Python base class methods

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -272,7 +272,7 @@ class CGThing():
 
     def define(self):
         """Produce code for a Rust file."""
-        assert(False)  # Override me!
+        raise NotImplementedError  # Override me!
 
 
 class CGNativePropertyHooks(CGThing):
@@ -2134,7 +2134,7 @@ class CGAbstractMethod(CGThing):
         return "\n}\n"
 
     def definition_body(self):
-        assert(False)  # Override me!
+        raise NotImplementedError  # Override me!
 
 
 def CreateBindingJSObject(descriptor, parent=None):
@@ -2843,7 +2843,7 @@ let global = global_object_for_js_object(JS_CALLEE(cx, vp).to_object());
         return CGList([preamble, self.generate_code()])
 
     def generate_code(self):
-        assert False  # Override me
+        raise NotImplementedError  # Override me!
 
 
 class CGSpecializedMethod(CGAbstractExternMethod):
@@ -4538,8 +4538,7 @@ let this: *const %s = native_from_reflector::<%s>(obj);
         ])
 
     def generate_code(self):
-        # Override me
-        assert(False)
+        raise NotImplementedError  # Override me!
 
 
 def finalizeHook(descriptor, hookName, context):


### PR DESCRIPTION
From the Python docs:

https://docs.python.org/2/library/exceptions.html#exceptions.NotImplementedError

"In user defined base classes, abstract methods should raise this
exception when they require derived classes to override the method."

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6592)

<!-- Reviewable:end -->
