### PR TITLE
Adding a reference test where a bigger area than the original element

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4153,6 +4153,18 @@
         ]
       },
       "testharness": {
+        "css/canvas_over_area.html": [
+          {
+            "path": "css/canvas_over_area.html",
+            "references": [
+              [
+                "/_mozilla/css/canvas_over_area_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/canvas_over_area.html"
+          }
+        ],
         "css/test_variable_legal_values.html": [
           {
             "path": "css/test_variable_legal_values.html",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1007,6 +1007,18 @@
             "url": "/_mozilla/css/canvas_linear_gradient_a.html"
           }
         ],
+        "css/canvas_over_area.html": [
+          {
+            "path": "css/canvas_over_area.html",
+            "references": [
+              [
+                "/_mozilla/css/canvas_over_area_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/canvas_over_area.html"
+          }
+        ],
         "css/case-insensitive-font-family.html": [
           {
             "path": "css/case-insensitive-font-family.html",
@@ -4153,18 +4165,6 @@
         ]
       },
       "testharness": {
-        "css/canvas_over_area.html": [
-          {
-            "path": "css/canvas_over_area.html",
-            "references": [
-              [
-                "/_mozilla/css/canvas_over_area_ref.html",
-                "=="
-              ]
-            ],
-            "url": "/_mozilla/css/canvas_over_area.html"
-          }
-        ],
         "css/test_variable_legal_values.html": [
           {
             "path": "css/test_variable_legal_values.html",
@@ -5740,6 +5740,18 @@
             ]
           ],
           "url": "/_mozilla/css/canvas_linear_gradient_a.html"
+        }
+      ],
+      "css/canvas_over_area.html": [
+        {
+          "path": "css/canvas_over_area.html",
+          "references": [
+            [
+              "/_mozilla/css/canvas_over_area_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/canvas_over_area.html"
         }
       ],
       "css/case-insensitive-font-family.html": [

--- a/tests/wpt/mozilla/tests/css/canvas_over_area.html
+++ b/tests/wpt/mozilla/tests/css/canvas_over_area.html
@@ -1,0 +1,32 @@
+<style>
+
+#base {
+  background-color: red;
+  height: 100px;
+  width: 100px;
+}
+
+#painted {
+  width: 100px;
+  height: 100px;
+  position: relative;
+  top: -100px;
+}
+</style>
+
+<div id="base"></div>
+<canvas id="painted"></canvas>
+
+
+<script>
+onload = function() {
+  var obj = document.getElementById("painted");
+  obj.width = 500;
+  obj.height = 500;
+  var context = obj.getContext("2d");
+  context.save();
+  context.fillStyle = "green";
+  context.fillRect(0, 0, 500, 500);
+  context.restore();
+};
+</script>

--- a/tests/wpt/mozilla/tests/css/canvas_over_area.html
+++ b/tests/wpt/mozilla/tests/css/canvas_over_area.html
@@ -1,3 +1,6 @@
+<!doctype html>
+<body>
+<link rel='match' href='canvas_over_area_ref.html'>
 <style>
 
 #base {
@@ -30,3 +33,5 @@ onload = function() {
   context.restore();
 };
 </script>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/canvas_over_area_ref.html
+++ b/tests/wpt/mozilla/tests/css/canvas_over_area_ref.html
@@ -1,0 +1,11 @@
+<style>
+
+#base {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+}
+
+</style>
+
+<div id="base"></div>


### PR DESCRIPTION
Adding a reference test where a bigger area than the original element size is defined at script.

To pass, this depends in a fix on rust-azure (i.e. #195). No for commit, we need the rust-azure to land and next update the deps.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7414)

<!-- Reviewable:end -->
