### PR TITLE
Add viewport configuration support to the compositor

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -93,6 +93,9 @@ pub struct IOCompositor<Window: WindowMethods> {
     /// The application window size.
     window_size: TypedSize2D<DevicePixel, u32>,
 
+    /// The overridden viewport.
+    viewport: Option<(TypedPoint2D<DevicePixel, u32>, TypedSize2D<DevicePixel, u32>)>,
+
     /// "Mobile-style" zoom that does not reflow the page.
     viewport_zoom: ScaleFactor<PagePx, ViewportPx, f32>,
 
@@ -292,6 +295,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 size: window_size.as_f32(),
             }),
             window_size: window_size,
+            viewport: None,
             hidpi_factor: hidpi_factor,
             channel_to_self: state.sender.clone_compositor_proxy(),
             scrolling_timer: ScrollingTimerProxy::new(state.sender),
@@ -1017,6 +1021,10 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.initialize_compositing();
             }
 
+            WindowEvent::Viewport(point, size) => {
+              self.viewport = Some((point, size));
+            }
+
             WindowEvent::Resize(size) => {
                 self.on_resize_window_event(size);
             }
@@ -1574,15 +1582,39 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         profile(ProfilerCategory::Compositing, None, self.time_profiler_chan.clone(), || {
             debug!("compositor: compositing");
             // Adjust the layer dimensions as necessary to correspond to the size of the window.
-            self.scene.viewport = Rect {
-                origin: Point2D::zero(),
-                size: self.window_size.as_f32(),
+            self.scene.viewport = match self.viewport {
+                Some((point, size)) => Rect {
+                    origin: point.as_f32(),
+                    size:   size.as_f32(),
+                },
+
+                None => Rect {
+                    origin: Point2D::zero(),
+                    size: self.window_size.as_f32(),
+                }
             };
 
             // Paint the scene.
             if let Some(ref layer) = self.scene.root {
                 match self.context {
-                    Some(context) => rendergl::render_scene(layer.clone(), context, &self.scene),
+                    Some(context) => {
+                        if let Some((point, size)) = self.viewport {
+                            let point = point.to_untyped();
+                            let size  = size.to_untyped();
+
+                            gl::scissor(point.x as GLint, point.y as GLint,
+                                        size.width as GLsizei, size.height as GLsizei);
+
+                            gl::enable(gl::SCISSOR_TEST);
+                            rendergl::render_scene(layer.clone(), context, &self.scene);
+                            gl::disable(gl::SCISSOR_TEST);
+
+                        }
+                        else {
+                            rendergl::render_scene(layer.clone(), context, &self.scene);
+                        }
+                    }
+
                     None => {
                         debug!("compositor: not compositing because context not yet set up")
                     }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -51,6 +51,8 @@ pub enum WindowEvent {
     InitializeCompositing,
     /// Sent when the window is resized.
     Resize(TypedSize2D<DevicePixel, u32>),
+    /// Sent when you want to override the viewport.
+    Viewport(TypedPoint2D<DevicePixel, u32>, TypedSize2D<DevicePixel, u32>),
     /// Sent when a new URL is to be loaded.
     LoadUrl(String),
     /// Sent when a mouse hit test is to be performed.
@@ -81,6 +83,7 @@ impl Debug for WindowEvent {
             WindowEvent::Refresh => write!(f, "Refresh"),
             WindowEvent::InitializeCompositing => write!(f, "InitializeCompositing"),
             WindowEvent::Resize(..) => write!(f, "Resize"),
+            WindowEvent::Viewport(..) => write!(f, "Viewport"),
             WindowEvent::KeyEvent(..) => write!(f, "Key"),
             WindowEvent::LoadUrl(..) => write!(f, "LoadUrl"),
             WindowEvent::MouseWindowEventClass(..) => write!(f, "Mouse"),


### PR DESCRIPTION
This allows me to do stuff like this.

![this](https://cloud.githubusercontent.com/assets/40204/9701150/58d593ae-541d-11e5-9f57-8d379f5c9ceb.png)

Those are two compositors rendered on the same OpenGL context, I need this so I can split windows and render them without getting mad with textures and framebuffers, it will also allow me to render the proper parts of the chrome as different web pages without involving dozens of framebuffers and textures.

If I recall correctly I did talk to @glennw about this on IRC some time ago.

This pull request requires https://github.com/servo/gleam/pull/39 to be merged first tho.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7552)

<!-- Reviewable:end -->
