### PR TITLE
Implement some methods on LayoutJS<Element>.

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -383,11 +383,9 @@ pub struct LayoutElement<'le> {
 
 impl<'le> LayoutElement<'le> {
     pub fn style_attribute(&self) -> &'le Option<PropertyDeclarationBlock> {
-        use script::dom::element::ElementHelpers;
-        let style: &Option<PropertyDeclarationBlock> = unsafe {
-            &*(*self.element.unsafe_get()).style_attribute().borrow_for_layout()
-        };
-        style
+        unsafe {
+            &*self.element.style_attribute()
+        }
     }
 }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -412,8 +412,8 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
 
     fn is_link(&self) -> bool {
         // FIXME: This is HTML only.
-        let node = NodeCast::from_layout_js(&self.element);
-        match unsafe { (*node.unsafe_get()).type_id_for_layout() } {
+        let node = self.as_node();
+        match node.type_id() {
             // https://html.spec.whatwg.org/multipage/#selector-link
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLAnchorElement)) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLAreaElement)) |

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -402,17 +402,12 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
 
     #[inline]
     fn get_local_name<'a>(&'a self) -> &'a Atom {
-        unsafe {
-            (*self.element.unsafe_get()).local_name()
-        }
+        self.element.local_name()
     }
 
     #[inline]
     fn get_namespace<'a>(&'a self) -> &'a Namespace {
-        use script::dom::element::ElementHelpers;
-        unsafe {
-            (*self.element.unsafe_get()).namespace()
-        }
+        self.element.namespace()
     }
 
     fn is_link(&self) -> bool {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -511,6 +511,7 @@ pub trait LayoutElementHelpers {
     unsafe fn html_element_in_html_document_for_layout(&self) -> bool;
     #[allow(unsafe_code)]
     unsafe fn has_attr_for_layout(&self, namespace: &Namespace, name: &Atom) -> bool;
+    fn style_attribute(&self) -> *const Option<PropertyDeclarationBlock>;
 }
 
 impl LayoutElementHelpers for LayoutJS<Element> {
@@ -527,6 +528,13 @@ impl LayoutElementHelpers for LayoutJS<Element> {
     #[allow(unsafe_code)]
     unsafe fn has_attr_for_layout(&self, namespace: &Namespace, name: &Atom) -> bool {
         get_attr_for_layout(&*self.unsafe_get(), namespace, name).is_some()
+    }
+
+    #[allow(unsafe_code)]
+    fn style_attribute(&self) -> *const Option<PropertyDeclarationBlock> {
+        unsafe {
+            (*self.unsafe_get()).style_attribute.borrow_for_layout()
+        }
     }
 }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -181,8 +181,6 @@ pub trait RawLayoutElementHelpers {
     unsafe fn get_indeterminate_state_for_layout(&self) -> bool;
     unsafe fn get_unsigned_integer_attribute_for_layout(&self, attribute: UnsignedIntegerAttribute)
                                                         -> Option<u32>;
-
-    fn local_name<'a>(&'a self) -> &'a Atom;
 }
 
 #[inline]
@@ -498,12 +496,6 @@ impl RawLayoutElementHelpers for Element {
             }
         }
     }
-
-    // Getters used in components/layout/wrapper.rs
-
-    fn local_name<'a>(&'a self) -> &'a Atom {
-        &self.local_name
-    }
 }
 
 pub trait LayoutElementHelpers {
@@ -512,6 +504,8 @@ pub trait LayoutElementHelpers {
     #[allow(unsafe_code)]
     unsafe fn has_attr_for_layout(&self, namespace: &Namespace, name: &Atom) -> bool;
     fn style_attribute(&self) -> *const Option<PropertyDeclarationBlock>;
+    fn local_name<'a>(&'a self) -> &'a Atom;
+    fn namespace<'a>(&'a self) -> &'a Namespace;
 }
 
 impl LayoutElementHelpers for LayoutJS<Element> {
@@ -534,6 +528,20 @@ impl LayoutElementHelpers for LayoutJS<Element> {
     fn style_attribute(&self) -> *const Option<PropertyDeclarationBlock> {
         unsafe {
             (*self.unsafe_get()).style_attribute.borrow_for_layout()
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn local_name<'a>(&'a self) -> &'a Atom {
+        unsafe {
+            &(*self.unsafe_get()).local_name
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn namespace<'a>(&'a self) -> &'a Namespace {
+        unsafe {
+            &(*self.unsafe_get()).namespace
         }
     }
 }


### PR DESCRIPTION
Part of my long-term plan to stop exposing `unsafe_get()` outside the script crate.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6698)

<!-- Reviewable:end -->
