### PR TITLE
Avoid undefined behaviour by allocating with align 1.

### DIFF
--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -25,7 +25,7 @@ struct User {
 }
 
 // FreeType doesn't require any particular alignment for allocations.
-const FT_ALIGNMENT: usize = 0;
+const FT_ALIGNMENT: usize = 1;
 
 extern fn ft_alloc(mem: FT_Memory, req_size: c_long) -> *mut c_void {
     unsafe {


### PR DESCRIPTION
The allocation APIs require that the alignment is a power-of-two;
meaning 1 is the "I don't care" alignment, not 0.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6852)

<!-- Reviewable:end -->
