### PR TITLE
Bump js (rust-mozjs) to the latest commit

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#85e4eff9936889436b24ceefd689d4467db302a9"
+source = "git+https://github.com/servo/rust-mozjs#ff77d7152515b8dbfe29cb5f883e3a348673741c"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#85e4eff9936889436b24ceefd689d4467db302a9"
+source = "git+https://github.com/servo/rust-mozjs#ff77d7152515b8dbfe29cb5f883e3a348673741c"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#85e4eff9936889436b24ceefd689d4467db302a9"
+source = "git+https://github.com/servo/rust-mozjs#ff77d7152515b8dbfe29cb5f883e3a348673741c"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
I need the constants added in
https://github.com/servo/rust-mozjs/pull/191 for
https://github.com/servo/servo/pull/7254

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7285)

<!-- Reviewable:end -->
