### PR TITLE
Issue #5478 - use std::process::exit instead of lib::exit in constellation.rs

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -74,7 +74,6 @@ features = [ "serde_serialization" ]
 log = "0.3"
 num = "0.1.24"
 time = "0.1.17"
-libc = "0.1"
 gleam = "0.1"
 euclid = "0.1"
 

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -24,7 +24,6 @@ use euclid::scale_factor::ScaleFactor;
 use gfx::font_cache_task::FontCacheTask;
 use ipc_channel::ipc::{self, IpcSender};
 use layout_traits::{LayoutControlChan, LayoutTaskFactory};
-use libc;
 use msg::compositor_msg::{Epoch, LayerId};
 use msg::constellation_msg::AnimationState;
 use msg::constellation_msg::Msg as ConstellationMsg;
@@ -48,6 +47,7 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::marker::PhantomData;
 use std::mem::replace;
+use std::process;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use style::viewport::ViewportConstraints;
 use url::Url;
@@ -547,7 +547,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
             // Hard fail exists for test runners so we crash and that's good enough.
             let mut stderr = io::stderr();
             stderr.write_all("Pipeline failed in hard-fail mode.  Crashing!\n".as_bytes()).unwrap();
-            unsafe { libc::exit(1); }
+            process::exit(1);
         }
 
         self.close_pipeline(pipeline_id, ExitPipelineMode::Force);

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -35,7 +35,6 @@ extern crate util;
 extern crate gleam;
 extern crate clipboard;
 
-extern crate libc;
 extern crate time;
 extern crate url;
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -178,7 +178,6 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "layout_traits 0.0.1",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",


### PR DESCRIPTION
First patch.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7028)

<!-- Reviewable:end -->
