### PR TITLE
Don't crash when Firefox doesn't send autoMargins.

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -459,7 +459,8 @@ impl Actor for PageStyleActor {
                                 .unwrap();
                 let (width, height) = rx.recv().unwrap();
 
-                let auto_margins = msg.get(&"autoMargins".to_string()).unwrap().as_boolean().unwrap();
+                let auto_margins = msg.get(&"autoMargins".to_string())
+                    .and_then(&Json::as_boolean).unwrap_or(false);
 
                 //TODO: the remaining layout properties (margin, border, padding, position)
                 //      as specified in getLayout in


### PR DESCRIPTION
Firefox Developer Tools doesn't always send autoMargins, as seen in this message:

```
{"type":"getLayout","node":"node14","to":"pageStyle9"}
```

So don't use unwrap.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6637)

<!-- Reviewable:end -->
