### PR TITLE
Properly consider radio button groups

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -338,6 +338,15 @@ impl HTMLInputElementMethods for HTMLInputElement {
 
 #[allow(unsafe_code)]
 fn broadcast_radio_checked(broadcaster: &HTMLInputElement, group: Option<&Atom>) {
+    match group {
+        None | Some(&atom!("")) => {
+            // Radio input elements with a missing or empty name are alone in their
+            // own group.
+            return;
+        },
+        _ => {},
+    }
+
     //TODO: if not in document, use root ancestor instead of document
     let owner = broadcaster.form_owner();
     let doc = document_from_node(broadcaster);
@@ -362,6 +371,7 @@ fn broadcast_radio_checked(broadcaster: &HTMLInputElement, group: Option<&Atom>)
     do_broadcast(doc_node, broadcaster, owner.r(), group)
 }
 
+// https://html.spec.whatwg.org/multipage/#radio-button-group
 fn in_same_group(other: &HTMLInputElement, owner: Option<&HTMLFormElement>,
                  group: Option<&Atom>) -> bool {
     let other_owner = other.form_owner();
@@ -371,8 +381,7 @@ fn in_same_group(other: &HTMLInputElement, owner: Option<&HTMLFormElement>,
     other_owner == owner &&
     // TODO should be a unicode compatibility caseless match
     match (other.get_radio_group_name(), group) {
-        (Some(ref s1), Some(s2)) => s1 == s2,
-        (None, None) => true,
+        (Some(ref s1), Some(s2)) => s1 == s2 && s2 != &atom!(""),
         _ => false
     }
 }

--- a/tests/wpt/metadata/dom/nodes/Element-matches.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-matches.html.ini
@@ -15,9 +15,6 @@
   [In-document Element.matches: :lang pseudo-class selector, matching specified language with partial value (with no refNodes): #pseudo-lang-div3:lang(en)]
     expected: FAIL
 
-  [In-document Element.matches: :checked pseudo-class selector, matching checked radio buttons and checkboxes (with no refNodes): #pseudo-ui :checked]
-    expected: FAIL
-
   [Detached Element.matches: Attribute hyphen-separated list selector, matching lang attribute with partial value (with no refNodes): #attr-hyphen-div3[lang|="en"\]]
     expected: FAIL
 
@@ -55,9 +52,6 @@
     expected: FAIL
 
   [In-document Element.matches: :lang pseudo-class selector, matching specified language with partial value (1) (with no refNodes): #pseudo-lang-div3:lang(en)]
-    expected: FAIL
-
-  [In-document Element.matches: :checked pseudo-class selector, matching checked radio buttons and checkboxes (1) (with no refNodes): #pseudo-ui :checked]
     expected: FAIL
 
   [In-document Element.matches: Class selector, matching element with class value using non-ASCII characters (with no refNodes): .台北Táiběi]

--- a/tests/wpt/metadata/dom/nodes/ParentNode-querySelector-All.html.ini
+++ b/tests/wpt/metadata/dom/nodes/ParentNode-querySelector-All.html.ini
@@ -48,12 +48,6 @@
   [Document.querySelector: :lang pseudo-class selector, not matching incorrect language: #pseudo-lang-div4:lang(es-AR)]
     expected: FAIL
 
-  [Document.querySelectorAll: :checked pseudo-class selector, matching checked radio buttons and checkboxes: #pseudo-ui :checked]
-    expected: FAIL
-
-  [Document.querySelector: :checked pseudo-class selector, matching checked radio buttons and checkboxes: #pseudo-ui :checked]
-    expected: FAIL
-
   [Document.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
@@ -250,12 +244,6 @@
     expected: FAIL
 
   [In-document Element.querySelector: :lang pseudo-class selector, not matching incorrect language: #pseudo-lang-div4:lang(es-AR)]
-    expected: FAIL
-
-  [In-document Element.querySelectorAll: :checked pseudo-class selector, matching checked radio buttons and checkboxes: #pseudo-ui :checked]
-    expected: FAIL
-
-  [In-document Element.querySelector: :checked pseudo-class selector, matching checked radio buttons and checkboxes: #pseudo-ui :checked]
     expected: FAIL
 
   [In-document Element.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]


### PR DESCRIPTION
Radio button groups with missing or empty names are always the only element of their respective radio button group.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7733)

<!-- Reviewable:end -->
