### PR TITLE
Fix build notifications in Python 2.x on Linux

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -98,6 +98,7 @@ def notify(title, text):
     platforms, this function acts as a no-op."""
     platforms = {
         "linux": notify_linux,
+        "linux2": notify_linux,
         "win": notify_win,
         "darwin": notify_darwin
     }


### PR DESCRIPTION
In Python 2.x on Linux, `sys.platform == 'linux2'`.

https://docs.python.org/2/library/sys.html#sys.platform

r? @frewsxcv

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7769)

<!-- Reviewable:end -->
