### PR TITLE
servo: Upgrade `ipc-channel`, and make the timeout value in WPT match that of Firefox in debug mode.

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -638,8 +638,10 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#1043d943a4da75ba302cfbe0b55afe1c84887560"
+source = "git+https://github.com/pcwalton/ipc-channel#dc8d3742cddc1daafd177047f7f0f2ab0ac13d16"
 dependencies = [
+ "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -630,8 +630,10 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#1043d943a4da75ba302cfbe0b55afe1c84887560"
+source = "git+https://github.com/pcwalton/ipc-channel#dc8d3742cddc1daafd177047f7f0f2ab0ac13d16"
 dependencies = [
+ "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -564,8 +564,10 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#1043d943a4da75ba302cfbe0b55afe1c84887560"
+source = "git+https://github.com/pcwalton/ipc-channel#dc8d3742cddc1daafd177047f7f0f2ab0ac13d16"
 dependencies = [
+ "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/wpt/harness/wptrunner/browsers/servo.py
+++ b/tests/wpt/harness/wptrunner/browsers/servo.py
@@ -34,6 +34,10 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     rv = base_executor_kwargs(test_type, server_config,
                               cache_manager, **kwargs)
     rv["pause_after_test"] = kwargs["pause_after_test"]
+    # Currently we always run Servo in debug mode. Like Firefox and B2G, we increase the timeout
+    # threefold in order to compensate for that.
+    if kwargs["timeout_multiplier"] is None:
+        rv["timeout_multiplier"] = 3
     return rv
 
 def env_options():

--- a/tests/wpt/metadata/dom/ranges/Range-mutations.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-mutations.html.ini
@@ -1,5 +1,6 @@
 [Range-mutations.html]
   type: testharness
+  expected: TIMEOUT
   [paras[0\].firstChild.splitText(376), with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 


### PR DESCRIPTION
One WPT test is still too slow. No reasonable timeout value made it fast
enough. Therefore, I have marked the test as a timeout. Optimizing during WPT
running or landing rust-lang/cargo#1826 would fix this as well, I suspect.

r? @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6719)

<!-- Reviewable:end -->
