### PR TITLE
layout: Stop double-counting inline margins on `<input type=button>` and friends.

### DIFF
--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -6518,6 +6518,19 @@ pub fn modify_style_for_text(style: &mut Arc<ComputedValues>) {
     }
 }
 
+/// Adjusts the `margin` property as necessary to account for the text of an `input` element.
+///
+/// Margins apply to the `input` element itself, so including them in the text will cause them to
+/// be double-counted.
+pub fn modify_style_for_input_text(style: &mut Arc<ComputedValues>) {
+    let mut style = Arc::make_unique(style);
+    let margin_style = Arc::make_unique(&mut style.margin);
+    margin_style.margin_top = computed::LengthOrPercentageOrAuto::Length(Au(0));
+    margin_style.margin_right = computed::LengthOrPercentageOrAuto::Length(Au(0));
+    margin_style.margin_bottom = computed::LengthOrPercentageOrAuto::Length(Au(0));
+    margin_style.margin_left = computed::LengthOrPercentageOrAuto::Length(Au(0));
+}
+
 pub fn is_supported_property(property: &str) -> bool {
     match_ignore_ascii_case! { property,
         % for property in SHORTHANDS + LONGHANDS[:-1]:

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -170,6 +170,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 # inline_text_align_a.html inline_text_align_b.html
 == inline_whitespace_a.html inline_whitespace_ref.html
 == inline_whitespace_b.html inline_whitespace_ref.html
+== input_button_margins_a.html input_button_margins_ref.html
 == input_button_size_a.html input_button_size_ref.html
 != input_height_a.html input_height_ref.html
 == inset.html inset_ref.html

--- a/tests/ref/input_button_margins_a.html
+++ b/tests/ref/input_button_margins_a.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+}
+input {
+    margin-left: 64px;
+}
+</style>
+<input type=button value=Hello>
+

--- a/tests/ref/input_button_margins_ref.html
+++ b/tests/ref/input_button_margins_ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+}
+input {
+    position: absolute;
+    left: 64px;
+}
+</style>
+<input type=button value=Hello>
+


### PR DESCRIPTION
Improves the Google home page.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7181)

<!-- Reviewable:end -->
