### PR TITLE
Simplify and unify compositor shutdown code paths

### DIFF
--- a/components/compositing/compositor_task.rs
+++ b/components/compositing/compositor_task.rs
@@ -280,7 +280,6 @@ impl CompositorTask {
 pub trait CompositorEventListener {
     fn handle_events(&mut self, events: Vec<WindowEvent>) -> bool;
     fn repaint_synchronously(&mut self);
-    fn shutdown(&mut self);
     fn pinch_zoom_level(&self) -> f32;
     /// Requests that the compositor send the title for the main frame as soon as possible.
     fn title_for_main_frame(&self);

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -186,10 +186,6 @@ impl Browser {
     pub fn request_title_for_main_frame(&self) {
         self.compositor.title_for_main_frame()
     }
-
-    pub fn shutdown(mut self) {
-        self.compositor.shutdown();
-    }
 }
 
 fn create_constellation(opts: opts::Opts,

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -75,11 +75,6 @@ fn main() {
     };
 
     maybe_unregister_glutin_resize_handler(&window);
-
-    let BrowserWrapper {
-        browser
-    } = browser;
-    browser.shutdown();
 }
 
 fn maybe_register_glutin_resize_handler(window: &Option<Rc<app::window::Window>>,

--- a/ports/gonk/src/main.rs
+++ b/ports/gonk/src/main.rs
@@ -98,9 +98,4 @@ fn main() {
             break
         }
     }
-
-    let BrowserWrapper {
-        browser
-    } = browser;
-    browser.shutdown();
 }


### PR DESCRIPTION
Unify all compositor shutdown code paths into two methods, one which
starts the shutdown and the other that finishes it. This simplifies the
way the compositor shuts down and prevents "leaking" pixmaps when
exiting in uncommon ways.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7913)

<!-- Reviewable:end -->
