### PR TITLE
Remove unused support/time from ORGANIZATION.md

### DIFF
--- a/ORGANIZATION.md
+++ b/ORGANIZATION.md
@@ -26,7 +26,6 @@ special integration:
 * [`support/android`][support/android]: Android-specific infrastructure.
 * [`support/android-rs-glue`][support/android-rs-glue]: Android apk builder.
 * [`support/rust-task_info`][support/rust-task_info]: A binding to the task_info library on OS X.
-* `support/time`: A temporary fork of libtime required for Android.
 
 ## Tests
 


### PR DESCRIPTION
As detailed in the explanation of `support/time`, it should be temporarily. In this case the documentation lags behind the reality. `support/time` was removed in commit e2912a855275bb468f71212b3da15f64237332de so it seems appropriate to remove it from `ORGANIZATION.md` as well.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7325)

<!-- Reviewable:end -->
