### PR TITLE
Add a high-level API for JS typed arrays

### DIFF
--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -123,7 +123,7 @@ pub enum CanvasWebGLMsg {
     BlendFunc(u32, u32),
     BlendFuncSeparate(u32, u32, u32, u32),
     AttachShader(u32, u32),
-    BufferData(u32, Vec<f32>, u32), //TODO: add variants for all possible buffer types
+    BufferData(u32, Vec<f32>, u32), //TODO: allow non-f32 values (#6791)
     Clear(u32),
     ClearColor(f32, f32, f32, f32),
     CompileShader(u32),

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -123,7 +123,7 @@ pub enum CanvasWebGLMsg {
     BlendFunc(u32, u32),
     BlendFuncSeparate(u32, u32, u32, u32),
     AttachShader(u32, u32),
-    BufferData(u32, Vec<f32>, u32),
+    BufferData(u32, Vec<f32>, u32), //TODO: add variants for all possible buffer types
     Clear(u32),
     ClearColor(f32, f32, f32, f32),
     CompileShader(u32),

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -148,6 +148,7 @@ pub mod num;
 pub mod str;
 pub mod structuredclone;
 pub mod trace;
+pub mod typedarray;
 
 /// Generated JS-Rust bindings.
 #[allow(missing_docs, non_snake_case)]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -391,7 +391,8 @@ impl RootedTraceableSet {
         }
     }
 
