### PR TITLE
Change where percentage height becomes auto when there is no explicit containing block height.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -929,6 +929,7 @@ impl BlockFlow {
             let (collapsible_margins, delta) =
                 margin_collapse_info.finish_and_compute_collapsible_margins(
                 &self.fragment,
+                self.base.block_container_explicit_block_size,
                 can_collapse_block_end_margin_with_kids);
             self.base.collapsible_margins = collapsible_margins;
             translate_including_floats(&mut cur_b, delta, &mut floats);

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -126,13 +126,16 @@ impl MarginCollapseInfo {
 
     pub fn finish_and_compute_collapsible_margins(mut self,
                                                   fragment: &Fragment,
+                                                  containing_block_size: Option<Au>,
                                                   can_collapse_block_end_margin_with_kids: bool)
                                                   -> (CollapsibleMargins, Au) {
         let state = match self.state {
             MarginCollapseState::AccumulatingCollapsibleTopMargin => {
                 match fragment.style().content_block_size() {
-                    LengthOrPercentageOrAuto::Auto | LengthOrPercentageOrAuto::Length(Au(0)) |
-                    LengthOrPercentageOrAuto::Percentage(0.) => {
+                    LengthOrPercentageOrAuto::Auto |
+                    LengthOrPercentageOrAuto::Length(Au(0)) |
+                    LengthOrPercentageOrAuto::Percentage(0.) |
+                    LengthOrPercentageOrAuto::Percentage(_) if containing_block_size.is_none() => {
                         match fragment.style().min_block_size() {
                             LengthOrPercentage::Length(Au(0)) | LengthOrPercentage::Percentage(0.) => {
                                 FinalMarginState::MarginsCollapseThrough

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -67,7 +67,7 @@ use smallvec::VecLike;
 use style::legacy::{UnsignedIntegerAttribute, from_declaration};
 use style::properties::{PropertyDeclarationBlock, PropertyDeclaration, parse_style_attribute};
 use style::properties::DeclaredValue::SpecifiedValue;
-use style::properties::longhands::{self, background_image, border_spacing, height};
+use style::properties::longhands::{self, background_image, border_spacing};
 use style::values::CSSFloat;
 use style::values::specified::{self, CSSColor, CSSRGBA};
 use util::geometry::Au;
@@ -390,15 +390,15 @@ impl RawLayoutElementHelpers for Element {
         match height {
             LengthOrPercentageOrAuto::Auto => {}
             LengthOrPercentageOrAuto::Percentage(percentage) => {
-                let width_value = specified::LengthOrPercentageOrAuto::Percentage(percentage);
-                hints.push(from_declaration(PropertyDeclaration::Height(SpecifiedValue(
-                                height::SpecifiedValue(width_value)))));
+                let height_value = specified::LengthOrPercentageOrAuto::Percentage(percentage);
+                hints.push(from_declaration(
+                    PropertyDeclaration::Height(SpecifiedValue(height_value))));
             }
             LengthOrPercentageOrAuto::Length(length) => {
-                let width_value = specified::LengthOrPercentageOrAuto::Length(
+                let height_value = specified::LengthOrPercentageOrAuto::Length(
                     specified::Length::Absolute(length));
-                hints.push(from_declaration(PropertyDeclaration::Height(SpecifiedValue(
-                                height::SpecifiedValue(width_value)))));
+                hints.push(from_declaration(
+                    PropertyDeclaration::Height(SpecifiedValue(height_value))));
             }
         }
 
@@ -443,8 +443,7 @@ impl RawLayoutElementHelpers for Element {
             let value = specified::Length::FontRelative(specified::FontRelativeLength::Em(rows as CSSFloat));
             hints.push(from_declaration(
                 PropertyDeclaration::Height(SpecifiedValue(
-                    longhands::height::SpecifiedValue(
-                        specified::LengthOrPercentageOrAuto::Length(value))))));
+                        specified::LengthOrPercentageOrAuto::Length(value)))));
         }
 
 

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -534,45 +534,10 @@ pub mod longhands {
     ${predefined_type("width", "LengthOrPercentageOrAuto",
                       "computed::LengthOrPercentageOrAuto::Auto",
                       "parse_non_negative")}
-    <%self:longhand name="height">
-        use values::computed::Context;
-        use cssparser::ToCss;
-        use std::fmt;
 
-        impl ToCss for SpecifiedValue {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                self.0.to_css(dest)
-            }
-        }
-
-        #[derive(Clone, PartialEq)]
-        pub struct SpecifiedValue(pub specified::LengthOrPercentageOrAuto);
-        pub mod computed_value {
-            pub use values::computed::LengthOrPercentageOrAuto as T;
-        }
-        #[inline]
-        pub fn get_initial_value() -> computed_value::T { computed::LengthOrPercentageOrAuto::Auto }
-        #[inline]
-        pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-            specified::LengthOrPercentageOrAuto::parse_non_negative(input).map(SpecifiedValue)
-        }
-
-        impl ToComputedValue for SpecifiedValue {
-            type ComputedValue = computed_value::T;
-
-            #[inline]
-            fn to_computed_value(&self, context: &Context) -> computed_value::T {
-                match (self.0, context.inherited_height) {
-                    (specified::LengthOrPercentageOrAuto::Percentage(_),
-                     computed::LengthOrPercentageOrAuto::Auto)
-                    if !context.is_root_element && !context.positioned => {
-                        computed::LengthOrPercentageOrAuto::Auto
-                    },
-                    _ => self.0.to_computed_value(context)
-                }
-            }
-        }
-    </%self:longhand>
+    ${predefined_type("height", "LengthOrPercentageOrAuto",
+                      "computed::LengthOrPercentageOrAuto::Auto",
+                      "parse_non_negative")}
 
     ${predefined_type("min-width", "LengthOrPercentage",
                       "computed::LengthOrPercentage::Length(Au(0))",
@@ -5809,7 +5774,6 @@ pub fn cascade(viewport_size: Size2D<Au>,
             viewport_size: viewport_size,
             inherited_font_weight: inherited_font_style.font_weight,
             inherited_font_size: inherited_font_style.font_size,
-            inherited_height: inherited_style.get_box().height,
             inherited_text_decorations_in_effect:
                 inherited_style.get_inheritedtext()._servo_text_decorations_in_effect,
             // To be overridden by applicable declarations:

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -873,7 +873,6 @@ pub mod computed {
         pub inherited_font_size: longhands::font_size::computed_value::T,
         pub inherited_text_decorations_in_effect:
             longhands::_servo_text_decorations_in_effect::computed_value::T,
-        pub inherited_height: longhands::height::computed_value::T,
         pub color: longhands::color::computed_value::T,
         pub text_decoration: longhands::text_decoration::computed_value::T,
         pub font_size: longhands::font_size::computed_value::T,


### PR DESCRIPTION
It's not possible to correctly determine during the css cascade whether the container height
is explicitly specified. Additionally, the spec https://drafts.csswg.org/css2/visudet.html#the-height-property
says this should affect the _used_ height, rather than the computed height.

This improves some of the layout in #6643 (a test case for this will be added when an unrelated
bug to absolute containing blocks is fixed).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6844)

<!-- Reviewable:end -->
