### PR TITLE
Cache results of HTMLCollection::create

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -18,10 +18,7 @@ use dom::bindings::codegen::InheritTypes::{DocumentDerived, EventCast, HTMLBodyE
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLHeadElementCast, ElementCast, HTMLIFrameElementCast};
 use dom::bindings::codegen::InheritTypes::{DocumentTypeCast, HTMLHtmlElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{EventTargetCast, HTMLAnchorElementCast};
-use dom::bindings::codegen::InheritTypes::{HTMLAnchorElementDerived, HTMLAppletElementDerived};
-use dom::bindings::codegen::InheritTypes::{HTMLAreaElementDerived, HTMLEmbedElementDerived};
-use dom::bindings::codegen::InheritTypes::{HTMLFormElementDerived, HTMLImageElementDerived};
-use dom::bindings::codegen::InheritTypes::{HTMLScriptElementDerived, HTMLTitleElementDerived};
+use dom::bindings::codegen::InheritTypes::HTMLTitleElementDerived;
 use dom::bindings::codegen::InheritTypes::ElementDerived;
 use dom::bindings::codegen::UnionTypes::NodeOrString;
 use dom::bindings::error::{ErrorResult, Fallible};
@@ -107,6 +104,8 @@ pub enum IsHTMLDocument {
     NonHTMLDocument,
 }
 
+pub type CollectionKey = (usize, CollectionFilter);
+
 // https://dom.spec.whatwg.org/#document
 #[dom_struct]
 pub struct Document {
@@ -121,13 +120,6 @@ pub struct Document {
     is_html_document: bool,
     url: Url,
     quirks_mode: Cell<QuirksMode>,
-    images: MutNullableHeap<JS<HTMLCollection>>,
-    embeds: MutNullableHeap<JS<HTMLCollection>>,
-    links: MutNullableHeap<JS<HTMLCollection>>,
-    forms: MutNullableHeap<JS<HTMLCollection>>,
-    scripts: MutNullableHeap<JS<HTMLCollection>>,
-    anchors: MutNullableHeap<JS<HTMLCollection>>,
-    applets: MutNullableHeap<JS<HTMLCollection>>,
     ready_state: Cell<DocumentReadyState>,
     /// The element that has most recently requested focus for itself.
     possibly_focused: MutNullableHeap<JS<Element>>,
@@ -150,6 +142,8 @@ pub struct Document {
     current_parser: MutNullableHeap<JS<ServoHTMLParser>>,
     /// When we should kick off a reflow. This happens during parsing.
     reflow_timeout: Cell<Option<u64>>,
+    /// A cache of HTMLCollections for fast querying
+    html_collections: RefCell<HashMap<CollectionKey, JS<HTMLCollection>>>,
 }
 
 impl PartialEq for Document {
@@ -161,63 +155,6 @@ impl PartialEq for Document {
 impl DocumentDerived for EventTarget {
     fn is_document(&self) -> bool {
         *self.type_id() == EventTargetTypeId::Node(NodeTypeId::Document)
-    }
-}
-
-#[derive(JSTraceable)]
-struct ImagesFilter;
-impl CollectionFilter for ImagesFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        elem.is_htmlimageelement()
-    }
-}
-
-#[derive(JSTraceable)]
-struct EmbedsFilter;
-impl CollectionFilter for EmbedsFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        elem.is_htmlembedelement()
-    }
-}
-
-#[derive(JSTraceable)]
-struct LinksFilter;
-impl CollectionFilter for LinksFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        (elem.is_htmlanchorelement() || elem.is_htmlareaelement()) &&
-            elem.has_attribute(&atom!("href"))
-    }
-}
-
-#[derive(JSTraceable)]
-struct FormsFilter;
-impl CollectionFilter for FormsFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        elem.is_htmlformelement()
-    }
-}
-
-#[derive(JSTraceable)]
-struct ScriptsFilter;
-impl CollectionFilter for ScriptsFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        elem.is_htmlscriptelement()
-    }
-}
-
-#[derive(JSTraceable)]
-struct AnchorsFilter;
-impl CollectionFilter for AnchorsFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        elem.is_htmlanchorelement() && elem.has_attribute(&atom!("href"))
-    }
-}
-
-#[derive(JSTraceable)]
-struct AppletsFilter;
-impl CollectionFilter for AppletsFilter {
-    fn filter(&self, elem: &Element, _root: &Node) -> bool {
-        elem.is_htmlappletelement()
     }
 }
 
