### PR TITLE
Add fix / hack for compositor repainting tiles on scroll layers that have stale clipping results.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1763,6 +1763,8 @@ impl Flow for BlockFlow {
                 (overflow_x::T::auto, _) | (overflow_x::T::scroll, _) |
                 (_, overflow_x::T::auto) | (_, overflow_x::T::scroll) => {
                     self.base.flags.insert(NEEDS_LAYER);
+                    self.base.clip = ClippingRegion::max();
+                    self.base.stacking_relative_position_of_display_port = MAX_RECT;
                 }
                 _ => {}
             }


### PR DESCRIPTION
Needed for #6643. Fixes #7153.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7183)

<!-- Reviewable:end -->
