### PR TITLE
Enable commented out inline_text_align_* ref test

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -179,7 +179,7 @@ experimental == iframe/size_attributes_vertical_writing_mode.html iframe/size_at
 == inline_margins_a.html inline_margins_ref.html
 == inline_margins_intrinsic_size_a.html inline_margins_intrinsic_size_ref.html
 == inline_padding_a.html inline_padding_b.html
-# inline_text_align_a.html inline_text_align_b.html
+== inline_text_align_a.html inline_text_align_b.html
 == inline_whitespace_a.html inline_whitespace_ref.html
 == inline_whitespace_b.html inline_whitespace_ref.html
 == input_button_margins_a.html input_button_margins_ref.html


### PR DESCRIPTION
At some point this test did not work, but now it does

Closes #1575

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7371)

<!-- Reviewable:end -->
