### PR TITLE
Tweak FragmentBorderBoxIterator to account for fragment's margins

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1983,8 +1983,7 @@ impl Flow for BlockFlow {
                                                             self.base
                                                                 .absolute_position_info
                                                                 .relative_containing_block_mode,
-                                                            CoordinateSystem::Own)
-                              .translate(stacking_context_position));
+                                                            CoordinateSystem::Parent));
     }
 
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1639,8 +1639,7 @@ impl Flow for InlineFlow {
                              &fragment.stacking_relative_border_box(stacking_relative_position,
                                                                     relative_containing_block_size,
                                                                     relative_containing_block_mode,
-                                                                    CoordinateSystem::Own)
-                                      .translate(stacking_context_position))
+                                                                    CoordinateSystem::Parent));
         }
     }
 


### PR DESCRIPTION
@pcwalton 
I switched these callers to do the same thing as http://mxr.mozilla.org/servo/source/components/layout/display_list_builder.rs#1141
I don't know if the changes to inline.rs are necessary, but the block.rs change fixes the problem I was seeing.
I can write a WPT for this, just not sure where to put it...

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6825)

<!-- Reviewable:end -->
