### PR TITLE
Make doc comments not truncated again.

### DIFF
--- a/etc/rustdoc-with-private
+++ b/etc/rustdoc-with-private
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Skip the strip-private and strip-hidden rustdoc passes
 # https://github.com/rust-lang/rust/issues/15347
-rustdoc --no-defaults --passes "collapse-docs unindent-comments" "$@"
+rustdoc --no-defaults --passes collapse-docs --passes unindent-comments "$@"


### PR DESCRIPTION
`rustdoc --passes "collapse-docs unindent-comments"` doesn’t work is intended. It still generate HTML files that look alright at a glance, but all doc-comments are truncated to their first line for some reason I don’t understand.

See http://doc.servo.org/script/dom/index.html for example. The module documentation there is currently just “The implementation of the DOM.”, but clicking the [src] link shows a much larger doc-comment.

The correct invocation is to use `--passes` multiple times.

https://github.com/rust-lang/rust/issues/15347#issuecomment-122785714

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6668)

<!-- Reviewable:end -->
