### PR TITLE
Actually store the overflow for inline-block elements.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -953,10 +953,11 @@ unsafe impl Sync for BaseFlow {}
 impl fmt::Debug for BaseFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f,
-               "@ {:?}, CC {}, ADC {}",
+               "@ {:?}, CC {}, ADC {}, Ovr {:?}",
                self.position,
                self.parallel.children_count.load(Ordering::SeqCst),
-               self.abs_descendants.len())
+               self.abs_descendants.len(),
+               self.overflow)
     }
 }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2179,11 +2179,11 @@ impl Fragment {
         match self.specific {
             SpecificFragmentInfo::InlineBlock(ref info) => {
                 let block_flow = info.flow_ref.as_block();
-                overflow = overflow.union(&block_flow.compute_overflow());
+                overflow = overflow.union(&flow::base(block_flow).overflow);
             }
             SpecificFragmentInfo::InlineAbsolute(ref info) => {
                 let block_flow = info.flow_ref.as_block();
-                overflow = overflow.union(&block_flow.compute_overflow());
+                overflow = overflow.union(&flow::base(block_flow).overflow);
             }
             _ => (),
         }

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -271,6 +271,7 @@ flaky_cpu == linebreak_simple_a.html linebreak_simple_b.html
 # Should be ==?
 != overflow_position_abs_inside_normal_a.html overflow_position_abs_inside_normal_b.html
 == overflow_position_abs_simple_a.html overflow_position_abs_simple_b.html
+== overflow_position_rel_inline_block.html overflow_position_rel_inline_block_ref.html
 == overflow_scroll.html overflow_simple_b.html
 == overflow_simple_a.html overflow_simple_b.html
 == overflow_wrap_a.html overflow_wrap_ref.html

--- a/tests/ref/overflow_position_rel_inline_block.html
+++ b/tests/ref/overflow_position_rel_inline_block.html
@@ -1,0 +1,11 @@
+<style>
+  div {
+    overflow:hidden;
+    display:inline-block;
+    position:relative;
+    width:100px;
+    height:100px;
+    background:red
+  }
+</style>
+<div></div>

--- a/tests/ref/overflow_position_rel_inline_block_ref.html
+++ b/tests/ref/overflow_position_rel_inline_block_ref.html
@@ -1,0 +1,9 @@
+<style>
+  div {
+    position:relative;
+    width:100px;
+    height:100px;
+    background:red
+  }
+</style>
+<div></div>


### PR DESCRIPTION
Fixes #7571

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7588)

<!-- Reviewable:end -->
