### PR TITLE
Move EventTargetTypeId/NodeTypeId to DOMClass

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1394,6 +1394,8 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
             Some(NodeTypeId::Document) => {
                 (display::T::none, float::T::none, position::T::static_)
             }
+            Some(NodeTypeId::Node) => unreachable!(),
+            Some(NodeTypeId::CharacterData(CharacterDataTypeId::CharacterData)) => unreachable!(),
         };
 
         debug!("building flow for node: {:?} {:?} {:?} {:?}", display, float, positioning, node.type_id());
@@ -1543,6 +1545,7 @@ impl<'ln> NodeUtils for ThreadSafeLayoutNode<'ln> {
             Some(NodeTypeId::Element(ElementTypeId::HTMLElement(
                         HTMLElementTypeId::HTMLObjectElement))) => self.has_object_data(),
             Some(NodeTypeId::Element(_)) => false,
+            Some(NodeTypeId::Node) => unreachable!(),
         }
     }
 

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1764,6 +1764,25 @@ class CGNamespace(CGWrapper):
         return CGNamespace(namespaces[0], inner, public=public)
 
 
+def EventTargetEnum(desc):
+    protochain = desc.prototypeChain
+    if protochain[0] != "EventTarget":
+        return "None"
+
+    inner = ""
+    name = desc.interface.identifier.name
+    if desc.interface.getUserData("hasConcreteDescendant", False):
+        inner = "(::dom::%s::%sTypeId::%s)" % (name.lower(), name, name)
+    prev_proto = ""
+    for proto in reversed(protochain):
+        if prev_proto != "":
+            inner = "(::dom::%s::%sTypeId::%s%s)" % (proto.lower(), proto, prev_proto, inner)
+        prev_proto = proto
+    if inner == "":
+        return "None"
+    return "Some%s" % inner
+
+
 def DOMClass(descriptor):
         protoList = ['PrototypeList::ID::' + proto for proto in descriptor.prototypeChain]
         # Pad out the list to the right length with ID::Count so we
@@ -1776,7 +1795,8 @@ def DOMClass(descriptor):
 DOMClass {
     interface_chain: [ %s ],
     native_hooks: &sNativePropertyHooks,
-}""" % prototypeChainString
+    type_id: %s,
+}""" % (prototypeChainString, EventTargetEnum(descriptor))
 
 
 class CGDOMJSClass(CGThing):

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -225,8 +225,9 @@ class Descriptor(DescriptorProvider):
                     if m.isDeleter():
                         addIndexedOrNamedOperation('Deleter', m)
 
-                iface.setUserData('hasConcreteDescendant', True)
                 iface = iface.parent
+                if iface:
+                    iface.setUserData('hasConcreteDescendant', True)
 
             if self.proxy:
                 iface = self.interface

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -645,7 +645,7 @@ pub unsafe fn native_from_reflector<T>(obj: *mut JSObject) -> *const T {
 }
 
 /// Get the `DOMClass` from `obj`, or `Err(())` if `obj` is not a DOM object.
