### PR TITLE
remove data field from websockets

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -76,7 +76,6 @@ pub struct WebSocket {
     clean_close: Cell<bool>, //Flag to tell if the websocket closed cleanly (not due to full or fail)
     code: Cell<u16>, //Closing code
     reason: DOMRefCell<DOMString>, //Closing reason
-    data: DOMRefCell<DOMString>, //Data from send - TODO: Remove after buffer is added.
     binary_type: Cell<BinaryType>,
 }
 
@@ -116,7 +115,6 @@ impl WebSocket {
             clean_close: Cell::new(true),
             code: Cell::new(0),
             reason: DOMRefCell::new("".to_owned()),
-            data: DOMRefCell::new("".to_owned()),
             binary_type: Cell::new(BinaryType::Blob),
         }
 


### PR DESCRIPTION
The data field is currently not used (no reads/ writes). This commit
removes this temp. field.

Ref.-Issue: #7859

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7880)

<!-- Reviewable:end -->
