### PR TITLE
Include private items in `./mach doc` and http://doc.servo.org/

### DIFF
--- a/etc/rustdoc-with-private
+++ b/etc/rustdoc-with-private
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Skip the strip-private and strip-hidden rustdoc passes
+# https://github.com/rust-lang/rust/issues/15347
+rustdoc --no-defaults --passes "collapse-docs unindent-comments" "$@"

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -156,8 +156,10 @@ class MachCommands(CommandBase):
                     else:
                         copy2(full_name, destination)
 
+        env = self.build_env()
+        env['RUSTDOC'] = '../../etc/rustdoc-with-private'
         return subprocess.call(["cargo", "doc"] + params,
-                               env=self.build_env(), cwd=self.servo_crate())
+                               env=env, cwd=self.servo_crate())
 
     @Command('browse-doc',
              description='Generate documentation and open it in a web browser',


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/15347

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6655)

<!-- Reviewable:end -->
