### PR TITLE
Fully implement the "align descendants" rule for div.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -655,14 +655,6 @@ static HAS_FLOATED_DESCENDANTS_BITMASK: FlowFlags = FlowFlags { bits: 0b0000_001
 static TEXT_ALIGN_SHIFT: usize = 11;
 
 impl FlowFlags {
-    /// Propagates text alignment flags from an appropriate parent flow per CSS 2.1.
-    ///
-    /// FIXME(#2265, pcwalton): It would be cleaner and faster to make this a derived CSS property
-    /// `-servo-text-align-in-effect`.
-    pub fn propagate_text_alignment_from_parent(&mut self, parent_flags: FlowFlags) {
-        self.set_text_align_override(parent_flags);
-    }
-
     #[inline]
     pub fn text_align(self) -> text_align::T {
         text_align::T::from_u32((self & TEXT_ALIGN).bits() >> TEXT_ALIGN_SHIFT).unwrap()
@@ -672,11 +664,6 @@ impl FlowFlags {
     pub fn set_text_align(&mut self, value: text_align::T) {
         *self = (*self & !TEXT_ALIGN) |
                 FlowFlags::from_bits(value.to_u32() << TEXT_ALIGN_SHIFT).unwrap();
-    }
-
-    #[inline]
-    pub fn set_text_align_override(&mut self, parent: FlowFlags) {
-        self.insert(parent & TEXT_ALIGN);
     }
 
     #[inline]

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1018,8 +1018,14 @@ impl InlineFlow {
         // Translate `left` and `right` to logical directions.
         let is_ltr = fragments.fragments[0].style().writing_mode.is_bidi_ltr();
         let line_align = match (line_align, is_ltr) {
-            (text_align::T::left, true) | (text_align::T::right, false) => text_align::T::start,
-            (text_align::T::left, false) | (text_align::T::right, true) => text_align::T::end,
+            (text_align::T::left, true) |
+            (text_align::T::servo_left, true) |
+            (text_align::T::right, false) |
+            (text_align::T::servo_right, false) => text_align::T::start,
+            (text_align::T::left, false) |
+            (text_align::T::servo_left, false) |
+            (text_align::T::right, true) |
+            (text_align::T::servo_right, true) => text_align::T::end,
             _ => line_align
         };
 
@@ -1039,7 +1045,10 @@ impl InlineFlow {
                 inline_start_position_for_fragment = inline_start_position_for_fragment +
                     slack_inline_size
             }
-            text_align::T::left | text_align::T::right => unreachable!()
+            text_align::T::left |
+            text_align::T::servo_left |
+            text_align::T::right |
+            text_align::T::servo_right => unreachable!()
         }
 
         // Lay out the fragments in visual order.

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -2020,6 +2020,8 @@ pub mod longhands {
                 center("center") => 4,
                 justify("justify") => 5,
                 servo_center("-servo-center") => 6,
+                servo_left("-servo-left") => 7,
+                servo_right("-servo-right") => 8,
             }
         }
         #[inline] pub fn get_initial_value() -> computed_value::T {

--- a/resources/presentational-hints.css
+++ b/resources/presentational-hints.css
@@ -7,12 +7,9 @@ https://html.spec.whatwg.org/multipage/#presentational-hints
 
 pre[wrap] { white-space: pre-wrap; }
 
-/*
-FIXME: also "align descendants"
-https://html.spec.whatwg.org/multipage/#align-descendants
-*/
-div[align=left i] { text-align: left; }
-div[align=right i] { text-align: right; }
+div[align=left i] { text-align: -servo-left; }
+div[align=right i] { text-align: -servo-right; }
+div[align=center i], div[align=middle i] { text-align: -servo-center; }
 div[align=justify i] { text-align: justify; }
 
 

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -24,5 +24,5 @@ td[align="left"]    { text-align: left; }
 td[align="center"]  { text-align: center; }
 td[align="right"]   { text-align: right; }
 
-center, div[align=center i], div[align=middle i] { text-align: -servo-center; }
+center { text-align: -servo-center; }
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -4254,6 +4254,16 @@
         "url": "/html/rendering/non-replaced-elements/flow-content-0/figure.html"
       },
       {
+        "path": "html/rendering/non-replaced-elements/flow-content-0/div-align.html",
+        "references": [
+          [
+            "/html/rendering/non-replaced-elements/flow-content-0/div-align-ref.html",
+            "=="
+          ]
+        ],
+        "url": "/html/rendering/non-replaced-elements/flow-content-0/div-align.html"
+      },
+      {
         "path": "html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-a.html",
         "references": [
           [

--- a/tests/wpt/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/div-align-ref.html
+++ b/tests/wpt/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/div-align-ref.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset=utf-8>
+<link rel="match" href="div-align-ref.html">
+<style>
+.test { width: 50px; background-color: yellow; }
+.center { text-align: center; }
+.center .test { margin: 0 auto; }
+.left { text-align: left; }
+.left .test { margin-right: auto; }
+.right { text-align: right; }
+.right .test { margin-left: auto; }
+.rtl { direction: rtl; }
+.ltr { direction: ltr; }
+.left .margin { margin-left: 1em; }
+.right .margin { margin-right: 1em; }
+</style>
+</head>
+<body>
+<!-- Centered tests -->
+<div class=center>
+<div class=test>t א</div>
+<div class="test rtl">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div class=center>
+<div class="test left">t א</div>
+<div class="test right">t א</div>
+</div>
+
+<div class=left>
+<div class=center>
+<div class=test>t א</div>
+</div>
+</div>
+
+<!-- Left-aligned tests -->
+<div class=left>
+<div class=test>t א</div>
+<div class="test rtl">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div class="left rtl">
+<div class=test>t א</div>
+<div class="test ltr">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div class=left>
+<div class="test center">t א</div>
+<div class="test right">t א</div>
+</div>
+
+<!-- Right-aligned tests -->
+<div class=right>
+<div class=test>t א</div>
+<div class="test rtl">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div class="right rtl">
+<div class=test>t א</div>
+<div class="test ltr">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div class=right>
+<div class="test left">t א</div>
+<div class="test center">t א</div>
+</div>
+
+</body>
+</html>
+

--- a/tests/wpt/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/div-align.html
+++ b/tests/wpt/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/div-align.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset=utf-8>
+<style>
+.test { width: 50px; background-color: yellow; }
+.rtl { direction: rtl; }
+.ltr { direction: ltr; }
+[align=left] .margin { margin-left: 1em }
+[align=right] .margin { margin-right: 1em }
+</style>
+</head>
+<body>
+<!-- Centered tests -->
+<div align=center>
+<div class=test>t א</div>
+<div class="test rtl">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div align=center>
+<div class=test align=left>t א</div>
+<div class=test align=right>t א</div>
+</div>
+
+<div align=left>
+<div align=center>
+<div class=test>t א</div>
+</div>
+</div>
+
+<!-- Left-aligned tests -->
+<div align=left>
+<div class=test>t א</div>
+<div class="test rtl">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div align=left class=rtl>
+<div class=test>t א</div>
+<div class="test ltr">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div align=left>
+<div class=test align=center>t א</div>
+<div class=test align=right>t א</div>
+</div>
+
+<!-- Right-aligned tests -->
+<div align=right>
+<div class=test>t א</div>
+<div class="test rtl">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div align=right class=rtl>
+<div class=test>t א</div>
+<div class="test ltr">t א</div>
+<div class="test margin">t א</div>
+</div>
+
+<div align=right>
+<div class=test align=left>t א</div>
+<div class=test align=center>t א</div>
+</div>
+
+</body>
+</html>
+


### PR DESCRIPTION
This adds -servo-left and -servo-right to complement -servo-center.

~~This intentionally doesn't try to address issue #7301.~~  Commit added to address #7301.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7825)

<!-- Reviewable:end -->
