### PR TITLE
style: Switch animation timestamps to be doubles instead of floats.

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -33,15 +33,16 @@ pub fn start_transitions_if_applicable(new_animations_sender: &Sender<Animation>
             property_animation.update(new_style, 0.0);
 
             // Kick off the animation.
-            let now = clock_ticks::precise_time_s() as f32;
+            let now = clock_ticks::precise_time_s();
             let animation_style = new_style.get_animation();
-            let start_time = now + animation_style.transition_delay.0.get_mod(i).seconds();
+            let start_time =
+                now + (animation_style.transition_delay.0.get_mod(i).seconds() as f64);
             new_animations_sender.send(Animation {
                 node: node.id(),
                 property_animation: property_animation,
                 start_time: start_time,
                 end_time: start_time +
-                    animation_style.transition_duration.0.get_mod(i).seconds(),
+                    (animation_style.transition_duration.0.get_mod(i).seconds() as f64),
             }).unwrap()
         }
     }
@@ -75,7 +76,7 @@ pub fn recalc_style_for_animation(flow: &mut Flow, animation: &Animation) {
             return
         }
 
-        let now = clock_ticks::precise_time_s() as f32;
+        let now = clock_ticks::precise_time_s() as f64;
         let mut progress = (now - animation.start_time) / animation.duration();
         if progress > 1.0 {
             progress = 1.0
@@ -100,7 +101,7 @@ pub fn recalc_style_for_animation(flow: &mut Flow, animation: &Animation) {
 /// Handles animation updates.
 pub fn tick_all_animations(layout_task: &LayoutTask, rw_data: &mut LayoutTaskData) {
     let running_animations = mem::replace(&mut rw_data.running_animations, Vec::new());
-    let now = clock_ticks::precise_time_s() as f32;
+    let now = clock_ticks::precise_time_s() as f64;
     for running_animation in running_animations.into_iter() {
         layout_task.tick_animation(&running_animation, rw_data);
 

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -208,15 +208,15 @@ pub struct Animation {
     /// A description of the property animation that is occurring.
     pub property_animation: PropertyAnimation,
     /// The start time of the animation, as returned by `time::precise_time_s()`.
-    pub start_time: f32,
+    pub start_time: f64,
     /// The end time of the animation, as returned by `time::precise_time_s()`.
-    pub end_time: f32,
+    pub end_time: f64,
 }
 
 impl Animation {
     /// Returns the duration of this animation in seconds.
     #[inline]
-    pub fn duration(&self) -> f32 {
+    pub fn duration(&self) -> f64 {
         self.end_time - self.start_time
     }
 }

--- a/components/util/bezier.rs
+++ b/components/util/bezier.rs
@@ -11,17 +11,17 @@ use euclid::point::Point2D;
 const NEWTON_METHOD_ITERATIONS: u8 = 8;
 
 pub struct Bezier {
-    ax: f32,
-    bx: f32,
-    cx: f32,
-    ay: f32,
-    by: f32,
-    cy: f32,
+    ax: f64,
+    bx: f64,
+    cx: f64,
+    ay: f64,
+    by: f64,
+    cy: f64,
 }
 
 impl Bezier {
     #[inline]
-    pub fn new(p1: Point2D<f32>, p2: Point2D<f32>) -> Bezier {
+    pub fn new(p1: Point2D<f64>, p2: Point2D<f64>) -> Bezier {
         let cx = 3.0 * p1.x;
         let bx = 3.0 * (p2.x - p1.x) - cx;
 
@@ -39,23 +39,23 @@ impl Bezier {
     }
 
     #[inline]
-    fn sample_curve_x(&self, t: f32) -> f32 {
+    fn sample_curve_x(&self, t: f64) -> f64 {
         // ax * t^3 + bx * t^2 + cx * t
         ((self.ax * t + self.bx) * t + self.cx) * t
     }
 
     #[inline]
-    fn sample_curve_y(&self, t: f32) -> f32 {
+    fn sample_curve_y(&self, t: f64) -> f64 {
         ((self.ay * t + self.by) * t + self.cy) * t
     }
 
     #[inline]
-    fn sample_curve_derivative_x(&self, t: f32) -> f32 {
+    fn sample_curve_derivative_x(&self, t: f64) -> f64 {
         (3.0 * self.ax * t + 2.0 * self.bx) * t + self.cx
     }
 
     #[inline]
-    fn solve_curve_x(&self, x: f32, epsilon: f32) -> f32 {
+    fn solve_curve_x(&self, x: f64, epsilon: f64) -> f64 {
         // Fast path: Use Newton's method.
         let mut t = x;
         for _ in 0..NEWTON_METHOD_ITERATIONS {
@@ -97,7 +97,7 @@ impl Bezier {
     }
 
     #[inline]
-    pub fn solve(&self, x: f32, epsilon: f32) -> f32 {
+    pub fn solve(&self, x: f64, epsilon: f64) -> f64 {
         self.sample_curve_y(self.solve_curve_x(x, epsilon))
     }
 }
@@ -106,9 +106,9 @@ trait ApproxEq {
     fn approx_eq(self, value: Self, epsilon: Self) -> bool;
 }
 
-impl ApproxEq for f32 {
+impl ApproxEq for f64 {
     #[inline]
-    fn approx_eq(self, value: f32, epsilon: f32) -> bool {
+    fn approx_eq(self, value: f64, epsilon: f64) -> bool {
         (self - value).abs() < epsilon
     }
 }


### PR DESCRIPTION
32-bit floats are not enough to hold timestamps since the epoch and
result in jank.

r? @metajack

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6894)

<!-- Reviewable:end -->
