### PR TITLE
Mark some tests as failing on Linux, not just Ubuntu 14.04.

### DIFF
--- a/tests/wpt/metadata-css/css21_dev/html4/absolute-replaced-height-007.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/absolute-replaced-height-007.htm.ini
@@ -2,4 +2,4 @@
   type: reftest
   disabled: unstable
   expected:
-    if (os == "linux") and (version == "Ubuntu 14.04"): FAIL
+    if (os == "linux"): FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/font-size-zero-1.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/font-size-zero-1.htm.ini
@@ -1,4 +1,4 @@
 [font-size-zero-1.htm]
   type: reftest
   expected:
-    if (os == "linux") and (version == "Ubuntu 14.04"): FAIL
+    if (os == "linux"): FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/font-size-zero-2.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/font-size-zero-2.htm.ini
@@ -1,4 +1,4 @@
 [font-size-zero-2.htm]
   type: reftest
   expected:
-    if (os == "linux") and (version == "Ubuntu 14.04"): FAIL
+    if (os == "linux"): FAIL


### PR DESCRIPTION
They also fail for me on Archlinux.

(`absolute-replaced-height-007.htm` is disabled anyway, but let’s change it as well for consistency.)

r? @larsbergstrom

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7082)

<!-- Reviewable:end -->
