### PR TITLE
Improve err msg when failing to output png

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1505,7 +1505,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 let mut img = self.draw_png(framebuffer_ids, texture_ids, width, height);
                 let path = opts::get().output_file.as_ref().unwrap();
                 let res = png::store_png(&mut img, &path);
-                assert!(res.is_ok());
+                assert!(res.is_ok(), format!("Error writing png: {}", res.unwrap_err()));
                 None
             }
         };


### PR DESCRIPTION
Before on at least Linux the following failure is hard to root cause:

```
[~/servo] ./target/debug/servo -o tmp.png ./tests/html/lipsum.html
thread '<main>' panicked at 'assertion failed: res.is_ok()', .../compositor.rs:1508
thread '<main>' panicked at 'You should have disposed of the
pixmap...', .../rust-layers/.../surface.rs:166
```

Now:

```
[~/servo] ./target/debug/servo -o tmp.png ./tests/html/lipsum.html
thread '<main>' panicked at 'Error writing png: Permission
denied (os error 13)', .../compositor.rs:1508
thread '<main>' panicked at 'You should have disposed of the pixmap
properly with destroy()! This pixmap will leak!', .../rust-layers/.../surface.rs:166
```

r? @mbrubeck

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7602)

<!-- Reviewable:end -->
