### PR TITLE
Fix spurious rebuilds of the script crate

### DIFF
--- a/components/script/makefile.cargo
+++ b/components/script/makefile.cargo
@@ -3,7 +3,7 @@
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) \
   $(filter $(subst *,%,$2),$d))
 
-PYTHON = $(shell which python2.7 2>/dev/null || echo python)
+PYTHON = $(shell which python2.7 2>/dev/null || echo python) -B
 BINDINGS_SRC = $(shell pwd)/dom/bindings/codegen
 WEBIDLS_SRC = $(shell pwd)/dom/webidls
 WEBIDLS = $(call rwildcard,$(WEBIDLS_SRC),*.webidl)


### PR DESCRIPTION
The script crate currently has a build script, and Cargo will consider all files
in the script crate as inputs to the build script as it otherwise doesn't know
[what the input files are](https://github.com/rust-lang/cargo/issues/1162). This means that if any file in the
source tree of the script crate changes (or is created) then Cargo will think it
needs to re-run the build script and rebuild the crate.

The build script of the script crate is invoking python, and consequently Python
is generating some bytecode files in the source tree. On the second build of
Servo, Cargo will see these new files, think that something has changed, and
will re-run the build script of the script crate.

This change passes the `-B` flag to python to avoid generating these bytecode
files, which should avoid tampering with the source tree and appease Cargo by
ensuring that it doesn't get rebuilt.

---

As a helpful tip to if this comes up again, this was discovered by using the
changes in rust-lang/cargo@c447e9d plus the change in rust-lang/cargo#2044. Once
`RUST_LOG` was set to `cargo::ops::cargo_rustc::fingerprint=info`, the second
run of `./mach build` printed out:

```
precalculated components have changed:
  1444364448.000000000s (/build/servo/components/script/dom/bindings/codegen/parser/WebIDL.pyc) !=
  1444364235.000000000s (/build/servo/components/script/document_loader.rs)
```

Which should help easily diagnose these kinds of problems in the future!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7936)

<!-- Reviewable:end -->
