### PR TITLE
Allow `./mach build` to enable Servo's headless mode

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -134,6 +134,10 @@ class MachCommands(CommandBase):
     @CommandArgument('--dev', '-d',
                      action='store_true',
                      help='Build in development mode')
+    @CommandArgument('--headless',
+                     default=None,
+                     action='store_true',
+                     help='Enable headless mode (OSMesa)')
     @CommandArgument('--jobs', '-j',
                      default=None,
                      help='Number of jobs to run in parallel')
@@ -155,7 +159,7 @@ class MachCommands(CommandBase):
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
     def build(self, target=None, release=False, dev=False, jobs=None,
-              features=None, android=None, verbose=False, debug_mozjs=False, params=None):
+              features=None, headless=False, android=None, verbose=False, debug_mozjs=False, params=None):
         if android is None:
             android = self.config["build"]["android"]
         features = features or []
@@ -203,9 +207,13 @@ class MachCommands(CommandBase):
         if debug_mozjs or self.config["build"]["debug-mozjs"]:
             features += ["script/debugmozjs"]
 
-        if is_headless_build():
-            opts += ["--no-default-features"]
-            features += ["headless"]
+        if headless or is_headless_build():
+            if sys.platform.startswith("linux"):
+                opts += ["--no-default-features"]
+                features += ["headless"]
+            else:
+                print("Headless mode (OSMesa) is not supported on your platform.")
+                print("Building without headless mode.")
 
         if android:
             features += ["android_glue"]

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -29,6 +29,16 @@ def is_headless_build():
     return int(os.getenv('SERVO_HEADLESS', 0)) == 1
 
 
+def headless_supported():
+    supported = sys.platform.startswith("linux")
+
+    if not supported:
+        print("Headless mode (OSMesa) is not supported on your platform.")
+        print("Building without headless mode.")
+
+    return supported
+
+
 def notify_linux(title, text):
     try:
         import dbus
@@ -207,13 +217,9 @@ class MachCommands(CommandBase):
         if debug_mozjs or self.config["build"]["debug-mozjs"]:
             features += ["script/debugmozjs"]
 
-        if headless or is_headless_build():
-            if sys.platform.startswith("linux"):
-                opts += ["--no-default-features"]
-                features += ["headless"]
-            else:
-                print("Headless mode (OSMesa) is not supported on your platform.")
-                print("Building without headless mode.")
+        if (headless or is_headless_build()) and headless_supported():
+            opts += ["--no-default-features"]
+            features += ["headless"]
 
         if android:
             features += ["android_glue"]
@@ -332,15 +338,19 @@ class MachCommands(CommandBase):
     @Command('build-tests',
              description='Build the Servo test suites',
              category='build')
+    @CommandArgument('--headless',
+                     default=None,
+                     action='store_true',
+                     help='Enable headless mode (OSMesa)')
     @CommandArgument('--jobs', '-j',
                      default=None,
                      help='Number of jobs to run in parallel')
     @CommandArgument('--release', default=False, action="store_true",
                      help="Build tests with release mode")
-    def build_tests(self, jobs=None, verbose=False, release=False):
+    def build_tests(self, headless=False, jobs=None, verbose=False, release=False):
         self.ensure_bootstrapped()
         args = ["cargo", "test", "--no-run"]
-        if is_headless_build():
+        if (headless or is_headless_build()) and headless_supported():
             args += ["--no-default-features", "--features", "headless"]
         if release:
             args += ["--release"]


### PR DESCRIPTION
As mentioned in #7512 and #7637, the environment variable SERVO_HEADLESS
enables building the OSMesa version of Servo when it is set to 1.

Instead, this should be a command line option to mach's build command.

Fixes #7637.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7734)

<!-- Reviewable:end -->
