### PR TITLE
Move away from the repeat().take().collect() pattern.

### DIFF
--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -4,7 +4,6 @@
 
 use euclid::point::Point2D;
 use std::cmp::{Ordering, PartialOrd};
-use std::iter::repeat;
 use std::mem;
 use std::u16;
 use std::vec::Vec;
@@ -530,8 +529,7 @@ impl<'a> GlyphStore {
         assert!(length > 0);
 
         GlyphStore {
-            entry_buffer: repeat(GlyphEntry::initial()).take(length)
-                                                       .collect(),
+            entry_buffer: vec![GlyphEntry::initial(); length],
             detail_store: DetailedGlyphStore::new(),
             is_whitespace: is_whitespace,
         }

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -43,7 +43,6 @@ use libc::{c_uint, c_int, c_void, c_char};
 use util::geometry::Au;
 use util::range::Range;
 use std::char;
-use std::iter::repeat;
 use std::mem;
 use std::cmp;
 use std::ptr;
@@ -292,10 +291,9 @@ impl Shaper {
 
         // fast path: all chars are single-byte.
         if byte_max == char_max {
-            byte_to_glyph = repeat(NO_GLYPH).take(byte_max).collect();
+            byte_to_glyph = vec![NO_GLYPH; byte_max];
         } else {
-            byte_to_glyph = repeat(CONTINUATION_BYTE).take(byte_max)
-                                                     .collect();
+            byte_to_glyph = vec![CONTINUATION_BYTE; byte_max];
             for (i, _) in text.char_indices() {
                 byte_to_glyph[i] = NO_GLYPH;
             }

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -39,7 +39,6 @@ use net_traits::image_cache_task::UsePlaceholder;
 use net_traits::image::base::{Image, PixelFormat};
 use std::cmp;
 use std::default::Default;
-use std::iter::repeat;
 use std::sync::Arc;
 use std::f32;
 use style::computed_values::filter::Filter;
@@ -1104,7 +1103,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                 CanvasCommonMsg::SendPixelContents(sender))).unwrap();
                         receiver.recv().unwrap()
                     },
-                    None => repeat(0xFFu8).take(width * height * 4).collect(),
+                    None => vec![0xFFu8; width * height * 4],
                 };
                 display_list.content.push_back(DisplayItem::ImageClass(box ImageDisplayItem{
                     base: BaseDisplayItem::new(stacking_relative_content_box,

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -25,7 +25,6 @@ use euclid::{Point2D, Rect};
 use gfx::display_list::DisplayList;
 use std::cmp;
 use std::fmt;
-use std::iter;
 use std::sync::Arc;
 use style::computed_values::{border_collapse, border_spacing, table_layout};
 use style::properties::ComputedValues;
@@ -718,8 +717,7 @@ fn perform_border_collapse_for_row(child_table_row: &mut TableRowFlow,
         }
         PreviousBlockCollapsedBorders::FromTable(collapsed_border) => {
             child_table_row.final_collapsed_borders.block_start =
-                iter::repeat(collapsed_border).take(child_table_row.block_flow.base.children.len())
-                                              .collect()
+                vec![collapsed_border; child_table_row.block_flow.base.children.len()]
         }
         PreviousBlockCollapsedBorders::NotCollapsingBorders => {}
     }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5232,7 +5232,6 @@ class CGBindingRoot(CGThing):
             'util::str::DOMString',
             'std::borrow::ToOwned',
             'std::cmp',
-            'std::iter::repeat',
             'std::mem',
             'std::num',
             'std::ptr',
@@ -5555,7 +5554,7 @@ class CallbackMember(CGNativeMember):
         if self.argCount > 0:
             replacements["argCount"] = self.argCountStr
             replacements["argvDecl"] = string.Template(
-                "let mut argv = repeat(UndefinedValue()).take(${argCount}).collect::<Vec<_>>();\n"
+                "let mut argv = vec![UndefinedValue(); ${argCount}];\n"
             ).substitute(replacements)
         else:
             # Avoid weird 0-sized arrays

--- a/components/util/cache.rs
+++ b/components/util/cache.rs
@@ -7,7 +7,6 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::hash_state::DefaultState;
 use rand::Rng;
 use std::hash::{Hash, Hasher, SipHasher};
-use std::iter::repeat;
 use rand;
 use std::slice::Iter;
 use std::default::Default;
@@ -121,7 +120,7 @@ impl<K:Clone+Eq+Hash,V:Clone> SimpleHashCache<K,V> {
     pub fn new(cache_size: usize) -> SimpleHashCache<K,V> {
         let mut r = rand::thread_rng();
         SimpleHashCache {
-            entries: repeat(None).take(cache_size).collect(),
+            entries: vec![None; cache_size],
             k0: r.gen(),
             k1: r.gen(),
         }


### PR DESCRIPTION
This was the preferred pattern between the deprecation of Vec::from_elem and
the addition of the count argument to the vec![] macro.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6621)

<!-- Reviewable:end -->
