### PR TITLE
Remove unrooted_must_root annotation from unions (fixes #2661).

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3445,7 +3445,6 @@ class CGUnionStruct(CGThing):
         # XXXManishearth The following should be #[must_root],
         # however we currently allow it till #2661 is fixed
         return ("""\
-#[allow(unrooted_must_root)]
 pub enum %s {
 %s
 }


### PR DESCRIPTION
The unsafety was fixed as part of the SpiderMonkey upgrade; this removes the
now unused annotation.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6809)

<!-- Reviewable:end -->
