### PR TITLE
gfx: Fix bug with 1px width borders disappearing

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -67,6 +67,7 @@ flaky_cpu == append_style_a.html append_style_b.html
 != border_radius_dashed_a.html border_radius_dashed_ref.html
 == border_radius_elliptical_a.html border_radius_elliptical_ref.html
 == border_radius_overlapping_a.html border_radius_overlapping_ref.html
+== border_rounding_1px_invisible_issue_7184_a.html border_rounding_1px_invisible_issue_7184_ref.html
 == border_spacing_a.html border_spacing_ref.html
 == border_spacing_auto_layout_a.html border_spacing_ref.html
 == border_spacing_empty_table.html border_spacing_empty_table_ref.html

--- a/tests/ref/border_rounding_1px_invisible_issue_7184_a.html
+++ b/tests/ref/border_rounding_1px_invisible_issue_7184_a.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+         .onyx {
+             color: white;
+         }
+         .item {
+             background-color: #333;
+             border-bottom: 1px solid white;
+         }
+         .top {
+             margin: 0px;
+             border: 0px;
+             height: 1px;
+         }
+        </style>
+    </head>
+    <body>
+        <div class="onyx">
+            <div class="top"></div>
+            <div class="item">1</div>
+            <div class="item">2</div>
+            <div class="item">3</div>
+            <div class="item">4</div>
+        </div>
+    </body>
+</html>

--- a/tests/ref/border_rounding_1px_invisible_issue_7184_ref.html
+++ b/tests/ref/border_rounding_1px_invisible_issue_7184_ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style type="text/css">
+         .onyx {
+             color: white;
+         }
+         .item {
+             background-color: #333;
+             border-top: 1px solid white;
+         }
+        </style>
+    </head>
+    <body>
+        <div class="onyx">
+            <div class="item">1</div>
+            <div class="item">2</div>
+            <div class="item">3</div>
+            <div class="item">4</div>
+        </div>
+    </body>
+</html>

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-035.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-035.htm.ini
@@ -1,4 +1,3 @@
 [position-relative-035.htm]
   type: reftest
-  expected:
-    if os == "mac": FAIL
+  expected: FAIL


### PR DESCRIPTION
In to_nearest_azure_rect when rounding to pixel coordinates, maintain
the invariant of rect non-overlap (if before rounding two rects don't overlap).

The previous code rounded the rect top left corner to the nearest pixel with
the size rounded to the nearest pixel multiple which can violate the
non-overlap condition, e.g.
10px×9.60px at (0px,6.6px) & 10px×9.60px at (0px,16.2px)
would round to
10px×10.0px at (0px,7.0px) & 10px×10.0px at (0px,16.0px), which overlap.

Instead round each corner to the nearest pixel.

For rects that dont need to satify the non-overlap condition and with
width or height between 0.5px and 1px, rounding each rect corner to the
nearest pixel can yield an empty rect e.g.
10px×0.6px at 0px,28.56px -> 10px×0px at 0px,29px.

For this scenario a new function to_nearest_non_empty_azure_rect
rounds the rect top left corner to the nearest pixel and the rect size
to the nearest pixel multiple. It's possible for non-overlapping rects
after this rounding to overlap.

This should fix https://github.com/servo/servo/issues/7184 "rounding ...borders not to be visible", without breaking https://github.com/servo/servo/issues/7152 "Underlines less than 1px high sometimes invisible".

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7577)

<!-- Reviewable:end -->
