### PR TITLE
Allow 'script' component to enter a 'built' state

### DIFF
--- a/components/script/dom/bindings/codegen/BindingGen.py
+++ b/components/script/dom/bindings/codegen/BindingGen.py
@@ -26,20 +26,22 @@ def generate_binding_rs(config, outputprefix, webidlfile):
 def main():
     # Parse arguments.
     from optparse import OptionParser
-    usagestring = "usage: %prog configFile outputPrefix webIDLFile"
+    usagestring = "usage: %prog configFile outputdir outputPrefix webIDLFile"
     o = OptionParser(usage=usagestring)
     o.add_option("--verbose-errors", action='store_true', default=False,
                  help="When an error happens, display the Python traceback.")
     (options, args) = o.parse_args()
 
-    if len(args) != 3:
+    if len(args) != 4:
         o.error(usagestring)
     configFile = os.path.normpath(args[0])
-    outputPrefix = args[1]
-    webIDLFile = os.path.normpath(args[2])
+    outputdir = args[1]
+    outputPrefix = args[2]
+    webIDLFile = os.path.normpath(args[3])
 
     # Load the parsing results
-    with open('ParserResults.pkl', 'rb') as f:
+    resultsPath = os.path.join(outputdir, 'ParserResults.pkl')
+    with open(resultsPath, 'rb') as f:
         parserData = cPickle.load(f)
 
     # Create the configuration data.

--- a/components/script/dom/bindings/codegen/GlobalGen.py
+++ b/components/script/dom/bindings/codegen/GlobalGen.py
@@ -54,7 +54,8 @@ def main():
     parserResults = parser.finish()
 
     # Write the parser results out to a pickle.
-    with open('ParserResults.pkl', 'wb') as resultsFile:
+    resultsPath = os.path.join(outputdir, 'ParserResults.pkl')
+    with open(resultsPath, 'wb') as resultsFile:
         cPickle.dump(parserResults, resultsFile, -1)
 
     # Load the configuration.

--- a/components/script/makefile.cargo
+++ b/components/script/makefile.cargo
@@ -43,6 +43,7 @@ $(AUTOGEN_SRC): $(OUT_DIR)/Bindings/%Binding.rs: $(bindinggen_dependencies) \
 	$(PYTHON) \
 	  $(BINDINGS_SRC)/BindingGen.py \
 	    $(BINDINGS_SRC)/Bindings.conf \
+	    $(OUT_DIR) \
 	    $(OUT_DIR)/Bindings/$*Binding \
 	    $(addprefix $(WEBIDLS_SRC)/,$*.webidl)
 	touch $@


### PR DESCRIPTION
After this pull request merged:

https://github.com/servo/servo/pull/7209

the 'script' component would never enter a 'built' state. In other
words, if one calls `mach build`, lets it complete, then calls `mach
build` again, the 'script' component would rebuild even though we
supposedly just built it. This was due to the `ParserResults.pkl`
getting placed in the `components/script` directory instead of the
output directory, causing cargo to think that there were unbuilt files.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7516)

<!-- Reviewable:end -->
