### PR TITLE
Make iframes block the enclosing document's load event

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -832,7 +832,7 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
         let parent_pipeline = self.pipeline(subframe_parent.0);
         let msg = ConstellationControlMsg::DispatchFrameLoadEvent {
             target: pipeline_id,
-            parent: subframe_parent.0
+            parent: subframe_parent.0,
         };
         parent_pipeline.script_chan.send(msg).unwrap();
     }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -120,6 +120,7 @@ impl DocumentLoader {
         }
     }
 
+    /// Add a load to the list of blocking loads.
     pub fn add_blocking_load(&mut self, load: LoadType) {
         self.blocking_loads.push(load);
     }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -5,10 +5,13 @@
 //! Tracking of pending loads in a document.
 //! https://html.spec.whatwg.org/multipage/#the-end
 
+use dom::bindings::js::JS;
+use dom::document::Document;
 use msg::constellation_msg::PipelineId;
 use net_traits::AsyncResponseTarget;
 use net_traits::{PendingAsyncLoad, ResourceThread, LoadContext};
 use std::sync::Arc;
+use std::thread;
 use url::Url;
 
 #[derive(JSTraceable, PartialEq, Clone, Debug, HeapSizeOf)]
@@ -37,6 +40,50 @@ impl LoadType {
             LoadType::Script(_) => LoadContext::Script,
             LoadType::Subframe(_) | LoadType::PageSource(_) => LoadContext::Browsing,
             LoadType::Stylesheet(_) => LoadContext::Style
+        }
+    }
+}
+
+/// Canary value ensuring that manually added blocking loads (ie. ones that weren't
+/// created via DocumentLoader::prepare_async_load) are always removed by the time
+/// that the owner is destroyed.
+#[derive(JSTraceable, HeapSizeOf)]
+#[must_root]
+pub struct LoadBlocker {
+    /// The document whose load event is blocked by this object existing.
+    doc: JS<Document>,
+    /// The load that is blocking the document's load event.
+    load: Option<LoadType>,
+}
+
+impl LoadBlocker {
+    /// Mark the document's load event as blocked on this new load.
+    pub fn new(doc: &Document, load: LoadType) -> LoadBlocker {
+        doc.add_blocking_load(load.clone());
+        LoadBlocker {
+            doc: JS::from_ref(doc),
+            load: Some(load),
+        }
+    }
+
+    /// Remove this load from the associated document's list of blocking loads.
+    pub fn terminate(blocker: &mut Option<LoadBlocker>) {
+        if let Some(this) = blocker.as_mut() {
+            this.doc.finish_load(this.load.take().unwrap());
+        }
+        *blocker = None;
+    }
+
+    /// Return the url associated with this load.
+    pub fn url(&self) -> Option<&Url> {
+        self.load.as_ref().map(LoadType::url)
+    }
+}
+
+impl Drop for LoadBlocker {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            assert!(self.load.is_none());
         }
     }
 }
@@ -73,12 +120,16 @@ impl DocumentLoader {
         }
     }
 
+    pub fn add_blocking_load(&mut self, load: LoadType) {
+        self.blocking_loads.push(load);
+    }
+
     /// Create a new pending network request, which can be initiated at some point in
     /// the future.
     pub fn prepare_async_load(&mut self, load: LoadType) -> PendingAsyncLoad {
         let context = load.to_load_context();
         let url = load.url().clone();
-        self.blocking_loads.push(load);
+        self.add_blocking_load(load);
         PendingAsyncLoad::new(context, (*self.resource_thread).clone(), url, self.pipeline)
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1231,6 +1231,7 @@ impl Document {
                            ReflowReason::RequestAnimationFrame);
     }
 
+    /// Add a load to the list of loads blocking this document's load.
     pub fn add_blocking_load(&self, load: LoadType) {
         let mut loader = self.loader.borrow_mut();
         loader.add_blocking_load(load)

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1296,8 +1296,8 @@ impl Document {
         };
 
         if self.script_blocking_stylesheets_count.get() == 0 && script.is_ready_to_be_executed() {
-            script.execute();
             self.pending_parsing_blocking_script.set(None);
+            script.execute();
             return ParserBlockedByScript::Unblocked;
         }
         ParserBlockedByScript::Blocked

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1231,6 +1231,11 @@ impl Document {
                            ReflowReason::RequestAnimationFrame);
     }
 
