### PR TITLE
Upgrade to the latest rust-layers

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -860,7 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#c4fa565228a9741a1c138a96421fcbd156ad1e45"
+source = "git+https://github.com/servo/rust-layers#a8400005fd3ee37ced92865184974c9a93201bc0"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -845,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#c4fa565228a9741a1c138a96421fcbd156ad1e45"
+source = "git+https://github.com/servo/rust-layers#a8400005fd3ee37ced92865184974c9a93201bc0"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1446,12 +1446,17 @@ name = "servo"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "canvas 0.0.1",
+ "canvas_traits 0.0.1",
  "compositing 0.0.1",
  "devtools 0.0.1",
  "devtools_traits 0.0.1",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
+ "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_app 0.0.1",
+ "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1461,6 +1466,8 @@ dependencies = [
  "profile 0.0.1",
  "profile_traits 0.0.1",
  "script 0.0.1",
+ "script_traits 0.0.1",
+ "style 0.0.1",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -729,7 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "layers"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-layers#c4fa565228a9741a1c138a96421fcbd156ad1e45"
+source = "git+https://github.com/servo/rust-layers#a8400005fd3ee37ced92865184974c9a93201bc0"
 dependencies = [
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1312,11 +1312,16 @@ name = "servo"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "canvas 0.0.1",
+ "canvas_traits 0.0.1",
  "compositing 0.0.1",
  "devtools 0.0.1",
  "devtools_traits 0.0.1",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
+ "gleam 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1326,10 +1331,11 @@ dependencies = [
  "profile 0.0.1",
  "profile_traits 0.0.1",
  "script 0.0.1",
+ "script_traits 0.0.1",
+ "style 0.0.1",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
- "webdriver_server 0.0.1",
 ]
 
 [[package]]
@@ -1561,33 +1567,6 @@ dependencies = [
 name = "void"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "webdriver"
-version = "0.2.2"
-source = "git+https://github.com/jgraham/webdriver-rust.git#2265894866bea9659c06a7082f2f96cad238ff34"
-dependencies = [
- "hyper 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "webdriver_server"
-version = "0.0.1"
-dependencies = [
- "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "msg 0.0.1",
- "png 0.1.0 (git+https://github.com/servo/rust-png)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "util 0.0.1",
- "uuid 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "webdriver 0.2.2 (git+https://github.com/jgraham/webdriver-rust.git)",
-]
 
 [[package]]
 name = "websocket"

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -125,6 +125,7 @@ prefs:"layout.flex.enabled" == flex_row_direction.html flex_row_direction_ref.ht
 == hide_after_create.html hide_after_create_ref.html
 
 == iframe/bg_color.html iframe/bg_color_ref.html
+== iframe/hide_after_load.html iframe/hide_after_load_ref.html
 == iframe/hide_and_show.html iframe/hide_and_show_ref.html
 == iframe/hide_layers1.html iframe/hide_layers_ref.html
 == iframe/hide_layers2.html iframe/hide_layers_ref.html

--- a/tests/ref/iframe/hide_after_load.html
+++ b/tests/ref/iframe/hide_after_load.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <body style="background: green;">
+        <iframe style="border: 0" src="hide_after_load_inner_frame.html"></iframe>
+        <script type="text/javascript">
+            var iframe = document.getElementsByTagName('iframe')[0];
+            iframe.onload = function() {
+                iframe.style.display = "none";
+
+                // We do this in a timeout, so that the compositor has a chance
+                // to update the layer tree.
+                setTimeout(function() {
+                    document.documentElement.classList.remove("reftest-wait");
+                }, 0);
+            }
+        </script>
+    </body>
+</html>

--- a/tests/ref/iframe/hide_after_load_inner_frame.html
+++ b/tests/ref/iframe/hide_after_load_inner_frame.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body style="background: red;">
+        hidden content
+    </body>
+</html>

--- a/tests/ref/iframe/hide_after_load_ref.html
+++ b/tests/ref/iframe/hide_after_load_ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+    <body style="background: green;"> </body>
+</html>


### PR DESCRIPTION
This should fix a bug where hidden iframes are not properly clipped
away from the compositor scene. This commit adds a test for this
behavior.

Fixes #6849.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7503)

<!-- Reviewable:end -->
