### PR TITLE
Creates empty string when passed null

### DIFF
--- a/components/script/dom/webidls/WebSocket.webidl
+++ b/components/script/dom/webidls/WebSocket.webidl
@@ -28,7 +28,7 @@ interface WebSocket : EventTarget {
     //messaging
     attribute EventHandler onmessage;
     attribute BinaryType binaryType;
-    [Throws] void send(optional USVString data);
+    [Throws] void send(USVString data);
     //void send(Blob data);
     //void send(ArrayBuffer data);
     //void send(ArrayBufferView data);

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -256,7 +256,7 @@ impl WebSocketMethods for WebSocket {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-websocket-send
-    fn Send(&self, data: Option<USVString>) -> Fallible<()> {
+    fn Send(&self, data: USVString) -> Fallible<()> {
         match self.ready_state.get() {
             WebSocketRequestState::Connecting => {
                 return Err(Error::InvalidState);
@@ -278,7 +278,7 @@ impl WebSocketMethods for WebSocket {
         */
         let mut other_sender = self.sender.borrow_mut();
         let my_sender = other_sender.as_mut().unwrap();
-        let _ = my_sender.lock().unwrap().send_message(Message::Text(data.unwrap().0));
+        let _ = my_sender.lock().unwrap().send_message(Message::Text(data.0));
         Ok(())
     }
 

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -8739,18 +8739,6 @@
   [Location interface: window.location must have own property "reload"]
     expected: FAIL
 
-  [WebSocket interface: operation send(DOMString)]
-    expected: FAIL
-
-  [WebSocket interface: operation send(Blob)]
-    expected: FAIL
-
-  [WebSocket interface: operation send(ArrayBuffer)]
-    expected: FAIL
-
-  [WebSocket interface: operation send(ArrayBufferView)]
-    expected: FAIL
-
   [HTMLOptionElement must be primary interface of new Option()]
     expected: FAIL
 

--- a/tests/wpt/metadata/websockets/interfaces.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces.html.ini
@@ -15,18 +15,6 @@
   [WebSocket interface: attribute protocol]
     expected: FAIL
 
-  [WebSocket interface: operation send(DOMString)]
-    expected: FAIL
-
-  [WebSocket interface: operation send(Blob)]
-    expected: FAIL
-
-  [WebSocket interface: operation send(ArrayBuffer)]
-    expected: FAIL
-
-  [WebSocket interface: operation send(ArrayBufferView)]
-    expected: FAIL
-
   [Stringification of new WebSocket("ws://foo")]
     expected: FAIL
 
@@ -37,18 +25,6 @@
     expected: FAIL
 
   [WebSocket interface: new WebSocket("ws://foo") must inherit property "protocol" with the proper type (11)]
-    expected: FAIL
-
-  [WebSocket interface: calling send(DOMString) on new WebSocket("ws://foo") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [WebSocket interface: calling send(Blob) on new WebSocket("ws://foo") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [WebSocket interface: calling send(ArrayBuffer) on new WebSocket("ws://foo") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [WebSocket interface: calling send(ArrayBufferView) on new WebSocket("ws://foo") with too few arguments must throw TypeError]
     expected: FAIL
 
   [CloseEvent interface: existence and properties of interface object]

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/send/001.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/send/001.html.ini
@@ -1,5 +1,0 @@
-[001.html]
-  type: testharness
-  [WebSockets: send() with no args]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/navigator.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/navigator.html.ini
@@ -1,12 +1,10 @@
 [navigator.html]
   type: testharness
-
   [navigator.platform linux]
     expected:
       if os != "linux": FAIL
-      PASS
 
   [navigator.platform mac]
     expected:
       if os != "mac": FAIL
-      PASS
+


### PR DESCRIPTION
This should fix #7858.  An empty `USVString` is now used when `data` is `None`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7885)

<!-- Reviewable:end -->
