### PR TITLE
Add form getters for additional elements; update test expectations

### DIFF
--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -5,7 +5,7 @@
 use dom::attr::Attr;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding;
 use dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;
-use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLLegendElementDerived};
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, HTMLLegendElementDerived};
 use dom::bindings::codegen::InheritTypes::{HTMLFieldSetElementDerived, NodeCast};
 use dom::bindings::js::{Root, RootedReference};
 use dom::document::Document;
@@ -13,6 +13,7 @@ use dom::element::{AttributeMutation, Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::node::{Node, NodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
@@ -79,6 +80,11 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
 
     // https://www.whatwg.org/html/#dom-fieldset-disabled
     make_bool_setter!(SetDisabled, "disabled");
+
+    // https://html.spec.whatwg.org/multipage#dom-fae-form
+    fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
 }
 
 impl VirtualMethods for HTMLFieldSetElement {
@@ -148,5 +154,11 @@ impl VirtualMethods for HTMLFieldSetElement {
             },
             _ => {},
         }
+    }
+}
+
+impl<'a> FormControl<'a> for &'a HTMLFieldSetElement {
+    fn to_element(self) -> &'a Element {
+        ElementCast::from_ref(self)
     }
 }

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -3,12 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::HTMLLabelElementBinding;
+use dom::bindings::codegen::Bindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
+use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLLabelElementDerived;
 use dom::bindings::js::Root;
 use dom::document::Document;
-use dom::element::ElementTypeId;
+use dom::element::{Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::node::{Node, NodeTypeId};
 use util::str::DOMString;
 
@@ -41,5 +44,18 @@ impl HTMLLabelElement {
                document: &Document) -> Root<HTMLLabelElement> {
         let element = HTMLLabelElement::new_inherited(localName, prefix, document);
         Node::reflect_node(box element, document, HTMLLabelElementBinding::Wrap)
+    }
+}
+
+impl HTMLLabelElementMethods for HTMLLabelElement {
+    // https://html.spec.whatwg.org/multipage#dom-fae-form
+    fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
+}
+
+impl<'a> FormControl<'a> for &'a HTMLLabelElement {
+    fn to_element(self) -> &'a Element {
+        ElementCast::from_ref(self)
     }
 }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -10,9 +10,10 @@ use dom::bindings::codegen::InheritTypes::HTMLObjectElementDerived;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::js::Root;
 use dom::document::Document;
-use dom::element::{AttributeMutation, ElementTypeId};
+use dom::element::{AttributeMutation, Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::node::{Node, NodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
@@ -92,6 +93,11 @@ impl HTMLObjectElementMethods for HTMLObjectElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-object-type
     make_setter!(SetType, "type");
+
+    // https://html.spec.whatwg.org/multipage#dom-fae-form
+    fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
 }
 
 impl VirtualMethods for HTMLObjectElement {
@@ -110,5 +116,11 @@ impl VirtualMethods for HTMLObjectElement {
             },
             _ => {},
         }
+    }
+}
+
+impl<'a> FormControl<'a> for &'a HTMLObjectElement {
+    fn to_element(self) -> &'a Element {
+        ElementCast::from_ref(self)
     }
 }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -4,12 +4,14 @@
 
 use dom::bindings::codegen::Bindings::HTMLOutputElementBinding;
 use dom::bindings::codegen::Bindings::HTMLOutputElementBinding::HTMLOutputElementMethods;
+use dom::bindings::codegen::InheritTypes::ElementCast;
 use dom::bindings::codegen::InheritTypes::HTMLOutputElementDerived;
 use dom::bindings::js::Root;
 use dom::document::Document;
-use dom::element::ElementTypeId;
+use dom::element::{Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::node::{Node, NodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
 use util::str::DOMString;
@@ -51,5 +53,16 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
     fn Validity(&self) -> Root<ValidityState> {
         let window = window_from_node(self);
         ValidityState::new(window.r())
+    }
+
+    // https://html.spec.whatwg.org/multipage#dom-fae-form
+    fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
+}
+
+impl<'a> FormControl<'a> for &'a HTMLOutputElement {
+    fn to_element(self) -> &'a Element {
+        ElementCast::from_ref(self)
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -5,15 +5,16 @@
 use dom::attr::{Attr, AttrValue};
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding;
 use dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElementMethods;
-use dom::bindings::codegen::InheritTypes::{HTMLElementCast, NodeCast};
+use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast, NodeCast};
 use dom::bindings::codegen::InheritTypes::{HTMLFieldSetElementDerived, HTMLSelectElementDerived};
 use dom::bindings::codegen::UnionTypes::HTMLElementOrLong;
 use dom::bindings::codegen::UnionTypes::HTMLOptionElementOrHTMLOptGroupElement;
 use dom::bindings::js::Root;
 use dom::document::Document;
