### PR TITLE
layout: Take inline margins into account when determining the intrinsic sizes of fragments.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1343,8 +1343,10 @@ impl Fragment {
                     let border_width = node.style.logical_border_width().inline_start_end();
                     let padding_inline_size =
                         model::padding_from_style(&*node.style, Au(0)).inline_start_end();
+                    let margin_inline_size =
+                        model::specified_margin_from_style(&*node.style).inline_start_end();
                     result.surrounding_size = result.surrounding_size + border_width +
-                        padding_inline_size;
+                        padding_inline_size + margin_inline_size;
                 }
             }
         }

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -297,6 +297,7 @@ impl IntrinsicISizes {
 }
 
 /// The temporary result of the computation of intrinsic inline-sizes.
+#[derive(Debug)]
 pub struct IntrinsicISizesContribution {
     /// Intrinsic sizes for the content only (not counting borders, padding, or margins).
     pub content_intrinsic_sizes: IntrinsicISizes,
@@ -428,6 +429,20 @@ pub fn padding_from_style(style: &ComputedValues, containing_block_inline_size: 
         specified(padding_style.padding_right, containing_block_inline_size),
         specified(padding_style.padding_bottom, containing_block_inline_size),
         specified(padding_style.padding_left, containing_block_inline_size)))
+}
+
+/// Returns the explicitly-specified margin lengths from the given style. Percentage and auto
+/// margins are returned as zero.
+///
+/// This is used when calculating intrinsic inline sizes.
+#[inline]
+pub fn specified_margin_from_style(style: &ComputedValues) -> LogicalMargin<Au> {
+    let margin_style = style.get_margin();
+    LogicalMargin::from_physical(style.writing_mode, SideOffsets2D::new(
+        MaybeAuto::from_style(margin_style.margin_top, Au(0)).specified_or_zero(),
+        MaybeAuto::from_style(margin_style.margin_right, Au(0)).specified_or_zero(),
+        MaybeAuto::from_style(margin_style.margin_bottom, Au(0)).specified_or_zero(),
+        MaybeAuto::from_style(margin_style.margin_left, Au(0)).specified_or_zero()))
 }
 
 pub trait ToGfxMatrix {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -162,6 +162,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 == inline_hypothetical_box_a.html inline_hypothetical_box_ref.html
 == inline_margin_multiple_fragments_a.html inline_margin_multiple_fragments_ref.html
 == inline_margins_a.html inline_margins_ref.html
+== inline_margins_intrinsic_size_a.html inline_margins_intrinsic_size_ref.html
 == inline_padding_a.html inline_padding_b.html
 # inline_text_align_a.html inline_text_align_b.html
 == inline_whitespace_a.html inline_whitespace_ref.html

--- a/tests/ref/inline_margins_intrinsic_size_a.html
+++ b/tests/ref/inline_margins_intrinsic_size_a.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+span {
+    margin: 0 1em;
+}
+div {
+    float: left;
+}
+body {
+    margin: 0;
+    padding: 0;
+}
+</style>
+<div>foo<span>/</span>bar</div>
+

--- a/tests/ref/inline_margins_intrinsic_size_ref.html
+++ b/tests/ref/inline_margins_intrinsic_size_ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+span {
+    padding: 0 1em;
+}
+div {
+    float: left;
+}
+body {
+    margin: 0;
+    padding: 0;
+}
+</style>
+<div>foo<span>/</span>bar</div>
+


### PR DESCRIPTION
Avoids a needless wrapped line in the repository name on GitHub.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7011)

<!-- Reviewable:end -->
