### PR TITLE
Avoid marking codegen method bodies as unsafe twice

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2089,7 +2089,9 @@ class CGAbstractMethod(CGThing):
 
     def define(self):
         body = self.definition_body()
-        if self.unsafe:
+
+        # Method will already be marked `unsafe` if `self.extern == True`
+        if self.unsafe and not self.extern:
             body = CGWrapper(CGIndenter(body), pre="unsafe {\n", post="\n}")
 
         return CGWrapper(CGIndenter(body),


### PR DESCRIPTION
`CGAbstractMethod` takes a couple boolean parameters, among others:
- `extern`: will mark the method as `unsafe` and `extern`
- `unsafe`: will wrap the method body in an `unsafe` block

Passing both as `True` should not mark it as `unsafe` twice.

Example from a generated `HTMLCollectionBinding.rs`:

Before:

```
unsafe extern fn get_length(..) -> u8 {
    unsafe {
        // code here
    }
}
```

After

```
unsafe extern fn get_length(..) -> u8 {
    // code here
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7196)

<!-- Reviewable:end -->
