### PR TITLE
Fixes #6879 (Improper connections to the devtools server)

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -172,8 +172,8 @@ fn run_server(sender: Sender<DevtoolsControlMsg>,
                     println!("error: EOF");
                     break 'outer
                 }
-                Err(e) => {
-                    println!("error: {}", e.description());
+                Err(err_msg) => {
+                    println!("error: {}", err_msg);
                     break 'outer
                 }
             }


### PR DESCRIPTION
Modifies how we behave in the case that something attempts to communicate with the devtools server improperly. This includes...
- Invalid encoding (Non `UTF8`) of the packet length / error parsing / none specified
- JSON encoding error (such as a `Parser::SyntaxError` or a `Parser::IoError`)

Happy to make changes if anyone has an issue with this or feels another way is more idiomatic!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7010)

<!-- Reviewable:end -->
