### PR TITLE
Lock and flush stdout in Window#alert.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -72,6 +72,7 @@ use std::cell::{Cell, Ref, RefMut, RefCell};
 use std::collections::HashSet;
 use std::default::Default;
 use std::ffi::CString;
+use std::io::{stdout, Write};
 use std::mem as std_mem;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -342,7 +343,10 @@ impl<'a> WindowMethods for &'a Window {
     // https://html.spec.whatwg.org/#dom-alert
     fn Alert(self, s: DOMString) {
         // Right now, just print to the console
-        println!("ALERT: {}", s);
+        let stdout = stdout();
+        let mut stdout = stdout.lock();
+        writeln!(&mut stdout, "ALERT: {}", s).unwrap();
+        stdout.flush().unwrap();
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window-close


### PR DESCRIPTION
We use alert() to communicate test results to wptrunner. Unfortunately,
sometimes the alert output is interleaved with other output on stdout,
causing wptrunner to classify the test result as a timeout. I hope this will
avoid that scenario.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6917)

<!-- Reviewable:end -->
