### PR TITLE
Implement Element.client{Top,Left,Width,Height}

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -70,6 +70,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 use style::computed_values::{filter, mix_blend_mode};
 use style::media_queries::{MediaType, MediaQueryList, Device};
+use style::properties::style_structs;
 use style::selector_matching::Stylist;
 use style::stylesheets::{Origin, Stylesheet, CSSRuleIteratorExt};
 use url::Url;
@@ -126,7 +127,7 @@ pub struct LayoutTaskData {
     /// A queued response for the content boxes of a node.
     pub content_boxes_response: Vec<Rect<Au>>,
 
-    /// A queued response for the client {top, left, width, height} of a node.
+    /// A queued response for the client {top, left, width, height} of a node in pixels.
     pub client_rect_response: Rect<i32>,
 
     /// The list of currently-running animations.
@@ -1436,11 +1437,13 @@ impl FragmentLocatingFragmentIterator {
 
 impl FragmentBorderBoxIterator for FragmentLocatingFragmentIterator {
     fn process(&mut self, fragment: &Fragment, border_box: &Rect<Au>) {
-        let border_style_struct = fragment.style.get_border();
-        let top_width = border_style_struct.border_top_width;
-        let right_width = border_style_struct.border_right_width;
-        let bottom_width = border_style_struct.border_bottom_width;
-        let left_width = border_style_struct.border_left_width;
+        let style_structs::Border {
+            border_top_width: top_width,
+            border_right_width: right_width,
+            border_bottom_width: bottom_width,
+            border_left_width: left_width,
+            ..
+        } = *fragment.style.get_border();
         self.client_rect.origin.y = top_width.to_px();
         self.client_rect.origin.x = left_width.to_px();
         self.client_rect.size.width = (border_box.size.width - left_width - right_width).to_px();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1296,6 +1296,26 @@ impl<'a> ElementMethods for &'a Element {
             rect.origin.x + rect.size.width)
     }
 
+    fn ClientTop(self) -> i32 {
+        let node = NodeCast::from_ref(self);
+        node.get_client_rect().origin.y
+    }
+
+    fn ClientLeft(self) -> i32 {
+        let node = NodeCast::from_ref(self);
+        node.get_client_rect().origin.x
+    }
+
+    fn ClientWidth(self) -> i32 {
+        let node = NodeCast::from_ref(self);
+        node.get_client_rect().size.width
+    }
+
+    fn ClientHeight(self) -> i32 {
+        let node = NodeCast::from_ref(self);
+        node.get_client_rect().size.height
+    }
+
     // https://dvcs.w3.org/hg/innerhtml/raw-file/tip/index.html#widl-Element-innerHTML
     fn GetInnerHTML(self) -> Fallible<DOMString> {
         //XXX TODO: XML case

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -504,6 +504,7 @@ pub trait NodeHelpers {
 
     fn get_bounding_content_box(self) -> Rect<Au>;
     fn get_content_boxes(self) -> Vec<Rect<Au>>;
+    fn get_client_rect(self) -> Rect<i32>;
 
     fn before(self, nodes: Vec<NodeOrString>) -> ErrorResult;
     fn after(self, nodes: Vec<NodeOrString>) -> ErrorResult;
@@ -804,6 +805,10 @@ impl<'a> NodeHelpers for &'a Node {
 
     fn get_content_boxes(self) -> Vec<Rect<Au>> {
         window_from_node(self).r().content_boxes_query(self.to_trusted_node_address())
+    }
+
+    fn get_client_rect(self) -> Rect<i32> {
+        window_from_node(self).r().client_rect_query(self.to_trusted_node_address())
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-before

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -59,6 +59,11 @@ interface Element : Node {
 partial interface Element {
   DOMRectList getClientRects();
   DOMRect getBoundingClientRect();
+
+  readonly attribute long clientTop;
+  readonly attribute long clientLeft;
+  readonly attribute long clientWidth;
+  readonly attribute long clientHeight;
 };
 
 // https://domparsing.spec.whatwg.org/#extensions-to-the-element-interface

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -534,6 +534,7 @@ pub trait WindowHelpers {
     fn layout(&self) -> &LayoutRPC;
     fn content_box_query(self, content_box_request: TrustedNodeAddress) -> Rect<Au>;
     fn content_boxes_query(self, content_boxes_request: TrustedNodeAddress) -> Vec<Rect<Au>>;
+    fn client_rect_query(self, node_geometry_request: TrustedNodeAddress) -> Rect<i32>;
     fn handle_reflow_complete_msg(self, reflow_id: u32);
     fn handle_resize_inactive_msg(self, new_size: WindowSizeData);
     fn set_fragment_name(self, fragment: Option<String>);
@@ -762,6 +763,13 @@ impl<'a> WindowHelpers for &'a Window {
         self.join_layout(); //FIXME: is this necessary, or is layout_rpc's mutex good enough?
         let ContentBoxesResponse(rects) = self.layout_rpc.content_boxes();
         rects
+    }
+
+    fn client_rect_query(self, node_geometry_request: TrustedNodeAddress) -> Rect<i32> {
+        self.reflow(ReflowGoal::ForScriptQuery,
+                    ReflowQueryType::NodeGeometryQuery(node_geometry_request),
+                    ReflowReason::Query);
+        self.layout_rpc.node_geometry().client_rect
     }
 
     fn handle_reflow_complete_msg(self, reflow_id: u32) {
@@ -1072,6 +1080,7 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
         ReflowQueryType::NoQuery => "\tNoQuery",
         ReflowQueryType::ContentBoxQuery(_n) => "\tContentBoxQuery",
         ReflowQueryType::ContentBoxesQuery(_n) => "\tContentBoxesQuery",
+        ReflowQueryType::NodeGeometryQuery(_n) => "\tNodeGeometryQuery",
     });
 
     debug_msg.push_str(match *reason {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -95,7 +95,7 @@ pub trait LayoutRPC {
     fn content_box(&self) -> ContentBoxResponse;
     /// Requests the dimensions of all the content boxes, as in the `getClientRects()` call.
     fn content_boxes(&self) -> ContentBoxesResponse;
-    /// Requests the clientTop.
+    /// Requests the geometry of this node. Used by APIs such as `clientTop`.
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the node containing the point of interest
     fn hit_test(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<HitTestResponse, ()>;

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -95,6 +95,8 @@ pub trait LayoutRPC {
     fn content_box(&self) -> ContentBoxResponse;
     /// Requests the dimensions of all the content boxes, as in the `getClientRects()` call.
     fn content_boxes(&self) -> ContentBoxesResponse;
+    /// Requests the clientTop.
+    fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the node containing the point of interest
     fn hit_test(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<HitTestResponse, ()>;
     fn mouse_over(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<MouseOverResponse, ()>;
@@ -102,6 +104,9 @@ pub trait LayoutRPC {
 
 pub struct ContentBoxResponse(pub Rect<Au>);
 pub struct ContentBoxesResponse(pub Vec<Rect<Au>>);
+pub struct NodeGeometryResponse {
+    pub client_rect: Rect<i32>,
+}
 pub struct HitTestResponse(pub UntrustedNodeAddress);
 pub struct MouseOverResponse(pub Vec<UntrustedNodeAddress>);
 
@@ -120,6 +125,7 @@ pub enum ReflowQueryType {
     NoQuery,
     ContentBoxQuery(TrustedNodeAddress),
     ContentBoxesQuery(TrustedNodeAddress),
+    NodeGeometryQuery(TrustedNodeAddress),
 }
 
 /// Information needed for a reflow.

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -275,6 +275,12 @@
             "url": "/_mozilla/mozilla/child_reparenting.html"
           }
         ],
+        "mozilla/client-top-left-height-width.html": [
+          {
+            "path": "mozilla/client-top-left-height-width.html",
+            "url": "/_mozilla/mozilla/client-top-left-height-width.html"
+          }
+        ],
         "mozilla/collections.html": [
           {
             "path": "mozilla/collections.html",

--- a/tests/wpt/mozilla/tests/mozilla/client-top-left-height-width.html
+++ b/tests/wpt/mozilla/tests/mozilla/client-top-left-height-width.html
@@ -63,6 +63,12 @@
   background-color: green;
   display: inline-block;
 }
+#display-none {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+  display: none;
+}
 </style>
 </head>
 <body>
@@ -78,6 +84,7 @@
     </div>
     <div id='rotated'>rotated</div>
     <div id='inline-block'>inline-block</div>
+    <div id='display-none'>display-none</div>
     <script>
     test_rect = function(name, left, top, height, width) {
       var div = document.getElementById(name);
@@ -99,6 +106,7 @@
         test_rect('abs3', 0, 0, 40, 48);
         test_rect('span1', 0, 0, 0, 0);
         test_rect('inline-block', 0, 0, 100, 100);
+        test_rect('display-none', 0, 0, 0, 0);
     });
     </script>
 </body>

--- a/tests/wpt/mozilla/tests/mozilla/client-top-left-height-width.html
+++ b/tests/wpt/mozilla/tests/mozilla/client-top-left-height-width.html
@@ -76,17 +76,13 @@
     <div id="with-border">my div</div>
     <div id="with-border-and-padding">my div</div>
     <div id="abs1">
-        <div id="abs2">
-            <div id="abs3">
-                <span id="span1">X</span>
-            </div>
-        </div>
+        <span id="span1">X</span>
     </div>
     <div id='rotated'>rotated</div>
     <div id='inline-block'>inline-block</div>
     <div id='display-none'>display-none</div>
     <script>
-    test_rect = function(name, left, top, height, width) {
+    function test_rect(name, left, top, height, width) {
       var div = document.getElementById(name);
       var rect = div.getBoundingClientRect();
 
@@ -96,18 +92,14 @@
       assert_equals(div.clientWidth, width);
     }
 
-    test(function() {
-        test_rect('no-border', 0, 0, 100, 100);
-        test_rect('with-border', 10, 10, 100, 100);
-        test_rect('with-border-and-padding', 10, 10, 120, 120);
-        test_rect('abs1', 0, 0, 120, 100);
-        test_rect('rotated', 0, 0, 100, 100);
-        test_rect('abs2', 0, 0, 80, 80);
-        test_rect('abs3', 0, 0, 40, 48);
-        test_rect('span1', 0, 0, 0, 0);
-        test_rect('inline-block', 0, 0, 100, 100);
-        test_rect('display-none', 0, 0, 0, 0);
-    });
+    test(function() { test_rect('no-border', 0, 0, 100, 100); }, 'Block without border');
+    test(function() { test_rect('with-border', 10, 10, 100, 100); }, 'Block with border');
+    test(function() { test_rect('with-border-and-padding', 10, 10, 120, 120); }, 'Block without border and padding');
+    test(function() { test_rect('abs1', 0, 0, 120, 100); }, 'Absolutely positioned block');
+    test(function() { test_rect('rotated', 0, 0, 100, 100); }, 'Rotated block');
+    test(function() { test_rect('span1', 0, 0, 0, 0); }, 'Span');
+    test(function() { test_rect('inline-block', 0, 0, 100, 100); }, 'Inline block');
+    test(function() { test_rect('display-none', 0, 0, 0, 0); }, 'display: none');
     </script>
 </body>
 </html>

--- a/tests/wpt/mozilla/tests/mozilla/client-top-left-height-width.html
+++ b/tests/wpt/mozilla/tests/mozilla/client-top-left-height-width.html
@@ -1,0 +1,105 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@font-face {
+    font-family: 'ahem';
+    src: url(../css/fonts/ahem/ahem.ttf);
+}
+#no-border {
+    width: 100px;
+    height: 100px;
+}
+#with-border {
+    border: 10px solid black;
+    width: 100px;
+    height: 100px;
+}
+#with-border-and-padding {
+    border: 10px solid black;
+    padding: 10px;
+    width: 100px;
+    height: 100px;
+}
+#abs1 {
+    position: absolute;
+    background-color: red;
+    top: 45px;
+    left: 155px;
+    width: 100px;
+    height: 120px;
+}
+#abs2 {
+    position: absolute;
+    background-color: green;
+    top: 5px;
+    left: 5px;
+    width: 80px;
+    height: 80px;
+}
+#abs3 {
+    position: absolute;
+    background-color: blue;
+    top: 12px;
+    left: 14px;
+    width: 48px;
+    height: 40px;
+}
+#span1 {
+    font-family: 'ahem';
+    font-size: 20px;
+    line-height: 1;
+}
+#rotated {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+  transform: rotate(45deg);
+}
+#inline-block {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+  display: inline-block;
+}
+</style>
+</head>
+<body>
+    <div id="no-border">my div</div>
+    <div id="with-border">my div</div>
+    <div id="with-border-and-padding">my div</div>
+    <div id="abs1">
+        <div id="abs2">
+            <div id="abs3">
+                <span id="span1">X</span>
+            </div>
+        </div>
+    </div>
+    <div id='rotated'>rotated</div>
+    <div id='inline-block'>inline-block</div>
+    <script>
+    test_rect = function(name, left, top, height, width) {
+      var div = document.getElementById(name);
+      var rect = div.getBoundingClientRect();
+
+      assert_equals(div.clientLeft, left);
+      assert_equals(div.clientTop, top);
+      assert_equals(div.clientHeight, height);
+      assert_equals(div.clientWidth, width);
+    }
+
+    test(function() {
+        test_rect('no-border', 0, 0, 100, 100);
+        test_rect('with-border', 10, 10, 100, 100);
+        test_rect('with-border-and-padding', 10, 10, 120, 120);
+        test_rect('abs1', 0, 0, 120, 100);
+        test_rect('rotated', 0, 0, 100, 100);
+        test_rect('abs2', 0, 0, 80, 80);
+        test_rect('abs3', 0, 0, 40, 48);
+        test_rect('span1', 0, 0, 0, 0);
+        test_rect('inline-block', 0, 0, 100, 100);
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This isn't done, but contains a working implementation of at least `clientTop`. Feedback would be much appreciated: it's probably far from ideal.

Implementing `clientLeft` is straight-forward, I think, but `clientWidth` and `clientHeight` require accessing the `border_box` - and I don't know how that works, yet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6662)

<!-- Reviewable:end -->
