### PR TITLE
Optimize `Node.normalize()`.

### DIFF
--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -79,7 +79,7 @@ impl<'a> CharacterDataMethods for &'a CharacterData {
 
     // https://dom.spec.whatwg.org/#dom-characterdata-appenddatadata
     fn AppendData(self, data: DOMString) {
-        self.data.borrow_mut().push_str(&data);
+        self.append_data(&*data);
     }
 
     // https://dom.spec.whatwg.org/#dom-characterdata-insertdataoffset-data
@@ -159,12 +159,17 @@ pub enum CharacterDataTypeId {
 
 pub trait CharacterDataHelpers<'a> {
     fn data(self) -> Ref<'a, DOMString>;
+    fn append_data(self, data: &str);
 }
 
 impl<'a> CharacterDataHelpers<'a> for &'a CharacterData {
     #[inline]
     fn data(self) -> Ref<'a, DOMString> {
         self.data.borrow()
+    }
+    #[inline]
+    fn append_data(self, data: &str) {
+        self.data.borrow_mut().push_str(data)
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2330,10 +2330,9 @@ impl<'a> NodeMethods for &'a Node {
                     } else {
                         match prev_text {
                             Some(ref text_node) => {
-                                let text_node = text_node.clone();
                                 let prev_characterdata =
                                     CharacterDataCast::from_ref(text_node.r());
-                                let _ = prev_characterdata.AppendData(characterdata.Data());
+                                prev_characterdata.append_data(&**characterdata.data());
                                 self.remove_child(child.r());
                             },
                             None => prev_text = Some(Root::from_ref(text))


### PR DESCRIPTION
Do not copy the discarded node's text data, borrow it.

Closes #6658.

p.s. What's the `let text_node = text_node.clone();` for? I removed it because it doesn't seem to be necessary, but I'd like to be sure.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6667)

<!-- Reviewable:end -->
