### PR TITLE
Clears #5909

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1820,11 +1820,12 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
         }
 
 
+        // FIXME(Savago): a SC (Stacking Context) within another SC may not be displayed.
+        // It is a bit unclear if the issue is at the Paint step or after optimizing the Display list.
+        // In such cases, we have to set has_stacking_context to false to correctly draw
+        // (but not for filtered elements).
         if self.fragments.fragments.len() > 0 {
-            match self.fragments.fragments[0].specific {
-                SpecificFragmentInfo::Canvas(_) => has_stacking_context = true,
-                _ => debug!("InlineFlow::build_display_list: has stacking context {}", has_stacking_context),
-            }
+            has_stacking_context = !self.fragments.fragments[0].style().get_effects().filter.is_empty();
         }
 
         self.base.display_list_building_result = if has_stacking_context {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1819,15 +1819,13 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
                                                              self.fragments.fragments[0].node);
         }
 
-        // FIXME(Savago): fix Fragment::establishes_stacking_context() for absolute positioned item
-        // and remove the check for filter presence. Further details on #5812.
-        has_stacking_context = has_stacking_context && {
-            if let SpecificFragmentInfo::Canvas(_) = self.fragments.fragments[0].specific {
-                true
-            } else {
-                !self.fragments.fragments[0].style().get_effects().filter.is_empty()
+
+        if self.fragments.fragments.len() > 0 {
+            match self.fragments.fragments[0].specific {
+                SpecificFragmentInfo::Canvas(_) => has_stacking_context = true,
+                _ => debug!("InlineFlow::build_display_list: has stacking context {}", has_stacking_context),
             }
-        };
+        }
 
         self.base.display_list_building_result = if has_stacking_context {
             DisplayListBuildingResult::StackingContext(


### PR DESCRIPTION
Recent changes on Fragment::establishes_stacking_context() makes this hack no longer necessary for displaying filtered inline elements.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7302)

<!-- Reviewable:end -->
