### PR TITLE
script: Use `Arc::make_unique` instead of `Arc::get_mut` when updating inline styles.

### DIFF
--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -5669,7 +5669,7 @@ impl<T: ToCss> DeclaredValue<T> {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum PropertyDeclaration {
     % for property in LONGHANDS:
         ${property.camel_case}(DeclaredValue<longhands::${property.ident}::SpecifiedValue>),


### PR DESCRIPTION
Transitions make the reasoning in the comment in the relevant sections
not true.

r? @SimonSapin

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6896)

<!-- Reviewable:end -->
