### PR TITLE
Change transforms to use LengthOrPercentage.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -18,7 +18,7 @@ use fragment::{CoordinateSystem, Fragment, IframeFragmentInfo, ImageFragmentInfo
 use fragment::{ScannedTextFragmentInfo, SpecificFragmentInfo};
 use inline::InlineFlow;
 use list_item::ListItemFlow;
-use model::{self, MaybeAuto, ToGfxMatrix, ToAu};
+use model::{self, MaybeAuto, ToGfxMatrix};
 use table_cell::CollapsedBordersForCell;
 
 use canvas_traits::{CanvasMsg, FromLayoutMsg};
@@ -1176,8 +1176,8 @@ impl FragmentDisplayListBuilding for Fragment {
                         Matrix4::create_scale(sx, sy, sz)
                     }
                     &transform::ComputedOperation::Translate(tx, ty, tz) => {
-                        let tx = tx.to_au(border_box.size.width).to_f32_px();
-                        let ty = ty.to_au(border_box.size.height).to_f32_px();
+                        let tx = model::specified(tx, border_box.size.width).to_f32_px();
+                        let ty = model::specified(ty, border_box.size.height).to_f32_px();
                         let tz = tz.to_f32_px();
                         Matrix4::create_translation(tx, ty, tz)
                     }

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -13,7 +13,7 @@ use std::cmp::{max, min};
 use std::fmt;
 use style::computed_values::transform::ComputedMatrix;
 use style::properties::ComputedValues;
-use style::values::computed::{LengthAndPercentage, LengthOrPercentageOrAuto};
+use style::values::computed::LengthOrPercentageOrAuto;
 use style::values::computed::{LengthOrPercentageOrNone, LengthOrPercentage};
 use util::geometry::Au;
 use util::logical_geometry::LogicalMargin;
@@ -439,15 +439,3 @@ impl ToGfxMatrix for ComputedMatrix {
         }
     }
 }
-
-pub trait ToAu {
-    fn to_au(&self, containing_size: Au) -> Au;
-}
-
-impl ToAu for LengthAndPercentage {
-    #[inline]
-    fn to_au(&self, containing_size: Au) -> Au {
-        self.length + Au::from_f32_px(self.percentage * containing_size.to_f32_px())
-    }
-}
-

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -21,7 +21,7 @@ use properties::longhands::transform::computed_value::ComputedMatrix;
 use properties::longhands::transform::computed_value::ComputedOperation as TransformOperation;
 use properties::longhands::transform::computed_value::T as TransformList;
 use values::computed::{Angle, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
-use values::computed::{LengthAndPercentage, LengthOrPercentage, Length, Time};
+use values::computed::{LengthOrPercentage, Length, Time};
 use values::CSSFloat;
 use cssparser::{RGBA, Color};
 
@@ -506,17 +506,6 @@ impl Interpolate for LengthOrPercentage {
     }
 }
 
