### PR TITLE
script: Stop reallocating so much when converting DOM strings to JS values.

### DIFF
--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -394,8 +394,9 @@ impl<T: Float + FromJSValConvertible<Config=()>> FromJSValConvertible for Finite
 
 impl ToJSValConvertible for str {
     fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        let mut string_utf16: Vec<u16> = Vec::with_capacity(self.len());
         unsafe {
-            let string_utf16: Vec<u16> = self.utf16_units().collect();
+            string_utf16.extend(self.utf16_units());
             let jsstr = JS_NewUCStringCopyN(cx, string_utf16.as_ptr() as *const i16,
                                             string_utf16.len() as libc::size_t);
             if jsstr.is_null() {


### PR DESCRIPTION
This is split out from #6900.

`size_hint()` in `utf16_units()` seems busted, so we do it ourselves.

r? @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7765)

<!-- Reviewable:end -->
