### PR TITLE
Layerize StackingContexts that are on top of layers

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -2058,7 +2058,7 @@ impl Flow for BlockFlow {
         // FIXME(#2010, pcwalton): This is a hack and is totally bogus in the presence of pseudo-
         // elements. But until we have incremental reflow we can't do better--we recreate the flow
         // for every DOM node so otherwise we nuke layers on every reflow.
-        LayerId(self.fragment.node.id() as usize, fragment_index)
+        LayerId(self.fragment.node.id() as usize, fragment_index, 0)
     }
 
     fn is_absolute_containing_block(&self) -> bool {

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -361,7 +361,7 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     #[allow(unsafe_code)]
     fn layer_id(&self, fragment_id: u32) -> LayerId {
         let obj = unsafe { mem::transmute::<&&Self, &raw::TraitObject>(&self) };
-        LayerId(obj.data as usize, fragment_id)
+        LayerId(obj.data as usize, fragment_id, 0)
     }
 
     /// Attempts to perform incremental fixup of this flow by replacing its fragment's style with

--- a/components/msg/compositor_msg.rs
+++ b/components/msg/compositor_msg.rs
@@ -36,19 +36,35 @@ impl FrameTreeId {
 }
 
 #[derive(Clone, PartialEq, Eq, Copy, Hash, Deserialize, Serialize, HeapSizeOf)]
-pub struct LayerId(pub usize, pub u32);
+pub struct LayerId(
+    /// A base layer ID, currently derived from DOM element pointer address.
+    pub usize,
+
+    /// FIXME(#2010, pcwalton): A marker for overflow scroll layers.
+    pub u32,
+
+    /// A sub ID, which is used for synthesizing new layers for content that
+    /// belongs on top of this layer. This prevents accidentally making colliding
+    /// layer ids.
+    pub u32
+);
 
 impl Debug for LayerId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let LayerId(a, b) = *self;
-        write!(f, "Layer({}, {})", a, b)
+        let LayerId(a, b, c) = *self;
+        write!(f, "Layer({}, {}, {})", a, b, c)
     }
 }
 
 impl LayerId {
     /// FIXME(#2011, pcwalton): This is unfortunate. Maybe remove this in the future.
     pub fn null() -> LayerId {
-        LayerId(0, 0)
+        LayerId(0, 0, 0)
+    }
+
+    pub fn next_layer_id(&self) -> LayerId {
+        let LayerId(a, b, sub_id) = *self;
+        LayerId(a, b, sub_id + 1)
     }
 }
 

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -323,6 +323,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 == servo_center_a.html servo_center_ref.html
 == setattribute_id_restyle_a.html setattribute_id_restyle_b.html
 == simple_inline_absolute_containing_block_a.html simple_inline_absolute_containing_block_ref.html
+== stacked_layers.html stacked_layers_ref.html
 == stacking_context_overflow_a.html stacking_context_overflow_ref.html
 == stacking_context_overflow_relative_outline_a.html stacking_context_overflow_relative_outline_ref.html
 == style_is_in_doc.html style_is_in_doc_ref.html

--- a/tests/ref/stacked_layers.html
+++ b/tests/ref/stacked_layers.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .test { float: left; margin-right: 25px; }
+            .box { height: 50px; width: 50px; }
+            .gray { background: rgb(200, 200, 200); }
+            .grayer { background: rgb(80, 80, 80); }
+            .grayest { background: rgb(0, 0, 0); }
+        </style>
+    </head>
+    <body>
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: fixed;"></div>
+            <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: relative; top: 10px; z-index: 5;"> </div>
+        </div>
+
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: fixed;"></div>
+            <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: absolute; top: 20px; z-index: 5;"> </div>
+        </div>
+    </body>
+</html>

--- a/tests/ref/stacked_layers_ref.html
+++ b/tests/ref/stacked_layers_ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .test { float: left; margin-right: 25px; }
+            .box { height: 50px; width: 50px; }
+            .gray { background: rgb(200, 200, 200); }
+            .grayer { background: rgb(80, 80, 80); }
+            .grayest { background: rgb(0, 0, 0); }
+        </style>
+    </head>
+<body>
+    <div class="test grayest box">
+        <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
+        <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: relative; top: 10px; z-index: 5;"></div>
+    </div>
+
+    <div class="test grayest box">
+        <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
+        <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: absolute; top: 20px; z-index: 5;"></div>
+    </div>
+</body>
+</html>

--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/the-fieldset-element-0/min-width-not-important.html.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/the-fieldset-element-0/min-width-not-important.html.ini
@@ -1,5 +1,0 @@
-[min-width-not-important.html]
-  type: reftest
-  reftype: ==
-  refurl: /html/rendering/non-replaced-elements/the-fieldset-element-0/ref.html
-  expected: FAIL


### PR DESCRIPTION
StackingContexts that should be painted on top of StackingContexts that
are already layerized should automatically get their own layer. This
will ensure proper painting order.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7563)

<!-- Reviewable:end -->
