### PR TITLE
layout: Don't crash if `quotes: none` is specified and generated content uses quotes.

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -298,6 +298,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == pre_with_tab.html pre_with_tab_ref.html
 == pseudo_element_a.html pseudo_element_b.html
 == pseudo_inherit.html pseudo_inherit_ref.html
+== quotes_none_a.html quotes_none_ref.html
 == quotes_simple_a.html quotes_simple_ref.html
 == root_height_a.html root_height_b.html
 == root_margin_collapse_a.html root_margin_collapse_b.html

--- a/tests/ref/quotes_none_a.html
+++ b/tests/ref/quotes_none_a.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+q {
+    quotes: none;
+}
+</style>
+<q>Don't crash!

--- a/tests/ref/quotes_none_ref.html
+++ b/tests/ref/quotes_none_ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+Don't crash!

--- a/tests/wpt/metadata-css/css21_dev/html4/quotes-035.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/quotes-035.htm.ini
@@ -1,3 +1,3 @@
 [quotes-035.htm]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/quotes-035a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/quotes-035a.htm.ini
@@ -1,3 +1,3 @@
 [quotes-035a.htm]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/quotes-036.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/quotes-036.htm.ini
@@ -1,3 +1,3 @@
 [quotes-036.htm]
   type: reftest
-  expected: CRASH
+  expected: FAIL


### PR DESCRIPTION
Avoids a crash on The Verge.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7340)

<!-- Reviewable:end -->