-use dom::element::{AttributeMutation, ElementTypeId};
+use dom::element::{AttributeMutation, Element, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
+use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::node::{Node, NodeTypeId, window_from_node};
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
@@ -72,6 +73,11 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
 
     // https://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
+
+    // https://html.spec.whatwg.org/multipage#dom-fae-form
+    fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-multiple
     make_bool_getter!(Multiple);
@@ -152,5 +158,11 @@ impl VirtualMethods for HTMLSelectElement {
             &atom!("size") => AttrValue::from_u32(value, DEFAULT_SELECT_SIZE),
             _ => self.super_type().unwrap().parse_plain_attribute(local_name, value),
         }
+    }
+}
+
+impl<'a> FormControl<'a> for &'a HTMLSelectElement {
+    fn to_element(self) -> &'a Element {
+        ElementCast::from_ref(self)
     }
 }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -19,7 +19,7 @@ use dom::element::{AttributeMutation, Element, ElementTypeId};
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlelement::{HTMLElement, HTMLElementTypeId};
-use dom::htmlformelement::FormControl;
+use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::keyboardevent::KeyboardEvent;
 use dom::node::{ChildrenMutation, Node, NodeDamage};
 use dom::node::{NodeTypeId, document_from_node, window_from_node};
@@ -128,6 +128,11 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
 
     // https://www.whatwg.org/html/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
+
+    // https://html.spec.whatwg.org/multipage#dom-fae-form
+    fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
+        self.form_owner()
+    }
 
     // https://html.spec.whatwg.org/multipage/#attr-fe-name
     make_getter!(Name);

