### PR TITLE
Make the use of gold linker configurable

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -101,6 +101,7 @@ class CommandBase(object):
         if not self.config["tools"]["system-cargo"]:
             self.config["tools"]["cargo-root"] = path.join(
                 context.sharedir, "cargo", self.cargo_build_id())
+        self.config["tools"].setdefault("rustc-with-gold", True)
 
         self.config.setdefault("build", {})
         self.config["build"].setdefault("android", False)
@@ -308,8 +309,9 @@ class CommandBase(object):
 
         env['RUSTDOC'] = path.join(self.context.topdir, 'etc', 'rustdoc-with-private')
 
-        if subprocess.call(['which', 'ld.gold'], stdout=PIPE, stderr=PIPE) == 0:
-            env['RUSTC'] = path.join(self.context.topdir, 'etc', 'rustc-with-gold')
+        if self.config["tools"]["rustc-with-gold"]:
+            if subprocess.call(['which', 'ld.gold'], stdout=PIPE, stderr=PIPE) == 0:
+                env['RUSTC'] = path.join(self.context.topdir, 'etc', 'rustc-with-gold')
 
         return env
 

--- a/servobuild.example
+++ b/servobuild.example
@@ -23,6 +23,10 @@ system-rust = false
 system-cargo = false
 #cargo-root = "/path/to/cargo"
 
+# If rustc-with-gold is true, will try to find and use gold linker with rustc.
+# Defaults to true
+rustc-with-gold = true
+
 [build]
 # Set "mode = dev" or use `mach build --dev` to build the project with warning.
 # or Set "mode = release" or use `mach build --release` for optimized build.


### PR DESCRIPTION
Currently, ld.gold is always used for linking if found on the
system. There are some cases however when one may want to opt out
from using it. This patch adds the boolean field `rustc-with-gold`
to the `[tools]` section of `.servobuild`, which if set false,
disables the use of ld.gold.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7565)

<!-- Reviewable:end -->
