### PR TITLE
Remove unnecessary `mut` on variables declared in ports/gonk/src/window.rs

### DIFF
--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -650,7 +650,7 @@ impl Window {
             assert!(ret == 0, "Failed to get HWC module!");
         }
 
-        let mut hwc_device: *mut hwc_composer_device;
+        let hwc_device: *mut hwc_composer_device;
         unsafe {
             let mut device = ptr::null();
             let cstr = CString::new("composer").unwrap();
@@ -675,7 +675,7 @@ impl Window {
         }
 
         let mut gralloc_mod = ptr::null();
-        let mut alloc_dev: *mut alloc_device;
+        let alloc_dev: *mut alloc_device;
         unsafe {
             let mut device = ptr::null();
             let cstr = CString::new("gralloc").unwrap();


### PR DESCRIPTION
Fixes #7048.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7057)

<!-- Reviewable:end -->
