### PR TITLE
layout: Make sure anonymous table flows are statically positioned.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -45,7 +45,6 @@ use layout_debug;
 use layout_task::DISPLAY_PORT_SIZE_FACTOR;
 use model::{IntrinsicISizes, MarginCollapseInfo};
 use model::{MaybeAuto, CollapsibleMargins, specified, specified_or_none};
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect, Size2D};
 use gfx::display_list::{ClippingRegion, DisplayList};
@@ -572,13 +571,10 @@ impl Encodable for BlockFlowFlags {
 }
 
 impl BlockFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode,
-                                  fragment: Fragment,
-                                  float_kind: Option<FloatKind>)
-                                  -> BlockFlow {
-        let writing_mode = node.style().writing_mode;
+    pub fn from_fragment(fragment: Fragment, float_kind: Option<FloatKind>) -> BlockFlow {
+        let writing_mode = fragment.style().writing_mode;
         BlockFlow {
-            base: BaseFlow::new(Some((*node).clone()), writing_mode, match float_kind {
+            base: BaseFlow::new(Some(fragment.style()), writing_mode, match float_kind {
                 Some(_) => ForceNonfloatedFlag::FloatIfNecessary,
                 None => ForceNonfloatedFlag::ForceNonfloated,
             }),

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -17,7 +17,6 @@ use generated_content;
 use incremental::RESOLVE_GENERATED_CONTENT;
 use inline::InlineMetrics;
 use text;
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use gfx::display_list::DisplayList;
@@ -39,13 +38,12 @@ pub struct ListItemFlow {
 }
 
 impl ListItemFlow {
-    pub fn from_node_fragments_and_flotation(node: &ThreadSafeLayoutNode,
-                                             main_fragment: Fragment,
-                                             marker_fragment: Option<Fragment>,
-                                             flotation: Option<FloatKind>)
-                                             -> ListItemFlow {
+    pub fn from_fragments_and_flotation(main_fragment: Fragment,
+                                        marker_fragment: Option<Fragment>,
+                                        flotation: Option<FloatKind>)
+                                        -> ListItemFlow {
         let mut this = ListItemFlow {
-            block_flow: BlockFlow::from_node_and_fragment(node, main_fragment, flotation),
+            block_flow: BlockFlow::from_fragment(main_fragment, flotation),
             marker: marker_fragment,
         };
 

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -11,7 +11,6 @@ use context::LayoutContext;
 use floats::FloatKind;
 use flow::{FlowClass, Flow, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator};
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use util::geometry::Au;
@@ -25,12 +24,9 @@ pub struct MulticolFlow {
 }
 
 impl MulticolFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode,
-                                  fragment: Fragment,
-                                  float_kind: Option<FloatKind>)
-                                  -> MulticolFlow {
+    pub fn from_fragment(fragment: Fragment, float_kind: Option<FloatKind>) -> MulticolFlow {
         MulticolFlow {
-            block_flow: BlockFlow::from_node_and_fragment(node, fragment, float_kind)
+            block_flow: BlockFlow::from_fragment(fragment, float_kind)
         }
     }
 }

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -19,7 +19,6 @@ use model::{IntrinsicISizes, IntrinsicISizesContribution, MaybeAuto};
 use table_row::{self, CellIntrinsicInlineSize, CollapsedBorder, CollapsedBorderProvenance};
 use table_row::{TableRowFlow};
 use table_wrapper::TableLayout;
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use gfx::display_list::DisplayList;
@@ -61,10 +60,8 @@ pub struct TableFlow {
 }
 
 impl TableFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode,
-                                  fragment: Fragment)
-                                  -> TableFlow {
-        let mut block_flow = BlockFlow::from_node_and_fragment(node, fragment, None);
+    pub fn from_fragment(fragment: Fragment) -> TableFlow {
+        let mut block_flow = BlockFlow::from_fragment(fragment, None);
         let table_layout =
             if block_flow.fragment().style().get_table().table_layout == table_layout::T::fixed {
                 TableLayout::Fixed

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -10,7 +10,6 @@ use block::BlockFlow;
 use context::LayoutContext;
 use flow::{FlowClass, Flow, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator};
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use util::geometry::Au;
@@ -25,10 +24,9 @@ pub struct TableCaptionFlow {
 }
 
 impl TableCaptionFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode, fragment: Fragment)
-                                  -> TableCaptionFlow {
+    pub fn from_fragment(fragment: Fragment) -> TableCaptionFlow {
         TableCaptionFlow {
-            block_flow: BlockFlow::from_node_and_fragment(node, fragment, None)
+            block_flow: BlockFlow::from_fragment(fragment, None)
         }
     }
 }

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -51,7 +51,7 @@ impl TableCellFlow {
                                                   visible: bool)
                                                   -> TableCellFlow {
         TableCellFlow {
-            block_flow: BlockFlow::from_node_and_fragment(node, fragment, None),
+            block_flow: BlockFlow::from_fragment(fragment, None),
             collapsed_borders: CollapsedBordersForCell::new(),
             column_span: node.get_unsigned_integer_attribute(UnsignedIntegerAttribute::ColSpan)
                              .unwrap_or(1),

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -10,7 +10,6 @@ use context::LayoutContext;
 use flow::{BaseFlow, FlowClass, Flow, ForceNonfloatedFlag, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, SpecificFragmentInfo};
 use layout_debug;
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use util::geometry::{Au, ZERO_RECT};
@@ -39,13 +38,12 @@ pub struct TableColGroupFlow {
 }
 
 impl TableColGroupFlow {
-    pub fn from_node_and_fragments(node: &ThreadSafeLayoutNode,
-                                   fragment: Fragment,
-                                   fragments: Vec<Fragment>)
-                                   -> TableColGroupFlow {
-        let writing_mode = node.style().writing_mode;
+    pub fn from_fragments(fragment: Fragment, fragments: Vec<Fragment>) -> TableColGroupFlow {
+        let writing_mode = fragment.style().writing_mode;
         TableColGroupFlow {
-            base: BaseFlow::new(Some((*node).clone()), writing_mode, ForceNonfloatedFlag::ForceNonfloated),
+            base: BaseFlow::new(Some(fragment.style()),
+                                writing_mode,
+                                ForceNonfloatedFlag::ForceNonfloated),
             fragment: Some(fragment),
             cols: fragments,
             inline_sizes: vec!(),

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -16,7 +16,6 @@ use layout_debug;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, InternalTable, VecExt};
 use table_cell::{CollapsedBordersForCell, TableCellFlow};
 use model::MaybeAuto;
-use wrapper::ThreadSafeLayoutNode;
 
 use cssparser::{Color, RGBA};
 use euclid::{Point2D, Rect};
@@ -80,11 +79,10 @@ pub struct CellIntrinsicInlineSize {
 
 
 impl TableRowFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode, fragment: Fragment)
-                                  -> TableRowFlow {
+    pub fn from_fragment(fragment: Fragment) -> TableRowFlow {
         let writing_mode = fragment.style().writing_mode;
         TableRowFlow {
-            block_flow: BlockFlow::from_node_and_fragment(node, fragment, None),
+            block_flow: BlockFlow::from_fragment(fragment, None),
             cell_intrinsic_inline_sizes: Vec::new(),
             column_computed_inline_sizes: Vec::new(),
             spacing: border_spacing::T {

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -14,7 +14,6 @@ use layout_debug;
 use style::computed_values::{border_collapse, border_spacing};
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, InternalTable, TableLikeFlow};
 use table_row::{self, CollapsedBordersForRow};
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use rustc_serialize::{Encoder, Encodable};
@@ -63,11 +62,10 @@ impl Encodable for TableRowGroupFlow {
 }
 
 impl TableRowGroupFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode, fragment: Fragment)
-                                  -> TableRowGroupFlow {
+    pub fn from_fragment(fragment: Fragment) -> TableRowGroupFlow {
         let writing_mode = fragment.style().writing_mode;
         TableRowGroupFlow {
-            block_flow: BlockFlow::from_node_and_fragment(node, fragment, None),
+            block_flow: BlockFlow::from_fragment(fragment, None),
             column_intrinsic_inline_sizes: Vec::new(),
             column_computed_inline_sizes: Vec::new(),
             spacing: border_spacing::T {

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -23,7 +23,6 @@ use fragment::{Fragment, FragmentBorderBoxIterator};
 use model::MaybeAuto;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize};
 use table_row;
-use wrapper::ThreadSafeLayoutNode;
 
 use euclid::{Point2D, Rect};
 use util::geometry::Au;
@@ -56,11 +55,8 @@ pub struct TableWrapperFlow {
 }
 
 impl TableWrapperFlow {
-    pub fn from_node_and_fragment(node: &ThreadSafeLayoutNode,
-                                  fragment: Fragment,
-                                  float_kind: Option<FloatKind>)
-                                  -> TableWrapperFlow {
-        let mut block_flow = BlockFlow::from_node_and_fragment(node, fragment, float_kind);
+    pub fn from_fragment(fragment: Fragment, float_kind: Option<FloatKind>) -> TableWrapperFlow {
+        let mut block_flow = BlockFlow::from_fragment(fragment, float_kind);
         let table_layout = if block_flow.fragment().style().get_table().table_layout ==
                               table_layout::T::fixed {
             TableLayout::Fixed

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -6517,6 +6517,17 @@ pub fn modify_style_for_inline_sides(style: &mut Arc<ComputedValues>,
     }
 }
 
+/// Adjusts the display and position properties as appropriate for an anonymous table object.
+#[inline]
+pub fn modify_style_for_anonymous_table_object(
+        style: &mut Arc<ComputedValues>,
+        new_display_value: longhands::display::computed_value::T) {
+    let mut style = Arc::make_unique(style);
+    let box_style = Arc::make_unique(&mut style.box_);
+    box_style.display = new_display_value;
+    box_style.position = longhands::position::computed_value::T::static_;
+}
+
 pub fn is_supported_property(property: &str) -> bool {
     match_ignore_ascii_case! { property,
         % for property in SHORTHANDS + LONGHANDS[:-1]:

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-004c.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-004c.htm.ini
@@ -1,3 +1,3 @@
 [abspos-containing-block-initial-004c.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-004d.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-004d.htm.ini
@@ -1,3 +1,3 @@
 [abspos-containing-block-initial-004d.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005b.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005b.htm.ini
@@ -1,3 +1,3 @@
 [abspos-containing-block-initial-005b.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005d.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005d.htm.ini
@@ -1,3 +1,3 @@
 [abspos-containing-block-initial-005d.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-001a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-001a.htm.ini
@@ -1,0 +1,4 @@
+[float-applies-to-001a.htm]
+  type: reftest
+  expected: FAIL
+

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-004a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-004a.htm.ini
@@ -1,0 +1,4 @@
+[float-applies-to-004a.htm]
+  type: reftest
+  expected: FAIL
+

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-005.htm.ini
@@ -1,0 +1,4 @@
+[float-applies-to-005.htm]
+  type: reftest
+  expected: FAIL
+

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-006.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-006.htm.ini
@@ -1,0 +1,4 @@
+[float-applies-to-006.htm]
+  type: reftest
+  expected: FAIL
+


### PR DESCRIPTION
The failing `float-applies-to-*` CSS 2.1 tests never really should have
been passing in the first place; they depend on floats inside
fixed-layout tables working properly, which they don't.

Closes #6078.
Closes #6709.
Closes #6858.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6977)

<!-- Reviewable:end -->
