### PR TITLE
HTMLTableSectionElement improvements

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -223,7 +223,11 @@ pub fn create_element(name: QualName, prefix: Option<Atom>,
         atom!("td")         => make!(HTMLTableDataCellElement),
         atom!("template")   => make!(HTMLTemplateElement),
         atom!("textarea")   => make!(HTMLTextAreaElement),
+        // https://html.spec.whatwg.org/multipage/#the-tfoot-element:concept-element-dom
+        atom!("tfoot")      => make!(HTMLTableSectionElement),
         atom!("th")         => make!(HTMLTableHeaderCellElement),
+        // https://html.spec.whatwg.org/multipage/#the-thead-element:concept-element-dom
+        atom!("thead")      => make!(HTMLTableSectionElement),
         atom!("time")       => make!(HTMLTimeElement),
         atom!("title")      => make!(HTMLTitleElement),
         atom!("tr")         => make!(HTMLTableRowElement),

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -4,14 +4,17 @@
 
 use cssparser::RGBA;
 use dom::attr::Attr;
-use dom::bindings::codegen::Bindings::HTMLTableSectionElementBinding;
-use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableSectionElementDerived};
-use dom::bindings::js::Root;
+use dom::bindings::codegen::Bindings::HTMLTableSectionElementBinding::{self, HTMLTableSectionElementMethods};
+use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use dom::bindings::codegen::InheritTypes::NodeCast;
+use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableRowElementDerived, HTMLTableSectionElementDerived};
+use dom::bindings::js::{Root, RootedReference};
 use dom::document::Document;
