### PR TITLE
Improve DOM interfaces' extended attributes

### DIFF
--- a/components/script/dom/webidls/Attr.webidl
+++ b/components/script/dom/webidls/Attr.webidl
@@ -9,15 +9,24 @@
  */
 
 interface Attr {
+  [Constant]
   readonly attribute DOMString? namespaceURI;
+  [Constant]
   readonly attribute DOMString? prefix;
+  [Constant]
   readonly attribute DOMString localName;
+  [Constant]
   readonly attribute DOMString name;
+  [Pure]
            attribute DOMString value;
+  [Pure]
            attribute DOMString textContent; // alias of .value
+  [Pure]
            attribute DOMString nodeValue; // alias of .value
 
+  [Pure]
   readonly attribute Element? ownerElement;
 
+  [Constant]
   readonly attribute boolean specified; // useless; always returns true
 };

--- a/components/script/dom/webidls/CharacterData.webidl
+++ b/components/script/dom/webidls/CharacterData.webidl
@@ -11,9 +11,9 @@
  */
 
 interface CharacterData : Node {
-  [TreatNullAs=EmptyString] attribute DOMString data;
-  readonly attribute unsigned long length;
-  [Throws]
+  [Pure, TreatNullAs=EmptyString] attribute DOMString data;
+  [Pure] readonly attribute unsigned long length;
+  [Pure, Throws]
   DOMString substringData(unsigned long offset, unsigned long count);
   void appendData(DOMString data);
   [Throws]

--- a/components/script/dom/webidls/DOMImplementation.webidl
+++ b/components/script/dom/webidls/DOMImplementation.webidl
@@ -23,5 +23,6 @@ interface DOMImplementation {
   [NewObject]
   Document createHTMLDocument(optional DOMString title);
 
+  [Pure]
   boolean hasFeature(); // useless, always return true
 };

--- a/components/script/dom/webidls/DOMTokenList.webidl
+++ b/components/script/dom/webidls/DOMTokenList.webidl
@@ -5,10 +5,12 @@
 
 // https://dom.spec.whatwg.org/#domtokenlist
 interface DOMTokenList {
+  [Pure]
   readonly attribute unsigned long length;
+  [Pure]
   getter DOMString? item(unsigned long index);
 
-  [Throws]
+  [Pure, Throws]
   boolean contains(DOMString token);
   [Throws]
   void add(DOMString... tokens);

--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -13,15 +13,20 @@
 interface Document : Node {
   [SameObject]
   readonly attribute DOMImplementation implementation;
+  [Constant]
   readonly attribute DOMString URL;
   readonly attribute Element? activeElement;
+  [Constant]
   readonly attribute DOMString documentURI;
   readonly attribute DOMString compatMode;
   readonly attribute DOMString characterSet;
   readonly attribute DOMString inputEncoding; // legacy alias of .characterSet
+  [Constant]
   readonly attribute DOMString contentType;
 
+  [Pure]
   readonly attribute DocumentType? doctype;
+  [Pure]
   readonly attribute Element? documentElement;
   HTMLCollection getElementsByTagName(DOMString localName);
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);

--- a/components/script/dom/webidls/DocumentType.webidl
+++ b/components/script/dom/webidls/DocumentType.webidl
@@ -11,8 +11,11 @@
  */
 
 interface DocumentType : Node {
+  [Constant]
   readonly attribute DOMString name;
+  [Constant]
   readonly attribute DOMString publicId;
+  [Constant]
   readonly attribute DOMString systemId;
 };
 

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -28,10 +28,10 @@ interface Element : Node {
            attribute DOMString id;
   [Pure]
            attribute DOMString className;
-  [Constant]
+  [SameObject]
   readonly attribute DOMTokenList classList;
 
-  [Constant]
+  [SameObject]
   readonly attribute NamedNodeMap attributes;
   DOMString? getAttribute(DOMString name);
   DOMString? getAttributeNS(DOMString? namespace, DOMString localName);

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -14,12 +14,12 @@
  */
 
 interface Element : Node {
-
-  readonly attribute DOMString? prefix;
-  readonly attribute DOMString localName;
-
   [Constant]
   readonly attribute DOMString? namespaceURI;
+  [Constant]
+  readonly attribute DOMString? prefix;
+  [Constant]
+  readonly attribute DOMString localName;
   // Not [Constant] because it depends on which document we're in
   [Pure]
   readonly attribute DOMString tagName;
@@ -33,7 +33,9 @@ interface Element : Node {
 
   [SameObject]
   readonly attribute NamedNodeMap attributes;
+  [Pure]
   DOMString? getAttribute(DOMString name);
+  [Pure]
   DOMString? getAttributeNS(DOMString? namespace, DOMString localName);
   [Throws]
   void setAttribute(DOMString name, DOMString value);
@@ -44,10 +46,10 @@ interface Element : Node {
   boolean hasAttribute(DOMString name);
   boolean hasAttributeNS(DOMString? namespace, DOMString localName);
 
-  [Throws]
+  [Pure, Throws]
   Element? closest(DOMString selectors);
 
-  [Throws]
+  [Pure, Throws]
   boolean matches(DOMString selectors);
 
   HTMLCollection getElementsByTagName(DOMString localName);

--- a/components/script/dom/webidls/Event.webidl
+++ b/components/script/dom/webidls/Event.webidl
@@ -12,6 +12,7 @@
 
 [Constructor(DOMString type, optional EventInit eventInitDict)]
 interface Event {
+  [Pure]
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
   readonly attribute EventTarget? currentTarget;
@@ -25,12 +26,16 @@ interface Event {
   void stopPropagation();
   void stopImmediatePropagation();
 
+  [Pure]
   readonly attribute boolean bubbles;
+  [Pure]
   readonly attribute boolean cancelable;
   void preventDefault();
+  [Pure]
   readonly attribute boolean defaultPrevented;
 
   readonly attribute boolean isTrusted;
+  [Constant]
   readonly attribute DOMTimeStamp timeStamp;
 
   void initEvent(DOMString type, boolean bubbles, boolean cancelable);

--- a/components/script/dom/webidls/HTMLCollection.webidl
+++ b/components/script/dom/webidls/HTMLCollection.webidl
@@ -6,7 +6,10 @@
 // https://dom.spec.whatwg.org/#interface-htmlcollection
 
 interface HTMLCollection {
+  [Pure]
   readonly attribute unsigned long length;
+  [Pure]
   getter Element? item(unsigned long index);
+  [Pure]
   getter Element? namedItem(DOMString name);
 };

--- a/components/script/dom/webidls/NamedNodeMap.webidl
+++ b/components/script/dom/webidls/NamedNodeMap.webidl
@@ -5,9 +5,13 @@
 // https://dom.spec.whatwg.org/#interface-namednodemap
 
 interface NamedNodeMap {
+  [Pure]
   readonly attribute unsigned long length;
+  [Pure]
   getter Attr? item(unsigned long index);
+  [Pure]
   getter Attr? getNamedItem(DOMString name);
+  [Pure]
   Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
   //[Throws]
   //Attr? setNamedItem(Attr attr);

--- a/components/script/dom/webidls/Node.webidl
+++ b/components/script/dom/webidls/Node.webidl
@@ -34,6 +34,7 @@ interface Node : EventTarget {
   readonly attribute Node? parentNode;
   [Pure]
   readonly attribute Element? parentElement;
+  [Pure]
   boolean hasChildNodes();
   [SameObject]
   readonly attribute NodeList childNodes;
@@ -53,6 +54,7 @@ interface Node : EventTarget {
   void normalize();
 
   Node cloneNode(optional boolean deep = false);
+  [Pure]
   boolean isEqualNode(Node? node);
 
   const unsigned short DOCUMENT_POSITION_DISCONNECTED = 0x01;
@@ -61,11 +63,16 @@ interface Node : EventTarget {
   const unsigned short DOCUMENT_POSITION_CONTAINS = 0x08;
   const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 0x10;
   const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
+  [Pure]
   unsigned short compareDocumentPosition(Node other);
+  [Pure]
   boolean contains(Node? other);
 
+  [Pure]
   DOMString? lookupPrefix(DOMString? namespace);
+  [Pure]
   DOMString? lookupNamespaceURI(DOMString? prefix);
+  [Pure]
   boolean isDefaultNamespace(DOMString? namespace);
 
   [Throws]

--- a/components/script/dom/webidls/Node.webidl
+++ b/components/script/dom/webidls/Node.webidl
@@ -35,7 +35,7 @@ interface Node : EventTarget {
   [Pure]
   readonly attribute Element? parentElement;
   boolean hasChildNodes();
-  [Constant]
+  [SameObject]
   readonly attribute NodeList childNodes;
   [Pure]
   readonly attribute Node? firstChild;

--- a/components/script/dom/webidls/NodeIterator.webidl
+++ b/components/script/dom/webidls/NodeIterator.webidl
@@ -24,5 +24,6 @@ interface NodeIterator {
   [Throws]
   Node? previousNode();
 
+  [Pure]
   void detach();
 };

--- a/components/script/dom/webidls/NodeIterator.webidl
+++ b/components/script/dom/webidls/NodeIterator.webidl
@@ -8,7 +8,7 @@
 // Import from http://hg.mozilla.org/mozilla-central/raw-file/a5a720259d79/dom/webidl/NodeIterator.webidl
 
 interface NodeIterator {
-  [Constant]
+  [SameObject]
   readonly attribute Node root;
   [Pure]
   readonly attribute Node referenceNode;

--- a/components/script/dom/webidls/NodeList.webidl
+++ b/components/script/dom/webidls/NodeList.webidl
@@ -8,6 +8,8 @@
  */
 
 interface NodeList {
+  [Pure]
   readonly attribute unsigned long length;
+  [Pure]
   getter Node? item(unsigned long index);
 };

--- a/components/script/dom/webidls/NonElementParentNode.webidl
+++ b/components/script/dom/webidls/NonElementParentNode.webidl
@@ -7,5 +7,6 @@
 [NoInterfaceObject,
  Exposed=Window]
 interface NonElementParentNode {
+  [Pure]
   Element? getElementById(DOMString elementId);
 };

--- a/components/script/dom/webidls/ParentNode.webidl
+++ b/components/script/dom/webidls/ParentNode.webidl
@@ -9,7 +9,7 @@
 
 [NoInterfaceObject]
 interface ParentNode {
-  [Constant]
+  [SameObject]
   readonly attribute HTMLCollection children;
   [Pure]
   readonly attribute Element? firstElementChild;
@@ -28,7 +28,6 @@ interface ParentNode {
   //Elements queryAll(DOMString relativeSelectors);
   [Throws]
   Element? querySelector(DOMString selectors);
-  //[NewObject]
-  [Throws]
+  [NewObject, Throws]
   NodeList querySelectorAll(DOMString selectors);
 };

--- a/components/script/dom/webidls/ParentNode.webidl
+++ b/components/script/dom/webidls/ParentNode.webidl
@@ -26,7 +26,7 @@ interface ParentNode {
   //Element? query(DOMString relativeSelectors);
   //[NewObject]
   //Elements queryAll(DOMString relativeSelectors);
-  [Throws]
+  [Pure, Throws]
   Element? querySelector(DOMString selectors);
   [NewObject, Throws]
   NodeList querySelectorAll(DOMString selectors);

--- a/components/script/dom/webidls/ProcessingInstruction.webidl
+++ b/components/script/dom/webidls/ProcessingInstruction.webidl
@@ -8,5 +8,6 @@
  */
 
 interface ProcessingInstruction : CharacterData {
+  [Constant]
   readonly attribute DOMString target;
 };

--- a/components/script/dom/webidls/Range.webidl
+++ b/components/script/dom/webidls/Range.webidl
@@ -11,11 +11,17 @@
 
 [Constructor /*, Exposed=Window */]
 interface Range {
+  [Pure]
   readonly attribute Node startContainer;
+  [Pure]
   readonly attribute unsigned long startOffset;
+  [Pure]
   readonly attribute Node endContainer;
+  [Pure]
   readonly attribute unsigned long endOffset;
+  [Pure]
   readonly attribute boolean collapsed;
+  [Pure]
   readonly attribute Node commonAncestorContainer;
 
   [Throws]
@@ -40,7 +46,7 @@ interface Range {
   const unsigned short START_TO_END = 1;
   const unsigned short END_TO_END = 2;
   const unsigned short END_TO_START = 3;
-  [Throws]
+  [Pure, Throws]
   short compareBoundaryPoints(unsigned short how, Range sourceRange);
   // [Throws]
   // void deleteContents();
@@ -55,13 +61,15 @@ interface Range {
 
   [NewObject]
   Range cloneRange();
+  [Pure]
   void detach();
 
-  [Throws]
+  [Pure, Throws]
   boolean isPointInRange(Node node, unsigned long offset);
-  [Throws]
+  [Pure, Throws]
   short comparePoint(Node node, unsigned long offset);
 
+  [Pure]
   boolean intersectsNode(Node node);
 
   // stringifier;

--- a/components/script/dom/webidls/Text.webidl
+++ b/components/script/dom/webidls/Text.webidl
@@ -15,5 +15,6 @@
 interface Text : CharacterData {
   [NewObject, Throws]
   Text splitText(unsigned long offset);
+  [Pure]
   readonly attribute DOMString wholeText;
 };


### PR DESCRIPTION
Some should have been `[SameObject]` instead of `[Constant]`. The rest of the changes are additional `[Constant]` and `[Pure]` extended attributes on many operations.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7601)

<!-- Reviewable:end -->
