### PR TITLE
Avoid a panic when handling collapsing borders (fixes #7144)

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -262,32 +262,6 @@ impl Flow for TableFlow {
         {
             let mut iterator = self.block_flow.base.child_iter().peekable();
             while let Some(kid) = iterator.next() {
-                let next_index_and_sibling = iterator.peek();
-                let next_collapsed_borders_in_block_direction = if collapsing_borders {
-                    match next_index_and_sibling {
-                        Some(next_sibling) => {
-                            if next_sibling.is_table_rowgroup() {
-                                NextBlockCollapsedBorders::FromNextRow(
-                                    &next_sibling.as_immutable_table_rowgroup()
-                                                 .preliminary_collapsed_borders
-                                                 .block_start)
-                            } else {
-                                NextBlockCollapsedBorders::FromNextRow(
-                                    &next_sibling.as_immutable_table_row()
-                                                 .preliminary_collapsed_borders
-                                                 .block_start)
-                            }
-                        }
-                        None => {
-                            NextBlockCollapsedBorders::FromTable(
-                                CollapsedBorder::block_end(&*self.block_flow.fragment.style,
-                                                           CollapsedBorderProvenance::FromTable))
-                        }
-                    }
-                } else {
-                    NextBlockCollapsedBorders::NotCollapsingBorders
-                };
-
                 if kid.is_table_colgroup() {
                     for specified_inline_size in &kid.as_table_colgroup().inline_sizes {
                         self.column_intrinsic_inline_sizes.push(ColumnIntrinsicInlineSize {
@@ -313,6 +287,28 @@ impl Flow for TableFlow {
                             first_row,
                             self.table_layout);
                     if collapsing_borders {
+                        let next_index_and_sibling = iterator.peek();
+                        let next_collapsed_borders_in_block_direction =
+                            match next_index_and_sibling {
+                                Some(next_sibling) => {
+                                    if next_sibling.is_table_rowgroup() {
+                                        NextBlockCollapsedBorders::FromNextRow(
+                                            &next_sibling.as_immutable_table_rowgroup()
+                                                         .preliminary_collapsed_borders
+                                                         .block_start)
+                                    } else {
+                                        NextBlockCollapsedBorders::FromNextRow(
+                                            &next_sibling.as_immutable_table_row()
+                                                         .preliminary_collapsed_borders
+                                                         .block_start)
+                                    }
+                                }
+                                None => {
+                                    NextBlockCollapsedBorders::FromTable(
+                                        CollapsedBorder::block_end(&*self.block_flow.fragment.style,
+                                                                   CollapsedBorderProvenance::FromTable))
+                                }
+                            };
                         perform_border_collapse_for_row(
                             kid.as_table_row(),
                             table_inline_collapsed_borders.as_ref().unwrap(),

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-colgroup-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-colgroup-001.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-colgroup-001.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-colgroup-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-colgroup-002.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-colgroup-002.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-colgroup-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-colgroup-003.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-colgroup-003.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-column-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-column-001.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-column-001.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-column-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-column-002.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-column-002.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-column-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-column-003.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-column-003.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-001.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-table-001.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-002.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-table-002.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-003.htm.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-table-003.htm]
-  type: reftest
-  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-cell-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-cell-001.htm.ini
@@ -1,3 +1,3 @@
 [table-backgrounds-bc-cell-001.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-colgroup-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-colgroup-001.htm.ini
@@ -1,3 +1,3 @@
 [table-backgrounds-bc-colgroup-001.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-column-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-column-001.htm.ini
@@ -1,3 +1,3 @@
 [table-backgrounds-bc-column-001.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-row-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-row-001.htm.ini
@@ -1,3 +1,3 @@
 [table-backgrounds-bc-row-001.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-rowgroup-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-rowgroup-001.htm.ini
@@ -1,3 +1,3 @@
 [table-backgrounds-bc-rowgroup-001.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-table-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-backgrounds-bc-table-001.htm.ini
@@ -1,3 +1,3 @@
 [table-backgrounds-bc-table-001.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL


### PR DESCRIPTION
There is no need to compute next_collapsed_borders_in_block_direction for all kind of flows when it's used only in the table row case. That also avoids a panic when the next child is a table colgroup (this should not happen when iterating over a table row).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7243)

<!-- Reviewable:end -->
