### PR TITLE
layout: Make the compositor rather than layout determine the position of each iframe.

### DIFF
--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use azure::azure_hl;
-use compositor::IOCompositor;
+use compositor::{IOCompositor, RemovedPipelineInfo};
 use euclid::length::Length;
 use euclid::point::{Point2D, TypedPoint2D};
 use euclid::rect::Rect;
@@ -12,7 +12,7 @@ use layers::color::Color;
 use layers::geometry::LayerPixel;
 use layers::layers::{Layer, LayerBufferSet};
 use msg::compositor_msg::{Epoch, LayerId, LayerProperties, ScrollPolicy};
-use msg::constellation_msg::PipelineId;
+use msg::constellation_msg::{PipelineId, SubpageId};
 use script_traits::CompositorEvent::{ClickEvent, MouseDownEvent, MouseMoveEvent, MouseUpEvent};
 use script_traits::ConstellationControlMsg;
 use std::rc::Rc;
@@ -42,6 +42,9 @@ pub struct CompositorData {
     /// The scroll offset originating from this scrolling root. This allows scrolling roots
     /// to track their current scroll position even while their content_offset does not change.
     pub scroll_offset: TypedPoint2D<LayerPixel, f32>,
+
+    /// The pipeline ID and subpage ID of this layer, if it represents a subpage.
+    pub subpage_info: Option<(PipelineId, SubpageId)>,
 }
 
 impl CompositorData {
@@ -58,6 +61,9 @@ impl CompositorData {
             requested_epoch: Epoch(0),
             painted_epoch: Epoch(0),
             scroll_offset: Point2D::typed(0., 0.),
+            subpage_info: layer_properties.subpage_layer_info.map(|subpage_layer_info| {
+                (subpage_layer_info.pipeline_id, subpage_layer_info.subpage_id)
+            }),
         };
 
         Rc::new(Layer::new(Rect::from_untyped(&layer_properties.rect),
@@ -96,14 +102,6 @@ pub trait CompositorLayer {
                                                   compositor: &mut IOCompositor<Window>,
                                                   pipeline_id: PipelineId)
                                                   where Window: WindowMethods;
-
-    /// Traverses the existing layer hierarchy and removes any layers that
-    /// currently exist but which are no longer required.
-    fn collect_old_layers<Window>(&self,
-                                  compositor: &mut IOCompositor<Window>,
-                                  pipeline_id: PipelineId,
-                                  new_layers: &[LayerProperties])
-                                  where Window: WindowMethods;
 
     /// Destroys all tiles of all layers, including children, *without* sending them back to the
     /// painter. You must call this only when the paint task is destined to be going down;
@@ -149,6 +147,17 @@ pub trait CompositorLayer {
 
     /// Return the pipeline id associated with this layer.
     fn pipeline_id(&self) -> PipelineId;
+}
+
+pub trait RcCompositorLayer {
+    /// Traverses the existing layer hierarchy and removes any layers that
+    /// currently exist but which are no longer required.
+    fn collect_old_layers<Window>(&self,
+                                  compositor: &mut IOCompositor<Window>,
+                                  pipeline_id: PipelineId,
+                                  new_layers: &[LayerProperties],
+                                  pipelines_removed: &mut Vec<RemovedPipelineInfo>)
+                                  where Window: WindowMethods;
 }
 
 #[derive(Copy, PartialEq, Clone, Debug)]
@@ -279,43 +288,6 @@ impl CompositorLayer for Layer<CompositorData> {
         }
     }
 
-    fn collect_old_layers<Window>(&self,
-                                  compositor: &mut IOCompositor<Window>,
-                                  pipeline_id: PipelineId,
-                                  new_layers: &[LayerProperties])
-                                  where Window: WindowMethods {
-        // Traverse children first so that layers are removed
-        // bottom up - allowing each layer being removed to properly
-        // clean up any tiles it owns.
-        for kid in &*self.children() {
-            kid.collect_old_layers(compositor, pipeline_id, new_layers);
-        }
-
-        // Retain child layers that also exist in the new layer list.
-        self.children().retain(|child| {
-            let extra_data = child.extra_data.borrow();
-
-            // Never remove root layers or layers from other pipelines.
-            if pipeline_id != extra_data.pipeline_id ||
-               extra_data.id == LayerId::null() {
-                true
-            } else {
-                // Keep this layer if it exists in the new layer list.
-                let keep_layer = new_layers.iter().any(|properties| {
-                    properties.id == extra_data.id
-                });
-
-                // When removing a layer, clear any tiles and surfaces
-                // associated with the layer.
-                if !keep_layer {
-                    child.clear_all_tiles(compositor);
-                }
-
-                keep_layer
-            }
-        });
-    }
-
     /// Destroys all tiles of all layers, including children, *without* sending them back to the
     /// painter. You must call this only when the paint task is destined to be going down;
     /// otherwise, you will leak tiles.
@@ -403,8 +375,11 @@ impl CompositorLayer for Layer<CompositorData> {
                 MouseUpEvent(button, event_point),
         };
 
-        let pipeline = compositor.pipeline(self.pipeline_id());
-        let _ = pipeline.script_chan.send(ConstellationControlMsg::SendEvent(pipeline.id.clone(), message));
+        if let Some(pipeline) = compositor.pipeline(self.pipeline_id()) {
+            pipeline.script_chan
+                    .send(ConstellationControlMsg::SendEvent(pipeline.id.clone(), message))
+                    .unwrap();
+        }
     }
 
     fn send_mouse_move_event<Window>(&self,
@@ -412,8 +387,11 @@ impl CompositorLayer for Layer<CompositorData> {
                                      cursor: TypedPoint2D<LayerPixel, f32>)
                                      where Window: WindowMethods {
         let message = MouseMoveEvent(cursor.to_untyped());
-        let pipeline = compositor.pipeline(self.pipeline_id());
-        let _ = pipeline.script_chan.send(ConstellationControlMsg::SendEvent(pipeline.id.clone(), message));
+        if let Some(pipeline) = compositor.pipeline(self.pipeline_id()) {
+            pipeline.script_chan
+                    .send(ConstellationControlMsg::SendEvent(pipeline.id.clone(), message))
+                    .unwrap();
+        }
     }
 
     fn scroll_layer_and_all_child_layers(&self, new_offset: TypedPoint2D<LayerPixel, f32>)
@@ -443,3 +421,97 @@ impl CompositorLayer for Layer<CompositorData> {
         self.extra_data.borrow().pipeline_id
     }
 }
+
+impl RcCompositorLayer for Rc<Layer<CompositorData>> {
+    fn collect_old_layers<Window>(&self,
+                                  compositor: &mut IOCompositor<Window>,
+                                  pipeline_id: PipelineId,
+                                  new_layers: &[LayerProperties],
+                                  pipelines_removed: &mut Vec<RemovedPipelineInfo>)
+                                  where Window: WindowMethods {
+        fn find_root_layer_for_pipeline(layer: &Rc<Layer<CompositorData>>, pipeline_id: PipelineId)
+                                        -> Option<Rc<Layer<CompositorData>>> {
+            let extra_data = layer.extra_data.borrow();
+            if extra_data.pipeline_id == pipeline_id {
+                return Some((*layer).clone())
+            }
+
+            for kid in &*layer.children() {
+                if let Some(layer) = find_root_layer_for_pipeline(kid, pipeline_id) {
+                    return Some(layer.clone())
+                }
+            }
+            None
+        }
+
+        fn collect_old_layers_for_pipeline<Window>(
+                layer: &Layer<CompositorData>,
+                compositor: &mut IOCompositor<Window>,
+                pipeline_id: PipelineId,
+                new_layers: &[LayerProperties],
+                pipelines_removed: &mut Vec<RemovedPipelineInfo>)
+                where Window: WindowMethods {
+            // Traverse children first so that layers are removed
+            // bottom up - allowing each layer being removed to properly
+            // clean up any tiles it owns.
+            for kid in &*layer.children() {
+                collect_old_layers_for_pipeline(kid,
+                                                compositor,
+                                                pipeline_id,
+                                                new_layers,
+                                                pipelines_removed);
+            }
+
+            // Retain child layers that also exist in the new layer list.
+            layer.children().retain(|child| {
+                let extra_data = child.extra_data.borrow();
+                if pipeline_id == extra_data.pipeline_id {
+                    // Never remove our own root layer.
+                    if extra_data.id == LayerId::null() {
+                        return true
+                    }
+
+                    // Keep this layer if it exists in the new layer list.
+                    return new_layers.iter().any(|properties| properties.id == extra_data.id);
+                }
+
+                if let Some(ref subpage_info_for_this_layer) = extra_data.subpage_info {
+                    for layer_properties in new_layers.iter() {
+                        // Keep this layer if a reference to it exists.
+                        if let Some(ref subpage_layer_info) = layer_properties.subpage_layer_info {
+                            if subpage_layer_info.pipeline_id == subpage_info_for_this_layer.0 &&
+                                    subpage_layer_info.subpage_id ==
+                                    subpage_info_for_this_layer.1 {
+                                return true
+                            }
+                        }
+                    }
+
+                    pipelines_removed.push(RemovedPipelineInfo {
+                        parent_pipeline_id: subpage_info_for_this_layer.0,
+                        parent_subpage_id: subpage_info_for_this_layer.1,
+                        child_pipeline_id: extra_data.pipeline_id,
+                    });
+                }
+
+                // When removing a layer, clear any tiles and surfaces associated with the layer.
+                child.clear_all_tiles(compositor);
+                false
+            });
+        }
+
+        // First, find the root layer with the given pipeline ID.
+        let root_layer = match find_root_layer_for_pipeline(self, pipeline_id) {
+            Some(root_layer) => root_layer,
+            None => return,
+        };
+
+        // Then collect all old layers underneath that layer.
+        collect_old_layers_for_pipeline(&root_layer,
+                                        compositor,
+                                        pipeline_id,
+                                        new_layers,
+                                        pipelines_removed);
+    }
+}
+

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -100,7 +100,6 @@ impl CompositorEventListener for NullCompositor {
             // SetFrameTree.
 
             Msg::InitializeLayersForPipeline(..) |
-            Msg::SetLayerRect(..) |
             Msg::AssignPaintedBuffers(..) |
             Msg::ScrollFragmentPoint(..) |
             Msg::Status(..) |
@@ -122,6 +121,8 @@ impl CompositorEventListener for NullCompositor {
             Msg::HeadParsed => {}
             Msg::ReturnUnusedNativeSurfaces(..) => {}
             Msg::CollectMemoryReports(..) => {}
+            Msg::PipelineExited(..) => {}
+            Msg::CreateLayerForSubpage(..) => {}
         }
         true
     }

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -2126,10 +2126,11 @@ impl Flow for BlockFlow {
     }
 
     fn compute_overflow(&self) -> Rect<Au> {
-        self.fragment.compute_overflow(&self.base.early_absolute_position_info
-                                                 .relative_containing_block_size,
-                                       self.base.early_absolute_position_info
-                                                .relative_containing_block_mode)
+        let flow_size = self.base.position.size.to_physical(self.base.writing_mode);
+        self.fragment.compute_overflow(&flow_size,
+                                       &self.base
+                                            .early_absolute_position_info
+                                            .relative_containing_block_size)
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -285,15 +285,6 @@ impl<'a> FlowConstructor<'a> {
     fn set_flow_construction_result(&self,
                                     node: &ThreadSafeLayoutNode,
                                     result: ConstructionResult) {
-        if let ConstructionResult::None = result {
-            let mut layout_data_ref = node.mutate_layout_data();
-            let layout_data = layout_data_ref.as_mut().expect("no layout data");
-            layout_data.remove_compositor_layers(self.layout_context
-                                                     .shared
-                                                     .constellation_chan
-                                                     .clone());
-        }
-
         node.set_flow_construction_result(result);
     }
 

--- a/components/layout/data.rs
+++ b/components/layout/data.rs
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use construct::{ConstructionItem, ConstructionResult};
+use construct::ConstructionResult;
 use incremental::RestyleDamage;
-use msg::constellation_msg::ConstellationChan;
 use parallel::DomParallelInfo;
 use script::dom::node::SharedLayoutData;
 use std::sync::Arc;
@@ -62,30 +61,6 @@ bitflags! {
 pub struct LayoutDataWrapper {
     pub shared_data: SharedLayoutData,
     pub data: Box<PrivateLayoutData>,
-}
-
-impl LayoutDataWrapper {
-    pub fn remove_compositor_layers(&self, constellation_chan: ConstellationChan) {
-        match self.data.flow_construction_result {
-            ConstructionResult::None => {}
-            ConstructionResult::Flow(ref flow_ref, _) => {
-                flow_ref.remove_compositor_layers(constellation_chan);
-            }
-            ConstructionResult::ConstructionItem(ref construction_item) => {
-                match *construction_item {
-                    ConstructionItem::InlineFragments(ref inline_fragments) => {
-                        for fragment in &inline_fragments.fragments.fragments {
-                            fragment.remove_compositor_layers(constellation_chan.clone());
-                        }
-                    }
-                    ConstructionItem::Whitespace(..) => {}
-                    ConstructionItem::TableColumnFragment(ref fragment) => {
-                        fragment.remove_compositor_layers(constellation_chan.clone());
-                    }
-                }
-            }
-        }
-    }
 }
 
 #[allow(dead_code, unsafe_code)]

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use azure::azure_hl::Color;
-use constellation_msg::{Key, KeyModifiers, KeyState, PipelineId};
+use constellation_msg::{Key, KeyModifiers, KeyState, PipelineId, SubpageId};
 use euclid::{Matrix4, Point2D, Rect, Size2D};
 use ipc_channel::ipc::IpcSender;
 use layers::layers::{BufferRequest, LayerBufferSet};
 use layers::platform::surface::NativeDisplay;
 use std::fmt::{self, Debug, Formatter};
+use util::geometry::Au;
 
 /// A newtype struct for denoting the age of messages; prevents race conditions.
 #[derive(PartialEq, Eq, Debug, Copy, Clone, PartialOrd, Ord, Deserialize, Serialize)]
@@ -124,6 +125,9 @@ pub struct LayerProperties {
     pub transform: Matrix4,
     /// The perspective transform for this layer
     pub perspective: Matrix4,
+    /// The subpage that this layer represents. If this is `Some`, this layer represents an
+    /// iframe.
+    pub subpage_layer_info: Option<SubpageLayerInfo>,
     /// Whether this layer establishes a new 3d rendering context.
     pub establishes_3d_context: bool,
     /// Whether this layer scrolls its overflow area.
@@ -166,3 +170,15 @@ pub enum ScriptToCompositorMsg {
     ResizeTo(Size2D<u32>),
     Exit,
 }
+
+/// Subpage (i.e. iframe)-specific information about each layer.
+#[derive(Clone, Copy, Deserialize, Serialize, HeapSizeOf)]
+pub struct SubpageLayerInfo {
+    /// The ID of the pipeline.
+    pub pipeline_id: PipelineId,
+    /// The ID of the subpage.
+    pub subpage_id: SubpageId,
+    /// The offset of the subpage within this layer (to account for borders).
+    pub origin: Point2D<Au>,
+}
+

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -7,7 +7,6 @@
 
 use canvas_traits::CanvasMsg;
 use compositor_msg::Epoch;
-use euclid::rect::Rect;
 use euclid::scale_factor::ScaleFactor;
 use euclid::size::{Size2D, TypedSize2D};
 use hyper::header::Headers;
@@ -221,7 +220,7 @@ pub enum Msg {
     LoadComplete(PipelineId),
     /// Dispatched after the DOM load event has fired on a document
     DOMLoad(PipelineId),
-    FrameRect(PipelineId, SubpageId, Rect<f32>),
+    FrameSize(PipelineId, SubpageId, Size2D<f32>),
     LoadUrl(PipelineId, LoadData),
     ScriptLoadedURLInIFrame(Url, PipelineId, SubpageId, Option<SubpageId>, IFrameSandboxState),
     Navigate(Option<(PipelineId, SubpageId)>, NavigationDirection),
@@ -273,6 +272,9 @@ pub enum Msg {
                          IpcSender<Result<(IpcSender<CanvasMsg>, usize), String>>),
     /// Status message to be displayed in the chrome, eg. a link URL on mouseover.
     NodeStatus(Option<String>),
+    /// Requests that the pipeline ID of the subpage identified by a (pipeline ID, subpage ID)
+    /// pair be sent to the compositor via a `CreateLayerForSubpage` message.
+    PrepareForSubpageLayerCreation(PipelineId, SubpageId),
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -149,6 +149,7 @@ prefs:"layout.flex.enabled" == flex_row_direction.html flex_row_direction_ref.ht
 == iframe/size_attributes.html iframe/size_attributes_ref.html
 prefs:"layout.writing-mode.enabled" == iframe/size_attributes_vertical_writing_mode.html iframe/size_attributes_vertical_writing_mode_ref.html
 == iframe/stacking_context.html iframe/stacking_context_ref.html
+== iframe/stacking_context_position_a.html iframe/stacking_context_position_ref.html
 
 != image_rendering_auto_a.html image_rendering_pixelated_a.html
 == image_rendering_pixelated_a.html image_rendering_pixelated_ref.html

--- a/tests/ref/iframe/stacking_context_position_a.html
+++ b/tests/ref/iframe/stacking_context_position_a.html
@@ -1,0 +1,5 @@
+<body style="background:tan">
+    <div style="transform: translateX(0px)">
+        <iframe src="data:text/html,%3Cspan%3EJust%20a%20simple%20little%20iframe.%3C%2Fspan%3E"></iframe>
+    </div>
+</body>

--- a/tests/ref/iframe/stacking_context_position_ref.html
+++ b/tests/ref/iframe/stacking_context_position_ref.html
@@ -1,0 +1,5 @@
+<body style="background:tan">
+    <div>
+        <iframe style="transform: translateX(0px)" src="data:text/html,%3Cspan%3EJust%20a%20simple%20little%20iframe.%3C%2Fspan%3E"></iframe>
+    </div>
+</body>


### PR DESCRIPTION
The old code that attempted to do this during layout wasn't able to work
for multiple reasons: it couldn't know where the iframe was going to be
on the page (because of nested iframes), and at the time it was building
the display list for a fragment it couldn't know where that fragment was
going to be in page coordinates.

This patch rewrites that code so that only the size of an iframe is
determined during layout, and the position is determined by the
compositor. Layout layerizes iframes and marks the iframe layers with
the appropriate subpage ID so that the compositor can place them
correctly.

Closes #7377.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7423)

<!-- Reviewable:end -->
