### PR TITLE
Remove 'get_*' on getters as per RFC 0344 on canevas, compositing, devtools, gfx, layout, net, profile, servo and webdriver_server

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -170,7 +170,7 @@ impl<'a> CanvasPaintTask<'a> {
                             Canvas2dMsg::SetGlobalAlpha(alpha) => painter.set_global_alpha(alpha),
                             Canvas2dMsg::SetGlobalComposition(op) => painter.set_global_composition(op),
                             Canvas2dMsg::GetImageData(dest_rect, canvas_size, chan)
-                                => painter.get_image_data(dest_rect, canvas_size, chan),
+                                => painter.image_data(dest_rect, canvas_size, chan),
                             Canvas2dMsg::PutImageData(imagedata, offset, image_data_size, dirty_rect)
                                 => painter.put_image_data(imagedata, offset, image_data_size, dirty_rect),
                             Canvas2dMsg::SetShadowOffsetX(value) => painter.set_shadow_offset_x(value),
@@ -516,7 +516,7 @@ impl<'a> CanvasPaintTask<'a> {
         unimplemented!()
     }
 
-    fn get_image_data(&self,
+    fn image_data(&self,
                       dest_rect: Rect<i32>,
                       canvas_size: Size2D<f64>,
                       chan: IpcSender<Vec<u8>>) {

--- a/components/canvas/webgl_paint_task.rs
+++ b/components/canvas/webgl_paint_task.rs
@@ -57,7 +57,7 @@ impl WebGLPaintTask {
     pub fn handle_webgl_message(&self, message: CanvasWebGLMsg) {
         match message {
             CanvasWebGLMsg::GetContextAttributes(sender) =>
-                self.get_context_attributes(sender),
+                self.context_attributes(sender),
             CanvasWebGLMsg::ActiveTexture(target) =>
                 gl::active_texture(target),
             CanvasWebGLMsg::BlendColor(r, g, b, a) =>
@@ -111,11 +111,11 @@ impl WebGLPaintTask {
             CanvasWebGLMsg::EnableVertexAttribArray(attrib_id) =>
                 gl::enable_vertex_attrib_array(attrib_id),
             CanvasWebGLMsg::GetAttribLocation(program_id, name, chan) =>
-                self.get_attrib_location(program_id, name, chan),
+                self.attrib_location(program_id, name, chan),
             CanvasWebGLMsg::GetShaderParameter(shader_id, param_id, chan) =>
-                self.get_shader_parameter(shader_id, param_id, chan),
+                self.shader_parameter(shader_id, param_id, chan),
             CanvasWebGLMsg::GetUniformLocation(program_id, name, chan) =>
-                self.get_uniform_location(program_id, name, chan),
+                self.uniform_location(program_id, name, chan),
             CanvasWebGLMsg::CompileShader(shader_id, source) =>
                 self.compile_shader(shader_id, source),
             CanvasWebGLMsg::CreateBuffer(chan) =>
@@ -214,7 +214,7 @@ impl WebGLPaintTask {
     }
 
     #[inline]
-    fn get_context_attributes(&self, sender: IpcSender<GLContextAttributes>) {
+    fn context_attributes(&self, sender: IpcSender<GLContextAttributes>) {
         sender.send(*self.gl_context.borrow_attributes()).unwrap()
     }
 
@@ -305,7 +305,7 @@ impl WebGLPaintTask {
         gl::compile_shader(shader_id);
     }
 
-    fn get_attrib_location(&self, program_id: u32, name: String, chan: IpcSender<Option<i32>> ) {
+    fn attrib_location(&self, program_id: u32, name: String, chan: IpcSender<Option<i32>> ) {
         let attrib_location = gl::get_attrib_location(program_id, &name);
 
         let attrib_location = if attrib_location == -1 {
@@ -317,7 +317,7 @@ impl WebGLPaintTask {
         chan.send(attrib_location).unwrap();
     }
 
-    fn get_shader_parameter(&self,
+    fn shader_parameter(&self,
                             shader_id: u32,
                             param_id: u32,
                             chan: IpcSender<WebGLShaderParameter>) {
@@ -332,7 +332,7 @@ impl WebGLPaintTask {
         chan.send(result).unwrap();
     }
 
-    fn get_uniform_location(&self, program_id: u32, name: String, chan: IpcSender<Option<i32>>) {
+    fn uniform_location(&self, program_id: u32, name: String, chan: IpcSender<Option<i32>>) {
         let location = gl::get_uniform_location(program_id, &name);
         let location = if location == -1 {
             None

--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -404,7 +404,7 @@ impl CompositorLayer for Layer<CompositorData> {
                 MouseUpEvent(button, event_point),
         };
 
-        let pipeline = compositor.get_pipeline(self.pipeline_id());
+        let pipeline = compositor.pipeline(self.pipeline_id());
         let _ = pipeline.script_chan.send(ConstellationControlMsg::SendEvent(pipeline.id.clone(), message));
     }
 
@@ -413,7 +413,7 @@ impl CompositorLayer for Layer<CompositorData> {
                                      cursor: TypedPoint2D<LayerPixel, f32>)
                                      where Window: WindowMethods {
         let message = MouseMoveEvent(cursor.to_untyped());
-        let pipeline = compositor.get_pipeline(self.pipeline_id());
+        let pipeline = compositor.pipeline(self.pipeline_id());
         let _ = pipeline.script_chan.send(ConstellationControlMsg::SendEvent(pipeline.id.clone(), message));
     }
 

--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -294,5 +294,5 @@ pub trait CompositorEventListener {
     fn shutdown(&mut self);
     fn pinch_zoom_level(&self) -> f32;
     /// Requests that the compositor send the title for the main frame as soon as possible.
-    fn get_title_for_main_frame(&self);
+    fn title_for_main_frame(&self);
 }

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -152,5 +152,5 @@ impl CompositorEventListener for NullCompositor {
         1.0
     }
 
-    fn get_title_for_main_frame(&self) {}
+    fn title_for_main_frame(&self) {}
 }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -82,7 +82,7 @@ impl ActorRegistry {
     }
 
     /// Get shareable registry through threads
-    pub fn get_shareable(&self) -> Arc<Mutex<ActorRegistry>> {
+    pub fn shareable(&self) -> Arc<Mutex<ActorRegistry>> {
         self.shareable.as_ref().unwrap().clone()
     }
 

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -204,7 +204,7 @@ impl Actor for TimelineActor {
                     }
                 }
 
-                let emitter = Emitter::new(self.name(), registry.get_shareable(),
+                let emitter = Emitter::new(self.name(), registry.shareable(),
                                            registry.start_stamp(),
                                            stream.try_clone().unwrap(),
                                            self.memory_actor.borrow().clone(),

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -42,7 +42,7 @@ pub trait FontHandleMethods: Sized {
     fn glyph_h_advance(&self, GlyphId) -> Option<FractionalPixel>;
     fn glyph_h_kerning(&self, GlyphId, GlyphId) -> FractionalPixel;
     fn metrics(&self) -> FontMetrics;
-    fn get_table_for_tag(&self, FontTableTag) -> Option<Box<FontTable>>;
+    fn table_for_tag(&self, FontTableTag) -> Option<Box<FontTable>>;
 }
 
 // Used to abstract over the shaper's choice of fixed int representation.
@@ -170,8 +170,8 @@ impl Font {
         self.shaper.as_ref().unwrap()
     }
 
-    pub fn get_table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
-        let result = self.handle.get_table_for_tag(tag);
+    pub fn table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
+        let result = self.handle.table_for_tag(tag);
         let status = if result.is_some() { "Found" } else { "Didn't find" };
 
         debug!("{} font table[{}] with family={}, face={}",

--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use platform::font_context::FontContextHandle;
-use platform::font_list::get_available_families;
-use platform::font_list::get_last_resort_font_families;
-use platform::font_list::get_system_default_family;
-use platform::font_list::get_variations_for_family;
-
 use font_template::{FontTemplate, FontTemplateDescriptor};
 use net_traits::{ResourceTask, load_whole_resource};
+use platform::font_context::FontContextHandle;
+use platform::font_list::for_each_available_family;
+use platform::font_list::for_each_variation;
+use platform::font_list::last_resort_font_families;
+use platform::font_list::system_default_family;
 use platform::font_template::FontTemplateData;
 use std::borrow::ToOwned;
 use std::collections::HashMap;
@@ -42,7 +41,7 @@ impl FontFamily {
         // TODO(Issue #190): if not in the fast path above, do
         // expensive matching of weights, etc.
         for template in &mut self.templates {
-            let maybe_template = template.get_if_matches(fctx, desc);
+            let maybe_template = template.data_for_descriptor(fctx, desc);
             if maybe_template.is_some() {
                 return maybe_template;
             }
@@ -103,7 +102,7 @@ struct FontCache {
 
 fn add_generic_font(generic_fonts: &mut HashMap<LowercaseString, LowercaseString>,
                     generic_name: &str, mapped_name: &str) {
-    let opt_system_default = get_system_default_family(generic_name);
+    let opt_system_default = system_default_family(generic_name);
     let family_name = match opt_system_default {
         Some(system_default) => LowercaseString::new(&system_default),
         None => LowercaseString::new(mapped_name),
@@ -119,11 +118,11 @@ impl FontCache {
             match msg {
                 Command::GetFontTemplate(family, descriptor, result) => {
                     let family = LowercaseString::new(&family);
-                    let maybe_font_template = self.get_font_template(&family, &descriptor);
+                    let maybe_font_template = self.find_font_template(&family, &descriptor);
                     result.send(Reply::GetFontTemplateReply(maybe_font_template)).unwrap();
                 }
                 Command::GetLastResortFontTemplate(descriptor, result) => {
-                    let font_template = self.get_last_resort_font_template(&descriptor);
+                    let font_template = self.last_resort_font_template(&descriptor);
                     result.send(Reply::GetFontTemplateReply(Some(font_template))).unwrap();
                 }
                 Command::AddWebFont(family_name, src, result) => {
@@ -149,7 +148,7 @@ impl FontCache {
                         }
                         Source::Local(ref local_family_name) => {
                             let family = &mut self.web_families.get_mut(&family_name).unwrap();
-                            get_variations_for_family(&local_family_name, |path| {
+                            for_each_variation(&local_family_name, |path| {
                                 family.add_template(Atom::from_slice(&path), None);
                             });
                         }
@@ -166,7 +165,7 @@ impl FontCache {
 
     fn refresh_local_families(&mut self) {
         self.local_families.clear();
-        get_available_families(|family_name| {
+        for_each_available_family(|family_name| {
             let family_name = LowercaseString::new(&family_name);
             if !self.local_families.contains_key(&family_name) {
                 let family = FontFamily::new();
@@ -191,7 +190,7 @@ impl FontCache {
             let s = self.local_families.get_mut(family_name).unwrap();
 
             if s.templates.is_empty() {
-                get_variations_for_family(family_name, |path| {
+                for_each_variation(family_name, |path| {
                     s.add_template(Atom::from_slice(&path), None);
                 });
             }
@@ -221,7 +220,7 @@ impl FontCache {
         }
     }
 
-    fn get_font_template(&mut self, family: &LowercaseString, desc: &FontTemplateDescriptor)
+    fn find_font_template(&mut self, family: &LowercaseString, desc: &FontTemplateDescriptor)
                             -> Option<Arc<FontTemplateData>> {
         let transformed_family_name = self.transform_family(family);
         let mut maybe_template = self.find_font_in_web_family(&transformed_family_name, desc);
@@ -231,9 +230,9 @@ impl FontCache {
         maybe_template
     }
 
-    fn get_last_resort_font_template(&mut self, desc: &FontTemplateDescriptor)
+    fn last_resort_font_template(&mut self, desc: &FontTemplateDescriptor)
                                         -> Arc<FontTemplateData> {
-        let last_resort = get_last_resort_font_families();
+        let last_resort = last_resort_font_families();
 
         for family in &last_resort {
             let family = LowercaseString::new(family);
@@ -285,7 +284,7 @@ impl FontCacheTask {
         }
     }
 
-    pub fn get_font_template(&self, family: String, desc: FontTemplateDescriptor)
+    pub fn find_font_template(&self, family: String, desc: FontTemplateDescriptor)
                                                 -> Option<Arc<FontTemplateData>> {
 
         let (response_chan, response_port) = channel();
@@ -300,7 +299,7 @@ impl FontCacheTask {
         }
     }
 
-    pub fn get_last_resort_font_template(&self, desc: FontTemplateDescriptor)
+    pub fn last_resort_font_template(&self, desc: FontTemplateDescriptor)
                                                 -> Arc<FontTemplateData> {
 
         let (response_chan, response_port) = channel();

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -134,7 +134,7 @@ impl FontContext {
     /// Create a group of fonts for use in layout calculations. May return
     /// a cached font if this font instance has already been used by
     /// this context.
-    pub fn get_layout_font_group_for_style(&mut self, style: Arc<SpecifiedFontStyle>)
+    pub fn layout_font_group_for_style(&mut self, style: Arc<SpecifiedFontStyle>)
                                             -> Rc<FontGroup> {
         let address = &*style as *const SpecifiedFontStyle as usize;
         if let Some(ref cached_font_group) = self.layout_font_group_cache.get(&address) {
@@ -186,9 +186,9 @@ impl FontContext {
             }
 
             if !cache_hit {
-                let font_template = self.font_cache_task.get_font_template(family.name()
-                                                                                 .to_owned(),
-                                                                           desc.clone());
+                let font_template = self.font_cache_task.find_font_template(family.name()
+                                                                            .to_owned(),
+                                                                            desc.clone());
                 match font_template {
                     Some(font_template) => {
                         let layout_font = self.create_layout_font(font_template,
@@ -236,7 +236,7 @@ impl FontContext {
             }
 
             if !cache_hit {
-                let font_template = self.font_cache_task.get_last_resort_font_template(desc.clone());
+                let font_template = self.font_cache_task.last_resort_font_template(desc.clone());
                 let layout_font = self.create_layout_font(font_template,
                                                           desc.clone(),
                                                           style.font_size,
@@ -261,7 +261,7 @@ impl FontContext {
 
     /// Create a paint font for use with azure. May return a cached
     /// reference if already used by this font context.
-    pub fn get_paint_font_from_template(&mut self,
+    pub fn paint_font_from_template(&mut self,
                                         template: &Arc<FontTemplateData>,
                                         pt_size: Au)
                                         -> Rc<RefCell<ScaledFont>> {

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -88,7 +88,7 @@ impl FontTemplate {
     }
 
     /// Get the data for creating a font if it matches a given descriptor.
-    pub fn get_if_matches(&mut self,
+    pub fn data_for_descriptor(&mut self,
                           fctx: &FontContextHandle,
                           requested_desc: &FontTemplateDescriptor)
                           -> Option<Arc<FontTemplateData>> {
@@ -100,13 +100,13 @@ impl FontTemplate {
         match self.descriptor {
             Some(actual_desc) => {
                 if *requested_desc == actual_desc {
-                    Some(self.get_data())
+                    Some(self.data())
                 } else {
                     None
                 }
             },
             None if self.is_valid => {
-                let data = self.get_data();
+                let data = self.data();
                 let handle: Result<FontHandle, ()> =
                     FontHandleMethods::new_from_template(fctx, data.clone(), None);
                 match handle {
@@ -138,7 +138,7 @@ impl FontTemplate {
     /// Get the data for creating a font.
     pub fn get(&mut self) -> Option<Arc<FontTemplateData>> {
         if self.is_valid {
-            Some(self.get_data())
+            Some(self.data())
         } else {
             None
         }
@@ -147,7 +147,7 @@ impl FontTemplate {
     /// Get the font template data. If any strong references still
     /// exist, it will return a clone, otherwise it will load the
     /// font data and store a weak reference to it internally.
-    pub fn get_data(&mut self) -> Arc<FontTemplateData> {
+    pub fn data(&mut self) -> Arc<FontTemplateData> {
         let maybe_data = match self.weak_ref {
             Some(ref data) => data.upgrade(),
             None => None,

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -1272,7 +1272,7 @@ impl<'a> PaintContext<'a> {
             self.create_draw_target_for_blur_if_necessary(&text.base.bounds, text.blur_radius);
         {
             // FIXME(https://github.com/rust-lang/rust/issues/23338)
-            let font = self.font_context.get_paint_font_from_template(
+            let font = self.font_context.paint_font_from_template(
                 &text.text_run.font_template, text.text_run.actual_pt_size);
             font.borrow()
                 .draw_text(&temporary_draw_target.draw_target,

--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -320,7 +320,7 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
             }
             let new_buffers = (0..tile_count).map(|i| {
                 let thread_id = i % self.worker_threads.len();
-                self.worker_threads[thread_id].get_painted_tile_buffer()
+                self.worker_threads[thread_id].painted_tile_buffer()
             }).collect();
 
             let layer_buffer_set = box LayerBufferSet {
@@ -483,7 +483,7 @@ impl WorkerThreadProxy {
         self.sender.send(msg).unwrap()
     }
 
-    fn get_painted_tile_buffer(&mut self) -> Box<LayerBuffer> {
+    fn painted_tile_buffer(&mut self) -> Box<LayerBuffer> {
         match self.receiver.recv().unwrap() {
             MsgFromWorkerThread::PaintedTile(layer_buffer) => layer_buffer,
         }

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -263,7 +263,7 @@ impl FontHandleMethods for FontHandle {
         return metrics;
     }
 
-    fn get_table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
+    fn table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
         let tag = tag as FT_ULong;
 
         unsafe {

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -27,7 +27,7 @@ static FC_FILE: &'static [u8] = b"file\0";
 static FC_INDEX: &'static [u8] = b"index\0";
 static FC_FONTFORMAT: &'static [u8] = b"fontformat\0";
 
-pub fn get_available_families<F>(mut callback: F) where F: FnMut(String) {
+pub fn for_each_available_family<F>(mut callback: F) where F: FnMut(String) {
     unsafe {
         let config = FcConfigGetCurrent();
         let fontSet = FcConfigGetFonts(config, FcSetSystem);
@@ -57,7 +57,7 @@ pub fn get_available_families<F>(mut callback: F) where F: FnMut(String) {
     }
 }
 
-pub fn get_variations_for_family<F>(family_name: &str, mut callback: F)
+pub fn for_each_variation<F>(family_name: &str, mut callback: F)
     where F: FnMut(String)
 {
     debug!("getting variations for {}", family_name);
@@ -111,7 +111,7 @@ pub fn get_variations_for_family<F>(family_name: &str, mut callback: F)
     }
 }
 
-pub fn get_system_default_family(generic_name: &str) -> Option<String> {
+pub fn system_default_family(generic_name: &str) -> Option<String> {
     let generic_name_c = CString::new(generic_name).unwrap();
     let generic_name_ptr = generic_name_c.as_ptr();
 
@@ -140,7 +140,7 @@ pub fn get_system_default_family(generic_name: &str) -> Option<String> {
 }
 
 #[cfg(target_os = "linux")]
-pub fn get_last_resort_font_families() -> Vec<String> {
+pub fn last_resort_font_families() -> Vec<String> {
     vec!(
         "Fira Sans".to_owned(),
         "DejaVu Sans".to_owned(),
@@ -149,6 +149,6 @@ pub fn get_last_resort_font_families() -> Vec<String> {
 }
 
 #[cfg(target_os = "android")]
-pub fn get_last_resort_font_families() -> Vec<String> {
+pub fn last_resort_font_families() -> Vec<String> {
     vec!("Roboto".to_owned())
 }

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -192,7 +192,7 @@ impl FontHandleMethods for FontHandle {
         return metrics;
     }
 
-    fn get_table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
+    fn table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
         let result: Option<CFData> = self.ctfont.get_font_table(tag);
         result.and_then(|data| {
             Some(box FontTable::wrap(data))

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -10,7 +10,7 @@ use core_text::font_descriptor::{CTFontDescriptor, CTFontDescriptorRef};
 use std::borrow::ToOwned;
 use std::mem;
 
-pub fn get_available_families<F>(mut callback: F) where F: FnMut(String) {
+pub fn for_each_available_family<F>(mut callback: F) where F: FnMut(String) {
     let family_names = core_text::font_collection::get_family_names();
     for strref in family_names.iter() {
         let family_name_ref: CFStringRef = unsafe { mem::transmute(strref) };
@@ -20,7 +20,7 @@ pub fn get_available_families<F>(mut callback: F) where F: FnMut(String) {
     }
 }
 
-pub fn get_variations_for_family<F>(family_name: &str, mut callback: F) where F: FnMut(String) {
+pub fn for_each_variation<F>(family_name: &str, mut callback: F) where F: FnMut(String) {
     debug!("Looking for faces of family: {}", family_name);
 
     let family_collection = core_text::font_collection::create_for_family(family_name);
@@ -35,10 +35,10 @@ pub fn get_variations_for_family<F>(family_name: &str, mut callback: F) where F:
     }
 }
 
-pub fn get_system_default_family(_generic_name: &str) -> Option<String> {
+pub fn system_default_family(_generic_name: &str) -> Option<String> {
     None
 }
 
-pub fn get_last_resort_font_families() -> Vec<String> {
+pub fn last_resort_font_families() -> Vec<String> {
     vec!("Arial Unicode MS".to_owned(), "Arial".to_owned())
 }

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -238,7 +238,7 @@ impl<'a> DetailedGlyphStore {
         self.lookup_is_sorted = false;
     }
 
-    fn get_detailed_glyphs_for_entry(&'a self, entry_offset: CharIndex, count: u16)
+    fn detailed_glyphs_for_entry(&'a self, entry_offset: CharIndex, count: u16)
                                   -> &'a [DetailedGlyph] {
         debug!("Requesting detailed glyphs[n={}] for entry[off={:?}]", count, entry_offset);
 
@@ -264,7 +264,7 @@ impl<'a> DetailedGlyphStore {
         &self.detail_buffer[i .. i + count as usize]
     }
 
-    fn get_detailed_glyph_with_index(&'a self,
+    fn detailed_glyph_with_index(&'a self,
                                      entry_offset: CharIndex,
                                      detail_offset: u16)
             -> &'a DetailedGlyph {
@@ -357,7 +357,7 @@ impl<'a> GlyphInfo<'a> {
         match self {
             GlyphInfo::Simple(store, entry_i) => store.entry_buffer[entry_i.to_usize()].id(),
             GlyphInfo::Detail(store, entry_i, detail_j) => {
-                store.detail_store.get_detailed_glyph_with_index(entry_i, detail_j).id
+                store.detail_store.detailed_glyph_with_index(entry_i, detail_j).id
             }
         }
     }
@@ -368,7 +368,7 @@ impl<'a> GlyphInfo<'a> {
         match self {
             GlyphInfo::Simple(store, entry_i) => store.entry_buffer[entry_i.to_usize()].advance(),
             GlyphInfo::Detail(store, entry_i, detail_j) => {
-                store.detail_store.get_detailed_glyph_with_index(entry_i, detail_j).advance
+                store.detail_store.detailed_glyph_with_index(entry_i, detail_j).advance
             }
         }
     }
@@ -377,7 +377,7 @@ impl<'a> GlyphInfo<'a> {
         match self {
             GlyphInfo::Simple(_, _) => None,
             GlyphInfo::Detail(store, entry_i, detail_j) => {
-                Some(store.detail_store.get_detailed_glyph_with_index(entry_i, detail_j).offset)
+                Some(store.detail_store.detailed_glyph_with_index(entry_i, detail_j).offset)
             }
         }
     }
@@ -608,7 +608,7 @@ impl<'a> GlyphIterator<'a> {
     #[inline(never)]
     fn next_complex_glyph(&mut self, entry: &GlyphEntry, i: CharIndex)
                           -> Option<(CharIndex, GlyphInfo<'a>)> {
-        let glyphs = self.store.detail_store.get_detailed_glyphs_for_entry(i, entry.glyph_count());
+        let glyphs = self.store.detail_store.detailed_glyphs_for_entry(i, entry.glyph_count());
         self.glyph_range = Some(range::each_index(CharIndex(0), CharIndex(glyphs.len() as isize)));
         self.next()
     }

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -176,8 +176,8 @@ impl<'a> LayoutContext<'a> {
     pub fn get_or_request_image(&self, url: Url, use_placeholder: UsePlaceholder)
                                 -> Option<Arc<Image>> {
         // See if the image is already available
-        let result = self.shared.image_cache_task.get_image_if_available(url.clone(),
-                                                                         use_placeholder);
+        let result = self.shared.image_cache_task.find_image(url.clone(),
+                                                             use_placeholder);
 
         match result {
             Ok(image) => Some(image),

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -159,7 +159,7 @@ impl TextRunScanner {
                 let in_fragment = self.clump.front().unwrap();
                 let font_style = in_fragment.style().get_font_arc();
                 let inherited_text_style = in_fragment.style().get_inheritedtext();
-                fontgroup = font_context.get_layout_font_group_for_style(font_style);
+                fontgroup = font_context.layout_font_group_for_style(font_style);
                 compression = match in_fragment.white_space() {
                     white_space::T::normal | white_space::T::nowrap => {
                         CompressionMode::CompressWhitespaceNewline
@@ -358,7 +358,7 @@ fn bounding_box_for_run_metrics(metrics: &RunMetrics, writing_mode: WritingMode)
 #[inline]
 pub fn font_metrics_for_style(font_context: &mut FontContext, font_style: Arc<FontStyle>)
                               -> FontMetrics {
-    let fontgroup = font_context.get_layout_font_group_for_style(font_style);
+    let fontgroup = font_context.layout_font_group_for_style(font_style);
     // FIXME(https://github.com/rust-lang/rust/issues/23338)
     let font = fontgroup.fonts[0].borrow();
     font.metrics.clone()

--- a/components/net_traits/image_cache_task.rs
+++ b/components/net_traits/image_cache_task.rs
@@ -111,7 +111,7 @@ impl ImageCacheTask {
     }
 
     /// Get the current state of an image. See ImageCacheCommand::GetImageIfAvailable.
-    pub fn get_image_if_available(&self, url: Url, use_placeholder: UsePlaceholder)
+    pub fn find_image(&self, url: Url, use_placeholder: UsePlaceholder)
                                   -> Result<Arc<Image>, ImageState> {
         let (sender, receiver) = ipc::channel().unwrap();
         let msg = ImageCacheCommand::GetImageIfAvailable(url, use_placeholder, sender);

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -187,8 +187,8 @@ impl Browser {
         self.compositor.pinch_zoom_level()
     }
 
-    pub fn get_title_for_main_frame(&self) {
-        self.compositor.get_title_for_main_frame()
+    pub fn request_title_for_main_frame(&self) {
+        self.compositor.title_for_main_frame()
     }
 
     pub fn shutdown(mut self) {

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -42,7 +42,7 @@ fn main() {
     env_logger::init().unwrap();
 
     // Parse the command line options and store them globally
-    opts::from_cmdline_args(&*get_args());
+    opts::from_cmdline_args(&*args());
 
     setup_logging();
 
@@ -138,7 +138,7 @@ fn setup_logging() {
 }
 
 #[cfg(target_os = "android")]
-fn get_args() -> Vec<String> {
+fn args() -> Vec<String> {
     vec![
         "servo".to_owned(),
         "http://en.wikipedia.org/wiki/Rust".to_owned()
@@ -146,7 +146,7 @@ fn get_args() -> Vec<String> {
 }
 
 #[cfg(not(target_os = "android"))]
-fn get_args() -> Vec<String> {
+fn args() -> Vec<String> {
     use std::env;
     env::args().collect()
 }

--- a/ports/cef/browser.rs
+++ b/ports/cef/browser.rs
@@ -40,10 +40,10 @@ impl ServoBrowser {
         }
     }
 
-    pub fn get_title_for_main_frame(&self) {
+    pub fn request_title_for_main_frame(&self) {
         match *self {
-            ServoBrowser::OnScreen(ref browser) => browser.get_title_for_main_frame(),
-            ServoBrowser::OffScreen(ref browser) => browser.get_title_for_main_frame(),
+            ServoBrowser::OnScreen(ref browser) => browser.request_title_for_main_frame(),
+            ServoBrowser::OffScreen(ref browser) => browser.request_title_for_main_frame(),
             ServoBrowser::Invalid => {}
         }
     }
@@ -165,7 +165,7 @@ impl ServoCefBrowser {
 pub trait ServoCefBrowserExtensions {
     fn init(&self, window_info: &cef_window_info_t);
     fn send_window_event(&self, event: WindowEvent);
-    fn get_title_for_main_frame(&self);
+    fn request_title_for_main_frame(&self);
     fn pinch_zoom_level(&self) -> f32;
 }
 
@@ -207,8 +207,8 @@ impl ServoCefBrowserExtensions for CefBrowser {
         }
     }
 
-    fn get_title_for_main_frame(&self) {
-        self.downcast().servo_browser.borrow().get_title_for_main_frame()
+    fn request_title_for_main_frame(&self) {
+        self.downcast().servo_browser.borrow().request_title_for_main_frame()
     }
 
     fn pinch_zoom_level(&self) -> f32 {

--- a/ports/cef/frame.rs
+++ b/ports/cef/frame.rs
@@ -46,7 +46,7 @@ full_cef_class_impl! {
         fn get_text(&this, visitor: *mut cef_string_visitor_t [CefStringVisitor],) -> () {{
             let this = this.downcast();
             *this.title_visitor.borrow_mut() = Some(visitor);
-            this.browser.borrow().as_ref().unwrap().get_title_for_main_frame();
+            this.browser.borrow().as_ref().unwrap().request_title_for_main_frame();
         }}
     }
 }


### PR DESCRIPTION
Hi guys,

I just gave a big pass of RFC-0344 as per issue #6224 .

Pretty much renamed all the get_\* fn that were used to fetch values. 

I hope I didn't rename too much. 

As said in the issue discussion, I didn't touch at the scripts folder so we keep the unsafe ones pretty explicit.

I've ran the whole pass of test, everything seems to be still working right :).

Please give feedback on this PR.

Thanks for looking into it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7559)

<!-- Reviewable:end -->