--- a/components/script/dom/webidls/HTMLFieldSetElement.webidl
+++ b/components/script/dom/webidls/HTMLFieldSetElement.webidl
@@ -6,7 +6,7 @@
 // https://www.whatwg.org/html/#htmlfieldsetelement
 interface HTMLFieldSetElement : HTMLElement {
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString name;
 
   //readonly attribute DOMString type;

--- a/components/script/dom/webidls/HTMLLabelElement.webidl
+++ b/components/script/dom/webidls/HTMLLabelElement.webidl
@@ -5,7 +5,7 @@
 
 // https://www.whatwg.org/html/#htmllabelelement
 interface HTMLLabelElement : HTMLElement {
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString htmlFor;
   //readonly attribute HTMLElement? control;
 };

--- a/components/script/dom/webidls/HTMLObjectElement.webidl
+++ b/components/script/dom/webidls/HTMLObjectElement.webidl
@@ -10,7 +10,7 @@ interface HTMLObjectElement : HTMLElement {
   //         attribute boolean typeMustMatch;
   //         attribute DOMString name;
   //         attribute DOMString useMap;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString width;
   //         attribute DOMString height;
   //readonly attribute Document? contentDocument;

--- a/components/script/dom/webidls/HTMLOutputElement.webidl
+++ b/components/script/dom/webidls/HTMLOutputElement.webidl
@@ -6,7 +6,7 @@
 // https://www.whatwg.org/html/#htmloutputelement
 interface HTMLOutputElement : HTMLElement {
   //[PutForwards=value] readonly attribute DOMSettableTokenList htmlFor;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString name;
 
   //readonly attribute DOMString type;

--- a/components/script/dom/webidls/HTMLSelectElement.webidl
+++ b/components/script/dom/webidls/HTMLSelectElement.webidl
@@ -7,7 +7,7 @@
 interface HTMLSelectElement : HTMLElement {
   //         attribute boolean autofocus;
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
            attribute boolean multiple;
            attribute DOMString name;
   //         attribute boolean required;

--- a/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -11,7 +11,7 @@ interface HTMLTextAreaElement : HTMLElement {
              attribute unsigned long cols;
   //         attribute DOMString dirName;
            attribute boolean disabled;
-  //readonly attribute HTMLFormElement? form;
+  readonly attribute HTMLFormElement? form;
   //         attribute DOMString inputMode;
   //         attribute long maxLength;
   //         attribute long minLength;

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -2730,9 +2730,6 @@
   [HTMLObjectElement interface: attribute useMap]
     expected: FAIL
 
-  [HTMLObjectElement interface: attribute form]
-    expected: FAIL
-
   [HTMLObjectElement interface: attribute width]
     expected: FAIL
 
@@ -5031,16 +5028,10 @@
   [HTMLLabelElement interface: existence and properties of interface object]
     expected: FAIL
 
-  [HTMLLabelElement interface: attribute form]
-    expected: FAIL
-
   [HTMLLabelElement interface: attribute htmlFor]
     expected: FAIL
 
   [HTMLLabelElement interface: attribute control]
-    expected: FAIL
-
-  [HTMLLabelElement interface: document.createElement("label") must inherit property "form" with the proper type (0)]
     expected: FAIL
 
   [HTMLLabelElement interface: document.createElement("label") must inherit property "htmlFor" with the proper type (1)]
@@ -5391,9 +5382,6 @@
   [HTMLSelectElement interface: attribute autofocus]
     expected: FAIL
 
-  [HTMLSelectElement interface: attribute form]
-    expected: FAIL
-
   [HTMLSelectElement interface: attribute required]
     expected: FAIL
 
@@ -5446,9 +5434,6 @@
     expected: FAIL
 
   [HTMLSelectElement interface: document.createElement("select") must inherit property "autofocus" with the proper type (1)]
-    expected: FAIL
-
-  [HTMLSelectElement interface: document.createElement("select") must inherit property "form" with the proper type (3)]
     expected: FAIL
 
   [HTMLSelectElement interface: document.createElement("select") must inherit property "required" with the proper type (6)]
@@ -5553,9 +5538,6 @@
   [HTMLTextAreaElement interface: attribute dirName]
     expected: FAIL
 
-  [HTMLTextAreaElement interface: attribute form]
-    expected: FAIL
-
   [HTMLTextAreaElement interface: attribute inputMode]
     expected: FAIL
 
@@ -5617,9 +5599,6 @@
     expected: FAIL
 
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "dirName" with the proper type (3)]
-    expected: FAIL
-
-  [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "form" with the proper type (5)]
     expected: FAIL
 
   [HTMLTextAreaElement interface: document.createElement("textarea") must inherit property "inputMode" with the proper type (6)]
@@ -5799,9 +5778,6 @@
   [HTMLOutputElement interface: attribute htmlFor]
     expected: FAIL
 
-  [HTMLOutputElement interface: attribute form]
-    expected: FAIL
-
   [HTMLOutputElement interface: attribute name]
     expected: FAIL
 
@@ -5833,9 +5809,6 @@
     expected: FAIL
 
   [HTMLOutputElement interface: document.createElement("output") must inherit property "htmlFor" with the proper type (0)]
-    expected: FAIL
-
-  [HTMLOutputElement interface: document.createElement("output") must inherit property "form" with the proper type (1)]
     expected: FAIL
 
   [HTMLOutputElement interface: document.createElement("output") must inherit property "name" with the proper type (2)]
@@ -5944,9 +5917,6 @@
     expected: FAIL
 
   [HTMLFieldSetElement interface: existence and properties of interface object]
-    expected: FAIL
-
-  [HTMLFieldSetElement interface: attribute form]
     expected: FAIL
 
   [HTMLFieldSetElement interface: attribute name]

--- a/tests/wpt/metadata/html/semantics/forms/form-control-infrastructure/form.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-control-infrastructure/form.html.ini
@@ -1,23 +1,5 @@
 [form.html]
   type: testharness
-  [fieldset.form]
-    expected: FAIL
-
   [keygen.form]
-    expected: FAIL
-
-  [label.form]
-    expected: FAIL
-
-  [object.form]
-    expected: FAIL
-
-  [output.form]
-    expected: FAIL
-
-  [select.form]
-    expected: FAIL
-
-  [textarea.form]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html.ini
@@ -3,9 +3,6 @@
   [The type attribute must return 'fieldset']
     expected: FAIL
 
-  [The form attribute must return the fieldset's form owner]
-    expected: FAIL
-
   [The elements must return an HTMLFormControlsCollection object]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/the-label-element/label-attributes.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-label-element/label-attributes.html.ini
@@ -27,12 +27,6 @@
   [A form control has no label 2.]
     expected: FAIL
 
-  [A label's form attribute should return its form owner.]
-    expected: FAIL
-
-  [Check that the labels property of a form control with no label returns a zero-length NodeList.]
-    expected: FAIL
-
   [A label's htmlFor attribute must reflect the for content attribute]
     expected: FAIL
 


### PR DESCRIPTION
This adds form getters for fieldset, label, object, output, select and
textarea elements.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7760)

<!-- Reviewable:end -->
