### PR TITLE
Fixes #2240 - NamedGetter and NamedSetter do not assume that the arg is named `name`

### DIFF
--- a/components/script/dom/webidls/TestBindingProxy.webidl
+++ b/components/script/dom/webidls/TestBindingProxy.webidl
@@ -15,9 +15,9 @@
 interface TestBindingProxy : TestBinding {
   readonly attribute unsigned long length;
 
-  getter DOMString getNamedItem(DOMString name);
+  getter DOMString getNamedItem(DOMString item_name);
 
-  setter creator void setNamedItem(DOMString name, DOMString value);
+  setter creator void setNamedItem(DOMString item_name, DOMString value);
 
   getter DOMString getItem(unsigned long index);
 


### PR DESCRIPTION
I'm not totally sure about how to test this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7387)

<!-- Reviewable:end -->
