### PR TITLE
layout: Take negative margins of floats into account when placing them.

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -99,6 +99,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == float_under_top_margin_a.html float_under_top_margin_ref.html
 == floated_generated_content_a.html floated_generated_content_b.html
 == floated_list_item_a.html floated_list_item_ref.html
+== floated_negative_margins_a.html floated_negative_margins_ref.html
 == floated_table_with_margin_a.html floated_table_with_margin_ref.html
 == focus_selector.html focus_selector_ref.html
 == font_advance.html font_advance_ref.html

--- a/tests/ref/floated_negative_margins_a.html
+++ b/tests/ref/floated_negative_margins_a.html
@@ -1,0 +1,16 @@
+<style>
+body {
+    margin: 0;
+    padding: 0;
+}
+#a {
+    float: left;
+    margin-left: -64px;
+    width: 128px;
+    height: 128px;
+    background: purple;
+}
+</style>
+<body>
+<div id=a></div>Hello
+

--- a/tests/ref/floated_negative_margins_ref.html
+++ b/tests/ref/floated_negative_margins_ref.html
@@ -1,0 +1,15 @@
+<style>
+body {
+    margin: 0;
+    padding: 0;
+}
+#a {
+    float: left;
+    width: 64px;
+    height: 128px;
+    background: purple;
+}
+</style>
+<body>
+<div id=a></div>Hello
+


### PR DESCRIPTION
Removes extraneous inline space on GitHub pull requests.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7008)

<!-- Reviewable:end -->
