### PR TITLE
Replace reftest with a problematic file name with a unit test.

### DIFF
--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -125,7 +125,6 @@ prefs:"layout.flex.enabled" == flex_row_direction.html flex_row_direction_ref.ht
 == font_style.html font_style_ref.html
 == height_compute_reset.html height_compute.html
 # `?` and `#` in the name is a test for https://github.com/servo/servo/issues/3340
-== hello_a?foo#bar.html hello_b.html
 == hide_after_create.html hide_after_create_ref.html
 
 == iframe/bg_color.html iframe/bg_color_ref.html

--- a/tests/ref/hello_a?foo#bar.html
+++ b/tests/ref/hello_a?foo#bar.html
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <title>hello</title>
-  </head>
-  <body>
-    <strong>Hello!</strong>
-  </body>
-</html>

--- a/tests/ref/hello_b.html
+++ b/tests/ref/hello_b.html
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <title>hello</title>
-  </head>
-  <body>
-    <b>Hello!</b>
-  </body>
-</html>

--- a/tests/unit/util/lib.rs
+++ b/tests/unit/util/lib.rs
@@ -14,3 +14,4 @@ extern crate euclid;
 #[cfg(test)] mod vec;
 #[cfg(test)] mod mem;
 #[cfg(test)] mod str;
+#[cfg(test)] mod opts;

--- a/tests/unit/util/opts.rs
+++ b/tests/unit/util/opts.rs
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::path::Path;
+use util::opts::parse_url_or_filename;
+
+#[test]
+fn test_argument_parsing() {
+    let fake_cwd = Path::new("/fake/cwd");
+    assert!(parse_url_or_filename(fake_cwd, "http://example.net:invalid").is_err());
+
+    let url = parse_url_or_filename(fake_cwd, "http://example.net").unwrap();
+    assert_eq!(url.scheme, "http");
+
+    let url = parse_url_or_filename(fake_cwd, "file:///foo/bar.html").unwrap();
+    assert_eq!(url.scheme, "file");
+    assert_eq!(url.path().unwrap(), ["foo", "bar.html"]);
+
+    let url = parse_url_or_filename(fake_cwd, "bar.html").unwrap();
+    assert_eq!(url.scheme, "file");
+    assert_eq!(url.path().unwrap(), ["fake", "cwd", "bar.html"]);
+
+    // '?' and '#' have a special meaning in URLs...
+    let url = parse_url_or_filename(fake_cwd, "file:///foo/bar?baz#buzz.html").unwrap();
+    assert_eq!(&*url.to_file_path().unwrap(), Path::new("/foo/bar"));
+    assert_eq!(url.scheme, "file");
+    assert_eq!(url.path().unwrap(), ["foo", "bar"]);
+    assert_eq!(url.query.unwrap(), "baz");
+    assert_eq!(url.fragment.unwrap(), "buzz.html");
+
+    // but not in file names.
+    let url = parse_url_or_filename(fake_cwd, "./bar?baz#buzz.html").unwrap();
+    assert_eq!(&*url.to_file_path().unwrap(), Path::new("/fake/cwd/bar?baz#buzz.html"));
+    assert_eq!(url.scheme, "file");
+    assert_eq!(url.path().unwrap(), ["fake", "cwd", "bar%3Fbaz%23buzz.html"]);
+    assert!(url.query.is_none());
+    assert!(url.fragment.is_none());
+}


### PR DESCRIPTION
Fix #7609, "error: unable to create file tests/ref/hello_a?foo#bar.html (Invalid argument)" during git checkout on Windows.

Behavior change: passing an nonexistent file name on the command line now shows a blank page (like network errors) rather than exit with an error message.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7610)

<!-- Reviewable:end -->
