### PR TITLE
layout: Use a special path that treats `margin: auto` as zero for inline-block inline size computation.

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -168,6 +168,8 @@ prefs:"layout.writing-mode.enabled" == iframe/size_attributes_vertical_writing_m
 == inline_block_border_intrinsic_size_a.html inline_block_border_intrinsic_size_ref.html
 == inline_block_img_a.html inline_block_img_ref.html
 == inline_block_margin_a.html inline_block_margin_ref.html
+== inline_block_margin_auto_a.html inline_block_margin_auto_ref.html
+== inline_block_margin_auto_zero_a.html inline_block_margin_auto_zero_ref.html
 == inline_block_min_width.html inline_block_min_width_ref.html
 == inline_block_overflow.html inline_block_overflow_ref.html
 == inline_block_overflow_hidden_a.html inline_block_overflow_hidden_ref.html

--- a/tests/ref/inline_block_margin_auto_a.html
+++ b/tests/ref/inline_block_margin_auto_a.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+#a {
+    display: block;
+    background: lime;
+    text-align: center;
+    width: 96px;
+}
+#b {
+    background: gold;
+    display: inline-block;
+    margin: 0 auto;
+    padding: 16px 16px;
+}
+</style>
+<div id=a><div id=b></div>
+

--- a/tests/ref/inline_block_margin_auto_ref.html
+++ b/tests/ref/inline_block_margin_auto_ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+#a {
+    display: block;
+    background: lime;
+    text-align: center;
+    width: 96px;
+}
+#b {
+    background: gold;
+    display: inline-block;
+    margin: 0 32px 0 32px;
+    padding: 16px 16px;
+}
+</style>
+<div id=a><div id=b></div>
+

--- a/tests/ref/inline_block_margin_auto_zero_a.html
+++ b/tests/ref/inline_block_margin_auto_zero_a.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+section {
+    width: 300px;
+    height: 100px;
+    background: blue;
+}
+nav {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    margin: 0 auto;
+    background: gold;
+}
+</style>
+<section><nav></nav></section>
+

--- a/tests/ref/inline_block_margin_auto_zero_ref.html
+++ b/tests/ref/inline_block_margin_auto_zero_ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+section {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: 0;
+    left: 0;
+    background: gold;
+}
+nav {
+    position: absolute;
+    width: 200px;
+    height: 100px;
+    top: 0;
+    left: 100px;
+    background: blue;
+}
+</style>
+<section></section><nav></nav>
+

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-block-replaced-width-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-block-replaced-width-001.htm.ini
@@ -1,3 +1,0 @@
-[inline-block-replaced-width-001.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Places the search icon in the right place on the Google SERPs.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7533)

<!-- Reviewable:end -->
