### PR TITLE
Add support for Android URL loading

### DIFF
--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -144,10 +144,39 @@ fn setup_logging() {
 }
 
 #[cfg(target_os="android")]
+const URL_LOCATION: &'static str = "/sdcard/servo/url.txt";
+
+#[cfg(target_os="android")]
+const DEFAULT_HOMEPAGE: &'static str = "http://en.wikipedia.org/wiki/Rust";
+
+#[cfg(target_os="android")]
 fn get_args() -> Vec<String> {
+    use std::io::prelude::*;
+    use std::io::BufReader;
+    use std::fs::File;
+
+    let f = File::open(URL_LOCATION);
+    let mut str = String::new();
+
+    match f {
+        Ok(file) => {
+            let mut reader = BufReader::new(file);
+
+            match reader.read_line(&mut str) {
+                Ok(_) => {},
+                Err(_) => {
+                    str.push_str(DEFAULT_HOMEPAGE);
+                }
+            }
+        },
+        Err(_) => {
+            str.push_str(DEFAULT_HOMEPAGE);
+        }
+    }
+
     vec![
         "servo".to_owned(),
-        "http://en.wikipedia.org/wiki/Rust".to_owned()
+        str
     ]
 }
 


### PR DESCRIPTION
@metajack 

We probably don't want to actually land this, as it require changes to android-rs-glue that I landed to a servo fork of it and we couldn't possibly upstream.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7226)

<!-- Reviewable:end -->
