### PR TITLE
Disable html tests in __dir__.ini rather than include.ini.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -13,62 +13,6 @@ skip: true
   skip: false
 [html]
   skip: false
-  [browsers]
-    skip: false
-    [browsing-the-web]
-      skip: false
-      [unloading-documents]
-        skip: true
-    [history]
-      skip: false
-      [the-history-interface]
-        skip: true
-    [offline]
-      skip: true
-  [dom]
-    skip: false
-    [dynamic-markup-insertion]
-      skip: true
-  [editing]
-    skip: true
-  [infrastructure]
-    skip: false
-    [urls]
-      skip: false
-      [resolving-urls]
-        skip: true
-  [semantics]
-    skip: false
-    [embedded-content]
-      skip: false
-      [the-ol-element]
-        skip: false
-        [grouping-ol]
-          skip: true
-      [the-li-element]
-        skip: false
-        [grouping-li]
-          skip: true
-      [media-elements]
-        skip: true
-      [the-audio-element]
-        skip: true
-      [the-video-element]
-        skip: true
-    [scripting-1]
-      skip: false
-      [the-template-element]
-        skip: true
-  [syntax]
-    skip: false
-    [parsing]
-      skip: true
-    [parsing-html-fragments]
-      skip: true
-  [webappapis]
-    skip: false
-    [system-state-and-capabilities]
-      skip: true
 [url]
   skip: false
 [workers]

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/unloading-documents/__dir__.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/unloading-documents/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/__dir__.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/browsers/offline/__dir__.ini
+++ b/tests/wpt/metadata/html/browsers/offline/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/dom/dynamic-markup-insertion/__dir__.ini
+++ b/tests/wpt/metadata/html/dom/dynamic-markup-insertion/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/editing/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/infrastructure/urls/resolving-urls/query-encoding/__dir__.ini
+++ b/tests/wpt/metadata/html/infrastructure/urls/resolving-urls/query-encoding/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/__dir__.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-audio-element/__dir__.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-audio-element/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-li-element/grouping-li/__dir__.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-li-element/grouping-li/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-ol-element/grouping-ol/__dir__.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-ol-element/grouping-ol/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-video-element/__dir__.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-video-element/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-template-element/__dir__.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-template-element/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/syntax/parsing-html-fragments/__dir__.ini
+++ b/tests/wpt/metadata/html/syntax/parsing-html-fragments/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/syntax/parsing/__dir__.ini
+++ b/tests/wpt/metadata/html/syntax/parsing/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/webappapis/system-state-and-capabilities/__dir__.ini
+++ b/tests/wpt/metadata/html/webappapis/system-state-and-capabilities/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now


### PR DESCRIPTION
This ensures those tests are skipped when running ./mach test-wpt html.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7530)

<!-- Reviewable:end -->