@@ -289,6 +226,8 @@ pub trait DocumentHelpers<'a> {
     fn set_current_parser(self, script: Option<&ServoHTMLParser>);
     fn get_current_parser(self) -> Option<Root<ServoHTMLParser>>;
     fn find_iframe(self, subpage_id: SubpageId) -> Option<Root<HTMLIFrameElement>>;
+    fn get_collection(self, key: &CollectionKey) -> Option<Root<HTMLCollection>>;
+    fn add_collection(self, key: CollectionKey, value: &HTMLCollection);
 }
 
 impl<'a> DocumentHelpers<'a> for &'a Document {
@@ -997,6 +936,14 @@ impl<'a> DocumentHelpers<'a> for &'a Document {
             .filter_map(HTMLIFrameElementCast::to_root)
             .find(|node| node.r().subpage_id() == Some(subpage_id))
     }
+
+    fn get_collection(self, key: &CollectionKey) -> Option<Root<HTMLCollection>> {
+        self.html_collections.borrow().get(key).map(|r| r.root())
+    }
+
+    fn add_collection(self, key: CollectionKey, value: &HTMLCollection) {
+        self.html_collections.borrow_mut().insert(key, JS::from_ref(value));
+    }
 }
 
 pub enum MouseEventType {
@@ -1064,13 +1011,6 @@ impl Document {
             // https://dom.spec.whatwg.org/#concept-document-encoding
             encoding_name: DOMRefCell::new("UTF-8".to_owned()),
             is_html_document: is_html_document == IsHTMLDocument::HTMLDocument,
-            images: Default::default(),
-            embeds: Default::default(),
-            links: Default::default(),
-            forms: Default::default(),
-            scripts: Default::default(),
-            anchors: Default::default(),
-            applets: Default::default(),
             ready_state: Cell::new(ready_state),
             possibly_focused: Default::default(),
             focused: Default::default(),
@@ -1081,6 +1021,7 @@ impl Document {
             loader: DOMRefCell::new(doc_loader),
             current_parser: Default::default(),
             reflow_timeout: Cell::new(None),
+            html_collections: RefCell::new(HashMap::new()),
         }
     }
 
@@ -1112,6 +1053,54 @@ impl Document {
             node.set_owner_doc(document.r());
         }
         document
+    }
+
+    // https://html.spec.whatwg.org/#dom-document-nameditem-filter
+    pub fn filter_by_name(name: &Atom, node: &Node) -> bool {
+        let html_elem_type = match node.type_id() {
+            NodeTypeId::Element(ElementTypeId::HTMLElement(type_)) => type_,
+            _ => return false,
+        };
+        let elem = match ElementCast::to_ref(node) {
+            Some(elem) => elem,
+            None => return false,
+        };
+        match html_elem_type {
+            HTMLElementTypeId::HTMLAppletElement => {
+                match elem.get_attribute(&ns!(""), &atom!("name")) {
+                    Some(ref attr) if attr.r().value().atom() == Some(name) => true,
+                    _ => {
+                        match elem.get_attribute(&ns!(""), &atom!("id")) {
+                            Some(ref attr) => attr.r().value().atom() == Some(name),
+                            None => false,
+                        }
+                    },
+                }
+            },
+            HTMLElementTypeId::HTMLFormElement => {
+                match elem.get_attribute(&ns!(""), &atom!("name")) {
+                    Some(ref attr) => attr.r().value().atom() == Some(name),
+                    None => false,
+                }
+            },
+            HTMLElementTypeId::HTMLImageElement => {
+                match elem.get_attribute(&ns!(""), &atom!("name")) {
+                    Some(ref attr) => {
+                        if attr.r().value().atom() == Some(name) {
+                            true
+                        } else {
+                            match elem.get_attribute(&ns!(""), &atom!("id")) {
+                                Some(ref attr) => attr.r().value().atom() == Some(name),
+                                None => false,
+                            }
+                        }
+                    },
+                    None => false,
+                }
+            },
+            // TODO: Handle <embed>, <iframe> and <object>.
+            _ => false,
+        }
     }
 }
 
