### PR TITLE
Define the parsed attribute getters for HTMLTableCellElement on LayoutJS.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -45,6 +45,7 @@ use dom::eventtarget::{EventTarget, EventTargetTypeId};
 use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElementTypeId;
 use dom::htmlinputelement::{HTMLInputElement, RawLayoutHTMLInputElementHelpers};
+use dom::htmltablecellelement::HTMLTableCellElementLayoutHelpers;
 use dom::htmltableelement::HTMLTableElement;
 use dom::htmltextareaelement::RawLayoutHTMLTextAreaElementHelpers;
 use dom::namednodemap::NamedNodeMap;
@@ -270,7 +271,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         } else if let Some(this) = HTMLTableElementCast::to_layout_js(self) {
             (*this.unsafe_get()).get_background_color()
         } else if let Some(this) = HTMLTableCellElementCast::to_layout_js(self) {
-            (*this.unsafe_get()).get_background_color()
+            this.get_background_color()
         } else if let Some(this) = HTMLTableRowElementCast::to_layout_js(self) {
             (*this.unsafe_get()).get_background_color()
         } else if let Some(this) = HTMLTableSectionElementCast::to_layout_js(self) {
@@ -387,7 +388,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         } else if let Some(this) = HTMLTableElementCast::to_layout_js(self) {
             (*this.unsafe_get()).get_width()
         } else if let Some(this) = HTMLTableCellElementCast::to_layout_js(self) {
-            (*this.unsafe_get()).get_width()
+            this.get_width()
         } else {
             LengthOrPercentageOrAuto::Auto
         };
@@ -504,7 +505,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         match attribute {
             UnsignedIntegerAttribute::ColSpan => {
                 if let Some(this) = HTMLTableCellElementCast::to_layout_js(self) {
-                    (*this.unsafe_get()).get_colspan()
+                    this.get_colspan()
                 } else {
                     // Don't panic since `display` can cause this to be called on arbitrary
                     // elements.

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -6,6 +6,7 @@ use cssparser::RGBA;
 use dom::attr::{Attr, AttrValue};
 use dom::bindings::codegen::Bindings::HTMLTableCellElementBinding::HTMLTableCellElementMethods;
 use dom::bindings::codegen::InheritTypes::{HTMLElementCast, HTMLTableCellElementDerived};
+use dom::bindings::js::LayoutJS;
 use dom::document::Document;
 use dom::element::{AttributeMutation, ElementTypeId};
 use dom::eventtarget::{EventTarget, EventTargetTypeId};
@@ -80,17 +81,30 @@ impl HTMLTableCellElementMethods for HTMLTableCellElement {
 }
 
 
-impl HTMLTableCellElement {
-    pub fn get_background_color(&self) -> Option<RGBA> {
-        self.background_color.get()
+pub trait HTMLTableCellElementLayoutHelpers {
+    fn get_background_color(&self) -> Option<RGBA>;
+    fn get_colspan(&self) -> Option<u32>;
+    fn get_width(&self) -> LengthOrPercentageOrAuto;
+}
+
+#[allow(unsafe_code)]
+impl HTMLTableCellElementLayoutHelpers for LayoutJS<HTMLTableCellElement> {
+    fn get_background_color(&self) -> Option<RGBA> {
+        unsafe {
+            (*self.unsafe_get()).background_color.get()
+        }
     }
 
-    pub fn get_colspan(&self) -> Option<u32> {
-        self.colspan.get()
+    fn get_colspan(&self) -> Option<u32> {
+        unsafe {
+            (*self.unsafe_get()).colspan.get()
+        }
     }
 
-    pub fn get_width(&self) -> LengthOrPercentageOrAuto {
-        self.width.get()
+    fn get_width(&self) -> LengthOrPercentageOrAuto {
+        unsafe {
+            (*self.unsafe_get()).width.get()
+        }
     }
 }
 


### PR DESCRIPTION
This documents their intended usage and prevents script callers from using
them.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7874)

<!-- Reviewable:end -->
