### PR TITLE
allow `./mach test` to run tests in tests/wpt/mozilla/

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -81,18 +81,19 @@ class MachCommands(CommandBase):
         suites = OrderedDict([
             ("tidy", {}),
             ("ref", {"kwargs": {"kind": render_mode},
-                     "path": path.abspath(path.join("tests", "ref")),
+                     "paths": [path.abspath(path.join("tests", "ref"))],
                      "include_arg": "name"}),
             ("wpt", {"kwargs": {"release": release},
-                     "path": path.abspath(path.join("tests", "wpt", "web-platform-tests")),
+                     "paths": [path.abspath(path.join("tests", "wpt", "web-platform-tests")),
+                               path.abspath(path.join("tests", "wpt", "mozilla"))],
                      "include_arg": "include"}),
             ("css", {"kwargs": {"release": release},
-                     "path": path.abspath(path.join("tests", "wpt", "css-tests")),
+                     "paths": [path.abspath(path.join("tests", "wpt", "css-tests"))],
                      "include_arg": "include"}),
             ("unit", {}),
         ])
 
-        suites_by_prefix = {v["path"]: k for k, v in suites.iteritems() if "path" in v}
+        suites_by_prefix = {path: k for k, v in suites.iteritems() if "paths" in v for path in v["paths"]}
 
         selected_suites = OrderedDict()
 


### PR DESCRIPTION
Allows running WPT tests in the tests/wpt/mozilla/ directory by using commands such as: 

```
./mach test tests/wpt/mozilla/tests/mozilla/union.html
```

Fixes #7772.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7789)

<!-- Reviewable:end -->
