### PR TITLE
Prevent crash trying to freeze script task with no page.

### DIFF
--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1282,6 +1282,11 @@ impl ScriptTask {
 
     /// Handles freeze message
     fn handle_freeze_msg(&self, id: PipelineId) {
+        // Workaround for a race condition when navigating before the initial page has
+        // been constructed c.f. https://github.com/servo/servo/issues/7677
+        if self.page.borrow().is_none() {
+            return
+        };
         let page = self.root_page();
         let page = page.find(id).expect("ScriptTask: received freeze msg for a
                     pipeline ID not associated with this script task. This is a bug.");


### PR DESCRIPTION
This fixes a crash resulting from a race between loading an initial
document and navigating to a subsequent document. If the navigation
happens before the initial document has had a chance to create its
root page, we crash trying to unwrap a None. Note that the are likely
further similar timing issues with more complex sequences of navigation
and history manipulation.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7675)

<!-- Reviewable:end -->
