### PR TITLE
Fix Element::set_inline_style_property_priority’s handling of priority

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -712,7 +712,7 @@ impl<'a> ElementHelpers<'a> for &'a Element {
             let (from, to) = if style_priority == StylePriority::Important {
                 (&mut declarations.normal, &mut declarations.important)
             } else {
-                (&mut declarations.normal, &mut declarations.important)
+                (&mut declarations.important, &mut declarations.normal)
             };
 
             // Usually, the reference counts of `from` and `to` will be 1 here. But transitions

--- a/tests/wpt/mozilla/tests/css/setpropertypriority.html
+++ b/tests/wpt/mozilla/tests/css/setpropertypriority.html
@@ -1,9 +1,20 @@
 <link rel=match href=setpropertypriority_ref.html>
 <body>
-<p id="hello" style="color: green">This text should be green.</p>
+
+<p id="control_1" style="color: red">This text should be green.</p>
+<p id="test_1" style="color: green">This text should be green.</p>
+
+<p id="control_2" style="color: green !important">This text should be green.</p>
+<p id="test_2" style="color: red !important">This text should be green.</p>
+
 <style>
-  #hello { color: red !important }
+  #control_1 { color: green !important }
+  #test_1 { color: red !important }
+
+  #control_2 { color: red !important }
+  #test_2 { color: green !important }
 </style>
 <script>
-  document.getElementById("hello").style.setPropertyPriority("color", "important");
+  document.getElementById("test_1").style.setPropertyPriority("color", "important");
+  document.getElementById("test_2").style.setPropertyPriority("color", "");
 </script>

--- a/tests/wpt/mozilla/tests/css/setpropertypriority_ref.html
+++ b/tests/wpt/mozilla/tests/css/setpropertypriority_ref.html
@@ -1,1 +1,4 @@
 <p style="color: green">This text should be green.
+<p style="color: green">This text should be green.
+<p style="color: green">This text should be green.
+<p style="color: green">This text should be green.


### PR DESCRIPTION
Thanks to @michaelwu for pointing out a copy-paste error.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7188)

<!-- Reviewable:end -->