-    fn remove<T: JSTraceable>(traceable: &T) {
+    /// Remove a previously-registered JSTraceable pointer from the set.
+    pub fn remove<T: JSTraceable>(traceable: &T) {
         ROOTED_TRACEABLES.with(|ref traceables| {
             let mut traceables = traceables.borrow_mut();
             let idx =
@@ -404,7 +405,8 @@ impl RootedTraceableSet {
         });
     }
 
-    fn add<T: JSTraceable>(traceable: &T) {
+    /// Remove a JSTraceable pointer to the set of known traceable objects.
+    pub fn add<T: JSTraceable>(traceable: &T) {
         ROOTED_TRACEABLES.with(|ref traceables| {
             fn trace<T: JSTraceable>(obj: *const libc::c_void, tracer: *mut JSTracer) {
                 let obj: &T = unsafe { &*(obj as *const T) };

--- a/components/script/dom/bindings/typedarray.rs
+++ b/components/script/dom/bindings/typedarray.rs
@@ -1,0 +1,401 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! High-level, safe bindings for JS typed array APIs. Allows creating new
+//! typed arrays or wrapping existing JS reflectors, and prevents reinterpreting
+//! existing buffers as different types except in well-defined cases.
+
+use js::jsapi::{JS_NewUint8Array, JS_NewUint16Array, JS_NewUint32Array, JS_NewInt8Array};
+use js::jsapi::{JS_NewInt16Array, JS_NewInt32Array, JS_NewFloat32Array, JS_NewFloat64Array};
+use js::jsapi::{JS_NewUint8ClampedArray, JS_GetUint8ArrayData, JS_GetUint16ArrayData};
+use js::jsapi::{JS_GetUint32ArrayData, JS_GetInt8ArrayData, JS_GetInt16ArrayData, JSObject};
+use js::jsapi::{JS_GetInt32ArrayData, JS_GetUint8ClampedArrayData, JS_GetFloat32ArrayData};
+use js::jsapi::{JS_GetFloat64ArrayData, JSContext, Type};
+use js::jsapi::{UnwrapInt8Array, UnwrapInt16Array, UnwrapInt32Array, UnwrapUint8ClampedArray};
+use js::jsapi::{UnwrapUint8Array, UnwrapUint16Array, UnwrapUint32Array, UnwrapArrayBufferView};
+use js::jsapi::{UnwrapFloat32Array, UnwrapFloat64Array, GetUint8ArrayLengthAndData};
+use js::jsapi::{JS_NewArrayBuffer, JS_GetArrayBufferData, JS_GetArrayBufferViewType};
+use js::jsapi::{UnwrapArrayBuffer, GetArrayBufferLengthAndData, GetArrayBufferViewLengthAndData};
+use js::glue::{GetUint8ClampedArrayLengthAndData, GetFloat32ArrayLengthAndData};
+use js::glue::{GetUint16ArrayLengthAndData, GetUint32ArrayLengthAndData};
+use js::glue::{GetInt8ArrayLengthAndData, GetFloat64ArrayLengthAndData};
+use js::glue::{GetInt16ArrayLengthAndData, GetInt32ArrayLengthAndData};
+
+use core::nonzero::NonZero;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::slice;
+use std::ptr;
+
+struct TypedArrayObjectStorage {
+    typed_obj: *mut JSObject,
+    wrapped_obj: *mut JSObject,
+}
+
+impl TypedArrayObjectStorage {
+    fn new() -> TypedArrayObjectStorage {
+        TypedArrayObjectStorage {
+            typed_obj: ptr::null_mut(),
+            wrapped_obj: ptr::null_mut(),
+        }
+    }
+}
+
+/// Internal trait used to associate an element type with an underlying representation
+/// and various functions required to manipulate typed arrays of that element type.
+pub trait TypedArrayElement {
+    /// Underlying primitive representation of this element type.
+    type FundamentalType;
+    /// Unwrap a typed array JS reflector for this element type.
+    fn unwrap_array(obj: *mut JSObject) -> *mut JSObject;
+    /// Retrieve the length and data of a typed array's buffer for this element type.
+    fn length_and_data(obj: *mut JSObject) -> (u32, *mut Self::FundamentalType);
+}
+
+macro_rules! typed_array_element {
+    ($t: ty, $fundamental: ty, $unwrap: ident, $length_and_data: ident) => (
+        impl TypedArrayElement for $t {
+            type FundamentalType = $fundamental;
+            fn unwrap_array(obj: *mut JSObject) -> *mut JSObject {
+                unsafe {
+                    $unwrap(obj)
+                }
+            }
+
+            fn length_and_data(obj: *mut JSObject) -> (u32, *mut Self::FundamentalType) {
+                unsafe {
+                    let mut len = 0;
+                    let mut data = ptr::null_mut();
+                    $length_and_data(obj, &mut len, &mut data);
+                    (len, data)
+                }
+            }
+        }
+    );
+    ($t: ty, $unwrap: ident, $length_and_data: ident) => {
+        typed_array_element!($t, $t, $unwrap, $length_and_data);
+    };
+}
+
+#[derive(Clone, Copy)]
+/// Wrapped for u8 to allow different utility methods for Uint8ClampedArray objects.
+pub struct ClampedU8(pub u8);
+
+#[derive(Clone, Copy)]
+/// Wrapped for u8 to allow different utility methods for ArrayBuffer objects.
+pub struct ArrayBufferU8(pub u8);
+
+#[derive(Clone, Copy)]
+/// Wrapped for u8 to allow different utility methods for ArrayBufferView objects.
+pub struct ArrayBufferViewU8(pub u8);
+
+typed_array_element!(u8, UnwrapUint8Array, GetUint8ArrayLengthAndData);
+typed_array_element!(u16, UnwrapUint16Array, GetUint16ArrayLengthAndData);
+typed_array_element!(u32, UnwrapUint32Array, GetUint32ArrayLengthAndData);
+typed_array_element!(i8, UnwrapInt8Array, GetInt8ArrayLengthAndData);
+typed_array_element!(i16, UnwrapInt16Array, GetInt16ArrayLengthAndData);
+typed_array_element!(i32, UnwrapInt32Array, GetInt32ArrayLengthAndData);
+typed_array_element!(f32, UnwrapFloat32Array, GetFloat32ArrayLengthAndData);
+typed_array_element!(f64, UnwrapFloat64Array, GetFloat64ArrayLengthAndData);
+typed_array_element!(ClampedU8, u8, UnwrapUint8ClampedArray, GetUint8ClampedArrayLengthAndData);
+typed_array_element!(ArrayBufferU8, u8, UnwrapArrayBuffer, GetArrayBufferLengthAndData);
+typed_array_element!(ArrayBufferViewU8, u8, UnwrapArrayBufferView, GetArrayBufferViewLengthAndData);
+
+/// The base representation for all typed arrays.
+pub struct TypedArrayBase<T: TypedArrayElement> {
+    /// The JS wrapper storage.
+    storage: TypedArrayObjectStorage,
+    /// The underlying memory buffer.
+    data: *mut T::FundamentalType,
+    /// The number of elements that make up the buffer.
+    length: u32,
+    /// True if the length and data of this typed array have been computed.
+    /// Any attempt to interact with the underlying buffer must compute it first,
+    /// to minimize the window of potential GC hazards.
+    computed: bool,
+}
+
+impl<T: TypedArrayElement> TypedArrayBase<T> {
+    /// Create an uninitialized typed array representation.
+    pub fn new() -> TypedArrayBase<T> {
+        TypedArrayBase {
+            storage: TypedArrayObjectStorage::new(),
+            data: ptr::null_mut(),
+            length: 0,
+            computed: false,
+        }
+    }
+
+    fn inited(&self) -> bool {
+        !self.storage.typed_obj.is_null()
+    }
+
+    /// Initialize this typed array representaiton from an existing JS reflector
+    /// for a typed array. This operation will fail if attempted on a JS object
+    /// that does not match the expected typed array details.
+    pub fn init(&mut self, obj: *mut JSObject) -> Result<(), ()> {
+        assert!(!self.inited());
+        self.storage.typed_obj = T::unwrap_array(obj);
+        self.storage.wrapped_obj = self.storage.typed_obj;
+        if self.inited() {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// Return the underlying buffer as a slice of the element type.
+    /// Length and data must be computed first.
+    pub fn as_slice(&self) -> &[T::FundamentalType] {
+        assert!(self.computed);
+        unsafe {
+            slice::from_raw_parts(self.data, self.length as usize)
+        }
+    }
+
+    /// Return the underlying buffer as a mutable slice of the element type.
+    /// Length and data must be computed first.
+    pub fn as_mut_slice(&mut self) -> &mut [T::FundamentalType] {
+        assert!(self.computed);
+        unsafe {
+            slice::from_raw_parts_mut(self.data, self.length as usize)
+        }
+    }
+
+    /// Compute the length and data of this typed array.
+    /// This operation that must only be performed once, as soon as
+    /// possible before making use of the resulting buffer.
+    pub fn compute_length_and_data(&mut self) {
+        assert!(self.inited());
+        assert!(!self.computed);
+        let (length, data) = T::length_and_data(self.storage.typed_obj);
+        self.length = length;
+        self.data = data;
+        self.computed = true;
+    }
+}
+
+impl TypedArrayBase<ArrayBufferViewU8> {
+    unsafe fn as_slice_transmute<T>(&self) -> &[T] {
+        assert!(self.computed);
+        slice::from_raw_parts(self.data as *mut T, self.length as usize / mem::size_of::<T>())
+    }
+}
+
+trait TypedArrayElementCreator: TypedArrayElement {
+    fn create_new(cx: *mut JSContext, length: u32) -> *mut JSObject;
+    fn get_data(obj: *mut JSObject) -> *mut Self::FundamentalType;
+}
+
+macro_rules! typed_array_element_creator {
+    ($t: ty, $create_new: ident, $get_data: ident) => (
+        impl TypedArrayElementCreator for $t {
+            fn create_new(cx: *mut JSContext, length: u32) -> *mut JSObject {
+                unsafe {
+                    $create_new(cx, length)
+                }
+            }
+
+            fn get_data(obj: *mut JSObject) -> *mut Self::FundamentalType {
+                unsafe {
+                    $get_data(obj, ptr::null_mut())
+                }
+            }
+        }
+    )
+}
+
+typed_array_element_creator!(u8, JS_NewUint8Array, JS_GetUint8ArrayData);
+typed_array_element_creator!(u16, JS_NewUint16Array, JS_GetUint16ArrayData);
+typed_array_element_creator!(u32, JS_NewUint32Array, JS_GetUint32ArrayData);
+typed_array_element_creator!(i8, JS_NewInt8Array, JS_GetInt8ArrayData);
+typed_array_element_creator!(i16, JS_NewInt16Array, JS_GetInt16ArrayData);
+typed_array_element_creator!(i32, JS_NewInt32Array, JS_GetInt32ArrayData);
+typed_array_element_creator!(f32, JS_NewFloat32Array, JS_GetFloat32ArrayData);
+typed_array_element_creator!(f64, JS_NewFloat64Array, JS_GetFloat64ArrayData);
+typed_array_element_creator!(ClampedU8, JS_NewUint8ClampedArray, JS_GetUint8ClampedArrayData);
+typed_array_element_creator!(ArrayBufferU8, JS_NewArrayBuffer, JS_GetArrayBufferData);
+
+/// A wrapper that can be used to create a new typed array from scratch, or
+/// initialized from an existing JS reflector as necessary.
+pub struct TypedArray<T: TypedArrayElement> {
+    base: TypedArrayBase<T>,
+}
+
+impl<T: TypedArrayElement> Deref for TypedArray<T> {
+    type Target = TypedArrayBase<T>;
+    fn deref<'a>(&'a self) -> &'a TypedArrayBase<T> {
+        &self.base
+    }
+}
+
+impl<T: TypedArrayElement> DerefMut for TypedArray<T> {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut TypedArrayBase<T> {
+        &mut self.base
+    }
+}
+
+impl<T: TypedArrayElementCreator + TypedArrayElement> TypedArray<T> {
+    /// Create an uninitialized wrapper around a future typed array.
+    pub fn new() -> TypedArray<T> {
+        TypedArray {
+            base: TypedArrayBase::new(),
+        }
+    }
+
+    /// Create a new JS typed array, optionally providing initial data that will
+    /// be copied into the newly-allocated buffer. Returns the new JS reflector.
+    pub fn create(cx: *mut JSContext, length: u32, data: Option<&[T::FundamentalType]>)
+                  -> Option<NonZero<*mut JSObject>> {
+        let obj = T::create_new(cx, length);
+        if obj.is_null() {
+            return None;
+        }
+
+        if let Some(data) = data {
+            assert!(data.len() <= length as usize);
+            let buf = T::get_data(obj);
+            unsafe {
+                ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
+            }
+        }
+
+        unsafe {
+            Some(NonZero::new(obj))
+        }
+    }
+}
+
+/// A wrapper around a JS ArrayBufferView object.
+pub struct ArrayBufferViewBase<T: TypedArrayElement> {
+    typed_array: TypedArrayBase<T>,
+    type_: Option<Type>,
+}
+
+trait ArrayBufferViewType {
+    fn get_view_type(obj: *mut JSObject) -> Type;
+}
+
+macro_rules! array_buffer_view_type {
+    ($t: ty, $get_view_type: ident) => (
+        impl ArrayBufferViewType for $t {
+            fn get_view_type(obj: *mut JSObject) -> Type {
+                unsafe {
+                    $get_view_type(obj)
+                }
+            }
+        }
+    )
+}
+
+array_buffer_view_type!(ArrayBufferViewU8, JS_GetArrayBufferViewType);
+
+/// Internal trait used to perform compile-time reflection of specific
+/// typed array element types.
+pub trait ArrayBufferViewOutput {
+    /// Fetch the compile-type type representation for this type.
+    fn get_view_type() -> Type;
+}
+
+macro_rules! array_buffer_view_output {
+    ($t: ty, $scalar: ident) => (
+        impl ArrayBufferViewOutput for $t {
+            fn get_view_type() -> Type { Type::$scalar }
+        }
+    )
+}
+
+array_buffer_view_output!(u8, Uint8);
+array_buffer_view_output!(i8, Int8);
+array_buffer_view_output!(u16, Uint16);
+array_buffer_view_output!(i16, Int16);
+array_buffer_view_output!(u32, Uint32);
+array_buffer_view_output!(i32, Int32);
+array_buffer_view_output!(f32, Float32);
+array_buffer_view_output!(f64, Float64);
+array_buffer_view_output!(ClampedU8, Uint8Clamped);
+
+impl<T: TypedArrayElement + ArrayBufferViewType> ArrayBufferViewBase<T> {
+    /// Create an uninitilized ArrayBufferView wrapper.
+    pub fn new() -> ArrayBufferViewBase<T> {
+        ArrayBufferViewBase {
+            typed_array: TypedArrayBase::new(),
+            type_: None,
+        }
+    }
+
+    /// Initialize this wrapper with a JS ArrayBufferView reflector. Fails
+    /// if the JS reflector is not an ArrayBufferView, or if it is not
+    /// one of the primitive numeric types (ie. SharedArrayBufferView, SIMD, etc.).
+    pub fn init(&mut self, obj: *mut JSObject) -> Result<(), ()> {
+        try!(self.typed_array.init(obj));
+        let scalar_type = T::get_view_type(obj);
+        if (scalar_type as u32) < Type::MaxTypedArrayViewType as u32 {
+            self.type_ = Some(scalar_type);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// Compute the length and data of this typed array.
+    /// This operation that must only be performed once, as soon as
+    /// possible before making use of the resulting buffer.
+    pub fn compute_length_and_data(&mut self) {
+        self.typed_array.compute_length_and_data();
+    }
+
+    /// Return the element type of the wrapped ArrayBufferView.
+    pub fn element_type(&self) -> Type {
+        assert!(self.type_.is_some());
+        self.type_.unwrap()
+    }
+
+    /// Return a slice of the bytes of the underlying buffer.
+    /// Length and data must be computed first.
+    pub fn as_untyped_slice(&self) -> &[u8] {
+        unsafe { &*(self.typed_array.as_slice() as *const [T::FundamentalType] as *const [u8]) }
+    }
+
+    /// Return a mutable slice of the bytes of the underlying buffer.
+    /// Length and data must be computed first.
+    pub fn as_mut_untyped_slice(&mut self) -> &mut [u8] {
+        unsafe { &mut *(self.typed_array.as_mut_slice() as *mut [T::FundamentalType] as *mut [u8]) }
+    }
+}
+
+impl ArrayBufferViewBase<ArrayBufferViewU8> {
+    /// Return a slice of the underlying buffer reinterpreted as a different element type.
+    /// Length and data must be computed first.
+    pub fn as_slice<U: ArrayBufferViewOutput>(&mut self) -> Result<&[U], ()> {
+        assert!(self.type_.is_some());
+        if U::get_view_type() as u32 == self.type_.unwrap() as u32 {
+            unsafe {
+                Ok(self.typed_array.as_slice_transmute())
+            }
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[allow(missing_docs)]
+mod typedefs {
+    use super::{TypedArray, ArrayBufferViewBase, ClampedU8, ArrayBufferViewU8, ArrayBufferU8};
+    pub type Uint8ClampedArray = TypedArray<ClampedU8>;
+    pub type Uint8Array = TypedArray<u8>;
+    pub type Int8Array = TypedArray<i8>;
+    pub type Uint16Array = TypedArray<u16>;
+    pub type Int16Array = TypedArray<i16>;
+    pub type Uint32Array = TypedArray<u32>;
+    pub type Int32Array = TypedArray<i32>;
+    pub type Float32Array = TypedArray<f32>;
+    pub type Float64Array = TypedArray<f64>;
+    pub type ArrayBufferView = ArrayBufferViewBase<ArrayBufferViewU8>;
+    pub type ArrayBuffer = TypedArray<ArrayBufferU8>;
+}
+
+pub use self::typedefs::{Uint8ClampedArray, Uint8Array, Uint16Array, Uint32Array};
+pub use self::typedefs::{Int8Array, Int16Array, Int32Array, Float64Array, Float32Array};
+pub use self::typedefs::{ArrayBuffer, ArrayBufferView};

--- a/components/script/dom/bindings/typedarray.rs
+++ b/components/script/dom/bindings/typedarray.rs
@@ -96,18 +96,49 @@ typed_array_element!(ClampedU8, u8, UnwrapUint8ClampedArray, GetUint8ClampedArra
 typed_array_element!(ArrayBufferU8, u8, UnwrapArrayBuffer, GetArrayBufferLengthAndData);
 typed_array_element!(ArrayBufferViewU8, u8, UnwrapArrayBufferView, GetArrayBufferViewLengthAndData);
 
+/// The underlying buffer representation for a typed array.
+pub struct TypedArrayBuffer<'a, T: TypedArrayElement> {
+    buffer: *mut T::FundamentalType,
+    elements: u32,
+    _typed_array: &'a TypedArrayObjectStorage,
+}
+
+impl<'owner, T: TypedArrayElement> TypedArrayBuffer<'owner, T> {
+    /// Return the underlying buffer as a slice of the element type.
+    pub fn as_slice(&self) -> &[T::FundamentalType] {
+        unsafe {
+            slice::from_raw_parts(self.buffer, self.elements as usize)
+        }
+    }
+
+    /// Return the underlying buffer as a mutable slice of the element type.
+    /// Creating multiple mutable slices of the same buffer simultaneously
+    /// will result in undefined behaviour.
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [T::FundamentalType] {
+        slice::from_raw_parts_mut(self.buffer, self.elements as usize)
+    }
+
+    fn data(&self) -> *mut T::FundamentalType {
+        self.buffer
+    }
+
+    fn length(&self) -> u32 {
+        self.elements
+    }
+}
+
+impl<'owner> TypedArrayBuffer<'owner, ArrayBufferViewU8> {
+    unsafe fn as_slice_transmute<T: TypedArrayElement>(&self) -> &[T] {
+        slice::from_raw_parts(self.buffer as *mut T, self.elements as usize / mem::size_of::<T>())
+    }
+}
+
 /// The base representation for all typed arrays.
 pub struct TypedArrayBase<'a, T: 'a + TypedArrayElement> {
     /// The JS wrapper storage.
     storage: TypedArrayObjectStorage,
-    /// The underlying memory buffer.
-    data: *mut T::FundamentalType,
-    /// The number of elements that make up the buffer.
-    length: u32,
-    /// True if the length and data of this typed array have been computed.
-    /// Any attempt to interact with the underlying buffer must compute it first,
-    /// to minimize the window of potential GC hazards.
-    computed: bool,
+    /// The underlying memory buffer and number of contained elements, if computed
+    computed: Option<(*mut T::FundamentalType, u32)>,
     rooter: &'a mut TypedArrayRooter,
 }
 
@@ -126,9 +157,7 @@ impl<'a, T: TypedArrayElement> TypedArrayBase<'a, T> {
             storage: TypedArrayObjectStorage {
                 typed_obj: obj,
             },
-            data: ptr::null_mut(),
-            length: 0,
-            computed: false,
+            computed: None,
             rooter: rooter,
         })
     }
@@ -143,45 +172,24 @@ impl<'a, T: TypedArrayElement> TypedArrayBase<'a, T> {
         self.rooter.init(&mut self.storage);
     }
 
-    /// Return the underlying buffer as a slice of the element type.
-    /// Length and data must be computed first.
-    pub fn as_slice(&self) -> &[T::FundamentalType] {
-        assert!(self.computed);
-        unsafe {
-            slice::from_raw_parts(self.data, self.length as usize)
+    /// Retrieve a usable buffer from this typed array.
+    pub fn extract(&mut self) -> TypedArrayBuffer<T> {
+        assert!(self.inited());
+        let (data, length) = match self.computed.as_ref() {
+            None => {
+                let (length, data) = T::length_and_data(self.storage.typed_obj);
+                self.computed = Some((data, length));
+                (data, length)
+            }
+            Some(&(data, length)) => (data, length)
+        };
+        TypedArrayBuffer {
+            buffer: data,
+            elements: length,
+            _typed_array: &self.storage
         }
     }
 
-    /// Return the underlying buffer as a mutable slice of the element type.
-    /// Length and data must be computed first.
-    /// Creating multiple mutable slices of the same buffer simultaneously
-    /// will result in undefined behaviour.
-    pub unsafe fn as_mut_slice(&mut self) -> &mut [T::FundamentalType] {
-        assert!(self.computed);
-        slice::from_raw_parts_mut(self.data, self.length as usize)
-    }
-
-    /// Compute the length and data of this typed array.
-    /// This operation that must only be performed once, as soon as
-    /// possible before making use of the resulting buffer.
-    pub fn compute_length_and_data(&mut self) {
-        assert!(self.inited());
-        assert!(!self.computed);
-        let (length, data) = T::length_and_data(self.storage.typed_obj);
-        self.length = length;
-        self.data = data;
-        self.computed = true;
-    }
-
-    fn data(&self) -> *mut T::FundamentalType {
-        assert!(self.computed);
-        self.data
-    }
-
-    fn length(&self) -> u32 {
-        assert!(self.computed);
-        self.length
-    }
 }
 
 impl<'a, T: TypedArrayElement> Drop for TypedArrayBase<'a, T> {
@@ -190,13 +198,6 @@ impl<'a, T: TypedArrayElement> Drop for TypedArrayBase<'a, T> {
         let storage = &mut self.storage as *mut _;
         let original = self.rooter.typed_array;
         assert_eq!(storage, original);
-    }
-}
-
-impl<'a> TypedArrayBase<'a, ArrayBufferViewU8> {
-    unsafe fn as_slice_transmute<T: TypedArrayElement>(&self) -> &[T] {
-        assert!(self.computed);
-        slice::from_raw_parts(self.data as *mut T, self.length as usize / mem::size_of::<T>())
     }
 }
 
@@ -335,6 +336,30 @@ array_buffer_view_output!(f32, Float32);
 array_buffer_view_output!(f64, Float64);
 array_buffer_view_output!(ClampedU8, Uint8Clamped);
 
+/// The underlying buffer representation for a typed array.
+pub struct ArrayBufferBuffer<'owner, T: TypedArrayElement> {
+    base: TypedArrayBuffer<'owner, T>,
+    type_: Type,
+}
+
+impl<'owner, T: TypedArrayElement> ArrayBufferBuffer<'owner, T> {
+    /// Return a slice of the bytes of the underlying buffer.
+    pub fn as_untyped_slice(&self) -> &[u8] {
+        unsafe {
+            let num_bytes = self.base.length() as usize * mem::size_of::<T::FundamentalType>();
+            slice::from_raw_parts(self.base.data() as *const _ as *const u8, num_bytes)
+        }
+    }
+
+    /// Return a mutable slice of the bytes of the underlying buffer.
+    /// Creating multiple mutable slices of the same buffer simultaneously
+    /// will result in undefined behaviour.
+    pub unsafe fn as_mut_untyped_slice(&mut self) -> &mut [u8] {
+        let num_bytes = self.base.length() as usize * mem::size_of::<T::FundamentalType>();
+        slice::from_raw_parts_mut(self.base.data() as *mut u8, num_bytes)
+    }
+}
+
 impl<'a, T: TypedArrayElement + ArrayBufferViewType> ArrayBufferViewBase<'a, T> {
     /// Create an ArrayBufferView wrapper for a JS reflector.
     /// Fails if the JS reflector is not an ArrayBufferView, or if it is not
@@ -359,45 +384,27 @@ impl<'a, T: TypedArrayElement + ArrayBufferViewType> ArrayBufferViewBase<'a, T> 
         self.typed_array.init();
     }
 
-    /// Compute the length and data of this typed array.
-    /// This operation that must only be performed once, as soon as
-    /// possible before making use of the resulting buffer.
-    pub fn compute_length_and_data(&mut self) {
-        self.typed_array.compute_length_and_data();
+    /// Retrieve a usable buffer from this typed array.
+    pub fn extract(&mut self) -> ArrayBufferBuffer<T> {
+        ArrayBufferBuffer {
+            base: self.typed_array.extract(),
+            type_: self.type_,
+        }
     }
 
     /// Return the element type of the wrapped ArrayBufferView.
     pub fn element_type(&self) -> Type {
         self.type_
     }
-
-    /// Return a slice of the bytes of the underlying buffer.
-    /// Length and data must be computed first.
-    pub fn as_untyped_slice(&self) -> &[u8] {
-        unsafe {
-            let num_bytes = self.typed_array.length() as usize * mem::size_of::<T::FundamentalType>();
-            slice::from_raw_parts(self.typed_array.data() as *const _ as *const u8, num_bytes)
-        }
-    }
-
-    /// Return a mutable slice of the bytes of the underlying buffer.
-    /// Length and data must be computed first.
-    /// Creating multiple mutable slices of the same buffer simultaneously
-    /// will result in undefined behaviour.
-    pub unsafe fn as_mut_untyped_slice(&mut self) -> &mut [u8] {
-        let num_bytes = self.typed_array.length() as usize * mem::size_of::<T::FundamentalType>();
-        slice::from_raw_parts_mut(self.typed_array.data() as *mut u8, num_bytes)
-    }
 }
 
-impl<'a> ArrayBufferViewBase<'a, ArrayBufferViewU8> {
+impl<'owner> ArrayBufferBuffer<'owner, ArrayBufferViewU8> {
     /// Return a slice of the underlying buffer reinterpreted as a different element type.
-    /// Length and data must be computed first.
-    pub fn as_slice<U>(&mut self) -> Result<&[U], ()>
-                                  where U: ArrayBufferViewOutput + TypedArrayElement {
+    pub fn as_slice<U>(&self) -> Result<&[U], ()>
+                              where U: ArrayBufferViewOutput + TypedArrayElement {
         if U::get_view_type() as u32 == self.type_ as u32 {
             unsafe {
-                Ok(self.typed_array.as_slice_transmute())
+                Ok(self.base.as_slice_transmute())
             }
         } else {
             Err(())
@@ -452,7 +459,7 @@ impl TypedArrayRooter {
 impl JSTraceable for TypedArrayRooter {
     fn trace(&self, trc: *mut JSTracer) {
         unsafe {
-            let storage = &mut (*self.typed_array);
+            let storage = &mut *self.typed_array;
             if !storage.typed_obj.is_null() {
                 JS_CallUnbarrieredObjectTracer(trc,
                                                &mut storage.typed_obj,

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -963,12 +963,12 @@ impl<'a> CanvasRenderingContext2DMethods for &'a CanvasRenderingContext2D {
             return Err(IndexSize)
         }
 
-        Ok(ImageData::new(self.global.root().r(), sw.abs().to_u32().unwrap(), sh.abs().to_u32().unwrap(), None))
+        ImageData::new(self.global.root().r(), sw.abs().to_u32().unwrap(), sh.abs().to_u32().unwrap(), None)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
     fn CreateImageData_(self, imagedata: &ImageData) -> Fallible<Root<ImageData>> {
-        Ok(ImageData::new(self.global.root().r(), imagedata.Width(), imagedata.Height(), None))
+        ImageData::new(self.global.root().r(), imagedata.Width(), imagedata.Height(), None)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata
@@ -995,7 +995,7 @@ impl<'a> CanvasRenderingContext2DMethods for &'a CanvasRenderingContext2D {
             .send(CanvasMsg::Canvas2d(Canvas2dMsg::GetImageData(dest_rect, canvas_size, sender)))
             .unwrap();
         let data = receiver.recv().unwrap();
-        Ok(ImageData::new(self.global.root().r(), sw.abs().to_u32().unwrap(), sh.abs().to_u32().unwrap(), Some(data)))
+        ImageData::new(self.global.root().r(), sw.abs().to_u32().unwrap(), sh.abs().to_u32().unwrap(), Some(&data))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -7,14 +7,11 @@ use dom::bindings::codegen::Bindings::CryptoBinding::CryptoMethods;
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
+use dom::bindings::typedarray::{ArrayBufferView};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::cell::DOMRefCell;
 
-use js::jsapi::{JSContext, JSObject};
-use js::jsapi::{JS_GetObjectAsArrayBufferView, JS_GetArrayBufferViewType, Type};
-
-use std::ptr;
-use std::slice;
+use js::jsapi::{JSContext, JSObject, Type};
 
 use rand::{Rng, OsRng};
 
@@ -41,35 +38,33 @@ impl Crypto {
 }
 
 impl<'a> CryptoMethods for &'a Crypto {
-    #[allow(unsafe_code)]
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#Crypto-method-getRandomValues
     fn GetRandomValues(self, _cx: *mut JSContext, input: *mut JSObject)
                        -> Fallible<*mut JSObject> {
-        let mut length = 0;
-        let mut data = ptr::null_mut();
-        if unsafe { JS_GetObjectAsArrayBufferView(input, &mut length, &mut data).is_null() } {
+        let mut array_buffer_view = ArrayBufferView::new();
+        if array_buffer_view.init(input).is_err() {
             return Err(Error::Type("Argument to Crypto.getRandomValues is not an ArrayBufferView".to_owned()));
         }
-        if !is_integer_buffer(input) {
+
+        if !is_integer_buffer(&array_buffer_view) {
             return Err(Error::TypeMismatch);
         }
-        if length > 65536 {
+
+        array_buffer_view.compute_length_and_data();
+        let mut buffer = array_buffer_view.as_mut_untyped_slice();
+
+        if buffer.len() > 65536 {
             return Err(Error::QuotaExceeded);
         }
 
-        let mut buffer = unsafe {
-            slice::from_raw_parts_mut(data, length as usize)
-        };
-
-        self.rng.borrow_mut().fill_bytes(&mut buffer);
+        self.rng.borrow_mut().fill_bytes(buffer);
 
         Ok(input)
     }
 }
 
-#[allow(unsafe_code)]
-fn is_integer_buffer(input: *mut JSObject) -> bool {
-    match unsafe { JS_GetArrayBufferViewType(input) } {
+fn is_integer_buffer(input: &ArrayBufferView) -> bool {
+    match input.element_type() {
         Type::Uint8 |
         Type::Uint8Clamped |
         Type::Int8 |

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::Bindings::CryptoBinding::CryptoMethods;
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
-use dom::bindings::typedarray::{ArrayBufferView};
+use dom::bindings::typedarray::{ArrayBufferView, TypedArrayRooter};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::cell::DOMRefCell;
 
@@ -41,7 +41,8 @@ impl<'a> CryptoMethods for &'a Crypto {
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#Crypto-method-getRandomValues
     fn GetRandomValues(self, _cx: *mut JSContext, input: *mut JSObject)
                        -> Fallible<*mut JSObject> {
-        let mut array_buffer_view = ArrayBufferView::new();
+        let mut rooter = TypedArrayRooter::new();
+        let mut array_buffer_view = ArrayBufferView::new(&mut rooter);
         if array_buffer_view.init(input).is_err() {
             return Err(Error::Type("Argument to Crypto.getRandomValues is not an ArrayBufferView".to_owned()));
         }

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -54,9 +54,9 @@ impl<'a> CryptoMethods for &'a Crypto {
             return Err(Error::TypeMismatch);
         }
 
-        array_buffer_view.compute_length_and_data();
+        let mut data = array_buffer_view.extract();
         let mut buffer = unsafe {
-            array_buffer_view.as_mut_untyped_slice()
+            data.as_mut_untyped_slice()
         };
 
         if buffer.len() > 65536 {

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -61,8 +61,8 @@ impl<'a> ImageDataHelpers for &'a ImageData {
             Err(_) => return vec![],
         };
         typed_array.init();
-        typed_array.compute_length_and_data();
-        typed_array.as_slice().to_vec()
+        let data = typed_array.extract();
+        data.as_slice().to_vec()
     }
 
     fn get_size(self) -> Size2D<i32> {

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -4,16 +4,14 @@
 
 use dom::bindings::codegen::Bindings::ImageDataBinding;
 use dom::bindings::codegen::Bindings::ImageDataBinding::ImageDataMethods;
+use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
+use dom::bindings::typedarray::Uint8ClampedArray;
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use euclid::size::Size2D;
 use js::jsapi::{JSContext, JSObject, Heap};
-use js::jsapi::{JS_NewUint8ClampedArray, JS_GetUint8ClampedArrayData};
-use libc::uint8_t;
 use std::vec::Vec;
-use std::slice;
-use std::ptr;
 use std::default::Default;
 
 #[dom_struct]
@@ -26,8 +24,8 @@ pub struct ImageData {
 }
 
 impl ImageData {
-    #[allow(unsafe_code)]
-    pub fn new(global: GlobalRef, width: u32, height: u32, data: Option<Vec<u8>>) -> Root<ImageData> {
+    pub fn new(global: GlobalRef, width: u32, height: u32, data: Option<&[u8]>)
+               -> Fallible<Root<ImageData>> {
         let mut imagedata = box ImageData {
             reflector_: Reflector::new(),
             width: width,
@@ -35,19 +33,12 @@ impl ImageData {
             data: Heap::default(),
         };
 
-        unsafe {
-            let cx = global.get_cx();
-            let js_object: *mut JSObject = JS_NewUint8ClampedArray(cx, width * height * 4);
-
-            if let Some(vec) = data {
-                let js_object_data: *mut uint8_t = JS_GetUint8ClampedArrayData(js_object, ptr::null());
-                ptr::copy_nonoverlapping(vec.as_ptr(), js_object_data, vec.len())
-            }
-            (*imagedata).data.set(js_object);
+        match Uint8ClampedArray::create(global.get_cx(), width * height * 4, data) {
+            Some(js_object) => imagedata.data.set(*js_object),
+            None => return Err(Error::JSFailed)
         }
 
-        reflect_dom_object(imagedata,
-                           global, ImageDataBinding::Wrap)
+        Ok(reflect_dom_object(imagedata, global, ImageDataBinding::Wrap))
     }
 }
 
@@ -57,14 +48,13 @@ pub trait ImageDataHelpers {
 }
 
 impl<'a> ImageDataHelpers for &'a ImageData {
-    #[allow(unsafe_code)]
-    fn get_data_array(self, global: &GlobalRef) -> Vec<u8> {
-        unsafe {
-            let cx = global.get_cx();
-            let data: *const uint8_t = JS_GetUint8ClampedArrayData(self.Data(cx), ptr::null()) as *const uint8_t;
-            let len = self.Width() * self.Height() * 4;
-            slice::from_raw_parts(data, len as usize).to_vec()
+    fn get_data_array(self, _global: &GlobalRef) -> Vec<u8> {
+        let mut typed_array = Uint8ClampedArray::new();
+        if typed_array.init(self.data.get()).is_err() {
+            return vec!();
         }
+        typed_array.compute_length_and_data();
+        typed_array.as_slice().to_vec()
     }
 
     fn get_size(self) -> Size2D<i32> {

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -7,7 +7,7 @@ use dom::bindings::codegen::Bindings::ImageDataBinding::ImageDataMethods;
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
-use dom::bindings::typedarray::Uint8ClampedArray;
+use dom::bindings::typedarray::{Uint8ClampedArray, TypedArrayRooter};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use euclid::size::Size2D;
 use js::jsapi::{JSContext, JSObject, Heap};
@@ -49,7 +49,8 @@ pub trait ImageDataHelpers {
 
 impl<'a> ImageDataHelpers for &'a ImageData {
     fn get_data_array(self, _global: &GlobalRef) -> Vec<u8> {
-        let mut typed_array = Uint8ClampedArray::new();
+        let mut rooter = TypedArrayRooter::new();
+        let mut typed_array = Uint8ClampedArray::new(&mut rooter);
         if typed_array.init(self.data.get()).is_err() {
             return vec!();
         }

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -9,7 +9,7 @@ use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
 use dom::bindings::str::USVString;
 use dom::bindings::trace::JSTraceable;
-use dom::bindings::typedarray::{ArrayBufferView, ArrayBuffer};
+use dom::bindings::typedarray::{ArrayBufferView, ArrayBuffer, TypedArrayRooter};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 
 use util::str::DOMString;
@@ -90,9 +90,11 @@ impl<'a> TextDecoderMethods for &'a TextDecoder {
             None => return Ok(USVString("".to_owned())),
         };
 
-        let mut array_buffer_view = ArrayBufferView::new();
+        let mut rooter = TypedArrayRooter::new();
+        let mut array_buffer_view = ArrayBufferView::new(&mut rooter);
         if array_buffer_view.init(input).is_err() {
-            let mut array_buffer = ArrayBuffer::new();
+            let mut rooter = TypedArrayRooter::new();
+            let mut array_buffer = ArrayBuffer::new(&mut rooter);
             if array_buffer.init(input).is_err() {
                 return Err(Error::Type("Argument to TextDecoder.decode is not an ArrayBufferView \
                                         or ArrayBuffer".to_owned()));

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -102,15 +102,13 @@ impl<'a> TextDecoderMethods for &'a TextDecoder {
                                                 ArrayBufferView or ArrayBuffer".to_owned())),
                 };
                 array_buffer.init();
-                array_buffer.compute_length_and_data();
-                let buffer = array_buffer.as_slice();
-                return decode_from_slice(buffer, self.fatal, &self.encoding);
+                let data = array_buffer.extract();
+                return decode_from_slice(data.as_slice(), self.fatal, &self.encoding);
             }
         };
         array_buffer_view.init();
-        array_buffer_view.compute_length_and_data();
-        let buffer = array_buffer_view.as_untyped_slice();
-        decode_from_slice(buffer, self.fatal, &self.encoding)
+        let data = array_buffer_view.extract();
+        decode_from_slice(data.as_untyped_slice(), self.fatal, &self.encoding)
     }
 }
 

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -9,6 +9,7 @@ use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
 use dom::bindings::str::USVString;
 use dom::bindings::trace::JSTraceable;
+use dom::bindings::typedarray::{ArrayBufferView, ArrayBuffer};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 
 use util::str::DOMString;
@@ -17,11 +18,8 @@ use encoding::Encoding;
 use encoding::types::{EncodingRef, DecoderTrap};
 use encoding::label::encoding_from_whatwg_label;
 use js::jsapi::{JSContext, JSObject};
-use js::jsapi::JS_GetObjectAsArrayBufferView;
 
 use std::borrow::ToOwned;
-use std::ptr;
-use std::slice;
 
 #[dom_struct]
 pub struct TextDecoder {
@@ -92,23 +90,32 @@ impl<'a> TextDecoderMethods for &'a TextDecoder {
             None => return Ok(USVString("".to_owned())),
         };
 
-        let mut length = 0;
-        let mut data = ptr::null_mut();
-        if unsafe { JS_GetObjectAsArrayBufferView(input, &mut length, &mut data).is_null() } {
-            return Err(Error::Type("Argument to TextDecoder.decode is not an ArrayBufferView".to_owned()));
+        let mut array_buffer_view = ArrayBufferView::new();
+        if array_buffer_view.init(input).is_err() {
+            let mut array_buffer = ArrayBuffer::new();
+            if array_buffer.init(input).is_err() {
+                return Err(Error::Type("Argument to TextDecoder.decode is not an ArrayBufferView \
+                                        or ArrayBuffer".to_owned()));
+            }
+            array_buffer.compute_length_and_data();
+            let buffer = array_buffer.as_slice();
+            return decode_from_slice(buffer, self.fatal, &self.encoding);
         }
-
-        let buffer = unsafe {
-            slice::from_raw_parts(data as *const _, length as usize)
-        };
-        let trap = if self.fatal {
-            DecoderTrap::Strict
-        } else {
-            DecoderTrap::Replace
-        };
-        match self.encoding.decode(buffer, trap) {
-            Ok(s) => Ok(USVString(s)),
-            Err(_) => Err(Error::Type("Decoding failed".to_owned())),
-        }
+        array_buffer_view.compute_length_and_data();
+        let buffer = array_buffer_view.as_untyped_slice();
+        return decode_from_slice(buffer, self.fatal, &self.encoding);
     }
 }
+
+fn decode_from_slice(buffer: &[u8], fatal: bool, encoding: &EncodingRef) -> Result<USVString, Error> {
+    let trap = if fatal {
+        DecoderTrap::Strict
+    } else {
+        DecoderTrap::Replace
+    };
+    match encoding.decode(buffer, trap) {
+        Ok(s) => Ok(USVString(s)),
+        Err(_) => Err(Error::Type("Decoding failed".to_owned())),
+    }
+}
+

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -284,10 +284,11 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
         };
 
         let mut rooter = TypedArrayRooter::new();
-        let mut array_buffer_view = ArrayBufferView::new(&mut rooter);
-        if array_buffer_view.init(data).is_err() {
-            return;
-        }
+        let mut array_buffer_view = match ArrayBufferView::from(data, &mut rooter) {
+            Ok(view) => view,
+            Err(_) => return,
+        };
+        array_buffer_view.init();
         array_buffer_view.compute_length_and_data();
         let data_vec = match array_buffer_view.as_slice() {
             Ok(data) => data.to_vec(),
@@ -489,10 +490,11 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
         };
 
         let mut rooter = TypedArrayRooter::new();
-        let mut typed_array = Float32Array::new(&mut rooter);
-        if typed_array.init(data).is_err() {
-            return;
-        }
+        let mut typed_array = match Float32Array::from(data, &mut rooter) {
+            Ok(array) => array,
+            Err(_) => return,
+        };
+        typed_array.init();
         typed_array.compute_length_and_data();
         let data_vec = typed_array.as_slice().iter().cloned().take(4).collect();
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -13,6 +13,7 @@ use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JS, LayoutJS, Root};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::conversions::ToJSValConvertible;
+use dom::bindings::typedarray::{ArrayBufferView, Float32Array};
 use dom::htmlcanvaselement::{HTMLCanvasElement};
 use dom::webglbuffer::{WebGLBuffer, WebGLBufferHelpers};
 use dom::webglframebuffer::{WebGLFramebuffer, WebGLFramebufferHelpers};
@@ -24,13 +25,9 @@ use dom::webgluniformlocation::{WebGLUniformLocation, WebGLUniformLocationHelper
 use euclid::size::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
 use js::jsapi::{JSContext, JSObject, RootedValue};
-use js::jsapi::{JS_GetFloat32ArrayData, JS_GetObjectAsArrayBufferView};
 use js::jsval::{JSVal, UndefinedValue, NullValue, Int32Value, BooleanValue};
 use msg::constellation_msg::Msg as ConstellationMsg;
 use std::cell::Cell;
-use std::mem;
-use std::ptr;
-use std::slice;
 use std::sync::mpsc::channel;
 use util::str::DOMString;
 use offscreen_gl_context::GLContextAttributes;
@@ -279,23 +276,21 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
         }
     }
 
-    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
     fn BufferData(self, _cx: *mut JSContext, target: u32, data: Option<*mut JSObject>, usage: u32) {
         let data = match data {
             Some(data) => data,
             None => return,
         };
-        let data_vec = unsafe {
-            let mut length = 0;
-            let mut ptr = ptr::null_mut();
-            let buffer_data = JS_GetObjectAsArrayBufferView(data, &mut length, &mut ptr);
-            if buffer_data.is_null() {
-                panic!("Argument data to WebGLRenderingContext.bufferdata is not a Float32Array")
-            }
-            let data_f32 = JS_GetFloat32ArrayData(buffer_data, ptr::null());
-            let data_vec_length = length / mem::size_of::<f32>() as u32;
-            slice::from_raw_parts(data_f32, data_vec_length as usize).to_vec()
+
+        let mut array_buffer_view = ArrayBufferView::new();
+        if array_buffer_view.init(data).is_err() {
+            return;
+        }
+        array_buffer_view.compute_length_and_data();
+        let data_vec = match array_buffer_view.as_slice() {
+            Ok(data) => data.to_vec(),
+            Err(_) => return,
         };
         self.ipc_renderer
             .send(CanvasMsg::WebGL(CanvasWebGLMsg::BufferData(target, data_vec, usage)))
@@ -477,7 +472,6 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
         }
     }
 
-    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn Uniform4fv(self,
                   _cx: *mut JSContext,
@@ -493,10 +487,13 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
             None => return,
         };
 
-        let data_vec = unsafe {
-            let data_f32 = JS_GetFloat32ArrayData(data, ptr::null());
-            slice::from_raw_parts(data_f32, 4).to_vec()
-        };
+        let mut typed_array = Float32Array::new();
+        if typed_array.init(data).is_err() {
+            return;
+        }
+        typed_array.compute_length_and_data();
+        let data_vec = typed_array.as_slice().iter().cloned().take(4).collect();
+
         self.ipc_renderer
             .send(CanvasMsg::WebGL(CanvasWebGLMsg::Uniform4fv(uniform_id, data_vec)))
             .unwrap()

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -289,8 +289,8 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
             Err(_) => return,
         };
         array_buffer_view.init();
-        array_buffer_view.compute_length_and_data();
-        let data_vec = match array_buffer_view.as_slice() {
+        let data_buffer = array_buffer_view.extract();
+        let data_vec = match data_buffer.as_slice() {
             Ok(data) => data.to_vec(),
             Err(_) => return,
         };
@@ -495,8 +495,8 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
             Err(_) => return,
         };
         typed_array.init();
-        typed_array.compute_length_and_data();
-        let data_vec = typed_array.as_slice().iter().cloned().take(4).collect();
+        let data_buffer = typed_array.extract();
+        let data_vec = data_buffer.as_slice().iter().cloned().take(4).collect();
 
         self.ipc_renderer
             .send(CanvasMsg::WebGL(CanvasWebGLMsg::Uniform4fv(uniform_id, data_vec)))

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -13,7 +13,7 @@ use dom::bindings::global::{GlobalRef, GlobalField};
 use dom::bindings::js::{JS, LayoutJS, Root};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::bindings::conversions::ToJSValConvertible;
-use dom::bindings::typedarray::{ArrayBufferView, Float32Array};
+use dom::bindings::typedarray::{ArrayBufferView, Float32Array, TypedArrayRooter};
 use dom::htmlcanvaselement::{HTMLCanvasElement};
 use dom::webglbuffer::{WebGLBuffer, WebGLBufferHelpers};
 use dom::webglframebuffer::{WebGLFramebuffer, WebGLFramebufferHelpers};
@@ -283,7 +283,8 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
             None => return,
         };
 
-        let mut array_buffer_view = ArrayBufferView::new();
+        let mut rooter = TypedArrayRooter::new();
+        let mut array_buffer_view = ArrayBufferView::new(&mut rooter);
         if array_buffer_view.init(data).is_err() {
             return;
         }
@@ -487,7 +488,8 @@ impl<'a> WebGLRenderingContextMethods for &'a WebGLRenderingContext {
             None => return,
         };
 
-        let mut typed_array = Float32Array::new();
+        let mut rooter = TypedArrayRooter::new();
+        let mut typed_array = Float32Array::new(&mut rooter);
         if typed_array.init(data).is_err() {
             return;
         }


### PR DESCRIPTION
This largely a Rust-y port of Gecko's API. No codegen support yet, but it's a lot easier to work with typed arrays properly now.

r? @Ms2ger

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6779)

<!-- Reviewable:end -->
