### PR TITLE
Reconstruct flows when text/font styles change

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1296,10 +1296,9 @@ impl<'a> FlowConstructor<'a> {
     pub fn repair_if_possible(&mut self, node: &ThreadSafeLayoutNode) -> bool {
         // We can skip reconstructing the flow if we don't have to reconstruct and none of our kids
         // did either.
-        if node.restyle_damage().contains(RECONSTRUCT_FLOW) {
-            return false
-        }
-
+        //
+        // We visit the kids first and reset their HAS_NEWLY_CONSTRUCTED_FLOW flags after checking
+        // them.  NOTE: Make sure not to bail out early before resetting all the flags!
         let mut need_to_reconstruct = false;
         for kid in node.children() {
             if kid.flags().contains(HAS_NEWLY_CONSTRUCTED_FLOW) {
@@ -1310,6 +1309,11 @@ impl<'a> FlowConstructor<'a> {
         if need_to_reconstruct {
             return false
         }
+
+        if node.restyle_damage().contains(RECONSTRUCT_FLOW) {
+            return false
+        }
+
 
         let mut style = node.style().clone();
         let mut layout_data_ref = node.mutate_layout_data();

--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -175,13 +175,22 @@ pub fn compute_damage(old: &Option<Arc<ComputedValues>>, new: &ComputedValues) -
         get_padding.padding_top, get_padding.padding_right,
         get_padding.padding_bottom, get_padding.padding_left,
         get_box.width, get_box.height,
-        get_font.font_family, get_font.font_size, get_font.font_style, get_font.font_weight,
         get_inheritedtext.text_align, get_text.text_decoration, get_inheritedbox.line_height
     ]);
 
     add_if_not_equal!(old, new, damage,
-                      [ REPAINT, BUBBLE_ISIZES, REFLOW_OUT_OF_FLOW, REFLOW, RECONSTRUCT_FLOW ],
-                      [ get_box.float, get_box.display, get_box.position ]);
+                      [ REPAINT, BUBBLE_ISIZES, REFLOW_OUT_OF_FLOW, REFLOW, RECONSTRUCT_FLOW ], [
+        get_box.float, get_box.display, get_box.position, get_box.content,
+        get_counters.counter_reset, get_counters.counter_increment,
+        get_list.quotes, get_list.list_style_type,
+
+        // If these text or font properties change, we need to reconstruct the flow so that
+        // text shaping is re-run.
+        get_inheritedtext.letter_spacing, get_inheritedtext.text_rendering,
+        get_inheritedtext.text_transform, get_inheritedtext.word_spacing,
+        get_font.font_family, get_font.font_style, get_font.font_variant, get_font.font_weight,
+        get_font.font_size, get_font.font_stretch
+    ]);
 
     // FIXME: test somehow that we checked every CSS property
     damage

--- a/tests/ref/basic.list
+++ b/tests/ref/basic.list
@@ -160,6 +160,7 @@ prefs:"layout.writing-mode.enabled" == iframe/size_attributes_vertical_writing_m
 == img_width_style_intrinsic_width_a.html img_width_style_intrinsic_width_ref.html
 == incremental_float_a.html incremental_float_ref.html
 == incremental_inline_layout_a.html incremental_inline_layout_ref.html
+== incremental_letter_spacing_a.html incremental_letter_spacing_ref.html
 == inline_absolute_hypothetical_clip_a.html inline_absolute_hypothetical_clip_ref.html
 == inline_absolute_out_of_flow_a.html inline_absolute_out_of_flow_ref.html
 != inline_background_a.html inline_background_ref.html

--- a/tests/ref/incremental_letter_spacing_a.html
+++ b/tests/ref/incremental_letter_spacing_a.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Incremental layout letter-spacing test</title>
+  </head>
+  <body>
+    <p>Hello, world!</p>
+    <script>
+      window.addEventListener("load", function() {
+        document.querySelector("p").style.letterSpacing = "1em";
+      });
+    </script>
+  </body>
+</html>

--- a/tests/ref/incremental_letter_spacing_ref.html
+++ b/tests/ref/incremental_letter_spacing_ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Incremental layout letter-spacing reference</title>
+  </head>
+  <body>
+    <p style="letter-spacing: 1em">Hello, world!</p>
+  </body>
+</html>


### PR DESCRIPTION
These styles are used during text shaping.  When they change, we need to re-run shaping and construct new flows.

Fixes #6501. r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7656)

<!-- Reviewable:end -->
