### PR TITLE
Prevent flake8 from crashing tidy

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -153,7 +153,7 @@ def check_flake8(file_name, contents):
     with stdout_redirect(output):
         check_code(contents, ignore=ignore)
     for error in output.getvalue().splitlines():
-        _, line_num, _, message = error.split(":")
+        _, line_num, _, message = error.split(":", 3)
         yield line_num, message.strip()
 
 


### PR DESCRIPTION
If someone were to write:

```
def hello() :
    print "hello world"
```

flake8 would warn:

```
stdin:54:45: E203 whitespace before ':'
```

Normally there are only three colons in a flake8 error message, but this
one has four, which causes issue with this line:

```
_, line_num, _, message = error.split(":")
```

...causing this error:

```
ValueError: too many values to unpack
```

This commit updates the `str.split` call to utilize the `maxsplit`
parameter to prevent this error from occurring.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/6996)

<!-- Reviewable:end -->
