### PR TITLE
Handle zero-sized source surfaces properly, and upgrade `ipc-channel` to incorporate the fix for zero-sized shmem on Mac.

### DIFF
--- a/components/canvas/canvas_paint_task.rs
+++ b/components/canvas/canvas_paint_task.rs
@@ -459,11 +459,15 @@ impl<'a> CanvasPaintTask<'a> {
     }
 
     fn set_fill_style(&mut self, style: FillOrStrokeStyle) {
-        self.state.fill_style = style.to_azure_pattern(&self.drawtarget)
+        if let Some(pattern) = style.to_azure_pattern(&self.drawtarget) {
+            self.state.fill_style = pattern
+        }
     }
 
     fn set_stroke_style(&mut self, style: FillOrStrokeStyle) {
-        self.state.stroke_style = style.to_azure_pattern(&self.drawtarget)
+        if let Some(pattern) = style.to_azure_pattern(&self.drawtarget) {
+            self.state.stroke_style = pattern
+        }
     }
 
     fn set_line_width(&mut self, width: f32) {
@@ -604,13 +608,15 @@ impl<'a> CanvasPaintTask<'a> {
             src_line += (image_size.width * 4) as usize;
         }
 
-        let source_surface = self.drawtarget.create_source_surface_from_data(
-            &dest,
-            dest_rect.size, dest_rect.size.width * 4, SurfaceFormat::B8G8R8A8);
-
-        self.drawtarget.copy_surface(source_surface,
-                                     Rect::new(Point2D::new(0, 0), dest_rect.size),
-                                     dest_rect.origin);
+        if let Some(source_surface) = self.drawtarget.create_source_surface_from_data(
+                &dest,
+                dest_rect.size,
+                dest_rect.size.width * 4,
+                SurfaceFormat::B8G8R8A8) {
+            self.drawtarget.copy_surface(source_surface,
+                                         Rect::new(Point2D::new(0, 0), dest_rect.size),
+                                         dest_rect.origin);
+        }
     }
 
     fn set_shadow_offset_x(&mut self, value: f64) {
@@ -728,18 +734,20 @@ fn write_image(draw_target: &DrawTarget,
     // azure_hl operates with integers. We need to cast the image size
     let image_size = image_size.to_i32();
 
-    let source_surface = draw_target.create_source_surface_from_data(
-        &image_data,
-        image_size, image_size.width * 4, SurfaceFormat::B8G8R8A8);
+    if let Some(source_surface) =
+            draw_target.create_source_surface_from_data(&image_data,
+                                                        image_size,
+                                                        image_size.width * 4,
+                                                        SurfaceFormat::B8G8R8A8) {
+        let draw_surface_options = DrawSurfaceOptions::new(filter, true);
+        let draw_options = DrawOptions::new(global_alpha, composition_op, AntialiasMode::None);
 
-    let draw_surface_options = DrawSurfaceOptions::new(filter, true);
-    let draw_options = DrawOptions::new(global_alpha, composition_op, AntialiasMode::None);
-
-    draw_target.draw_surface(source_surface,
-                             dest_rect.to_azfloat(),
-                             image_rect.to_azfloat(),
-                             draw_surface_options,
-                             draw_options);
+        draw_target.draw_surface(source_surface,
+                                 dest_rect.to_azfloat(),
+                                 image_rect.to_azfloat(),
+                                 draw_surface_options,
+                                 draw_options);
+    }
 }
 
 fn is_zero_size_gradient(pattern: &Pattern) -> bool {

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -286,13 +286,13 @@ pub enum FillOrStrokeStyle {
 }
 
 impl FillOrStrokeStyle {
-    pub fn to_azure_pattern(&self, drawtarget: &DrawTarget) -> Pattern {
+    pub fn to_azure_pattern(&self, drawtarget: &DrawTarget) -> Option<Pattern> {
         match *self {
             FillOrStrokeStyle::Color(ref color) => {
-                Pattern::Color(ColorPattern::new(color::new(color.red,
-                                                            color.green,
-                                                            color.blue,
-                                                            color.alpha)))
+                Some(Pattern::Color(ColorPattern::new(color::new(color.red,
+                                                                 color.green,
+                                                                 color.blue,
+                                                                 color.alpha))))
             },
             FillOrStrokeStyle::LinearGradient(ref linear_gradient_style) => {
                 let gradient_stops: Vec<GradientStop> = linear_gradient_style.stops.iter().map(|s| {
@@ -302,11 +302,11 @@ impl FillOrStrokeStyle {
                     }
                 }).collect();
 
-                Pattern::LinearGradient(LinearGradientPattern::new(
+                Some(Pattern::LinearGradient(LinearGradientPattern::new(
                     &Point2D::new(linear_gradient_style.x0 as AzFloat, linear_gradient_style.y0 as AzFloat),
                     &Point2D::new(linear_gradient_style.x1 as AzFloat, linear_gradient_style.y1 as AzFloat),
                     drawtarget.create_gradient_stops(&gradient_stops, ExtendMode::Clamp),
-                    &Matrix2D::identity()))
+                    &Matrix2D::identity())))
             },
             FillOrStrokeStyle::RadialGradient(ref radial_gradient_style) => {
                 let gradient_stops: Vec<GradientStop> = radial_gradient_style.stops.iter().map(|s| {
@@ -316,25 +316,25 @@ impl FillOrStrokeStyle {
                     }
                 }).collect();
 
-                Pattern::RadialGradient(RadialGradientPattern::new(
+                Some(Pattern::RadialGradient(RadialGradientPattern::new(
                     &Point2D::new(radial_gradient_style.x0 as AzFloat, radial_gradient_style.y0 as AzFloat),
                     &Point2D::new(radial_gradient_style.x1 as AzFloat, radial_gradient_style.y1 as AzFloat),
                     radial_gradient_style.r0 as AzFloat, radial_gradient_style.r1 as AzFloat,
                     drawtarget.create_gradient_stops(&gradient_stops, ExtendMode::Clamp),
-                    &Matrix2D::identity()))
+                    &Matrix2D::identity())))
             },
             FillOrStrokeStyle::Surface(ref surface_style) => {
-                let source_surface = drawtarget.create_source_surface_from_data(
-                    &surface_style.surface_data,
-                    surface_style.surface_size,
-                    surface_style.surface_size.width * 4,
-                    SurfaceFormat::B8G8R8A8);
-
-                Pattern::Surface(SurfacePattern::new(
-                    source_surface.azure_source_surface,
-                    surface_style.repeat_x,
-                    surface_style.repeat_y,
-                    &Matrix2D::identity()))
+                drawtarget.create_source_surface_from_data(&surface_style.surface_data,
+                                                           surface_style.surface_size,
+                                                           surface_style.surface_size.width * 4,
+                                                           SurfaceFormat::B8G8R8A8)
+                          .map(|source_surface| {
+                    Pattern::Surface(SurfacePattern::new(
+                        source_surface.azure_source_surface,
+                        surface_style.repeat_x,
+                        surface_style.repeat_y,
+                        &Matrix2D::identity()))
+                    })
             }
         }
     }

--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -196,10 +196,14 @@ impl<'a> PaintContext<'a> {
 
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
-        let azure_surface = draw_target_ref.create_source_surface_from_data(&image.bytes,
-                                                                            size,
-                                                                            stride as i32,
-                                                                            source_format);
+        let azure_surface = match draw_target_ref.create_source_surface_from_data(&image.bytes,
+                                                                                  size,
+                                                                                  stride as i32,
+                                                                                  source_format) {
+            Some(azure_surface) => azure_surface,
+            None => return,
+        };
+
         let source_rect = Rect::new(Point2D::new(0.0, 0.0),
                                     Size2D::new(image.width as AzFloat, image.height as AzFloat));
         let dest_rect = bounds.to_nearest_azure_rect(scale);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#befed8e71a7e66027905546e2057404edb0532f4"
+source = "git+https://github.com/servo/rust-azure#f517e08c00fcd0249f031ac1f976e18b57f3da60"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#63a7b00deb5296ff890cc2c7964e039dbd7aeb13"
+source = "git+https://github.com/pcwalton/ipc-channel#5e71fe6a1831e61e01ec8580bd3c3280b25d6054"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -82,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#befed8e71a7e66027905546e2057404edb0532f4"
+source = "git+https://github.com/servo/rust-azure#f517e08c00fcd0249f031ac1f976e18b57f3da60"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#63a7b00deb5296ff890cc2c7964e039dbd7aeb13"
+source = "git+https://github.com/pcwalton/ipc-channel#5e71fe6a1831e61e01ec8580bd3c3280b25d6054"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -50,6 +50,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "app_units"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "euclid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aster"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,7 +68,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "azure"
 version = "0.1.0"
-source = "git+https://github.com/servo/rust-azure#befed8e71a7e66027905546e2057404edb0532f4"
+source = "git+https://github.com/servo/rust-azure#f517e08c00fcd0249f031ac1f976e18b57f3da60"
 dependencies = [
  "core-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,6 +196,7 @@ dependencies = [
 name = "compositing"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -485,6 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gfx"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -496,7 +509,7 @@ dependencies = [
  "fontconfig 0.1.0 (git+https://github.com/servo/rust-fontconfig)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
- "harfbuzz 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
  "layers 0.1.0 (git+https://github.com/servo/rust-layers)",
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -517,6 +530,7 @@ dependencies = [
  "string_cache 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -569,11 +583,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "harfbuzz"
-version = "0.1.2"
+name = "harfbuzz-sys"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -692,7 +707,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/pcwalton/ipc-channel#63a7b00deb5296ff890cc2c7964e039dbd7aeb13"
+source = "git+https://github.com/pcwalton/ipc-channel#5e71fe6a1831e61e01ec8580bd3c3280b25d6054"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -758,6 +773,7 @@ dependencies = [
 name = "layout"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
@@ -789,6 +805,7 @@ dependencies = [
  "string_cache_plugin 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "unicode-bidi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
@@ -902,6 +919,7 @@ dependencies = [
 name = "msg"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -1230,6 +1248,7 @@ name = "script"
 version = "0.0.1"
 dependencies = [
  "angle 0.1.0 (git+https://github.com/ecoal95/angle?branch=servo)",
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1272,6 +1291,7 @@ dependencies = [
 name = "script_traits"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "euclid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -1447,6 +1467,7 @@ dependencies = [
 name = "style"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1551,6 +1572,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-script"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "harfbuzz-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unreachable"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1611,7 @@ dependencies = [
 name = "util"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.1.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Depends on servo/rust-azure#201 and pcwalton/ipc-channel#10.

Closes #7422.

r? @mbrubeck (don't r+ until the upstream dependencies have landed)

cc @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7802)

<!-- Reviewable:end -->
