### PR TITLE
Prefer `.cloned()` over `.map(|foo| foo.clone())`

### DIFF
--- a/components/net/storage_task.rs
+++ b/components/net/storage_task.rs
@@ -106,7 +106,7 @@ impl StorageManager {
         let data = self.select_data(storage_type);
         sender.send(data.get(&origin)
                     .and_then(|entry| entry.keys().nth(index as usize))
-                    .map(|key| key.clone())).unwrap();
+                    .cloned()).unwrap();
     }
 
     fn keys(&self,

--- a/components/util/prefs.rs
+++ b/components/util/prefs.rs
@@ -176,7 +176,7 @@ pub fn reset_pref(name: &str) -> Arc<PrefValue> {
 
 pub fn reset_all_prefs() {
     let names = {
-        PREFS.lock().unwrap().keys().map(|x| x.clone()).collect::<Vec<String>>()
+        PREFS.lock().unwrap().keys().cloned().collect::<Vec<String>>()
     };
     for name in names.iter() {
         reset_pref(name);

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -100,7 +100,7 @@ fn main() {
 
     match run(test_opts,
               all_tests,
-              servo_args.iter().map(|x| x.clone()).collect()) {
+              servo_args.iter().cloned().collect()) {
         Ok(false) => process::exit(1), // tests failed
         Err(_) => process::exit(2),    // I/O-related failure
         _ => (),


### PR DESCRIPTION
There are other combinations of map and clone in the code, but
this commit only addresses the straightforward ones.

Fixes #7906.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7946)

<!-- Reviewable:end -->
