### PR TITLE
Refactor tests/ref/iframe/size_attributes_vertical_writing_mode.html

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -138,7 +138,7 @@ experimental == flex_row_direction.html flex_row_direction_ref.html
 == iframe/simple_inline_width_height.html iframe/simple_inline_width_height_ref.html
 == iframe/simple_inline_width_percentage.html iframe/simple_inline_width_percentage_ref.html
 == iframe/size_attributes.html iframe/size_attributes_ref.html
-experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_attributes_ref.html
+experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_attributes_vertical_writing_mode_ref.html
 == iframe/stacking_context.html iframe/stacking_context_ref.html
 
 != image_rendering_auto_a.html image_rendering_pixelated_a.html

--- a/tests/ref/iframe/size_attributes_vertical_writing_mode_ref.html
+++ b/tests/ref/iframe/size_attributes_vertical_writing_mode_ref.html
@@ -4,15 +4,16 @@
 <style>
 body {
     background: purple;
+    text-align: right;
 }
-
 iframe {
-    writing-mode: vertical-rl;
+    width: 200px;
+    height: 100px;
 }
 </style>
 </head>
 <body>
-<iframe src="about:blank" width=200 height=100></iframe>
+<iframe src="about:blank"></iframe>
 </body>
 </html>
 


### PR DESCRIPTION
… to not use an arbitrary 104px offset that just happens to match the reference and relies on incorrect behavior.

See discussion in #7313.

r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7355)

<!-- Reviewable:end -->
