### PR TITLE
Completed implementation of devtools' `getLayout`. (#3598)

### DIFF
--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -32,5 +32,6 @@ log = "0.3"
 time = "0.1"
 rustc-serialize = "0.3"
 serde = "0.5"
+serde_json = "0.5"
 serde_macros = "0.5"
 

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -14,11 +14,11 @@ use protocol::JsonPacketStream;
 
 use ipc_channel::ipc::{self, IpcSender};
 use msg::constellation_msg::PipelineId;
-use rustc_serialize::json::{self, Json, ToJson};
+use rustc_serialize::json::{self, Json};
+use serde_json;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::net::TcpStream;
-use std::sync::mpsc::channel;
 
 pub struct InspectorActor {
     pub name: String,
@@ -400,21 +400,49 @@ struct AppliedSheet {
     ruleCount: usize,
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct GetLayoutReply {
-    width: i32,
-    height: i32,
-    autoMargins: Json,
     from: String,
-}
 
-#[derive(RustcEncodable)]
-#[allow(dead_code)]
-struct AutoMargins {
-    top: String,
-    bottom: String,
-    left: String,
-    right: String,
+    display: String,
+    position: String,
+    #[serde(rename="z-index")]
+    zIndex: String,
+    #[serde(rename="box-sizing")]
+    boxSizing: String,
+
+    // Would be nice to use a proper struct, blocked by
+    // https://github.com/serde-rs/serde/issues/43
+    autoMargins: serde_json::value::Value,
+    #[serde(rename="margin-top")]
+    marginTop: String,
+    #[serde(rename="margin-right")]
+    marginRight: String,
+    #[serde(rename="margin-bottom")]
+    marginBottom: String,
+    #[serde(rename="margin-left")]
+    marginLeft: String,
+
+    #[serde(rename="border-top-width")]
+    borderTopWidth: String,
+    #[serde(rename="border-right-width")]
+    borderRightWidth: String,
+    #[serde(rename="border-bottom-width")]
+    borderBottomWidth: String,
+    #[serde(rename="border-left-width")]
+    borderLeftWidth: String,
+
+    #[serde(rename="padding-top")]
+    paddingTop: String,
+    #[serde(rename="padding-right")]
+    paddingRight: String,
+    #[serde(rename="padding-bottom")]
+    paddingBottom: String,
+    #[serde(rename="padding-left")]
+    paddingLeft: String,
+
+    width: f32,
+    height: f32,
 }
 
 impl Actor for PageStyleActor {
@@ -458,31 +486,52 @@ impl Actor for PageStyleActor {
                                       registry.actor_to_script(target.to_string()),
                                       tx))
                                 .unwrap();
-                let ComputedNodeLayout { width, height } = rx.recv().unwrap();
+                let ComputedNodeLayout {
+                    display, position, zIndex, boxSizing,
+                    autoMargins, marginTop, marginRight, marginBottom, marginLeft,
+                    borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth,
+                    paddingTop, paddingRight, paddingBottom, paddingLeft,
+                    width, height,
+                } = rx.recv().unwrap();
 
                 let auto_margins = msg.get(&"autoMargins".to_string())
                     .and_then(&Json::as_boolean).unwrap_or(false);
 
-                //TODO: the remaining layout properties (margin, border, padding, position)
-                //      as specified in getLayout in
-                //      http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/styles.js
+                // http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/styles.js
                 let msg = GetLayoutReply {
-                    width: width.round() as i32,
-                    height: height.round() as i32,
-                    autoMargins: if auto_margins {
-                        //TODO: real values like processMargins in
-                        //  http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/styles.js
-                        let mut m = BTreeMap::new();
-                        m.insert("top".to_string(), "auto".to_string().to_json());
-                        m.insert("bottom".to_string(), "auto".to_string().to_json());
-                        m.insert("left".to_string(), "auto".to_string().to_json());
-                        m.insert("right".to_string(), "auto".to_string().to_json());
-                        Json::Object(m)
-                    } else {
-                        Json::Null
-                    },
                     from: self.name(),
+                    display: display,
+                    position: position,
+                    zIndex: zIndex,
+                    boxSizing: boxSizing,
+                    autoMargins: if auto_margins {
+                        let mut m = BTreeMap::new();
+                        let auto = serde_json::value::Value::String("auto".to_string());
+                        if autoMargins.top { m.insert("top".to_string(), auto.clone()); }
+                        if autoMargins.right { m.insert("right".to_string(), auto.clone()); }
+                        if autoMargins.bottom { m.insert("bottom".to_string(), auto.clone()); }
+                        if autoMargins.left { m.insert("left".to_string(), auto.clone()); }
+                        serde_json::value::Value::Object(m)
+                    } else {
+                        serde_json::value::Value::Null
+                    },
+                    marginTop: marginTop,
+                    marginRight: marginRight,
+                    marginBottom: marginBottom,
+                    marginLeft: marginLeft,
+                    borderTopWidth: borderTopWidth,
+                    borderRightWidth: borderRightWidth,
+                    borderBottomWidth: borderBottomWidth,
+                    borderLeftWidth: borderLeftWidth,
+                    paddingTop: paddingTop,
+                    paddingRight: paddingRight,
+                    paddingBottom: paddingBottom,
+                    paddingLeft: paddingLeft,
+                    width: width,
+                    height: height,
                 };
+                let msg = &serde_json::to_string(&msg).unwrap();
+                let msg = Json::from_str(msg).unwrap();
                 stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
             }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -11,6 +11,7 @@
 #![crate_type = "rlib"]
 
 #![feature(box_syntax)]
+#![feature(custom_attribute)]
 #![feature(custom_derive)]
 #![feature(plugin)]
 #![plugin(serde_macros)]
@@ -25,6 +26,7 @@ extern crate devtools_traits;
 extern crate rustc_serialize;
 extern crate ipc_channel;
 extern crate serde;
+extern crate serde_json;
 extern crate msg;
 extern crate time;
 extern crate util;

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -148,8 +148,37 @@ pub enum TimelineMarkerType {
 /// The properties of a DOM node as computed by layout.
 #[derive(Deserialize, Serialize)]
 pub struct ComputedNodeLayout {
+    pub display: String,
+    pub position: String,
+    pub zIndex: String,
+    pub boxSizing: String,
+
+    pub autoMargins: AutoMargins,
+    pub marginTop: String,
+    pub marginRight: String,
+    pub marginBottom: String,
+    pub marginLeft: String,
+
+    pub borderTopWidth: String,
+    pub borderRightWidth: String,
+    pub borderBottomWidth: String,
+    pub borderLeftWidth: String,
+
+    pub paddingTop: String,
+    pub paddingRight: String,
+    pub paddingBottom: String,
+    pub paddingLeft: String,
+
     pub width: f32,
     pub height: f32,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct AutoMargins {
+    pub top: bool,
+    pub right: bool,
+    pub bottom: bool,
+    pub left: bool,
 }
 
 /// Messages to process in a particular script task, as instructed by a devtools client.

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -117,7 +117,7 @@ pub fn handle_get_layout(page: &Rc<Page>,
         position: computed_style.Position(),
         zIndex: computed_style.ZIndex(),
         boxSizing: computed_style.BoxSizing(),
-        autoMargins: determine_auto_margins(&node),
+        autoMargins: determine_auto_margins(node.r()),
         marginTop: computed_style.MarginTop(),
         marginRight: computed_style.MarginRight(),
         marginBottom: computed_style.MarginBottom(),
@@ -135,8 +135,8 @@ pub fn handle_get_layout(page: &Rc<Page>,
     }).unwrap();
 }
 
-fn determine_auto_margins(node: &Root<Node>) -> AutoMargins {
-    node.r().query_style(|style| {
+fn determine_auto_margins(node: &Node) -> AutoMargins {
+    node.query_style(|style| {
         let margin = style.get_margin();
 
         AutoMargins {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -142,7 +142,7 @@ fn determine_auto_margins(node: &Root<Node>) -> AutoMargins {
 
         AutoMargins {
             top: margin.margin_top == margin_top::computed_value::T::Auto,
-            right: margin.margin_right== margin_right::computed_value::T::Auto,
+            right: margin.margin_right == margin_right::computed_value::T::Auto,
             bottom: margin.margin_bottom == margin_bottom::computed_value::T::Auto,
             left: margin.margin_left == margin_left::computed_value::T::Auto,
         }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -10,7 +10,7 @@ use dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast, HTMLElementCast};
+use dom::bindings::codegen::InheritTypes::{NodeCast, ElementCast};
 use dom::bindings::conversions::FromJSValConvertible;
 use dom::bindings::conversions::jsstring_to_str;
 use dom::bindings::global::GlobalRef;
@@ -110,8 +110,7 @@ pub fn handle_get_layout(page: &Rc<Page>,
     let height = *rect.r().Height();
 
     let window = page.window();
-    let html_elem = HTMLElementCast::to_ref(node.r()).expect("should be getting layout of element");
-    let computed_style = window.r().GetComputedStyle(html_elem, None);
+    let computed_style = window.r().GetComputedStyle(elem, None);
 
     reply.send(ComputedNodeLayout {
         display: computed_style.Display(),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -223,7 +223,7 @@ pub struct SharedLayoutData {
 #[allow(raw_pointer_derive)]
 #[derive(HeapSizeOf)]
 pub struct LayoutData {
-    _shared_data: SharedLayoutData,
+    shared_data: SharedLayoutData,
     #[ignore_heap_size_of = "TODO(#6910) Box value that should be counted but the type lives in layout"]
     _data: NonZero<*const ()>,
 }
@@ -966,7 +966,7 @@ impl Node {
         let layout_data = layout_data.as_ref()
             .expect("Layout data not yet computed.");
 
-        let style = layout_data._shared_data.style.as_ref().unwrap();
+        let style = layout_data.shared_data.style.as_ref().unwrap();
         let style = style.deref();
 
         query(style)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -58,7 +58,6 @@ use util::str::DOMString;
 use util::task_state;
 
 use core::nonzero::NonZero;
-use core::ops::Deref;
 use js::jsapi::{JSContext, JSObject, JSRuntime};
 use libc;
 use libc::{uintptr_t, c_void};
@@ -967,7 +966,6 @@ impl Node {
             .expect("Layout data not yet computed.");
 
         let style = layout_data.shared_data.style.as_ref().unwrap();
-        let style = style.deref();
 
         query(style)
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -959,7 +959,6 @@ impl Node {
         Ok(fragment)
     }
 
-    #[allow(unsafe_code)]
     pub fn query_style<F, R>(&self, query: F) -> R
         where F: Fn(&ComputedValues) -> R {
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "msg 0.0.1",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
First PR; be gentle. ;)
Fixes #3598.

**Notes**
- I'm using serde_json for serialization, I will file a separate PR for converting the rest of devtools.
- As suggested I'm accessing the shared layout data from the directly from the script task.
  - Should the corresponding field be renamed ( `_shared_data` → `shared_data` )? I couldn't find any naming conventions, but I assume the underscore means "don't access".
  - Should any other documentation be updated?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7267)

<!-- Reviewable:end -->
