### PR TITLE
Refactor away unnecessary use of regex

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -351,7 +351,7 @@ def check_rust(file_name, contents):
             mods = []
 
         # There should not be any extra pointer dereferencing
-        if re.search(r": &Vec<", line) is not None:
+        if ": &Vec<" in line:
             yield (idx + 1, "use &[T] instead of &Vec<T>")
 
 


### PR DESCRIPTION
We don't need regex matching since ": &Vec<" doesn't
contain any special character.

New code reads better.

Fixes #7914.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7945)

<!-- Reviewable:end -->
