### PR TITLE
Upgrade cssparser

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -96,7 +96,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "gleam 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -113,7 +113,7 @@ name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -737,7 +737,7 @@ dependencies = [
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
  "clock_ticks 0.0.6 (git+https://github.com/tomaka/clock_ticks)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1187,7 +1187,7 @@ dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1253,7 +1253,7 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-selectors#e4d0af9115b82e47890a67a678aaa27aa270f083"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1372,7 +1372,7 @@ name = "style"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1396,7 +1396,7 @@ dependencies = [
 name = "style_tests"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
  "string_cache 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1502,7 +1502,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -100,7 +100,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "gleam 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -117,7 +117,7 @@ name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -735,7 +735,7 @@ dependencies = [
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
  "clock_ticks 0.0.6 (git+https://github.com/tomaka/clock_ticks)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1171,7 +1171,7 @@ dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1229,7 +1229,7 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-selectors#e4d0af9115b82e47890a67a678aaa27aa270f083"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1374,7 +1374,7 @@ name = "style"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1490,7 +1490,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -81,7 +81,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "gleam 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -98,7 +98,7 @@ name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -662,7 +662,7 @@ dependencies = [
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
  "clock_ticks 0.0.6 (git+https://github.com/tomaka/clock_ticks)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1072,7 +1072,7 @@ dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1130,7 +1130,7 @@ version = "0.1.0"
 source = "git+https://github.com/servo/rust-selectors#e4d0af9115b82e47890a67a678aaa27aa270f083"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1265,7 +1265,7 @@ name = "style"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1372,7 +1372,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-047.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-047.htm.ini
@@ -1,3 +1,0 @@
-[background-color-047.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-057.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-057.htm.ini
@@ -1,3 +1,0 @@
-[background-color-057.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-068.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-068.htm.ini
@@ -1,3 +1,0 @@
-[background-color-068.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-069.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-069.htm.ini
@@ -1,3 +1,0 @@
-[background-color-069.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-078.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-078.htm.ini
@@ -1,3 +1,0 @@
-[background-color-078.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-088.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-088.htm.ini
@@ -1,3 +1,0 @@
-[background-color-088.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-089.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-089.htm.ini
@@ -1,3 +1,0 @@
-[background-color-089.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-098.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-098.htm.ini
@@ -1,3 +1,0 @@
-[background-color-098.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-108.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-108.htm.ini
@@ -1,3 +1,0 @@
-[background-color-108.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-109.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-109.htm.ini
@@ -1,3 +1,0 @@
-[background-color-109.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-118.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-118.htm.ini
@@ -1,3 +1,0 @@
-[background-color-118.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-color-128.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-color-128.htm.ini
@@ -1,3 +1,0 @@
-[background-color-128.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-047.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-047.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-047.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-057.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-057.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-057.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-068.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-068.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-068.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-069.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-069.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-069.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-078.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-078.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-078.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-088.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-088.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-088.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-089.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-089.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-089.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-098.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-098.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-098.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-108.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-108.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-108.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-109.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-109.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-109.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-118.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-118.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-118.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-128.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-128.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-128.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-047.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-047.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-047.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-057.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-057.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-057.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-068.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-068.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-068.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-069.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-069.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-069.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-078.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-078.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-078.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-088.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-088.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-088.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-089.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-089.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-089.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-098.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-098.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-098.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-108.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-108.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-108.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-109.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-109.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-109.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-118.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-118.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-118.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-128.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-128.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-128.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-047.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-047.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-047.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-057.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-057.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-057.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-068.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-068.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-068.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-069.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-069.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-069.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-078.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-078.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-078.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-088.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-088.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-088.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-089.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-089.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-089.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-098.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-098.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-098.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-108.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-108.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-108.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-109.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-109.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-109.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-118.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-118.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-118.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-128.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-128.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-128.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-047.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-047.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-047.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-057.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-057.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-057.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-068.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-068.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-068.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-069.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-069.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-069.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-078.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-078.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-078.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-088.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-088.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-088.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-089.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-089.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-089.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-098.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-098.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-098.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-108.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-108.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-108.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-109.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-109.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-109.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-118.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-118.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-118.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-top-color-128.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-top-color-128.htm.ini
@@ -1,3 +1,0 @@
-[border-top-color-128.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-1.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-1.html.ini
@@ -1,5 +1,0 @@
-[2d.fillStyle.parse.rgb-clamp-1.html]
-  type: testharness
-  [Canvas test: 2d.fillStyle.parse.rgb-clamp-1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-2.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-2.html.ini
@@ -1,5 +1,0 @@
-[2d.fillStyle.parse.rgb-clamp-2.html]
-  type: testharness
-  [Canvas test: 2d.fillStyle.parse.rgb-clamp-2]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-3.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-3.html.ini
@@ -1,3 +1,0 @@
-[2d.fillStyle.parse.rgb-clamp-3.html]
-  type: testharness
-  disabled: 5285 and https://github.com/servo/rust-cssparser/issues/72

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-4.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-4.html.ini
@@ -1,3 +1,0 @@
-[2d.fillStyle.parse.rgb-clamp-4.html]
-  type: testharness
-  disabled: 5285 and https://github.com/servo/rust-cssparser/issues/72

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html.ini
@@ -1,3 +1,0 @@
-[2d.fillStyle.parse.rgb-clamp-5.html]
-  type: testharness
-  disabled: 5285 and https://github.com/servo/rust-cssparser/issues/72

--- a/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.get.clamp.html.ini
+++ b/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.get.clamp.html.ini
@@ -1,5 +1,0 @@
-[2d.imageData.get.clamp.html]
-  type: testharness
-  [getImageData() clamps colours to the range [0, 255\]]
-    expected: FAIL
-


### PR DESCRIPTION
Pick up the fix for https://github.com/servo/rust-cssparser/issues/76

`*.ini` files removal based on running `./mach test-css tests/wpt/css-tests/css21_dev/html4/*color*`, I didn’t run the whole test suite.

r? @larsbergstrom

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6957)

<!-- Reviewable:end -->
