### PR TITLE
Do not use rustc-with-gold on mac

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -303,7 +303,9 @@ class CommandBase(object):
             env['HOST_FILE'] = hosts_file_path
 
         env['RUSTDOC'] = path.join(self.context.topdir, 'etc', 'rustdoc-with-private')
-        env['RUSTC'] = path.join(self.context.topdir, 'etc', 'rustc-with-gold')
+
+        if sys.platform != "darwin":
+          env['RUSTC'] = path.join(self.context.topdir, 'etc', 'rustc-with-gold')
 
         return env
 


### PR DESCRIPTION
Fix #7247

`DYLD_LIBRARY_PATH` is not defined in `rustc-with-gold`. `DYLD_LIBRARY_PATH` can't be exported to childprocesses. It's a security feature introduced in osx 10.11. See https://github.com/rust-lang/cargo/issues/1816#issuecomment-130478526

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7248)

<!-- Reviewable:end -->