@@ -1578,22 +1567,18 @@ impl<'a> DocumentMethods for &'a Document {
 
     // https://html.spec.whatwg.org/#dom-document-images
     fn Images(self) -> Root<HTMLCollection> {
-        self.images.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box ImagesFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Images;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-embeds
     fn Embeds(self) -> Root<HTMLCollection> {
-        self.embeds.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box EmbedsFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Embeds;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-plugins
@@ -1603,53 +1588,43 @@ impl<'a> DocumentMethods for &'a Document {
 
     // https://html.spec.whatwg.org/#dom-document-links
     fn Links(self) -> Root<HTMLCollection> {
-        self.links.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box LinksFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Links;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-forms
     fn Forms(self) -> Root<HTMLCollection> {
-        self.forms.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box FormsFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Forms;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-scripts
     fn Scripts(self) -> Root<HTMLCollection> {
-        self.scripts.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box ScriptsFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Scripts;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-anchors
     fn Anchors(self) -> Root<HTMLCollection> {
-        self.anchors.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box AnchorsFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Anchors;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-applets
     fn Applets(self) -> Root<HTMLCollection> {
         // FIXME: This should be return OBJECT elements containing applets.
-        self.applets.or_init(|| {
-            let window = self.window.root();
-            let root = NodeCast::from_ref(self);
-            let filter = box AppletsFilter;
-            HTMLCollection::create(window.r(), root, filter)
-        })
+        let window = self.window.root();
+        let root = NodeCast::from_ref(self);
+        let filter = CollectionFilter::Applets;
+        HTMLCollection::create(window.r(), root, filter)
     }
 
     // https://html.spec.whatwg.org/#dom-document-location
@@ -1751,68 +1726,12 @@ impl<'a> DocumentMethods for &'a Document {
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
     fn NamedGetter(self, _cx: *mut JSContext, name: DOMString, found: &mut bool)
                    -> *mut JSObject {
-        #[derive(JSTraceable)]
-        struct NamedElementFilter {
-            name: Atom,
-        }
-        impl CollectionFilter for NamedElementFilter {
-            fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                filter_by_name(&self.name, NodeCast::from_ref(elem))
-            }
-        }
-        // https://html.spec.whatwg.org/#dom-document-nameditem-filter
-        fn filter_by_name(name: &Atom, node: &Node) -> bool {
-            let html_elem_type = match node.type_id() {
-                NodeTypeId::Element(ElementTypeId::HTMLElement(type_)) => type_,
-                _ => return false,
-            };
-            let elem = match ElementCast::to_ref(node) {
-                Some(elem) => elem,
-                None => return false,
-            };
-            match html_elem_type {
-                HTMLElementTypeId::HTMLAppletElement => {
-                    match elem.get_attribute(&ns!(""), &atom!("name")) {
-                        Some(ref attr) if attr.r().value().atom() == Some(name) => true,
-                        _ => {
-                            match elem.get_attribute(&ns!(""), &atom!("id")) {
-                                Some(ref attr) => attr.r().value().atom() == Some(name),
-                                None => false,
-                            }
-                        },
-                    }
-                },
-                HTMLElementTypeId::HTMLFormElement => {
-                    match elem.get_attribute(&ns!(""), &atom!("name")) {
-                        Some(ref attr) => attr.r().value().atom() == Some(name),
-                        None => false,
-                    }
-                },
-                HTMLElementTypeId::HTMLImageElement => {
-                    match elem.get_attribute(&ns!(""), &atom!("name")) {
-                        Some(ref attr) => {
-                            if attr.r().value().atom() == Some(name) {
-                                true
-                            } else {
-                                match elem.get_attribute(&ns!(""), &atom!("id")) {
-                                    Some(ref attr) => attr.r().value().atom() == Some(name),
-                                    None => false,
-                                }
-                            }
-                        },
-                        None => false,
-                    }
-                },
-                // TODO: Handle <embed>, <iframe> and <object>.
-                _ => false,
-            }
-        }
         let name = Atom::from_slice(&name);
         let root = NodeCast::from_ref(self);
         {
             // Step 1.
             let mut elements = root.traverse_preorder().filter(|node| {
-                filter_by_name(&name, node.r())
+                Document::filter_by_name(&name, node.r())
             }).peekable();
             if let Some(first) = elements.next() {
                 if elements.is_empty() {
@@ -1829,8 +1748,8 @@ impl<'a> DocumentMethods for &'a Document {
         // Step 4.
         *found = true;
         let window = self.window();
-        let filter = NamedElementFilter { name: name };
-        let collection = HTMLCollection::create(window.r(), root, box filter);
+        let filter = CollectionFilter::NamedElement(name);
+        let collection = HTMLCollection::create(window.r(), root, filter);
         collection.r().reflector().get_jsobject().get()
     }
 

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -4,29 +4,102 @@
 
 use dom::bindings::codegen::Bindings::HTMLCollectionBinding;
 use dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
+use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::InheritTypes::{ElementCast, NodeCast};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::trace::JSTraceable;
 use dom::bindings::utils::{namespace_from_domstring, Reflector, reflect_dom_object};
 use dom::element::{Element, AttributeHandlers, ElementHelpers};
+use dom::document::{Document, DocumentHelpers};
 use dom::node::{Node, NodeHelpers, TreeIterator};
 use dom::window::Window;
-use util::str::{DOMString, split_html_space_chars};
+use util::str::{DOMString, StaticStringVec, split_html_space_chars};
 
 use std::ascii::AsciiExt;
 use std::iter::{FilterMap, Skip};
 use string_cache::{Atom, Namespace};
 
-pub trait CollectionFilter : JSTraceable {
-    fn filter<'a>(&self, elem: &'a Element, root: &'a Node) -> bool;
+use dom::bindings::codegen::InheritTypes::{HTMLAnchorElementDerived, HTMLAppletElementDerived};
+use dom::bindings::codegen::InheritTypes::{HTMLAreaElementDerived, HTMLEmbedElementDerived};
+use dom::bindings::codegen::InheritTypes::{HTMLFormElementDerived, HTMLImageElementDerived};
+use dom::bindings::codegen::InheritTypes::{HTMLScriptElementDerived};
+use dom::bindings::codegen::InheritTypes::HTMLOptionElementDerived;
+
+#[derive(Clone, Hash, PartialEq, Eq, JSTraceable)]
+pub enum CollectionFilter {
+    AllElements(Option<Namespace>),
+    TagName(Atom, Atom),
+    TagNameNS(Atom, Option<Namespace>),
+    ClassName(Vec<Atom>),
+    ElementChild,
+    Images,
+    Embeds,
+    Links,
+    Forms,
+    Scripts,
+    Anchors,
+    Applets,
+    NamedElement(Atom),
+    DataListOptions,
+    FieldSetElements,
+}
+
+impl CollectionFilter {
+    fn filter(&self, elem: &Element, root: &Node) -> bool {
+        match self {
+            &CollectionFilter::AllElements(ref namespace_filter) => {
+                match namespace_filter {
+                    &None => true,
+                    &Some(ref namespace) => elem.namespace() == namespace
+                }
+            },
+            &CollectionFilter::TagName(ref tag, ref ascii_lower_tag) => {
+                if elem.html_element_in_html_document() {
+                    elem.local_name() == ascii_lower_tag
+                } else {
+                    elem.local_name() == tag
+                }
+            },
+            &CollectionFilter::TagNameNS(ref tag, ref namespace_filter) => {
+                let ns_match = match namespace_filter {
+                    &Some(ref namespace) => {
+                        elem.namespace() == namespace
+                    },
+                    &None => true
+                };
+                ns_match && elem.local_name() == tag
+             },
+             &CollectionFilter::ClassName(ref classes) =>
+                 classes.iter().all(|class| elem.has_class(class)),
+             &CollectionFilter::ElementChild => root.is_parent_of(NodeCast::from_ref(elem)),
+             &CollectionFilter::Images => elem.is_htmlimageelement(),
+             &CollectionFilter::Embeds => elem.is_htmlembedelement(),
+             &CollectionFilter::Links =>
+                (elem.is_htmlanchorelement() || elem.is_htmlareaelement()) &&
+                    elem.has_attribute(&atom!("href")),
+             &CollectionFilter::Forms => elem.is_htmlformelement(),
+             &CollectionFilter::Scripts => elem.is_htmlscriptelement(),
+             &CollectionFilter::Anchors =>
+                 elem.is_htmlanchorelement() && elem.has_attribute(&atom!("href")),
+             &CollectionFilter::Applets => elem.is_htmlappletelement(),
+             &CollectionFilter::NamedElement(ref name) =>
+                 Document::filter_by_name(&name, NodeCast::from_ref(elem)),
+             &CollectionFilter::DataListOptions => elem.is_htmloptionelement(),
+             &CollectionFilter::FieldSetElements => {
+                static TAG_NAMES: StaticStringVec = &["button", "fieldset", "input",
+                    "keygen", "object", "output", "select", "textarea"];
+                TAG_NAMES.iter().any(|&tag_name| tag_name == &**elem.local_name())
+             }
+        }
+    }
 }
 
 #[derive(JSTraceable)]
 #[must_root]
 pub enum CollectionTypeId {
     Static(Vec<JS<Element>>),
-    Live(JS<Node>, Box<CollectionFilter+'static>)
+    Live(JS<Node>, CollectionFilter)
 }
 
 #[dom_struct]
@@ -51,26 +124,23 @@ impl HTMLCollection {
 
 impl HTMLCollection {
     pub fn create(window: &Window, root: &Node,
-                  filter: Box<CollectionFilter+'static>) -> Root<HTMLCollection> {
-        HTMLCollection::new(window, CollectionTypeId::Live(JS::from_ref(root), filter))
+                  filter: CollectionFilter) -> Root<HTMLCollection> {
+        let key = (root as *const Node as usize, filter.clone());
+        match window.Document().get_collection(&key) {
+            Some(existing) => existing,
+            _ => {
+                let collection =
+                    HTMLCollection::new(window, CollectionTypeId::Live(JS::from_ref(root), filter));
+                window.Document().add_collection(key, collection.r());
+                collection
+            }
+        }
     }
 
     fn all_elements(window: &Window, root: &Node,
                     namespace_filter: Option<Namespace>) -> Root<HTMLCollection> {
-        #[derive(JSTraceable)]
-        struct AllElementFilter {
-            namespace_filter: Option<Namespace>
-        }
-        impl CollectionFilter for AllElementFilter {
-            fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                match self.namespace_filter {
-                    None => true,
-                    Some(ref namespace) => *elem.namespace() == *namespace
-                }
-            }
-        }
-        let filter = AllElementFilter {namespace_filter: namespace_filter};
-        HTMLCollection::create(window, root, box filter)
+        let filter = CollectionFilter::AllElements(namespace_filter);
+        HTMLCollection::create(window, root, filter)
     }
 
     pub fn by_tag_name(window: &Window, root: &Node, tag: DOMString)
@@ -79,25 +149,9 @@ impl HTMLCollection {
             return HTMLCollection::all_elements(window, root, None);
         }
 
-        #[derive(JSTraceable)]
-        struct TagNameFilter {
-            tag: Atom,
-            ascii_lower_tag: Atom,
-        }
-        impl CollectionFilter for TagNameFilter {
-            fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                if elem.html_element_in_html_document() {
-                    *elem.local_name() == self.ascii_lower_tag
-                } else {
-                    *elem.local_name() == self.tag
-                }
-            }
-        }
-        let filter = TagNameFilter {
-            tag: Atom::from_slice(&tag),
-            ascii_lower_tag: Atom::from_slice(&tag.to_ascii_lowercase()),
-        };
-        HTMLCollection::create(window, root, box filter)
+        let filter = CollectionFilter::TagName(Atom::from_slice(&tag),
+                                               Atom::from_slice(&tag.to_ascii_lowercase()));
+        HTMLCollection::create(window, root, filter)
     }
 
     pub fn by_tag_name_ns(window: &Window, root: &Node, tag: DOMString,
@@ -110,57 +164,23 @@ impl HTMLCollection {
         if tag == "*" {
             return HTMLCollection::all_elements(window, root, namespace_filter);
         }
-        #[derive(JSTraceable)]
-        struct TagNameNSFilter {
-            tag: Atom,
-            namespace_filter: Option<Namespace>
-        }
-        impl CollectionFilter for TagNameNSFilter {
-            fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                let ns_match = match self.namespace_filter {
-                    Some(ref namespace) => {
-                        *elem.namespace() == *namespace
-                    },
-                    None => true
-                };
-                ns_match && *elem.local_name() == self.tag
-            }
-        }
-        let filter = TagNameNSFilter {
-            tag: Atom::from_slice(&tag),
-            namespace_filter: namespace_filter
-        };
-        HTMLCollection::create(window, root, box filter)
+        let filter = CollectionFilter::TagNameNS(Atom::from_slice(&tag), namespace_filter);
+        HTMLCollection::create(window, root, filter)
     }
 
     pub fn by_class_name(window: &Window, root: &Node, classes: DOMString)
                          -> Root<HTMLCollection> {
-        #[derive(JSTraceable)]
-        struct ClassNameFilter {
-            classes: Vec<Atom>
-        }
-        impl CollectionFilter for ClassNameFilter {
-            fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                self.classes.iter().all(|class| elem.has_class(class))
-            }
-        }
-        let filter = ClassNameFilter {
-            classes: split_html_space_chars(&classes).map(|class| {
-                         Atom::from_slice(class)
-                     }).collect()
-        };
-        HTMLCollection::create(window, root, box filter)
+        let filter = CollectionFilter::ClassName(
+            split_html_space_chars(&classes).map(|class| {
+                Atom::from_slice(class)
+            }).collect()
+        );
+
+        HTMLCollection::create(window, root, filter)
     }
 
     pub fn children(window: &Window, root: &Node) -> Root<HTMLCollection> {
-        #[derive(JSTraceable)]
-        struct ElementChildFilter;
-        impl CollectionFilter for ElementChildFilter {
-            fn filter(&self, elem: &Element, root: &Node) -> bool {
-                root.is_parent_of(NodeCast::from_ref(elem))
-            }
-        }
-        HTMLCollection::create(window, root, box ElementChildFilter)
+        HTMLCollection::create(window, root, CollectionFilter::ElementChild)
     }
 
     fn traverse(root: &Node)

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -4,11 +4,10 @@
 
 use dom::bindings::codegen::Bindings::HTMLDataListElementBinding;
 use dom::bindings::codegen::Bindings::HTMLDataListElementBinding::HTMLDataListElementMethods;
-use dom::bindings::codegen::InheritTypes::{HTMLDataListElementDerived, HTMLOptionElementDerived};
+use dom::bindings::codegen::InheritTypes::{HTMLDataListElementDerived};
 use dom::bindings::codegen::InheritTypes::NodeCast;
 use dom::bindings::js::Root;
 use dom::document::Document;
-use dom::element::Element;
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlcollection::{HTMLCollection, CollectionFilter};
 use dom::element::ElementTypeId;
@@ -51,15 +50,8 @@ impl HTMLDataListElement {
 impl<'a> HTMLDataListElementMethods for &'a HTMLDataListElement {
     // https://html.spec.whatwg.org/multipage/#dom-datalist-options
     fn Options(self) -> Root<HTMLCollection> {
-        #[derive(JSTraceable)]
-        struct HTMLDataListOptionsFilter;
-        impl CollectionFilter for HTMLDataListOptionsFilter {
-            fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                elem.is_htmloptionelement()
-            }
-        }
         let node = NodeCast::from_ref(self);
-        let filter = box HTMLDataListOptionsFilter;
+        let filter = CollectionFilter::DataListOptions;
         let window = window_from_node(node);
         HTMLCollection::create(window.r(), node, filter)
     }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -10,7 +10,7 @@ use dom::bindings::codegen::InheritTypes::{HTMLFieldSetElementDerived, NodeCast}
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLLegendElementDerived};
 use dom::bindings::js::{Root, RootedReference};
 use dom::document::Document;
-use dom::element::{AttributeHandlers, Element, ElementHelpers};
+use dom::element::{AttributeHandlers, ElementHelpers};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlcollection::{HTMLCollection, CollectionFilter};
 use dom::element::ElementTypeId;
@@ -19,7 +19,7 @@ use dom::node::{DisabledStateHelpers, Node, NodeHelpers, NodeTypeId, window_from
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 
-use util::str::{DOMString, StaticStringVec};
+use util::str::DOMString;
 
 #[dom_struct]
 pub struct HTMLFieldSetElement {
@@ -56,17 +56,8 @@ impl HTMLFieldSetElement {
 impl<'a> HTMLFieldSetElementMethods for &'a HTMLFieldSetElement {
     // https://www.whatwg.org/html/#dom-fieldset-elements
     fn Elements(self) -> Root<HTMLCollection> {
-        #[derive(JSTraceable)]
-        struct ElementsFilter;
-        impl CollectionFilter for ElementsFilter {
-            fn filter<'a>(&self, elem: &'a Element, _root: &'a Node) -> bool {
-                static TAG_NAMES: StaticStringVec = &["button", "fieldset", "input",
-                    "keygen", "object", "output", "select", "textarea"];
-                TAG_NAMES.iter().any(|&tag_name| tag_name == &**elem.local_name())
-            }
-        }
         let node = NodeCast::from_ref(self);
-        let filter = box ElementsFilter;
+        let filter = CollectionFilter::FieldSetElements;
         let window = window_from_node(node);
         HTMLCollection::create(window.r(), node, filter)
     }


### PR DESCRIPTION
The first commit doesn't actually improve speed, it just caches the HTMLCollection itself.  This matches what other browsers do and although not required by the spec, content may rely on things like 

```
document.getElementsByTagName("table").foo=3
alert(document.getElementsByTagName("table").foo)
```

The second commit caches the actual elements found, until the HTMLCollection becomes dirty.  This is broken because the dirty flag is currently not set anywhere, but it shouldn't be too hard to add some sets to document and call those when nodes are added/removed/modified/etc.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6927)

<!-- Reviewable:end -->
