### PR TITLE
layout: Stop double-counting `position: relative` offsets for stacking contexts.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1913,7 +1913,6 @@ impl Flow for BlockFlow {
             self.base.position.size.to_physical(self.base.writing_mode);
 
         // Compute the origin and clipping rectangle for children.
-        let relative_offset = relative_offset.to_physical(self.base.writing_mode);
         let origin_for_children;
         let clip_in_child_coordinate_system;
         let is_stacking_context = self.fragment.establishes_stacking_context();
@@ -1925,10 +1924,11 @@ impl Flow for BlockFlow {
             //
             // FIXME(pcwalton): Is this vertical-writing-direction-safe?
             let margin = self.fragment.margin.to_physical(self.base.writing_mode);
-            origin_for_children = Point2D::new(-margin.left, Au(0)) + relative_offset;
+            origin_for_children = Point2D::new(-margin.left, Au(0));
             clip_in_child_coordinate_system =
                 self.base.clip.translate(&-self.base.stacking_relative_position);
         } else {
+            let relative_offset = relative_offset.to_physical(self.base.writing_mode);
             origin_for_children = self.base.stacking_relative_position + relative_offset;
             clip_in_child_coordinate_system = self.base.clip.clone();
         }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -298,6 +298,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == position_relative_inline_block_a.html position_relative_inline_block_ref.html
 == position_relative_painting_order_a.html position_relative_painting_order_ref.html
 == position_relative_stacking_context_a.html position_relative_stacking_context_ref.html
+== position_relative_stacking_context_contents_a.html position_relative_stacking_context_contents_ref.html
 == position_relative_top_percentage_a.html position_relative_top_percentage_b.html
 == position_relative_vertical_percentage_overflow_a.html position_relative_vertical_percentage_overflow_ref.html
 == pre_ignorable_whitespace_a.html pre_ignorable_whitespace_ref.html

--- a/tests/ref/position_relative_stacking_context_contents_a.html
+++ b/tests/ref/position_relative_stacking_context_contents_a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+aside {
+    display: block;
+    position: relative;
+    left: 12px;
+    z-index: 3;  /* force creation of stacking context */
+    background: red;
+}
+div {
+    float: left;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<aside><div></div></aside>
+

--- a/tests/ref/position_relative_stacking_context_contents_ref.html
+++ b/tests/ref/position_relative_stacking_context_contents_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+html, body {
+    margin: 0;
+}
+aside {
+    display: block;
+    position: absolute;
+    left: 12px;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+</style>
+<aside></aside>
+


### PR DESCRIPTION
Fixes the location of the gear menu on the Google SERPs.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7544)

<!-- Reviewable:end -->
