### PR TITLE
Allows object evaluation in devtools -- Closes #6724

### DIFF
--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use actor::{Actor, ActorRegistry};
+use rustc_serialize::json;
+use std::net::TcpStream;
+
+pub struct ObjectActor {
+    pub name: String,
+    pub uuid: String,
+}
+
+impl Actor for ObjectActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+    fn handle_message(&self,
+                      _: &ActorRegistry,
+                      _: &str,
+                      _: &json::Object,
+                      _: &mut TcpStream) -> Result<bool, ()> {
+        Ok(false)
+    }
+}
+
+impl ObjectActor {
+    pub fn new(registry: &ActorRegistry, uuid: String) -> String {
+        if !registry.script_actor_registered(uuid.clone()) {
+            let name = registry.new_name("object");
+            let actor = ObjectActor {
+                name: name.clone(),
+                uuid: uuid.clone(),
+            };
+
+            registry.register_script_actor(uuid, name.clone());
+            registry.register_later(box actor);
+
+            name
+        } else {
+            registry.script_to_actor(uuid)
+        }
+    }
+}

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -40,6 +40,7 @@ use actors::console::ConsoleActor;
 use actors::network_event::{NetworkEventActor, EventActor, ResponseStartMsg};
 use actors::framerate::FramerateActor;
 use actors::inspector::InspectorActor;
+use actors::object::ObjectActor;
 use actors::root::RootActor;
 use actors::tab::TabActor;
 use actors::timeline::TimelineActor;
@@ -68,13 +69,14 @@ mod actor;
 mod actors {
     pub mod console;
     pub mod framerate;
-    pub mod memory;
     pub mod inspector;
+    pub mod memory;
+    pub mod network_event;
+    pub mod object;
     pub mod root;
     pub mod tab;
     pub mod timeline;
     pub mod worker;
-    pub mod network_event;
 }
 mod protocol;
 

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -77,7 +77,7 @@ pub enum EvaluateJSReply {
     BooleanValue(bool),
     NumberValue(f64),
     StringValue(String),
-    ActorValue(String),
+    ActorValue { class: String, uuid: String },
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
The purpose of this is to fix how objects were previously evaluated in
the developer tools.
- Before this, evaluating an object such as the `window` would `panic!`
- After this, evaluating an object such as the `window` outputs `[object
  Window]`

A few things to note:
- This commit contains `unsafe` code.
- This does not contain a test because the developer tools cannot be properly tested until #5971 lands.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7101)

<!-- Reviewable:end -->
