### PR TITLE
Don't generate useless InheritTypes interfaces

### DIFF
--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -227,9 +227,9 @@ class Descriptor(DescriptorProvider):
 
             if self.proxy:
                 iface = self.interface
-                while iface:
-                    iface.setUserData('hasProxyDescendant', True)
+                while iface.parent:
                     iface = iface.parent
+                    iface.setUserData('hasProxyDescendant', True)
 
         self.name = interface.identifier.name
 


### PR DESCRIPTION
Interfaces with no descendant need neither a Base trait nor upcast functions, and interfaces with no ancestors neither a Derived trait nor downcast functions.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7735)

<!-- Reviewable:end -->
