### PR TITLE
Make SSL cert verification errors work again. Add a horrible, no-good…

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4559,6 +4559,12 @@
             "url": "/_mozilla/mozilla/MouseEvent.html"
           }
         ],
+        "mozilla/bad_cert_detected.html": [
+          {
+            "path": "mozilla/bad_cert_detected.html",
+            "url": "/_mozilla/mozilla/bad_cert_detected.html"
+          }
+        ],
         "mozilla/blob.html": [
           {
             "path": "mozilla/blob.html",

--- a/tests/wpt/mozilla/tests/mozilla/bad_cert_detected.html
+++ b/tests/wpt/mozilla/tests/mozilla/bad_cert_detected.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/origin_helpers.js?pipe=sub"></script>
+</head>
+<body>
+<script>
+var t = async_test("Invalid SSL cert noticed");
+t.step(function() {
+  var target = location.href.replace(HTTP_ORIGIN, HTTPS_ORIGIN)
+                            .replace('bad_cert_detected.html',
+                                     'resources/origin_helpers.js');
+  // Servo currently lacks the ability to introspect any content that is blocked
+  // due to a cert error, so we use a roundabout method to infer that that's happened.
+  // When the worker has a cert failure, that translates into attempting to evaluate the
+  // contents of badcert.html as JS, which triggers an exception that currently does not
+  // propagate to the parent scope. If we _do_ get an error event in the parent scope,
+  // that means that the cert verification was treated no different than any other
+  // network error, since we dispatch an error event in that case.
+  var w = new Worker(target);
+  w.addEventListener('error', t.unreached_func("cert not detected as invalid"), false);
+  // We infer that we detected an invalid cert if nothing happens for a few seconds.
+  setTimeout(function() { t.done() }, 3000);
+});
+</script>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/resources/origin_helpers.js
+++ b/tests/wpt/mozilla/tests/mozilla/resources/origin_helpers.js
@@ -1,0 +1,5 @@
+var HTTP_PORT = '{{ports[http][0]}}';
+var HTTPS_PORT = '{{ports[https][0]}}';
+var ORIGINAL_HOST = '\'{{host}}\'';
+var HTTP_ORIGIN = 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT;
+var HTTPS_ORIGIN = 'https://' + ORIGINAL_HOST + ':' + HTTPS_PORT;


### PR DESCRIPTION
…, very bad regression test.

Here are the list of awful things this test exploits:
- Servo can't load HTTPS content in WPT tests (#6919)
- Our web workers don't report error events to the parent worker object after the initial network load completes
- Our worker resource load don't have a same-origin check

The good news is that this test should start failing if any of those "features" change, so this should not silently break on us.

Other attempts to test this included:
- iframes (didn't work because of #6672 and #3939)
- XMLHttpRequest (I was hit by CORS, I think; maybe I could have made it work if I returned the right headers)

r? @Ms2ger

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6935)

<!-- Reviewable:end -->
