### PR TITLE
Make the global options more resilient to unit tests running in paral…

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
  "gl_generator 0.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -944,7 +944,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1235,7 +1235,7 @@ name = "shared_library"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1283,7 +1283,7 @@ name = "string_cache"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1297,7 +1297,7 @@ name = "string_cache_plugin"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1316,7 +1316,7 @@ dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1428,6 +1428,7 @@ dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/util/Cargo.toml
+++ b/components/util/Cargo.toml
@@ -35,4 +35,4 @@ url = "0.2.36"
 euclid = "0.1"
 serde = "0.4"
 serde_macros = "0.4"
-
+lazy_static = "0.1"

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -4,6 +4,7 @@
 
 #![feature(alloc)]
 #![feature(box_syntax)]
+#![feature(box_raw)]
 #![feature(core_intrinsics)]
 #![feature(custom_derive)]
 #![feature(fnbox)]
@@ -22,6 +23,7 @@
 #![plugin(serde_macros)]
 
 #[macro_use] extern crate log;
+#[macro_use] extern crate lazy_static;
 
 extern crate azure;
 extern crate alloc;

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
  "gl_generator 0.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -924,7 +924,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1233,7 +1233,7 @@ name = "shared_library"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1281,7 +1281,7 @@ name = "string_cache"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1295,7 +1295,7 @@ name = "string_cache_plugin"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1314,7 +1314,7 @@ dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1412,6 +1412,7 @@ dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/core.rs
+++ b/ports/cef/core.rs
@@ -76,7 +76,7 @@ pub extern "C" fn cef_initialize(args: *const cef_main_args_t,
     temp_opts.enable_canvas_antialiasing = true;
     temp_opts.resources_path = None;
     temp_opts.url = None;
-    opts::set(temp_opts);
+    opts::set_defaults(temp_opts);
 
     if unsafe { (*settings).windowless_rendering_enabled != 0 } {
         init_window();

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -841,7 +841,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1179,7 +1179,7 @@ name = "string_cache"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_macros 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,7 +1193,7 @@ name = "string_cache_plugin"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1212,7 +1212,7 @@ dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,6 +1301,7 @@ dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
…lel.

This should allow #6490 to land, since it's hitting problems with unit tests that create a resource task and therefore race on calling opts::get().

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6681)

<!-- Reviewable:end -->
