### PR TITLE
Lock stderr while printing the alert() message.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -72,7 +72,7 @@ use std::cell::{Cell, Ref, RefMut, RefCell};
 use std::collections::HashSet;
 use std::default::Default;
 use std::ffi::CString;
-use std::io::{stdout, Write};
+use std::io::{stdout, stderr, Write};
 use std::mem as std_mem;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -361,10 +361,15 @@ impl<'a> WindowMethods for &'a Window {
     // https://html.spec.whatwg.org/#dom-alert
     fn Alert(self, s: DOMString) {
         // Right now, just print to the console
+        // Ensure that stderr doesn't trample through the alert() we use to
+        // communicate test results.
+        let stderr = stderr();
+        let mut stderr = stderr.lock();
         let stdout = stdout();
         let mut stdout = stdout.lock();
         writeln!(&mut stdout, "ALERT: {}", s).unwrap();
         stdout.flush().unwrap();
+        stderr.flush().unwrap();
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window-close


### PR DESCRIPTION
2a7f262b7df8761261a0fa618394f4e991733a5e was unsufficient for the case where
the interleaved output was actually on stderr rather than stdout, such as
output from the error macro.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7027)

<!-- Reviewable:end -->
