### PR TITLE
Combine script profiling with profile crates. Fixes #7514.

### DIFF
--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -331,6 +331,7 @@ impl PipelineContent {
                                   self.resource_task,
                                   self.storage_task.clone(),
                                   self.image_cache_task.clone(),
+                                  self.time_profiler_chan.clone(),
                                   self.mem_profiler_chan.clone(),
                                   self.devtools_chan,
                                   self.window_size,

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -77,6 +77,22 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::PaintingPrepBuff => "Buffer Prep",
             ProfilerCategory::Painting => "Painting",
             ProfilerCategory::ImageDecoding => "Image Decoding",
+            ProfilerCategory::ScriptAttachLayout => "Script Attach Layout",
+            ProfilerCategory::ScriptConstellationMsg => "Script Constellation Msg",
+            ProfilerCategory::ScriptDevtoolsMsg => "Script Devtools Msg",
+            ProfilerCategory::ScriptDocumentEvent => "Script Document Event",
+            ProfilerCategory::ScriptDomEvent => "Script Dom Event",
+            ProfilerCategory::ScriptFileRead => "Script File Read",
+            ProfilerCategory::ScriptImageCacheMsg => "Script Image Cache Msg",
+            ProfilerCategory::ScriptInputEvent => "Script Input Event",
+            ProfilerCategory::ScriptNetworkEvent => "Script Network Event",
+            ProfilerCategory::ScriptResize => "Script Resize",
+            ProfilerCategory::ScriptEvent => "Script Event",
+            ProfilerCategory::ScriptUpdateReplacedElement => "Script Update Replaced Element",
+            ProfilerCategory::ScriptSetViewport => "Script Set Viewport",
+            ProfilerCategory::ScriptWebSocketEvent => "Script Web Socket Event",
+            ProfilerCategory::ScriptWorkerEvent => "Script Worker Event",
+            ProfilerCategory::ScriptXhrEvent => "Script Xhr Event",
         };
         format!("{}{}", padding, name)
     }

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -56,6 +56,22 @@ pub enum ProfilerCategory {
     PaintingPrepBuff,
     Painting,
     ImageDecoding,
+    ScriptAttachLayout,
+    ScriptConstellationMsg,
+    ScriptDevtoolsMsg,
+    ScriptDocumentEvent,
+    ScriptDomEvent,
+    ScriptFileRead,
+    ScriptImageCacheMsg,
+    ScriptInputEvent,
+    ScriptNetworkEvent,
+    ScriptResize,
+    ScriptEvent,
+    ScriptUpdateReplacedElement,
+    ScriptSetViewport,
+    ScriptWebSocketEvent,
+    ScriptWorkerEvent,
+    ScriptXhrEvent,
 }
 
 #[derive(Eq, PartialEq)]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -57,7 +57,8 @@ use msg::constellation_msg::{PipelineId, SubpageId, WindowSizeData, WorkerId};
 use net_traits::image::base::Image;
 use net_traits::image_cache_task::{ImageCacheChan, ImageCacheTask};
 use net_traits::storage_task::StorageType;
-use profile_traits::mem::ProfilerChan;
+use profile_traits::mem::ProfilerChan as MemProfilerChan;
+use profile_traits::time::ProfilerChan as TimeProfilerChan;
 use script_traits::UntrustedNodeAddress;
 use selectors::parser::PseudoElement;
 use serde::{Serialize, Deserialize};
@@ -304,7 +305,8 @@ no_jsmanaged_fields!(CanvasGradientStop, LinearGradientStyle, RadialGradientStyl
 no_jsmanaged_fields!(LineCapStyle, LineJoinStyle, CompositionOrBlending);
 no_jsmanaged_fields!(RepetitionStyle);
 no_jsmanaged_fields!(WebGLError);
-no_jsmanaged_fields!(ProfilerChan);
+no_jsmanaged_fields!(TimeProfilerChan);
+no_jsmanaged_fields!(MemProfilerChan);
 no_jsmanaged_fields!(PseudoElement);
 
 impl JSTraceable for Box<ScriptChan + Send> {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -32,7 +32,7 @@ use msg::webdriver_msg::WebDriverScriptCommand;
 use net_traits::ResourceTask;
 use net_traits::image_cache_task::ImageCacheTask;
 use net_traits::storage_task::StorageTask;
-use profile_traits::mem;
+use profile_traits::{mem, time};
 use std::any::Any;
 use std::sync::mpsc::{Receiver, Sender};
 use url::Url;
@@ -187,6 +187,7 @@ pub trait ScriptTaskFactory {
               resource_task: ResourceTask,
               storage_task: StorageTask,
               image_cache_task: ImageCacheTask,
+              time_profiler_chan: time::ProfilerChan,
               mem_profiler_chan: mem::ProfilerChan,
               devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
               window_size: Option<WindowSizeData>,


### PR DESCRIPTION
The script crate had its own built-in profiling which was basically doing the same thing as the profile crate.  This wraps the internal profiling around the main profile functionality.  Script-related tasks are now added to the ProfilerCategory enum.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7547)

<!-- Reviewable:end -->
