### PR TITLE
profile: Make the time and memory profilers run over IPC.

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -44,6 +44,9 @@ git = "https://github.com/servo/skia"
 [dependencies.script_traits]
 path = "../script_traits"
 
+[dependencies.ipc-channel]
+git = "https://github.com/pcwalton/ipc-channel"
+
 [dependencies]
 log = "0.3"
 fnv = "1.0"

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -24,6 +24,7 @@ extern crate azure;
 #[macro_use] extern crate bitflags;
 extern crate fnv;
 extern crate euclid;
+extern crate ipc_channel;
 extern crate layers;
 extern crate libc;
 #[macro_use]

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -15,6 +15,8 @@ use euclid::Matrix4;
 use euclid::point::Point2D;
 use euclid::rect::Rect;
 use euclid::size::Size2D;
+use ipc_channel::ipc;
+use ipc_channel::router::ROUTER;
 use layers::platform::surface::{NativeDisplay, NativeSurface};
 use layers::layers::{BufferRequest, LayerBuffer, LayerBufferSet};
 use layers;
@@ -24,7 +26,7 @@ use msg::compositor_msg::{LayerProperties, PaintListener, ScrollPolicy};
 use msg::constellation_msg::Msg as ConstellationMsg;
 use msg::constellation_msg::{ConstellationChan, Failure, PipelineId};
 use msg::constellation_msg::PipelineExitType;
-use profile_traits::mem::{self, Reporter, ReportsChan};
+use profile_traits::mem::{self, Reporter, ReporterRequest, ReportsChan};
 use profile_traits::time::{self, profile};
 use rand::{self, Rng};
 use std::borrow::ToOwned;
@@ -95,14 +97,6 @@ impl PaintChan {
     pub fn send_opt(&self, msg: Msg) -> Result<(), Msg> {
         let &PaintChan(ref chan) = self;
         chan.send(msg).map_err(|e| e.0)
-    }
-}
-
-impl Reporter for PaintChan {
-    // Just injects an appropriate event into the paint task's queue.
-    fn collect_reports(&self, reports_chan: ReportsChan) -> bool {
-        let PaintChan(ref c) = *self;
-        c.send(Msg::CollectReports(reports_chan)).is_ok()
     }
 }
 
@@ -179,11 +173,20 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
                     canvas_map: HashMap::new()
                 };
 
-                // Register this thread as a memory reporter, via its own channel.
-                let reporter = box chan.clone();
+                // Register the memory reporter.
                 let reporter_name = format!("paint-reporter-{}", id.0);
-                let msg = mem::ProfilerMsg::RegisterReporter(reporter_name.clone(), reporter);
-                mem_profiler_chan.send(msg);
+                let (reporter_sender, reporter_receiver) =
+                    ipc::channel::<ReporterRequest>().unwrap();
+                let paint_chan_for_reporter = chan.clone();
+                ROUTER.add_route(reporter_receiver.to_opaque(), box move |message| {
+                    // Just injects an appropriate event into the paint task's queue.
+                    let request: ReporterRequest = message.to().unwrap();
+                    paint_chan_for_reporter.0.send(Msg::CollectReports(request.reports_channel))
+                                             .unwrap();
+                });
+                mem_profiler_chan.send(mem::ProfilerMsg::RegisterReporter(
+                        reporter_name.clone(),
+                        Reporter(reporter_sender)));
 
                 paint_task.start();
 
@@ -261,8 +264,9 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
                 Msg::PaintPermissionRevoked => {
                     self.paint_permission = false;
                 }
