### PR TITLE
Check for font_variant equality in LayoutFontGroupCacheKey::eq.

### DIFF
--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -325,6 +325,7 @@ impl PartialEq for LayoutFontGroupCacheKey {
             self.pointer.font_stretch == other.pointer.font_stretch &&
             self.pointer.font_style == other.pointer.font_style &&
             self.pointer.font_weight as u16 == other.pointer.font_weight as u16 &&
+            self.pointer.font_variant == other.pointer.font_variant &&
             self.size == other.size
     }
 }


### PR DESCRIPTION
This fixes an issue whereby normal text would intermittently be rendered as
small-caps and vice versa.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7827)

<!-- Reviewable:end -->