+    pub fn add_blocking_load(&self, load: LoadType) {
+        let mut loader = self.loader.borrow_mut();
+        loader.add_blocking_load(load)
+    }
+
     pub fn prepare_async_load(&self, load: LoadType) -> PendingAsyncLoad {
         let mut loader = self.loader.borrow_mut();
         loader.prepare_async_load(load)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1662,7 +1662,7 @@ impl ScriptThread {
         let page = get_page(&self.root_page(), containing_pipeline);
         let document = page.document();
         if let Some(iframe) = document.find_iframe_by_pipeline(id) {
-            iframe.iframe_load_event_steps();
+            iframe.iframe_load_event_steps(id);
         }
     }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -142,7 +142,7 @@ pub enum ConstellationControlMsg {
         /// The pipeline that has been marked as loaded.
         target: PipelineId,
         /// The pipeline that contains a frame loading the target pipeline.
-        parent: PipelineId
+        parent: PipelineId,
     },
     /// Notifies a parent frame that one of its child frames is now active.
     FramedContentChanged(PipelineId, SubpageId),

--- a/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
@@ -1,4 +1,23 @@
 [send-entity-body-document.htm]
   type: testharness
-  disabled: https://github.com/servo/servo/issues/8157
+  [XML document, windows-1252]
+    expected: FAIL
+
+  [HTML document, invalid UTF-8]
+    expected: FAIL
+
+  [HTML document, shift-jis]
+    expected: FAIL
+
+  [plain text file]
+    expected: FAIL
+
+  [image file]
+    expected: FAIL
+
+  [img tag]
+    expected: FAIL
+
+  [empty div]
+    expected: FAIL
 

--- a/tests/wpt/metadata/dom/ranges/Range-deleteContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-deleteContents.html.ini
@@ -35,4 +35,3 @@
 
   [Resulting cursor position for range 51 [paras[3\], 1, comment, 8\]]
     expected: FAIL
-

--- a/tests/wpt/metadata/dom/ranges/Range-extractContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-extractContents.html.ini
@@ -14,4 +14,3 @@
 
   [Resulting cursor position for range 51 [paras[3\], 1, comment, 8\]]
     expected: FAIL
-

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/location_reload.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/location_reload.html.ini
@@ -1,0 +1,3 @@
+[location_reload.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/location_reload.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/location_reload.html.ini
@@ -1,3 +1,0 @@
-[location_reload.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/html/infrastructure/terminology/plugins/text-plain.html.ini
+++ b/tests/wpt/metadata/html/infrastructure/terminology/plugins/text-plain.html.ini
@@ -1,3 +1,0 @@
-[text-plain.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/9286

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_multiple.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_multiple.html.ini
@@ -1,6 +1,6 @@
 [base_multiple.html]
   type: testharness
-  expected: ERROR
+  expected: TIMEOUT
   [The attributes of the a element must be affected by the first base element]
-    expected: FAIL
+    expected: NOTRUN
 

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_multiple.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_multiple.html.ini
@@ -1,6 +1,5 @@
 [base_multiple.html]
   type: testharness
-  expected: TIMEOUT
   [The attributes of the a element must be affected by the first base element]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_03.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_03.html.ini
@@ -1,3 +1,0 @@
-[move_iframe_in_dom_03.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html.ini
@@ -1,3 +1,109 @@
 [viewport-change.html]
   type: testharness
-  expected: TIMEOUT
+  disabled: unsupported feature and prone to intermittent incorrect results
+  bug: 9560
+  [img (no src), onload, narrow]
+    expected: FAIL
+
+  [img (empty src), onload, narrow]
+    expected: FAIL
+
+  [img (src only) broken image, onload, narrow]
+    expected: FAIL
+
+  [img (src only) valid image, onload, narrow]
+    expected: FAIL
+
+  [img (srcset 1 cand) broken image, onload, narrow]
+    expected: FAIL
+
+  [img (srcset 1 cand) valid image, onload, narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img broken image, onload, narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img broken image, resize to wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img valid image, onload, narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img valid image, resize to wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img broken image, onload, narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img broken image, resize to wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img valid image, onload, narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img valid image, resize to wide]
+    expected: FAIL
+
+  [picture: same URL in source (max-width:500px) and img, onload, narrow]
+    expected: FAIL
+
+  [img (no src), onload, wide]
+    expected: FAIL
+
+  [img (empty src), onload, wide]
+    expected: FAIL
+
+  [img (src only) broken image, onload, wide]
+    expected: FAIL
+
+  [img (src only) valid image, onload, wide]
+    expected: FAIL
+
+  [img (srcset 1 cand) broken image, onload, wide]
+    expected: FAIL
+
+  [img (srcset 1 cand) valid image, onload, wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img broken image, onload, wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img broken image, resize to narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img valid image, onload, wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) broken image, img valid image, resize to narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img broken image, onload, wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img broken image, resize to narrow]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img valid image, onload, wide]
+    expected: FAIL
+
+  [picture: source (max-width:500px) valid image, img valid image, resize to narrow]
+    expected: FAIL
+
+  [picture: same URL in source (max-width:500px) and img, onload, wide]
+    expected: FAIL
+
+  [img (empty src), resize to wide]
+    expected: FAIL
+
+  [img (src only) broken image, resize to wide]
+    expected: FAIL
+
+  [img (src only) valid image, resize to wide]
+    expected: FAIL
+
+  [picture: same URL in source (max-width:500px) and img, resize to wide]
+    expected: FAIL
+
+  [picture: same URL in source (max-width:500px) and img, resize to narrow]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html.ini
@@ -1,3 +1,1828 @@
 [parse-a-sizes-attribute.html]
   type: testharness
-  expected: TIMEOUT
+  disabled: unsupported feature and prone to intermittent incorrect results
+  bug: 9560
+  [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?b2 450w, /images/green-16x16.png?b2 451w"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?c2 600w, /images/green-16x16.png?c2 601w"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?d2 900w, /images/green-16x16.png?d2 901w"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e2 50w, /images/green-16x16.png?e2 51w" sizes="0"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e3 50w, /images/green-16x16.png?e3 51w" sizes="-0"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e4 50w, /images/green-16x16.png?e4 51w" sizes="+0"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e5 50w, /images/green-16x16.png?e5 51w" sizes="+1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e6 50w, /images/green-16x16.png?e6 51w" sizes=".1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e7 50w, /images/green-16x16.png?e7 51w" sizes="0.1em"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e8 50w, /images/green-16x16.png?e8 51w" sizes="0.1ex"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e9 50w, /images/green-16x16.png?e9 51w" sizes="0.1ch"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e10 50w, /images/green-16x16.png?e10 51w" sizes="0.1rem"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e11 50w, /images/green-16x16.png?e11 51w" sizes="0.1vw"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e12 50w, /images/green-16x16.png?e12 51w" sizes="0.1vh"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e13 50w, /images/green-16x16.png?e13 51w" sizes="0.1vmin"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e14 50w, /images/green-16x16.png?e14 51w" sizes="0.1vmax"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e15 50w, /images/green-16x16.png?e15 51w" sizes="0.1cm"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e16 50w, /images/green-16x16.png?e16 51w" sizes="1mm"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e17 50w, /images/green-16x16.png?e17 51w" sizes="1q"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e18 50w, /images/green-16x16.png?e18 51w" sizes="0.01in"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e19 50w, /images/green-16x16.png?e19 51w" sizes="0.1pc"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e20 50w, /images/green-16x16.png?e20 51w" sizes="0.1pt"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e21 50w, /images/green-16x16.png?e21 51w" sizes="/* */1px/* */"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e22 50w, /images/green-16x16.png?e22 51w" sizes=" /**/ /**/ 1px /**/ /**/ "> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e23 50w, /images/green-16x16.png?e23 51w" sizes="(),1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e24 50w, /images/green-16x16.png?e24 51w" sizes="x(),1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e25 50w, /images/green-16x16.png?e25 51w" sizes="{},1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e26 50w, /images/green-16x16.png?e26 51w" sizes="[\],1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e27 50w, /images/green-16x16.png?e27 51w" sizes="1px,("> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e28 50w, /images/green-16x16.png?e28 51w" sizes="1px,x("> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e29 50w, /images/green-16x16.png?e29 51w" sizes="1px,{"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e30 50w, /images/green-16x16.png?e30 51w" sizes="1px,["> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e31 50w, /images/green-16x16.png?e31 51w" sizes="\\(,1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e32 50w, /images/green-16x16.png?e32 51w" sizes="x\\(,1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w" sizes="\\{,1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\\[,1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\\p\\x"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e41 50w, /images/green-16x16.png?e41 51w" sizes="(min-width:0) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e42 50w, /images/green-16x16.png?e42 51w" sizes="not (min-width:0) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e54 50w, /images/green-16x16.png?e54 51w" sizes="not print 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e55 50w, /images/green-16x16.png?e55 51w" sizes="unknown-media-type 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e56 50w, /images/green-16x16.png?e56 51w" sizes="not unknown-media-type 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e57 50w, /images/green-16x16.png?e57 51w" sizes="(min-width:0) or (min-width:0) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e58 50w, /images/green-16x16.png?e58 51w" sizes="(min-width:0) or (unknown-mf-name) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w" sizes="(min-width:0) or (min-width:unknown-mf-value) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (!) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e68 50w, /images/green-16x16.png?e68 51w" sizes="not (!) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e69 50w, /images/green-16x16.png?e69 51w" sizes="! 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e70 50w, /images/green-16x16.png?e70 51w" sizes="not ! 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e71 50w, /images/green-16x16.png?e71 51w" sizes="(\]) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e72 50w, /images/green-16x16.png?e72 51w" sizes="not (\]) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e73 50w, /images/green-16x16.png?e73 51w" sizes="\] 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e74 50w, /images/green-16x16.png?e74 51w" sizes="not \] 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e75 50w, /images/green-16x16.png?e75 51w" sizes="(}) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e76 50w, /images/green-16x16.png?e76 51w" sizes="not (}) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e77 50w, /images/green-16x16.png?e77 51w" sizes="} 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e78 50w, /images/green-16x16.png?e78 51w" sizes="not } 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e79 50w, /images/green-16x16.png?e79 51w" sizes=") 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e80 50w, /images/green-16x16.png?e80 51w" sizes="not ) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e81 50w, /images/green-16x16.png?e81 51w" sizes="(;) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e82 50w, /images/green-16x16.png?e82 51w" sizes="not (;) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e86 50w, /images/green-16x16.png?e86 51w" sizes="not ; 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e87 50w, /images/green-16x16.png?e87 51w" sizes=", 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e88 50w, /images/green-16x16.png?e88 51w" sizes="1px,"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e89 50w, /images/green-16x16.png?e89 51w" sizes="(min-width:0) 1px,"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e90 50w, /images/green-16x16.png?e90 51w" sizes="-0e-0px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e91 50w, /images/green-16x16.png?e91 51w" sizes="+0.11e+01px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e92 50w, /images/green-16x16.png?e92 51w" sizes="0.2e1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e93 50w, /images/green-16x16.png?e93 51w" sizes="0.3E1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e94 50w, /images/green-16x16.png?e94 51w" sizes=".4E1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e95 50w, /images/green-16x16.png?e95 51w" sizes="all 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e96 50w, /images/green-16x16.png?e96 51w" sizes="all and (min-width:0) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e97 50w, /images/green-16x16.png?e97 51w" sizes="min-width:0 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e98 50w, /images/green-16x16.png?e98 51w" sizes="1px, 100vw"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e99 50w, /images/green-16x16.png?e99 51w" sizes="1px, (min-width:0) 100vw"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e100 50w, /images/green-16x16.png?e100 51w" sizes="1px, foo bar"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f3 50w, /images/green-16x16.png?f3 51w" sizes=","> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f4 50w, /images/green-16x16.png?f4 51w" sizes="-1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f5 50w, /images/green-16x16.png?f5 51w" sizes="1"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f6 50w, /images/green-16x16.png?f6 51w" sizes="0.1%"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f7 50w, /images/green-16x16.png?f7 51w" sizes="0.1deg"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f8 50w, /images/green-16x16.png?f8 51w" sizes="0.1grad"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f9 50w, /images/green-16x16.png?f9 51w" sizes="0.1rad"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f10 50w, /images/green-16x16.png?f10 51w" sizes="0.1turn"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f11 50w, /images/green-16x16.png?f11 51w" sizes="0.1s"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f12 50w, /images/green-16x16.png?f12 51w" sizes="0.1ms"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f13 50w, /images/green-16x16.png?f13 51w" sizes="0.1Hz"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f14 50w, /images/green-16x16.png?f14 51w" sizes="0.1kHz"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f15 50w, /images/green-16x16.png?f15 51w" sizes="0.1dpi"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f16 50w, /images/green-16x16.png?f16 51w" sizes="0.1dpcm"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f17 50w, /images/green-16x16.png?f17 51w" sizes="0.1dppx"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f18 50w, /images/green-16x16.png?f18 51w" data-foo="1px" sizes="attr(data-foo, length, 1px)"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f19 50w, /images/green-16x16.png?f19 51w" data-foo="1" sizes="attr(data-foo, px, 1px)"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f20 50w, /images/green-16x16.png?f20 51w" sizes="toggle(1px)"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f21 50w, /images/green-16x16.png?f21 51w" sizes="inherit"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f22 50w, /images/green-16x16.png?f22 51w" sizes="auto"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f23 50w, /images/green-16x16.png?f23 51w" sizes="initial"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f24 50w, /images/green-16x16.png?f24 51w" sizes="unset"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f25 50w, /images/green-16x16.png?f25 51w" sizes="default"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f26 50w, /images/green-16x16.png?f26 51w" sizes="1/* */px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f27 50w, /images/green-16x16.png?f27 51w" sizes="1p/* */x"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f28 50w, /images/green-16x16.png?f28 51w" sizes="-/**/0"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f29 50w, /images/green-16x16.png?f29 51w" sizes="((),1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f30 50w, /images/green-16x16.png?f30 51w" sizes="x(x(),1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f31 50w, /images/green-16x16.png?f31 51w" sizes="{{},1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f32 50w, /images/green-16x16.png?f32 51w" sizes="[[\],1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f33 50w, /images/green-16x16.png?f33 51w" sizes="1px !important"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f34 50w, /images/green-16x16.png?f34 51w" sizes="\\1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f35 50w, /images/green-16x16.png?f35 51w" sizes="all 1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f36 50w, /images/green-16x16.png?f36 51w" sizes="all and (min-width:0) 1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f37 50w, /images/green-16x16.png?f37 51w" sizes="min-width:0 1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f38 50w, /images/green-16x16.png?f38 51w" sizes="100vw, 1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f39 50w, /images/green-16x16.png?f39 51w" sizes="100vw, (min-width:0) 1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f40 50w, /images/green-16x16.png?f40 51w" sizes="foo bar"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f41 50w, /images/green-16x16.png?f41 51w" sizes="foo-bar"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f42 50w, /images/green-16x16.png?f42 51w" sizes="(min-width:0) 1px foo bar"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f43 50w, /images/green-16x16.png?f43 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w" sizes="(min-width:0) 1"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?b2 450w, /images/green-16x16.png?b2 451w"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?c2 600w, /images/green-16x16.png?c2 601w"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?d2 900w, /images/green-16x16.png?d2 901w"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e2 50w, /images/green-16x16.png?e2 51w" sizes="0"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e3 50w, /images/green-16x16.png?e3 51w" sizes="-0"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e4 50w, /images/green-16x16.png?e4 51w" sizes="+0"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e5 50w, /images/green-16x16.png?e5 51w" sizes="+1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e6 50w, /images/green-16x16.png?e6 51w" sizes=".1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e7 50w, /images/green-16x16.png?e7 51w" sizes="0.1em"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e8 50w, /images/green-16x16.png?e8 51w" sizes="0.1ex"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e9 50w, /images/green-16x16.png?e9 51w" sizes="0.1ch"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e10 50w, /images/green-16x16.png?e10 51w" sizes="0.1rem"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e11 50w, /images/green-16x16.png?e11 51w" sizes="0.1vw"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e12 50w, /images/green-16x16.png?e12 51w" sizes="0.1vh"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e13 50w, /images/green-16x16.png?e13 51w" sizes="0.1vmin"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e14 50w, /images/green-16x16.png?e14 51w" sizes="0.1vmax"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e15 50w, /images/green-16x16.png?e15 51w" sizes="0.1cm"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e16 50w, /images/green-16x16.png?e16 51w" sizes="1mm"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e17 50w, /images/green-16x16.png?e17 51w" sizes="1q"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e18 50w, /images/green-16x16.png?e18 51w" sizes="0.01in"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e19 50w, /images/green-16x16.png?e19 51w" sizes="0.1pc"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e20 50w, /images/green-16x16.png?e20 51w" sizes="0.1pt"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e21 50w, /images/green-16x16.png?e21 51w" sizes="/* */1px/* */"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e22 50w, /images/green-16x16.png?e22 51w" sizes=" /**/ /**/ 1px /**/ /**/ "> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e23 50w, /images/green-16x16.png?e23 51w" sizes="(),1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e24 50w, /images/green-16x16.png?e24 51w" sizes="x(),1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e25 50w, /images/green-16x16.png?e25 51w" sizes="{},1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e26 50w, /images/green-16x16.png?e26 51w" sizes="[\],1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e27 50w, /images/green-16x16.png?e27 51w" sizes="1px,("> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e28 50w, /images/green-16x16.png?e28 51w" sizes="1px,x("> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e29 50w, /images/green-16x16.png?e29 51w" sizes="1px,{"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e30 50w, /images/green-16x16.png?e30 51w" sizes="1px,["> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e31 50w, /images/green-16x16.png?e31 51w" sizes="\\(,1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e32 50w, /images/green-16x16.png?e32 51w" sizes="x\\(,1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w" sizes="\\{,1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\\[,1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\\p\\x"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e41 50w, /images/green-16x16.png?e41 51w" sizes="(min-width:0) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e42 50w, /images/green-16x16.png?e42 51w" sizes="not (min-width:0) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e54 50w, /images/green-16x16.png?e54 51w" sizes="not print 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e55 50w, /images/green-16x16.png?e55 51w" sizes="unknown-media-type 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e56 50w, /images/green-16x16.png?e56 51w" sizes="not unknown-media-type 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e57 50w, /images/green-16x16.png?e57 51w" sizes="(min-width:0) or (min-width:0) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e58 50w, /images/green-16x16.png?e58 51w" sizes="(min-width:0) or (unknown-mf-name) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w" sizes="(min-width:0) or (min-width:unknown-mf-value) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (!) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e68 50w, /images/green-16x16.png?e68 51w" sizes="not (!) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e69 50w, /images/green-16x16.png?e69 51w" sizes="! 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e70 50w, /images/green-16x16.png?e70 51w" sizes="not ! 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e71 50w, /images/green-16x16.png?e71 51w" sizes="(\]) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e72 50w, /images/green-16x16.png?e72 51w" sizes="not (\]) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e73 50w, /images/green-16x16.png?e73 51w" sizes="\] 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e74 50w, /images/green-16x16.png?e74 51w" sizes="not \] 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e75 50w, /images/green-16x16.png?e75 51w" sizes="(}) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e76 50w, /images/green-16x16.png?e76 51w" sizes="not (}) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e77 50w, /images/green-16x16.png?e77 51w" sizes="} 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e78 50w, /images/green-16x16.png?e78 51w" sizes="not } 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e79 50w, /images/green-16x16.png?e79 51w" sizes=") 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e80 50w, /images/green-16x16.png?e80 51w" sizes="not ) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e81 50w, /images/green-16x16.png?e81 51w" sizes="(;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e82 50w, /images/green-16x16.png?e82 51w" sizes="not (;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e86 50w, /images/green-16x16.png?e86 51w" sizes="not ; 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e87 50w, /images/green-16x16.png?e87 51w" sizes=", 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e88 50w, /images/green-16x16.png?e88 51w" sizes="1px,"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e89 50w, /images/green-16x16.png?e89 51w" sizes="(min-width:0) 1px,"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e90 50w, /images/green-16x16.png?e90 51w" sizes="-0e-0px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e91 50w, /images/green-16x16.png?e91 51w" sizes="+0.11e+01px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e92 50w, /images/green-16x16.png?e92 51w" sizes="0.2e1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e93 50w, /images/green-16x16.png?e93 51w" sizes="0.3E1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e94 50w, /images/green-16x16.png?e94 51w" sizes=".4E1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e95 50w, /images/green-16x16.png?e95 51w" sizes="all 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e96 50w, /images/green-16x16.png?e96 51w" sizes="all and (min-width:0) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e97 50w, /images/green-16x16.png?e97 51w" sizes="min-width:0 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e98 50w, /images/green-16x16.png?e98 51w" sizes="1px, 100vw"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e99 50w, /images/green-16x16.png?e99 51w" sizes="1px, (min-width:0) 100vw"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e100 50w, /images/green-16x16.png?e100 51w" sizes="1px, foo bar"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f3 50w, /images/green-16x16.png?f3 51w" sizes=","> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f4 50w, /images/green-16x16.png?f4 51w" sizes="-1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f5 50w, /images/green-16x16.png?f5 51w" sizes="1"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f6 50w, /images/green-16x16.png?f6 51w" sizes="0.1%"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f7 50w, /images/green-16x16.png?f7 51w" sizes="0.1deg"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f8 50w, /images/green-16x16.png?f8 51w" sizes="0.1grad"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f9 50w, /images/green-16x16.png?f9 51w" sizes="0.1rad"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f10 50w, /images/green-16x16.png?f10 51w" sizes="0.1turn"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f11 50w, /images/green-16x16.png?f11 51w" sizes="0.1s"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f12 50w, /images/green-16x16.png?f12 51w" sizes="0.1ms"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f13 50w, /images/green-16x16.png?f13 51w" sizes="0.1Hz"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f14 50w, /images/green-16x16.png?f14 51w" sizes="0.1kHz"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f15 50w, /images/green-16x16.png?f15 51w" sizes="0.1dpi"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f16 50w, /images/green-16x16.png?f16 51w" sizes="0.1dpcm"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f17 50w, /images/green-16x16.png?f17 51w" sizes="0.1dppx"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f18 50w, /images/green-16x16.png?f18 51w" data-foo="1px" sizes="attr(data-foo, length, 1px)"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f19 50w, /images/green-16x16.png?f19 51w" data-foo="1" sizes="attr(data-foo, px, 1px)"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f20 50w, /images/green-16x16.png?f20 51w" sizes="toggle(1px)"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f21 50w, /images/green-16x16.png?f21 51w" sizes="inherit"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f22 50w, /images/green-16x16.png?f22 51w" sizes="auto"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f23 50w, /images/green-16x16.png?f23 51w" sizes="initial"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f24 50w, /images/green-16x16.png?f24 51w" sizes="unset"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f25 50w, /images/green-16x16.png?f25 51w" sizes="default"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f26 50w, /images/green-16x16.png?f26 51w" sizes="1/* */px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f27 50w, /images/green-16x16.png?f27 51w" sizes="1p/* */x"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f28 50w, /images/green-16x16.png?f28 51w" sizes="-/**/0"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f29 50w, /images/green-16x16.png?f29 51w" sizes="((),1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f30 50w, /images/green-16x16.png?f30 51w" sizes="x(x(),1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f31 50w, /images/green-16x16.png?f31 51w" sizes="{{},1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f32 50w, /images/green-16x16.png?f32 51w" sizes="[[\],1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f33 50w, /images/green-16x16.png?f33 51w" sizes="1px !important"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f34 50w, /images/green-16x16.png?f34 51w" sizes="\\1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f35 50w, /images/green-16x16.png?f35 51w" sizes="all 1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f36 50w, /images/green-16x16.png?f36 51w" sizes="all and (min-width:0) 1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f37 50w, /images/green-16x16.png?f37 51w" sizes="min-width:0 1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f38 50w, /images/green-16x16.png?f38 51w" sizes="100vw, 1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f39 50w, /images/green-16x16.png?f39 51w" sizes="100vw, (min-width:0) 1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f40 50w, /images/green-16x16.png?f40 51w" sizes="foo bar"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f41 50w, /images/green-16x16.png?f41 51w" sizes="foo-bar"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f42 50w, /images/green-16x16.png?f42 51w" sizes="(min-width:0) 1px foo bar"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f43 50w, /images/green-16x16.png?f43 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w" sizes="(min-width:0) 1"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?b2 450w, /images/green-16x16.png?b2 451w"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?c2 600w, /images/green-16x16.png?c2 601w"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?d2 900w, /images/green-16x16.png?d2 901w"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e2 50w, /images/green-16x16.png?e2 51w" sizes="0"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e3 50w, /images/green-16x16.png?e3 51w" sizes="-0"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e4 50w, /images/green-16x16.png?e4 51w" sizes="+0"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e5 50w, /images/green-16x16.png?e5 51w" sizes="+1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e6 50w, /images/green-16x16.png?e6 51w" sizes=".1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e7 50w, /images/green-16x16.png?e7 51w" sizes="0.1em"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e8 50w, /images/green-16x16.png?e8 51w" sizes="0.1ex"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e9 50w, /images/green-16x16.png?e9 51w" sizes="0.1ch"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e10 50w, /images/green-16x16.png?e10 51w" sizes="0.1rem"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e11 50w, /images/green-16x16.png?e11 51w" sizes="0.1vw"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e12 50w, /images/green-16x16.png?e12 51w" sizes="0.1vh"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e13 50w, /images/green-16x16.png?e13 51w" sizes="0.1vmin"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e14 50w, /images/green-16x16.png?e14 51w" sizes="0.1vmax"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e15 50w, /images/green-16x16.png?e15 51w" sizes="0.1cm"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e16 50w, /images/green-16x16.png?e16 51w" sizes="1mm"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e17 50w, /images/green-16x16.png?e17 51w" sizes="1q"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e18 50w, /images/green-16x16.png?e18 51w" sizes="0.01in"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e19 50w, /images/green-16x16.png?e19 51w" sizes="0.1pc"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e20 50w, /images/green-16x16.png?e20 51w" sizes="0.1pt"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e21 50w, /images/green-16x16.png?e21 51w" sizes="/* */1px/* */"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e22 50w, /images/green-16x16.png?e22 51w" sizes=" /**/ /**/ 1px /**/ /**/ "> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e23 50w, /images/green-16x16.png?e23 51w" sizes="(),1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e24 50w, /images/green-16x16.png?e24 51w" sizes="x(),1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e25 50w, /images/green-16x16.png?e25 51w" sizes="{},1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e26 50w, /images/green-16x16.png?e26 51w" sizes="[\],1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e27 50w, /images/green-16x16.png?e27 51w" sizes="1px,("> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e28 50w, /images/green-16x16.png?e28 51w" sizes="1px,x("> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e29 50w, /images/green-16x16.png?e29 51w" sizes="1px,{"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e30 50w, /images/green-16x16.png?e30 51w" sizes="1px,["> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e31 50w, /images/green-16x16.png?e31 51w" sizes="\\(,1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e32 50w, /images/green-16x16.png?e32 51w" sizes="x\\(,1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w" sizes="\\{,1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\\[,1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\\p\\x"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e41 50w, /images/green-16x16.png?e41 51w" sizes="(min-width:0) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e42 50w, /images/green-16x16.png?e42 51w" sizes="not (min-width:0) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e54 50w, /images/green-16x16.png?e54 51w" sizes="not print 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e55 50w, /images/green-16x16.png?e55 51w" sizes="unknown-media-type 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e56 50w, /images/green-16x16.png?e56 51w" sizes="not unknown-media-type 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e57 50w, /images/green-16x16.png?e57 51w" sizes="(min-width:0) or (min-width:0) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e58 50w, /images/green-16x16.png?e58 51w" sizes="(min-width:0) or (unknown-mf-name) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w" sizes="(min-width:0) or (min-width:unknown-mf-value) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (!) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e68 50w, /images/green-16x16.png?e68 51w" sizes="not (!) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e69 50w, /images/green-16x16.png?e69 51w" sizes="! 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e70 50w, /images/green-16x16.png?e70 51w" sizes="not ! 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e71 50w, /images/green-16x16.png?e71 51w" sizes="(\]) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e72 50w, /images/green-16x16.png?e72 51w" sizes="not (\]) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e73 50w, /images/green-16x16.png?e73 51w" sizes="\] 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e74 50w, /images/green-16x16.png?e74 51w" sizes="not \] 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e75 50w, /images/green-16x16.png?e75 51w" sizes="(}) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e76 50w, /images/green-16x16.png?e76 51w" sizes="not (}) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e77 50w, /images/green-16x16.png?e77 51w" sizes="} 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e78 50w, /images/green-16x16.png?e78 51w" sizes="not } 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e79 50w, /images/green-16x16.png?e79 51w" sizes=") 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e80 50w, /images/green-16x16.png?e80 51w" sizes="not ) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e81 50w, /images/green-16x16.png?e81 51w" sizes="(;) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e82 50w, /images/green-16x16.png?e82 51w" sizes="not (;) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e86 50w, /images/green-16x16.png?e86 51w" sizes="not ; 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e87 50w, /images/green-16x16.png?e87 51w" sizes=", 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e88 50w, /images/green-16x16.png?e88 51w" sizes="1px,"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e89 50w, /images/green-16x16.png?e89 51w" sizes="(min-width:0) 1px,"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e90 50w, /images/green-16x16.png?e90 51w" sizes="-0e-0px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e91 50w, /images/green-16x16.png?e91 51w" sizes="+0.11e+01px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e92 50w, /images/green-16x16.png?e92 51w" sizes="0.2e1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e93 50w, /images/green-16x16.png?e93 51w" sizes="0.3E1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e94 50w, /images/green-16x16.png?e94 51w" sizes=".4E1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e95 50w, /images/green-16x16.png?e95 51w" sizes="all 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e96 50w, /images/green-16x16.png?e96 51w" sizes="all and (min-width:0) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e97 50w, /images/green-16x16.png?e97 51w" sizes="min-width:0 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e98 50w, /images/green-16x16.png?e98 51w" sizes="1px, 100vw"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e99 50w, /images/green-16x16.png?e99 51w" sizes="1px, (min-width:0) 100vw"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e100 50w, /images/green-16x16.png?e100 51w" sizes="1px, foo bar"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f3 50w, /images/green-16x16.png?f3 51w" sizes=","> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f4 50w, /images/green-16x16.png?f4 51w" sizes="-1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f5 50w, /images/green-16x16.png?f5 51w" sizes="1"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f6 50w, /images/green-16x16.png?f6 51w" sizes="0.1%"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f7 50w, /images/green-16x16.png?f7 51w" sizes="0.1deg"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f8 50w, /images/green-16x16.png?f8 51w" sizes="0.1grad"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f9 50w, /images/green-16x16.png?f9 51w" sizes="0.1rad"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f10 50w, /images/green-16x16.png?f10 51w" sizes="0.1turn"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f11 50w, /images/green-16x16.png?f11 51w" sizes="0.1s"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f12 50w, /images/green-16x16.png?f12 51w" sizes="0.1ms"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f13 50w, /images/green-16x16.png?f13 51w" sizes="0.1Hz"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f14 50w, /images/green-16x16.png?f14 51w" sizes="0.1kHz"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f15 50w, /images/green-16x16.png?f15 51w" sizes="0.1dpi"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f16 50w, /images/green-16x16.png?f16 51w" sizes="0.1dpcm"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f17 50w, /images/green-16x16.png?f17 51w" sizes="0.1dppx"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f18 50w, /images/green-16x16.png?f18 51w" data-foo="1px" sizes="attr(data-foo, length, 1px)"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f19 50w, /images/green-16x16.png?f19 51w" data-foo="1" sizes="attr(data-foo, px, 1px)"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f20 50w, /images/green-16x16.png?f20 51w" sizes="toggle(1px)"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f21 50w, /images/green-16x16.png?f21 51w" sizes="inherit"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f22 50w, /images/green-16x16.png?f22 51w" sizes="auto"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f23 50w, /images/green-16x16.png?f23 51w" sizes="initial"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f24 50w, /images/green-16x16.png?f24 51w" sizes="unset"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f25 50w, /images/green-16x16.png?f25 51w" sizes="default"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f26 50w, /images/green-16x16.png?f26 51w" sizes="1/* */px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f27 50w, /images/green-16x16.png?f27 51w" sizes="1p/* */x"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f28 50w, /images/green-16x16.png?f28 51w" sizes="-/**/0"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f29 50w, /images/green-16x16.png?f29 51w" sizes="((),1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f30 50w, /images/green-16x16.png?f30 51w" sizes="x(x(),1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f31 50w, /images/green-16x16.png?f31 51w" sizes="{{},1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f32 50w, /images/green-16x16.png?f32 51w" sizes="[[\],1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f33 50w, /images/green-16x16.png?f33 51w" sizes="1px !important"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f34 50w, /images/green-16x16.png?f34 51w" sizes="\\1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f35 50w, /images/green-16x16.png?f35 51w" sizes="all 1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f36 50w, /images/green-16x16.png?f36 51w" sizes="all and (min-width:0) 1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f37 50w, /images/green-16x16.png?f37 51w" sizes="min-width:0 1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f38 50w, /images/green-16x16.png?f38 51w" sizes="100vw, 1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f39 50w, /images/green-16x16.png?f39 51w" sizes="100vw, (min-width:0) 1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f40 50w, /images/green-16x16.png?f40 51w" sizes="foo bar"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f41 50w, /images/green-16x16.png?f41 51w" sizes="foo-bar"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f42 50w, /images/green-16x16.png?f42 51w" sizes="(min-width:0) 1px foo bar"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f43 50w, /images/green-16x16.png?f43 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w" sizes="(min-width:0) 1"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?b2 450w, /images/green-16x16.png?b2 451w"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?c2 600w, /images/green-16x16.png?c2 601w"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?d2 900w, /images/green-16x16.png?d2 901w"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e2 50w, /images/green-16x16.png?e2 51w" sizes="0"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e3 50w, /images/green-16x16.png?e3 51w" sizes="-0"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e4 50w, /images/green-16x16.png?e4 51w" sizes="+0"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e5 50w, /images/green-16x16.png?e5 51w" sizes="+1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e6 50w, /images/green-16x16.png?e6 51w" sizes=".1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e7 50w, /images/green-16x16.png?e7 51w" sizes="0.1em"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e8 50w, /images/green-16x16.png?e8 51w" sizes="0.1ex"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e9 50w, /images/green-16x16.png?e9 51w" sizes="0.1ch"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e10 50w, /images/green-16x16.png?e10 51w" sizes="0.1rem"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e11 50w, /images/green-16x16.png?e11 51w" sizes="0.1vw"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e12 50w, /images/green-16x16.png?e12 51w" sizes="0.1vh"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e13 50w, /images/green-16x16.png?e13 51w" sizes="0.1vmin"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e14 50w, /images/green-16x16.png?e14 51w" sizes="0.1vmax"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e15 50w, /images/green-16x16.png?e15 51w" sizes="0.1cm"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e16 50w, /images/green-16x16.png?e16 51w" sizes="1mm"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e17 50w, /images/green-16x16.png?e17 51w" sizes="1q"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e18 50w, /images/green-16x16.png?e18 51w" sizes="0.01in"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e19 50w, /images/green-16x16.png?e19 51w" sizes="0.1pc"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e20 50w, /images/green-16x16.png?e20 51w" sizes="0.1pt"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e21 50w, /images/green-16x16.png?e21 51w" sizes="/* */1px/* */"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e22 50w, /images/green-16x16.png?e22 51w" sizes=" /**/ /**/ 1px /**/ /**/ "> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e23 50w, /images/green-16x16.png?e23 51w" sizes="(),1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e24 50w, /images/green-16x16.png?e24 51w" sizes="x(),1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e25 50w, /images/green-16x16.png?e25 51w" sizes="{},1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e26 50w, /images/green-16x16.png?e26 51w" sizes="[\],1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e27 50w, /images/green-16x16.png?e27 51w" sizes="1px,("> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e28 50w, /images/green-16x16.png?e28 51w" sizes="1px,x("> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e29 50w, /images/green-16x16.png?e29 51w" sizes="1px,{"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e30 50w, /images/green-16x16.png?e30 51w" sizes="1px,["> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e31 50w, /images/green-16x16.png?e31 51w" sizes="\\(,1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e32 50w, /images/green-16x16.png?e32 51w" sizes="x\\(,1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w" sizes="\\{,1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\\[,1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\\p\\x"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e41 50w, /images/green-16x16.png?e41 51w" sizes="(min-width:0) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e42 50w, /images/green-16x16.png?e42 51w" sizes="not (min-width:0) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e54 50w, /images/green-16x16.png?e54 51w" sizes="not print 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e55 50w, /images/green-16x16.png?e55 51w" sizes="unknown-media-type 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e56 50w, /images/green-16x16.png?e56 51w" sizes="not unknown-media-type 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e57 50w, /images/green-16x16.png?e57 51w" sizes="(min-width:0) or (min-width:0) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e58 50w, /images/green-16x16.png?e58 51w" sizes="(min-width:0) or (unknown-mf-name) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w" sizes="(min-width:0) or (min-width:unknown-mf-value) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (!) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e68 50w, /images/green-16x16.png?e68 51w" sizes="not (!) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e69 50w, /images/green-16x16.png?e69 51w" sizes="! 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e70 50w, /images/green-16x16.png?e70 51w" sizes="not ! 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e71 50w, /images/green-16x16.png?e71 51w" sizes="(\]) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e72 50w, /images/green-16x16.png?e72 51w" sizes="not (\]) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e73 50w, /images/green-16x16.png?e73 51w" sizes="\] 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e74 50w, /images/green-16x16.png?e74 51w" sizes="not \] 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e75 50w, /images/green-16x16.png?e75 51w" sizes="(}) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e76 50w, /images/green-16x16.png?e76 51w" sizes="not (}) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e77 50w, /images/green-16x16.png?e77 51w" sizes="} 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e78 50w, /images/green-16x16.png?e78 51w" sizes="not } 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e79 50w, /images/green-16x16.png?e79 51w" sizes=") 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e80 50w, /images/green-16x16.png?e80 51w" sizes="not ) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e81 50w, /images/green-16x16.png?e81 51w" sizes="(;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e82 50w, /images/green-16x16.png?e82 51w" sizes="not (;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e86 50w, /images/green-16x16.png?e86 51w" sizes="not ; 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e87 50w, /images/green-16x16.png?e87 51w" sizes=", 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e88 50w, /images/green-16x16.png?e88 51w" sizes="1px,"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e89 50w, /images/green-16x16.png?e89 51w" sizes="(min-width:0) 1px,"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e90 50w, /images/green-16x16.png?e90 51w" sizes="-0e-0px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e91 50w, /images/green-16x16.png?e91 51w" sizes="+0.11e+01px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e92 50w, /images/green-16x16.png?e92 51w" sizes="0.2e1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e93 50w, /images/green-16x16.png?e93 51w" sizes="0.3E1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e94 50w, /images/green-16x16.png?e94 51w" sizes=".4E1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e95 50w, /images/green-16x16.png?e95 51w" sizes="all 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e96 50w, /images/green-16x16.png?e96 51w" sizes="all and (min-width:0) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e97 50w, /images/green-16x16.png?e97 51w" sizes="min-width:0 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e98 50w, /images/green-16x16.png?e98 51w" sizes="1px, 100vw"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e99 50w, /images/green-16x16.png?e99 51w" sizes="1px, (min-width:0) 100vw"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e100 50w, /images/green-16x16.png?e100 51w" sizes="1px, foo bar"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f3 50w, /images/green-16x16.png?f3 51w" sizes=","> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f4 50w, /images/green-16x16.png?f4 51w" sizes="-1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f5 50w, /images/green-16x16.png?f5 51w" sizes="1"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f6 50w, /images/green-16x16.png?f6 51w" sizes="0.1%"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f7 50w, /images/green-16x16.png?f7 51w" sizes="0.1deg"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f8 50w, /images/green-16x16.png?f8 51w" sizes="0.1grad"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f9 50w, /images/green-16x16.png?f9 51w" sizes="0.1rad"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f10 50w, /images/green-16x16.png?f10 51w" sizes="0.1turn"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f11 50w, /images/green-16x16.png?f11 51w" sizes="0.1s"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f12 50w, /images/green-16x16.png?f12 51w" sizes="0.1ms"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f13 50w, /images/green-16x16.png?f13 51w" sizes="0.1Hz"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f14 50w, /images/green-16x16.png?f14 51w" sizes="0.1kHz"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f15 50w, /images/green-16x16.png?f15 51w" sizes="0.1dpi"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f16 50w, /images/green-16x16.png?f16 51w" sizes="0.1dpcm"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f17 50w, /images/green-16x16.png?f17 51w" sizes="0.1dppx"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f18 50w, /images/green-16x16.png?f18 51w" data-foo="1px" sizes="attr(data-foo, length, 1px)"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f19 50w, /images/green-16x16.png?f19 51w" data-foo="1" sizes="attr(data-foo, px, 1px)"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f20 50w, /images/green-16x16.png?f20 51w" sizes="toggle(1px)"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f21 50w, /images/green-16x16.png?f21 51w" sizes="inherit"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f22 50w, /images/green-16x16.png?f22 51w" sizes="auto"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f23 50w, /images/green-16x16.png?f23 51w" sizes="initial"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f24 50w, /images/green-16x16.png?f24 51w" sizes="unset"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f25 50w, /images/green-16x16.png?f25 51w" sizes="default"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f26 50w, /images/green-16x16.png?f26 51w" sizes="1/* */px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f27 50w, /images/green-16x16.png?f27 51w" sizes="1p/* */x"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f28 50w, /images/green-16x16.png?f28 51w" sizes="-/**/0"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f29 50w, /images/green-16x16.png?f29 51w" sizes="((),1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f30 50w, /images/green-16x16.png?f30 51w" sizes="x(x(),1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f31 50w, /images/green-16x16.png?f31 51w" sizes="{{},1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f32 50w, /images/green-16x16.png?f32 51w" sizes="[[\],1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f33 50w, /images/green-16x16.png?f33 51w" sizes="1px !important"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f34 50w, /images/green-16x16.png?f34 51w" sizes="\\1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f35 50w, /images/green-16x16.png?f35 51w" sizes="all 1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f36 50w, /images/green-16x16.png?f36 51w" sizes="all and (min-width:0) 1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f37 50w, /images/green-16x16.png?f37 51w" sizes="min-width:0 1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f38 50w, /images/green-16x16.png?f38 51w" sizes="100vw, 1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f39 50w, /images/green-16x16.png?f39 51w" sizes="100vw, (min-width:0) 1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f40 50w, /images/green-16x16.png?f40 51w" sizes="foo bar"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f41 50w, /images/green-16x16.png?f41 51w" sizes="foo-bar"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f42 50w, /images/green-16x16.png?f42 51w" sizes="(min-width:0) 1px foo bar"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f43 50w, /images/green-16x16.png?f43 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w" sizes="(min-width:0) 1"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (width:1000px)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/selectors/pseudo-classes/focus.html.ini
+++ b/tests/wpt/metadata/html/semantics/selectors/pseudo-classes/focus.html.ini
@@ -6,3 +6,6 @@
   [editable elements are focusable]
     expected: FAIL
 
+  [':focus' doesn't match focused elements in iframe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/workers/nested_worker.worker.js.ini
+++ b/tests/wpt/metadata/workers/nested_worker.worker.js.ini
@@ -3,4 +3,6 @@
   expected: TIMEOUT
   [Nested worker]
     expected: FAIL
+  [Checking contents for text file]
+    expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5850,6 +5850,12 @@
             "url": "/_mozilla/mozilla/htmlspacechars.html"
           }
         ],
+        "mozilla/iframe-unblock-onload.html": [
+          {
+            "path": "mozilla/iframe-unblock-onload.html",
+            "url": "/_mozilla/mozilla/iframe-unblock-onload.html"
+          }
+        ],
         "mozilla/iframe_contentDocument.html": [
           {
             "path": "mozilla/iframe_contentDocument.html",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5916,6 +5916,12 @@
             "url": "/_mozilla/mozilla/mozbrowser/iframe_goback.html"
           }
         ],
+        "mozilla/mozbrowser/iframe_reload_twice.html": [
+          {
+            "path": "mozilla/mozbrowser/iframe_reload_twice.html",
+            "url": "/_mozilla/mozilla/mozbrowser/iframe_reload_twice.html"
+          }
+        ],
         "mozilla/mozbrowser/mozbrowsericonchange_event.html": [
           {
             "path": "mozilla/mozbrowser/mozbrowsericonchange_event.html",

--- a/tests/wpt/mozilla/tests/mozilla/iframe-unblock-onload.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe-unblock-onload.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<iframe src="resources/iframe_contentDocument_inner.html?pipe=trickle(d20)"></iframe>
+<script>
+  async_test(function(t) {
+    window.addEventListener('load', t.step_func(function() {
+      t.done();
+    }, false));
+
+    document.querySelector('iframe').remove();
+  }, "Document load is unblocked by iframe removal");
+</script>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_reload_twice.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_reload_twice.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Reloading an iframe twice doesn't panic</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe></iframe>
+<script>
+async_test(function(t) {
+  var iframe = document.querySelector('iframe');
+  var loaded = false;
+  iframe.onload = t.step_func(function() {
+    if (!loaded) {
+      loaded = true;
+      iframe.reload();
+      iframe.reload();
+    } else {
+      t.done();
+    }
+  });
+  iframe.mozbrowser = true;
+  iframe.src = "about:blank";
+});
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/history/the-location-interface/location_reload.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/the-location-interface/location_reload.html
@@ -21,6 +21,7 @@
           assert_equals(url, innerURL, "iframe url (" + pingCount + ")");
           pingCount++;
           if (pingCount == 5) {
+            iframe.src = 'about:blank';
             t.done();
           }
       });

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-base-element/base_multiple.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-base-element/base_multiple.html
@@ -5,33 +5,23 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-base-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<body onload="on_load()">
+<body>
   <div id="log"></div>
   <iframe id="test1" src="example.html" style="width:0;height:0" frameborder="0"></iframe>
   <iframe id="test2" src="example.html" name="targetWin" style="width:0;height:0" frameborder="0"></iframe>
   <script>
-    var t = async_test("The attributes of the a element must be affected by the first base element"),
-        doc1,
-        fr2,
-        a1;
-
-    function on_load() {
-      setup(function (){
-        doc1 = document.getElementById("test1").contentDocument;
-        fr2 = document.getElementById("test2");
-        a1 = doc1.getElementById("a1");
-      });
-
-      fr2.addEventListener("load", function () {
-        t.step(function () {
+    async_test(function() {
+      window.onload = this.step_func(function() {
+        var fr2 = document.getElementById("test2");
+        fr2.addEventListener("load", this.step_func_done(function () {
           var doc2 = fr2.contentDocument;
           assert_not_equals(doc2.location.href.indexOf("example2.html"), -1, "The target attribute does not impact the a element.");
           assert_equals(doc2.getElementById("d1").innerHTML, "PASS", "The opend page should be the example2.html.");
-        });
-        t.done();
-      }, true);
+        }), true);
 
-      a1.click();
-    }
+        var doc1 = document.getElementById("test1").contentDocument;
+        doc1.getElementById("a1").click();
+      });
+    }, "The attributes of the a element must be affected by the first base element");
   </script>
 </body>

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-base-element/base_multiple.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-base-element/base_multiple.html
@@ -12,6 +12,9 @@
   <script>
     async_test(function() {
       window.onload = this.step_func(function() {
+        var fr1 = document.getElementById("test1");
+        fr1.addEventListener("load", this.unreached_func("loaded in the wrong iframe"));
+
         var fr2 = document.getElementById("test2");
         fr2.addEventListener("load", this.step_func_done(function () {
           var doc2 = fr2.contentDocument;
@@ -19,8 +22,7 @@
           assert_equals(doc2.getElementById("d1").innerHTML, "PASS", "The opend page should be the example2.html.");
         }), true);
 
-        var doc1 = document.getElementById("test1").contentDocument;
-        doc1.getElementById("a1").click();
+        fr1.contentDocument.getElementById("a1").click();
       });
     }, "The attributes of the a element must be affected by the first base element");
   </script>


### PR DESCRIPTION
It occurs to me as I write this that this doesn't handle the case of removing the iframe from the document before it's finished loading. Consider this an early feedback release!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6677)

<!-- Reviewable:end -->
