### PR TITLE
construct: When repairing styles for incremental reflow, only repair styles of nodes that represent the dirty node.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1272,6 +1272,11 @@ impl<'a> FlowConstructor<'a> {
                 for fragment in inline_fragments_construction_result.fragments
                                                                     .fragments
                                                                     .iter_mut() {
+                    // Only mutate the styles of fragments that represent the dirty node.
+                    if fragment.node != node.opaque() {
+                        continue
+                    }
+
                     match fragment.specific {
                         SpecificFragmentInfo::InlineBlock(ref mut inline_block_fragment) => {
                             flow::mut_base(&mut *inline_block_fragment.flow_ref).restyle_damage


### PR DESCRIPTION
Fixes jumpiness on many pages; e.g. the WPT results pages.

For some reason, this would not reproduce with an automated test.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6938)

<!-- Reviewable:end -->
