### PR TITLE
Use the correct container size in compute_overflow

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -2126,9 +2126,10 @@ impl Flow for BlockFlow {
     }
 
     fn compute_overflow(&self) -> Rect<Au> {
-        self.fragment.compute_overflow(&self.base
-                                            .early_absolute_position_info
-                                            .relative_containing_block_size)
+        self.fragment.compute_overflow(&self.base.early_absolute_position_info
+                                                 .relative_containing_block_size,
+                                       self.base.early_absolute_position_info
+                                                .relative_containing_block_mode)
     }
 
     fn iterate_through_fragment_border_boxes(&self,

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2160,9 +2160,12 @@ impl Fragment {
     }
 
     /// Computes the overflow rect of this fragment relative to the start of the flow.
-    pub fn compute_overflow(&self, relative_containing_block_size: &LogicalSize<Au>) -> Rect<Au> {
-        // FIXME(pcwalton, #2795): Get the real container size.
-        let container_size = Size2D::zero();
+    pub fn compute_overflow(&self,
+                            relative_containing_block_size: &LogicalSize<Au>,
+                            relative_containing_block_mode: WritingMode)
+                            -> Rect<Au> {
+        let container_size =
+            relative_containing_block_size.to_physical(relative_containing_block_mode);
         let mut border_box = self.border_box.to_physical(self.style.writing_mode, container_size);
 
         // Relative position can cause us to draw outside our border box.

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1775,7 +1775,8 @@ impl Flow for InlineFlow {
         let mut overflow = ZERO_RECT;
         for fragment in &self.fragments.fragments {
             overflow = overflow.union(&fragment.compute_overflow(
-                    &self.base.early_absolute_position_info.relative_containing_block_size))
+                    &self.base.early_absolute_position_info.relative_containing_block_size,
+                    self.base.early_absolute_position_info.relative_containing_block_mode));
         }
         overflow
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -111,6 +111,18 @@
             "url": "/_mozilla/css/setpropertypriority.html"
           }
         ],
+        "css/stacking_context_rtl.html": [
+          {
+            "path": "css/stacking_context_rtl.html",
+            "references": [
+              [
+                "/_mozilla/css/stacking_context_rtl-ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/stacking_context_rtl.html"
+          }
+        ],
         "css/word-spacing.html": [
           {
             "path": "css/word-spacing.html",

--- a/tests/wpt/mozilla/tests/css/stacking_context_rtl-ref.html
+++ b/tests/wpt/mozilla/tests/css/stacking_context_rtl-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <style>
+      div {
+        background: green;
+        height: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    Test passes if there is a green rectangle below.
+    <div></div>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/stacking_context_rtl.html
+++ b/tests/wpt/mozilla/tests/css/stacking_context_rtl.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <link rel=match href="stacking_context_rtl-ref.html">
+    <style>
+      div {
+        background: green;
+        height: 100px;
+        direction: rtl;
+        position: relative;
+        z-index: 0;
+      }
+    </style>
+  </head>
+  <body>
+    Test passes if there is a green rectangle below.
+    <div></div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #7768 - positioning of RTL stacking contexts. r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7771)

<!-- Reviewable:end -->
