### PR TITLE
Implement the Form Owner concept

### DIFF
--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -35,6 +35,7 @@ use script_task::STACK_ROOTS;
 use core::nonzero::NonZero;
 use std::cell::{Cell, UnsafeCell};
 use std::default::Default;
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 /// A traced reference to a DOM object. Must only be used as a field in other
@@ -99,6 +100,14 @@ impl<T> Copy for LayoutJS<T> {}
 impl<T> PartialEq for JS<T> {
     fn eq(&self, other: &JS<T>) -> bool {
         self.ptr == other.ptr
+    }
+}
+
+impl<T> Eq for JS<T> { }
+
+impl<T> Hash for JS<T> {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
+        self.ptr.hash(state);
     }
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -37,6 +37,7 @@ use script_task::ScriptChan;
 use canvas_traits::{CanvasGradientStop, LinearGradientStyle, RadialGradientStyle};
 use canvas_traits::{LineCapStyle, LineJoinStyle, CompositionOrBlending, RepetitionStyle};
 use canvas_traits::WebGLError;
+use devtools_traits::TimelineMarkerType;
 use cssparser::RGBA;
 use encoding::types::EncodingRef;
 use euclid::matrix2d::Matrix2D;
@@ -260,6 +261,20 @@ impl<K,V,S> JSTraceable for HashMap<K, V, S>
     }
 }
 
+impl<T, S> JSTraceable for HashSet<T, S>
+    where T: Hash + Eq + JSTraceable,
+    S: HashState,
+    <S as HashState>::Hasher: Hasher,
+{
+    #[inline]
+    fn trace(&self, trc: *mut JSTracer) {
+        for v in self.iter() {
+            v.trace(trc);
+        }
+    }
+}
+
+
 impl<A: JSTraceable, B: JSTraceable> JSTraceable for (A, B) {
     #[inline]
     fn trace(&self, trc: *mut JSTracer) {
@@ -282,7 +297,6 @@ no_jsmanaged_fields!(Image, ImageCacheChan, ImageCacheTask, ScriptControlChan);
 no_jsmanaged_fields!(Atom, Namespace);
 no_jsmanaged_fields!(Trusted<T>);
 no_jsmanaged_fields!(PropertyDeclarationBlock);
-no_jsmanaged_fields!(HashSet<T>);
 // These three are interdependent, if you plan to put jsmanaged data
 // in one of these make sure it is propagated properly to containing structs
 no_jsmanaged_fields!(SubpageId, WindowSizeData, PipelineId);
@@ -303,6 +317,7 @@ no_jsmanaged_fields!(LineCapStyle, LineJoinStyle, CompositionOrBlending);
 no_jsmanaged_fields!(RepetitionStyle);
 no_jsmanaged_fields!(WebGLError);
 no_jsmanaged_fields!(ProfilerChan);
+no_jsmanaged_fields!(TimelineMarkerType);
 
 impl JSTraceable for Box<ScriptChan+Send> {
     #[inline]

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -16,7 +16,8 @@ use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use dom::bindings::codegen::Bindings::NamedNodeMapBinding::NamedNodeMapMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
-use dom::bindings::codegen::InheritTypes::{ElementCast, ElementDerived, EventTargetCast};
+use dom::bindings::codegen::InheritTypes::{ElementBase, ElementCast, ElementDerived};
+use dom::bindings::codegen::InheritTypes::{EventTargetCast};
 use dom::bindings::codegen::InheritTypes::{HTMLBodyElementDerived, HTMLFontElementDerived};
 use dom::bindings::codegen::InheritTypes::{HTMLIFrameElementDerived, HTMLInputElementCast};
 use dom::bindings::codegen::InheritTypes::{HTMLInputElementDerived, HTMLTableElementCast};
@@ -32,6 +33,7 @@ use dom::bindings::error::Error::NoModificationAllowed;
 use dom::bindings::js::{JS, LayoutJS, MutNullableHeap};
 use dom::bindings::js::{Root, RootedReference};
 use dom::bindings::trace::RootedVec;
+use dom::bindings::utils::Reflectable;
 use dom::bindings::utils::{namespace_from_domstring, xml_name_type, validate_and_extract};
 use dom::bindings::utils::XMLName::InvalidXMLName;
 use dom::create::create_element;
@@ -554,6 +556,8 @@ pub trait ElementHelpers<'a> {
     fn serialize(self, traversal_scope: TraversalScope) -> Fallible<DOMString>;
     fn get_root_element(self) -> Root<Element>;
     fn lookup_prefix(self, namespace: Namespace) -> Option<DOMString>;
+    fn is_in_same_home_subtree<T>(self, other: &T) -> bool
+        where T: ElementBase + Reflectable;
 }
 
 impl<'a> ElementHelpers<'a> for &'a Element {
@@ -740,6 +744,15 @@ impl<'a> ElementHelpers<'a> for &'a Element {
         }
         None
     }
+
+    // https://html.spec.whatwg.org/multipage/#home-subtree
+    fn is_in_same_home_subtree<T>(self, other: &T) -> bool
+        where T: ElementBase + Reflectable
+    {
+        let other = ElementCast::from_ref(other);
+        self.get_root_element() == other.get_root_element()
+    }
+
 }
 
 pub trait FocusElementHelpers {

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -6,24 +6,29 @@ use dom::attr::Attr;
 use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;
-use dom::bindings::codegen::InheritTypes::{HTMLFieldSetElementDerived, NodeCast};
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLFieldSetElementDerived, NodeCast};
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLLegendElementDerived};
-use dom::bindings::js::{Root, RootedReference};
+use dom::bindings::js::{JS, MutNullableHeap, Root, RootedReference};
 use dom::document::Document;
 use dom::element::{AttributeHandlers, Element, ElementHelpers};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlcollection::{HTMLCollection, CollectionFilter};
 use dom::element::ElementTypeId;
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{HTMLFormElement, FormControl};
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, NodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 
+use string_cache::Atom;
 use util::str::{DOMString, StaticStringVec};
+
+use std::default::Default;
 
 #[dom_struct]
 pub struct HTMLFieldSetElement {
-    htmlelement: HTMLElement
+    htmlelement: HTMLElement,
+    form_owner: MutNullableHeap<JS<HTMLFormElement>>,
 }
 
 impl HTMLFieldSetElementDerived for EventTarget {
@@ -40,7 +45,8 @@ impl HTMLFieldSetElement {
                      document: &Document) -> HTMLFieldSetElement {
         HTMLFieldSetElement {
             htmlelement:
-                HTMLElement::new_inherited(HTMLElementTypeId::HTMLFieldSetElement, localName, prefix, document)
+                HTMLElement::new_inherited(HTMLElementTypeId::HTMLFieldSetElement, localName, prefix, document),
+            form_owner: Default::default(),
         }
     }
 
@@ -74,6 +80,11 @@ impl<'a> HTMLFieldSetElementMethods for &'a HTMLFieldSetElement {
     fn Validity(self) -> Root<ValidityState> {
         let window = window_from_node(self);
         ValidityState::new(window.r())
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-fae-form
+    fn GetForm(self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
     }
 
     // https://www.whatwg.org/html/#dom-fieldset-disabled
@@ -125,6 +136,9 @@ impl<'a> VirtualMethods for &'a HTMLFieldSetElement {
                     }
                 }
             },
+            &atom!("form") => {
+                self.after_set_form_attr();
+            },
             _ => ()
         }
     }
@@ -165,8 +179,53 @@ impl<'a> VirtualMethods for &'a HTMLFieldSetElement {
                     }
                 }
             },
+            &atom!("form") => {
+                self.before_remove_form_attr();
+            },
             _ => ()
         }
     }
