### PR TITLE
Use one version of serde_macros

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -74,8 +74,8 @@ dependencies = [
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -88,7 +88,7 @@ dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -130,8 +130,8 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -260,8 +260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -287,8 +287,8 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -303,8 +303,8 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -393,8 +393,8 @@ dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -509,8 +509,8 @@ dependencies = [
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -679,7 +679,7 @@ dependencies = [
  "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,8 +710,8 @@ dependencies = [
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -791,9 +791,9 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -814,8 +814,8 @@ dependencies = [
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -911,8 +911,8 @@ dependencies = [
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -967,8 +967,8 @@ dependencies = [
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1014,8 +1014,8 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1110,8 +1110,8 @@ dependencies = [
  "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "png-sys 1.6.16 (git+https://github.com/servo/rust-png)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1138,8 +1138,8 @@ name = "profile_traits"
 version = "0.0.1"
 dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1245,7 +1245,7 @@ dependencies = [
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,8 +1278,8 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1319,24 +1319,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1396,7 +1388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1437,8 +1429,8 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1539,7 +1531,7 @@ dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1572,8 +1564,8 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -73,8 +73,8 @@ dependencies = [
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -87,7 +87,7 @@ dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,8 +129,8 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -259,8 +259,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -286,8 +286,8 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -302,8 +302,8 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -392,8 +392,8 @@ dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -508,8 +508,8 @@ dependencies = [
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,7 +671,7 @@ dependencies = [
  "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -702,8 +702,8 @@ dependencies = [
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -783,9 +783,9 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,8 +806,8 @@ dependencies = [
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -903,8 +903,8 @@ dependencies = [
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -945,8 +945,8 @@ dependencies = [
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -992,8 +992,8 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1088,8 +1088,8 @@ dependencies = [
  "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "png-sys 1.6.16 (git+https://github.com/servo/rust-png)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1116,8 +1116,8 @@ name = "profile_traits"
 version = "0.0.1"
 dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1223,7 +1223,7 @@ dependencies = [
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1248,8 +1248,8 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1289,24 +1289,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1392,7 +1384,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1433,8 +1425,8 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1521,7 +1513,7 @@ dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1554,8 +1546,8 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -59,8 +59,8 @@ dependencies = [
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "freetype-sys 2.4.11 (git+https://github.com/servo/libfreetype2)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -73,7 +73,7 @@ dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,8 +115,8 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -234,8 +234,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -261,8 +261,8 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -277,8 +277,8 @@ dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -377,8 +377,8 @@ dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -485,8 +485,8 @@ dependencies = [
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -603,7 +603,7 @@ dependencies = [
  "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -634,8 +634,8 @@ dependencies = [
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -715,9 +715,9 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -738,8 +738,8 @@ dependencies = [
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -827,8 +827,8 @@ dependencies = [
  "plugins 0.0.1",
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -869,8 +869,8 @@ dependencies = [
  "png 0.1.0 (git+https://github.com/servo/rust-png)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex_macros 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_image 0.1.0 (git+https://github.com/servo/rust-stb-image)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -907,8 +907,8 @@ dependencies = [
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -994,8 +994,8 @@ dependencies = [
  "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "png-sys 1.6.16 (git+https://github.com/servo/rust-png)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1022,8 +1022,8 @@ name = "profile_traits"
 version = "0.0.1"
 dependencies = [
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1129,7 +1129,7 @@ dependencies = [
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1154,8 +1154,8 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1195,24 +1195,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_macros"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1288,7 +1280,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1329,8 +1321,8 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1417,7 +1409,7 @@ dependencies = [
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1450,8 +1442,8 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Refs: https://github.com/servo/servo/issues/7130

Ran `./mach update-cargo -a` and only seeing version 0.5.1:

```
$ git grep serde_macros
components/canvas_traits/Cargo.toml:serde_macros = "0.5"
components/canvas_traits/lib.rs:#![plugin(serde_macros)]
components/devtools/Cargo.toml:serde_macros = "0.5"
components/devtools/lib.rs:#![plugin(serde_macros)]
components/devtools_traits/Cargo.toml:serde_macros = "0.5"
components/devtools_traits/lib.rs:#![plugin(serde_macros)]
components/gfx/Cargo.toml:serde_macros = "0.5"
components/gfx/lib.rs:#![plugin(serde_macros)]
components/layout/Cargo.toml:serde_macros = "0.5"
components/layout_traits/Cargo.toml:serde_macros = "0.5"
components/layout_traits/lib.rs:#![plugin(serde_macros)]
components/msg/Cargo.toml:serde_macros = "0.5"
components/msg/lib.rs:#![plugin(serde_macros, plugins)]
components/net_traits/Cargo.toml:serde_macros = "0.5"
components/net_traits/lib.rs:#![plugin(serde_macros)]
components/profile_traits/Cargo.toml:serde_macros = "0.5"
components/profile_traits/lib.rs:#![plugin(serde_macros)]
components/script_traits/Cargo.toml:serde_macros = "0.5"
components/script_traits/lib.rs:#![plugin(serde_macros)]
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock:name = "serde_macros"
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/servo/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
components/style/Cargo.toml:serde_macros = "0.5"
components/style/lib.rs:#![plugin(serde_macros)]
components/style/lib.rs:#![plugin(serde_macros)]
components/util/Cargo.toml:serde_macros = "0.5"
components/util/lib.rs:#![plugin(serde_macros)]
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock:name = "serde_macros"
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/cef/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock:name = "serde_macros"
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
ports/gonk/Cargo.lock: "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7164)

<!-- Reviewable:end -->
