### PR TITLE
Use JS_GetOwnPropertyDescriptorById in BrowserContext

### DIFF
--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -24,7 +24,6 @@ use js::glue::{GetProxyPrivate};
 use js::glue::{WrapperNew, CreateWrapperProxyHandler, ProxyTraps};
 use js::{JSTrue, JSFalse};
 
-use std::ptr;
 use std::default::Default;
 
 #[derive(JSTraceable, HeapSizeOf)]
@@ -134,12 +133,7 @@ unsafe extern fn getOwnPropertyDescriptor(cx: *mut JSContext, proxy: HandleObjec
         return JSFalse;
     }
 
-    if (*desc.ptr).obj != target.ptr {
-        // Not an own property
-        (*desc.ptr).obj = ptr::null_mut();
-    } else {
-        (*desc.ptr).obj = *proxy.ptr;
-    }
+    assert!((*desc.ptr).obj.is_null() || (*desc.ptr).obj == *proxy.ptr);
 
     JSTrue
 }

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -16,7 +16,7 @@ use dom::window::WindowHelpers;
 use js::jsapi::{JSContext, JSObject, JSPropertyDescriptor, JSErrNum};
 use js::jsapi::{HandleObject, HandleId, MutableHandle, MutableHandleValue};
 use js::jsapi::{JS_AlreadyHasOwnPropertyById, JS_ForwardGetPropertyTo};
-use js::jsapi::{JS_GetPropertyDescriptorById, JS_DefinePropertyById6};
+use js::jsapi::{JS_GetOwnPropertyDescriptorById, JS_DefinePropertyById6};
 use js::jsapi::{JS_ForwardSetPropertyTo, ObjectOpResult, RootedObject, RootedValue, Handle, HandleValue, Heap};
 use js::jsapi::{JSAutoRequest, JSAutoCompartment};
 use js::jsval::{ObjectValue, UndefinedValue};
@@ -129,8 +129,8 @@ unsafe extern fn getOwnPropertyDescriptor(cx: *mut JSContext, proxy: HandleObjec
     }
 
     let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
-    // XXX This should be JS_GetOwnPropertyDescriptorById
-    if JS_GetPropertyDescriptorById(cx, target.handle(), id, desc) == 0 {
+
+    if JS_GetOwnPropertyDescriptorById(cx, target.handle(), id, desc) == 0 {
         return JSFalse;
     }
 


### PR DESCRIPTION
JS_GetOwnPropertyDescriptorById should be used in place of
JS_GetPropertyDescriptorById in getOwnPropertyDescriptor.

Fixes #6984.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7012)

<!-- Reviewable:end -->