+
+    fn after_remove_attr(&self, attr: &Atom) {
+        if let Some(ref s) = self.super_type() {
+            s.after_remove_attr(attr);
+        }
+
+        match attr {
+            &atom!("form") => {
+                self.after_remove_form_attr();
+            }
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
+        }
+
+        self.bind_form_control_to_tree();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
+        }
+
+        self.unbind_form_control_from_tree();
+    }
 }
 
+impl<'a> FormControl for &'a HTMLFieldSetElement {
+    fn form_owner(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner.get().map(Root::from_rooted)
+    }
+
+    fn set_form_owner(&self, form: Option<&HTMLFormElement>) {
+        self.form_owner.set(form.map(JS::from_ref));
+    }
+
+    fn to_element<'b>(&'b self) -> &'b Element {
+        ElementCast::from_ref(*self)
+    }
+}

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -3,23 +3,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::attr::AttrValue;
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLFormElementBinding;
 use dom::bindings::codegen::Bindings::HTMLFormElementBinding::HTMLFormElementMethods;
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
+use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::EventTargetCast;
+use dom::bindings::codegen::InheritTypes::HTMLButtonElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLDataListElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLFieldSetElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLFormElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLFormElementDerived;
+use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLLabelElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLOutputElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLSelectElementCast;
 use dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementCast, NodeCast};
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{Root};
+use dom::bindings::js::{JS, Root, RootedReference};
+use dom::bindings::trace::RootedVec;
 use dom::document::{Document, DocumentHelpers};
-use dom::element::{Element, AttributeHandlers};
+use dom::element::{Element, ElementHelpers, AttributeHandlers};
 use dom::event::{Event, EventHelpers, EventBubbles, EventCancelable};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::element::ElementTypeId;
@@ -28,6 +38,7 @@ use dom::htmlinputelement::{HTMLInputElement, HTMLInputElementHelpers};
 use dom::htmlbuttonelement::{HTMLButtonElement};
 use dom::htmltextareaelement::HTMLTextAreaElementHelpers;
 use dom::node::{Node, NodeHelpers, NodeTypeId, document_from_node, window_from_node};
+use dom::node::{VecPreOrderInsertionHelper, PARSER_ASSOCIATED_FORM_OWNER};
 use dom::virtualmethods::VirtualMethods;
 use hyper::method::Method;
 use hyper::header::ContentType;
