### PR TITLE
Improve style nit check for space after a comma

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -194,7 +194,7 @@ def check_rust(file_name, contents):
         # get rid of comments and attributes
         line = re.sub('//.*?$|/\*.*?$|^\*.*?$|^#.*?$', '', line)
 
-        match = re.search(r",[A-Za-z0-9]", line)
+        match = re.search(r",[^\s]", line)
         if match:
             yield (idx + 1, "missing space after ,")
 


### PR DESCRIPTION
Only a small number of things that followed a comma were flagged.
This improves the thoroughness of that check.

Fixes #7345.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7351)

<!-- Reviewable:end -->
