### PR TITLE
Fix some bugs in PutImageData

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -56,55 +56,6 @@ impl<'a> CanvasPaintTask<'a> {
 
         image_data
     }
-
-    /// dirty_rect: original dirty_rect provided by the putImageData call
-    /// image_data_rect: the area of the image to be copied
-    /// Result: It retuns the modified dirty_rect by the rules described in
-    /// the spec https://html.spec.whatwg.org/#dom-context-2d-putimagedata
-    fn calculate_dirty_rect(&self,
-                            mut dirty_rect: Rect<f64>,
-                            image_data_rect: Rect<f64>) -> Rect<f64>{
-        // 1) If dirtyWidth is negative,
-        // let dirtyX be dirtyX+dirtyWidth,
-        // and let dirtyWidth be equal to the absolute magnitude of dirtyWidth.
-        if dirty_rect.size.width < 0.0f64 {
-            dirty_rect.origin.x = dirty_rect.origin.x + dirty_rect.size.width;
-            dirty_rect.size.width = -dirty_rect.size.width;
-        }
-
-        // 2) If dirtyHeight is negative, let dirtyY be dirtyY+dirtyHeight,
-        // and let dirtyHeight be equal to the absolute magnitude of dirtyHeight.
-        if dirty_rect.size.height < 0.0f64 {
-            dirty_rect.origin.y = dirty_rect.origin.y + dirty_rect.size.height;
-            dirty_rect.size.height = -dirty_rect.size.height;
-        }
-
-        // 3) If dirtyX is negative, let dirtyWidth be dirtyWidth+dirtyX, and let dirtyX be zero.
-        if dirty_rect.origin.x < 0.0f64 {
-            dirty_rect.size.width += dirty_rect.origin.x;
-            dirty_rect.origin.x = 0.0f64;
-        }
-
-        // 3) If dirtyY is negative, let dirtyHeight be dirtyHeight+dirtyY, and let dirtyY be zero.
-        if dirty_rect.origin.y < 0.0f64 {
-            dirty_rect.size.height += dirty_rect.origin.y;
-            dirty_rect.origin.y = 0.0f64;
-        }
-
-        // 4) If dirtyX+dirtyWidth is greater than the width attribute of the imagedata argument,
-        // let dirtyWidth be the value of that width attribute, minus the value of dirtyX.
-        if dirty_rect.origin.x + dirty_rect.size.width > image_data_rect.size.width {
-            dirty_rect.size.width = image_data_rect.size.width - dirty_rect.origin.x;
-        }
-
-        // 4) If dirtyY+dirtyHeight is greater than the height attribute of the imagedata argument,
-        // let dirtyHeight be the value of that height attribute, minus the value of dirtyY.
-        if dirty_rect.origin.y + dirty_rect.size.height > image_data_rect.size.height {
-            dirty_rect.size.height = image_data_rect.size.height - dirty_rect.origin.y;
-        }
-
-        dirty_rect
-    }
 }
 
 pub struct CanvasPaintTask<'a> {