@@ -47,6 +58,7 @@ use std::cell::Cell;
 pub struct HTMLFormElement {
     htmlelement: HTMLElement,
     marked_for_reset: Cell<bool>,
+    controls: DOMRefCell<Vec<JS<Element>>>,
 }
 
 impl PartialEq for HTMLFormElement {
@@ -70,6 +82,7 @@ impl HTMLFormElement {
         HTMLFormElement {
             htmlelement: HTMLElement::new_inherited(HTMLElementTypeId::HTMLFormElement, localName, prefix, document),
             marked_for_reset: Cell::new(false),
+            controls: DOMRefCell::new(Vec::new()),
         }
     }
 
@@ -169,6 +182,9 @@ pub trait HTMLFormElementHelpers {
     fn get_form_dataset(self, submitter: Option<FormSubmitter>) -> Vec<FormDatum>;
     // https://html.spec.whatwg.org/multipage/#dom-form-reset
     fn reset(self, submit_method_flag: ResetFrom);
+
+    fn add_control<T: ?Sized + FormControl>(self, control: &T);
+    fn remove_control<T: ?Sized + FormControl>(self, control: &T);
 }
 
 impl<'a> HTMLFormElementHelpers for &'a HTMLFormElement {
@@ -268,21 +284,21 @@ impl<'a> HTMLFormElementHelpers for &'a HTMLFormElement {
             buf
         }
 
-        let node = NodeCast::from_ref(self);
-        // TODO: This is an incorrect way of getting controls owned
-        //       by the form, but good enough until html5ever lands
-        let data_set = node.traverse_preorder().filter_map(|child| {
-            if child.r().get_disabled_state() {
+        let controls = self.controls.borrow();
+        let data_set = controls.iter().filter_map(|child| {
+            let child = child.root();
+            let child = NodeCast::from_ref(child.r());
+            if child.get_disabled_state() {
                 return None;
             }
-            if child.r().ancestors()
-                        .any(|a| HTMLDataListElementCast::to_root(a).is_some()) {
+            if child.ancestors()
+                    .any(|a| HTMLDataListElementCast::to_root(a).is_some()) {
                 return None;
             }
             // XXXManishearth don't include it if it is a button but not the submitter
-            match child.r().type_id() {
+            match child.type_id() {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLInputElement)) => {
-                    let input = HTMLInputElementCast::to_ref(child.r()).unwrap();
+                    let input = HTMLInputElementCast::to_ref(child).unwrap();
                     let ty = input.Type();
                     let name = input.Name();
                     match &*ty {
@@ -381,14 +397,13 @@ impl<'a> HTMLFormElementHelpers for &'a HTMLFormElement {
             return;
         }
 
-        let node = NodeCast::from_ref(self);
-
-        // TODO: This is an incorrect way of getting controls owned
-        //       by the form, but good enough until html5ever lands
-        for child in node.traverse_preorder() {
-            match child.r().type_id() {
+        let controls = self.controls.borrow();
+        for child in controls.iter() {
+            let child = child.root();
+            let child = NodeCast::from_ref(child.r());
+            match child.type_id() {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLInputElement)) => {
-                    let input = HTMLInputElementCast::to_ref(child.r()).unwrap();
+                    let input = HTMLInputElementCast::to_ref(child).unwrap();
                     input.reset()
                 }
                 // TODO HTMLKeygenElement unimplemented
@@ -401,7 +416,7 @@ impl<'a> HTMLFormElementHelpers for &'a HTMLFormElement {
                     {}
                 }
                 NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLTextAreaElement)) => {
-                    let textarea = HTMLTextAreaElementCast::to_ref(child.r()).unwrap();
+                    let textarea = HTMLTextAreaElementCast::to_ref(child).unwrap();
                     textarea.reset()
                 }
                 NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOutputElement)) => {
@@ -412,6 +427,23 @@ impl<'a> HTMLFormElementHelpers for &'a HTMLFormElement {
             }
         };
         self.marked_for_reset.set(false);
+    }
+
+    fn add_control<T: ?Sized + FormControl>(self, control: &T) {
+        let elem = ElementCast::from_ref(self);
+        let root = elem.get_root_element();
+        let root = NodeCast::from_ref(root.r());
+
+        let mut controls = self.controls.borrow_mut();
+        controls.insert_pre_order(control.to_element(), root);
+    }
+
+    fn remove_control<T: ?Sized + FormControl>(self, control: &T) {
+        let control = control.to_element();
+        let mut controls = self.controls.borrow_mut();
+        controls.iter().map(|c| c.root())
+                       .position(|c| c.r() == control)
+                       .map(|idx| controls.remove(idx));
     }
 }
 
@@ -526,33 +558,124 @@ impl<'a> FormSubmitter<'a> {
     }
 }
 
-pub trait FormControl<'a> : Copy + Sized {
-    // FIXME: This is wrong (https://github.com/servo/servo/issues/3553)
-    //        but we need html5ever to do it correctly
-    fn form_owner(self) -> Option<Root<HTMLFormElement>> {
-        // https://html.spec.whatwg.org/multipage/#reset-the-form-owner
+pub trait FormControl {
+
+    fn form_owner(&self) -> Option<Root<HTMLFormElement>>;
+
+    fn set_form_owner(&self, form: Option<&HTMLFormElement>);
+
+    fn to_element<'a>(&'a self) -> &'a Element;
+
+    fn is_reassociatable(&self) -> bool {
+        true
+    }
+
+    // https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token
+    // Part of step 4.
+    // '..suppress the running of the reset the form owner algorithm
+    // when the parser subsequently attempts to insert the element..'
+    fn set_form_owner_from_parser(&self, form: &HTMLFormElement) {
         let elem = self.to_element();
-        let owner = elem.get_string_attribute(&atom!("form"));
-        if !owner.is_empty() {
-            let doc = document_from_node(elem);
-            let owner = doc.r().GetElementById(owner);
-            match owner {
-                Some(ref o) => {
-                    let maybe_form = HTMLFormElementCast::to_ref(o.r());
-                    if maybe_form.is_some() {
-                        return maybe_form.map(Root::from_ref);
-                    }
-                },
-                _ => ()
-            }
-        }
         let node = NodeCast::from_ref(elem);
-        for ancestor in node.ancestors() {
-            if let Some(ancestor) = HTMLFormElementCast::to_ref(ancestor.r()) {
-                return Some(Root::from_ref(ancestor))
+        node.set_flag(PARSER_ASSOCIATED_FORM_OWNER, true);
+        form.add_control(self);
+        self.set_form_owner(Some(form));
+    }
+
+    // https://html.spec.whatwg.org/multipage/#reset-the-form-owner
+    fn reset_form_owner(&self) {
+        let elem = self.to_element();
+        let node = NodeCast::from_ref(elem);
+        let old_owner = self.form_owner();
+        let has_form_id = elem.has_attribute(&atom!(form));
+        let nearest_form_ancestor = node.ancestors()
+                                        .filter_map(HTMLFormElementCast::to_root)
+                                        .next();
+
+        if (!self.is_reassociatable() || !has_form_id) && old_owner.is_some() {
+            if nearest_form_ancestor == old_owner {
+                return;
             }
         }
-        None
+
+        let new_owner = if self.is_reassociatable() && has_form_id && node.is_in_doc() {
+            // Step 3
+            let doc = document_from_node(node);
+            let form_id = elem.get_string_attribute(&atom!(form));
+            doc.GetElementById(form_id).and_then(HTMLFormElementCast::to_root)
+        } else {
+            // Step 4
+            nearest_form_ancestor
+        };
+
+        if old_owner != new_owner {
+            old_owner.r().map(|o| o.remove_control(self));
+            new_owner.r().map(|o| o.add_control(self));
+            self.set_form_owner(new_owner.r());
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/#form-owner
+    fn after_set_form_attr(&self) {
+        let elem = self.to_element();
+        let form_id = elem.get_string_attribute(&atom!(form));
+        let node = NodeCast::from_ref(elem);
+
+        if self.is_reassociatable() && !form_id.is_empty() && node.is_in_doc() {
+            let doc = document_from_node(node);
+            doc.register_form_id_listener(form_id, self);
+        }
+
+        self.reset_form_owner();
+    }
+
+    fn before_remove_form_attr(&self) {
+        let elem = self.to_element();
+        let form_id = elem.get_string_attribute(&atom!(form));
+
+        if self.is_reassociatable() && !form_id.is_empty() {
+            let doc = document_from_node(NodeCast::from_ref(elem));
+            doc.unregister_form_id_listener(form_id, self);
+        }
+    }
+
+    fn after_remove_form_attr(&self) {
+        self.reset_form_owner();
+    }
+
+    fn bind_form_control_to_tree(&self) {
+        let elem = self.to_element();
+        let node = NodeCast::from_ref(elem);
+
+        // https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token
+        // Part of step 4.
+        // '..suppress the running of the reset the form owner algorithm
+        // when the parser subsequently attempts to insert the element..'
+        let must_skip_reset = node.get_flag(PARSER_ASSOCIATED_FORM_OWNER);
+        node.set_flag(PARSER_ASSOCIATED_FORM_OWNER, false);
+
+        if !must_skip_reset {
+            self.after_set_form_attr();
+        }
+    }
+
+    fn unbind_form_control_from_tree(&self) {
+        let elem = self.to_element();
+        let has_form_attr = elem.has_attribute(&atom!(form));
+        let same_subtree = self.form_owner().map_or(true, |form| {
+            elem.is_in_same_home_subtree(form.r())
+        });
+
+        self.before_remove_form_attr();
+
+        // Since this control has been unregistered from the id->listener map
+        // in the previous step, reset_form_owner will not be invoked on it
+        // when the form owner element is unbound (i.e it is in the same
+        // subtree) if it appears later in the tree order. Hence invoke
+        // reset from here if this control has the form attribute set.
+        if !same_subtree || (self.is_reassociatable() && has_form_attr) {
+            self.reset_form_owner();
+        }
     }
 
     fn get_form_attribute<InputFn, OwnerFn>(self,
@@ -561,7 +684,8 @@ pub trait FormControl<'a> : Copy + Sized {
                                             owner: OwnerFn)
                                             -> DOMString
         where InputFn: Fn(Self) -> DOMString,
-              OwnerFn: Fn(&HTMLFormElement) -> DOMString
+              OwnerFn: Fn(&HTMLFormElement) -> DOMString,
+              Self: Sized
     {
         if self.to_element().has_attribute(attr) {
             input(self)
@@ -569,8 +693,6 @@ pub trait FormControl<'a> : Copy + Sized {
             self.form_owner().map_or("".to_owned(), |t| owner(t.r()))
         }
     }
-
-    fn to_element(self) -> &'a Element;
 }
 
 impl<'a> VirtualMethods for &'a HTMLFormElement {
@@ -582,6 +704,78 @@ impl<'a> VirtualMethods for &'a HTMLFormElement {
         match name {
             &atom!("name") => AttrValue::from_atomic(value),
             _ => self.super_type().unwrap().parse_plain_attribute(name, value),
+        }
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
+        }
+
+        // Collect the controls to reset because reset_form_owner
+        // will mutably borrow self.controls
+        let mut to_reset: RootedVec<JS<Element>> = RootedVec::new();
+        to_reset.extend(self.controls.borrow().iter()
+                        .filter(|c| !c.root().is_in_same_home_subtree(*self))
+                        .map(|c| c.clone()));
+
+        for control in to_reset.iter() {
+            let control = control.root();
+            control.r().as_maybe_form_control()
+                       .expect("Element must be a form control")
+                       .reset_form_owner();
+        }
+    }
+}
+
+pub trait FormControlElementHelpers {
+    fn as_maybe_form_control<'a>(&'a self) -> Option<&'a FormControl>;
+}
+
+impl<'a> FormControlElementHelpers for &'a Element {
+    fn as_maybe_form_control<'b>(&'b self) -> Option<&'b FormControl> {
+        let node = NodeCast::from_ref(*self);
+
+        match node.type_id() {
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLButtonElement)) => {
+                let element = HTMLButtonElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLFieldSetElement)) => {
+                let element = HTMLFieldSetElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLImageElement)) => {
+                let element = HTMLImageElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLInputElement)) => {
+                let element = HTMLInputElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLLabelElement)) => {
+                let element = HTMLLabelElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLObjectElement)) => {
+                let element = HTMLObjectElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOutputElement)) => {
+                let element = HTMLOutputElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLSelectElement)) => {
+                let element = HTMLSelectElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLTextAreaElement)) => {
+                let element = HTMLTextAreaElementCast::to_borrowed_ref(self).unwrap();
+                Some(element as &FormControl)
+            },
+            _ => {
+                None
+            }
         }
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -592,7 +592,8 @@ pub trait FormControl {
                                         .filter_map(HTMLFormElementCast::to_root)
                                         .next();
 
-        if (!self.is_reassociatable() || !has_form_id) && old_owner.is_some() {
+        // Step 1
+        if old_owner.is_some() && !(self.is_reassociatable() && has_form_id) {
             if nearest_form_ancestor == old_owner {
                 return;
             }

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -2,19 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::Attr;
+use dom::attr::AttrHelpers;
 use dom::bindings::codegen::Bindings::HTMLLabelElementBinding;
+use dom::bindings::codegen::Bindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
+use dom::bindings::codegen::InheritTypes::ElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLLabelElementDerived;
-use dom::bindings::js::Root;
+use dom::bindings::js::{JS, MutNullableHeap, Root};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
-use dom::element::ElementTypeId;
+use dom::element::{Element, ElementTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{HTMLFormElement, FormControl};
 use dom::node::{Node, NodeTypeId};
+use dom::virtualmethods::VirtualMethods;
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
 pub struct HTMLLabelElement {
     htmlelement: HTMLElement,
+    form_owner: MutNullableHeap<JS<HTMLFormElement>>,
 }
 
 impl HTMLLabelElementDerived for EventTarget {
@@ -31,7 +40,8 @@ impl HTMLLabelElement {
                      document: &Document) -> HTMLLabelElement {
         HTMLLabelElement {
             htmlelement:
-                HTMLElement::new_inherited(HTMLElementTypeId::HTMLLabelElement, localName, prefix, document)
+                HTMLElement::new_inherited(HTMLElementTypeId::HTMLLabelElement, localName, prefix, document),
+            form_owner: Default::default(),
         }
     }
 
@@ -44,3 +54,85 @@ impl HTMLLabelElement {
     }
 }
 
+impl<'a> HTMLLabelElementMethods for &'a HTMLLabelElement {
+    // https://html.spec.whatwg.org/multipage/#dom-fae-form
+    fn GetForm(self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
+}
+
+impl<'a> VirtualMethods for &'a HTMLLabelElement {
+    fn super_type<'b>(&'b self) -> Option<&'b VirtualMethods> {
+        let htmlelement: &&HTMLElement = HTMLElementCast::from_borrowed_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, attr: &Attr) {
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
+        }
+
+        match attr.local_name() {
+            &atom!("form") => {
+                self.after_set_form_attr();
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, attr: &Attr) {
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
+        }
+
+        match attr.local_name() {
+            &atom!("form") => {
+                self.before_remove_form_attr();
+            },
+            _ => ()
+        }
+    }
+
+    fn after_remove_attr(&self, attr: &Atom) {
+        if let Some(ref s) = self.super_type() {
+            s.after_remove_attr(attr);
+        }
+
+        match attr {
+            &atom!("form") => {
+                self.after_remove_form_attr();
+            }
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
+        }
+
+        self.bind_form_control_to_tree();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
+        }
+
+        self.unbind_form_control_from_tree();
+    }
+}
+
+impl<'a> FormControl for &'a HTMLLabelElement {
+    fn form_owner(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner.get().map(Root::from_rooted)
+    }
+
+    fn set_form_owner(&self, form: Option<&HTMLFormElement>) {
+        self.form_owner.set(form.map(JS::from_ref));
+    }
+
+    fn to_element<'b>(&'b self) -> &'b Element {
+        ElementCast::from_ref(*self)
+    }
+}

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -2,21 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::{Attr, AttrHelpers};
 use dom::bindings::codegen::Bindings::HTMLOutputElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOutputElementBinding::HTMLOutputElementMethods;