-impl Interpolate for LengthAndPercentage {
-    #[inline]
-    fn interpolate(&self, other: &LengthAndPercentage, time: f32)
-                   -> Option<LengthAndPercentage> {
-        Some(LengthAndPercentage {
-            length: self.length.interpolate(&other.length, time).unwrap(),
-            percentage: self.percentage.interpolate(&other.percentage, time).unwrap(),
-        })
-    }
-}
-
 impl Interpolate for LengthOrPercentageOrAuto {
     #[inline]
     fn interpolate(&self, other: &LengthOrPercentageOrAuto, time: f32)
@@ -795,8 +784,8 @@ fn build_identity_transform_list(list: &Vec<TransformOperation>) -> Vec<Transfor
                 result.push(TransformOperation::Skew(0.0, 0.0));
             }
             &TransformOperation::Translate(..) => {
-                result.push(TransformOperation::Translate(LengthAndPercentage::zero(),
-                                                          LengthAndPercentage::zero(),
+                result.push(TransformOperation::Translate(LengthOrPercentage::zero(),
+                                                          LengthOrPercentage::zero(),
                                                           Au(0)));
             }
             &TransformOperation::Scale(..) => {

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -3245,8 +3245,8 @@ pub mod longhands {
             pub enum ComputedOperation {
                 Matrix(ComputedMatrix),
                 Skew(CSSFloat, CSSFloat),
-                Translate(computed::LengthAndPercentage,
-                          computed::LengthAndPercentage,
+                Translate(computed::LengthOrPercentage,
+                          computed::LengthOrPercentage,
                           computed::Length),
                 Scale(CSSFloat, CSSFloat, CSSFloat),
                 Rotate(CSSFloat, CSSFloat, CSSFloat, computed::Angle),
@@ -3259,13 +3259,13 @@ pub mod longhands {
         pub use self::computed_value::ComputedMatrix as SpecifiedMatrix;
 
         fn parse_two_lengths_or_percentages(input: &mut Parser)
-                                            -> Result<(specified::LengthAndPercentage,
-                                                       specified::LengthAndPercentage),()> {
-            let first = try!(specified::LengthAndPercentage::parse(input));
+                                            -> Result<(specified::LengthOrPercentage,
+                                                       specified::LengthOrPercentage),()> {
+            let first = try!(specified::LengthOrPercentage::parse(input));
             let second = input.try(|input| {
                 try!(input.expect_comma());
-                specified::LengthAndPercentage::parse(input)
-            }).unwrap_or(specified::LengthAndPercentage::zero());
+                specified::LengthOrPercentage::parse(input)
+            }).unwrap_or(specified::LengthOrPercentage::zero());
             Ok((first, second))
         }
 
@@ -3282,8 +3282,8 @@ pub mod longhands {
         enum SpecifiedOperation {
             Matrix(SpecifiedMatrix),
             Skew(CSSFloat, CSSFloat),
-            Translate(specified::LengthAndPercentage,
-                      specified::LengthAndPercentage,
+            Translate(specified::LengthOrPercentage,
+                      specified::LengthOrPercentage,
                       specified::Length),
             Scale(CSSFloat, CSSFloat, CSSFloat),
             Rotate(CSSFloat, CSSFloat, CSSFloat, specified::Angle),
@@ -3381,9 +3381,8 @@ pub mod longhands {
                         try!(input.parse_nested_block(|input| {
                             let tx = try!(specified::LengthOrPercentage::parse(input));
                             result.push(SpecifiedOperation::Translate(
-                                specified::LengthAndPercentage::from_length_or_percentage(
-                                    &tx),
-                                specified::LengthAndPercentage::zero(),
+                                tx,
+                                specified::LengthOrPercentage::zero(),
                                 specified::Length::Absolute(Au(0))));
                             Ok(())
                         }))
@@ -3392,9 +3391,8 @@ pub mod longhands {
                         try!(input.parse_nested_block(|input| {
                             let ty = try!(specified::LengthOrPercentage::parse(input));
                             result.push(SpecifiedOperation::Translate(
-                                specified::LengthAndPercentage::zero(),
-                                specified::LengthAndPercentage::from_length_or_percentage(
-                                    &ty),
+                                specified::LengthOrPercentage::zero(),
+                                ty,
                                 specified::Length::Absolute(Au(0))));
                             Ok(())
                         }))
@@ -3403,8 +3401,8 @@ pub mod longhands {
                         try!(input.parse_nested_block(|input| {
                             let tz = try!(specified::Length::parse(input));
                             result.push(SpecifiedOperation::Translate(
-                                specified::LengthAndPercentage::zero(),
-                                specified::LengthAndPercentage::zero(),
+                                specified::LengthOrPercentage::zero(),
+                                specified::LengthOrPercentage::zero(),
                                 tz));
                             Ok(())
                         }))
@@ -3417,8 +3415,8 @@ pub mod longhands {
                             try!(input.expect_comma());
                             let tz = try!(specified::Length::parse(input));
                             result.push(SpecifiedOperation::Translate(
-                                specified::LengthAndPercentage::from_length_or_percentage(&tx),
-                                specified::LengthAndPercentage::from_length_or_percentage(&ty),
+                                tx,
+                                ty,
                                 tz));
                             Ok(())
                         }))


### PR DESCRIPTION
This simplifies an upcoming PR to support serializing transform values for css style declarations.

Related to issue #6643.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6796)

<!-- Reviewable:end -->
