### PR TITLE
script: change requestAnimationFrame returns the unsigned long type.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -142,11 +142,11 @@ pub struct Document {
     scripting_enabled: Cell<bool>,
     /// https://html.spec.whatwg.org/multipage/#animation-frame-callback-identifier
     /// Current identifier of animation frame callback
-    animation_frame_ident: Cell<i32>,
+    animation_frame_ident: Cell<u32>,
     /// https://html.spec.whatwg.org/multipage/#list-of-animation-frame-callbacks
     /// List of animation frame callbacks
     #[ignore_heap_size_of = "closures are hard"]
-    animation_frame_list: RefCell<HashMap<i32, Box<FnBox(f64)>>>,
+    animation_frame_list: RefCell<HashMap<u32, Box<FnBox(f64)>>>,
     /// Tracks all outstanding loads related to this document.
     loader: DOMRefCell<DocumentLoader>,
     /// The current active HTML parser, to allow resuming after interruptions.
@@ -870,7 +870,7 @@ impl Document {
     }
 
     /// https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe
-    pub fn request_animation_frame(&self, callback: Box<FnBox(f64)>) -> i32 {
+    pub fn request_animation_frame(&self, callback: Box<FnBox(f64)>) -> u32 {
         let window = self.window.root();
         let window = window.r();
         let ident = self.animation_frame_ident.get() + 1;
@@ -888,7 +888,7 @@ impl Document {
     }
 
     /// https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe
-    pub fn cancel_animation_frame(&self, ident: i32) {
+    pub fn cancel_animation_frame(&self, ident: u32) {
         self.animation_frame_list.borrow_mut().remove(&ident);
         if self.animation_frame_list.borrow().is_empty() {
             let window = self.window.root();

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -56,8 +56,8 @@
   //void print();
   //any showModalDialog(DOMString url, optional any argument);
 
-  long requestAnimationFrame(FrameRequestCallback callback);
-  void cancelAnimationFrame(long handle);
+  unsigned long requestAnimationFrame(FrameRequestCallback callback);
+  void cancelAnimationFrame(unsigned long handle);
 
   //void postMessage(any message, DOMString targetOrigin, optional sequence<Transferable> transfer);
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -535,7 +535,7 @@ impl WindowMethods for Window {
     }
 
     /// https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe
-    fn RequestAnimationFrame(&self, callback: Rc<FrameRequestCallback>) -> i32 {
+    fn RequestAnimationFrame(&self, callback: Rc<FrameRequestCallback>) -> u32 {
         let doc = self.Document();
 
         let callback  = move |now: f64| {
@@ -548,7 +548,7 @@ impl WindowMethods for Window {
     }
 
     /// https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe
-    fn CancelAnimationFrame(&self, ident: i32) {
+    fn CancelAnimationFrame(&self, ident: u32) {
         let doc = self.Document();
         doc.r().cancel_animation_frame(ident);
     }


### PR DESCRIPTION
By https://github.com/whatwg/html/pull/97, the returned type of`requestAnimationFrame()` and the argument type of `cancelAnimationFrame()` are changed to `unsigned long` WebIDL type.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7538)

<!-- Reviewable:end -->