-unsafe fn get_dom_class(obj: *mut JSObject) -> Result<DOMClass, ()> {
+pub unsafe fn get_dom_class(obj: *mut JSObject) -> Result<&'static DOMClass, ()> {
     use dom::bindings::utils::DOMJSClass;
     use js::glue::GetProxyHandlerExtra;
 
@@ -653,12 +653,12 @@ unsafe fn get_dom_class(obj: *mut JSObject) -> Result<DOMClass, ()> {
     if is_dom_class(&*clasp) {
         debug!("plain old dom object");
         let domjsclass: *const DOMJSClass = clasp as *const DOMJSClass;
-        return Ok((*domjsclass).dom_class);
+        return Ok(&(&*domjsclass).dom_class);
     }
     if is_dom_proxy(obj) {
         debug!("proxy dom object");
         let dom_class: *const DOMClass = GetProxyHandlerExtra(obj) as *const DOMClass;
-        return Ok(*dom_class);
+        return Ok(&*dom_class);
     }
     debug!("not a dom object");
     return Err(());

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -14,6 +14,7 @@ use dom::bindings::error::throw_type_error;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
 use dom::bindings::trace::trace_object;
+use dom::eventtarget::EventTargetTypeId;
 use dom::browsercontext;
 use dom::window;
 use util::mem::HeapSizeOf;
@@ -156,6 +157,9 @@ pub struct DOMClass {
     /// A list of interfaces that this object implements, in order of decreasing
     /// derivedness.
     pub interface_chain: [PrototypeList::ID; MAX_PROTO_CHAIN_LENGTH],
+
+    /// The EventTarget type, if this is derived from an EventTarget.
+    pub type_id: Option<EventTargetTypeId>,
 
     /// The NativePropertyHooks for the interface associated with this class.
     pub native_hooks: &'static NativePropertyHooks,

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -151,8 +151,10 @@ impl<'a> CharacterDataMethods for &'a CharacterData {
 }
 
 /// The different types of CharacterData.
-#[derive(JSTraceable, Copy, Clone, PartialEq, Debug, HeapSizeOf)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum CharacterDataTypeId {
+    CharacterData,
+
     Comment,
     Text,
     ProcessingInstruction,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -116,8 +116,7 @@ impl DedicatedWorkerGlobalScope {
                      -> DedicatedWorkerGlobalScope {
         DedicatedWorkerGlobalScope {
             workerglobalscope: WorkerGlobalScope::new_inherited(
-                WorkerGlobalScopeTypeId::DedicatedGlobalScope, init, worker_url,
-                runtime, devtools_port),
+                init, worker_url, runtime, devtools_port),
             id: id,
             receiver: receiver,
             own_sender: own_sender,
@@ -375,7 +374,7 @@ impl<'a> DedicatedWorkerGlobalScopeMethods for &'a DedicatedWorkerGlobalScope {
 impl DedicatedWorkerGlobalScopeDerived for EventTarget {
     fn is_dedicatedworkerglobalscope(&self) -> bool {
         match *self.type_id() {
-            EventTargetTypeId::WorkerGlobalScope(WorkerGlobalScopeTypeId::DedicatedGlobalScope) => true,
+            EventTargetTypeId::WorkerGlobalScope(WorkerGlobalScopeTypeId::DedicatedWorkerGlobalScope) => true,
             _ => false
         }
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -120,7 +120,7 @@ impl PartialEq for Element {
     }
 }
 
-#[derive(JSTraceable, Copy, Clone, PartialEq, Debug, HeapSizeOf)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ElementTypeId {
     HTMLElement(HTMLElementTypeId),
     Element,

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -13,7 +13,7 @@ use dom::bindings::js::{Root, JS, MutNullableHeap};
 use dom::bindings::refcounted::Trusted;
 use dom::bindings::utils::{reflect_dom_object, Reflectable};
 use dom::event::{EventHelpers, EventCancelable, EventBubbles};
-use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
+use dom::eventtarget::{EventTarget, EventTargetHelpers};
 use dom::blob::{Blob, BlobHelpers};
 use dom::domexception::{DOMException, DOMErrorName};
 use dom::progressevent::ProgressEvent;
@@ -100,7 +100,7 @@ pub struct FileReader {
 impl FileReader {
     pub fn new_inherited(global: GlobalRef) -> FileReader {
         FileReader {
-            eventtarget: EventTarget::new_inherited(EventTargetTypeId::FileReader),//?
+            eventtarget: EventTarget::new_inherited(),//?
             global: GlobalField::from_rooted(&global),
             ready_state: Cell::new(FileReaderReadyState::Empty),
             error: MutNullableHeap::new(None),

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -366,7 +366,7 @@ impl<'a> VirtualMethods for &'a HTMLElement {
     }
 }
 
-#[derive(JSTraceable, Copy, Clone, Debug, HeapSizeOf)]
+#[derive(Copy, Clone, Debug)]
 pub enum HTMLElementTypeId {
     HTMLElement,
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -41,8 +41,10 @@ impl HTMLMediaElement {
     }
 }
 
-#[derive(JSTraceable, Copy, Clone, Debug, HeapSizeOf)]
+#[derive(Copy, Clone, Debug)]
 pub enum HTMLMediaElementTypeId {
+    HTMLMediaElement = -1,
+
     HTMLAudioElement = 0,
     HTMLVideoElement = 1,
 }

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -22,8 +22,10 @@ use std::cmp::max;
 
 const DEFAULT_COLSPAN: u32 = 1;
 
-#[derive(JSTraceable, Copy, Clone, Debug, HeapSizeOf)]
+#[derive(Copy, Clone, Debug)]
 pub enum HTMLTableCellElementTypeId {
+    HTMLTableCellElement = -1,
+
     HTMLTableDataCellElement = 0,
     HTMLTableHeaderCellElement = 1,
 }

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -18,7 +18,7 @@ use dom::bindings::trace::JSTraceable;
 use dom::bindings::utils::reflect_dom_object;
 use dom::closeevent::CloseEvent;
 use dom::event::{Event, EventBubbles, EventCancelable, EventHelpers};
-use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
+use dom::eventtarget::{EventTarget, EventTargetHelpers};
 use script_task::Runnable;
 use script_task::ScriptMsg;
 use std::cell::{Cell, RefCell};
@@ -79,7 +79,7 @@ fn establish_a_websocket_connection(url: (Host, String, bool), origin: String)
 impl WebSocket {
     fn new_inherited(global: GlobalRef, url: Url) -> WebSocket {
         WebSocket {
-            eventtarget: EventTarget::new_inherited(EventTargetTypeId::WebSocket),
+            eventtarget: EventTarget::new_inherited(),
             url: url,
             global: GlobalField::from_rooted(&global),
             ready_state: Cell::new(WebSocketRequestState::Connecting),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1098,7 +1098,7 @@ impl Window {
         };
 
         let win = box Window {
-            eventtarget: EventTarget::new_inherited(EventTargetTypeId::Window),
+            eventtarget: EventTarget::new_inherited(),
             script_chan: script_chan,
             image_cache_chan: image_cache_chan,
             control_chan: control_chan,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -18,7 +18,7 @@ use dom::window::WindowHelpers;
 use dom::dedicatedworkerglobalscope::DedicatedWorkerGlobalScope;
 use dom::errorevent::ErrorEvent;
 use dom::event::{Event, EventBubbles, EventCancelable, EventHelpers};
-use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
+use dom::eventtarget::{EventTarget, EventTargetHelpers};
 use dom::messageevent::MessageEvent;
 use dom::workerglobalscope::WorkerGlobalScopeInit;
 use script_task::{ScriptChan, ScriptMsg, Runnable};
@@ -51,7 +51,7 @@ pub struct Worker {
 impl Worker {
     fn new_inherited(global: GlobalRef, sender: Sender<(TrustedWorkerAddress, ScriptMsg)>) -> Worker {
         Worker {
-            eventtarget: EventTarget::new_inherited(EventTargetTypeId::Worker),
+            eventtarget: EventTarget::new_inherited(),
             global: GlobalField::from_rooted(&global),
             sender: sender,
         }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -13,7 +13,7 @@ use dom::bindings::utils::Reflectable;
 use dom::console::Console;
 use dom::crypto::Crypto;
 use dom::dedicatedworkerglobalscope::DedicatedWorkerGlobalScopeHelpers;
-use dom::eventtarget::{EventTarget, EventTargetTypeId};
+use dom::eventtarget::EventTarget;
 use dom::workerlocation::WorkerLocation;
 use dom::workernavigator::WorkerNavigator;
 use dom::window::{base64_atob, base64_btoa};
@@ -37,9 +37,11 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::mpsc::Receiver;
 
-#[derive(JSTraceable, Copy, Clone, PartialEq, HeapSizeOf)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum WorkerGlobalScopeTypeId {
-    DedicatedGlobalScope,
+    WorkerGlobalScope,
+
+    DedicatedWorkerGlobalScope,
 }
 
 pub struct WorkerGlobalScopeInit {
@@ -84,14 +86,13 @@ pub struct WorkerGlobalScope {
 }
 
 impl WorkerGlobalScope {
-    pub fn new_inherited(type_id: WorkerGlobalScopeTypeId,
-                         init: WorkerGlobalScopeInit,
+    pub fn new_inherited(init: WorkerGlobalScopeInit,
                          worker_url: Url,
                          runtime: Rc<Runtime>,
                          devtools_receiver: Receiver<DevtoolScriptControlMsg>)
                          -> WorkerGlobalScope {
         WorkerGlobalScope {
-            eventtarget: EventTarget::new_inherited(EventTargetTypeId::WorkerGlobalScope(type_id)),
+            eventtarget: EventTarget::new_inherited(),
             next_worker_id: Cell::new(WorkerId(0)),
             worker_id: init.worker_id,
             worker_url: worker_url,

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -150,7 +150,7 @@ pub struct XMLHttpRequest {
 impl XMLHttpRequest {
     fn new_inherited(global: GlobalRef) -> XMLHttpRequest {
         XMLHttpRequest {
-            eventtarget: XMLHttpRequestEventTarget::new_inherited(XMLHttpRequestEventTargetTypeId::XMLHttpRequest),
+            eventtarget: XMLHttpRequestEventTarget::new_inherited(),
             ready_state: Cell::new(XMLHttpRequestState::Unsent),
             timeout: Cell::new(0u32),
             with_credentials: Cell::new(false),

--- a/components/script/dom/xmlhttprequesteventtarget.rs
+++ b/components/script/dom/xmlhttprequesteventtarget.rs
@@ -8,8 +8,10 @@ use dom::bindings::codegen::InheritTypes::EventTargetCast;
 use dom::bindings::codegen::InheritTypes::XMLHttpRequestEventTargetDerived;
 use dom::eventtarget::{EventTarget, EventTargetHelpers, EventTargetTypeId};
 
-#[derive(JSTraceable, Copy, Clone, PartialEq, HeapSizeOf)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum XMLHttpRequestEventTargetTypeId {
+    XMLHttpRequestEventTarget,
+
     XMLHttpRequest,
     XMLHttpRequestUpload,
 }
@@ -20,9 +22,9 @@ pub struct XMLHttpRequestEventTarget {
 }
 
 impl XMLHttpRequestEventTarget {
-    pub fn new_inherited(type_id: XMLHttpRequestEventTargetTypeId) -> XMLHttpRequestEventTarget {
+    pub fn new_inherited() -> XMLHttpRequestEventTarget {
         XMLHttpRequestEventTarget {
-            eventtarget: EventTarget::new_inherited(EventTargetTypeId::XMLHttpRequestEventTarget(type_id))
+            eventtarget: EventTarget::new_inherited()
         }
     }
 

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -19,8 +19,7 @@ pub struct XMLHttpRequestUpload {
 impl XMLHttpRequestUpload {
     fn new_inherited() -> XMLHttpRequestUpload {
         XMLHttpRequestUpload {
-            eventtarget: XMLHttpRequestEventTarget::new_inherited(
-                XMLHttpRequestEventTargetTypeId::XMLHttpRequestUpload)
+            eventtarget: XMLHttpRequestEventTarget::new_inherited(),
         }
     }
     pub fn new(global: GlobalRef) -> Root<XMLHttpRequestUpload> {

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -196,6 +196,8 @@ impl<'a> Serializable for &'a Node {
                                  traversal_scope: TraversalScope) -> io::Result<()> {
         let node = *self;
         match (traversal_scope, node.type_id()) {
+            (_, NodeTypeId::Node) => unreachable!(),
+            (_, NodeTypeId::CharacterData(CharacterDataTypeId::CharacterData)) => unreachable!(),
             (_, NodeTypeId::Element(..)) => {
                 let elem = ElementCast::to_ref(node).unwrap();
                 let name = QualName::new(elem.namespace().clone(),

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -38,11 +38,11 @@ macro_rules! sizeof_checker (
 );
 
 // Update the sizes here
-sizeof_checker!(size_event_target, EventTarget, 48);
-sizeof_checker!(size_node, Node, 184);
-sizeof_checker!(size_element, Element, 296);
-sizeof_checker!(size_htmlelement, HTMLElement, 312);
-sizeof_checker!(size_div, HTMLDivElement, 312);
-sizeof_checker!(size_span, HTMLSpanElement, 312);
-sizeof_checker!(size_text, Text, 216);
-sizeof_checker!(size_characterdata, CharacterData, 216);
+sizeof_checker!(size_event_target, EventTarget, 40);
+sizeof_checker!(size_node, Node, 168);
+sizeof_checker!(size_element, Element, 280);
+sizeof_checker!(size_htmlelement, HTMLElement, 296);
+sizeof_checker!(size_div, HTMLDivElement, 296);
+sizeof_checker!(size_span, HTMLSpanElement, 296);
+sizeof_checker!(size_text, Text, 200);
+sizeof_checker!(size_characterdata, CharacterData, 200);


### PR DESCRIPTION
Saves 16 bytes in `Node`, and 8 bytes in `EventTarget` objects that aren't nodes.

A number of *TypeId enums were adjusted to allow CodegenRust to automatically generate enums.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6615)

<!-- Reviewable:end -->
