### PR TITLE
layout: Take relative position offsets for inlines and inline-blocks into account only once.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -39,7 +39,7 @@ use style::computed_values::content::ContentItem;
 use style::computed_values::{border_collapse, clear, mix_blend_mode, overflow_wrap, overflow_x};
 use style::computed_values::{position, text_align, text_decoration, transform_style, white_space};
 use style::computed_values::{word_break, z_index};
-use style::properties::{self, ComputedValues, cascade_anonymous};
+use style::properties::{self, ComputedValues};
 use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto};
 use style::values::computed::{LengthOrPercentageOrNone};
 use text::TextRunScanner;
@@ -750,37 +750,6 @@ impl Fragment {
         Fragment {
             node: node.opaque(),
             style: style,
-            restyle_damage: node.restyle_damage(),
-            border_box: LogicalRect::zero(writing_mode),
-            border_padding: LogicalMargin::zero(writing_mode),
-            margin: LogicalMargin::zero(writing_mode),
-            specific: specific,
-            inline_context: None,
-            pseudo: node.get_pseudo_element_type().strip(),
-            debug_id: layout_debug::generate_unique_debug_id(),
-        }
-    }
-
-    /// Constructs a new `Fragment` instance for an anonymous table object.
-    pub fn new_anonymous_from_specific_info(node: &ThreadSafeLayoutNode,
-                                            specific: SpecificFragmentInfo)
-                                            -> Fragment {
-        // CSS 2.1 § 17.2.1 This is for non-inherited properties on anonymous table fragments
-        // example:
-        //
-        //     <div style="display: table">
-        //         Foo
-        //     </div>
-        //
-        // Anonymous table fragments, SpecificFragmentInfo::TableRow and
-        // SpecificFragmentInfo::TableCell, are generated around `Foo`, but they shouldn't inherit
-        // the border.
-
-        let node_style = cascade_anonymous(&**node.style());
-        let writing_mode = node_style.writing_mode;
-        Fragment {
-            node: node.opaque(),
-            style: Arc::new(node_style),
             restyle_damage: node.restyle_damage(),
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -272,6 +272,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == position_fixed_tile_edge_2.html position_fixed_tile_edge_ref.html
 == position_fixed_tile_edge_3.html position_fixed_tile_edge_ref.html
 == position_relative_a.html position_relative_b.html
+== position_relative_inline_block_a.html position_relative_inline_block_ref.html
 == position_relative_painting_order_a.html position_relative_painting_order_ref.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html

--- a/tests/ref/position_relative_inline_block_a.html
+++ b/tests/ref/position_relative_inline_block_a.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+    padding: 0;
+}
+div {
+    display: inline-block;
+    position: relative;
+    top: 20px;
+    width: 20px;
+    height: 20px;
+    background: red;
+}
+</style>
+<div></div>
+

--- a/tests/ref/position_relative_inline_block_ref.html
+++ b/tests/ref/position_relative_inline_block_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+    padding: 0;
+}
+div {
+    display: block;
+    position: absolute;
+    top: 20px;
+    width: 20px;
+    height: 20px;
+    background: red;
+}
+</style>
+<div></div>
+

--- a/tests/wpt/metadata-css/css21_dev/html4/floats-153.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/floats-153.htm.ini
@@ -1,3 +1,0 @@
-[floats-153.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-001.htm.ini
@@ -1,3 +1,0 @@
-[margin-collapse-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-032.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-032.htm.ini
@@ -1,3 +1,0 @@
-[position-relative-032.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/run-in-relpos-between-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/run-in-relpos-between-001.htm.ini
@@ -1,3 +1,0 @@
-[run-in-relpos-between-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/run-in-relpos-between-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/run-in-relpos-between-002.htm.ini
@@ -1,3 +1,0 @@
-[run-in-relpos-between-002.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
There were two bugs here: (1) relative position applied to
scanned/unscanned text fragments independently of the container element
that applied that relative position, causing double-counting; (2)
relative position applied to inline block fragments independently of the
wrapped block itself, causing double-counting.

Closes #7067.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7150)

<!-- Reviewable:end -->
