### PR TITLE
layout: If the container of a block formatting context has margins in the inline direction, subtract those from the inline size of preceding floats.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1300,8 +1300,10 @@ impl BlockFlow {
         let mut inline_size_of_preceding_left_floats = Au(0);
         let mut inline_size_of_preceding_right_floats = Au(0);
         if self.formatting_context_type() == FormattingContextType::None {
-            inline_size_of_preceding_left_floats = self.inline_size_of_preceding_left_floats;
-            inline_size_of_preceding_right_floats = self.inline_size_of_preceding_right_floats;
+            inline_size_of_preceding_left_floats =
+                max(self.inline_size_of_preceding_left_floats - inline_start_content_edge, Au(0));
+            inline_size_of_preceding_right_floats =
+                max(self.inline_size_of_preceding_right_floats - inline_end_content_edge, Au(0));
         }
 
         let opaque_self = OpaqueFlow::from_flow(self);
@@ -1319,7 +1321,6 @@ impl BlockFlow {
         // FIXME (mbrubeck): Get correct mode for absolute containing block
         let containing_block_mode = self.base.writing_mode;
 
-        // This value is used only for table cells.
         let mut inline_start_margin_edge = inline_start_content_edge;
         let mut inline_end_margin_edge = inline_end_content_edge;
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -43,6 +43,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == block_formatting_context_float_placement_a.html block_formatting_context_float_placement_ref.html
 == block_formatting_context_relative_a.html block_formatting_context_ref.html
 == block_formatting_context_translation_a.html block_formatting_context_translation_ref.html
+== block_formatting_context_with_margin_a.html block_formatting_context_with_margin_ref.html
 == block_image.html 500x300_green.html
 != block_image.html noteq_500x300_white.html
 == block_replaced_content_a.html block_replaced_content_ref.html

--- a/tests/ref/block_formatting_context_with_margin_a.html
+++ b/tests/ref/block_formatting_context_with_margin_a.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+<style>
+#float {
+    float: right;
+    width: 150px;
+}
+
+section {
+    margin-right: 450px;
+    background: gold;
+}
+
+#a {
+    font-size: 48px;
+    overflow: hidden;
+}
+</style>
+</head>
+
+<body>
+<div id=float></div>
+<section>
+    <div id=a>set breakpoints from within the comfort of your editor</div>
+</section>
+</body>
+</html>

--- a/tests/ref/block_formatting_context_with_margin_ref.html
+++ b/tests/ref/block_formatting_context_with_margin_ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+<style>
+#float {
+    float: right;
+    width: 150px;
+}
+
+section {
+    margin-right: 450px;
+    background: gold;
+}
+
+#a {
+    font-size: 48px;
+}
+</style>
+</head>
+
+<body>
+<div id=float></div>
+<section>
+    <div id=a>set breakpoints from within the comfort of your editor</div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
Makes the content area on http://reddit.com/r/rust visible.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6946)

<!-- Reviewable:end -->
