### PR TITLE
Support the updated spidermonkey bindings

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -341,7 +341,7 @@ class CGMethodCall(CGThing):
                 code = (
                     "if argc < %d {\n"
                     "    throw_type_error(cx, \"Not enough arguments to %s.\");\n"
-                    "    return JSFalse;\n"
+                    "    return false;\n"
                     "}" % (requiredArgs, methodName))
                 self.cgRoot.prepend(
                     CGWrapper(CGGeneric(code), pre="\n", post="\n"))
@@ -514,11 +514,11 @@ class CGMethodCall(CGThing):
             CGSwitch("argcount",
                      argCountCases,
                      CGGeneric("throw_type_error(cx, \"Not enough arguments to %s.\");\n"
-                               "return JSFalse;" % methodName)))
+                               "return false;" % methodName)))
         # XXXjdm Avoid unreachable statement warnings
         # overloadCGThings.append(
         #     CGGeneric('panic!("We have an always-returning default case");\n'
-        #               'return JSFalse;'))
+        #               'return false;'))
         self.cgRoot = CGWrapper(CGList(overloadCGThings, "\n"),
                                 pre="\n")
 
@@ -659,7 +659,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
     # failureCode will prevent pending exceptions from being set in cases when
     # they really should be!
     if exceptionCode is None:
-        exceptionCode = "return JSFalse;"
+        exceptionCode = "return false;"
 
     needsRooting = typeNeedsRooting(type, descriptorProvider)
 
@@ -890,7 +890,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         if invalidEnumValueFatal:
             handleInvalidEnumValueCode = exceptionCode
         else:
-            handleInvalidEnumValueCode = "return JSTrue;"
+            handleInvalidEnumValueCode = "return true;"
 
         transmute = "mem::transmute(index)"
         if isMember == 'Dictionary':
@@ -943,7 +943,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             else:
                 template = conversion
         else:
-            template = CGIfElseWrapper("IsCallable(${val}.get().to_object()) != 0",
+            template = CGIfElseWrapper("IsCallable(${val}.get().to_object())",
                                        conversion,
                                        onFailureNotCallable(failureCode)).define()
             template = wrapObjectTemplate(
@@ -1019,7 +1019,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         declType = CGGeneric(typeName)
         template = ("match %s::new(cx, ${val}) {\n"
                     "    Ok(dictionary) => dictionary,\n"
-                    "    Err(_) => return JSFalse,\n"
+                    "    Err(_) => return false,\n"
                     "}" % typeName)
 
         return handleOptional(template, declType, handleDefaultNull("%s::empty(cx)" % typeName))
@@ -1044,7 +1044,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         conversionBehavior = "()"
 
     if failureCode is None:
-        failureCode = 'return JSFalse'
+        failureCode = 'return false'
 
     declType = CGGeneric(builtinNames[type.tag()])
     if type.nullable():
@@ -1223,7 +1223,7 @@ class CGArgumentConverter(CGThing):
         return self.converter.define()
 
 
-def wrapForType(jsvalRef, result='result', successCode='return JSTrue;', pre=''):
+def wrapForType(jsvalRef, result='result', successCode='return true;', pre=''):
     """
     Reflect a Rust value into JS.
 
@@ -1767,7 +1767,7 @@ class CGDOMJSClass(CGThing):
     def define(self):
         traceHook = 'Some(%s)' % TRACE_HOOK_NAME
         if self.descriptor.isGlobal():
-            traceHook = "Some(js::jsapi::_Z24JS_GlobalObjectTraceHookP8JSTracerP8JSObject)"
+            traceHook = "Some(js::jsapi::JS_GlobalObjectTraceHook)"
             flags = "JSCLASS_IS_GLOBAL | JSCLASS_DOM_GLOBAL"
             slots = "JSCLASS_GLOBAL_SLOT_COUNT + 1"
         else:
@@ -1807,7 +1807,7 @@ static Class: DOMJSClass = DOMJSClass {
         ext: js::jsapi::ClassExtension {
             outerObject: %s,
             innerObject: None,
-            isWrappedNative: 0,
+            isWrappedNative: false,
             weakmapKeyDelegateOp: None,
             objectMovedOp: None,
         },
@@ -2687,7 +2687,7 @@ class CGPerSignatureCall(CGThing):
 
         errorResult = None
         if self.isFallible():
-            errorResult = " JSFalse"
+            errorResult = " false"
 
         cgThings.append(CGCallGenerator(
             errorResult,
@@ -2810,7 +2810,7 @@ class CGSetterCall(CGPerSignatureCall):
 
     def wrap_return_value(self):
         # We have no return value
-        return "\nreturn JSTrue;"
+        return "\nreturn true;"
 
     def getArgc(self):
         return "1"
@@ -2830,7 +2830,7 @@ class CGAbstractStaticBindingMethod(CGAbstractMethod):
             Argument('libc::c_uint', 'argc'),
             Argument('*mut JSVal', 'vp'),
         ]
-        CGAbstractMethod.__init__(self, descriptor, name, "u8", args, extern=True)
+        CGAbstractMethod.__init__(self, descriptor, name, "bool", args, extern=True)
 
     def definition_body(self):
         preamble = CGGeneric("""\
@@ -2853,7 +2853,7 @@ class CGSpecializedMethod(CGAbstractExternMethod):
         args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', '_obj'),
                 Argument('*const %s' % descriptor.concreteType, 'this'),
                 Argument('*const JSJitMethodCallArgs', 'args')]
-        CGAbstractExternMethod.__init__(self, descriptor, name, 'u8', args)
+        CGAbstractExternMethod.__init__(self, descriptor, name, 'bool', args)
 
     def definition_body(self):
         nativeName = CGSpecializedMethod.makeNativeName(self.descriptor,
@@ -2862,7 +2862,7 @@ class CGSpecializedMethod(CGAbstractExternMethod):
                                       self.descriptor, self.method),
                          pre="let this = &*this;\n"
                              "let args = &*args;\n"
-                             "let argc = args.argc_;\n")
+                             "let argc = args._base.argc_;\n")
 
     @staticmethod
     def makeNativeName(descriptor, method):
@@ -2902,7 +2902,7 @@ class CGSpecializedGetter(CGAbstractExternMethod):
                 Argument('HandleObject', '_obj'),
                 Argument('*const %s' % descriptor.concreteType, 'this'),
                 Argument('JSJitGetterCallArgs', 'args')]
-        CGAbstractExternMethod.__init__(self, descriptor, name, "u8", args)
+        CGAbstractExternMethod.__init__(self, descriptor, name, "bool", args)
 
     def definition_body(self):
         nativeName = CGSpecializedGetter.makeNativeName(self.descriptor,
@@ -2957,7 +2957,7 @@ class CGSpecializedSetter(CGAbstractExternMethod):
                 Argument('HandleObject', 'obj'),
                 Argument('*const %s' % descriptor.concreteType, 'this'),
                 Argument('JSJitSetterCallArgs', 'args')]
-        CGAbstractExternMethod.__init__(self, descriptor, name, "u8", args)
+        CGAbstractExternMethod.__init__(self, descriptor, name, "bool", args)
 
     def definition_body(self):
         nativeName = CGSpecializedSetter.makeNativeName(self.descriptor,
@@ -2991,7 +2991,7 @@ class CGStaticSetter(CGAbstractStaticBindingMethod):
             "let args = CallArgs::from_vp(vp, argc);\n"
             "if argc == 0 {\n"
             "    throw_type_error(cx, \"Not enough arguments to %s setter.\");\n"
-            "    return JSFalse;\n"
+            "    return false;\n"
             "}" % self.attr.identifier.name)
         call = CGSetterCall(["global.r()"], self.attr.type, nativeName, self.descriptor,
                             self.attr)
