### PR TITLE
script: Update `rust-selectors` to get `:active` support.

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -479,6 +479,12 @@ impl<'le> ::selectors::Element for LayoutElement<'le> {
     }
 
     #[inline]
+    fn get_active_state(&self) -> bool {
+        let node = NodeCast::from_layout_js(&self.element);
+        node.get_active_state_for_layout()
+    }
+
+    #[inline]
     fn get_id(&self) -> Option<Atom> {
         unsafe {
             (*self.element.unsafe_get()).get_attr_atom_for_layout(&ns!(""), &atom!("id"))

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1754,6 +1754,10 @@ impl<'a> ::selectors::Element for Root<Element> {
         let node = NodeCast::from_ref(&**self);
         node.get_hover_state()
     }
+    fn get_active_state(&self) -> bool {
+        let node = NodeCast::from_ref(&**self);
+        node.get_active_state()
+    }
     fn get_focus_state(&self) -> bool {
         // TODO: Also check whether the top-level browsing context has the system focus,
         // and whether this element is a browsing context container.

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -170,6 +170,8 @@ bitflags! {
         #[doc = "Specifies whether this node is focusable and whether it is supposed \
                  to be reachable with using sequential focus navigation."]
         const SEQUENTIALLY_FOCUSABLE = 0x400,
+        #[doc = "Specifies whether this node is active."]
+        const IN_ACTIVE_STATE = 0x800,
     }
 }
 
@@ -458,6 +460,9 @@ pub trait NodeHelpers {
     fn get_focus_state(self) -> bool;
     fn set_focus_state(self, state: bool);
 
+    fn get_active_state(self) -> bool;
+    fn set_active_state(self, state: bool);
+
     fn get_disabled_state(self) -> bool;
     fn set_disabled_state(self, state: bool);
 
@@ -632,6 +637,15 @@ impl<'a> NodeHelpers for &'a Node {
 
     fn set_focus_state(self, state: bool) {
         self.set_flag(IN_FOCUS_STATE, state);
+        self.dirty(NodeDamage::NodeStyleDamaged);
+    }
+
+    fn get_active_state(self) -> bool {
+        self.get_flag(IN_ACTIVE_STATE)
+    }
+
+    fn set_active_state(self, state: bool) {
+        self.set_flag(IN_ACTIVE_STATE, state);
         self.dirty(NodeDamage::NodeStyleDamaged);
     }
 
@@ -1115,6 +1129,7 @@ pub trait LayoutNodeHelpers {
 
     fn get_hover_state_for_layout(&self) -> bool;
     fn get_focus_state_for_layout(&self) -> bool;
+    fn get_active_state_for_layout(&self) -> bool;
     fn get_disabled_state_for_layout(&self) -> bool;
     fn get_enabled_state_for_layout(&self) -> bool;
 }
@@ -1225,6 +1240,13 @@ impl LayoutNodeHelpers for LayoutJS<Node> {
     fn get_focus_state_for_layout(&self) -> bool {
         unsafe {
             self.get_flag(IN_FOCUS_STATE)
+        }
+    }
+    #[inline]
+    #[allow(unsafe_code)]
+    fn get_active_state_for_layout(&self) -> bool {
+        unsafe {
+            self.get_flag(IN_ACTIVE_STATE)
         }
     }
     #[inline]

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#e4d0af9115b82e47890a67a678aaa27aa270f083"
+source = "git+https://github.com/servo/rust-selectors#572353b3209af040cd3e6261978b09c7f8122844"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#e4d0af9115b82e47890a67a678aaa27aa270f083"
+source = "git+https://github.com/servo/rust-selectors#572353b3209af040cd3e6261978b09c7f8122844"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-selectors#e4d0af9115b82e47890a67a678aaa27aa270f083"
+source = "git+https://github.com/servo/rust-selectors#572353b3209af040cd3e6261978b09c7f8122844"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
I couldn't find the place in the spec where the precise behavior of
`:active` is described, so I don't set it. However, all the machinery to
keep track of its status is in place.

Improves YouTube.

r? @Ms2ger

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7258)

<!-- Reviewable:end -->
