### PR TITLE
Raise max length error over 120 chars not at 120 chars. python/tidy.py

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -76,7 +76,7 @@ def check_length(file_name, idx, line):
     if file_name.endswith(".lock"):
         raise StopIteration
     max_length = 120
-    if len(line) >= max_length:
+    if len(line.rstrip('\n')) > max_length:
         yield (idx + 1, "Line is longer than %d characters" % max_length)
 
 


### PR DESCRIPTION
This is a follow up of issue : Tidy has an off-by-one error #7686 

It allows to raise the max length error when line is over than 120 not at 120 specifically.

Thanks for looking into it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7692)

<!-- Reviewable:end -->