@@ -3013,12 +3013,12 @@ class CGSpecializedForwardingSetter(CGSpecializedSetter):
         assert all(ord(c) < 128 for c in forwardToAttrName)
         return CGGeneric("""\
 let mut v = RootedValue::new(cx, UndefinedValue());
-if JS_GetProperty(cx, obj, %s as *const u8 as *const libc::c_char, v.handle_mut()) == 0 {
-    return JSFalse;
+if !JS_GetProperty(cx, obj, %s as *const u8 as *const libc::c_char, v.handle_mut()) {
+    return false;
 }
 if !v.ptr.is_object() {
     throw_type_error(cx, "Value.%s is not an object.");
-    return JSFalse;
+    return false;
 }
 let target_obj = RootedObject::new(cx, v.ptr.to_object());
 JS_SetProperty(cx, target_obj.handle(), %s as *const u8 as *const libc::c_char, args.get(0))
@@ -3051,18 +3051,21 @@ class CGMemberJITInfo(CGThing):
             initializer = fill(
                 """
                 JSJitInfo {
-                    _bindgen_data_1_: ${opName} as *const ::libc::c_void,
+                    call: ${opName} as *const ::libc::c_void,
                     protoID: PrototypeList::ID::${name} as u16,
                     depth: ${depth},
-                    _bitfield_1: ((JSJitInfo_OpType::${opType} as u32) << 0) |
-                                 ((JSJitInfo_AliasSet::${aliasSet} as u32) << 4) |
-                                 ((JSValueType::${returnType} as u32) << 8) |
-                                 ((${isInfallible} as u32) << 16) |
-                                 ((${isMovable} as u32) << 17) |
-                                 ((${isAlwaysInSlot} as u32) << 18) |
-                                 ((${isLazilyCachedInSlot} as u32) << 19) |
-                                 ((${isTypedMethod} as u32) << 20) |
-                                 ((${slotIndex} as u32) << 21)
+                    _bitfield_1:
+                        JSJitInfo::new_bitfield_1(
+                            OpType::${opType} as u8,
+                            AliasSet::${aliasSet} as u8,
+                            JSValueType::${returnType} as u8,
+                            ${isInfallible},
+                            ${isMovable},
+                            ${isAlwaysInSlot},
+                            ${isLazilyCachedInSlot},
+                            ${isTypedMethod},
+                            ${slotIndex} as u16,
+                        )
                 }
                 """,
                 opName=opName,
@@ -3953,7 +3956,7 @@ class CGProxySpecialOperation(CGPerSignatureCall):
             argument = arguments[1]
             info = getJSToNativeConversionInfo(
                 argument.type, descriptor, treatNullAs=argument.treatNullAs,
-                exceptionCode="return JSFalse;")
+                exceptionCode="return false;")
             template = info.template
             declType = info.declType
             needsRooting = info.needsRooting
@@ -4082,7 +4085,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
                 Argument('HandleId', 'id'),
                 Argument('MutableHandle<JSPropertyDescriptor>', 'desc')]
         CGAbstractExternMethod.__init__(self, descriptor, "getOwnPropertyDescriptor",
-                                        "u8", args)
+                                        "bool", args)
         self.descriptor = descriptor
 
     def getBody(self):
@@ -4097,7 +4100,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             readonly = toStringBool(self.descriptor.operations['IndexedSetter'] is None)
             fillDescriptor = ("desc.get().value = result_root.ptr;\n"
                               "fill_property_descriptor(&mut *desc.ptr, *proxy.ptr, %s);\n"
-                              "return JSTrue;" % readonly)
+                              "return true;" % readonly)
             templateValues = {
                 'jsvalRef': 'result_root.handle_mut()',
                 'successCode': fillDescriptor,
@@ -4114,7 +4117,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             readonly = toStringBool(self.descriptor.operations['NamedSetter'] is None)
             fillDescriptor = ("desc.get().value = result_root.ptr;\n"
                               "fill_property_descriptor(&mut *desc.ptr, *proxy.ptr, %s);\n"
-                              "return JSTrue;" % readonly)
+                              "return true;" % readonly)
             templateValues = {
                 'jsvalRef': 'result_root.handle_mut()',
                 'successCode': fillDescriptor,
@@ -4124,7 +4127,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             # ResolveOwnProperty or EnumerateOwnProperties filter out named
             # properties that shadow prototype properties.
             namedGet = ("\n" +
-                        "if RUST_JSID_IS_STRING(id) != 0 && !has_property_on_prototype(cx, proxy, id) {\n" +
+                        "if RUST_JSID_IS_STRING(id) && !has_property_on_prototype(cx, proxy, id) {\n" +
                         CGIndenter(CGProxyNamedGetter(self.descriptor, templateValues)).define() + "\n" +
                         "}\n")
         else:
@@ -4134,18 +4137,18 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
 let expando = RootedObject::new(cx, get_expando_object(proxy));
 //if (!xpc::WrapperFactory::IsXrayWrapper(proxy) && (expando = GetExpandoObject(proxy))) {
 if !expando.ptr.is_null() {
-    if JS_GetPropertyDescriptorById(cx, expando.handle(), id, desc) == 0 {
-        return JSFalse;
+    if !JS_GetPropertyDescriptorById(cx, expando.handle(), id, desc) {
+        return false;
     }
     if !desc.get().obj.is_null() {
         // Pretend the property lives on the wrapper.
         desc.get().obj = *proxy.ptr;
-        return JSTrue;
+        return true;
     }
 }
 """ + namedGet + """\
 desc.get().obj = ptr::null_mut();
-return JSTrue;"""
+return true;"""
 
     def definition_body(self):
         return CGGeneric(self.getBody())
@@ -4158,7 +4161,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                 Argument('HandleId', 'id'),
                 Argument('Handle<JSPropertyDescriptor>', 'desc'),
                 Argument('*mut ObjectOpResult', 'opresult')]
-        CGAbstractExternMethod.__init__(self, descriptor, "defineProperty", "u8", args)
+        CGAbstractExternMethod.__init__(self, descriptor, "defineProperty", "bool", args)
         self.descriptor = descriptor
 
     def getBody(self):
@@ -4171,25 +4174,25 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "    let this = UnwrapProxy(proxy);\n" +
                     "    let this = &*this;\n" +
                     CGIndenter(CGProxyIndexedSetter(self.descriptor)).define() +
-                    "    return JSTrue;\n" +
+                    "    return true;\n" +
                     "}\n")
         elif self.descriptor.operations['IndexedGetter']:
             set += ("if get_array_index_from_id(cx, id).is_some() {\n" +
-                    "    return JSFalse;\n" +
+                    "    return false;\n" +
                     "    //return ThrowErrorMessage(cx, MSG_NO_PROPERTY_SETTER, \"%s\");\n" +
                     "}\n") % self.descriptor.name
 
         namedSetter = self.descriptor.operations['NamedSetter']
         if namedSetter:
-            set += ("if RUST_JSID_IS_STRING(id) != 0 {\n" +
+            set += ("if RUST_JSID_IS_STRING(id) {\n" +
                     CGIndenter(CGProxyNamedSetter(self.descriptor)).define() +
                     "    (*opresult).code_ = 0; /* SpecialCodes::OkCode */\n" +
-                    "    return JSTrue;\n" +
+                    "    return true;\n" +
                     "} else {\n" +
-                    "    return JSFalse;\n" +
+                    "    return false;\n" +
                     "}\n")
         else:
-            set += ("if RUST_JSID_IS_STRING(id) != 0 {\n" +
+            set += ("if RUST_JSID_IS_STRING(id) {\n" +
                     CGIndenter(CGProxyNamedGetter(self.descriptor)).define() +
                     "    if (found) {\n"
                     # TODO(Issue 5876)
@@ -4197,10 +4200,10 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "        //       ? opresult.succeed()\n" +
                     "        //       : ThrowErrorMessage(cx, MSG_NO_NAMED_SETTER, \"${name}\");\n" +
                     "        (*opresult).code_ = 0; /* SpecialCodes::OkCode */\n" +
-                    "        return JSTrue;\n" +
+                    "        return true;\n" +
                     "    }\n" +
                     "    (*opresult).code_ = 0; /* SpecialCodes::OkCode */\n" +
-                    "    return JSTrue;\n"
+                    "    return true;\n"
                     "}\n") % (self.descriptor.name, self.descriptor.name)
             set += "return proxyhandler::define_property(%s);" % ", ".join(a.name for a in self.args)
         return set
@@ -4214,14 +4217,14 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
         args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', 'proxy'),
                 Argument('HandleId', 'id'),
                 Argument('*mut ObjectOpResult', 'res')]
-        CGAbstractExternMethod.__init__(self, descriptor, "delete", "u8", args)
+        CGAbstractExternMethod.__init__(self, descriptor, "delete", "bool", args)
         self.descriptor = descriptor
 
     def getBody(self):
         set = ""
         if self.descriptor.operations['NamedDeleter']:
             set += CGProxyNamedDeleter(self.descriptor).define()
-        set += "return proxyhandler::delete(%s) as u8;" % ", ".join(a.name for a in self.args)
+        set += "return proxyhandler::delete(%s);" % ", ".join(a.name for a in self.args)
         return set
 
     def definition_body(self):
@@ -4233,7 +4236,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
         args = [Argument('*mut JSContext', 'cx'),
                 Argument('HandleObject', 'proxy'),
                 Argument('*mut AutoIdVector', 'props')]
-        CGAbstractExternMethod.__init__(self, descriptor, "own_property_keys", "u8", args)
+        CGAbstractExternMethod.__init__(self, descriptor, "own_property_keys", "bool", args)
         self.descriptor = descriptor
 
     def getBody(self):
@@ -4272,7 +4275,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
                 GetPropertyKeys(cx, rooted_expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
             }
 
-            return JSTrue;
+            return true;
             """)
 
         return body
