### PR TITLE
layout: Centralize the logic that determines whether fragments get layers in the fragment.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -111,6 +111,9 @@ pub struct Fragment {
     /// The pseudo-element that this fragment represents.
     pub pseudo: PseudoElementType<()>,
 
+    /// Various flags for this fragment.
+    pub flags: FragmentFlags,
+
     /// A debug ID that is consistent for the life of this fragment (via transform etc).
     pub debug_id: u16,
 }
@@ -761,6 +764,7 @@ impl Fragment {
             specific: specific,
             inline_context: None,
             pseudo: node.get_pseudo_element_type().strip(),
+            flags: FragmentFlags::empty(),
             debug_id: layout_debug::generate_unique_debug_id(),
         }
     }
@@ -783,6 +787,7 @@ impl Fragment {
             specific: specific,
             inline_context: None,
             pseudo: pseudo,
+            flags: FragmentFlags::empty(),
             debug_id: layout_debug::generate_unique_debug_id(),
         }
     }
@@ -816,6 +821,7 @@ impl Fragment {
             specific: info,
             inline_context: self.inline_context.clone(),
             pseudo: self.pseudo.clone(),
+            flags: FragmentFlags::empty(),
             debug_id: self.debug_id,
         }
     }
@@ -1987,6 +1993,9 @@ impl Fragment {
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.
     pub fn establishes_stacking_context(&self) -> bool {
+        if self.flags.contains(HAS_LAYER) {
+            return true
+        }
         if self.style().get_effects().opacity != 1.0 {
             return true
         }
@@ -2373,3 +2382,11 @@ impl WhitespaceStrippingResult {
         }
     }
 }
+
+bitflags! {
+    flags FragmentFlags: u8 {
+        /// Whether this fragment has a layer.
+        const HAS_LAYER = 0x01,
+    }
+}
+

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -257,6 +257,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 # Should be == with expected failure. See #2797
 != overconstrained_block.html overconstrained_block_ref.html
 == overflow_auto.html overflow_simple_b.html
+== overflow_auto_stacking_order_a.html overflow_auto_stacking_order_ref.html
 # Should be ==?
 != overflow_position_abs_inside_normal_a.html overflow_position_abs_inside_normal_b.html
 == overflow_position_abs_simple_a.html overflow_position_abs_simple_b.html

--- a/tests/ref/overflow_auto_stacking_order_a.html
+++ b/tests/ref/overflow_auto_stacking_order_a.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+#a {
+    background: red;
+    overflow: auto;
+}
+#b {
+    background: green;
+    top: 0;
+    left: 0;
+}
+</style>
+<div id=a></div>
+<div id=b></div>
+

--- a/tests/ref/overflow_auto_stacking_order_ref.html
+++ b/tests/ref/overflow_auto_stacking_order_ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+#a {
+    background: green;
+    top: 0;
+    left: 0;
+}
+</style>
+<div id=a></div>
+
+

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-010.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-010.htm.ini
@@ -1,0 +1,4 @@
+[abspos-overflow-010.htm]
+  type: reftest
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-011.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-011.htm.ini
@@ -1,0 +1,3 @@
+[abspos-overflow-011.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/max-height-107.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/max-height-107.htm.ini
@@ -1,0 +1,3 @@
+[max-height-107.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/max-height-110.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/max-height-110.htm.ini
@@ -1,0 +1,3 @@
+[max-height-110.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-104.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-104.htm.ini
@@ -1,0 +1,3 @@
+[min-height-104.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-105.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-105.htm.ini
@@ -1,0 +1,3 @@
+[min-height-105.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-106.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-106.htm.ini
@@ -1,0 +1,3 @@
+[min-height-106.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/the-fieldset-element-0/min-width-not-important.html.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/the-fieldset-element-0/min-width-not-important.html.ini
@@ -1,0 +1,5 @@
+[min-width-not-important.html]
+  type: reftest
+  reftype: ==
+  refurl: /html/rendering/non-replaced-elements/the-fieldset-element-0/ref.html
+  expected: FAIL


### PR DESCRIPTION
…so that it can be activated when we're forcing
the creation of extra layers due to positioned descendants that
themselves have layers.

The newly failing tests were tests that accidentally passed due to
incorrect stacking order.

Closes #7281.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7291)

<!-- Reviewable:end -->
