### PR TITLE
Use the correct IDL setter for <font>.size

### DIFF
--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -70,7 +70,11 @@ impl HTMLFontElementMethods for HTMLFontElement {
     make_getter!(Size);
 
     // https://html.spec.whatwg.org/multipage/#dom-font-size
-    make_setter!(SetSize, "size");
+    fn SetSize(&self, value: DOMString) {
+        let element = ElementCast::from_ref(self);
+        let length = parse_length(&value);
+        element.set_attribute(&Atom::from_slice("size"), AttrValue::Length(value, length));
+    }
 }
 
 impl VirtualMethods for HTMLFontElement {
@@ -100,7 +104,7 @@ impl VirtualMethods for HTMLFontElement {
         match name {
             &atom!("face") => AttrValue::from_atomic(value),
             &atom!("size") => {
-                let length = parse_legacy_font_size(&value).and_then(|parsed| specified::Length::from_str(&parsed));
+                let length = parse_length(&value);
                 AttrValue::Length(value, length)
             },
             _ => self.super_type().unwrap().parse_plain_attribute(name, value),
@@ -132,4 +136,8 @@ impl HTMLFontElement {
                 .cloned()
         }
     }
+}
+
+fn parse_length(value: &str) -> Option<specified::Length> {
+    parse_legacy_font_size(&value).and_then(|parsed| specified::Length::from_str(&parsed))
 }

--- a/tests/wpt/mozilla/tests/mozilla/htmlfontelement_size_attribute.html
+++ b/tests/wpt/mozilla/tests/mozilla/htmlfontelement_size_attribute.html
@@ -20,6 +20,11 @@ var sizes = ["0", "1", "2", "3", "4", "5", "6", "7", "8"];
 var testSize = function (attrValue) {
   elem.setAttribute("size", attrValue);
   assert_equals(elem.getAttribute("size"), attrValue);
+  assert_equals(elem.size, attrValue);
+
+  elem.size = attrValue;
+  assert_equals(elem.getAttribute("size"), attrValue);
+  assert_equals(elem.size, attrValue);
 }
 
 var args = [];


### PR DESCRIPTION
Previously, the IDL attribute would incorrectly set the `size` attribute
for `<font>` elements as `AttrValue::String`. Now it correctly sets it
as `AttrValue::Length`. Also included is a regression test.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7898)

<!-- Reviewable:end -->
