### PR TITLE
Disable a test that intermittently crashes in release builds. Update …

### DIFF
--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/relevant-mutations.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/relevant-mutations.html.ini
@@ -1,6 +1,7 @@
 [relevant-mutations.html]
   type: testharness
   expected: TIMEOUT
+  disabled: unstable failures and timeouts in release builds
   [src removed]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/webstorage/storage_local_setitem_quotaexceedederr.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_setitem_quotaexceedederr.html.ini
@@ -1,3 +1,4 @@
 [storage_local_setitem_quotaexceedederr.html]
   type: testharness
+  disabled: intermittently crashes instead of times out in release
   expected: TIMEOUT


### PR DESCRIPTION
…expectations for relevant-mutations.html to account for differences in release builds.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6736)

<!-- Reviewable:end -->
