### PR TITLE
layout: Introduce infrastructure for tracking, backing up, and splitting at the last known good split point, and use it for `white-space: nowrap`.

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -352,6 +352,7 @@ experimental == viewport_rule.html viewport_rule_ref.html
 == webgl-context/draw_arrays_simple.html webgl-context/draw_arrays_simple_ref.html
 
 == whitespace_nowrap_a.html whitespace_nowrap_ref.html
+== whitespace_nowrap_line_breaking_a.html whitespace_nowrap_line_breaking_ref.html
 == whitespace_pre.html whitespace_pre_ref.html
 == width_nonreplaced_block_simple_a.html width_nonreplaced_block_simple_b.html
 == word_break_a.html word_break_ref.html

--- a/tests/ref/whitespace_nowrap_line_breaking_a.html
+++ b/tests/ref/whitespace_nowrap_line_breaking_a.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+}
+em {
+    white-space: nowrap;
+}
+section {
+    background: gold;
+    width: 300px;
+}
+</style>
+<section>
+    <em>Daniel Dennett</em>
+    <em>Michael Tye</em>
+    <em>David Chalmers</em>
+    <em>Patricia Churchland</em>
+    <em>Colin McGinn</em>
+</section>
+
+

--- a/tests/ref/whitespace_nowrap_line_breaking_ref.html
+++ b/tests/ref/whitespace_nowrap_line_breaking_ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+}
+em {
+    white-space: nowrap;
+}
+section {
+    background: gold;
+    width: 300px;
+}
+#cover {
+    background: white;
+    position: absolute;
+    top: 0;
+    left: 300px;
+    right: 0;
+    bottom: 0;
+}
+</style>
+<section>
+    <em>Daniel Dennett</em>
+    <em>Michael Tye</em>
+    <em>David Chalmers</em>
+    <em>Patricia Churchland</em>
+    <em>Colin McGinn</em>
+</section>
+<div id=cover>
+</div>
+

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-formatting-context-012.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-formatting-context-012.htm.ini
@@ -1,3 +1,0 @@
-[inline-formatting-context-012.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Fixes overflowing tables on Wikipedia.

This infrastructure should form the basis of our fix for inline layout
of fragments that don't themselves constitute valid split points. That
will require some more work, however.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7056)

<!-- Reviewable:end -->
