### PR TITLE
layout: Allow list items to be absolute containing blocks.

### DIFF
--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -170,7 +170,9 @@ impl Flow for ListItemFlow {
                                              iterator: &mut FragmentBorderBoxIterator,
                                              level: i32,
                                              stacking_context_position: &Point2D<Au>) {
-        self.block_flow.iterate_through_fragment_border_boxes(iterator, level, stacking_context_position);
+        self.block_flow.iterate_through_fragment_border_boxes(iterator,
+                                                              level,
+                                                              stacking_context_position);
 
         for marker in &self.marker_fragments {
             if iterator.should_process(marker) {

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -24,7 +24,7 @@ use util::geometry::Au;
 use util::logical_geometry::LogicalSize;
 use util::opts;
 use style::properties::ComputedValues;
-use style::computed_values::list_style_type;
+use style::computed_values::{list_style_type, position};
 use std::sync::Arc;
 
 /// A block with the CSS `display` property equal to `list-item`.
@@ -130,6 +130,10 @@ impl Flow for ListItemFlow {
         self.block_flow.place_float_if_applicable(layout_context)
     }
 
+    fn is_absolute_containing_block(&self) -> bool {
+        self.block_flow.is_absolute_containing_block()
+    }
+
     fn update_late_computed_inline_position_if_necessary(&mut self, inline_position: Au) {
         self.block_flow.update_late_computed_inline_position_if_necessary(inline_position)
     }
@@ -155,6 +159,11 @@ impl Flow for ListItemFlow {
 
     fn generated_containing_block_size(&self, flow: OpaqueFlow) -> LogicalSize<Au> {
         self.block_flow.generated_containing_block_size(flow)
+    }
+
+    /// The 'position' property of this flow.
+    fn positioning(&self) -> position::T {
+        self.block_flow.positioning()
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -185,6 +185,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 == legacy_td_width_attribute_a.html legacy_td_width_attribute_ref.html
 == legacy_th_width_attribute_a.html legacy_td_width_attribute_ref.html
 == letter_spacing_a.html letter_spacing_ref.html
+== li_absolute_containing_block_a.html li_absolute_containing_block_ref.html
 == line_breaking_whitespace_collapse_a.html line_breaking_whitespace_collapse_ref.html
 == line_height_a.html line_height_ref.html
 == line_height_float_placement_a.html line_height_float_placement_ref.html

--- a/tests/ref/li_absolute_containing_block_a.html
+++ b/tests/ref/li_absolute_containing_block_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+body {
+    font-size: 64px;
+}
+li {
+    position: relative;
+}
+section {
+    position: absolute;
+    content: "";
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: blue;
+}
+</style>
+<li>X<section></section></li>

--- a/tests/ref/li_absolute_containing_block_ref.html
+++ b/tests/ref/li_absolute_containing_block_ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+body {
+    font-size: 64px;
+}
+div {
+    position: relative;
+}
+section {
+    position: absolute;
+    content: "";
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: blue;
+}
+</style>
+<div>X<section></section></div>


### PR DESCRIPTION
Fixes overflowing highlight in the side menu on GitHub.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7102)

<!-- Reviewable:end -->
