### PR TITLE
Don't use `is` operatory to compare Python strings

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1583,7 +1583,7 @@ class CGIndenter(CGThing):
 
     def define(self):
         defn = self.child.define()
-        if defn is not "":
+        if defn != "":
             return re.sub(lineStartDetector, self.indent, defn)
         else:
             return defn
@@ -3641,7 +3641,7 @@ class ClassMethod(ClassItem):
             'override': ' MOZ_OVERRIDE' if self.override else '',
             'args': args,
             'body': body,
-            'visibility': self.visibility + ' ' if self.visibility is not 'priv' else ''
+            'visibility': self.visibility + ' ' if self.visibility != 'priv' else ''
         })
 
     def define(self, cgClass):

--- a/components/script/dom/bindings/codegen/GenerateCSS2PropertiesWebIDL.py
+++ b/components/script/dom/bindings/codegen/GenerateCSS2PropertiesWebIDL.py
@@ -9,7 +9,7 @@ propList = eval(sys.stdin.read())
 props = ""
 for [prop, pref] in propList:
     extendedAttrs = ["Throws", "TreatNullAs=EmptyString"]
-    if pref is not "":
+    if pref != "":
         extendedAttrs.append("Pref=%s" % pref)
     if not prop.startswith("Moz"):
         prop = prop[0].lower() + prop[1:]


### PR DESCRIPTION
`is` checks identity. `==` checks value. I can't think of a reason why
we would want the former in these scenarios.

More info:
- http://stackoverflow.com/a/1504742
- https://docs.python.org/2/reference/expressions.html#is

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7315)

<!-- Reviewable:end -->
