### PR TITLE
CanvasGradient#addColorStop should throw for invalid colors and offsets

### DIFF
--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cssparser::RGBA;
 use canvas_traits::{CanvasGradientStop, FillOrStrokeStyle, LinearGradientStyle, RadialGradientStyle};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::CanvasGradientBinding;
 use dom::bindings::codegen::Bindings::CanvasGradientBinding::CanvasGradientMethods;
+use dom::bindings::error::Error::{IndexSize, Syntax};
+use dom::bindings::error::ErrorResult;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
 use dom::bindings::num::Finite;
@@ -44,18 +45,21 @@ impl CanvasGradient {
 
 impl<'a> CanvasGradientMethods for &'a CanvasGradient {
     // https://html.spec.whatwg.org/multipage/#dom-canvasgradient-addcolorstop
-    fn AddColorStop(self, offset: Finite<f64>, color: String) {
-        let default_black = RGBA {
-            red: 0.0,
-            green: 0.0,
-            blue: 0.0,
-            alpha: 1.0,
+    fn AddColorStop(self, offset: Finite<f64>, color: String) -> ErrorResult {
+        if *offset < 0f64 || *offset > 1f64 {
+            return Err(IndexSize);
+        }
+
+        let color = match parse_color(&color) {
+            Ok(color) => color,
+            _ => return Err(Syntax)
         };
 
         self.stops.borrow_mut().push(CanvasGradientStop {
             offset: (*offset) as f64,
-            color: parse_color(&color).unwrap_or(default_black),
+            color: color,
         });
+        Ok(())
     }
 }
 

--- a/components/script/dom/webidls/CanvasGradient.webidl
+++ b/components/script/dom/webidls/CanvasGradient.webidl
@@ -7,6 +7,7 @@
 // [Exposed=(Window,Worker)]
 interface CanvasGradient {
   // opaque object
+  [Throws]
   void addColorStop(double offset, DOMString color);
 };
 

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.current.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.current.html.ini
@@ -1,0 +1,5 @@
+[2d.gradient.object.current.html]
+  type: testharness
+  [Canvas test: 2d.gradient.object.current]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.invalidcolour.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.invalidcolour.html.ini
@@ -1,5 +1,0 @@
-[2d.gradient.object.invalidcolour.html]
-  type: testharness
-  [Canvas test: 2d.gradient.object.invalidcolour]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.invalidoffset.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.gradient.object.invalidoffset.html.ini
@@ -1,5 +1,0 @@
-[2d.gradient.object.invalidoffset.html]
-  type: testharness
-  [Canvas test: 2d.gradient.object.invalidoffset]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/2dcontext/fill-and-stroke-styles/2d.gradient.object.invalidoffset.html
+++ b/tests/wpt/web-platform-tests/2dcontext/fill-and-stroke-styles/2d.gradient.object.invalidoffset.html
@@ -22,9 +22,9 @@ _addTest(function(canvas, ctx) {
 var g = ctx.createLinearGradient(0, 0, 100, 0);
 assert_throws("INDEX_SIZE_ERR", function() { g.addColorStop(-1, '#000'); });
 assert_throws("INDEX_SIZE_ERR", function() { g.addColorStop(2, '#000'); });
-assert_throws("INDEX_SIZE_ERR", function() { g.addColorStop(Infinity, '#000'); });
-assert_throws("INDEX_SIZE_ERR", function() { g.addColorStop(-Infinity, '#000'); });
-assert_throws("INDEX_SIZE_ERR", function() { g.addColorStop(NaN, '#000'); });
+assert_throws(new TypeError(), function() { g.addColorStop(Infinity, '#000'); });
+assert_throws(new TypeError(), function() { g.addColorStop(-Infinity, '#000'); });
+assert_throws(new TypeError(), function() { g.addColorStop(NaN, '#000'); });
 
 
 });

--- a/tests/wpt/web-platform-tests/2dcontext/tools/tests2d.yaml
+++ b/tests/wpt/web-platform-tests/2dcontext/tools/tests2d.yaml
@@ -2013,9 +2013,9 @@
     var g = ctx.createLinearGradient(0, 0, 100, 0);
     @assert throws INDEX_SIZE_ERR g.addColorStop(-1, '#000');
     @assert throws INDEX_SIZE_ERR g.addColorStop(2, '#000');
-    @assert throws INDEX_SIZE_ERR g.addColorStop(Infinity, '#000');
-    @assert throws INDEX_SIZE_ERR g.addColorStop(-Infinity, '#000');
-    @assert throws INDEX_SIZE_ERR g.addColorStop(NaN, '#000');
+    @assert throws TypeError g.addColorStop(Infinity, '#000');
+    @assert throws TypeError g.addColorStop(-Infinity, '#000');
+    @assert throws TypeError g.addColorStop(NaN, '#000');
 
 - name: 2d.gradient.object.invalidcolour
   testing:


### PR DESCRIPTION
The new test failure is because the color stop has a value of 'currentColor' which we don't support yet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7104)

<!-- Reviewable:end -->
