### PR TITLE
Remove outdated comment about cloning elements

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1858,10 +1858,9 @@ impl Node {
                 copy_doc.set_quirks_mode(node_doc.quirks_mode());
             },
             NodeTypeId::Element(..) => {
-                let node_elem: &Element = ElementCast::to_ref(node).unwrap();
-                let copy_elem: &Element = ElementCast::to_ref(copy.r()).unwrap();
+                let node_elem = ElementCast::to_ref(node).unwrap();
+                let copy_elem = ElementCast::to_ref(copy.r()).unwrap();
 
-                // FIXME: https://github.com/mozilla/servo/issues/1737
                 let window = document.r().window();
                 for ref attr in node_elem.attrs().iter() {
                     let attr = attr.root();


### PR DESCRIPTION
The comment points to the "implement element prefix" issue, but we clone the element's prefix when we construct the element right above.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6760)

<!-- Reviewable:end -->
