### PR TITLE
Speedup mach startup

### DIFF
--- a/mach
+++ b/mach
@@ -16,7 +16,7 @@ import sys
 
 def main(args):
     topdir = os.path.dirname(sys.argv[0])
-    sys.path[0:0] = [os.path.join(topdir, "python")]
+    sys.path.insert(0, os.path.join(topdir, "python"))
     import mach_bootstrap
     mach = mach_bootstrap.bootstrap(topdir)
     sys.exit(mach.run(sys.argv[1:]))

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -96,12 +96,21 @@ def _activate_virtualenv(topdir):
     # chain each of the requirements files into the same `pip install` call
     # and it will check for conflicts.
     requirements_paths = [
-        os.path.join(topdir, "python", "requirements.txt"),
-        os.path.join(topdir, "tests", "wpt", "harness", "requirements.txt"),
-        os.path.join(topdir, "tests", "wpt", "harness", "requirements_servo.txt"),
+        os.path.join("python", "requirements.txt"),
+        os.path.join("tests", "wpt", "harness", "requirements.txt"),
+        os.path.join("tests", "wpt", "harness", "requirements_servo.txt"),
     ]
-    for path in requirements_paths:
-        subprocess.check_call(["pip", "install", "-q", "-r", path])
+    for req_rel_path in requirements_paths:
+        req_path = os.path.join(topdir, req_rel_path)
+        marker_file = req_rel_path.replace(os.path.sep, '-')
+        marker_path = os.path.join(virtualenv_path, marker_file)
+        try:
+            if os.path.getmtime(req_path) + 10 < os.path.getmtime(marker_path):
+                continue
+        except OSError:
+            open(marker_path, 'w').close()
+        subprocess.check_call(["pip", "install", "-q", "-r", req_path])
+        os.utime(marker_path, None)
 
 
 def bootstrap(topdir):


### PR DESCRIPTION
...by using a 'marker file' to indicate whether we actually need to run pip.

Also a minor tweak for clarity.

Before (consistently):

```
$ time ./mach >/dev/null

real    0m0.666s
user    0m0.477s
sys     0m0.190s
```

After:

```
$ time ./mach >/dev/null # first run

real    0m0.665s
user    0m0.501s
sys     0m0.166s
$ time ./mach >/dev/null

real    0m0.121s
user    0m0.083s
sys     0m0.039s
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7632)

<!-- Reviewable:end -->