+use dom::bindings::codegen::InheritTypes::ElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOutputElementDerived;
-use dom::bindings::js::Root;
+use dom::bindings::js::{JS, MutNullableHeap, Root};
 use dom::document::Document;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
-use dom::element::ElementTypeId;
+use dom::element::{Element, ElementTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{HTMLFormElement, FormControl};
 use dom::node::{Node, NodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
+use dom::virtualmethods::VirtualMethods;
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
 pub struct HTMLOutputElement {
-    htmlelement: HTMLElement
+    htmlelement: HTMLElement,
+    form_owner: MutNullableHeap<JS<HTMLFormElement>>,
 }
 
 impl HTMLOutputElementDerived for EventTarget {
@@ -33,7 +40,8 @@ impl HTMLOutputElement {
                      document: &Document) -> HTMLOutputElement {
         HTMLOutputElement {
             htmlelement:
-                HTMLElement::new_inherited(HTMLElementTypeId::HTMLOutputElement, localName, prefix, document)
+                HTMLElement::new_inherited(HTMLElementTypeId::HTMLOutputElement, localName, prefix, document),
+            form_owner: Default::default(),
         }
     }
 
@@ -50,6 +58,88 @@ impl<'a> HTMLOutputElementMethods for &'a HTMLOutputElement {
     fn Validity(self) -> Root<ValidityState> {
         let window = window_from_node(self);
         ValidityState::new(window.r())
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-fae-form
+    fn GetForm(self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
+}
+
+impl<'a> VirtualMethods for &'a HTMLOutputElement {
+    fn super_type<'b>(&'b self) -> Option<&'b VirtualMethods> {
+        let htmlelement: &&HTMLElement = HTMLElementCast::from_borrowed_ref(self);
+        Some(htmlelement as &VirtualMethods)
+    }
+
+    fn after_set_attr(&self, attr: &Attr) {
+        if let Some(ref s) = self.super_type() {
+            s.after_set_attr(attr);
+        }
+
+        match attr.local_name() {
+            &atom!("form") => {
+                self.after_set_form_attr();
+            },
+            _ => ()
+        }
+    }
+
+    fn before_remove_attr(&self, attr: &Attr) {
+        if let Some(ref s) = self.super_type() {
+            s.before_remove_attr(attr);
+        }
+
+        match attr.local_name() {
+            &atom!("form") => {
+                self.before_remove_form_attr();
+            },
+            _ => ()
+        }
+    }
+
+    fn after_remove_attr(&self, attr: &Atom) {
+        if let Some(ref s) = self.super_type() {
+            s.after_remove_attr(attr);
+        }
+
+        match attr {
+            &atom!("form") => {
+                self.after_remove_form_attr();
+            }
+            _ => ()
+        }
+    }
+
+    fn bind_to_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.bind_to_tree(tree_in_doc);
+        }
+
+        self.bind_form_control_to_tree();
+    }
+
+    fn unbind_from_tree(&self, tree_in_doc: bool) {
+        if let Some(ref s) = self.super_type() {
+            s.unbind_from_tree(tree_in_doc);
+        }
+
+        self.unbind_form_control_from_tree();
+    }
+
+}
+
+impl<'a> FormControl for &'a HTMLOutputElement {
+    fn form_owner(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner.get().map(Root::from_rooted)
+    }
+
+    fn set_form_owner(&self, form: Option<&HTMLFormElement>) {
+        self.form_owner.set(form.map(JS::from_ref));
+    }
+
+    fn to_element<'b>(&'b self) -> &'b Element {
+        ElementCast::from_ref(*self)
     }
 }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -13,7 +13,7 @@ use dom::bindings::codegen::InheritTypes::{ElementCast, EventTargetCast, HTMLEle
 use dom::bindings::codegen::InheritTypes::{HTMLTextAreaElementDerived, HTMLFieldSetElementDerived};
 use dom::bindings::codegen::InheritTypes::{KeyboardEventCast, TextDerived};
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{LayoutJS, Root};
+use dom::bindings::js::{JS, LayoutJS, MutNullableHeap, Root};
 use dom::bindings::refcounted::Trusted;
 use dom::document::{Document, DocumentHelpers};
 use dom::element::{Element, AttributeHandlers};
@@ -21,7 +21,7 @@ use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 use dom::element::ElementTypeId;
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
-use dom::htmlformelement::FormControl;
+use dom::htmlformelement::{HTMLFormElement, FormControl};
 use dom::keyboardevent::KeyboardEvent;
 use dom::node::{DisabledStateHelpers, Node, NodeHelpers, NodeDamage, NodeTypeId};
 use dom::node::{document_from_node, window_from_node};
@@ -36,6 +36,7 @@ use string_cache::Atom;
 
 use std::borrow::ToOwned;
 use std::cell::Cell;
+use std::default::Default;
 
 #[dom_struct]
 pub struct HTMLTextAreaElement {
@@ -45,6 +46,7 @@ pub struct HTMLTextAreaElement {
     rows: Cell<u32>,
     // https://html.spec.whatwg.org/multipage/#concept-textarea-dirty
     value_changed: Cell<bool>,
+    form_owner: MutNullableHeap<JS<HTMLFormElement>>
 }
 
 impl HTMLTextAreaElementDerived for EventTarget {
@@ -104,6 +106,7 @@ impl HTMLTextAreaElement {
             cols: Cell::new(DEFAULT_COLS),
             rows: Cell::new(DEFAULT_ROWS),
             value_changed: Cell::new(false),
+            form_owner: Default::default(),
         }
     }
 
@@ -200,6 +203,11 @@ impl<'a> HTMLTextAreaElementMethods for &'a HTMLTextAreaElement {
 
         self.force_relayout();
     }
+
+    // https://html.spec.whatwg.org/multipage/#dom-fae-form
+    fn GetForm(self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
 }
 
 pub trait HTMLTextAreaElementHelpers {
@@ -274,6 +282,9 @@ impl<'a> VirtualMethods for &'a HTMLTextAreaElement {
                     _ => panic!("Expected an AttrValue::UInt"),
                 }
             },
+            &atom!("form") => {
+                self.after_set_form_attr();
+            },
             _ => ()
         }
     }
