### PR TITLE
Use an actual byte string when defining the prototype of named constr…

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -233,7 +233,7 @@ pub fn do_create_interface_objects(cx: *mut JSContext,
         let constructor = RootedObject::new(cx, create_constructor(cx, cnative, cnargs, cs.as_ptr()));
         assert!(!constructor.ptr.is_null());
         unsafe {
-            assert!(JS_DefineProperty1(cx, constructor.handle(), "prototype".as_ptr() as *const libc::c_char,
+            assert!(JS_DefineProperty1(cx, constructor.handle(), b"prototype\0".as_ptr() as *const libc::c_char,
                                        rval.handle(),
                                        JSPROP_PERMANENT | JSPROP_READONLY,
                                        None, None) != 0);

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/Image-constructor.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/Image-constructor.html.ini
@@ -1,6 +1,0 @@
-[Image-constructor.html]
-  type: testharness
-  [Image and HTMLImageElement share a prototype]
-    expected:
-      if not debug: FAIL
-


### PR DESCRIPTION
…uctors. Fixes #6730.

r? @Ms2ger

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6834)

<!-- Reviewable:end -->
