### PR TITLE
Don't try to unwrap the result of requestAnimationFrame callback

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -531,7 +531,8 @@ impl<'a> WindowMethods for &'a Window {
 
         let callback  = move |now: f64| {
             // TODO: @jdm The spec says that any exceptions should be suppressed;
-            callback.Call__(Finite::wrap(now), ExceptionHandling::Report).unwrap();
+            // https://github.com/servo/servo/issues/6928
+            let _ = callback.Call__(Finite::wrap(now), ExceptionHandling::Report);
         };
 
         doc.r().request_animation_frame(Box::new(callback))

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -8978,3 +8978,4 @@
 
   [HTMLOptionElement interface: new Option() must inherit property "index" with the proper type (7)]
     expected: FAIL
+

--- a/tests/wpt/metadata/websockets/interfaces.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces.html.ini
@@ -56,3 +56,4 @@
 
   [CloseEvent interface: existence and properties of interface prototype object]
     expected: FAIL
+

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -773,6 +773,12 @@
             "url": "/_mozilla/mozilla/window_requestAnimationFrame.html"
           }
         ],
+        "mozilla/window_requestAnimationFrame2.html": [
+          {
+            "path": "mozilla/window_requestAnimationFrame2.html",
+            "url": "/_mozilla/mozilla/window_requestAnimationFrame2.html"
+          }
+        ],
         "mozilla/window_setInterval.html": [
           {
             "path": "mozilla/window_setInterval.html",

--- a/tests/wpt/mozilla/meta/mozilla/window_requestAnimationFrame2.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window_requestAnimationFrame2.html.ini
@@ -1,0 +1,6 @@
+[window_requestAnimationFrame2.html]
+  type: testharness
+  expected: TIMEOUT
+  [Test throwing an error inside requestAnimationFrame callback]
+    expected: NOTRUN
+

--- a/tests/wpt/mozilla/tests/mozilla/window_requestAnimationFrame2.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_requestAnimationFrame2.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Test throwing an error inside requestAnimationFrame callback</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+    var stepCalled = false;
+    function step() {
+        if (stepCalled) {
+          setTimeout(done, 0);
+        } else {
+          stepCalled = true;
+          window.requestAnimationFrame(step);
+        }
+        throw new Error();
+    }
+    window.requestAnimationFrame(step);
+    assert_equals(true, true, "rAF should not throw errors");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6880)

<!-- Reviewable:end -->
