### PR TITLE
Make util::str::str_join consistent with SliceConcatExt::join

### DIFF
--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -329,8 +329,8 @@ pub unsafe fn c_str_to_string(s: *const c_char) -> String {
 pub fn str_join<I, T>(strs: I, join: &str) -> String
     where I: IntoIterator<Item=T>, T: AsRef<str>,
 {
-    strs.into_iter().fold(String::new(), |mut acc, s| {
-        if !acc.is_empty() { acc.push_str(join); }
+    strs.into_iter().enumerate().fold(String::new(), |mut acc, (i, s)| {
+        if i > 0 { acc.push_str(join); }
         acc.push_str(s.as_ref());
         acc
     })

--- a/tests/unit/util/str.rs
+++ b/tests/unit/util/str.rs
@@ -2,11 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use util::str::split_html_space_chars;
+use util::str::{split_html_space_chars, str_join};
 
 
 #[test]
 pub fn split_html_space_chars_whitespace() {
     assert!(split_html_space_chars("").collect::<Vec<_>>().is_empty());
     assert!(split_html_space_chars("\u{0020}\u{0009}\u{000a}\u{000c}\u{000d}").collect::<Vec<_>>().is_empty());
+}
+
+#[test]
+pub fn test_str_join_empty() {
+    let slice = [] as [&str; 0];
+    let actual = str_join(&slice, "-");
+    let expected = "";
+    assert_eq!(actual, expected);
+}
+
+#[test]
+pub fn test_str_join_one() {
+    let slice = ["alpha"];
+    let actual = str_join(&slice, "-");
+    let expected = "alpha";
+    assert_eq!(actual, expected);
+}
+
+#[test]
+pub fn test_str_join_many() {
+    let slice = ["", "alpha", "", "beta", "gamma", ""];
+    let actual = str_join(&slice, "-");
+    let expected = "-alpha--beta-gamma-";
+    assert_eq!(actual, expected);
 }


### PR DESCRIPTION
Prior to this commit, `str_join` would skip empty items at the start of
the `Iterator` until it found a non-empty item. This contradicts
`SliceConcatExt::join` which doesn't skip anything.

Brought up in:

https://github.com/servo/servo/pull/7776#issuecomment-144317281

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7806)

<!-- Reviewable:end -->
