### PR TITLE
layout: Fix several bugs relating to inline borders, padding, and margins.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -18,7 +18,7 @@ use flow::{self, BaseFlow, Flow, IS_ABSOLUTELY_POSITIONED};
 use flow_ref;
 use fragment::{CoordinateSystem, Fragment, HAS_LAYER, IframeFragmentInfo, ImageFragmentInfo};
 use fragment::{ScannedTextFragmentInfo, SpecificFragmentInfo};
-use inline::InlineFlow;
+use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFlow, LAST_FRAGMENT_OF_ELEMENT};
 use list_item::ListItemFlow;
 use model::{self, MaybeAuto, ToGfxMatrix};
 use table_cell::CollapsedBordersForCell;
@@ -51,8 +51,8 @@ use style::computed_values::{background_attachment, background_clip, background_
 use style::computed_values::{background_repeat, background_size};
 use style::computed_values::{border_style, image_rendering, overflow_x, position};
 use style::computed_values::{visibility, transform, transform_style};
-use style::properties::ComputedValues;
 use style::properties::style_structs::Border;
+use style::properties::{self, ComputedValues};
 use style::values::RGBA;
 use style::values::computed;
 use style::values::computed::LinearGradient;
@@ -951,13 +951,20 @@ impl FragmentDisplayListBuilding for Fragment {
                         level,
                         &stacking_relative_border_box,
                         &clip);
+
+                    let mut style = node.style.clone();
+                    properties::modify_border_style_for_inline_sides(
+                        &mut style,
+                        node.flags.contains(FIRST_FRAGMENT_OF_ELEMENT),
+                        node.flags.contains(LAST_FRAGMENT_OF_ELEMENT));
                     self.build_display_list_for_borders_if_applicable(
-                        &*node.style,
+                        &*style,
                         border_painting_mode,
                         display_list,
                         &stacking_relative_border_box,
                         level,
                         &clip);
+
                     self.build_display_list_for_outline_if_applicable(
                         &*node.style,
                         display_list,

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1666,6 +1666,8 @@ impl Flow for InlineFlow {
                                                           .early_absolute_position_info
                                                           .relative_containing_block_mode,
                                                       CoordinateSystem::Parent);
+            let stacking_relative_content_box =
+                fragment.stacking_relative_content_box(&stacking_relative_border_box);
             let clip = fragment.clipping_region_for_children(&self.base.clip,
                                                              &stacking_relative_border_box,
                                                              false);
@@ -1689,7 +1691,7 @@ impl Flow for InlineFlow {
                     }
 
                     block_flow.base.stacking_relative_position =
-                        stacking_relative_border_box.origin;
+                        stacking_relative_content_box.origin;
                     block_flow.base.stacking_relative_position_of_display_port =
                         self.base.stacking_relative_position_of_display_port;
                 }
@@ -1817,6 +1819,20 @@ pub struct InlineFragmentNodeInfo {
     pub address: OpaqueNode,
     pub style: Arc<ComputedValues>,
     pub pseudo: PseudoElementType<()>,
+    pub flags: InlineFragmentNodeFlags,
+}
+
+bitflags! {
+    flags InlineFragmentNodeFlags: u8 {
+        const FIRST_FRAGMENT_OF_ELEMENT = 0x01,
+        const LAST_FRAGMENT_OF_ELEMENT = 0x02,
+    }
+}
+
+impl fmt::Debug for InlineFragmentNodeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.flags.bits())
+    }
 }
 
 #[derive(Clone)]

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -184,7 +184,6 @@ impl TextRunScanner {
                 };
 
                 let (mut start_position, mut end_position) = (0, 0);
