### PR TITLE
Stop using [T]::tail.

### DIFF
--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -11,7 +11,6 @@
 #![feature(exit_status)]
 #![feature(fs_walk)]
 #![feature(path_ext)]
-#![feature(slice_extras)]
 #![feature(slice_patterns)]
 #![feature(test)]
 
@@ -44,7 +43,7 @@ bitflags!(
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let mut parts = args.tail().split(|e| &**e == "--");
+    let mut parts = args[1..].split(|e| &**e == "--");
 
     let harness_args = parts.next().unwrap();  // .split() is never empty
     let servo_args = parts.next().unwrap_or(&[]);


### PR DESCRIPTION
It has been removed upstream (rust-lang/rust#27684).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7240)

<!-- Reviewable:end -->
