### PR TITLE
fixes #7390 : tidy now check the order of mod declarations even whith attribute

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -169,6 +169,8 @@ def check_rust(file_name, contents):
 
     uses = []
 
+    mods = []
+
     for idx, line in enumerate(contents):
         # simplify the analysis
         line = line.strip()
@@ -192,7 +194,7 @@ def check_rust(file_name, contents):
         line = re.sub('".*?"|\'.*?\'', '', line)
 
         # get rid of comments and attributes
-        line = re.sub('//.*?$|/\*.*?$|^\*.*?$|^#.*?$', '', line)
+        line = re.sub('//.*?$|/\*.*?$|^\*.*?$|^#!?\[.*?]\s', '', line)
 
         match = re.search(r",[A-Za-z0-9]", line)
         if match:
@@ -258,6 +260,29 @@ def check_rust(file_name, contents):
                     found = "\n\t\033[91mfound: {}\033[0m".format(uses[i])
                     yield (idx + 1 - len(uses) + i, message + expected + found)
             uses = []
+
+        # modules must be in the same line and alphabetically sorted
+        if line.startswith("mod ") or line.startswith("pub mod "):
+            mod = ""
+            if line.startswith("mod "):
+                mod = line[4:]
+            else:
+                mod = line[8:]
+
+            match = line.find(" {")
+            if match == -1:
+                if not mod.endswith(";"):
+                    yield (idx + 1, "mod statement spans multiple lines")
+                mods.append(mod[:len(mod) - 1])
+        elif len(mods) > 0:
+            sorted_mods = sorted(mods)
+            for i in range(len(mods)):
+                if sorted_mods[i] != mods[i]:
+                    message = "mod statement is not in alphabetical order"
+                    expected = "\n\t\033[93mexpected: {}\033[0m".format(sorted_mods[i])
+                    found = "\n\t\033[91mfound: {}\033[0m".format(mods[i])
+                    yield (idx + 1 - len(mods) + i, message + expected + found)
+            mods = []
 
 
 def check_webidl_spec(file_name, contents):


### PR DESCRIPTION
Update tidy.py to check if mod declarations are in alphabetical order.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7446)

<!-- Reviewable:end -->
