### PR TITLE
Disable workers tests in __dir__.ini rather than include.ini.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -73,18 +73,6 @@ skip: true
   skip: false
 [workers]
   skip: false
-  [constructors]
-    skip: false
-    [SharedWorker]
-      skip: true
-  [semantics]
-    skip: false
-    [navigation]
-      skip: true
-    [reporting-errors]
-      skip: true
-    [structured-clone]
-      skip: true
 [XMLHttpRequest]
   skip: false
 [old-tests]

--- a/tests/wpt/metadata/workers/constructors/SharedWorker/__dir__.ini
+++ b/tests/wpt/metadata/workers/constructors/SharedWorker/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: SharedWorker

--- a/tests/wpt/metadata/workers/semantics/navigation/001.html.ini
+++ b/tests/wpt/metadata/workers/semantics/navigation/001.html.ini
@@ -1,0 +1,3 @@
+[001.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/workers/semantics/navigation/002.html.ini
+++ b/tests/wpt/metadata/workers/semantics/navigation/002.html.ini
@@ -1,0 +1,5 @@
+[002.html]
+  type: testharness
+  [navigating 2]
+    expected: FAIL
+

--- a/tests/wpt/metadata/workers/semantics/reporting-errors/__dir__.ini
+++ b/tests/wpt/metadata/workers/semantics/reporting-errors/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: SharedWorker

--- a/tests/wpt/metadata/workers/semantics/structured-clone/__dir__.ini
+++ b/tests/wpt/metadata/workers/semantics/structured-clone/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: Broken somehow


### PR DESCRIPTION
This ensures those tests are skipped when running ./mach test-wpt workers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7454)

<!-- Reviewable:end -->