@@ -4284,8 +4287,8 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
 class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
     def __init__(self, descriptor):
         args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', 'proxy'),
-                Argument('HandleId', 'id'), Argument('*mut u8', 'bp')]
-        CGAbstractExternMethod.__init__(self, descriptor, "hasOwn", "u8", args)
+                Argument('HandleId', 'id'), Argument('*mut bool', 'bp')]
+        CGAbstractExternMethod.__init__(self, descriptor, "hasOwn", "bool", args)
         self.descriptor = descriptor
 
     def getBody(self):
@@ -4296,18 +4299,18 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
                        "    let this = UnwrapProxy(proxy);\n" +
                        "    let this = &*this;\n" +
                        CGIndenter(CGProxyIndexedGetter(self.descriptor)).define() + "\n" +
-                       "    *bp = found as u8;\n" +
-                       "    return JSTrue;\n" +
+                       "    *bp = found;\n" +
+                       "    return true;\n" +
                        "}\n\n")
         else:
             indexed = ""
 
         namedGetter = self.descriptor.operations['NamedGetter']
         if namedGetter:
-            named = ("if RUST_JSID_IS_STRING(id) != 0 && !has_property_on_prototype(cx, proxy, id) {\n" +
+            named = ("if RUST_JSID_IS_STRING(id) && !has_property_on_prototype(cx, proxy, id) {\n" +
                      CGIndenter(CGProxyNamedGetter(self.descriptor)).define() + "\n" +
-                     "    *bp = found as u8;\n"
-                     "    return JSTrue;\n"
+                     "    *bp = found;\n"
+                     "    return true;\n"
                      "}\n" +
                      "\n")
         else:
@@ -4316,16 +4319,16 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
         return indexed + """\
 let expando = RootedObject::new(cx, get_expando_object(proxy));
 if !expando.ptr.is_null() {
-    let mut b: u8 = 1;
-    let ok = JS_HasPropertyById(cx, expando.handle(), id, &mut b) != 0;
-    *bp = (b != 0) as u8;
-    if !ok || *bp != 0 {
-        return ok as u8;
+    let mut b = true;
+    let ok = JS_HasPropertyById(cx, expando.handle(), id, &mut b);
+    *bp = b;
+    if !ok || *bp {
+        return ok;
     }
 }
 """ + named + """\
-*bp = JSFalse;
-return JSTrue;"""
+*bp = false;
+return true;"""
 
     def definition_body(self):
         return CGGeneric(self.getBody())
@@ -4336,26 +4339,26 @@ class CGDOMJSProxyHandler_get(CGAbstractExternMethod):
         args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', 'proxy'),
                 Argument('HandleObject', '_receiver'), Argument('HandleId', 'id'),
                 Argument('MutableHandleValue', 'vp')]
-        CGAbstractExternMethod.__init__(self, descriptor, "get", "u8", args)
+        CGAbstractExternMethod.__init__(self, descriptor, "get", "bool", args)
         self.descriptor = descriptor
 
     def getBody(self):
         getFromExpando = """\
 let expando = RootedObject::new(cx, get_expando_object(proxy));
 if !expando.ptr.is_null() {
-    let mut hasProp = 0;
-    if JS_HasPropertyById(cx, expando.handle(), id, &mut hasProp) == 0 {
-        return JSFalse;
+    let mut hasProp = false;
+    if !JS_HasPropertyById(cx, expando.handle(), id, &mut hasProp) {
+        return false;
     }
 
-    if hasProp != 0 {
-        return (JS_GetPropertyById(cx, expando.handle(), id, vp) != 0) as u8;
+    if hasProp {
+        return JS_GetPropertyById(cx, expando.handle(), id, vp);
     }
 }"""
 
         templateValues = {
             'jsvalRef': 'vp',
-            'successCode': 'return JSTrue;',
+            'successCode': 'return true;',
         }
 
         indexedGetter = self.descriptor.operations['IndexedGetter']
@@ -4377,7 +4380,7 @@ if !expando.ptr.is_null() {
 
         namedGetter = self.descriptor.operations['NamedGetter']
         if namedGetter:
-            getNamed = ("if RUST_JSID_IS_STRING(id) != 0 {\n" +
+            getNamed = ("if RUST_JSID_IS_STRING(id) {\n" +
                         CGIndenter(CGProxyNamedGetter(self.descriptor, templateValues)).define() +
                         "}\n")
         else:
@@ -4390,15 +4393,15 @@ if !expando.ptr.is_null() {
 %s
 let mut found = false;
 if !get_property_on_prototype(cx, proxy, id, &mut found, vp) {
-    return JSFalse;
+    return false;
 }
 
 if found {
-    return JSTrue;
+    return true;
 }
 %s
 *vp.ptr = UndefinedValue();
-return JSTrue;""" % (getIndexedOrExpando, getNamed)
+return true;""" % (getIndexedOrExpando, getNamed)
 
     def definition_body(self):
         return CGGeneric(self.getBody())
@@ -4479,7 +4482,7 @@ class CGClassConstructHook(CGAbstractExternMethod):
     def __init__(self, descriptor):
         args = [Argument('*mut JSContext', 'cx'), Argument('u32', 'argc'), Argument('*mut JSVal', 'vp')]
         CGAbstractExternMethod.__init__(self, descriptor, CONSTRUCT_HOOK_NAME,
-                                        'u8', args)
+                                        'bool', args)
         self._ctor = self.descriptor.interface.ctor()
 
     def define(self):
@@ -4509,7 +4512,7 @@ class CGClassNameConstructHook(CGAbstractExternMethod):
         CGAbstractExternMethod.__init__(self, descriptor,
                                         CONSTRUCT_HOOK_NAME + "_" +
                                         self._ctor.identifier.name,
-                                        'u8', args)
+                                        'bool', args)
 
     def definition_body(self):
         preamble = CGGeneric("""\
@@ -5077,7 +5080,7 @@ class CGBindingRoot(CGThing):
             'js::jsapi::{RootedValue, JSNativeWrapper, JSNative, JSObject, JSPropertyDescriptor}',
             'js::jsapi::{RootedId, JS_InternString, RootedString, INTERNED_STRING_TO_JSID}',
             'js::jsapi::{JSPropertySpec}',
-            'js::jsapi::{JSString, JSTracer, JSJitInfo, JSJitInfo_OpType, JSJitInfo_AliasSet}',
+            'js::jsapi::{JSString, JSTracer, JSJitInfo, OpType, AliasSet}',
             'js::jsapi::{MutableHandle, Handle, HandleId, JSType, JSValueType}',
             'js::jsapi::{SymbolCode, ObjectOpResult, HandleValueArray}',
             'js::jsapi::{JSJitGetterCallArgs, JSJitSetterCallArgs, JSJitMethodCallArgs, CallArgs}',
@@ -5092,7 +5095,6 @@ class CGBindingRoot(CGThing):
             'js::glue::{RUST_JS_NumberValue, RUST_JSID_IS_STRING, int_to_jsid}',
             'js::glue::AppendToAutoIdVector',
             'js::rust::GCMethods',
-            'js::{JSTrue, JSFalse}',
             'dom::bindings',
             'dom::bindings::global::GlobalRef',
             'dom::bindings::global::global_object_for_js_object',
@@ -5629,7 +5631,7 @@ class CallbackMethod(CallbackMember):
             "            elements_: ${argv}\n"
             "        }, rval.handle_mut())\n"
             "};\n"
-            "if ok == 0 {\n"
+            "if !ok {\n"
             "    return Err(JSFailed);\n"
             "}\n").substitute(replacements)
 
@@ -5673,7 +5675,7 @@ class CallbackOperationBase(CallbackMethod):
         if not self.singleOperation:
             return 'JS::Rooted<JS::Value> callable(cx);\n' + getCallableFromProp
         return (
-            'let isCallable = unsafe { IsCallable(self.parent.callback()) != 0 };\n'
+            'let isCallable = unsafe { IsCallable(self.parent.callback()) };\n'
             'let callable =\n' +
             CGIndenter(
                 CGIfElseWrapper('isCallable',

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -186,7 +186,7 @@ impl ToJSValConvertible for () {
 impl ToJSValConvertible for JSVal {
     fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(*self);
-        if unsafe { JS_WrapValue(cx, rval) } == 0 {
+        if unsafe { !JS_WrapValue(cx, rval) } {
             panic!("JS_WrapValue failed.");
         }
     }
@@ -195,7 +195,7 @@ impl ToJSValConvertible for JSVal {
 impl ToJSValConvertible for HandleValue {
     fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(self.get());
-        if unsafe { JS_WrapValue(cx, rval) } == 0 {
+        if unsafe { !JS_WrapValue(cx, rval) } {
             panic!("JS_WrapValue failed.");
         }
     }
@@ -397,7 +397,7 @@ impl ToJSValConvertible for str {
         let mut string_utf16: Vec<u16> = Vec::with_capacity(self.len());
         unsafe {
             string_utf16.extend(self.utf16_units());
-            let jsstr = JS_NewUCStringCopyN(cx, string_utf16.as_ptr() as *const i16,
+            let jsstr = JS_NewUCStringCopyN(cx, string_utf16.as_ptr(),
                                             string_utf16.len() as libc::size_t);
             if jsstr.is_null() {
                 panic!("JS_NewUCStringCopyN failed");
@@ -426,7 +426,7 @@ pub enum StringificationBehavior {
 /// contain valid UTF-16.
 pub fn jsstring_to_str(cx: *mut JSContext, s: *mut JSString) -> DOMString {
     let mut length = 0;
-    let latin1 = unsafe { JS_StringHasLatin1Chars(s) != 0 };
+    let latin1 = unsafe { JS_StringHasLatin1Chars(s) };
     if latin1 {
         let chars = unsafe {
             JS_GetLatin1StringCharsAndLength(cx, ptr::null(), s, &mut length)
@@ -479,7 +479,7 @@ pub fn jsstring_to_str(cx: *mut JSContext, s: *mut JSString) -> DOMString {
 /// string, or if the string does not contain valid UTF-16.
 pub fn jsid_to_str(cx: *mut JSContext, id: HandleId) -> DOMString {
     unsafe {
-        assert!(RUST_JSID_IS_STRING(id) != 0);
+        assert!(RUST_JSID_IS_STRING(id));
         jsstring_to_str(cx, RUST_JSID_TO_STRING(id))
     }
 }
@@ -519,7 +519,7 @@ impl FromJSValConvertible for USVString {
             debug!("ToString failed");
             return Err(());
         }
-        let latin1 = unsafe { JS_StringHasLatin1Chars(jsstr) != 0 };
+        let latin1 = unsafe { JS_StringHasLatin1Chars(jsstr) };
         if latin1 {
             return Ok(USVString(jsstring_to_str(cx, jsstr)));
         }
@@ -555,7 +555,7 @@ impl FromJSValConvertible for ByteString {
             return Err(());
         }
 
-        let latin1 = unsafe { JS_StringHasLatin1Chars(string) != 0 };
+        let latin1 = unsafe { JS_StringHasLatin1Chars(string) };
         if latin1 {
             let mut length = 0;
             let chars = unsafe {
@@ -591,7 +591,7 @@ impl ToJSValConvertible for Reflector {
         let obj = self.get_jsobject().get();
         assert!(!obj.is_null());
         rval.set(ObjectValue(unsafe { &*obj }));
-        if unsafe { JS_WrapValue(cx, rval) } == 0 {
+        if unsafe { !JS_WrapValue(cx, rval) } {
             panic!("JS_WrapValue failed.");
         }
     }
@@ -670,14 +670,14 @@ pub unsafe fn private_from_proto_chain(mut obj: *mut JSObject,
                                        proto_id: u16, proto_depth: u16)
                                        -> Result<*const libc::c_void, ()> {
     let dom_class = try!(get_dom_class(obj).or_else(|_| {
-        if IsWrapper(obj) == 1 {
+        if IsWrapper(obj) {
             debug!("found wrapper");
             obj = UnwrapObject(obj, /* stopAtOuter = */ 0);
             if obj.is_null() {
                 debug!("unwrapping security wrapper failed");
                 Err(())
             } else {
-                assert!(IsWrapper(obj) == 0);
+                assert!(!IsWrapper(obj));
                 debug!("unwrapped successfully");
                 get_dom_class(obj)
             }
@@ -774,7 +774,7 @@ impl ToJSValConvertible for *mut JSObject {
     fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         rval.set(ObjectOrNullValue(*self));
         unsafe {
-            assert!(JS_WrapValue(cx, rval) != 0);
+            assert!(JS_WrapValue(cx, rval));
         }
     }
 }

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -577,7 +577,7 @@ impl FromJSValConvertible for ByteString {
             let char_vec = slice::from_raw_parts(chars, length as usize);
 
             if char_vec.iter().any(|&c| c > 0xFF) {
-                // XXX Throw
+                throw_type_error(cx, "Invalid ByteString");
                 Err(())
             } else {
                 Ok(ByteString::new(char_vec.iter().map(|&c| c as u8).collect()))

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -10,7 +10,7 @@ use dom::bindings::global::GlobalRef;
 use dom::domexception::{DOMErrorName, DOMException};
 use js::jsapi::JSAutoCompartment;
 use js::jsapi::{JSContext, JSObject, RootedValue};
-use js::jsapi::{JSErrorFormatString, JSExnType, JS_ReportErrorNumber1};
+use js::jsapi::{JSErrorFormatString, JSExnType, JS_ReportErrorNumber};
 use js::jsapi::{JS_IsExceptionPending, JS_ReportPendingException, JS_SetPendingException};
 use js::jsapi::{JS_RestoreFrameChain, JS_SaveFrameChain};
 use js::jsval::UndefinedValue;
@@ -105,22 +105,22 @@ pub fn throw_dom_exception(cx: *mut JSContext, global: GlobalRef,
         Error::QuotaExceeded => DOMErrorName::QuotaExceededError,
         Error::TypeMismatch => DOMErrorName::TypeMismatchError,
         Error::Type(message) => {
-            assert!(unsafe { JS_IsExceptionPending(cx) } == 0);
+            assert!(unsafe { !JS_IsExceptionPending(cx) });
             throw_type_error(cx, &message);
             return;
         },
         Error::Range(message) => {
-            assert!(unsafe { JS_IsExceptionPending(cx) } == 0);
+            assert!(unsafe { !JS_IsExceptionPending(cx) });
             throw_range_error(cx, &message);
             return;
         },
         Error::JSFailed => {
-            assert!(unsafe { JS_IsExceptionPending(cx) } == 1);
+            assert!(unsafe { JS_IsExceptionPending(cx) });
             return;
         }
     };
 
-    assert!(unsafe { JS_IsExceptionPending(cx) } == 0);
+    assert!(unsafe { !JS_IsExceptionPending(cx) });
     let exception = DOMException::new(global, code);
     let mut thrown = RootedValue::new(cx, UndefinedValue());
     exception.to_jsval(cx, thrown.handle_mut());
@@ -132,13 +132,13 @@ pub fn throw_dom_exception(cx: *mut JSContext, global: GlobalRef,
 /// Report a pending exception, thereby clearing it.
 pub fn report_pending_exception(cx: *mut JSContext, obj: *mut JSObject) {
     unsafe {
-        if JS_IsExceptionPending(cx) != 0 {
+        if JS_IsExceptionPending(cx) {
             let saved = JS_SaveFrameChain(cx);
             {
                 let _ac = JSAutoCompartment::new(cx, obj);
                 JS_ReportPendingException(cx);
             }
-            if saved != 0 {
+            if saved {
                 JS_RestoreFrameChain(cx);
             }
         }
@@ -148,7 +148,7 @@ pub fn report_pending_exception(cx: *mut JSContext, obj: *mut JSObject) {
 /// Throw an exception to signal that a `JSVal` can not be converted to any of
 /// the types in an IDL union type.
 pub fn throw_not_in_union(cx: *mut JSContext, names: &'static str) {
-    assert!(unsafe { JS_IsExceptionPending(cx) } == 0);
+    assert!(unsafe { !JS_IsExceptionPending(cx) });
     let error = format!("argument could not be converted to any of: {}", names);
     throw_type_error(cx, &error);
 }
@@ -156,7 +156,7 @@ pub fn throw_not_in_union(cx: *mut JSContext, names: &'static str) {
 /// Throw an exception to signal that a `JSObject` can not be converted to a
 /// given DOM type.
 pub fn throw_invalid_this(cx: *mut JSContext, proto_id: u16) {
-    debug_assert!(unsafe { JS_IsExceptionPending(cx) } == 0);
+    debug_assert!(unsafe { !JS_IsExceptionPending(cx) });
     let error = format!("\"this\" object does not implement interface {}.",
                         proto_id_to_name(proto_id));
     throw_type_error(cx, &error);
@@ -205,7 +205,7 @@ unsafe extern fn get_error_message(_user_ref: *mut libc::c_void,
 fn throw_js_error(cx: *mut JSContext, error: &str, error_number: u32) {
     let error = CString::new(error).unwrap();
     unsafe {
-        JS_ReportErrorNumber1(cx,
+        JS_ReportErrorNumber(cx,
             Some(get_error_message),
             ptr::null_mut(), error_number, error.as_ptr());
     }

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -31,7 +31,7 @@ impl StructuredCloneData {
                                     ptr::null(), ptr::null_mut(),
                                     HandleValue::undefined())
         };
-        if result == 0 {
+        if !result {
             unsafe { JS_ClearPendingException(cx); }
             return Err(Error::DataClone);
         }
@@ -49,7 +49,7 @@ impl StructuredCloneData {
             assert!(JS_ReadStructuredClone(
                 global.get_cx(), self.data, self.nbytes,
                 JS_STRUCTURED_CLONE_VERSION, rval,
-                ptr::null(), ptr::null_mut()) != 0);
+                ptr::null(), ptr::null_mut()));
         }
     }
 }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -204,7 +204,7 @@ unsafe impl Sync for NativeProperties {}
 
 /// A JSNative that cannot be null.
 pub type NonNullJSNative =
-    unsafe extern "C" fn (arg1: *mut JSContext, arg2: c_uint, arg3: *mut JSVal) -> u8;
+    unsafe extern "C" fn (arg1: *mut JSContext, arg2: c_uint, arg3: *mut JSVal) -> bool;
 
 /// Creates the *interface prototype object* (if a `proto_class` is given)
 /// and the *interface object* (if a `constructor` is given).
@@ -252,7 +252,7 @@ pub fn do_create_interface_objects(cx: *mut JSContext,
             assert!(JS_DefineProperty1(cx, constructor.handle(), b"prototype\0".as_ptr() as *const libc::c_char,
                                        rval.handle(),
                                        JSPROP_PERMANENT | JSPROP_READONLY,
-                                       None, None) != 0);
+                                       None, None));
         }
         define_constructor(cx, receiver, cs.as_ptr(), constructor.handle());
     }
@@ -280,13 +280,13 @@ fn define_constructor(cx: *mut JSContext,
                       name: *const libc::c_char,
                       constructor: HandleObject) {
     unsafe {
-        let mut already_defined = 0;
-        assert!(JS_AlreadyHasOwnProperty(cx, receiver, name, &mut already_defined) != 0);
+        let mut already_defined = false;
+        assert!(JS_AlreadyHasOwnProperty(cx, receiver, name, &mut already_defined));
 
-        if already_defined == 0 {
+        if !already_defined {
             assert!(JS_DefineProperty1(cx, receiver, name,
                                       constructor,
-                                      0, None, None) != 0);
+                                      0, None, None));
         }
 
     }
@@ -317,7 +317,7 @@ fn create_interface_object(cx: *mut JSContext,
 
     unsafe {
         if !proto.get().is_null() {
-            assert!(JS_LinkConstructorAndPrototype(cx, constructor.handle(), proto) != 0);
+            assert!(JS_LinkConstructorAndPrototype(cx, constructor.handle(), proto));
         }
     }
 
@@ -334,7 +334,7 @@ fn define_constants(cx: *mut JSContext, obj: HandleObject,
             assert!(JS_DefineProperty(cx, obj, spec.name.as_ptr() as *const libc::c_char,
                                       value.handle(),
                                       JSPROP_ENUMERATE | JSPROP_READONLY |
-                                      JSPROP_PERMANENT, None, None) != 0);
+                                      JSPROP_PERMANENT, None, None));
         }
     }
 }
@@ -345,7 +345,7 @@ fn define_constants(cx: *mut JSContext, obj: HandleObject,
 fn define_methods(cx: *mut JSContext, obj: HandleObject,
                   methods: &'static [JSFunctionSpec]) {
     unsafe {
-        assert!(JS_DefineFunctions(cx, obj, methods.as_ptr(), PropertyDefinitionBehavior::DefineAllProperties) != 0);
+        assert!(JS_DefineFunctions(cx, obj, methods.as_ptr(), PropertyDefinitionBehavior::DefineAllProperties));
     }
 }
 
@@ -355,7 +355,7 @@ fn define_methods(cx: *mut JSContext, obj: HandleObject,
 fn define_properties(cx: *mut JSContext, obj: HandleObject,
                      properties: &'static [JSPropertySpec]) {
     unsafe {
-        assert!(JS_DefineProperties(cx, obj, properties.as_ptr()) != 0);
+        assert!(JS_DefineProperties(cx, obj, properties.as_ptr()));
     }
 }
 
@@ -386,9 +386,9 @@ fn create_interface_prototype_object(cx: *mut JSContext, global: HandleObject,
 /// A throwing constructor, for those interfaces that have neither
 /// `NoInterfaceObject` nor `Constructor`.
 pub unsafe extern fn throwing_constructor(cx: *mut JSContext, _argc: c_uint,
-                                          _vp: *mut JSVal) -> u8 {
+                                          _vp: *mut JSVal) -> bool {
     throw_type_error(cx, "Illegal constructor.");
-    0
+    false
 }
 
 /// An array of *mut JSObject of size PrototypeList::ID::Count
@@ -450,7 +450,7 @@ impl Reflector {
     /// Get the reflector.
     #[inline]
     pub fn get_jsobject(&self) -> HandleObject {
-        HandleObject { ptr: self.object.get() }
+        unsafe { HandleObject::from_marked_location(self.object.get()) }
     }
 
     /// Initialize the reflector. (May be called only once.)
@@ -488,22 +488,22 @@ pub fn get_property_on_prototype(cx: *mut JSContext, proxy: HandleObject,
     unsafe {
       //let proto = GetObjectProto(proxy);
       let mut proto = RootedObject::new(cx, ptr::null_mut());
-      if JS_GetPrototype(cx, proxy, proto.handle_mut()) == 0 ||
+      if !JS_GetPrototype(cx, proxy, proto.handle_mut()) ||
          proto.ptr.is_null() {
           *found = false;
           return true;
       }
-      let mut has_property = 0;
-      if JS_HasPropertyById(cx, proto.handle(), id, &mut has_property) == 0 {
+      let mut has_property = false;
+      if !JS_HasPropertyById(cx, proto.handle(), id, &mut has_property) {
           return false;
       }
-      *found = has_property != 0;
+      *found = has_property;
       let no_output = vp.ptr.is_null();
-      if has_property == 0 || no_output {
+      if !has_property || no_output {
           return true;
       }
 
-      JS_ForwardGetPropertyTo(cx, proto.handle(), id, proxy, vp) != 0
+      JS_ForwardGetPropertyTo(cx, proto.handle(), id, proxy, vp)
   }
 }
 
@@ -511,7 +511,7 @@ pub fn get_property_on_prototype(cx: *mut JSContext, proxy: HandleObject,
 /// `jsid` is not an integer.
 pub fn get_array_index_from_id(_cx: *mut JSContext, id: HandleId) -> Option<u32> {
     unsafe {
-        if RUST_JSID_IS_INT(id) != 0 {
+        if RUST_JSID_IS_INT(id) {
             return Some(RUST_JSID_TO_INT(id) as u32);
         }
         None
@@ -558,7 +558,7 @@ pub fn is_platform_object(obj: *mut JSObject) -> bool {
             return true;
         }
         // Now for simplicity check for security wrappers before anything else
-        if IsWrapper(obj) == 1 {
+        if IsWrapper(obj) {
             let unwrapped_obj = UnwrapObject(obj, /* stopAtOuter = */ 0);
             if unwrapped_obj.is_null() {
                 return false;
@@ -579,15 +579,15 @@ pub fn get_dictionary_property(cx: *mut JSContext,
                                rval: MutableHandleValue)
                                -> Result<bool, ()> {
     fn has_property(cx: *mut JSContext, object: HandleObject, property: &CString,
-                    found: &mut u8) -> bool {
+                    found: &mut bool) -> bool {
         unsafe {
-            JS_HasProperty(cx, object, property.as_ptr(), found) != 0
+            JS_HasProperty(cx, object, property.as_ptr(), found)
         }
     }
     fn get_property(cx: *mut JSContext, object: HandleObject, property: &CString,
                     value: MutableHandleValue) -> bool {
         unsafe {
-            JS_GetProperty(cx, object, property.as_ptr(), value) != 0
+            JS_GetProperty(cx, object, property.as_ptr(), value)
         }
     }
 
@@ -596,12 +596,12 @@ pub fn get_dictionary_property(cx: *mut JSContext,
         return Ok(false);
     }
 
-    let mut found: u8 = 0;
+    let mut found = false;
     if !has_property(cx, object, &property, &mut found) {
         return Err(());
     }
 
-    if found == 0 {
+    if !found {
         return Ok(false);
     }
 
@@ -625,7 +625,7 @@ pub fn set_dictionary_property(cx: *mut JSContext,
 
     let property = CString::new(property).unwrap();
     unsafe {
-        if JS_SetProperty(cx, object, property.as_ptr(), value) == 0 {
+        if !JS_SetProperty(cx, object, property.as_ptr(), value) {
             return Err(());
         }
     }
@@ -639,7 +639,7 @@ pub fn has_property_on_prototype(cx: *mut JSContext, proxy: HandleObject,
     //  MOZ_ASSERT(js::IsProxy(proxy) && js::GetProxyHandler(proxy) == handler);
     let mut found = false;
     !get_property_on_prototype(cx, proxy, id, &mut found,
-                               MutableHandleValue { ptr: ptr::null_mut() }) || found
+                               unsafe { MutableHandleValue::from_marked_location(ptr::null_mut()) }) || found
 }
 
 /// Create a DOM global object with the given class.
@@ -648,7 +648,7 @@ pub fn create_dom_global(cx: *mut JSContext, class: *const JSClass,
                          -> *mut JSObject {
     unsafe {
         let mut options = CompartmentOptions::default();
-        options.version_ = JSVersion::JSVERSION_LATEST;
+        options.version_ = JSVersion::JSVERSION_ECMA_5;
         options.traceGlobal_ = trace;
 
         let obj =
@@ -725,7 +725,7 @@ pub unsafe extern fn outerize_global(_cx: *mut JSContext, obj: HandleObject) -> 
 
 /// Deletes the property `id` from `object`.
 pub unsafe fn delete_property_by_id(cx: *mut JSContext, object: HandleObject,
-                                    id: HandleId, bp: *mut ObjectOpResult) -> u8 {
+                                    id: HandleId, bp: *mut ObjectOpResult) -> bool {
     JS_DeletePropertyById1(cx, object, id, bp)
 }
 
@@ -734,12 +734,12 @@ unsafe fn generic_call(cx: *mut JSContext, argc: libc::c_uint, vp: *mut JSVal,
                        call: unsafe extern fn(*const JSJitInfo, *mut JSContext,
                                               HandleObject, *mut libc::c_void, u32,
                                               *mut JSVal)
-                                              -> u8)
-                       -> u8 {
+                                              -> bool)
+                       -> bool {
     let args = CallArgs::from_vp(vp, argc);
     let thisobj = args.thisv();
     if !thisobj.get().is_null_or_undefined() && !thisobj.get().is_object() {
-        return 0;
+        return false;
     }
     let obj = if thisobj.get().is_object() {
         thisobj.get().to_object()
@@ -754,12 +754,12 @@ unsafe fn generic_call(cx: *mut JSContext, argc: libc::c_uint, vp: *mut JSVal,
         Ok(val) => val,
         Err(()) => {
             if is_lenient {
-                debug_assert!(JS_IsExceptionPending(cx) == 0);
+                debug_assert!(!JS_IsExceptionPending(cx));
                 *vp = UndefinedValue();
-                return 1;
+                return true;
             } else {
                 throw_invalid_this(cx, proto_id);
-                return 0;
+                return false;
             }
         }
     };
@@ -769,14 +769,14 @@ unsafe fn generic_call(cx: *mut JSContext, argc: libc::c_uint, vp: *mut JSVal,
 /// Generic method of IDL interface.
 pub unsafe extern fn generic_method(cx: *mut JSContext,
                                     argc: libc::c_uint, vp: *mut JSVal)
-                                    -> u8 {
+                                    -> bool {
     generic_call(cx, argc, vp, false, CallJitMethodOp)
 }
 
 /// Generic getter of IDL interface.
 pub unsafe extern fn generic_getter(cx: *mut JSContext,
                                     argc: libc::c_uint, vp: *mut JSVal)
-                                    -> u8 {
+                                    -> bool {
     generic_call(cx, argc, vp, false, CallJitGetterOp)
 }
 
@@ -784,25 +784,25 @@ pub unsafe extern fn generic_getter(cx: *mut JSContext,
 pub unsafe extern fn generic_lenient_getter(cx: *mut JSContext,
                                             argc: libc::c_uint,
                                             vp: *mut JSVal)
-                                            -> u8 {
+                                            -> bool {
     generic_call(cx, argc, vp, true, CallJitGetterOp)
 }
 
 unsafe extern fn call_setter(info: *const JSJitInfo, cx: *mut JSContext,
                              handle: HandleObject, this: *mut libc::c_void,
                              argc: u32, vp: *mut JSVal)
-                             -> u8 {
-    if CallJitSetterOp(info, cx, handle, this, argc, vp) == 0 {
-        return 0;
+                             -> bool {
+    if !CallJitSetterOp(info, cx, handle, this, argc, vp) {
+        return false;
     }
     *vp = UndefinedValue();
-    1
+    true
 }
 
 /// Generic setter of IDL interface.
 pub unsafe extern fn generic_setter(cx: *mut JSContext,
                                     argc: libc::c_uint, vp: *mut JSVal)
-                                    -> u8 {
+                                    -> bool {
     generic_call(cx, argc, vp, false, call_setter)
 }
 
@@ -810,7 +810,7 @@ pub unsafe extern fn generic_setter(cx: *mut JSContext,
 pub unsafe extern fn generic_lenient_setter(cx: *mut JSContext,
                                             argc: libc::c_uint,
                                             vp: *mut JSVal)
-                                            -> u8 {
+                                            -> bool {
     generic_call(cx, argc, vp, true, call_setter)
 }
 
@@ -831,10 +831,10 @@ pub fn validate_qualified_name(qualified_name: &str) -> ErrorResult {
 
 unsafe extern "C" fn instance_class_has_proto_at_depth(clasp: *const js::jsapi::Class,
                                                        proto_id: u32,
-                                                       depth: u32) -> u8 {
+                                                       depth: u32) -> bool {
     let domclass: *const DOMJSClass = clasp as *const _;
     let domclass = &*domclass;
-    (domclass.dom_class.interface_chain[depth as usize] as u32 == proto_id) as u8
+    domclass.dom_class.interface_chain[depth as usize] as u32 == proto_id
 }
 
 #[allow(missing_docs)]  // FIXME

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -13,14 +13,13 @@ use dom::element::Element;
 use dom::window::Window;
 use js::glue::{CreateWrapperProxyHandler, ProxyTraps, WrapperNew};
 use js::glue::{GetProxyPrivate};
-use js::jsapi::{Handle, HandleValue, Heap, JS_ForwardSetPropertyTo, ObjectOpResult, RootedObject, RootedValue};
+use js::jsapi::{Handle, Heap, JS_ForwardSetPropertyTo, ObjectOpResult, RootedObject, RootedValue};
 use js::jsapi::{HandleId, HandleObject, MutableHandle, MutableHandleValue};
 use js::jsapi::{JSAutoCompartment, JSAutoRequest};
 use js::jsapi::{JSContext, JSErrNum, JSObject, JSPropertyDescriptor};
 use js::jsapi::{JS_AlreadyHasOwnPropertyById, JS_ForwardGetPropertyTo};
 use js::jsapi::{JS_DefinePropertyById6, JS_GetPropertyDescriptorById};
 use js::jsval::{ObjectValue, UndefinedValue};
-use js::{JSFalse, JSTrue};
 use std::default::Default;
 use std::ptr;
 
@@ -115,20 +114,20 @@ unsafe fn GetSubframeWindow(cx: *mut JSContext, proxy: HandleObject, id: HandleI
 
 #[allow(unsafe_code)]
 unsafe extern fn getOwnPropertyDescriptor(cx: *mut JSContext, proxy: HandleObject, id: HandleId,
-                                          desc: MutableHandle<JSPropertyDescriptor>) -> u8 {
+                                          desc: MutableHandle<JSPropertyDescriptor>) -> bool {
     let window = GetSubframeWindow(cx, proxy, id);
     if let Some(window) = window {
         let mut val = RootedValue::new(cx, UndefinedValue());
         window.to_jsval(cx, val.handle_mut());
         (*desc.ptr).value = val.ptr;
         fill_property_descriptor(&mut *desc.ptr, *proxy.ptr, true);
-        return JSTrue;
+        return true;
     }
 
     let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
     // XXX This should be JS_GetOwnPropertyDescriptorById
-    if JS_GetPropertyDescriptorById(cx, target.handle(), id, desc) == 0 {
-        return JSFalse;
+    if !JS_GetPropertyDescriptorById(cx, target.handle(), id, desc) {
+        return false;
     }
 
     if (*desc.ptr).obj != target.ptr {
@@ -138,7 +137,7 @@ unsafe extern fn getOwnPropertyDescriptor(cx: *mut JSContext, proxy: HandleObjec
         (*desc.ptr).obj = *proxy.ptr;
     }
 
-    JSTrue
+    true
 }
 
 #[allow(unsafe_code)]
@@ -146,14 +145,14 @@ unsafe extern fn defineProperty(cx: *mut JSContext,
                                 proxy: HandleObject,
                                 id: HandleId,
                                 desc: Handle<JSPropertyDescriptor>,
-                                res: *mut ObjectOpResult) -> u8 {
+                                res: *mut ObjectOpResult) -> bool {
     if get_array_index_from_id(cx, id).is_some() {
         // Spec says to Reject whether this is a supported index or not,
         // since we have no indexed setter or indexed creator.  That means
         // throwing in strict mode (FIXME: Bug 828137), doing nothing in
         // non-strict mode.
-       (*res).code_ = JSErrNum::JSMSG_CANT_DEFINE_WINDOW_ELEMENT as u32;
-       return JSTrue;
+       (*res).code_ = JSErrNum::JSMSG_CANT_DEFINE_WINDOW_ELEMENT as ::libc::uintptr_t;
+       return true;
     }
 
     let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
@@ -161,21 +160,21 @@ unsafe extern fn defineProperty(cx: *mut JSContext,
 }
 
 #[allow(unsafe_code)]
-unsafe extern fn hasOwn(cx: *mut JSContext, proxy: HandleObject, id: HandleId, bp: *mut u8) -> u8 {
+unsafe extern fn hasOwn(cx: *mut JSContext, proxy: HandleObject, id: HandleId, bp: *mut bool) -> bool {
     let window = GetSubframeWindow(cx, proxy, id);
     if window.is_some() {
-        *bp = JSTrue;
-        return JSTrue;
+        *bp = true;
+        return true;
     }
 
     let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
-    let mut found = 0;
-    if JS_AlreadyHasOwnPropertyById(cx, target.handle(), id, &mut found) == 0 {
-        return JSFalse;
+    let mut found = false;
+    if !JS_AlreadyHasOwnPropertyById(cx, target.handle(), id, &mut found) {
+        return false;
     }
 
-    *bp = (found != 0) as u8;
-    JSTrue
+    *bp = found;
+    true
 }
 
 #[allow(unsafe_code)]
@@ -183,11 +182,11 @@ unsafe extern fn get(cx: *mut JSContext,
                      proxy: HandleObject,
                      receiver: HandleObject,
                      id: HandleId,
-                     vp: MutableHandleValue) -> u8 {
+                     vp: MutableHandleValue) -> bool {
     let window = GetSubframeWindow(cx, proxy, id);
     if let Some(window) = window {
         window.to_jsval(cx, vp);
-        return JSTrue;
+        return true;
     }
 
     let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
@@ -200,16 +199,16 @@ unsafe extern fn set(cx: *mut JSContext,
                      receiver: HandleObject,
                      id: HandleId,
                      vp: MutableHandleValue,
-                     res: *mut ObjectOpResult) -> u8 {
+                     res: *mut ObjectOpResult) -> bool {
     if get_array_index_from_id(cx, id).is_some() {
         // Reject (which means throw if and only if strict) the set.
-        (*res).code_ = JSErrNum::JSMSG_READ_ONLY as u32;
-        return JSTrue;
+        (*res).code_ = JSErrNum::JSMSG_READ_ONLY as ::libc::uintptr_t;
+        return true;
     }
 
     let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
     let receiver = RootedValue::new(cx, ObjectValue(&**receiver.ptr));
-    JS_ForwardSetPropertyTo(cx, target.handle(), id, HandleValue { ptr: vp.ptr }, receiver.handle(), res)
+    JS_ForwardSetPropertyTo(cx, target.handle(), id, vp.to_handle(), receiver.handle(), res)
 }
 
 static PROXY_HANDLER: ProxyTraps = ProxyTraps {

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -51,6 +51,7 @@ impl CustomEvent {
         ev.r().InitCustomEvent(global.get_cx(), type_, bubbles, cancelable, detail);
         ev
     }
+    #[allow(unsafe_code)]
     pub fn Constructor(global: GlobalRef,
                        type_: DOMString,
                        init: &CustomEventBinding::CustomEventInit) -> Fallible<Root<CustomEvent>>{
@@ -58,7 +59,7 @@ impl CustomEvent {
                             type_,
                             init.parent.bubbles,
                             init.parent.cancelable,
-                            HandleValue { ptr: &init.detail }))
+                            unsafe { HandleValue::from_marked_location(&init.detail) }))
     }
 }
 

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -13,7 +13,7 @@ use dom::bindings::js::{MutHeapJSVal, Root};
 use dom::bindings::trace::JSTraceable;
 use dom::bindings::utils::reflect_dom_object;
 use dom::event::{Event, EventBubbles, EventCancelable};
-use js::jsapi::{HandleValue, JSContext};
+use js::jsapi::{RootedValue, HandleValue, JSContext};
 use js::jsval::JSVal;
 use std::borrow::ToOwned;
 use std::cell::Cell;
@@ -102,11 +102,14 @@ impl ErrorEvent {
             EventCancelable::NotCancelable
         };
 
+        // Dictionaries need to be rooted
+        // https://github.com/servo/servo/issues/6381
+        let error = RootedValue::new(global.get_cx(), init.error);
         let event = ErrorEvent::new(global, type_,
                                 bubbles, cancelable,
                                 msg, file_name,
                                 line_num, col_num,
-                                HandleValue { ptr: &init.error });
+                                error.handle());
         Ok(event)
     }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -224,11 +224,11 @@ impl EventTarget {
                             name.as_ptr(),
                             nargs,
                             ARG_NAMES.as_mut_ptr(),
-                            source.as_ptr() as *const i16,
+                            source.as_ptr(),
                             source.len() as size_t,
                             handler.handle_mut())
         };
-        if rv == 0 || handler.ptr.is_null() {
+        if !rv || handler.ptr.is_null() {
             report_pending_exception(cx, self.reflector().get_jsobject().get());
             return;
         }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -12,7 +12,7 @@ use dom::bindings::js::Root;
 use dom::bindings::utils::reflect_dom_object;
 use dom::event::Event;
 use dom::eventtarget::EventTarget;
-use js::jsapi::{HandleValue, Heap, JSContext};
+use js::jsapi::{RootedValue, HandleValue, Heap, JSContext};
 use js::jsval::JSVal;
 use std::borrow::ToOwned;
 use std::default::Default;
@@ -67,8 +67,11 @@ impl MessageEvent {
                        type_: DOMString,
                        init: &MessageEventBinding::MessageEventInit)
                        -> Fallible<Root<MessageEvent>> {
+        // Dictionaries need to be rooted
+        // https://github.com/servo/servo/issues/6381
+        let data = RootedValue::new(global.get_cx(), init.data);
         let ev = MessageEvent::new(global, type_, init.parent.bubbles, init.parent.cancelable,
-                                   HandleValue { ptr: &init.data },
+                                   data.handle(),
                                    init.origin.clone(), init.lastEventId.clone());
         Ok(ev)
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -779,9 +779,9 @@ impl<'a, T: Reflectable> ScriptHelpers for &'a T {
         let _ac = JSAutoCompartment::new(cx, globalhandle.get());
         let options = CompileOptionsWrapper::new(cx, filename.as_ptr(), 0);
         unsafe {
-            if Evaluate2(cx, options.ptr, code.as_ptr() as *const i16,
-                         code.len() as libc::size_t,
-                         rval) == 0 {
+            if !Evaluate2(cx, options.ptr, code.as_ptr(),
+                          code.len() as libc::size_t,
+                          rval) {
                 debug!("error evaluating JS string");
                 report_pending_exception(cx, globalhandle.get());
             }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -692,10 +692,10 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 let decoded = UTF_8.decode(&self.response.borrow(), DecoderTrap::Replace).unwrap().to_owned();
                 let decoded: Vec<u16> = decoded.utf16_units().collect();
                 unsafe {
-                    if JS_ParseJSON(cx,
-                                    decoded.as_ptr() as *const i16,
-                                    decoded.len() as u32,
-                                    rval.handle_mut()) == 0 {
+                    if !JS_ParseJSON(cx,
+                                     decoded.as_ptr(),
+                                     decoded.len() as u32,
+                                     rval.handle_mut()) {
                         JS_ClearPendingException(cx);
                         return NullValue();
                     }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -7,6 +7,7 @@
 #![feature(borrow_state)]
 #![feature(box_syntax)]
 #![feature(cell_extras)]
+#![feature(const_fn)]
 #![feature(core)]
 #![feature(core_intrinsics)]
 #![feature(custom_attribute)]
@@ -142,7 +143,7 @@ fn perform_platform_specific_initialization() {}
 #[allow(unsafe_code)]
 pub fn init() {
     unsafe {
-        assert_eq!(js::jsapi::JS_Init(), 1);
+        assert_eq!(js::jsapi::JS_Init(), true);
     }
 
     // Create the global vtables used by the (generated) DOM

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -658,7 +658,7 @@ impl ScriptTask {
         }
 
         unsafe {
-            unsafe extern "C" fn empty_wrapper_callback(_: *mut JSContext, _: *mut JSObject) -> u8 { 1 }
+            unsafe extern "C" fn empty_wrapper_callback(_: *mut JSContext, _: *mut JSObject) -> bool { true }
             SetDOMProxyInformation(ptr::null(), 0, Some(shadow_check_callback));
             SetDOMCallbacks(runtime.rt(), &DOM_CALLBACKS);
             SetPreserveWrapperCallback(runtime.rt(), Some(empty_wrapper_callback));

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -232,6 +232,7 @@ impl TimerManager {
         }
     }
 
+    #[allow(unsafe_code)]
     pub fn fire_timer<T: Reflectable>(&self, timer_id: TimerId, this: &T) {
 
         let (is_interval, callback, args): (IsInterval, TimerCallback, Vec<JSVal>) =
@@ -245,7 +246,9 @@ impl TimerManager {
 
         match callback {
             TimerCallback::FunctionTimerCallback(function) => {
-                let arg_handles = args.iter().by_ref().map(|arg| HandleValue { ptr: arg }).collect();
+                let arg_handles = args.iter().by_ref().map(|arg| unsafe {
+                    HandleValue::from_marked_location(arg)
+                }).collect();
                 let _ = function.Call_(this, arg_handles, Report);
             }
             TimerCallback::StringTimerCallback(code_str) => {

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#79e06de7709282104c9fef289014686db60551a8"
+source = "git+https://github.com/servo/rust-mozjs#01ff3cb8cb253a8a634cf6aecf64c10bf9c7d8c4"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#79e06de7709282104c9fef289014686db60551a8"
+source = "git+https://github.com/servo/rust-mozjs#01ff3cb8cb253a8a634cf6aecf64c10bf9c7d8c4"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-mozjs#79e06de7709282104c9fef289014686db60551a8"
+source = "git+https://github.com/servo/rust-mozjs#01ff3cb8cb253a8a634cf6aecf64c10bf9c7d8c4"
 dependencies = [
  "heapsize 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/wpt/metadata/XMLHttpRequest/setrequestheader-bogus-name.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/setrequestheader-bogus-name.htm.ini
@@ -1,0 +1,8 @@
+[setrequestheader-bogus-name.htm]
+  type: testharness
+  [setRequestHeader should throw with header name "ﾃｽﾄ".]
+    expected: FAIL
+
+  [setRequestHeader should throw with header name "X-ﾃｽﾄ".]
+    expected: FAIL
+

--- a/tests/wpt/metadata/XMLHttpRequest/setrequestheader-bogus-value.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/setrequestheader-bogus-value.htm.ini
@@ -1,0 +1,5 @@
+[setrequestheader-bogus-value.htm]
+  type: testharness
+  [XMLHttpRequest: setRequestHeader() value argument checks 4]
+    expected: FAIL
+


### PR DESCRIPTION
Still need to finish the rust-mozjs update and make cargo use it, but it's close enough that I don't expect much to change on the servo side.

Some changes here
- bools are properly translated now
- char16_t is handled as u16 now
- JS_GlobalObjectTraceHook isn't mangled now
- JSJitInfo has been adjusted
- A const fn is used to generate bitfields in JSJitInfo
- Manually generating handles now requires calling an unsafe function. It's not actually required, but it's too much of a hassle to generate them manually now due to bindgen++ adding base classes now.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7727)

<!-- Reviewable:end -->
