### PR TITLE
Implement document.domain getter

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -105,7 +105,7 @@ use string_cache::{Atom, QualName};
 use style::restyle_hints::ElementSnapshot;
 use style::stylesheets::Stylesheet;
 use time;
-use url::Url;
+use url::{Host, Url};
 use util::str::{DOMString, split_html_space_chars, str_join};
 
 #[derive(JSTraceable, PartialEq, HeapSizeOf)]
@@ -1578,6 +1578,19 @@ impl DocumentMethods for Document {
             }
             None => false
         }
+    }
+
+    // https://html.spec.whatwg.org/multipage/#relaxing-the-same-origin-restriction
+    fn Domain(&self) -> DOMString {
+        // TODO: This should use the effective script origin when it exists
+        let origin = self.window.get_url();
+
+        if let Some(&Host::Ipv6(ipv6)) = origin.host() {
+            // Omit square brackets for IPv6 addresses.
+            return DOMString::from(ipv6.serialize());
+        }
+
+        DOMString::from(origin.serialize_host().unwrap_or_else(|| "".to_owned()))
     }
 
     // https://dom.spec.whatwg.org/#dom-document-documenturi

--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -81,7 +81,7 @@ partial /*sealed*/ interface Document {
   // resource metadata management
   // [PutForwards=href, Unforgeable]
   readonly attribute Location/*?*/ location;
-  // attribute DOMString domain;
+  readonly attribute DOMString domain;
   // readonly attribute DOMString referrer;
   [Throws]
   attribute DOMString cookie;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4769,6 +4769,12 @@
             "url": "/_mozilla/mozilla/document_defaultView.html"
           }
         ],
+        "mozilla/document_domain.html": [
+          {
+            "path": "mozilla/document_domain.html",
+            "url": "/_mozilla/mozilla/document_domain.html"
+          }
+        ],
         "mozilla/document_getElementById.html": [
           {
             "path": "mozilla/document_getElementById.html",

--- a/tests/wpt/mozilla/meta/mozilla/document_domain.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/document_domain.html.ini
@@ -1,0 +1,4 @@
+[document_domain.html]
+  type: testharness
+  [new document]
+    expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/document_domain.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_domain.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+    <head>
+        <title></title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script>
+            test(function() {
+                assert_equals(typeof document.domain, "string", "document.domain is a string");
+                assert_not_equals(document.domain, "", "document.domain is not empty");
+            }, "sanity checks");
+
+            test(function() {
+                assert_equals(document.domain, window.location.hostname, "equals location.hostname");
+            }, "current document");
+
+            test(function() {
+                var doc = new Document();
+                assert_equals(doc.domain, "", "new document has empty domain");
+            }, "new document");
+        </script>
+    </head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
I think this might have the downside that assigning to document.domain will now throw in strict-mode.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6840)

<!-- Reviewable:end -->
