### PR TITLE
HTML Meta keyword nits in wpt webstorage files

### DIFF
--- a/tests/wpt/web-platform-tests/webstorage/storage_builtins.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_builtins.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - builtins</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_clear.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_clear.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - clear()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_getitem.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_getitem.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - getItem(key) and named getter</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_in.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_in.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - in operator</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_indexing.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_indexing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - indexed getter</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_key.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_key.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - key(index)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_length.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_length.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - length</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_removeitem.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_removeitem.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - removeItem(key)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/webstorage/storage_setitem.html
+++ b/tests/wpt/web-platform-tests/webstorage/storage_setitem.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<mete charset=utf-8>
+<meta charset=utf-8>
 <title>WebStorage Test: Storage - setItem(key, value)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Hi guys,

This PR is a small cleanup over Webstorage WPT tests.

Meta charset keywords were declared as <mete charset=utf-8 > instead of <meta charset=utf-8>

Thanks for looking into it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7694)

<!-- Reviewable:end -->
