### PR TITLE
display input caret for textarea. fixes #7758

### DIFF
--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -431,9 +431,19 @@ fn split_first_fragment_at_newline_if_necessary(fragments: &mut LinkedList<Fragm
 
             string_before =
                 unscanned_text_fragment_info.text[..(position + 1)].to_owned();
-            insertion_point_before = unscanned_text_fragment_info.insertion_point;
             unscanned_text_fragment_info.text =
                 unscanned_text_fragment_info.text[(position + 1)..].to_owned().into_boxed_str();
+            let offset = CharIndex(string_before.char_indices().count() as isize);
+            match unscanned_text_fragment_info.insertion_point {
+                Some(insertion_point) if insertion_point >= offset => {
+                    insertion_point_before = None;
+                    unscanned_text_fragment_info.insertion_point = Some(insertion_point - offset);
+                }
+                Some(_) | None => {
+                    insertion_point_before = unscanned_text_fragment_info.insertion_point;
+                    unscanned_text_fragment_info.insertion_point = None;
+                }
+            };
         }
         first_fragment.transform(first_fragment.border_box.size,
                                  SpecificFragmentInfo::UnscannedText(

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -46,6 +46,8 @@ pub struct HTMLTextAreaElement {
 pub trait LayoutHTMLTextAreaElementHelpers {
     #[allow(unsafe_code)]
     unsafe fn get_value_for_layout(self) -> String;
+    #[allow(unsafe_code)]
+    unsafe fn get_absolute_insertion_point_for_layout(self) -> usize;
 }
 
 pub trait RawLayoutHTMLTextAreaElementHelpers {
@@ -60,6 +62,12 @@ impl LayoutHTMLTextAreaElementHelpers for LayoutJS<HTMLTextAreaElement> {
     #[allow(unsafe_code)]
     unsafe fn get_value_for_layout(self) -> String {
         (*self.unsafe_get()).textinput.borrow_for_layout().get_content()
+    }
+
+    #[allow(unrooted_must_root)]
+    #[allow(unsafe_code)]
+    unsafe fn get_absolute_insertion_point_for_layout(self) -> usize {
+        (*self.unsafe_get()).textinput.borrow_for_layout().get_absolute_insertion_point()
     }
 }
 

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -455,4 +455,14 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.edit_point.line = min(self.edit_point.line, self.lines.len() - 1);
         self.edit_point.index = min(self.edit_point.index, self.current_line_length());
     }
+
+    pub fn get_absolute_insertion_point(&self) -> usize {
+        self.lines.iter().enumerate().fold(0, |acc, (i, val)| {
+            if i < self.edit_point.line {
+                acc + val.len() + 1 // +1 for the \n
+            } else {
+                acc
+            }
+        }) + self.edit_point.index
+    }
 }

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -11,7 +11,7 @@ use std::borrow::ToOwned;
 use std::ffi::CStr;
 use std::iter::{Filter, Peekable};
 use std::ops::Deref;
-use std::str::{FromStr, Split, from_utf8};
+use std::str::{CharIndices, FromStr, Split, from_utf8};
 
 pub type DOMString = String;
 pub type StaticCharVec = &'static [char];
@@ -419,4 +419,17 @@ pub fn slice_chars(s: &str, begin: usize, end: usize) -> &str {
         (_, None) => panic!("slice_chars: `end` is beyond end of string"),
         (Some(a), Some(b)) => unsafe { s.slice_unchecked(a, b) }
     }
+}
+
+// searches a character index in CharIndices
+// returns indices.count if not found
+pub fn search_index(index: usize, indices: CharIndices) -> isize {
+    let mut character_count = 0;
+    for (character_index, _) in indices {
+        if character_index == index {
+            return character_count;
+        }
+        character_count += 1
+    }
+    character_count
 }

--- a/tests/unit/util/str.rs
+++ b/tests/unit/util/str.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use util::str::{split_html_space_chars, str_join};
+use util::str::{search_index, split_html_space_chars, str_join};
 
 
 #[test]
@@ -33,4 +33,16 @@ pub fn test_str_join_many() {
     let actual = str_join(&slice, "-");
     let expected = "-alpha--beta-gamma-";
     assert_eq!(actual, expected);
+}
+
+#[test]
+pub fn test_search_index() {
+    let tuples = [("", 1, 0),
+                  ("foo", 8, 3),
+                  ("føo", 8, 3),
+                  ("foo", 2, 2),
+                  ("føo", 2, 3)];
+    for t in tuples.iter() {
+        assert_eq!(search_index(t.1, t.0.char_indices()), t.2);
+    };
 }


### PR DESCRIPTION
This adds the input caret for textareas. Although, it does not handle multiline textareas correctly. The caret gets displayed for each line.

I'll look into that but that will take more time. Some feedback on this small patch would be appreciated though.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7761)

<!-- Reviewable:end -->
