### PR TITLE
Remove deprecated 'creator' WebIDL attribute

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4156,8 +4156,6 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
 
         indexedSetter = self.descriptor.operations['IndexedSetter']
         if indexedSetter:
-            if self.descriptor.operations['IndexedCreator'] != indexedSetter:
-                raise TypeError("Can't handle creator that's different from the setter")
             set += ("let index = get_array_index_from_id(cx, id);\n" +
                     "if let Some(index) = index {\n" +
                     "    let this = UnwrapProxy(proxy);\n" +
@@ -4173,8 +4171,6 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
 
         namedSetter = self.descriptor.operations['NamedSetter']
         if namedSetter:
-            if self.descriptor.operations['NamedCreator'] != namedSetter:
-                raise TypeError("Can't handle creator that's different from the setter")
             set += ("if RUST_JSID_IS_STRING(id) != 0 {\n" +
                     CGIndenter(CGProxyNamedSetter(self.descriptor)).define() +
                     "    (*opresult).code_ = 0; /* SpecialCodes::OkCode */\n" +

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -179,11 +179,9 @@ class Descriptor(DescriptorProvider):
         self.operations = {
             'IndexedGetter': None,
             'IndexedSetter': None,
-            'IndexedCreator': None,
             'IndexedDeleter': None,
             'NamedGetter': None,
             'NamedSetter': None,
-            'NamedCreator': None,
             'NamedDeleter': None,
             'Stringifier': None,
         }

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -35,11 +35,6 @@ impl DOMStringMap {
 
 // https://html.spec.whatwg.org/#domstringmap
 impl DOMStringMapMethods for DOMStringMap {
-    // https://html.spec.whatwg.org/multipage/#dom-domstringmap-additem
-    fn NamedCreator(&self, name: DOMString, value: DOMString) -> ErrorResult {
-        self.NamedSetter(name, value)
-    }
-
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-removeitem
     fn NamedDeleter(&self, name: DOMString) {
         let element = self.element.root();

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -131,10 +131,6 @@ impl StorageMethods for Storage {
         self.SetItem(name, value);
     }
 
-    fn NamedCreator(&self, name: DOMString, value: DOMString) {
-        self.SetItem(name, value);
-    }
-
     fn NamedDeleter(&self, name: DOMString) {
         self.RemoveItem(name);
     }

--- a/components/script/dom/testbindingproxy.rs
+++ b/components/script/dom/testbindingproxy.rs
@@ -23,12 +23,10 @@ impl TestBindingProxyMethods for TestBindingProxy {
     fn SetItem(&self, _: u32, _: DOMString) -> () {}
     fn RemoveItem(&self, _: DOMString) -> () {}
     fn Stringifier(&self) -> DOMString { "".to_owned() }
-    fn NamedCreator(&self, _: DOMString, _: DOMString) -> () {}
     fn IndexedGetter(&self, _: u32, _: &mut bool) -> DOMString { "".to_owned() }
     fn NamedDeleter(&self, _: DOMString) -> () {}
     fn IndexedSetter(&self, _: u32, _: DOMString) -> () {}
     fn NamedSetter(&self, _: DOMString, _: DOMString) -> () {}
-    fn IndexedCreator(&self, _: u32, _: DOMString) -> () {}
     fn NamedGetter(&self, _: DOMString, _: &mut bool) -> DOMString { "".to_owned() }
 
 }

--- a/components/script/dom/webidls/DOMStringMap.webidl
+++ b/components/script/dom/webidls/DOMStringMap.webidl
@@ -8,6 +8,6 @@
 interface DOMStringMap {
   getter DOMString (DOMString name);
   [Throws]
-  setter creator void (DOMString name, DOMString value);
+  setter void (DOMString name, DOMString value);
   deleter void (DOMString name);
 };

--- a/components/script/dom/webidls/HTMLSelectElement.webidl
+++ b/components/script/dom/webidls/HTMLSelectElement.webidl
@@ -23,7 +23,7 @@ interface HTMLSelectElement : HTMLElement {
   void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
   //void remove(); // ChildNode overload
   //void remove(long index);
-  //setter creator void (unsigned long index, HTMLOptionElement? option);
+  //setter void (unsigned long index, HTMLOptionElement? option);
 
   //readonly attribute HTMLCollection selectedOptions;
   //         attribute long selectedIndex;

--- a/components/script/dom/webidls/Storage.webidl
+++ b/components/script/dom/webidls/Storage.webidl
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /*
  * The origin of this IDL file is
- * https://html.spec.whatwg.org/multipage/#webstorage
+ * https://html.spec.whatwg.org/multipage/#the-storage-interface
  *
  */
 

--- a/components/script/dom/webidls/Storage.webidl
+++ b/components/script/dom/webidls/Storage.webidl
@@ -16,7 +16,7 @@ interface Storage {
 
   getter DOMString? getItem(DOMString name);
 
-  setter creator void setItem(DOMString name, DOMString value);
+  setter void setItem(DOMString name, DOMString value);
 
   deleter void removeItem(DOMString name);
 

--- a/components/script/dom/webidls/TestBindingProxy.webidl
+++ b/components/script/dom/webidls/TestBindingProxy.webidl
@@ -17,11 +17,11 @@ interface TestBindingProxy : TestBinding {
 
   getter DOMString getNamedItem(DOMString item_name);
 
-  setter creator void setNamedItem(DOMString item_name, DOMString value);
+  setter void setNamedItem(DOMString item_name, DOMString value);
 
   getter DOMString getItem(unsigned long index);
 
-  setter creator void setItem(unsigned long index, DOMString value);
+  setter void setItem(unsigned long index, DOMString value);
 
   deleter void removeItem(DOMString name);
 


### PR DESCRIPTION
According to @Ms2ger, the 'creator' attribute was merged into 'setter'

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7691)

<!-- Reviewable:end -->
