### PR TITLE
Fix "'PaintWorker' panicked at 'index 0 and/or 4 in `*` do not lie on…

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -314,7 +314,7 @@ impl StackingContext {
 
             if opts::get().dump_display_list_optimized {
                 println!("**** optimized display list. Tile bounds: {:?}", paint_context.page_rect);
-                display_list.print_items("*".to_owned());
+                display_list.print_items("####".to_owned());
             }
 
             // Sort positioned children according to z-index.


### PR DESCRIPTION
… character boundary" when printing display list.

This whole piece of code seems a bit fragile, but it fixes the immediate problem for now.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7206)

<!-- Reviewable:end -->
