### PR TITLE
Cut required desktop OpenGL version from 3.0 to 2.1.

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -139,7 +139,7 @@ impl Window {
 
     #[cfg(not(target_os = "android"))]
     fn gl_version() -> GlRequest {
-        GlRequest::Specific(Api::OpenGl, (3, 0))
+        GlRequest::Specific(Api::OpenGl, (2, 1))
     }
 
     #[cfg(target_os = "android")]


### PR DESCRIPTION
Mesa software rendering on Ubuntu 14.04 only claims to support OpenGL 2.1,
so servo crashes on startup.  It seems to work fine if an OpenGL 2.1 context
is requested.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7525)

<!-- Reviewable:end -->
