### PR TITLE
Add tidy check for unused reftest html files

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -352,11 +352,27 @@ def check_reftest_order(files_to_check):
 
 def get_reftest_names(line):
     tokens = line.split()
-    if (len(tokens) == 3):
+    if len(tokens) == 3:
         return tokens[1] + tokens[2]
-    if (len(tokens) == 4):
+    if len(tokens) == 4:
         return tokens[2] + tokens[3]
     return None
+
+
+def get_html_file_names_from_reftest_list(reftest_dir, file_name):
+    for line in open(os.path.join(reftest_dir, file_name), "r"):
+        for token in line.split():
+            if fnmatch.fnmatch(token, '*.html'):
+                yield os.path.join(reftest_dir, token)
+
+
+def check_reftest_html_files_in_basic_list(reftest_dir):
+    basic_list_files = set(get_html_file_names_from_reftest_list(reftest_dir, "basic" + reftest_filetype))
+
+    for file_name in os.listdir(reftest_dir):
+        file_path = os.path.join(reftest_dir, file_name)
+        if fnmatch.fnmatch(file_path, '*.html') and file_path not in basic_list_files:
+            yield (file_path, "", "not found in basic.list")
 
 
 def scan():
@@ -370,10 +386,12 @@ def scan():
     errors = collect_errors_for_files(files_to_check, checking_functions)
 
     reftest_files = collect_file_names(reftest_directories)
+
     reftest_to_check = filter(should_check_reftest, reftest_files)
     r_errors = check_reftest_order(reftest_to_check)
+    not_found_in_basic_list_errors = check_reftest_html_files_in_basic_list(reftest_directories[0])
 
-    errors = list(itertools.chain(errors, r_errors))
+    errors = list(itertools.chain(errors, r_errors, not_found_in_basic_list_errors))
 
     if errors:
         for error in errors:


### PR DESCRIPTION
Refs: https://github.com/servo/servo/issues/7078

Sample output:

```
$ time ./mach test-tidy
tests/ref/background_image_a.html not used or commented out in basic.list
tests/ref/background_image_ref.html not used or commented out in basic.list
tests/ref/canvas_linear_gradient_a.html not used or commented out in basic.list
tests/ref/canvas_linear_gradient_ref.html not used or commented out in basic.list
tests/ref/canvas_radial_gradient_a.html not used or commented out in basic.list
tests/ref/canvas_radial_gradient_ref.html not used or commented out in basic.list
tests/ref/inline_border_a.html not used or commented out in basic.list
tests/ref/inline_border_b.html not used or commented out in basic.list
tests/ref/inline_text_align_a.html not used or commented out in basic.list
tests/ref/inline_text_align_b.html not used or commented out in basic.list
tests/ref/link_style_dynamic_addition.html not used or commented out in basic.list
tests/ref/link_style_dynamic_addition_ref.html not used or commented out in basic.list
tests/ref/overflow_position_abs_inside_normal_a.html not used or commented out in basic.list
tests/ref/overflow_position_abs_inside_normal_b.html not used or commented out in basic.list
tests/ref/overflow_position_abs_simple_a.html not used or commented out in basic.list
tests/ref/overflow_position_abs_simple_b.html not used or commented out in basic.list
tests/ref/position_fixed_a.html not used or commented out in basic.list
tests/ref/position_fixed_b.html not used or commented out in basic.list
tests/ref/position_fixed_simple_a.html not used or commented out in basic.list
tests/ref/position_fixed_simple_b.html not used or commented out in basic.list
tests/ref/position_fixed_static_y_a.html not used or commented out in basic.list
tests/ref/position_fixed_static_y_b.html not used or commented out in basic.list
tests/ref/style_is_in_doc.html not used or commented out in basic.list
tests/ref/style_is_in_doc_ref.html not used or commented out in basic.list
tests/ref/table_specified_width_a.html not used or commented out in basic.list
tests/ref/table_specified_width_ref.html not used or commented out in basic.list
tests/ref/text_decoration_propagation_a.html not used or commented out in basic.list
tests/ref/text_decoration_propagation_b.html not used or commented out in basic.list
tests/ref/text_shadow_multiple_shadows_a.html not used or commented out in basic.list
tests/ref/text_shadow_multiple_shadows_ref.html not used or commented out in basic.list
tests/ref/viewport_percentage_vmin_vmax_b.html not used or commented out in basic.list
tests/ref/viewport_percentage_vw_vh_b.html not used or commented out in basic.list
tests/ref/white_space_intrinsic_sizes_a.html not used or commented out in basic.list
tests/ref/white_space_intrinsic_sizes_ref.html not used or commented out in basic.list
tests/ref/fonts/takao-p-gothic/COPYING.html not used or commented out in basic.list
tests/ref/iframe/multiple_external_child.html not used or commented out in basic.list
...
```

I thought it might be helpful to say which files aren't used in `basic.list`.

`./mach test-tidy` is a second or two slower on my laptop.
Not sure if this counts as a warning or an error that should return 1.
Not sure whether unused file output should go before or after the line specific errors.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7118)

<!-- Reviewable:end -->