@@ -221,8 +172,8 @@ impl<'a> CanvasPaintTask<'a> {
                             Canvas2dMsg::SetGlobalComposition(op) => painter.set_global_composition(op),
                             Canvas2dMsg::GetImageData(dest_rect, canvas_size, chan)
                                 => painter.get_image_data(dest_rect, canvas_size, chan),
-                            Canvas2dMsg::PutImageData(imagedata, image_data_rect, dirty_rect)
-                                => painter.put_image_data(imagedata, image_data_rect, dirty_rect),
+                            Canvas2dMsg::PutImageData(imagedata, offset, image_data_size, dirty_rect)
+                                => painter.put_image_data(imagedata, offset, image_data_size, dirty_rect),
                             Canvas2dMsg::SetShadowOffsetX(value) => painter.set_shadow_offset_x(value),
                             Canvas2dMsg::SetShadowOffsetY(value) => painter.set_shadow_offset_y(value),
                             Canvas2dMsg::SetShadowBlur(value) => painter.set_shadow_blur(value),
@@ -592,50 +543,91 @@ impl<'a> CanvasPaintTask<'a> {
         chan.send(dest_data).unwrap();
     }
 
-    fn put_image_data(&mut self, mut imagedata: Vec<u8>,
-                      image_data_rect: Rect<f64>,
-                      dirty_rect: Option<Rect<f64>>) {
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
+    fn put_image_data(&mut self, imagedata: Vec<u8>,
+                      offset: Point2D<f64>,
+                      image_data_size: Size2D<f64>,
+                      mut dirty_rect: Rect<f64>) {
 
-        if image_data_rect.size.width <= 0.0 || image_data_rect.size.height <= 0.0 {
+        if image_data_size.width <= 0.0 || image_data_size.height <= 0.0 {
             return
         }
 
-        assert!(image_data_rect.size.width * image_data_rect.size.height * 4.0 == imagedata.len() as f64);
-        // rgba -> bgra
-        byte_swap(&mut imagedata);
+        assert!(image_data_size.width * image_data_size.height * 4.0 == imagedata.len() as f64);
 
-        let image_rect = Rect::new(Point2D::zero(),
-                                   Size2D::new(image_data_rect.size.width, image_data_rect.size.height));
+        // Step 1. TODO (neutered data)
 
-        // Dirty rectangle defines the area of the source image to be copied
-        // on the destination canvas
-        let source_rect = match dirty_rect {
-            Some(dirty_rect) =>
-                self.calculate_dirty_rect(dirty_rect, image_data_rect),
-            // If no dirty area is provided we consider the whole source image
-            // as the area to be copied to the canvas
-            None => image_rect,
-        };
+        // Step 2.
+        if dirty_rect.size.width < 0.0f64 {
+            dirty_rect.origin.x += dirty_rect.size.width;
+            dirty_rect.size.width = -dirty_rect.size.width;
+        }
 
-        // 5) If either dirtyWidth or dirtyHeight is negative or zero,
-        // stop without affecting any bitmaps
-        if source_rect.size.width <= 0.0 || source_rect.size.height <= 0.0 {
+        if dirty_rect.size.height < 0.0f64 {
+            dirty_rect.origin.y += dirty_rect.size.height;
+            dirty_rect.size.height = -dirty_rect.size.height;
+        }
+
+        // Step 3.
+        if dirty_rect.origin.x < 0.0f64 {
+            dirty_rect.size.width += dirty_rect.origin.x;
+            dirty_rect.origin.x = 0.0f64;
+        }
+
+        if dirty_rect.origin.y < 0.0f64 {
+            dirty_rect.size.height += dirty_rect.origin.y;
+            dirty_rect.origin.y = 0.0f64;
+        }
+
+        // Step 4.
+        if dirty_rect.max_x() > image_data_size.width {
+            dirty_rect.size.width = image_data_size.width - dirty_rect.origin.x;
+        }
+
+        if dirty_rect.max_y() > image_data_size.height {
+            dirty_rect.size.height = image_data_size.height - dirty_rect.origin.y;
+        }
+
+        // Step 5.
+        if dirty_rect.size.width <= 0.0 || dirty_rect.size.height <= 0.0 {
             return
         }
 
-        // 6) For all integer values of x and y where dirtyX ≤ x < dirty
-        // X+dirtyWidth and dirtyY ≤ y < dirtyY+dirtyHeight, copy the
-        // four channels of the pixel with coordinate (x, y) in the imagedata
-        // data structure's Canvas Pixel ArrayBuffer to the pixel with coordinate
-        // (dx+x, dy+y) in the rendering context's scratch bitmap.
-        // It also clips the destination rectangle to the canvas area
-        let dest_rect = Rect::new(
-            Point2D::new(image_data_rect.origin.x + source_rect.origin.x,
-                         image_data_rect.origin.y + source_rect.origin.y),
-            Size2D::new(source_rect.size.width, source_rect.size.height));
+        // Step 6.
+        let dest_rect = dirty_rect.translate(&offset).to_i32();
 
-        write_pixels(&self.drawtarget, &imagedata, image_data_rect.size, source_rect,
-                     dest_rect, true, self.state.draw_options.composition, self.state.draw_options.alpha)
+        // azure_hl operates with integers. We need to cast the image size
+        let image_size = image_data_size.to_i32();
+
+        let first_pixel = dest_rect.origin - offset.to_i32();
+        let mut src_line = (first_pixel.y * (image_size.width * 4) + first_pixel.x * 4) as usize;
+
+        let mut dest = Vec::new();
+        dest.reserve((dest_rect.size.width * dest_rect.size.height * 4) as usize);
+
+        for j in 0 .. dest_rect.size.height {
+            let mut src_offset = src_line.clone();
+            for i in 0 .. dest_rect.size.width {
+                // Premultiply alpha and swap RGBA -> BGRA.
+                // TODO: may want a precomputed premultiply table to make this fast.
+                // https://github.com/servo/servo/issues/6969
+                let alpha = imagedata[src_offset + 3] as f32 / 255.;
+                dest.push((imagedata[src_offset + 2] as f32 * alpha) as u8);
+                dest.push((imagedata[src_offset + 1] as f32 * alpha) as u8);
+                dest.push((imagedata[src_offset + 0] as f32 * alpha) as u8);
+                dest.push(imagedata[src_offset + 3]);
+                src_offset += 4;
+            }
+            src_line += (image_size.width * 4) as usize;
+        }
+
+        let source_surface = self.drawtarget.create_source_surface_from_data(
+            &dest,
+            dest_rect.size, dest_rect.size.width * 4, SurfaceFormat::B8G8R8A8);
+
+        self.drawtarget.copy_surface(source_surface,
+                                     Rect::new(Point2D::new(0, 0), dest_rect.size),
+                                     dest_rect.origin);
     }
 
     fn set_shadow_offset_x(&mut self, value: f64) {
@@ -790,6 +782,17 @@ fn is_zero_size_gradient(pattern: &Pattern) -> bool {
         }
     }
     return false;
+}
+
+pub trait PointToi32 {
+    fn to_i32(&self) -> Point2D<i32>;
+}
+
+impl PointToi32 for Point2D<f64> {
+    fn to_i32(&self) -> Point2D<i32> {
+        Point2D::new(self.x.to_i32().unwrap(),
+                     self.y.to_i32().unwrap())
+    }
 }
 
 pub trait SizeToi32 {

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -91,7 +91,7 @@ pub enum Canvas2dMsg {
     GetImageData(Rect<f64>, Size2D<f64>, IpcSender<Vec<u8>>),
     LineTo(Point2D<f32>),
     MoveTo(Point2D<f32>),
-    PutImageData(Vec<u8>, Rect<f64>, Option<Rect<f64>>),
+    PutImageData(Vec<u8>, Point2D<f64>, Size2D<f64>, Rect<f64>),
     QuadraticCurveTo(Point2D<f32>, Point2D<f32>),
     Rect(Rect<f32>),
     RestoreContext,

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -926,12 +926,12 @@ impl<'a> CanvasRenderingContext2DMethods for &'a CanvasRenderingContext2D {
     fn PutImageData_(self, imagedata: &ImageData, dx: Finite<f64>, dy: Finite<f64>,
                      dirtyX: Finite<f64>, dirtyY: Finite<f64>, dirtyWidth: Finite<f64>, dirtyHeight: Finite<f64>) {
         let data = imagedata.get_data_array(&self.global.root().r());
-        let image_data_rect = Rect::new(Point2D::new(*dx, *dy),
-                                        Size2D::new(imagedata.Width() as f64,
-                                                    imagedata.Height() as f64));
-        let dirty_rect = Some(Rect::new(Point2D::new(*dirtyX, *dirtyY),
-                                        Size2D::new(*dirtyWidth, *dirtyHeight)));
-        let msg = CanvasMsg::Canvas2d(Canvas2dMsg::PutImageData(data, image_data_rect, dirty_rect));
+        let offset = Point2D::new(*dx, *dy);
+        let image_data_size = Size2D::new(imagedata.Width() as f64,
+                                          imagedata.Height() as f64);
+        let dirty_rect = Rect::new(Point2D::new(*dirtyX, *dirtyY),
+                                   Size2D::new(*dirtyWidth, *dirtyHeight));
+        let msg = CanvasMsg::Canvas2d(Canvas2dMsg::PutImageData(data, offset, image_data_size, dirty_rect));
         self.ipc_renderer.send(msg).unwrap();
         self.mark_as_dirty();
     }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -64,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#a6d3af35eafe9a02af3fa58b1f1d30eb9cb57ccd"
+source = "git+https://github.com/servo/rust-azure#53e7b7d07bd43199b136d869b1605016ed882cbc"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#a6d3af35eafe9a02af3fa58b1f1d30eb9cb57ccd"
+source = "git+https://github.com/servo/rust-azure#53e7b7d07bd43199b136d869b1605016ed882cbc"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#a6d3af35eafe9a02af3fa58b1f1d30eb9cb57ccd"
+source = "git+https://github.com/servo/rust-azure#53e7b7d07bd43199b136d869b1605016ed882cbc"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.get.unaffected.html.ini
+++ b/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.get.unaffected.html.ini
@@ -1,5 +1,0 @@
-[2d.imageData.get.unaffected.html]
-  type: testharness
-  [getImageData() is not affected by context state]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.put.clip.html.ini
+++ b/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.put.clip.html.ini
@@ -1,5 +1,0 @@
-[2d.imageData.put.clip.html]
-  type: testharness
-  [putImageData() is not affected by clipping regions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.put.unaffected.html.ini
+++ b/tests/wpt/metadata/2dcontext/pixel-manipulation/2d.imageData.put.unaffected.html.ini
@@ -1,5 +1,0 @@
-[2d.imageData.put.unaffected.html]
-  type: testharness
-  [putImageData() is not affected by context state]
-    expected: FAIL
-


### PR DESCRIPTION
I think this might be faster, because instead of byte_swapping all of the image data and then calling draw_surface, we byte_swap only what we actually need to use and have it in a single array, so copy_surface can probably memcpy it.  Profiling didn't show a speedup though, because serde completely dominates everything else we do.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7059)

<!-- Reviewable:end -->
