### PR TITLE
Clarify some code in do_create_interface_objects

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -218,20 +218,21 @@ pub fn do_create_interface_objects(cx: *mut JSContext,
                                    dom_class: Option<&'static DOMClass>,
                                    members: &'static NativeProperties,
                                    rval: MutableHandleObject) {
+    assert!(rval.get().is_null());
     if let Some(proto_class) = proto_class {
         create_interface_prototype_object(cx, proto_proto,
                                           proto_class, members, rval);
-    }
 
-    if !rval.get().is_null() {
-        let dom_class_ptr = match dom_class {
-            Some(dom_class) => dom_class as *const DOMClass as *const libc::c_void,
-            None            => ptr::null() as *const libc::c_void,
-        };
+        if !rval.get().is_null() {
+            let dom_class_ptr = match dom_class {
+                Some(dom_class) => dom_class as *const DOMClass as *const libc::c_void,
+                None            => ptr::null() as *const libc::c_void,
+            };
 
-        unsafe {
-            JS_SetReservedSlot(rval.get(), DOM_PROTO_INSTANCE_CLASS_SLOT,
-                               PrivateValue(dom_class_ptr));
+            unsafe {
+                JS_SetReservedSlot(rval.get(), DOM_PROTO_INSTANCE_CLASS_SLOT,
+                                   PrivateValue(dom_class_ptr));
+            }
         }
     }
 


### PR DESCRIPTION
rval.get() is believed to be always null upon entering this function.
This assumption is verified by the added assertion.
It makes more sense to move the block of code that was moved inside
the if statement which is the only place where it can be initialized.

Fixes #7941.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7943)

<!-- Reviewable:end -->