-use dom::element::{AttributeMutation, ElementTypeId};
+use dom::element::{AttributeMutation, Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
+use dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
-use dom::node::{Node, NodeTypeId};
+use dom::node::{Node, NodeTypeId, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 use std::cell::Cell;
 use util::str::{self, DOMString};
@@ -51,6 +54,22 @@ impl HTMLTableSectionElement {
 
     pub fn get_background_color(&self) -> Option<RGBA> {
         self.background_color.get()
+    }
+}
+
+#[derive(JSTraceable)]
+struct RowsFilter;
+impl CollectionFilter for RowsFilter {
+    fn filter(&self, elem: &Element, root: &Node) -> bool {
+        elem.is_htmltablerowelement()
+            && NodeCast::from_ref(elem).GetParentNode().r() == Some(root)
+    }
+}
+
+impl HTMLTableSectionElementMethods for HTMLTableSectionElement {
+    // https://html.spec.whatwg.org/multipage/#dom-tbody-rows
+    fn Rows(&self) -> Root<HTMLCollection> {
+        HTMLCollection::create(&window_from_node(self), NodeCast::from_ref(self), box RowsFilter)
     }
 }
 

--- a/components/script/dom/webidls/HTMLTableSectionElement.webidl
+++ b/components/script/dom/webidls/HTMLTableSectionElement.webidl
@@ -5,7 +5,7 @@
 
 // https://www.whatwg.org/html/#htmltablesectionelement
 interface HTMLTableSectionElement : HTMLElement {
-  //readonly attribute HTMLCollection rows;
+  readonly attribute HTMLCollection rows;
   //HTMLElement insertRow(optional long index = -1);
   //void deleteRow(long index);
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -17744,6 +17744,18 @@
         "url": "/html/semantics/tabular-data/the-tbody-element/insertRow.html"
       },
       {
+        "path": "html/semantics/tabular-data/the-tbody-element/rows.html",
+        "url": "/html/semantics/tabular-data/the-tbody-element/rows.html"
+      },
+      {
+        "path": "html/semantics/tabular-data/the-tfoot-element/rows.html",
+        "url": "/html/semantics/tabular-data/the-tfoot-element/rows.html"
+      },
+      {
+        "path": "html/semantics/tabular-data/the-thead-element/rows.html",
+        "url": "/html/semantics/tabular-data/the-thead-element/rows.html"
+      },
+      {
         "path": "html/semantics/tabular-data/the-tr-element/cells.html",
         "url": "/html/semantics/tabular-data/the-tr-element/cells.html"
       },

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -4668,9 +4668,6 @@
   [HTMLTableSectionElement interface: existence and properties of interface object]
     expected: FAIL
 
-  [HTMLTableSectionElement interface: attribute rows]
-    expected: FAIL
-
   [HTMLTableSectionElement interface: operation insertRow(long)]
     expected: FAIL
 
@@ -4687,9 +4684,6 @@
     expected: FAIL
 
   [HTMLTableSectionElement interface: attribute vAlign]
-    expected: FAIL
-
-  [HTMLTableSectionElement interface: document.createElement("tbody") must inherit property "rows" with the proper type (0)]
     expected: FAIL
 
   [HTMLTableSectionElement interface: document.createElement("tbody") must inherit property "insertRow" with the proper type (1)]
@@ -4716,15 +4710,6 @@
   [HTMLTableSectionElement interface: document.createElement("tbody") must inherit property "vAlign" with the proper type (6)]
     expected: FAIL
 
-  [HTMLTableSectionElement must be primary interface of document.createElement("thead")]
-    expected: FAIL
-
-  [Stringification of document.createElement("thead")]
-    expected: FAIL
-
-  [HTMLTableSectionElement interface: document.createElement("thead") must inherit property "rows" with the proper type (0)]
-    expected: FAIL
-
   [HTMLTableSectionElement interface: document.createElement("thead") must inherit property "insertRow" with the proper type (1)]
     expected: FAIL
 
@@ -4747,15 +4732,6 @@
     expected: FAIL
 
   [HTMLTableSectionElement interface: document.createElement("thead") must inherit property "vAlign" with the proper type (6)]
-    expected: FAIL
-
-  [HTMLTableSectionElement must be primary interface of document.createElement("tfoot")]
-    expected: FAIL
-
-  [Stringification of document.createElement("tfoot")]
-    expected: FAIL
-
-  [HTMLTableSectionElement interface: document.createElement("tfoot") must inherit property "rows" with the proper type (0)]
     expected: FAIL
 
   [HTMLTableSectionElement interface: document.createElement("tfoot") must inherit property "insertRow" with the proper type (1)]

--- a/tests/wpt/metadata/html/semantics/interfaces.html.ini
+++ b/tests/wpt/metadata/html/semantics/interfaces.html.ini
@@ -18,12 +18,6 @@
   [Interfaces for plaintext]
     expected: FAIL
 
-  [Interfaces for tfoot]
-    expected: FAIL
-
-  [Interfaces for thead]
-    expected: FAIL
-
   [Interfaces for xmp]
     expected: FAIL
 
@@ -49,12 +43,6 @@
     expected: FAIL
 
   [Interfaces for PLAINTEXT]
-    expected: FAIL
-
-  [Interfaces for TFOOT]
-    expected: FAIL
-
-  [Interfaces for THEAD]
     expected: FAIL
 
   [Interfaces for XMP]

--- a/tests/wpt/web-platform-tests/html/semantics/tabular-data/html-table-section-element.js
+++ b/tests/wpt/web-platform-tests/html/semantics/tabular-data/html-table-section-element.js
@@ -1,0 +1,22 @@
+// https://html.spec.whatwg.org/multipage/#dom-tbody-rows
+function testRowsAttribute(localName) {
+  var elem = document.createElement(localName);
+  assert_equals(elem.rows.length, 0);
+
+  // Child <p> should *not* count as a row
+  elem.appendChild(document.createElement("p"));
+  assert_equals(elem.rows.length, 0);
+
+  // Child <tr> should count as a row
+  var childTr = document.createElement("tr");
+  elem.appendChild(childTr);
+  assert_equals(elem.rows.length, 1);
+
+  // Nested table with child <tr> should *not* count as a row
+  var nested = document.createElement(localName);
+  nested.appendChild(document.createElement("tr"));
+  var nestedTable = document.createElement("table");
+  nestedTable.appendChild(nested);
+  childTr.appendChild(nestedTable);
+  assert_equals(elem.rows.length, 1);
+}

--- a/tests/wpt/web-platform-tests/html/semantics/tabular-data/the-tbody-element/rows.html
+++ b/tests/wpt/web-platform-tests/html/semantics/tabular-data/the-tbody-element/rows.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>'tbody' element, 'rows' attribute</title>
+<link rel="author" title="Corey Farwell" href="mailto:coreyf@rwell.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/html/semantics/tabular-data/html-table-section-element.js"></script>
+
+<div id ="log"></div>
+
+<script>
+test(function () {
+  testRowsAttribute('tbody');
+});
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/tabular-data/the-tfoot-element/rows.html
+++ b/tests/wpt/web-platform-tests/html/semantics/tabular-data/the-tfoot-element/rows.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>'tfoot' element, 'rows' attribute</title>
+<link rel="author" title="Corey Farwell" href="mailto:coreyf@rwell.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/html/semantics/tabular-data/html-table-section-element.js"></script>
+
+<div id ="log"></div>
+
+<script>
+test(function () {
+  testRowsAttribute('tfoot');
+});
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/tabular-data/the-thead-element/rows.html
+++ b/tests/wpt/web-platform-tests/html/semantics/tabular-data/the-thead-element/rows.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>'thead' element, 'rows' attribute</title>
+<link rel="author" title="Corey Farwell" href="mailto:coreyf@rwell.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/html/semantics/tabular-data/html-table-section-element.js"></script>
+
+<div id ="log"></div>
+
+<script>
+test(function () {
+  testRowsAttribute('thead');
+});
+</script>


### PR DESCRIPTION
'thead' and 'tfoot' now create instances of HTMLTableSectionElement

HTMLTableSectionElement.rows has been implemented

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7750)

<!-- Reviewable:end -->
