### PR TITLE
layout: Don't panic if `requestAnimationFrame()` is called before first layout.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -767,6 +767,12 @@
             "url": "/_mozilla/mozilla/window_performance.html"
           }
         ],
+        "mozilla/window_requestAnimationFrame.html": [
+          {
+            "path": "mozilla/window_requestAnimationFrame.html",
+            "url": "/_mozilla/mozilla/window_requestAnimationFrame.html"
+          }
+        ],
         "mozilla/window_setInterval.html": [
           {
             "path": "mozilla/window_setInterval.html",

--- a/tests/wpt/mozilla/tests/mozilla/window_requestAnimationFrame.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_requestAnimationFrame.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <title>Test throwing an error inside requestAnimationFrame callback</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+    window.requestAnimationFrame(function() {});
+    assert_equals(true, true, "rAF shouldn't explode if called before layout begins");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #7115.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7220)

<!-- Reviewable:end -->
