### PR TITLE
Refactor away duplication of get_rooted functionality

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -303,7 +303,7 @@ impl Attr {
     }
 
     pub fn owner(&self) -> Option<Root<Element>> {
-        self.owner.get().map(Root::from_rooted)
+        self.owner.get_rooted()
     }
 
     pub fn summarize(&self) -> AttrInfo {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -290,7 +290,7 @@ impl Document {
 
     /// Returns the first `base` element in the DOM that has an `href` attribute.
     pub fn base_element(&self) -> Option<Root<HTMLBaseElement>> {
-        self.base_element.get().map(Root::from_rooted)
+        self.base_element.get_rooted()
     }
 
     /// Refresh the cached first base element in the DOM.
@@ -498,7 +498,7 @@ impl Document {
     /// Return the element that currently has focus.
     // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#events-focusevent-doc-focus
     pub fn get_focused_element(&self) -> Option<Root<Element>> {
-        self.focused.get().map(Root::from_rooted)
+        self.focused.get_rooted()
     }
 
     /// Initiate a new round of checking for elements requesting focus. The last element to call
@@ -519,14 +519,14 @@ impl Document {
     pub fn commit_focus_transaction(&self, focus_type: FocusType) {
         //TODO: dispatch blur, focus, focusout, and focusin events
 
-        if let Some(ref elem) = self.focused.get().map(|t| t.root()) {
+        if let Some(ref elem) = self.focused.get_rooted() {
             let node = NodeCast::from_ref(elem.r());
             node.set_focus_state(false);
         }
 
         self.focused.set(self.possibly_focused.get());
 
-        if let Some(ref elem) = self.focused.get().map(|t| t.root()) {
+        if let Some(ref elem) = self.focused.get_rooted() {
             let node = NodeCast::from_ref(elem.r());
             node.set_focus_state(true);
 
@@ -967,7 +967,7 @@ impl Document {
     }
 
     pub fn get_current_parser(&self) -> Option<Root<ServoHTMLParser>> {
-        self.current_parser.get().map(Root::from_rooted)
+        self.current_parser.get_rooted()
     }
 
     /// Find an iframe element in the document.
@@ -1509,7 +1509,7 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/#dom-document-currentscript
     fn GetCurrentScript(&self) -> Option<Root<HTMLScriptElement>> {
-        self.current_script.get().map(Root::from_rooted)
+        self.current_script.get_rooted()
     }
 
     // https://html.spec.whatwg.org/#dom-document-body

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -189,12 +189,12 @@ impl EventMethods for Event {
 
     // https://dom.spec.whatwg.org/#dom-event-target
     fn GetTarget(&self) -> Option<Root<EventTarget>> {
-        self.target.get().map(Root::from_rooted)
+        self.target.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-event-currenttarget
     fn GetCurrentTarget(&self) -> Option<Root<EventTarget>> {
-        self.current_target.get().map(Root::from_rooted)
+        self.current_target.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-event-defaultprevented

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -302,7 +302,7 @@ impl FileReaderMethods for FileReader {
 
     // https://w3c.github.io/FileAPI/#dfn-error
     fn GetError(&self) -> Option<Root<DOMException>> {
-        self.error.get().map(|error| error.root())
+        self.error.get_rooted()
     }
 
     // https://w3c.github.io/FileAPI/#dfn-result

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -162,7 +162,7 @@ impl MouseEventMethods for MouseEvent {
 
     // https://w3c.github.io/uievents/#widl-MouseEvent-relatedTarget
     fn GetRelatedTarget(&self) -> Option<Root<EventTarget>> {
-        self.related_target.get().map(Root::from_rooted)
+        self.related_target.get_rooted()
     }
 
     // See discussion at:

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -298,11 +298,11 @@ impl Node {
         assert!(new_child.next_sibling.get().is_none());
         match before {
             Some(ref before) => {
-                assert!(before.parent_node.get().map(Root::from_rooted).r() == Some(self));
+                assert!(before.parent_node.get_rooted().r() == Some(self));
                 let prev_sibling = before.GetPreviousSibling();
                 match prev_sibling {
                     None => {
-                        assert!(Some(*before) == self.first_child.get().map(Root::from_rooted).r());
+                        assert!(Some(*before) == self.first_child.get_rooted().r());
                         self.first_child.set(Some(JS::from_ref(new_child)));
                     },
                     Some(ref prev_sibling) => {
@@ -343,7 +343,7 @@ impl Node {
     ///
     /// Fails unless `child` is a child of this node.
     fn remove_child(&self, child: &Node) {
-        assert!(child.parent_node.get().map(Root::from_rooted).r() == Some(self));
+        assert!(child.parent_node.get_rooted().r() == Some(self));
         let prev_sibling = child.GetPreviousSibling();
         match prev_sibling {
             None => {
@@ -788,7 +788,7 @@ impl Node {
         let doc = self.owner_doc();
         let node = try!(doc.r().node_from_nodes_and_strings(nodes));
         // Step 2.
-        let first_child = self.first_child.get().map(Root::from_rooted);
+        let first_child = self.first_child.get_rooted();
         Node::pre_insert(node.r(), self, first_child.r()).map(|_| ())
     }
 
@@ -1937,7 +1937,7 @@ impl NodeMethods for Node {
 
     // https://dom.spec.whatwg.org/#dom-node-parentnode
     fn GetParentNode(&self) -> Option<Root<Node>> {
-        self.parent_node.get().map(Root::from_rooted)
+        self.parent_node.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-node-parentelement
@@ -1961,22 +1961,22 @@ impl NodeMethods for Node {
 
     // https://dom.spec.whatwg.org/#dom-node-firstchild
     fn GetFirstChild(&self) -> Option<Root<Node>> {
-        self.first_child.get().map(Root::from_rooted)
+        self.first_child.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-node-lastchild
     fn GetLastChild(&self) -> Option<Root<Node>> {
-        self.last_child.get().map(Root::from_rooted)
+        self.last_child.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-node-previoussibling
     fn GetPreviousSibling(&self) -> Option<Root<Node>> {
-        self.prev_sibling.get().map(Root::from_rooted)
+        self.prev_sibling.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-node-nextsibling
     fn GetNextSibling(&self) -> Option<Root<Node>> {
-        self.next_sibling.get().map(Root::from_rooted)
+        self.next_sibling.get_rooted()
     }
 
     // https://dom.spec.whatwg.org/#dom-node-nodevalue
@@ -2482,7 +2482,7 @@ impl VirtualMethods for Node {
                 self.children_count.set(added.len() as u32);
             },
         }
-        if let Some(list) = self.child_list.get().map(|list| list.root()) {
+        if let Some(list) = self.child_list.get_rooted() {
             list.as_children_list().children_changed(mutation);
         }
     }

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -108,6 +108,6 @@ impl StorageEventMethods for StorageEvent {
 
     // https://html.spec.whatwg.org/multipage/#dom-storageevent-storagearea
     fn GetStorageArea(&self) -> Option<Root<Storage>> {
-        self.storageArea.get().map(Root::from_rooted)
+        self.storageArea.get_rooted()
     }
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -87,7 +87,7 @@ impl UIEvent {
 impl UIEventMethods for UIEvent {
     // https://w3c.github.io/uievents/#widl-UIEvent-view
     fn GetView(&self) -> Option<Root<Window>> {
-        self.view.get().map(Root::from_rooted)
+        self.view.get_rooted()
     }
 
     // https://w3c.github.io/uievents/#widl-UIEvent-detail

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -724,7 +724,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
 
     // https://xhr.spec.whatwg.org/#the-responsexml-attribute
     fn GetResponseXML(&self) -> Option<Root<Document>> {
-        self.response_xml.get().map(Root::from_rooted)
+        self.response_xml.get_rooted()
     }
 }
 


### PR DESCRIPTION
Refactor .get().map(Root::from_rooted)
and .get().map(|foo| foo.root())
to .get_rooted() on MutNullableHeap objects.

First part done mechanically with the following comand:
sed -i s/"get().map(Root::from_rooted)"/"get_rooted()"/g *.rs

Second part done manually after finding them with
git grep ".get().map("

Fixes #7929.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7932)

<!-- Reviewable:end -->
