### PR TITLE
layout: Make `position: relative` with non-auto `z-index` create a stacking context.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2025,13 +2025,15 @@ impl Fragment {
             (position::T::fixed,
              z_index::T::Auto,
              overflow_x::T::visible,
+             overflow_x::T::visible) |
+            (position::T::relative,
+             z_index::T::Auto,
+             overflow_x::T::visible,
              overflow_x::T::visible) => false,
             (position::T::absolute, _, _, _) |
-            (position::T::fixed, _, _, _) => true,
-            (position::T::relative, _, _, _) |
+            (position::T::fixed, _, _, _) |
+            (position::T::relative, _, _, _) => true,
             (position::T::static_, _, _, _) => {
-                // FIXME(pcwalton): `position: relative` establishes a new stacking context if
-                // `z-index` is not `auto`. But this matches what we did before.
                 false
             }
         }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -291,6 +291,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == position_relative_a.html position_relative_b.html
 == position_relative_inline_block_a.html position_relative_inline_block_ref.html
 == position_relative_painting_order_a.html position_relative_painting_order_ref.html
+== position_relative_stacking_context_a.html position_relative_stacking_context_ref.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html
 == pre_with_tab.html pre_with_tab_ref.html

--- a/tests/ref/position_relative_stacking_context_a.html
+++ b/tests/ref/position_relative_stacking_context_a.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+}
+div {
+    width: 100px;
+    height: 100px;
+}
+#a {
+    position: relative;
+    z-index: 2;
+    background: green;
+}
+#b {
+    position: absolute;
+    background: red;
+    top: 0;
+    left: 0;
+}
+</style>
+<div id=a></div>
+<div id=b></div>
+

--- a/tests/ref/position_relative_stacking_context_ref.html
+++ b/tests/ref/position_relative_stacking_context_ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+body, html {
+    margin: 0;
+}
+#a {
+    position: absolute;
+    background: green;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+}
+</style>
+<div id=a></div>
+

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-106.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-106.htm.ini
@@ -1,3 +1,3 @@
-[floats-041.htm]
+[min-height-106.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/canvas/drawimage_html_image_5_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/drawimage_html_image_5_ref.html
@@ -20,7 +20,6 @@
     left: 50px;
     width: 64px;
     height: 32px;
-    overflow: hidden;
   }
 
   #destination .img img{


### PR DESCRIPTION
Improves imgur.com and Fast Company articles.

This change made `min-height-106.htm.ini` fail because the thing it was testing
for never worked: we were relying on the incorrect stacking order of `position:
relative` to get the green square to show up.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7277)

<!-- Reviewable:end -->
