### PR TITLE
layout: Avoid a division by zero in `tile_image()`.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -390,9 +390,13 @@ impl ImageFragmentInfo {
     }
 
     /// Tile an image
-    pub fn tile_image(position: &mut Au, size: &mut Au,
-                        virtual_position: Au, image_size: u32) {
+    pub fn tile_image(position: &mut Au, size: &mut Au, virtual_position: Au, image_size: u32) {
+        // Avoid division by zero below!
         let image_size = image_size as i32;
+        if image_size == 0 {
+            return
+        }
+
         let delta_pixels = (virtual_position - *position).to_px();
         let tile_count = (delta_pixels + image_size - 1) / image_size;
         let offset = Au::from_px(image_size * tile_count);

--- a/tests/ref/background_size_zero_a.html
+++ b/tests/ref/background_size_zero_a.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+body {
+    background-image: url(400x400_green.png);
+    background-size: 0 0;
+}
+</style>
+Don't crash!
+

--- a/tests/ref/background_size_zero_ref.html
+++ b/tests/ref/background_size_zero_ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+Don't crash!
+

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -37,6 +37,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == background_repeat_y_a.html background_repeat_y_b.html
 == background_size_a.html background_size_ref.html
 == background_size_shorthand_a.html background_size_shorthand_ref.html
+== background_size_zero_a.html background_size_zero_ref.html
 == background_style_attr.html background_ref.html
 == basic_width_px.html basic_width_em.html
 == block_formatting_context_a.html block_formatting_context_ref.html


### PR DESCRIPTION
Fixes a crash on Facebook Timeline.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7279)

<!-- Reviewable:end -->