-
                 for character in text.chars() {
                     // Search for the first font in this font group that contains a glyph for this
                     // character.
@@ -286,10 +285,15 @@ impl TextRunScanner {
         for (logical_offset, old_fragment) in
                 mem::replace(&mut self.clump, LinkedList::new()).into_iter().enumerate() {
              loop {
-                 match mappings.peek() {
-                     Some(mapping) if mapping.old_fragment_index == logical_offset => {}
-                     Some(_) | None => break,
-                 };
+                match mappings.peek() {
+                    Some(mapping) if mapping.old_fragment_index == logical_offset => {}
+                    Some(_) | None => {
+                        if let Some(ref mut last_fragment) = out_fragments.last_mut() {
+                            last_fragment.meld_with_next_inline_fragment(&old_fragment);
+                        }
+                        break;
+                    }
+                };
 
                 let mut mapping = mappings.next().unwrap();
                 let run = runs[mapping.text_run_index].clone();

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -6456,15 +6456,15 @@ pub fn modify_style_for_replaced_content(style: &mut Arc<ComputedValues>) {
     }
 }
 
-/// Adjusts borders, padding, and margins as appropriate to account for a fragment's status as the
-/// first or last fragment within the range of an element.
+/// Adjusts borders as appropriate to account for a fragment's status as the first or last fragment
+/// within the range of an element.
 ///
-/// Specifically, this function sets border/padding/margin widths to zero on the sides for which
-/// the fragment is not outermost.
+/// Specifically, this function sets border widths to zero on the sides for which the fragment is
+/// not outermost.
 #[inline]
-pub fn modify_style_for_inline_sides(style: &mut Arc<ComputedValues>,
-                                     is_first_fragment_of_element: bool,
-                                     is_last_fragment_of_element: bool) {
+pub fn modify_border_style_for_inline_sides(style: &mut Arc<ComputedValues>,
+                                            is_first_fragment_of_element: bool,
+                                            is_last_fragment_of_element: bool) {
     fn modify_side(style: &mut Arc<ComputedValues>, side: PhysicalSide) {
         let mut style = Arc::make_mut(style);
         let border = Arc::make_mut(&mut style.border);
@@ -6472,34 +6472,18 @@ pub fn modify_style_for_inline_sides(style: &mut Arc<ComputedValues>,
             PhysicalSide::Left => {
                 border.border_left_width = Au(0);
                 border.border_left_style = BorderStyle::none;
-                Arc::make_mut(&mut style.padding).padding_left =
-                    computed::LengthOrPercentage::Length(Au(0));
-                Arc::make_mut(&mut style.margin).margin_left =
-                    computed::LengthOrPercentageOrAuto::Length(Au(0))
             }
             PhysicalSide::Right => {
                 border.border_right_width = Au(0);
                 border.border_right_style = BorderStyle::none;
-                Arc::make_mut(&mut style.padding).padding_right =
-                    computed::LengthOrPercentage::Length(Au(0));
-                Arc::make_mut(&mut style.margin).margin_right =
-                    computed::LengthOrPercentageOrAuto::Length(Au(0))
             }
             PhysicalSide::Bottom => {
                 border.border_bottom_width = Au(0);
                 border.border_bottom_style = BorderStyle::none;
-                Arc::make_mut(&mut style.padding).padding_bottom =
-                    computed::LengthOrPercentage::Length(Au(0));
-                Arc::make_mut(&mut style.margin).margin_bottom =
-                    computed::LengthOrPercentageOrAuto::Length(Au(0))
             }
             PhysicalSide::Top => {
                 border.border_top_width = Au(0);
                 border.border_top_style = BorderStyle::none;
-                Arc::make_mut(&mut style.padding).padding_top =
-                    computed::LengthOrPercentage::Length(Au(0));
-                Arc::make_mut(&mut style.margin).margin_top =
-                    computed::LengthOrPercentageOrAuto::Length(Au(0))
             }
         }
     }
@@ -6534,7 +6518,7 @@ pub fn modify_style_for_outer_inline_block_fragment(style: &mut Arc<ComputedValu
     box_style.position = longhands::position::computed_value::T::static_
 }
 
-/// Adjusts the `position` property as necessary to account for text.
+/// Adjusts the `position` and `padding` properties as necessary to account for text.
 ///
 /// Text is never directly relatively positioned; it's always contained within an element that is
 /// itself relatively positioned.
@@ -6549,6 +6533,18 @@ pub fn modify_style_for_text(style: &mut Arc<ComputedValues>) {
         position_offsets.right = computed::LengthOrPercentageOrAuto::Auto;
         position_offsets.bottom = computed::LengthOrPercentageOrAuto::Auto;
         position_offsets.left = computed::LengthOrPercentageOrAuto::Auto;
+    }
+
+    if style.padding.padding_top != computed::LengthOrPercentage::Length(Au(0)) ||
+            style.padding.padding_right != computed::LengthOrPercentage::Length(Au(0)) ||
+            style.padding.padding_bottom != computed::LengthOrPercentage::Length(Au(0)) ||
+            style.padding.padding_left != computed::LengthOrPercentage::Length(Au(0)) {
+        let mut style = Arc::make_unique(style);
+        let mut padding = Arc::make_unique(&mut style.padding);
+        padding.padding_top = computed::LengthOrPercentage::Length(Au(0));
+        padding.padding_right = computed::LengthOrPercentage::Length(Au(0));
+        padding.padding_bottom = computed::LengthOrPercentage::Length(Au(0));
+        padding.padding_left = computed::LengthOrPercentage::Length(Au(0));
     }
 }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -224,6 +224,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 != list_style_type_a.html list_style_type_ref.html
 == many_brs_a.html many_brs_ref.html
 == margin_a.html margin_b.html
+== margin_padding_inline_block_a.html margin_padding_inline_block_ref.html
 == margins_inside_floats_a.html margins_inside_floats_ref.html
 == marker_block_direction_placement_a.html marker_block_direction_placement_ref.html
 == max_width_float_simple_a.html max_width_float_simple_b.html

--- a/tests/ref/input_button_margins_a.html
+++ b/tests/ref/input_button_margins_a.html
@@ -5,6 +5,8 @@ body, html {
 }
 input {
     margin-left: 64px;
+    border: none;
+    vertical-align: top;
 }
 </style>
 <input type=button value=Hello>

--- a/tests/ref/input_button_margins_ref.html
+++ b/tests/ref/input_button_margins_ref.html
@@ -6,6 +6,7 @@ body, html {
 input {
     position: absolute;
     left: 64px;
+    border: none;
 }
 </style>
 <input type=button value=Hello>

--- a/tests/ref/margin_padding_inline_block_a.html
+++ b/tests/ref/margin_padding_inline_block_a.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+</style>
+<div><span style="padding-left: 100px; display: inline-block">Boo</span></div>
+<div><span style="padding-left: 100px">Foo</span></div>
+<div><span style="margin-left: 100px">Foo</span></div>
+

--- a/tests/ref/margin_padding_inline_block_ref.html
+++ b/tests/ref/margin_padding_inline_block_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+div {
+    position: relative;
+}
+span {
+    position: relative;
+    left: 100px;
+}
+</style>
+<div><span>Boo</span></div>
+<div><span>Foo</span></div>
+<div><span>Foo</span></div>
+


### PR DESCRIPTION
- The code that attempted to strip out borders that span multiple
  fragments in the same element could go wrong if fragments were
  stripped out due to text clumping or whitespace stripping. This patch
  rewrites that code to maintain flags in the inline fragment context
  specifying whether the node is the beginning or end of the element.
  Not only is this easier to maintain, it's closer in spirit to what roc
  originally suggested two years ago: it's isomorphic to "begin element,
  end element" markers for inline layout.
- Padding and margins for spans containing inline-blocks are now
  properly handled via a division of labor between the `InlineBlock`
  fragment and the `BlockFlow` that represents the inline-block.
- Unscanned text fragments may not be joined together into a text run if
  borders, padding, or margins separate them.

Because Servo now matches the rendering of Gecko and WebKit on the
`input_button_margins_a` reftest, I had to modify it to add some
vertical alignment.

The combined effect of all of these fixes places "Advertising" on the
right place on google.com.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7207)

<!-- Reviewable:end -->
