### PR TITLE
Use SIMD in fast path for advance_for_char_range

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -103,3 +103,18 @@ git = "https://github.com/servo/rust-freetype"
 
 [target.x86_64-apple-darwin.dependencies.core-text]
 git = "https://github.com/servo/core-text-rs"
+
+[target.x86_64-unknown-linux-gnu.dependencies.simd]
+git = "https://github.com/huonw/simd"
+
+[target.x86_64-apple-darwin.dependencies.simd]
+git = "https://github.com/huonw/simd"
+
+[target.aarch64-unknown-linux-gnu.dependencies.simd]
+git = "https://github.com/huonw/simd"
+
+[target.x86_64-pc-windows-gnu.dependencies.simd]
+git = "https://github.com/huonw/simd"
+
+[target.x86_64-pc-windows-msvc.dependencies.simd]
+git = "https://github.com/huonw/simd"

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -5,6 +5,10 @@
 #![feature(arc_weak)]
 #![cfg_attr(any(target_os = "linux", target_os = "android"), feature(box_raw))]
 #![feature(box_syntax)]
+
+// For simd (currently x86_64/aarch64)
+#![cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), feature(convert))]
+
 #![feature(custom_attribute)]
 #![feature(custom_derive)]
 #![feature(hashmap_hasher)]
@@ -40,6 +44,10 @@ extern crate net_traits;
 extern crate util;
 extern crate msg;
 extern crate rand;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+extern crate simd;
+
 extern crate smallvec;
 extern crate string_cache;
 extern crate style;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -570,6 +570,7 @@ dependencies = [
  "script_traits 0.0.1",
  "serde 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1496,6 +1497,11 @@ dependencies = [
  "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "simd"
+version = "0.1.0"
+source = "git+https://github.com/huonw/simd#d9ad79d86eab50a8f36d45fe17aa9e3a533389ee"
 
 [[package]]
 name = "skia"


### PR DESCRIPTION
In advance_for_char_range add a fast SIMD code path for the the common
case where there are no detailed glyphs.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7527)

<!-- Reviewable:end -->
