### PR TITLE
Remove obsolete method call that breaks ./mach update-css.

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -315,7 +315,6 @@ class MachCommands(CommandBase):
              parser=updatecommandline.create_parser())
     def update_css(self, **kwargs):
         self.ensure_bootstrapped()
-        self.ensure_wpt_virtualenv()
         run_file = path.abspath(path.join("tests", "wpt", "update_css.py"))
         run_globals = {"__file__": run_file}
         execfile(run_file, run_globals)


### PR DESCRIPTION
r? @frewsxcv

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7528)

<!-- Reviewable:end -->