@@ -296,6 +307,22 @@ impl<'a> VirtualMethods for &'a HTMLTextAreaElement {
             &atom!("rows") => {
                 self.rows.set(DEFAULT_ROWS);
             },
+            &atom!("form") => {
+                self.before_remove_form_attr();
+            }
+            _ => ()
+        }
+    }
+
+    fn after_remove_attr(&self, attr: &Atom) {
+        if let Some(ref s) = self.super_type() {
+            s.after_remove_attr(attr);
+        }
+
+        match attr {
+            &atom!("form") => {
+                self.after_remove_form_attr();
+            }
             _ => ()
         }
     }
@@ -304,6 +331,8 @@ impl<'a> VirtualMethods for &'a HTMLTextAreaElement {
         if let Some(ref s) = self.super_type() {
             s.bind_to_tree(tree_in_doc);
         }
+
+        self.bind_form_control_to_tree();
 
         let node = NodeCast::from_ref(*self);
         node.check_ancestors_disabled_state_for_form_control();
@@ -321,6 +350,8 @@ impl<'a> VirtualMethods for &'a HTMLTextAreaElement {
         if let Some(ref s) = self.super_type() {
             s.unbind_from_tree(tree_in_doc);
         }
+
+        self.unbind_form_control_from_tree();
 
         let node = NodeCast::from_ref(*self);
         if node.ancestors().any(|ancestor| ancestor.r().is_htmlfieldsetelement()) {
@@ -379,9 +410,17 @@ impl<'a> VirtualMethods for &'a HTMLTextAreaElement {
     }
 }
 
-impl<'a> FormControl<'a> for &'a HTMLTextAreaElement {
-    fn to_element(self) -> &'a Element {
-        ElementCast::from_ref(self)
+impl<'a> FormControl for &'a HTMLTextAreaElement {
+    fn form_owner(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner.get().map(Root::from_rooted)
+    }
+
+    fn set_form_owner(&self, form: Option<&HTMLFormElement>) {
+        self.form_owner.set(form.map(JS::from_ref));
+    }
+
+    fn to_element<'b>(&'b self) -> &'b Element {
+        ElementCast::from_ref(*self)
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -312,6 +312,8 @@ impl<'a> PrivateNodeHelpers for &'a Node {
         assert!(self.parent_node.get().is_none());
         for node in self.traverse_preorder() {
             node.r().set_flag(IS_IN_DOC, false);
+        }
+        for node in self.traverse_preorder() {
             vtable_for(&node.r()).unbind_from_tree(parent_in_doc);
         }
         self.layout_data.dispose(self);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -165,6 +165,9 @@ bitflags! {
         #[doc = "Specifies whether this node is focusable and whether it is supposed \
                  to be reachable with using sequential focus navigation."]
         const SEQUENTIALLY_FOCUSABLE = 0x400,
+        #[doc = "Specifies whether the parser has set an associated form owner for
+                 this element. Only applicable for form-associatable elements."]
+        const PARSER_ASSOCIATED_FORM_OWNER = 0x800,
     }
 }
 
@@ -2673,4 +2676,34 @@ pub enum NodeDamage {
     NodeStyleDamaged,
     /// Other parts of a node changed; attributes, text content, etc.
     OtherNodeDamage,
+}
+
+/// Helper trait to insert an element into vector whose elements
+/// are maintained in tree order
+pub trait VecPreOrderInsertionHelper<T> {
+    fn insert_pre_order(&mut self, elem: &T, tree_root: &Node);
+}
+
+impl<T> VecPreOrderInsertionHelper<T> for Vec<JS<T>>
+    where T: NodeBase + Reflectable
+{
+    fn insert_pre_order(&mut self, elem: &T, tree_root: &Node) {
+        if self.len() == 0 {
+            self.push(JS::from_ref(elem));
+            return;
+        }
+
+        let elem_node = NodeCast::from_ref(elem);
+        let mut head: usize = 0;
+        for node in tree_root.traverse_preorder() {
+            let head_node = NodeCast::from_root(self[head].root());
+            if head_node == node {
+                head += 1;
+            }
+            if elem_node == node.r() || head == self.len() {
+                break;
+            }
+        }
+        self.insert(head, JS::from_ref(elem));
+    }
 }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -19,7 +19,9 @@ use dom::bindings::codegen::InheritTypes::HTMLIFrameElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLImageElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLInputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLLinkElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLLabelElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLObjectElementCast;
+use dom::bindings::codegen::InheritTypes::HTMLOutputElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptGroupElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOptionElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLScriptElementCast;
@@ -177,12 +179,20 @@ pub fn vtable_for<'a>(node: &'a &'a Node) -> &'a (VirtualMethods + 'a) {
             let element = HTMLInputElementCast::to_borrowed_ref(node).unwrap();
             element as &'a (VirtualMethods + 'a)
         }
+        NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLLabelElement)) => {
+            let element = HTMLLabelElementCast::to_borrowed_ref(node).unwrap();
+            element as &'a (VirtualMethods + 'a)
+        }
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLLinkElement)) => {
             let element = HTMLLinkElementCast::to_borrowed_ref(node).unwrap();
             element as &'a (VirtualMethods + 'a)
         }
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLObjectElement)) => {
             let element = HTMLObjectElementCast::to_borrowed_ref(node).unwrap();
+            element as &'a (VirtualMethods + 'a)
+        }
+        NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOutputElement)) => {
+            let element = HTMLOutputElementCast::to_borrowed_ref(node).unwrap();
             element as &'a (VirtualMethods + 'a)
         }
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOptGroupElement)) => {

--- a/components/script/dom/webidls/HTMLButtonElement.webidl
+++ b/components/script/dom/webidls/HTMLButtonElement.webidl
@@ -7,7 +7,7 @@
 interface HTMLButtonElement : HTMLElement {
   //         attribute boolean autofocus;
              attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
              attribute DOMString formAction;
              attribute DOMString formEnctype;
              attribute DOMString formMethod;

--- a/components/script/dom/webidls/HTMLFieldSetElement.webidl
+++ b/components/script/dom/webidls/HTMLFieldSetElement.webidl
@@ -6,7 +6,7 @@
 // https://www.whatwg.org/html/#htmlfieldsetelement
 interface HTMLFieldSetElement : HTMLElement {
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString name;
 
   //readonly attribute DOMString type;

--- a/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/components/script/dom/webidls/HTMLInputElement.webidl
@@ -13,7 +13,7 @@ interface HTMLInputElement : HTMLElement {
            attribute boolean checked;
   //         attribute DOMString dirName;
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //readonly attribute FileList? files;
              attribute DOMString formAction;
              attribute DOMString formEnctype;

--- a/components/script/dom/webidls/HTMLLabelElement.webidl
+++ b/components/script/dom/webidls/HTMLLabelElement.webidl
@@ -5,7 +5,7 @@
 
 // https://www.whatwg.org/html/#htmllabelelement
 interface HTMLLabelElement : HTMLElement {
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString htmlFor;
   //readonly attribute HTMLElement? control;
 };

--- a/components/script/dom/webidls/HTMLObjectElement.webidl
+++ b/components/script/dom/webidls/HTMLObjectElement.webidl
@@ -10,7 +10,7 @@ interface HTMLObjectElement : HTMLElement {
   //         attribute boolean typeMustMatch;
   //         attribute DOMString name;
   //         attribute DOMString useMap;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString width;
   //         attribute DOMString height;
   //readonly attribute Document? contentDocument;

--- a/components/script/dom/webidls/HTMLOutputElement.webidl
+++ b/components/script/dom/webidls/HTMLOutputElement.webidl
@@ -6,7 +6,7 @@
 // https://www.whatwg.org/html/#htmloutputelement
 interface HTMLOutputElement : HTMLElement {
   //[PutForwards=value] readonly attribute DOMSettableTokenList htmlFor;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString name;
 
   //readonly attribute DOMString type;

--- a/components/script/dom/webidls/HTMLSelectElement.webidl
+++ b/components/script/dom/webidls/HTMLSelectElement.webidl
@@ -7,7 +7,7 @@
 interface HTMLSelectElement : HTMLElement {
   //         attribute boolean autofocus;
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
            attribute boolean multiple;
            attribute DOMString name;
   //         attribute boolean required;

--- a/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -11,7 +11,7 @@ interface HTMLTextAreaElement : HTMLElement {
              attribute unsigned long cols;
   //         attribute DOMString dirName;
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString inputMode;
   //         attribute long maxLength;
   //         attribute long minLength;

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -10,7 +10,8 @@ use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::InheritTypes::{CharacterDataCast, DocumentTypeCast};
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLScriptElementCast};
-use dom::bindings::codegen::InheritTypes::{HTMLFormElementDerived, NodeCast};
+use dom::bindings::codegen::InheritTypes::{HTMLFormElementCast, HTMLFormElementDerived};
+use dom::bindings::codegen::InheritTypes::{NodeCast};
 use dom::bindings::codegen::InheritTypes::ProcessingInstructionCast;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::js::{RootedReference};
@@ -20,6 +21,7 @@ use dom::document::{Document, DocumentHelpers};
 use dom::document::{DocumentSource, IsHTMLDocument};
 use dom::documenttype::DocumentType;
 use dom::element::{Element, AttributeHandlers, ElementHelpers, ElementCreator};
+use dom::htmlformelement::FormControlElementHelpers;
 use dom::htmlscriptelement::HTMLScriptElement;
 use dom::htmlscriptelement::HTMLScriptElementHelpers;
 use dom::node::{Node, NodeHelpers, NodeTypeId};
@@ -84,6 +86,16 @@ impl<'a> TreeSink for servohtmlparser::Sink {
         }
     }
 
+    fn same_home_subtree(&self, x: JS<Node>, y: JS<Node>) -> bool {
+        let x = x.root();
+        let y = y.root();
+
+        let x = ElementCast::to_root(x).expect("Element node expected");
+        let y = ElementCast::to_root(y).expect("Element node expected");
+
+        x.is_in_same_home_subtree(y.r())
+    }
+
     fn create_element(&mut self, name: QualName, attrs: Vec<Attribute>)
             -> JS<Node> {
         let doc = self.document.root();
@@ -105,19 +117,37 @@ impl<'a> TreeSink for servohtmlparser::Sink {
         JS::from_rooted(&node)
     }
 
+    fn has_parent_node(&self, node: JS<Node>) -> bool {
+         node.root().GetParentNode().is_some()
+    }
+
+
+    fn associate_with_form(&mut self, target: JS<Node>, form: JS<Node>) {
+        let node = target.root();
+        let form = form.root();
+        let form = HTMLFormElementCast::to_root(form)
+            .expect("Owner must be a form element");
+
+        let elem = ElementCast::to_ref(node.r());
+        let control = elem.as_ref().and_then(|e| e.as_maybe_form_control());
+
+        if let Some(control) = control {
+            control.set_form_owner_from_parser(form.r());
+        } else {
+            // TODO remove this code when keygen is implemented.
+            assert!(node.NodeName() == "KEYGEN", "Unknown form-associatable element");
+        }
+    }
+
     fn append_before_sibling(&mut self,
             sibling: JS<Node>,
-            new_node: NodeOrText<JS<Node>>) -> Result<(), NodeOrText<JS<Node>>> {
-        // If there is no parent, return the node to the parser.
-        let sibling: Root<Node> = sibling.root();
-        let parent = match sibling.r().GetParentNode() {
-            Some(p) => p,
-            None => return Err(new_node),
-        };
+            new_node: NodeOrText<JS<Node>>) {
+        let sibling = sibling.root();
+        let parent = sibling.GetParentNode()
+            .expect("append_before_sibling called on node without parent");
 
         let child = self.get_or_create(new_node);
-        assert!(parent.r().InsertBefore(child.r(), Some(sibling.r())).is_ok());
-        Ok(())
+        assert!(parent.InsertBefore(child.r(), Some(sibling.r())).is_ok());
     }
 
     fn parse_error(&mut self, msg: Cow<'static, str>) {

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -2856,9 +2856,6 @@
   [HTMLObjectElement interface: attribute useMap]
     expected: FAIL
 
-  [HTMLObjectElement interface: attribute form]
-    expected: FAIL
-
   [HTMLObjectElement interface: attribute width]
     expected: FAIL
 
@@ -5187,16 +5184,10 @@
   [HTMLLabelElement interface: existence and properties of interface object]
     expected: FAIL
 
-  [HTMLLabelElement interface: attribute form]
-    expected: FAIL
-
   [HTMLLabelElement interface: attribute htmlFor]
     expected: FAIL
 
   [HTMLLabelElement interface: attribute control]
-    expected: FAIL
-
-  [HTMLLabelElement interface: document.createElement("label") must inherit property "form" with the proper type (0)]
     expected: FAIL
 
   [HTMLLabelElement interface: document.createElement("label") must inherit property "htmlFor" with the proper type (1)]
@@ -5221,9 +5212,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: attribute dirName]
-    expected: FAIL
-
-  [HTMLInputElement interface: attribute form]
     expected: FAIL
 
   [HTMLInputElement interface: attribute files]
@@ -5350,9 +5338,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "dirName" with the proper type (6)]
-    expected: FAIL
-
-  [HTMLInputElement interface: document.createElement("input") must inherit property "form" with the proper type (8)]
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "files" with the proper type (9)]
@@ -5490,9 +5475,6 @@
   [HTMLButtonElement interface: attribute autofocus]
     expected: FAIL
 
-  [HTMLButtonElement interface: attribute form]
-    expected: FAIL
-
   [HTMLButtonElement interface: attribute formNoValidate]
     expected: FAIL
 
@@ -5518,9 +5500,6 @@
     expected: FAIL
 
   [HTMLButtonElement interface: document.createElement("button") must inherit property "autofocus" with the proper type (0)]
-    expected: FAIL
-
-  [HTMLButtonElement interface: document.createElement("button") must inherit property "form" with the proper type (2)]
     expected: FAIL
 
   [HTMLButtonElement interface: document.createElement("button") must inherit property "formNoValidate" with the proper type (6)]
@@ -5557,9 +5536,6 @@
     expected: FAIL
 
   [HTMLSelectElement interface: attribute autofocus]
-    expected: FAIL
-
-  [HTMLSelectElement interface: attribute form]
     expected: FAIL
 
   [HTMLSelectElement interface: attribute required]
@@ -5614,9 +5590,6 @@
     expected: FAIL
 
   [HTMLSelectElement interface: document.createElement("select") must inherit property "autofocus" with the proper type (1)]
-    expected: FAIL
-
-  [HTMLSelectElement interface: document.createElement("select") must inherit property "form" with the proper type (3)]
     expected: FAIL
 
   [HTMLSelectElement interface: document.createElement("select") must inherit property "required" with the proper type (6)]
@@ -5721,9 +5694,6 @@
   [HTMLTextAreaElement interface: attribute dirName]
     expected: FAIL
 
-  [HTMLTextAreaElement interface: attribute form]
-    expected: FAIL
-
   [HTMLTextAreaElement interface: attribute inputMode]
     expected: FAIL
 
@@ -5785,9 +5755,6 @@
     expected: FAIL
 
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "dirName" with the proper type (3)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "form" with the proper type (5)]
     expected: FAIL
 
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "inputMode" with the proper type (6)]
@@ -5967,9 +5934,6 @@
   [HTMLOutputElement interface: attribute htmlFor]
     expected: FAIL
 
-  [HTMLOutputElement interface: attribute form]
-    expected: FAIL
-
   [HTMLOutputElement interface: attribute name]
     expected: FAIL
 
@@ -6001,9 +5965,6 @@
     expected: FAIL
 
   [HTMLOutputElement interface: document.createElement("output") must inherit property "htmlFor" with the proper type (0)]
-    expected: FAIL
-
-  [HTMLOutputElement interface: document.createElement("output") must inherit property "form" with the proper type (1)]
     expected: FAIL
 
   [HTMLOutputElement interface: document.createElement("output") must inherit property "name" with the proper type (2)]
@@ -6112,9 +6073,6 @@
     expected: FAIL
 
   [HTMLFieldSetElement interface: existence and properties of interface object]
-    expected: FAIL
-
-  [HTMLFieldSetElement interface: attribute form]
     expected: FAIL
 
   [HTMLFieldSetElement interface: attribute name]

--- a/tests/wpt/metadata/html/semantics/forms/form-control-infrastructure/form.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-control-infrastructure/form.html.ini
@@ -1,29 +1,5 @@
 [form.html]
   type: testharness
-  [button.form]
-    expected: FAIL
-
-  [fieldset.form]
-    expected: FAIL
-
-  [input.form]
-    expected: FAIL
-
   [keygen.form]
-    expected: FAIL
-
-  [label.form]
-    expected: FAIL
-
-  [object.form]
-    expected: FAIL
-
-  [output.form]
-    expected: FAIL
-
-  [select.form]
-    expected: FAIL
-
-  [textarea.form]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html.ini
@@ -3,9 +3,6 @@
   [The type attribute must return 'fieldset']
     expected: FAIL
 
-  [The form attribute must return the fieldset's form owner]
-    expected: FAIL
-
   [The elements must return an HTMLFormControlsCollection object]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/reset.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/reset.html.ini
@@ -3,9 +3,3 @@
   [the element is barred from constraint validation]
     expected: FAIL
 
-  [reset button resets controls associated with their form using the form element pointer]
-    expected: FAIL
-
-  [reset button resets controls associated with a form using the form attribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/forms/the-label-element/label-attributes.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-label-element/label-attributes.html.ini
@@ -27,9 +27,3 @@
   [A form control has no label 2.]
     expected: FAIL
 
-  [A label's form attribute should return its form owner.]
-    expected: FAIL
-
-  [Check that the labels property of a form control with no label returns a zero-length NodeList.]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -503,6 +503,24 @@
             "url": "/_mozilla/mozilla/focus_blur.html"
           }
         ],
+        "mozilla/form_attribute.html": [
+          {
+            "path": "mozilla/form_attribute.html",
+            "url": "/_mozilla/mozilla/form_attribute.html"
+          }
+        ],
+        "mozilla/form_owner_and_table.html": [
+          {
+            "path": "mozilla/form_owner_and_table.html",
+            "url": "/_mozilla/mozilla/form_owner_and_table.html"
+          }
+        ],
+        "mozilla/form_owner_and_table_2.html": [
+          {
+            "path": "mozilla/form_owner_and_table_2.html",
+            "url": "/_mozilla/mozilla/form_owner_and_table_2.html"
+          }
+        ],
         "mozilla/getBoundingClientRect.html": [
           {
             "path": "mozilla/getBoundingClientRect.html",

--- a/tests/wpt/mozilla/tests/mozilla/form_attribute.html
+++ b/tests/wpt/mozilla/tests/mozilla/form_attribute.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div>
+      <form id="f1"></form>
+      <form id="f2">
+        <input id="i1" />
+        <input id="i2" form="f1" />
+        <input id="i3" />
+      </form>
+      <script>
+        test(function() {
+          var i1 = document.getElementById("i1");
+          var i2 = document.getElementById("i2");
+          var i3 = document.getElementById("i3");
+          var f1 = document.getElementById("f1");
+          var f2 = document.getElementById("f2");
+
+          assert_equals(i1.form, f2,
+            "i1 must be associated with f2 by the parser");
+          assert_equals(i2.form, f1,
+            "i2 is not associated with f2 by the parser " +
+            "since it has the form attribute set to f1");
+
+          f1.appendChild(i1);
+          i3.setAttribute("form", "f1");
+
+          assert_equals(i1.form, f1,
+            "i1's form owner must be reset when parent changes");
+          assert_equals(i3.form, f1,
+            "i3's form owner must be reset when the form" +
+            "attribute is set");
+
+          assert_equals(i2.form, f1);
+        }, "Tests for parser inserted controls");
+      </script>
+    </div>
+
+    <div id="placeholder">
+    </div>
+
+    <script>
+      var reassociateableElements = [
+        "button",
+        "fieldset",
+        "input",
+        "label",
+        "object",
+        "output",
+        "select",
+        "textarea",
+      ];
+
+      var form1 = null;
+      var form2 = null;
+      var placeholder = document.getElementById("placeholder");
+
+      reassociateableElements.forEach(function(localName) {
+        function testControl(test_, desc) {
+          var control = document.createElement(localName);
+
+          while(placeholder.firstChild)
+            placeholder.removeChild(placeholder.firstChild);
+
+          form1 = document.createElement("form");
+          form2 = document.createElement("form");
+          form1.id = "form1";
+          form2.id = "form2";
+          placeholder.appendChild(form1);
+          placeholder.appendChild(form2);
+
+          test(function() {
+            test_.call(control);
+          }, "[" + localName.toUpperCase() + "] " + desc);
+        }
+
+        testControl(function() {
+          form1.appendChild(this);
+          assert_equals(this.form, form1);
+        }, "Basic form association - control with no form attribute is associated with ancestor");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+          form1.appendChild(this);
+          assert_equals(this.form, form1);
+
+          form1.id = "form-one";
+          assert_equals(this.form, null);
+        }, "Form owner is reset to null when control's form attribute is set to an ID " +
+           "that does not exist in the document");
+
+        testControl(function() {
+          this.setAttribute("form", "");
+          form1.appendChild(this);
+          assert_equals(this.form, null);
+        }, "Control whose form attribute is an empty string has no form owner");
+
+        testControl(function() {
+          form1.id = ""
+            this.setAttribute("form", "");
+          form1.appendChild(this);
+          assert_equals(this.form, null);
+        }, "Control whose form attribute is an empty string has no form owner " +
+           "even when form with empty attribute is present");
+
+        testControl(function() {
+          form1.id = "FORM1";
+          this.setAttribute("form", "form1");
+          form1.appendChild(this);
+          assert_equals(this.form, null);
+        }, "Control's form attribute must be a case sensitive match for the form's id");
+
+        testControl(function() {
+          form1.appendChild(this);
+          assert_equals(this.form, form1);
+
+          this.setAttribute("form", "form2");
+          assert_equals(this.form, form2);
+        }, "Setting the form attribute of a control to the id of a non-ancestor form works");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+
+          form2.appendChild(this);
+          assert_equals(this.form, form1);
+
+          this.removeAttribute("form");
+          assert_equals(this.form, form2);
+        }, "Removing form id from a control resets the form owner to ancestor");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+
+          form2.appendChild(this);
+          assert_equals(this.form, form1);
+
+          placeholder.removeChild(form1);
+
+          assert_equals(this.form, null);
+        }, "Removing the form owner of a control with form attribute resets " +
+           "the form owner to null");
+
+        testControl(function() {
+          var form3 = document.createElement("form");
+          form3.id =  "form3";
+          placeholder.appendChild(form3);
+          form3.appendChild(this);
+          assert_equals(this.form, form3);
+
+          this.setAttribute("form", "form2");
+          assert_equals(this.form, form2);
+
+          this.setAttribute("form", "form1");
+          assert_equals(this.form, form1);
+        }, "Changing form attibute of control resets form owner to correct form");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+          var form3 = document.createElement("form");
+          form3.id = "form3";
+
+          placeholder.appendChild(form3);
+          placeholder.appendChild(this);
+          assert_equals(this.form, form1);
+
+          form1.appendChild(this);
+          assert_equals(this.form, form1);
+
+          form2.appendChild(this);
+          assert_equals(this.form, form1);
+        }, "Moving the a control with form attribute within the document " +
+           "does not change the form owner");
+
+        testControl(function() {
+          form1.id = "form-one";
+          this.setAttribute("form", "form1");
+          form2.appendChild(this);
+          assert_equals(this.form, null);
+
+          form1.id = "form1";
+          assert_equals(this.form, form1);
+        }, "When the id of a non-ancestor form changes from not being a match for the " +
+           "form attribute to being a match, the control's form owner is reset");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+          form1.appendChild(this);
+          assert_equals(this.form, form1);
+
+          form2.id = "form1";
+          form1.parentNode.insertBefore(form2, form1);
+          assert_equals(this.form, form2);
+
+          form2.parentNode.removeChild(form2);
+          assert_equals(this.form, form1);
+
+          form1.parentNode.appendChild(form2);
+          assert_equals(this.form, form1);
+        }, "When form element with same ID as the control's form attribute is inserted " +
+           "earlier in tree order, the form owner is changed to the inserted form");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+          form2.appendChild(this);
+          assert_equals(this.form, form1);
+
+          var span = document.createElement("span");
+          span.id = "form1";
+          form1.parentNode.insertBefore(span, form1);
+          assert_equals(this.form, null);
+
+          form1.parentNode.appendChild(span);
+          assert_equals(this.form, form1);
+        }, "When non-form element with same ID as the control's form attribute is " +
+           "inserted earlier in tree order, the control does not have a form owner");
+
+        testControl(function() {
+          this.setAttribute("form", "form1");
+          form1.appendChild(this);
+          assert_equals(this.form, form1);
+
+          form1.parentNode.removeChild(form1);
+          assert_equals(this.form, form1);
+        }, "A control that is not in the document but has the form attribute set " +
+           "is associated with the nearest ancestor form if one exists");
+
+      });
+    </script>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/form_owner_and_table.html
+++ b/tests/wpt/mozilla/tests/mozilla/form_owner_and_table.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="root">
+      <form id='form1'></form>
+      <table id='table1'>
+        <form id='form2'>
+        <tr><td><input id='input1'></td></tr>
+        <tr><td><input id='input2' form='form1'></td></tr>
+      </table>
+      <form id="form3">
+        <input id="input3" />
+      </form>
+    </div>
+
+    <script>
+      test(function() {
+        var input1 = document.getElementById('input1');
+        var input2 = document.getElementById('input2');
+        var input3 = document.getElementById('input3');
+        var form1 = document.getElementById('form1');
+        var form2 = document.getElementById('form2');
+        var form3 = document.getElementById('form3');
+
+        var root = document.getElementById('root');
+
+        assert_equals(input1.form, form2,
+          "input1's form owner must be form2 as per the parsing rules");
+        assert_equals(input2.form, form1,
+          "input2's form owner must be the form with id 'form1'");
+        assert_equals(input3.form, form2,
+          "input3's form owner must be form2 as per the parsing rules");
+
+        root.parentNode.removeChild(root);
+
+        assert_equals(input1.form, form2,
+          "input1's form owner must not have changed since they are both in the same subtree");
+        assert_equals(input2.form, null,
+          "input2 must not have a form owner since it has the form attribute set");
+        assert_equals(input3.form, form2,
+          "input3's form owner must not have changed since they are both in the same subtree");
+
+      }, "Form element and form controls nested inside a table are correctly handled");
+    </script>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/form_owner_and_table_2.html
+++ b/tests/wpt/mozilla/tests/mozilla/form_owner_and_table_2.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div>
+      <form id='form1'></form>
+      <table id='table1'>
+        <form id='form2'>
+        <script>
+          var t = document.getElementById('table1');
+          var f = document.getElementById('form2');
+          t.removeChild(f);
+        </script>
+        <tr><td><input id='input1'></td></tr>
+        <tr><td><input id='input2' form='form1'></td></tr>
+      </table>
+      <form id="form3">
+        <input id="input3" />
+      </form>
+    </div>
+
+    <script>
+      test(function() {
+        var form1 = document.getElementById('form1');
+
+        assert_equals(document.getElementById('input1').form, null,
+          "input1's form owner must be null since form2 is not in the" +
+          "same home subtree");
+
+        assert_equals(document.getElementById('input2').form, form1,
+          "input2's form owner must be the form with id 'form1'");
+
+        assert_equals(document.getElementById('input3').form, null,
+          "input3's form owner must be null instead of form2 (as per parsing rules)" +
+          "since form2 is not in the same home subtree");
+
+      }, "Controls nested in tables are not associated with form element inside the " +
+         "table if the form had been removed by script before the controls were " +
+         "inserted by the parser");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Implement the core logic for form owners (#3553).

NOTE: servo/html5ever#137 must land to be able to build this PR.
This PR only implements the logic necessary to associate a form control with its owner and reset them as required.  It does not implement the other related interfaces such as HTMLFormControlCollections (form.elements) and the named getter for HTMLFormElement.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6613)

<!-- Reviewable:end -->
