### PR TITLE
Use Box<str> instead of Box<String> for UnscannedTextFragmentInfo

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -705,10 +705,7 @@ pub struct TruncationResult {
 #[derive(Clone)]
 pub struct UnscannedTextFragmentInfo {
     /// The text inside the fragment.
-    ///
-    /// FIXME(pcwalton): Is there something more clever we can do here that avoids the double
-    /// indirection while not penalizing all fragments?
-    pub text: Box<String>,
+    pub text: Box<str>,
 }
 
 impl UnscannedTextFragmentInfo {
@@ -716,7 +713,7 @@ impl UnscannedTextFragmentInfo {
     #[inline]
     pub fn from_text(text: String) -> UnscannedTextFragmentInfo {
         UnscannedTextFragmentInfo {
-            text: box text,
+            text: text.into_boxed_slice(),
         }
     }
 }

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -4,6 +4,7 @@
 
 #![feature(append)]
 #![feature(arc_unique)]
+#![feature(box_str)]
 #![feature(box_syntax)]
 #![feature(cell_extras)]
 #![feature(custom_derive)]

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -398,9 +398,9 @@ fn split_first_fragment_at_newline_if_necessary(fragments: &mut LinkedList<Fragm
             };
 
             string_before =
-                box unscanned_text_fragment_info.text[..(position + 1)].to_owned();
+                unscanned_text_fragment_info.text[..(position + 1)].to_owned().into_boxed_slice();
             unscanned_text_fragment_info.text =
-                box unscanned_text_fragment_info.text[(position + 1)..].to_owned();
+                unscanned_text_fragment_info.text[(position + 1)..].to_owned().into_boxed_slice();
         }
         first_fragment.transform(first_fragment.border_box.size,
                                  SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo {


### PR DESCRIPTION
This removes an extraneous layer of indirection, without increasing the size of the `SpecificFragmentInfo` enum (because `Box<str>` is a fat pointer, which is the same size as the `FlowRef` trait object that is already stored in `InlineAbsoluteHypotheticalFragmentInfo`)

r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7014)

<!-- Reviewable:end -->
