### PR TITLE
Replace surrogates in JS strings with U+FFFD instead of panicking.

### DIFF
--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -355,7 +355,9 @@ pub fn jsstring_to_str(cx: *mut JSContext, s: *mut JSString) -> DOMString {
         let char_vec = unsafe {
             slice::from_raw_parts(chars as *const u16, length as usize)
         };
-        String::from_utf16(char_vec).unwrap()
+        // This is a wilful spec violation.
+        // See https://github.com/servo/servo/issues/6564
+        String::from_utf16_lossy(char_vec)
     }
 }
 


### PR DESCRIPTION
Fix #6519.
See #6564.

r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6595)

<!-- Reviewable:end -->