-                Msg::CollectReports(_) => {
+                Msg::CollectReports(ref channel) => {
                     // FIXME(njn): should eventually measure the paint task.
+                    channel.send(Vec::new())
                 }
                 Msg::Exit(response_channel, _) => {
                     // Ask the compositor to remove any layers it is holding for this paint task.

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -13,6 +13,9 @@ path = "../profile_traits"
 [dependencies.util]
 path = "../util"
 
+[dependencies.ipc-channel]
+git = "https://github.com/pcwalton/ipc-channel"
+
 [dependencies]
 log = "0.3"
 libc = "0.1"

--- a/components/profile/lib.rs
+++ b/components/profile/lib.rs
@@ -9,6 +9,7 @@
 
 #[macro_use] extern crate log;
 
+extern crate ipc_channel;
 extern crate libc;
 #[macro_use]
 extern crate profile_traits;

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -4,26 +4,26 @@
 
 //! Memory profiling functions.
 
-use profile_traits::mem::{ProfilerChan, ProfilerMsg, Reporter, ReportsChan};
-use self::system_reporter::SystemReporter;
+use ipc_channel::ipc::{self, IpcReceiver};
+use ipc_channel::router::ROUTER;
+use profile_traits::mem::{ProfilerChan, ProfilerMsg, Reporter, ReporterRequest, ReportsChan};
 use std::borrow::ToOwned;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::thread::sleep_ms;
-use std::sync::mpsc::{channel, Receiver};
 use util::task::spawn_named;
 
 pub struct Profiler {
     /// The port through which messages are received.
-    pub port: Receiver<ProfilerMsg>,
+    pub port: IpcReceiver<ProfilerMsg>,
 
     /// Registered memory reporters.
-    reporters: HashMap<String, Box<Reporter + Send>>,
+    reporters: HashMap<String, Reporter>,
 }
 
 impl Profiler {
     pub fn create(period: Option<f64>) -> ProfilerChan {
-        let (chan, port) = channel();
+        let (chan, port) = ipc::channel().unwrap();
 
         // Create the timer thread if a period was provided.
         if let Some(period) = period {
@@ -48,16 +48,21 @@ impl Profiler {
 
         let mem_profiler_chan = ProfilerChan(chan);
 
-        // Register the system memory reporter, which will run on the memory profiler's own thread.
-        // It never needs to be unregistered, because as long as the memory profiler is running the
-        // system memory reporter can make measurements.
-        let system_reporter = box SystemReporter;
-        mem_profiler_chan.send(ProfilerMsg::RegisterReporter("system".to_owned(), system_reporter));
+        // Register the system memory reporter, which will run on its own thread. It never needs to
+        // be unregistered, because as long as the memory profiler is running the system memory
+        // reporter can make measurements.
+        let (system_reporter_sender, system_reporter_receiver) = ipc::channel().unwrap();
+        ROUTER.add_route(system_reporter_receiver.to_opaque(), box |message| {
+            let request: ReporterRequest = message.to().unwrap();
+            system_reporter::collect_reports(request)
+        });
+        mem_profiler_chan.send(ProfilerMsg::RegisterReporter("system".to_owned(),
+                                                             Reporter(system_reporter_sender)));
 
         mem_profiler_chan
     }
 
-    pub fn new(port: Receiver<ProfilerMsg>) -> Profiler {
+    pub fn new(port: IpcReceiver<ProfilerMsg>) -> Profiler {
         Profiler {
             port: port,
             reporters: HashMap::new(),
@@ -119,12 +124,11 @@ impl Profiler {
         // If anything goes wrong with a reporter, we just skip it.
         let mut forest = ReportsForest::new();
         for reporter in self.reporters.values() {
-            let (chan, port) = channel();
-            if reporter.collect_reports(ReportsChan(chan)) {
-                if let Ok(reports) = port.recv() {
-                    for report in reports.iter() {
-                        forest.insert(&report.path, report.size);
-                    }
+            let (chan, port) = ipc::channel().unwrap();
+            reporter.collect_reports(ReportsChan(chan));
+            if let Ok(reports) = port.recv() {
+                for report in reports.iter() {
+                    forest.insert(&report.path, report.size);
                 }
             }
         }
@@ -297,7 +301,7 @@ impl ReportsForest {
 
 mod system_reporter {
     use libc::{c_char, c_int, c_void, size_t};
-    use profile_traits::mem::{Report, Reporter, ReportsChan};
+    use profile_traits::mem::{Report, ReporterRequest};
     use std::borrow::ToOwned;
     use std::ffi::CString;
     use std::mem::size_of;
@@ -306,51 +310,46 @@ mod system_reporter {
     use task_info::task_basic_info::{virtual_size, resident_size};
 
     /// Collects global measurements from the OS and heap allocators.
-    pub struct SystemReporter;
-
-    impl Reporter for SystemReporter {
-        fn collect_reports(&self, reports_chan: ReportsChan) -> bool {
-            let mut reports = vec![];
-            {
-                let mut report = |path, size| {
-                    if let Some(size) = size {
-                        reports.push(Report { path: path, size: size });
-                    }
-                };
-
-                // Virtual and physical memory usage, as reported by the OS.
-                report(path!["vsize"], get_vsize());
-                report(path!["resident"], get_resident());
-
-                // Memory segments, as reported by the OS.
-                for seg in get_resident_segments().iter() {
-                    report(path!["resident-according-to-smaps", seg.0], Some(seg.1));
+    pub fn collect_reports(request: ReporterRequest) {
+        let mut reports = vec![];
+        {
+            let mut report = |path, size| {
+                if let Some(size) = size {
+                    reports.push(Report { path: path, size: size });
                 }
+            };
 
-                // Total number of bytes allocated by the application on the system
-                // heap.
-                report(path!["system-heap-allocated"], get_system_heap_allocated());
+            // Virtual and physical memory usage, as reported by the OS.
+            report(path!["vsize"], get_vsize());
+            report(path!["resident"], get_resident());
 
-                // The descriptions of the following jemalloc measurements are taken
-                // directly from the jemalloc documentation.
-
-                // "Total number of bytes allocated by the application."
-                report(path!["jemalloc-heap-allocated"], get_jemalloc_stat("stats.allocated"));
-
-                // "Total number of bytes in active pages allocated by the application.
-                // This is a multiple of the page size, and greater than or equal to
-                // |stats.allocated|."
-                report(path!["jemalloc-heap-active"], get_jemalloc_stat("stats.active"));
-
-                // "Total number of bytes in chunks mapped on behalf of the application.
-                // This is a multiple of the chunk size, and is at least as large as
-                // |stats.active|. This does not include inactive chunks."
-                report(path!["jemalloc-heap-mapped"], get_jemalloc_stat("stats.mapped"));
+            // Memory segments, as reported by the OS.
+            for seg in get_resident_segments().iter() {
+                report(path!["resident-according-to-smaps", seg.0], Some(seg.1));
             }
-            reports_chan.send(reports);
 
-            true
+            // Total number of bytes allocated by the application on the system
+            // heap.
+            report(path!["system-heap-allocated"], get_system_heap_allocated());
+
+            // The descriptions of the following jemalloc measurements are taken
+            // directly from the jemalloc documentation.
+
+            // "Total number of bytes allocated by the application."
+            report(path!["jemalloc-heap-allocated"], get_jemalloc_stat("stats.allocated"));
+
+            // "Total number of bytes in active pages allocated by the application.
+            // This is a multiple of the page size, and greater than or equal to
+            // |stats.allocated|."
+            report(path!["jemalloc-heap-active"], get_jemalloc_stat("stats.active"));
+
+            // "Total number of bytes in chunks mapped on behalf of the application.
+            // This is a multiple of the chunk size, and is at least as large as
+            // |stats.active|. This does not include inactive chunks."
+            report(path!["jemalloc-heap-mapped"], get_jemalloc_stat("stats.mapped"));
         }
+
+        request.reports_channel.send(reports);
     }
 
     #[cfg(target_os="linux")]

--- a/components/profile_traits/Cargo.toml
+++ b/components/profile_traits/Cargo.toml
@@ -7,7 +7,12 @@ authors = ["The Servo Project Developers"]
 name = "profile_traits"
 path = "lib.rs"
 
+[dependencies.ipc-channel]
+git = "https://github.com/pcwalton/ipc-channel"
+
 [dependencies]
+serde = "0.4"
+serde_macros = "0.4"
 time = "0.1.12"
 url = "0.2.36"
 

--- a/components/profile_traits/lib.rs
+++ b/components/profile_traits/lib.rs
@@ -6,5 +6,12 @@
 //! rest of Servo. These APIs are here instead of in `profile` so that these
 //! modules won't have to depend on `profile`.
 
+#![feature(custom_derive, plugin)]
+#![plugin(serde_macros)]
+
+extern crate ipc_channel;
+extern crate serde;
+
 pub mod mem;
 pub mod time;
+

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -5,19 +5,19 @@
 extern crate time as std_time;
 extern crate url;
 
+use ipc_channel::ipc::IpcSender;
 use self::std_time::precise_time_ns;
 use self::url::Url;
-use std::sync::mpsc::Sender;
 
-#[derive(PartialEq, Clone, PartialOrd, Eq, Ord)]
+#[derive(PartialEq, Clone, PartialOrd, Eq, Ord, Deserialize, Serialize)]
 pub struct TimerMetadata {
     pub url:         String,
     pub iframe:      bool,
     pub incremental: bool,
 }
 
-#[derive(Clone)]
-pub struct ProfilerChan(pub Sender<ProfilerMsg>);
+#[derive(Clone, Deserialize, Serialize)]
+pub struct ProfilerChan(pub IpcSender<ProfilerMsg>);
 
 impl ProfilerChan {
     pub fn send(&self, msg: ProfilerMsg) {
@@ -26,7 +26,7 @@ impl ProfilerChan {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum ProfilerMsg {
     /// Normal message used for reporting time
     Time((ProfilerCategory, Option<TimerMetadata>), f64),
@@ -37,7 +37,7 @@ pub enum ProfilerMsg {
 }
 
 #[repr(u32)]
-#[derive(PartialEq, Clone, PartialOrd, Eq, Ord)]
+#[derive(PartialEq, Clone, PartialOrd, Eq, Ord, Deserialize, Serialize)]
 pub enum ProfilerCategory {
     Compositing,
     LayoutPerform,

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -18,7 +18,7 @@ use msg::constellation_msg::{WindowSizeData};
 use msg::compositor_msg::Epoch;
 use net_traits::image_cache_task::ImageCacheTask;
 use net_traits::PendingAsyncLoad;
-use profile_traits::mem::{Reporter, ReportsChan};
+use profile_traits::mem::ReportsChan;
 use script_traits::{ConstellationControlMsg, LayoutControlMsg, ScriptControlChan};
 use script_traits::{OpaqueScriptLayoutChannel, StylesheetLoadResponder, UntrustedNodeAddress};
 use std::any::Any;
@@ -156,14 +156,6 @@ impl LayoutChan {
     pub fn new() -> (Receiver<Msg>, LayoutChan) {
         let (chan, port) = channel();
         (port, LayoutChan(chan))
-    }
-}
-
-impl Reporter for LayoutChan {
-    // Just injects an appropriate event into the layout task's queue.
-    fn collect_reports(&self, reports_chan: ReportsChan) -> bool {
-        let LayoutChan(ref c) = *self;
-        c.send(Msg::CollectReports(reports_chan)).is_ok()
     }
 }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
  "harfbuzz 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1049,6 +1050,7 @@ source = "git+https://github.com/servo/rust-png#3c3105672622c76fbb079a96384f78e4
 name = "profile"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "profile_traits 0.0.1",
@@ -1062,6 +1064,9 @@ dependencies = [
 name = "profile_traits"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "serde 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1221,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "serde_codegen"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1234,7 +1239,7 @@ name = "serde_macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
  "harfbuzz 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1028,6 +1029,7 @@ source = "git+https://github.com/servo/rust-png#653902184ce95d2dc44cd4674c8b273f
 name = "profile"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "profile_traits 0.0.1",
@@ -1041,6 +1043,9 @@ dependencies = [
 name = "profile_traits"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "serde 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1192,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "serde_codegen"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1205,7 +1210,7 @@ name = "serde_macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
  "harfbuzz 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -936,6 +937,7 @@ source = "git+https://github.com/servo/rust-png#3c3105672622c76fbb079a96384f78e4
 name = "profile"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "profile_traits 0.0.1",
@@ -949,6 +951,9 @@ dependencies = [
 name = "profile_traits"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
+ "serde 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1100,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "serde_codegen"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1113,7 +1118,7 @@ name = "serde_macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
Uses a couple of extra threads to work around the lack of cross-process
boxed trait objects.

r? @nnethercote

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6629)

<!-- Reviewable:end -->
