### PR TITLE
layout: Defend the block formatting context speculation against going wrong in the presence of blocks that overflow in the inline direction.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1327,10 +1327,16 @@ impl BlockFlow {
         let mut inline_size_of_preceding_left_floats = Au(0);
         let mut inline_size_of_preceding_right_floats = Au(0);
         if self.formatting_context_type() == FormattingContextType::None {
-            inline_size_of_preceding_left_floats =
-                max(self.inline_size_of_preceding_left_floats - inline_start_content_edge, Au(0));
-            inline_size_of_preceding_right_floats =
-                max(self.inline_size_of_preceding_right_floats - inline_end_content_edge, Au(0));
+            if inline_start_content_edge > Au(0) {
+                inline_size_of_preceding_left_floats =
+                    max(self.inline_size_of_preceding_left_floats - inline_start_content_edge,
+                        Au(0));
+            }
+            if inline_end_content_edge > Au(0) {
+                inline_size_of_preceding_right_floats =
+                    max(self.inline_size_of_preceding_right_floats - inline_end_content_edge,
+                        Au(0));
+            }
         }
 
         let opaque_self = OpaqueFlow::from_flow(self);

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -48,6 +48,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 == block_formatting_context_containing_floats_a.html block_formatting_context_containing_floats_ref.html
 == block_formatting_context_float_placement_a.html block_formatting_context_float_placement_ref.html
 == block_formatting_context_max_width_a.html block_formatting_context_max_width_ref.html
+== block_formatting_context_overflow_a.html block_formatting_context_overflow_ref.html
 == block_formatting_context_relative_a.html block_formatting_context_ref.html
 == block_formatting_context_translation_a.html block_formatting_context_translation_ref.html
 == block_formatting_context_with_margin_a.html block_formatting_context_with_margin_ref.html

--- a/tests/ref/block_formatting_context_overflow_a.html
+++ b/tests/ref/block_formatting_context_overflow_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+section {
+    display: block;
+    width: 0;
+}
+nav {
+    display: block;
+}
+aside {
+    display: block;
+    overflow: hidden;
+}
+main {
+    width: 500px;
+}
+</style>
+<section><main><nav><aside>Hello</aside>world!</nav></main></section>
+

--- a/tests/ref/block_formatting_context_overflow_ref.html
+++ b/tests/ref/block_formatting_context_overflow_ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div>Hello</div><div>world!</div>
+


### PR DESCRIPTION
Makes the Google search result links appear.

Closes #7298.

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7550)

<!-- Reviewable:end -->
