### PR TITLE
Initial implementation of ownPropertyKeys proxy handler

### DIFF
--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -11,7 +11,6 @@ use dom::bindings::utils::delete_property_by_id;
 use js::glue::GetProxyExtra;
 use js::glue::InvokeGetOwnPropertyDescriptor;
 use js::glue::{SetProxyExtra, GetProxyHandler};
-use js::jsapi::AutoIdVector;
 use js::jsapi::GetObjectProto;
 use js::jsapi::{Handle, HandleObject, HandleId, MutableHandle, RootedObject, ObjectOpResult};
 use js::jsapi::{JSContext, JSPropertyDescriptor, JSObject};
@@ -81,15 +80,6 @@ pub unsafe extern fn delete(cx: *mut JSContext, proxy: HandleObject, id: HandleI
     }
 
     delete_property_by_id(cx, expando.handle(), id, bp)
-}
-
-/// Stub for ownPropertyKeys
-pub unsafe extern fn own_property_keys(_cx: *mut JSContext,
-                                       _proxy: HandleObject,
-                                       _props: *mut AutoIdVector) -> u8 {
-    // FIXME: implement this
-    // https://github.com/servo/servo/issues/6390
-    JSTrue
 }
 
 /// Controls whether the Extensible bit can be changed

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1912,6 +1912,12 @@ impl<'a> DocumentMethods for &'a Document {
         collection.r().reflector().get_jsobject().get()
     }
 
+    // https://html.spec.whatwg.org/#document
+    fn SupportedPropertyNames(self) -> Vec<DOMString> {
+        // FIXME: unimplemented (https://github.com/servo/servo/issues/7273)
+        vec![]
+    }
+
     global_event_handlers!();
     event_handler!(readystatechange, GetOnreadystatechange, SetOnreadystatechange);
 }

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -67,5 +67,10 @@ impl<'a> DOMStringMapMethods for &'a DOMStringMap {
             }
         }
     }
-}
 
+    // https://html.spec.whatwg.org/multipage/#domstringmap
+    fn SupportedPropertyNames(self) -> Vec<DOMString> {
+        // FIXME: unimplemented (https://github.com/servo/servo/issues/7273)
+        vec![]
+    }
+}

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -227,5 +227,30 @@ impl<'a> HTMLCollectionMethods for &'a HTMLCollection {
         *found = maybe_elem.is_some();
         maybe_elem
     }
-}
 
+    // https://dom.spec.whatwg.org/#interface-htmlcollection
+    fn SupportedPropertyNames(self) -> Vec<DOMString> {
+        // Step 1
+        let mut result = vec![];
+
+        // Step 2
+        let ref filter = self.collection.1;
+        let root = self.collection.0.root();
+        let elems = HTMLCollection::traverse(root.r()).filter(|element| filter.filter(element.r(), root.r()));
+        for elem in elems {
+            // Step 2.1
+            let id_attr = elem.get_string_attribute(&atom!("id"));
+            if !id_attr.is_empty() && !result.contains(&id_attr) {
+                result.push(id_attr)
+            }
+            // Step 2.2
+            let name_attr = elem.get_string_attribute(&atom!("name"));
+            if !name_attr.is_empty() && !result.contains(&name_attr) && *elem.namespace() == ns!(HTML) {
+                result.push(name_attr)
+            }
+        }
+
+        // Step 3
+        result
+    }
+}

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -105,5 +105,9 @@ impl<'a> NamedNodeMapMethods for &'a NamedNodeMap {
         *found = item.is_some();
         item
     }
-}
 
