### PR TITLE
Cache the `id` attribute on Element

### DIFF
--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -40,9 +40,9 @@ macro_rules! sizeof_checker (
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 48);
 sizeof_checker!(size_node, Node, 184);
-sizeof_checker!(size_element, Element, 296);
-sizeof_checker!(size_htmlelement, HTMLElement, 312);
-sizeof_checker!(size_div, HTMLDivElement, 312);
-sizeof_checker!(size_span, HTMLSpanElement, 312);
+sizeof_checker!(size_element, Element, 320);
+sizeof_checker!(size_htmlelement, HTMLElement, 336);
+sizeof_checker!(size_div, HTMLDivElement, 336);
+sizeof_checker!(size_span, HTMLSpanElement, 336);
 sizeof_checker!(size_text, Text, 216);
 sizeof_checker!(size_characterdata, CharacterData, 216);


### PR DESCRIPTION
First stab at contributing to servo. Tried to fix #6359

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6717)

<!-- Reviewable:end -->
