### PR TITLE
layout: Lay absolutely-positioned blocks with inline containing blocks out of flow.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2378,6 +2378,13 @@ impl Fragment {
         self.style.get_box().position == position::T::absolute
     }
 
+    pub fn is_inline_absolute(&self) -> bool {
+        match self.specific {
+            SpecificFragmentInfo::InlineAbsolute(..) => true,
+            _ => false,
+        }
+    }
+
     pub fn meld_with_next_inline_fragment(&mut self, next_fragment: &Fragment) {
         if let Some(ref mut inline_context_of_this_fragment) = self.inline_context {
             if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -738,13 +738,17 @@ impl LineBreaker {
                                                     layout_context: &LayoutContext) {
         let indentation = self.indentation_for_pending_fragment();
         self.pending_line.range.extend_by(FragmentIndex(1));
-        self.pending_line.bounds.size.inline = self.pending_line.bounds.size.inline +
-            fragment.margin_box_inline_size() +
-            indentation;
-        self.pending_line.inline_metrics =
-            self.new_inline_metrics_for_line(&fragment, layout_context);
-        self.pending_line.bounds.size.block =
-            self.new_block_size_for_line(&fragment, layout_context);
+
+        if !fragment.is_inline_absolute() {
+            self.pending_line.bounds.size.inline = self.pending_line.bounds.size.inline +
+                fragment.margin_box_inline_size() +
+                indentation;
+            self.pending_line.inline_metrics =
+                self.new_inline_metrics_for_line(&fragment, layout_context);
+            self.pending_line.bounds.size.block =
+                self.new_block_size_for_line(&fragment, layout_context);
+        }
+
         self.new_fragments.push(fragment);
     }
 
@@ -1079,8 +1083,11 @@ impl InlineFlow {
                                                        fragment.border_box.size.inline,
                                                        fragment.border_box.size.block);
                 fragment.update_late_computed_inline_position_if_necessary();
-                inline_start_position_for_fragment = inline_start_position_for_fragment +
-                    fragment.border_box.size.inline + fragment.margin.inline_end;
+
+                if !fragment.is_inline_absolute() {
+                    inline_start_position_for_fragment = inline_start_position_for_fragment +
+                        fragment.border_box.size.inline + fragment.margin.inline_end;
+                }
             }
         }
     }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -159,6 +159,7 @@ prefs:"layout.writing-mode.enabled" == iframe/size_attributes_vertical_writing_m
 == incremental_float_a.html incremental_float_ref.html
 == incremental_inline_layout_a.html incremental_inline_layout_ref.html
 == inline_absolute_hypothetical_clip_a.html inline_absolute_hypothetical_clip_ref.html
+== inline_absolute_out_of_flow_a.html inline_absolute_out_of_flow_ref.html
 != inline_background_a.html inline_background_ref.html
 == inline_block_baseline_a.html inline_block_baseline_ref.html
 == inline_block_block_direction_margins_a.html inline_block_block_direction_margins_ref.html

--- a/tests/ref/inline_absolute_out_of_flow_a.html
+++ b/tests/ref/inline_absolute_out_of_flow_a.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+#a {
+    display: inline;
+    position: relative;
+}
+#b {
+    position: absolute;
+    display: block;
+}
+</style>
+<div>A<span id=a><div id=b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div></span>B</div>
+

--- a/tests/ref/inline_absolute_out_of_flow_ref.html
+++ b/tests/ref/inline_absolute_out_of_flow_ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div>AB</div>
+


### PR DESCRIPTION
Removes the long space before the site-specific drop-down in the Google SERPs.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7534)

<!-- Reviewable:end -->