+    fn SupportedPropertyNames(self) -> Vec<DOMString> {
+        // FIXME: unimplemented (https://github.com/servo/servo/issues/7273)
+        vec![]
+    }
+}

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -134,6 +134,11 @@ impl<'a> StorageMethods for &'a Storage {
     fn NamedDeleter(self, name: DOMString) {
         self.RemoveItem(name);
     }
+
+    fn SupportedPropertyNames(self) -> Vec<DOMString> {
+        // FIXME: unimplemented (https://github.com/servo/servo/issues/7273)
+        vec![]
+    }
 }
 
 trait PrivateStorageHelpers {

--- a/components/script/dom/testbindingproxy.rs
+++ b/components/script/dom/testbindingproxy.rs
@@ -16,7 +16,8 @@ pub struct TestBindingProxy {
 }
 
 impl<'a> TestBindingProxyMethods for &'a TestBindingProxy {
-
+    fn Length(self) -> u32 {0}
+    fn SupportedPropertyNames(self) -> Vec<DOMString> {vec![]}
     fn GetNamedItem(self, _: DOMString) -> DOMString {"".to_owned()}
     fn SetNamedItem(self, _: DOMString, _: DOMString) -> () {}
     fn GetItem(self, _: u32) -> DOMString {"".to_owned()}

--- a/components/script/dom/webidls/TestBindingProxy.webidl
+++ b/components/script/dom/webidls/TestBindingProxy.webidl
@@ -13,6 +13,7 @@
 // web pages.
 
 interface TestBindingProxy : TestBinding {
+  readonly attribute unsigned long length;
 
   getter DOMString getNamedItem(DOMString name);
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -13072,6 +13072,10 @@
         "url": "/dom/collections/HTMLCollection-empty-name.html"
       },
       {
+        "path": "dom/collections/HTMLCollection-supported-property-names.html",
+        "url": "/dom/collections/HTMLCollection-supported-property-names.html"
+      },
+      {
         "path": "dom/events/Event-constants.html",
         "url": "/dom/events/Event-constants.html"
       },
@@ -18070,6 +18074,10 @@
       {
         "path": "js/builtins/Object.prototype.freeze.html",
         "url": "/js/builtins/Object.prototype.freeze.html"
+      },
+      {
+        "path": "js/builtins/Object.prototype.getOwnPropertyNames.html",
+        "url": "/js/builtins/Object.prototype.getOwnPropertyNames.html"
       },
       {
         "path": "js/builtins/Object.prototype.hasOwnProperty-order.html",

--- a/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.forms.html.ini
+++ b/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.forms.html.ini
@@ -5,7 +5,3 @@
 
   [document.forms iteration]
     expected: FAIL
-
-  [document.forms getOwnPropertyNames]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/dom/collections/HTMLCollection-supported-property-names.html
+++ b/tests/wpt/web-platform-tests/dom/collections/HTMLCollection-supported-property-names.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<meta charset=utf-8>
+<link rel=help href=https://dom.spec.whatwg.org/#interface-htmlcollection>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<div id=log></div>
+
+<!-- with no attribute -->
+<span></span>
+
+<!-- with `id` attribute -->
+<span id=''></span>
+<span id='some-id'></span>
+<span id='some-id'></span><!-- to ensure no duplicates -->
+
+<!-- with `name` attribute -->
+<span name=''></span>
+<span name='some-name'></span>
+<span name='some-name'></span><!-- to ensure no duplicates -->
+
+<!-- with `name` and `id` attribute -->
+<span id='another-id' name='another-name'></span>
+
+<script>
+test(function () {
+  var elements = document.getElementsByTagName("span");
+  assert_array_equals(
+    Object.getOwnPropertyNames(elements),
+    ['0', '1', '2', '3', '4', '5', '6', '7', 'some-id', 'some-name', 'another-id', 'another-name']
+  );
+}, 'Object.getOwnPropertyNames on HTMLCollection');
+
+test(function () {
+  var elem = document.createElementNS('some-random-namespace', 'foo');
+  this.add_cleanup(function () {elem.remove();});
+  elem.setAttribute("name", "some-name");
+  document.body.appendChild(elem);
+
+  var elements = document.getElementsByTagName("foo");
+  assert_array_equals(Object.getOwnPropertyNames(elements), ['0']);
+}, 'Object.getOwnPropertyNames on HTMLCollection with non-HTML namespace');
+
+test(function () {
+  var elem = document.createElement('foo');
+  this.add_cleanup(function () {elem.remove();});
+  document.body.appendChild(elem);
+
+  var elements = document.getElementsByTagName("foo");
+  elements.someProperty = "some value";
+
+  assert_array_equals(Object.getOwnPropertyNames(elements), ['0', 'someProperty']);
+}, 'Object.getOwnPropertyNames on HTMLCollection with expando object');
+</script>

--- a/tests/wpt/web-platform-tests/js/builtins/Object.prototype.getOwnPropertyNames.html
+++ b/tests/wpt/web-platform-tests/js/builtins/Object.prototype.getOwnPropertyNames.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<title>Object.prototype.getOwnPropertyNames</title>
+<link rel=help href=http://es5.github.io/#x15.2.3.4>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<div id=log></div>
+<script>
+test(function () {
+  var obj = {0: 'a', 1: 'b', 2: 'c'};
+  assert_array_equals(
+    Object.getOwnPropertyNames(obj).sort(),
+    ['0', '1', '2']
+  );
+}, "object");
+
+test(function () {
+  var arr = ['a', 'b', 'c'];
+  assert_array_equals(
+    Object.getOwnPropertyNames(arr).sort(),
+    ['0', '1', '2', 'length']
+  );
+}, "array-like");
+
+test(function () {
+  var obj = Object.create({}, {
+    getFoo: {
+      value: function() { return this.foo; },
+      enumerable: false
+    }
+  });
+  obj.foo = 1;
+  assert_array_equals(
+    Object.getOwnPropertyNames(obj).sort(),
+    ['foo', 'getFoo']
+  );
+}, "non-enumerable property");
+
+test(function() {
+  function ParentClass() {}
+  ParentClass.prototype.inheritedMethod = function() {};
+
+  function ChildClass() {
+    this.prop = 5;
+    this.method = function() {};
+  }
+  ChildClass.prototype = new ParentClass;
+  ChildClass.prototype.prototypeMethod = function() {};
+
+  var obj = new ChildClass;
+  assert_array_equals(
+    Object.getOwnPropertyNames(obj).sort(),
+    ['method', 'prop']
+  );
+}, 'items on the prototype chain are not listed');
+</script>


### PR DESCRIPTION
Generates `SupportedPropertyNames` on DOM structs that should implement
it. Most of them are unimplemented now (which can be implemented in
later PRs), with the exception of `HTMLCollection`. Also added a couple
relevant WPT tests.

Closes #6390

Closes #2215 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7254)

<!-- Reviewable:end -->
