### PR TITLE
Add a `kind` field to memory reports.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -39,7 +39,7 @@ use msg::constellation_msg::{ConstellationChan, NavigationDirection};
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, LoadData};
 use msg::constellation_msg::{PipelineId, WindowSizeData};
 use png;
-use profile_traits::mem::{self, Reporter, ReporterRequest};
+use profile_traits::mem::{self, Reporter, ReporterRequest, ReportKind};
 use profile_traits::time::{self, ProfilerCategory, profile};
 use script_traits::{ConstellationControlMsg, LayoutControlMsg, ScriptControlChan};
 use std::collections::HashMap;
@@ -501,11 +501,17 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             (Msg::CollectMemoryReports(reports_chan), ShutdownState::NotShuttingDown) => {
                 let mut reports = vec![];
                 let name = "compositor-task";
+                // These are both `ExplicitUnknownLocationSize` because the memory might be in the
+                // GPU or on the heap.
                 reports.push(mem::Report {
-                    path: path![name, "surface-map"], size: self.surface_map.mem(),
+                    path: path![name, "surface-map"],
+                    kind: ReportKind::ExplicitUnknownLocationSize,
+                    size: self.surface_map.mem(),
                 });
                 reports.push(mem::Report {
-                    path: path![name, "layer-tree"], size: self.scene.get_memory_usage(),
+                    path: path![name, "layer-tree"],
+                    kind: ReportKind::ExplicitUnknownLocationSize,
+                    size: self.scene.get_memory_usage(),
                 });
                 reports_chan.send(reports);
             }

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -45,7 +45,7 @@ use log;
 use msg::compositor_msg::{Epoch, ScrollPolicy, LayerId};
 use msg::constellation_msg::Msg as ConstellationMsg;
 use msg::constellation_msg::{ConstellationChan, Failure, PipelineExitType, PipelineId};
-use profile_traits::mem::{self, Report, Reporter, ReporterRequest, ReportsChan};
+use profile_traits::mem::{self, Report, Reporter, ReporterRequest, ReportKind, ReportsChan};
 use profile_traits::time::{self, ProfilerMetadata, profile};
 use profile_traits::time::{TimerMetadataFrameType, TimerMetadataReflowType};
 use net_traits::{load_bytes_iter, PendingAsyncLoad};
@@ -600,13 +600,15 @@ impl LayoutTask {
         let rw_data = self.lock_rw_data(possibly_locked_rw_data);
         let stacking_context = rw_data.stacking_context.as_ref();
         reports.push(Report {
-            path: path!["pages", format!("url({})", self.url), "layout-task", "display-list"],
+            path: path![format!("url({})", self.url), "layout-task", "display-list"],
+            kind: ReportKind::ExplicitJemallocHeapSize,
             size: stacking_context.map_or(0, |sc| sc.heap_size_of_children()),
         });
 
         // The LayoutTask has a context in TLS...
         reports.push(Report {
-            path: path!["pages", format!("url({})", self.url), "layout-task", "local-context"],
+            path: path![format!("url({})", self.url), "layout-task", "local-context"],
+            kind: ReportKind::ExplicitJemallocHeapSize,
             size: heap_size_of_local_context(),
         });
 
@@ -615,9 +617,10 @@ impl LayoutTask {
             let sizes = traversal.heap_size_of_tls(heap_size_of_local_context);
             for (i, size) in sizes.iter().enumerate() {
                 reports.push(Report {
-                    path: path!["pages", format!("url({})", self.url),
+                    path: path![format!("url({})", self.url),
                                 format!("layout-worker-{}-local-context", i)],
-                    size: *size
+                    kind: ReportKind::ExplicitJemallocHeapSize,
+                    size: *size,
                 });
             }
         }


### PR DESCRIPTION
This is used for two memory reporting improvements.
- It's used to distinguish "explicit" memory reports from others. This
  mirrors the same categorization that is used in Firefox, and gives a single
  tree that's the best place to look. It replaces the "pages" tree which
  was always intended to be a temporary stand-in for "explicit".
- It's used to computed "heap-unclassified" values for both the jemalloc
  and system heaps, both of which are placed into the "explicit" tree.

Example output:

```
|  114.99 MiB -- explicit
|      52.34 MiB -- jemalloc-heap-unclassified
|      46.14 MiB -- system-heap-unclassified
|      14.95 MiB -- url(file:///home/njn/moz/servo2/../servo-static-suite/wikipe
dia/Guardians%20of%20the%20Galaxy%20(film)%20-%20Wikipedia,%20the%20free%20encyc
lopedia.html)
|          7.32 MiB -- js
|             3.07 MiB -- malloc-heap
|             3.00 MiB -- gc-heap
|                2.49 MiB -- used
|                0.34 MiB -- decommitted
|                0.09 MiB -- unused
|                0.09 MiB -- admin
|             1.25 MiB -- non-heap
|          1.36 MiB -- layout-worker-3-local-context
|          1.34 MiB -- layout-worker-0-local-context
|          1.24 MiB -- layout-worker-1-local-context
|          1.24 MiB -- layout-worker-4-local-context
|          1.16 MiB -- layout-worker-2-local-context
|          0.89 MiB -- layout-worker-5-local-context
|          0.38 MiB -- layout-task
|             0.31 MiB -- display-list
|             0.07 MiB -- local-context
|       1.56 MiB -- compositor-task
|          0.78 MiB -- surface-map
|          0.78 MiB -- layer-tree
```

The heap-unclassified values dominate the "explicit" tree because reporter
coverage is still quite poor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6802)

<!-- Reviewable:end -->
