### PR TITLE
mach: fix OS X notifications

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -66,19 +66,20 @@ def notify_win(title, text):
 def notify_darwin(title, text):
     try:
         import Foundation
-        import objc
 
-        NSUserNotification = objc.lookUpClass("NSUserNotification")
-        NSUserNotificationCenter = objc.lookUpClass("NSUserNotificationCenter")
+        bundleDict = Foundation.NSBundle.mainBundle().infoDictionary()
+        bundleIdentifier = 'CFBundleIdentifier'
+        if bundleIdentifier not in bundleDict:
+            bundleDict[bundleIdentifier] = 'mach'
 
-        note = NSUserNotification.alloc().init()
+        note = Foundation.NSUserNotification.alloc().init()
         note.setTitle_(title)
         note.setInformativeText_(text)
 
         now = Foundation.NSDate.dateWithTimeInterval_sinceDate_(0, Foundation.NSDate.date())
         note.setDeliveryDate_(now)
 
-        centre = NSUserNotificationCenter.defaultUserNotificationCenter()
+        centre = Foundation.NSUserNotificationCenter.defaultUserNotificationCenter()
         centre.scheduleNotification_(note)
     except ImportError:
         raise Exception("Please make sure that the Python pyobjc module is installed!")


### PR DESCRIPTION
Since mach now puts everything into a virtualenv, we need to set the bundle identifier to allow sending notifications.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7752)

<!-- Reviewable:end -->
