### PR TITLE
Disable storage_session_setitem_quotaexceedederr.html.

### DIFF
--- a/tests/wpt/metadata/webstorage/storage_local_setitem_quotaexceedederr.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_local_setitem_quotaexceedederr.html.ini
@@ -1,4 +1,3 @@
 [storage_local_setitem_quotaexceedederr.html]
   type: testharness
-  disabled: intermittently crashes instead of times out in release
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/6734

--- a/tests/wpt/metadata/webstorage/storage_session_setitem_quotaexceedederr.html.ini
+++ b/tests/wpt/metadata/webstorage/storage_session_setitem_quotaexceedederr.html.ini
@@ -1,3 +1,3 @@
 [storage_session_setitem_quotaexceedederr.html]
   type: testharness
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/6734


### PR DESCRIPTION
It fails intermittently due to OOM because we don't implement the quota check.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7405)

<!-- Reviewable:end -->
