### PR TITLE
Include the overflow of the inline block itself.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2175,6 +2175,19 @@ impl Fragment {
             overflow = overflow.union(&border_box.inflate(outline_width, outline_width))
         }
 
+        // Include the overflow of the block flow, if any.
+        match self.specific {
+            SpecificFragmentInfo::InlineBlock(ref info) => {
+                let block_flow = info.flow_ref.as_block();
+                overflow = overflow.union(&block_flow.compute_overflow());
+            }
+            SpecificFragmentInfo::InlineAbsolute(ref info) => {
+                let block_flow = info.flow_ref.as_block();
+                overflow = overflow.union(&block_flow.compute_overflow());
+            }
+            _ => (),
+        }
+
         // FIXME(pcwalton): Sometimes excessively fancy glyphs can make us draw outside our border
         // box too.
         overflow

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -267,6 +267,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 != overconstrained_block.html overconstrained_block_ref.html
 == overflow_auto.html overflow_simple_b.html
 == overflow_auto_stacking_order_a.html overflow_auto_stacking_order_ref.html
+== overflow_position_abs_inline_block.html overflow_position_abs_inline_block_ref.html
 # Should be ==?
 != overflow_position_abs_inside_normal_a.html overflow_position_abs_inside_normal_b.html
 == overflow_position_abs_simple_a.html overflow_position_abs_simple_b.html

--- a/tests/ref/overflow_position_abs_inline_block.html
+++ b/tests/ref/overflow_position_abs_inline_block.html
@@ -1,0 +1,23 @@
+<style>
+  #d1 {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    background: green;
+  }
+  #d2 {
+    display: inline-block;
+    width: 100px;
+    background: red;
+    height: 100px;
+    position: relative;
+    top: 20px;
+    left: 20px;
+  }
+</style>
+
+<div style="position:fixed"></div>
+<div id="d1">
+  <div id="d2"></div>
+</div>
+

--- a/tests/ref/overflow_position_abs_inline_block_ref.html
+++ b/tests/ref/overflow_position_abs_inline_block_ref.html
@@ -1,0 +1,23 @@
+<style>
+  #d1 {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    background: green;
+  }
+  #d2 {
+    display: block;
+    width: 100px;
+    background: red;
+    height: 100px;
+    position: relative;
+    top: 20px;
+    left: 20px;
+  }
+</style>
+
+<div style="position:fixed"></div>
+<div id="d1">
+  <div id="d2"></div>
+</div>
+


### PR DESCRIPTION
Closes #7372.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7560)

<!-- Reviewable:end -->
