### PR TITLE
Prevent ClipboardContext::new from panicing on OSX if NSPasteboard#ge…

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#b0092c8630d4362e4618533822bea90a034b0792"
+source = "git+https://github.com/aweinstock314/rust-clipboard#8c4c31e73a5ac5afd97825acc4c534dccfc0ab9b"
 dependencies = [
  "clipboard-win 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#b0092c8630d4362e4618533822bea90a034b0792"
+source = "git+https://github.com/aweinstock314/rust-clipboard#8c4c31e73a5ac5afd97825acc4c534dccfc0ab9b"
 dependencies = [
  "clipboard-win 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#b0092c8630d4362e4618533822bea90a034b0792"
+source = "git+https://github.com/aweinstock314/rust-clipboard#8c4c31e73a5ac5afd97825acc4c534dccfc0ab9b"
 dependencies = [
  "clipboard-win 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
…neralPasteboard fails (https://github.com/servo/servo/issues/7380).

https://github.com/aweinstock314/rust-clipboard/commit/8c4c31e73a5ac5afd97825acc4c534dccfc0ab9b

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7471)

<!-- Reviewable:end -->
