### PR TITLE
layout: Fix calculation of overflow for stacking contexts that contain `position: relative` fragments.

### DIFF
--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -382,7 +382,7 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
                     // When there is a new layer, the transforms and origin
                     // are handled by the compositor.
                     (Some(paint_layer.id),
-                     Point2D::zero(),
+                     -stacking_context.overflow.origin,
                      Matrix4::identity(),
                      Matrix4::identity())
                 }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2060,8 +2060,8 @@ impl Fragment {
         // the time. Can't we handle relative positioning by just adjusting `border_box`?
         let relative_position =
             self.relative_position(&LogicalSize::zero(self.style.writing_mode));
-        border_box =
-            border_box.translate_by_size(&relative_position.to_physical(self.style.writing_mode));
+        border_box = border_box.translate_by_size(&relative_position.to_physical(
+                self.style.writing_mode));
         let mut overflow = border_box;
 
         // Box shadows cause us to draw outside our border box.

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -54,7 +54,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 != block_image.html noteq_500x300_white.html
 == block_replaced_content_a.html block_replaced_content_ref.html
 == block_replaced_content_b.html block_replaced_content_ref.html
-== blur_a.html blur_ref.html
+!= blur_a.html blur_ref.html
 != border_black_groove.html border_black_solid.html
 != border_black_ridge.html border_black_groove.html
 != border_black_ridge.html border_black_solid.html

--- a/tests/ref/blur_a.html
+++ b/tests/ref/blur_a.html
@@ -6,17 +6,27 @@ div {
    width: 200px;
    height: 200px;
    background: green;
+   position: relative;
 }
 
 .ex {
-   position: relative;
-   width: 40px; height: 40px;
-   border-style: solid;
-   border-color: black;
-   top: 50px; left: 50px;
+   position: absolute;
+   width: 80px; height: 80px;
+   background: blue;
+   top: 60px; left: 60px;
    -webkit-filter: blur(30px);
    -moz-filter: blur(30px);
    filter: blur(30px);
+}
+
+.coveritup {
+   position: absolute;
+   background: green;
+   top: 60px;
+   left: 60px;
+   width: 80px;
+   height: 80px;
+   transform: translateX(0px);  /* force stacking context */
 }
 
 </style>
@@ -24,6 +34,7 @@ div {
 <body>
   <div>
     <div class="ex"></div>
+    <div class="coveritup"></div>
   </div>
 </body>
 </html>

--- a/tests/ref/blur_ref.html
+++ b/tests/ref/blur_ref.html
@@ -6,6 +6,7 @@ div {
    width: 200px;
    height: 200px;
    background: green;
+   position: relative;
 }
 
 </style>

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-004.htm.ini
@@ -1,3 +1,0 @@
-[margin-collapse-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/min-height-106.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/min-height-106.htm.ini
@@ -1,3 +1,0 @@
-[min-height-106.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Fixes placement of the header on espn.go.com.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7369)

<!-- Reviewable:end -->
