### PR TITLE
script: Make the legacy presentational attributes on `<td>` apply to `<th>` too.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -26,7 +26,6 @@ use dom::bindings::codegen::InheritTypes::{HTMLTableElementDerived, HTMLTableCel
 use dom::bindings::codegen::InheritTypes::{HTMLTableRowElementDerived, HTMLTextAreaElementDerived};
 use dom::bindings::codegen::InheritTypes::{HTMLTableSectionElementDerived, NodeCast};
 use dom::bindings::codegen::InheritTypes::HTMLAnchorElementCast;
-use dom::bindings::codegen::InheritTypes::HTMLTableDataCellElementDerived;
 use dom::bindings::codegen::InheritTypes::TextCast;
 use dom::bindings::codegen::UnionTypes::NodeOrString;
 use dom::bindings::error::{ErrorResult, Fallible};
@@ -259,7 +258,7 @@ impl RawLayoutElementHelpers for Element {
         } else if self.is_htmltableelement() {
             let this: &HTMLTableElement = mem::transmute(self);
             this.get_background_color()
-        } else if self.is_htmltabledatacellelement() {
+        } else if self.is_htmltablecellelement() {
             let this: &HTMLTableCellElement = mem::transmute(self);
             this.get_background_color()
         } else if self.is_htmltablerowelement() {
@@ -357,7 +356,7 @@ impl RawLayoutElementHelpers for Element {
         } else if self.is_htmltableelement() {
             let this: &HTMLTableElement = mem::transmute(self);
             this.get_width()
-        } else if self.is_htmltabledatacellelement() {
+        } else if self.is_htmltablecellelement() {
             let this: &HTMLTableCellElement = mem::transmute(self);
             this.get_width()
         } else {

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -179,6 +179,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 == legacy_table_border_attribute_a.html legacy_table_border_attribute_ref.html
 == legacy_td_bgcolor_attribute_a.html legacy_td_bgcolor_attribute_ref.html
 == legacy_td_width_attribute_a.html legacy_td_width_attribute_ref.html
+== legacy_th_width_attribute_a.html legacy_td_width_attribute_ref.html
 == letter_spacing_a.html letter_spacing_ref.html
 == line_breaking_whitespace_collapse_a.html line_breaking_whitespace_collapse_ref.html
 == line_height_a.html line_height_ref.html

--- a/tests/ref/legacy_th_width_attribute_a.html
+++ b/tests/ref/legacy_th_width_attribute_a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.a {
+    height: 16px;
+    background: blue;
+}
+.b {
+    background: green;
+}
+</style>
+</head>
+<body>
+<table><tr><th width=30 class=a></th><th width=200 class=b></th></tr></table>
+<table><tr><td width="30 " class=a></td><td width="  200 " class=b></td></tr></table>
+<table><tr><td width="30asdf" class=a></td><td width=200haha class=b></td></tr></table>
+</table>
+</body>
+</html>
+


### PR DESCRIPTION
Makes the Google SERPs not so narrow.

r? @Ms2ger

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7043)

<!-- Reviewable:end -->
