### PR TITLE
layout: Take borders into account when positioning inline fragments on their baselines.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1818,15 +1818,23 @@ impl Fragment {
                                                              .computed_block_size();
                 InlineMetrics {
                     block_size_above_baseline: computed_block_size +
-                                                   self.border_padding.block_start_end(),
-                    depth_below_baseline: Au(0),
-                    ascent: computed_block_size + self.border_padding.block_start_end(),
+                                                   self.border_padding.block_start,
+                    depth_below_baseline: self.border_padding.block_end,
+                    ascent: computed_block_size + self.border_padding.block_start,
                 }
             }
             SpecificFragmentInfo::ScannedText(ref text_fragment) => {
                 // See CSS 2.1 § 10.8.1.
                 let line_height = self.calculate_line_height(layout_context);
-                InlineMetrics::from_font_metrics(&text_fragment.run.font_metrics, line_height)
+                let font_derived_metrics =
+                    InlineMetrics::from_font_metrics(&text_fragment.run.font_metrics, line_height);
+                InlineMetrics {
+                    block_size_above_baseline: font_derived_metrics.block_size_above_baseline +
+                                                   self.border_padding.block_start,
+                    depth_below_baseline: font_derived_metrics.depth_below_baseline +
+                        self.border_padding.block_end,
+                    ascent: font_derived_metrics.ascent + self.border_padding.block_start,
+                }
             }
             SpecificFragmentInfo::InlineBlock(ref info) => {
                 // See CSS 2.1 § 10.8.1.

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -157,6 +157,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 == inline_block_stacking_context_a.html inline_block_stacking_context_ref.html
 == inline_block_with_margin_a.html inline_block_with_margin_ref.html
 # inline_border_a.html inline_border_b.html
+== inline_border_baseline_a.html inline_border_baseline_ref.html
 == inline_element_border_a.html inline_element_border_ref.html
 == inline_hypothetical_box_a.html inline_hypothetical_box_ref.html
 == inline_margin_multiple_fragments_a.html inline_margin_multiple_fragments_ref.html

--- a/tests/ref/inline_border_baseline_a.html
+++ b/tests/ref/inline_border_baseline_a.html
@@ -1,0 +1,7 @@
+<style>
+em {
+    border-top: solid white 3px;
+}
+</style>
+I am <em>very excited!</em>
+

--- a/tests/ref/inline_border_baseline_ref.html
+++ b/tests/ref/inline_border_baseline_ref.html
@@ -1,0 +1,7 @@
+<style>
+span {
+    border-top: solid white 3px;
+}
+</style>
+<span>I am <em>very excited!</em></span>
+


### PR DESCRIPTION
Improves the Rust GitHub page.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6980)

<!-- Reviewable:end -->
