### PR TITLE
Fix minor typo in lint docstring.

### DIFF
--- a/components/plugins/lints/privatize.rs
+++ b/components/plugins/lints/privatize.rs
@@ -13,7 +13,7 @@ declare_lint!(PRIVATIZE, Deny,
 /// Lint for keeping DOM fields private
 ///
 /// This lint (disable with `-A privatize`/`#[allow(privatize)]`) ensures all types marked with `#[privatize]`
-/// have no private fields
+/// have no public fields
 pub struct PrivatizePass;
 
 impl LintPass for PrivatizePass {


### PR DESCRIPTION
It checks for public, not private fields.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7007)

<!-- Reviewable:end -->
