### PR TITLE
Snap rectangles to nearest pixels consistently.

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -1171,16 +1171,10 @@ pub trait ToAzureRect {
 
 impl ToAzureRect for Rect<Au> {
     fn to_nearest_azure_rect(&self) -> Rect<AzFloat> {
-        let top_left = self.origin.to_nearest_azure_point();
-        let bottom_right = self.bottom_right().to_nearest_azure_point();
-        Rect::new(top_left,
-                  Size2D::new((bottom_right.x - top_left.x) as AzFloat,
-                              (bottom_right.y - top_left.y) as AzFloat))
-
+        Rect::new(self.origin.to_nearest_azure_point(), self.size.to_nearest_azure_size())
     }
     fn to_azure_rect(&self) -> Rect<AzFloat> {
-        Rect::new(self.origin.to_azure_point(), Size2D::new(self.size.width.to_f32_px(),
-                                                            self.size.height.to_f32_px()))
+        Rect::new(self.origin.to_azure_point(), self.size.to_azure_size())
     }
 }
 
@@ -1382,11 +1376,12 @@ impl DrawTargetExtensions for DrawTarget {
     }
 
     fn create_rectangular_path(&self, rect: &Rect<Au>) -> Path {
+        let rect = rect.to_nearest_azure_rect();
         let path_builder = self.create_path_builder();
-        path_builder.move_to(rect.origin.to_nearest_azure_point());
-        path_builder.line_to(Point2D::new(rect.max_x(), rect.origin.y).to_nearest_azure_point());
-        path_builder.line_to(Point2D::new(rect.max_x(), rect.max_y()).to_nearest_azure_point());
-        path_builder.line_to(Point2D::new(rect.origin.x, rect.max_y()).to_nearest_azure_point());
+        path_builder.move_to(rect.origin);
+        path_builder.line_to(Point2D::new(rect.max_x(), rect.origin.y));
+        path_builder.line_to(Point2D::new(rect.max_x(), rect.max_y()));
+        path_builder.line_to(Point2D::new(rect.origin.x, rect.max_y()));
         path_builder.finish()
     }
 }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -314,6 +314,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == text_decoration_cached.html text_decoration_cached_ref.html
 # text_decoration_propagation_a.html text_decoration_propagation_b.html
 != text_decoration_smoke_a.html text_decoration_smoke_ref.html
+!= text_decoration_underline_subpx_a.html text_decoration_underline_subpx_ref.html
 == text_indent_a.html text_indent_ref.html
 == text_justify_none_a.html text_justify_none_ref.html
 != text_overflow_a.html text_overflow_ref.html

--- a/tests/ref/text_decoration_underline_subpx_a.html
+++ b/tests/ref/text_decoration_underline_subpx_a.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Underline test</title>
+    <style>
+      p {
+        font: 14px "Times New Roman";
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Hello</p>
+  </body>
+</html>

--- a/tests/ref/text_decoration_underline_subpx_ref.html
+++ b/tests/ref/text_decoration_underline_subpx_ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Underline test</title>
+    <style>
+      p {
+        font: 14px "Times New Roman";
+      }
+    </style>
+  </head>
+  <body>
+    <p>Hello</p>
+  </body>
+</html>

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-035.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-035.htm.ini
@@ -1,3 +1,4 @@
 [position-relative-035.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL


### PR DESCRIPTION
Snapping the top-left and bottom-right corners separately can cause a rectangle to change size or even become empty when offset by a subpixel amount.  Instead, this patch snaps the top-left corner, then snaps the size to a whole pixel amount, so any rectangle of a given original size will always have the same snapped size.

Fixes #7152. r? @pcwalton or @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7161)

<!-- Reviewable:end -->
