### PR TITLE
Issue #7501 emove unused time function in time module of profile

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -209,16 +209,3 @@ impl Profiler {
         println!("");
     }
 }
-
-pub fn time<T, F>(msg: &str, callback: F) -> T
-    where F: Fn() -> T
-{
-    let start_time = precise_time_ns();
-    let val = callback();
-    let end_time = precise_time_ns();
-    let ms = (end_time - start_time) as f64 / 1000000f64;
-    if ms >= 5f64 {
-        debug!("{} took {} ms", msg, ms);
-    }
-    return val;
-}


### PR DESCRIPTION
Title sums it up. Time function in the time module of profile crate was unused. 

Unless we plan to use it soon, we should clean it up

See issue #7501 related to it.

Thanks.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7504)

<!-- Reviewable:end -->
