### PR TITLE
Make IDL attribute macros a bit more concise.

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -97,28 +97,16 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-coords
-    make_getter!(Coords);
-
-    // https://html.spec.whatwg.org/multipage/#dom-a-coords
-    make_setter!(SetCoords, "coords");
+    make_getter_setter!(Coords, SetCoords);
 
     // https://html.spec.whatwg.org/multipage/#dom-a-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#dom-a-name
-    make_setter!(SetName, "name");
+    make_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rev
-    make_getter!(Rev);
-
-    // https://html.spec.whatwg.org/multipage/#dom-a-rev
-    make_setter!(SetRev, "rev");
+    make_getter_setter!(Rev, SetRev);
 
     // https://html.spec.whatwg.org/multipage/#dom-a-shape
-    make_getter!(Shape);
-
-    // https://html.spec.whatwg.org/multipage/#dom-a-shape
-    make_setter!(SetShape, "shape");
+    make_getter_setter!(Shape, SetShape);
 }
 
 impl Activatable for HTMLAnchorElement {

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -51,10 +51,7 @@ impl HTMLAppletElement {
 
 impl HTMLAppletElementMethods for HTMLAppletElement {
     // https://html.spec.whatwg.org/#the-applet-element:dom-applet-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/#the-applet-element:dom-applet-name
-    make_atomic_setter!(SetName, "name");
+    make_atomic_getter_setter!(Name, SetName);
 }
 
 impl VirtualMethods for HTMLAppletElement {

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -68,10 +68,7 @@ impl HTMLBodyElement {
 
 impl HTMLBodyElementMethods for HTMLBodyElement {
     // https://html.spec.whatwg.org/multipage#dom-body-bgcolor
-    make_getter!(BgColor, "bgcolor");
-
-    // https://html.spec.whatwg.org/multipage#dom-body-bgcolor
-    make_setter!(SetBgColor, "bgcolor");
+    make_getter_setter!(BgColor, SetBgColor);
 
     // https://html.spec.whatwg.org/multipage/#the-body-element
     fn GetOnunload(&self) -> Option<Rc<EventHandlerNonNull>> {

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -77,10 +77,7 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
     }
 
     // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_setter!(SetDisabled, "disabled");
+    make_bool_getter_setter!(Disabled, SetDisabled);
 
     // https://html.spec.whatwg.org/multipage#dom-fae-form
     fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
@@ -88,56 +85,27 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-button-type
-    fn Type(&self) -> DOMString {
-        let elem = ElementCast::from_ref(self);
-        let mut ty = elem.get_string_attribute(&atom!("type"));
-        ty.make_ascii_lowercase();
-        // https://html.spec.whatwg.org/multipage/#attr-button-type
-        match &*ty {
-            "reset" | "button" | "menu" => ty,
-            _ => "submit".to_owned()
-        }
-    }
-
-    // https://html.spec.whatwg.org/multipage/#dom-button-type
-    make_setter!(SetType, "type");
+    make_enumerated_getter_setter!(Type, SetType, "submit", ("reset") | ("button") | ("menu"));
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formaction
-    make_url_or_base_getter!(FormAction);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-formaction
-    make_setter!(SetFormAction, "formaction");
+    make_url_or_base_getter_setter!(FormAction, SetFormAction);
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
-    make_enumerated_getter!(
-        FormEnctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
-    make_setter!(SetFormEnctype, "formenctype");
+    make_enumerated_getter_setter!(FormEnctype, SetFormEnctype,
+                                   "application/x-www-form-urlencoded",
+                                   ("text/plain") | ("multipart/form-data"));
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
-    make_enumerated_getter!(FormMethod, "get", ("post") | ("dialog"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
-    make_setter!(SetFormMethod, "formmethod");
+    make_enumerated_getter_setter!(FormMethod, SetFormMethod, "get", ("post") | ("dialog"));
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formtarget
-    make_getter!(FormTarget);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-formtarget
-    make_setter!(SetFormTarget, "formtarget");
+    make_getter_setter!(FormTarget, SetFormTarget);
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_setter!(SetName, "name");
+    make_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-button-value
-    make_getter!(Value);
-
-    // https://html.spec.whatwg.org/multipage/#dom-button-value
-    make_setter!(SetValue, "value");
+    make_getter_setter!(Value, SetValue);
 }
 
 impl VirtualMethods for HTMLButtonElement {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -236,6 +236,7 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-canvas-width
     fn SetWidth(&self, width: u32) {
+        // FIXME: This needs to cap width at 2147483647.
         let elem = ElementCast::from_ref(self);
         elem.set_uint_attribute(&atom!("width"), width)
     }
@@ -247,6 +248,7 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-canvas-height
     fn SetHeight(&self, height: u32) {
+        // FIXME: This needs to cap height at 2147483647.
         let elem = ElementCast::from_ref(self);
         elem.set_uint_attribute(&atom!("height"), height)
     }

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -51,10 +51,7 @@ impl HTMLDialogElement {
 
 impl HTMLDialogElementMethods for HTMLDialogElement {
     // https://html.spec.whatwg.org/multipage/#dom-dialog-open
-    make_bool_getter!(Open);
-
-    // https://html.spec.whatwg.org/multipage/#dom-dialog-open
-    make_bool_setter!(SetOpen, "open");
+    make_bool_getter_setter!(Open, SetOpen);
 
     // https://html.spec.whatwg.org/multipage/#dom-dialog-returnvalue
     fn ReturnValue(&self) -> DOMString {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -127,19 +127,13 @@ impl HTMLElementMethods for HTMLElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-title
-    make_getter!(Title);
-    // https://html.spec.whatwg.org/multipage/#attr-title
-    make_setter!(SetTitle, "title");
+    make_getter_setter!(Title, SetTitle);
 
     // https://html.spec.whatwg.org/multipage/#attr-lang
-    make_getter!(Lang);
-    // https://html.spec.whatwg.org/multipage/#attr-lang
-    make_setter!(SetLang, "lang");
+    make_getter_setter!(Lang, SetLang);
 
     // https://html.spec.whatwg.org/multipage/#dom-hidden
-    make_bool_getter!(Hidden);
-    // https://html.spec.whatwg.org/multipage/#dom-hidden
-    make_bool_setter!(SetHidden, "hidden");
+    make_bool_getter_setter!(Hidden, SetHidden);
 
     // https://html.spec.whatwg.org/multipage/#globaleventhandlers
     global_event_handlers!(NoOnload);

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -76,10 +76,7 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
     }
 
     // https://www.whatwg.org/html/#dom-fieldset-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html/#dom-fieldset-disabled
-    make_bool_setter!(SetDisabled, "disabled");
+    make_bool_getter_setter!(Disabled, SetDisabled);
 
     // https://html.spec.whatwg.org/multipage#dom-fae-form
     fn GetForm(&self) -> Option<Root<HTMLFormElement>> {

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -55,25 +55,22 @@ impl HTMLFontElement {
 
 impl HTMLFontElementMethods for HTMLFontElement {
     // https://html.spec.whatwg.org/multipage/#dom-font-color
-    make_getter!(Color, "color");
-
-    // https://html.spec.whatwg.org/multipage/#dom-font-color
-    make_setter!(SetColor, "color");
+    make_getter_setter!(Color, SetColor);
 
     // https://html.spec.whatwg.org/multipage/#dom-font-face
-    make_getter!(Face);
-
-    // https://html.spec.whatwg.org/multipage/#dom-font-face
-    make_atomic_setter!(SetFace, "face");
+    make_atomic_getter_setter!(Face, SetFace);
 
     // https://html.spec.whatwg.org/multipage/#dom-font-size
-    make_getter!(Size);
+    fn Size(&self) -> DOMString {
+        let element = ElementCast::from_ref(self);
+        element.get_string_attribute(&atom!("size"))
+    }
 
     // https://html.spec.whatwg.org/multipage/#dom-font-size
     fn SetSize(&self, value: DOMString) {
         let element = ElementCast::from_ref(self);
         let length = parse_length(&value);
-        element.set_attribute(&Atom::from_slice("size"), AttrValue::Length(value, length));
+        element.set_attribute(&atom!("size"), AttrValue::Length(value, length));
     }
 }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -82,28 +82,18 @@ impl HTMLFormElement {
 
 impl HTMLFormElementMethods for HTMLFormElement {
     // https://html.spec.whatwg.org/multipage/#dom-form-acceptcharset
-    make_getter!(AcceptCharset, "accept-charset");
-
-    // https://html.spec.whatwg.org/multipage/#dom-form-acceptcharset
-    make_setter!(SetAcceptCharset, "accept-charset");
+    make_getter_setter!(AcceptCharset, SetAcceptCharset, "accept-charset");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-action
-    make_url_or_base_getter!(Action);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-action
-    make_setter!(SetAction, "action");
+    make_url_or_base_getter_setter!(Action, SetAction);
 
     // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
-    make_enumerated_getter!(Autocomplete, "on", ("off"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
-    make_setter!(SetAutocomplete, "autocomplete");
+    make_enumerated_getter_setter!(Autocomplete, SetAutocomplete, "on", ("off"));
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
-    make_enumerated_getter!(Enctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
-    make_setter!(SetEnctype, "enctype");
+    make_enumerated_getter_setter!(Enctype, SetEnctype,
+                                   "application/x-www-form-urlencoded",
+                                   ("text/plain") | ("multipart/form-data"));
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-encoding
     fn Encoding(&self) -> DOMString {
@@ -116,28 +106,16 @@ impl HTMLFormElementMethods for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-method
-    make_enumerated_getter!(Method, "get", ("post") | ("dialog"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-method
-    make_setter!(SetMethod, "method");
+    make_enumerated_getter_setter!(Method, SetMethod, "get", ("post") | ("dialog"));
 
     // https://html.spec.whatwg.org/multipage/#dom-form-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#dom-form-name
-    make_atomic_setter!(SetName, "name");
+    make_atomic_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-novalidate
-    make_bool_getter!(NoValidate);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-novalidate
-    make_bool_setter!(SetNoValidate, "novalidate");
+    make_bool_getter_setter!(NoValidate, SetNoValidate);
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-target
-    make_getter!(Target);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fs-target
-    make_setter!(SetTarget, "target");
+    make_getter_setter!(Target, SetTarget);
 
     // https://html.spec.whatwg.org/multipage/#the-form-element:concept-form-submit
     fn Submit(&self) {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -253,6 +253,7 @@ pub fn Navigate(iframe: &HTMLIFrameElement, direction: NavigationDirection) -> F
 impl HTMLIFrameElementMethods for HTMLIFrameElement {
     // https://html.spec.whatwg.org/multipage/#dom-iframe-src
     fn Src(&self) -> DOMString {
+        // FIXME: This is supposed to be a URL attribute.
         let element = ElementCast::from_ref(self);
         element.get_string_attribute(&atom!("src"))
     }
@@ -352,14 +353,10 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-dim-width
-    make_getter!(Width);
-    // https://html.spec.whatwg.org/multipage/#dom-dim-width
-    make_setter!(SetWidth, "width");
+    make_getter_setter!(Width, SetWidth);
 
     // https://html.spec.whatwg.org/multipage/#dom-dim-height
-    make_getter!(Height);
-    // https://html.spec.whatwg.org/multipage/#dom-dim-height
-    make_setter!(SetHeight, "height");
+    make_getter_setter!(Height, SetHeight);
 }
 
 impl VirtualMethods for HTMLIFrameElement {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -196,28 +196,16 @@ impl LayoutHTMLImageElementHelpers for LayoutJS<HTMLImageElement> {
 
 impl HTMLImageElementMethods for HTMLImageElement {
     // https://html.spec.whatwg.org/multipage/#dom-img-alt
-    make_getter!(Alt);
-    // https://html.spec.whatwg.org/multipage/#dom-img-alt
-    make_setter!(SetAlt, "alt");
+    make_getter_setter!(Alt, SetAlt);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-src
-    make_url_getter!(Src);
-    // https://html.spec.whatwg.org/multipage/#dom-img-src
-    make_setter!(SetSrc, "src");
+    make_url_getter_setter!(Src, SetSrc);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-usemap
-    make_getter!(UseMap);
-    // https://html.spec.whatwg.org/multipage/#dom-img-usemap
-    make_setter!(SetUseMap, "usemap");
+    make_getter_setter!(UseMap, SetUseMap);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-ismap
-    make_bool_getter!(IsMap);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-ismap
-    fn SetIsMap(&self, is_map: bool) {
-        let element = ElementCast::from_ref(self);
-        element.set_string_attribute(&atom!("ismap"), is_map.to_string())
-    }
+    make_bool_getter_setter!(IsMap, SetIsMap);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-width
     fn Width(&self) -> u32 {
@@ -228,6 +216,7 @@ impl HTMLImageElementMethods for HTMLImageElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-img-width
     fn SetWidth(&self, width: u32) {
+        // FIXME: This needs to cap width at 2147483647.
         let elem = ElementCast::from_ref(self);
         elem.set_uint_attribute(&atom!("width"), width)
     }
@@ -241,6 +230,7 @@ impl HTMLImageElementMethods for HTMLImageElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-img-height
     fn SetHeight(&self, height: u32) {
+        // FIXME: This needs to cap height at 2147483647.
         let elem = ElementCast::from_ref(self);
         elem.set_uint_attribute(&atom!("height"), height)
     }
@@ -272,40 +262,22 @@ impl HTMLImageElementMethods for HTMLImageElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-img-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-name
-    make_atomic_setter!(SetName, "name");
+    make_atomic_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-align
-    make_getter!(Align);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-align
-    make_setter!(SetAlign, "align");
+    make_getter_setter!(Align, SetAlign);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-hspace
-    make_uint_getter!(Hspace);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-hspace
-    make_uint_setter!(SetHspace, "hspace");
+    make_uint_getter_setter!(Hspace, SetHspace);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-vspace
-    make_uint_getter!(Vspace);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-vspace
-    make_uint_setter!(SetVspace, "vspace");
+    make_uint_getter_setter!(Vspace, SetVspace);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-longdesc
-    make_getter!(LongDesc);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-longdesc
-    make_setter!(SetLongDesc, "longdesc");
+    make_getter_setter!(LongDesc, SetLongDesc);
 
     // https://html.spec.whatwg.org/multipage/#dom-img-border
-    make_getter!(Border);
-
-    // https://html.spec.whatwg.org/multipage/#dom-img-border
-    make_setter!(SetBorder, "border");
+    make_getter_setter!(Border, SetBorder);
 }
 
 impl VirtualMethods for HTMLImageElement {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -229,10 +229,7 @@ impl RawLayoutHTMLInputElementHelpers for HTMLInputElement {
 
 impl HTMLInputElementMethods for HTMLInputElement {
     // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_setter!(SetDisabled, "disabled");
+    make_bool_getter_setter!(Disabled, SetDisabled);
 
     // https://html.spec.whatwg.org/multipage/#dom-fae-form
     fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
@@ -240,10 +237,7 @@ impl HTMLInputElementMethods for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-input-defaultchecked
-    make_bool_getter!(DefaultChecked, "checked");
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-defaultchecked
-    make_bool_setter!(SetDefaultChecked, "checked");
+    make_bool_getter_setter!(DefaultChecked, SetDefaultChecked, "checked");
 
     // https://html.spec.whatwg.org/multipage/#dom-input-checked
     fn Checked(&self) -> bool {
@@ -256,28 +250,19 @@ impl HTMLInputElementMethods for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-input-readonly
-    make_bool_getter!(ReadOnly);
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-readonly
-    make_bool_setter!(SetReadOnly, "readonly");
+    make_bool_getter_setter!(ReadOnly, SetReadOnly);
 
     // https://html.spec.whatwg.org/multipage/#dom-input-size
-    make_uint_getter!(Size, "size", DEFAULT_INPUT_SIZE);
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-size
-    make_limited_uint_setter!(SetSize, "size", DEFAULT_INPUT_SIZE);
+    make_limited_uint_getter_setter!(Size, SetSize, "size", DEFAULT_INPUT_SIZE);
 
     // https://html.spec.whatwg.org/multipage/#dom-input-type
-    make_enumerated_getter!(Type, "text", ("hidden") | ("search") | ("tel") |
-                                  ("url") | ("email") | ("password") |
-                                  ("datetime") | ("date") | ("month") |
-                                  ("week") | ("time") | ("datetime-local") |
-                                  ("number") | ("range") | ("color") |
-                                  ("checkbox") | ("radio") | ("file") |
-                                  ("submit") | ("image") | ("reset") | ("button"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-type
-    make_setter!(SetType, "type");
+    make_enumerated_getter_setter!(Type, SetType, "text", ("hidden") | ("search") | ("tel") |
+                                                          ("url") | ("email") | ("password") |
+                                                          ("datetime") | ("date") | ("month") |
+                                                          ("week") | ("time") | ("datetime-local") |
+                                                          ("number") | ("range") | ("color") |
+                                                          ("checkbox") | ("radio") | ("file") |
+                                                          ("submit") | ("image") | ("reset") | ("button"));
 
     // https://html.spec.whatwg.org/multipage/#dom-input-value
     fn Value(&self) -> DOMString {
@@ -292,47 +277,27 @@ impl HTMLInputElementMethods for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-input-defaultvalue
-    make_getter!(DefaultValue, "value");
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-defaultvalue
-    make_setter!(SetDefaultValue, "value");
+    make_getter_setter!(DefaultValue, SetDefaultValue, "value");
 
     // https://html.spec.whatwg.org/multipage/#attr-fe-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#attr-fe-name
-    make_atomic_setter!(SetName, "name");
+    make_atomic_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#attr-input-placeholder
-    make_getter!(Placeholder);
-
-    // https://html.spec.whatwg.org/multipage/#attr-input-placeholder
-    make_setter!(SetPlaceholder, "placeholder");
+    make_getter_setter!(Placeholder, SetPlaceholder);
 
     // https://html.spec.whatwg.org/multipage/#dom-input-formaction
-    make_url_or_base_getter!(FormAction);
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-formaction
-    make_setter!(SetFormAction, "formaction");
+    make_url_or_base_getter_setter!(FormAction, SetFormAction);
 
     // https://html.spec.whatwg.org/multipage/#dom-input-formenctype
-    make_enumerated_getter!(
-        FormEnctype, "application/x-www-form-urlencoded", ("text/plain") | ("multipart/form-data"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-formenctype
-    make_setter!(SetFormEnctype, "formenctype");
+    make_enumerated_getter_setter!(FormEnctype, SetFormEnctype,
+                                   "application/x-www-form-urlencoded",
+                                   ("text/plain") | ("multipart/form-data"));
 
     // https://html.spec.whatwg.org/multipage/#dom-input-formmethod
-    make_enumerated_getter!(FormMethod, "get", ("post") | ("dialog"));
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-formmethod
-    make_setter!(SetFormMethod, "formmethod");
+    make_enumerated_getter_setter!(FormMethod, SetFormMethod, "get", ("post") | ("dialog"));
 
     // https://html.spec.whatwg.org/multipage/#dom-input-formtarget
-    make_getter!(FormTarget);
-
-    // https://html.spec.whatwg.org/multipage/#dom-input-formtarget
-    make_setter!(SetFormTarget, "formtarget");
+    make_getter_setter!(FormTarget, SetFormTarget);
 
     // https://html.spec.whatwg.org/multipage/#dom-input-indeterminate
     fn Indeterminate(&self) -> bool {

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -202,34 +202,20 @@ impl HTMLLinkElement {
 
 impl HTMLLinkElementMethods for HTMLLinkElement {
     // https://html.spec.whatwg.org/multipage/#dom-link-href
-    make_url_getter!(Href);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-href
-    make_setter!(SetHref, "href");
+    make_url_getter_setter!(Href, SetHref);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-rel
-    make_getter!(Rel);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-rel
-    make_setter!(SetRel, "rel");
+    // FIXME: This should be make_tokenlist_getter_setter.
+    make_getter_setter!(Rel, SetRel);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-media
-    make_getter!(Media);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-media
-    make_setter!(SetMedia, "media");
+    make_getter_setter!(Media, SetMedia);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-hreflang
-    make_getter!(Hreflang);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-hreflang
-    make_setter!(SetHreflang, "hreflang");
+    make_getter_setter!(Hreflang, SetHreflang);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-type
-    make_getter!(Type);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-type
-    make_setter!(SetType, "type");
+    make_getter_setter!(Type, SetType);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-rellist
     fn RelList(&self) -> Root<DOMTokenList> {
@@ -239,22 +225,13 @@ impl HTMLLinkElementMethods for HTMLLinkElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-link-charset
-    make_getter!(Charset);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-charset
-    make_setter!(SetCharset, "charset");
+    make_getter_setter!(Charset, SetCharset);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-rev
-    make_getter!(Rev);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-rev
-    make_setter!(SetRev, "rev");
+    make_getter_setter!(Rev, SetRev);
 
     // https://html.spec.whatwg.org/multipage/#dom-link-target
-    make_getter!(Target);
-
-    // https://html.spec.whatwg.org/multipage/#dom-link-target
-    make_setter!(SetTarget, "target");
+    make_getter_setter!(Target, SetTarget);
 }
 
 pub struct StylesheetLoadDispatcher {

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -80,16 +80,10 @@ impl HTMLMetaElement {
 
 impl HTMLMetaElementMethods for HTMLMetaElement {
     // https://html.spec.whatwg.org/multipage/#dom-meta-name
-    make_getter!(Name, "name");
-
-    // https://html.spec.whatwg.org/multipage/#dom-meta-name
-    make_setter!(SetName, "name");
+    make_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-meta-content
-    make_getter!(Content, "content");
-
-    // https://html.spec.whatwg.org/multipage/#dom-meta-content
-    make_setter!(SetContent, "content");
+    make_getter_setter!(Content, SetContent);
 }
 
 impl VirtualMethods for HTMLMetaElement {

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -89,10 +89,7 @@ impl HTMLObjectElementMethods for HTMLObjectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-object-type
-    make_getter!(Type);
-
-    // https://html.spec.whatwg.org/multipage/#dom-object-type
-    make_setter!(SetType, "type");
+    make_getter_setter!(Type, SetType);
 
     // https://html.spec.whatwg.org/multipage#dom-fae-form
     fn GetForm(&self) -> Option<Root<HTMLFormElement>> {

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -50,10 +50,7 @@ impl HTMLOptGroupElement {
 
 impl HTMLOptGroupElementMethods for HTMLOptGroupElement {
     // https://www.whatwg.org/html#dom-optgroup-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html#dom-optgroup-disabled
-    make_bool_setter!(SetDisabled, "disabled");
+    make_bool_getter_setter!(Disabled, SetDisabled);
 }
 
 impl VirtualMethods for HTMLOptGroupElement {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -79,13 +79,7 @@ fn collect_text(element: &Element, value: &mut DOMString) {
 
 impl HTMLOptionElementMethods for HTMLOptionElement {
     // https://www.whatwg.org/html/#dom-option-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html/#dom-option-disabled
-    fn SetDisabled(&self, disabled: bool) {
-        let elem = ElementCast::from_ref(self);
-        elem.set_bool_attribute(&atom!("disabled"), disabled)
-    }
+    make_bool_getter_setter!(Disabled, SetDisabled);
 
     // https://www.whatwg.org/html/#dom-option-text
     fn Text(&self) -> DOMString {
@@ -113,7 +107,10 @@ impl HTMLOptionElementMethods for HTMLOptionElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-option-value
-    make_setter!(SetValue, "value");
+    fn SetValue(&self, value: DOMString) {
+        let element = ElementCast::from_ref(self);
+        element.set_string_attribute(&atom!("value"), value)
+    }
 
     // https://html.spec.whatwg.org/multipage/#attr-option-label
     fn Label(&self) -> DOMString {
@@ -127,13 +124,13 @@ impl HTMLOptionElementMethods for HTMLOptionElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-option-label
-    make_setter!(SetLabel, "label");
+    fn SetLabel(&self, value: DOMString) {
+        let element = ElementCast::from_ref(self);
+        element.set_string_attribute(&atom!("label"), value)
+    }
 
     // https://html.spec.whatwg.org/multipage/#dom-option-defaultselected
-    make_bool_getter!(DefaultSelected, "selected");
-
-    // https://html.spec.whatwg.org/multipage/#dom-option-defaultselected
-    make_bool_setter!(SetDefaultSelected, "selected");
+    make_bool_getter_setter!(DefaultSelected, SetDefaultSelected, "selected");
 
     // https://html.spec.whatwg.org/multipage/#dom-option-selected
     fn Selected(&self) -> bool {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -579,9 +579,7 @@ impl VirtualMethods for HTMLScriptElement {
 
 impl HTMLScriptElementMethods for HTMLScriptElement {
     // https://html.spec.whatwg.org/multipage/#dom-script-src
-    make_url_getter!(Src);
-    // https://html.spec.whatwg.org/multipage/#dom-script-src
-    make_setter!(SetSrc, "src");
+    make_url_getter_setter!(Src, SetSrc);
 
     // https://www.whatwg.org/html/#dom-script-text
     fn Text(&self) -> DOMString {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -69,10 +69,7 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     }
 
     // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_setter!(SetDisabled, "disabled");
+    make_bool_getter_setter!(Disabled, SetDisabled);
 
     // https://html.spec.whatwg.org/multipage#dom-fae-form
     fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
@@ -80,22 +77,13 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-multiple
-    make_bool_getter!(Multiple);
-
-    // https://html.spec.whatwg.org/multipage/#dom-select-multiple
-    make_bool_setter!(SetMultiple, "multiple");
+    make_bool_getter_setter!(Multiple, SetMultiple);
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_setter!(SetName, "name");
+    make_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-select-size
-    make_uint_getter!(Size, "size", DEFAULT_SELECT_SIZE);
-
-    // https://html.spec.whatwg.org/multipage/#dom-select-size
-    make_uint_setter!(SetSize, "size", DEFAULT_SELECT_SIZE);
+    make_uint_getter_setter!(Size, SetSize, "size", DEFAULT_SELECT_SIZE);
 
     // https://html.spec.whatwg.org/multipage/#dom-select-type
     fn Type(&self) -> DOMString {

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -74,10 +74,7 @@ impl HTMLTableCellElement {
 
 impl HTMLTableCellElementMethods for HTMLTableCellElement {
     // https://html.spec.whatwg.org/multipage/#dom-tdth-colspan
-    make_uint_getter!(ColSpan, "colspan", DEFAULT_COLSPAN);
-
-    // https://html.spec.whatwg.org/multipage/#dom-tdth-colspan
-    make_uint_setter!(SetColSpan, "colspan");
+    make_uint_getter_setter!(ColSpan, SetColSpan, "colspan", DEFAULT_COLSPAN);
 }
 
 

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -129,10 +129,7 @@ impl HTMLTableElementMethods for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-bgcolor
-    make_getter!(BgColor);
-
-    // https://html.spec.whatwg.org/multipage/#dom-table-bgcolor
-    make_setter!(SetBgColor, "bgcolor");
+    make_getter_setter!(BgColor, SetBgColor);
 }
 
 

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -75,10 +75,7 @@ impl HTMLTableRowElement {
 
 impl HTMLTableRowElementMethods for HTMLTableRowElement {
     // https://html.spec.whatwg.org/multipage/#dom-tr-bgcolor
-    make_getter!(BgColor);
-
-    // https://html.spec.whatwg.org/multipage/#dom-tr-bgcolor
-    make_setter!(SetBgColor, "bgcolor");
+    make_getter_setter!(BgColor, SetBgColor);
 
     // https://html.spec.whatwg.org/multipage/#dom-tr-cells
     fn Cells(&self) -> Root<HTMLCollection> {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -118,16 +118,10 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     // constraints
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-cols
-    make_uint_getter!(Cols, "cols", DEFAULT_COLS);
-
-    // https://html.spec.whatwg.org/multipage/#dom-textarea-cols
-    make_limited_uint_setter!(SetCols, "cols", DEFAULT_COLS);
+    make_limited_uint_getter_setter!(Cols, SetCols, "cols", DEFAULT_COLS);
 
     // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_getter!(Disabled);
-
-    // https://www.whatwg.org/html/#dom-fe-disabled
-    make_bool_setter!(SetDisabled, "disabled");
+    make_bool_getter_setter!(Disabled, SetDisabled);
 
     // https://html.spec.whatwg.org/multipage#dom-fae-form
     fn GetForm(&self) -> Option<Root<HTMLFormElement>> {
@@ -135,40 +129,22 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-fe-name
-    make_getter!(Name);
-
-    // https://html.spec.whatwg.org/multipage/#attr-fe-name
-    make_setter!(SetName, "name");
+    make_getter_setter!(Name, SetName);
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-placeholder
-    make_getter!(Placeholder);
-
-    // https://html.spec.whatwg.org/multipage/#dom-textarea-placeholder
-    make_setter!(SetPlaceholder, "placeholder");
+    make_getter_setter!(Placeholder, SetPlaceholder);
 
     // https://html.spec.whatwg.org/multipage/#attr-textarea-readonly
-    make_bool_getter!(ReadOnly);
-
-    // https://html.spec.whatwg.org/multipage/#attr-textarea-readonly
-    make_bool_setter!(SetReadOnly, "readonly");
+    make_bool_getter_setter!(ReadOnly, SetReadOnly);
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-required
-    make_bool_getter!(Required);
-
-    // https://html.spec.whatwg.org/multipage/#dom-textarea-required
-    make_bool_setter!(SetRequired, "required");
+    make_bool_getter_setter!(Required, SetRequired);
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-rows
-    make_uint_getter!(Rows, "rows", DEFAULT_ROWS);
-
-    // https://html.spec.whatwg.org/multipage/#dom-textarea-rows
-    make_limited_uint_setter!(SetRows, "rows", DEFAULT_ROWS);
+    make_limited_uint_getter_setter!(Rows, SetRows, "rows", DEFAULT_ROWS);
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-wrap
-    make_getter!(Wrap);
-
-    // https://html.spec.whatwg.org/multipage/#dom-textarea-wrap
-    make_setter!(SetWrap, "wrap");
+    make_getter_setter!(Wrap, SetWrap);
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-type
     fn Type(&self) -> DOMString {


### PR DESCRIPTION
Instead of making the getter and setter separate macros, just combine
them into one, which is almost always what we want to do.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7900)

<!-- Reviewable:end -->
