### PR TITLE
Implement console#time and console#timeEnd methods

### DIFF
--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -8,8 +8,11 @@ use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::Root;
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::window::WindowHelpers;
+use dom::document::DocumentHelpers;
+use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use devtools_traits::{DevtoolsControlMsg, ConsoleMessage, LogLevel};
 use util::str::DOMString;
+use time;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Console
 #[dom_struct]
@@ -81,6 +84,54 @@ impl<'a> ConsoleMethods for &'a Console {
             println!("Assertion failed: {}", message);
             propagate_console_msg(&self, prepare_message(LogLevel::Error, message.to_owned()));
         }
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Console/time
+    fn Time(self, name: Option<DOMString>) {
+        let name = match name {
+            Some(name) => name,
+            _ => return
+        };
+        let msg = format!("{}: timer started", name);
+        println!("{}", msg);
+        let global = self.global.root();
+        match global.r() {
+            GlobalRef::Window(window_ref) => {
+                window_ref.Document().add_console_timer(&name);
+            },
+
+            GlobalRef::Worker(_) => {
+                // TODO: support worker console timers.
+                return
+            }
+        }
+        propagate_console_msg(&self, prepare_message(LogLevel::Log, msg.to_owned()));
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Console/timeEnd
+    fn TimeEnd(self, name: Option<DOMString>) {
+        let name = match name {
+            Some(name) => name,
+            _ => return,
+        };
+        let global = self.global.root();
+        let start_time = match global.r() {
+            GlobalRef::Window(window_ref) => {
+                match window_ref.Document().remove_console_timer(&name) {
+                    Some(time) => time,
+                    _ => return
+                }
+            },
+
+            GlobalRef::Worker(_) => {
+                // TODO: support worker console timers.
+                return
+            }
+        };
+        let time = (time::precise_time_ns() - start_time) / 10000;
+        let msg = format!("{}: {}ms", name, time as f64 / 100.);
+        println!("{}", msg);
+        propagate_console_msg(&self, prepare_message(LogLevel::Log, msg.to_owned()));
     }
 }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -92,8 +92,6 @@ impl<'a> ConsoleMethods for &'a Console {
             Some(name) => name,
             _ => return
         };
-        let msg = format!("{}: timer started", name);
-        println!("{}", msg);
         let global = self.global.root();
         match global.r() {
             GlobalRef::Window(window_ref) => {
@@ -105,6 +103,8 @@ impl<'a> ConsoleMethods for &'a Console {
                 return
             }
         }
+        let msg = format!("{}: timer started", name);
+        println!("{}", msg);
         propagate_console_msg(&self, prepare_message(LogLevel::Log, msg.to_owned()));
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -112,7 +112,7 @@ pub struct Document {
     node: Node,
     window: JS<Window>,
     idmap: DOMRefCell<HashMap<Atom, Vec<JS<Element>>>>,
-    console_timers: DOMRefCell<HashMap<Atom, u64>>,
+    console_timers: DOMRefCell<HashMap<DOMString, u64>>,
     implementation: MutNullableHeap<JS<DOMImplementation>>,
     location: MutNullableHeap<JS<Location>>,
     content_type: DOMString,
@@ -462,19 +462,15 @@ impl<'a> DocumentHelpers<'a> for &'a Document {
         }
     }
 
-    fn add_console_timer(self,
-                         name: &DOMString) {
-        let name = atom!(name);
+    fn add_console_timer(self, name: &DOMString) {
         let mut console_timers = self.console_timers.borrow_mut();
         let startTime = time::precise_time_ns();
-        console_timers.insert(name, startTime);
+        console_timers.insert(name.clone(), startTime);
     }
 
-    fn remove_console_timer(self,
-                            name: &DOMString) -> Option<u64> {
-        let name = &atom!(name);
+    fn remove_console_timer(self, name: &DOMString) -> Option<u64> {
         let mut console_timers = self.console_timers.borrow_mut();
-        console_timers.remove(name)
+        console_timers.remove(&*name)
     }
 
     fn load_anchor_href(self, href: DOMString) {

--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -18,4 +18,6 @@ interface Console {
   void warn(DOMString... messages);
   void error(DOMString... messages);
   void assert(boolean condition, optional DOMString message);
+  void time(optional DOMString time);
+  void timeEnd(optional DOMString time);
 };


### PR DESCRIPTION
These methods are unspecified right now, but implemented in all major engines and fairly simple. The most complicated part is storing the timers on the document. The implementation works, but I don't know if it's optimal.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6646)

<!-- Reviewable:end -->
