### PR TITLE
Make Linux build notifications transient

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -35,7 +35,7 @@ def notify_linux(title, text):
         bus = dbus.SessionBus()
         notify_obj = bus.get_object("org.freedesktop.Notifications", "/org/freedesktop/Notifications")
         method = notify_obj.get_dbus_method("Notify", "org.freedesktop.Notifications")
-        method(title, 0, "", text, "", [], [], -1)
+        method(title, 0, "", text, "", [], {"transient": True}, -1)
     except:
         raise Exception("Please make sure that the Python dbus module is installed!")
 


### PR DESCRIPTION
Continuous non-transient notifications, common in workflows involving
many syntax errors, can completely take over the message tray. Making
Linux build notifications transient prevents them from stacking up in
Gnome Shell without having to click them individually.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7824)

<!-- Reviewable:end -->
