### PR TITLE
Make sure to correctly destroy old layers in collect_old_layers_for_pipeline.

### DIFF
--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -472,7 +472,9 @@ impl RcCompositorLayer for Rc<Layer<CompositorData>> {
                     }
 
                     // Keep this layer if it exists in the new layer list.
-                    return new_layers.iter().any(|properties| properties.id == extra_data.id);
+                    if new_layers.iter().any(|properties| properties.id == extra_data.id) {
+                        return true
+                    }
                 }
 
                 if let Some(ref subpage_info_for_this_layer) = extra_data.subpage_info {


### PR DESCRIPTION
The previous code would skip calling clear_all_tiles(), which led to a
panic in rust-layers. ("You should have disposed of the pixmap properly
with destroy()! This pixmap will leak!")

Ran into this messing around with pdf.js; no minimized testcase.
Maybe related to #7895.

r? @pcwalton

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7912)

<!-- Reviewable:end -->
