### PR TITLE
Adds bufferedAmount to Websocket (fixes #7856).

### DIFF
--- a/components/script/dom/webidls/WebSocket.webidl
+++ b/components/script/dom/webidls/WebSocket.webidl
@@ -15,7 +15,7 @@ interface WebSocket : EventTarget {
     const unsigned short CLOSING = 2;
     const unsigned short CLOSED = 3;
     readonly attribute unsigned short readyState;
-    //readonly attribute unsigned long bufferedAmount;
+    readonly attribute unsigned long bufferedAmount;
 
     //networking
     attribute EventHandler onopen;

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -132,6 +132,8 @@ pub struct WebSocket {
     url: Url,
     global: GlobalField,
     ready_state: Cell<WebSocketRequestState>,
+    buffered_amount: Cell<u32>,
+    clearing_buffer: Cell<bool>, //Flag to tell if there is a running task to clear buffered_amount
     #[ignore_heap_size_of = "Defined in std"]
     sender: RefCell<Option<Arc<Mutex<Sender<WebSocketStream>>>>>,
     failed: Cell<bool>, //Flag to tell if websocket was closed due to failure
@@ -172,6 +174,8 @@ impl WebSocket {
             url: url,
             global: GlobalField::from_rooted(&global),
             ready_state: Cell::new(WebSocketRequestState::Connecting),
+            buffered_amount: Cell::new(0),
+            clearing_buffer: Cell::new(false),
             failed: Cell::new(false),
             sender: RefCell::new(None),
             full: Cell::new(false),
@@ -314,6 +318,11 @@ impl WebSocketMethods for WebSocket {
         self.ready_state.get() as u16
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-websocket-bufferedamount
+    fn BufferedAmount(&self) -> u32 {
+        self.buffered_amount.get()
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-websocket-binarytype
     fn BinaryType(&self) -> BinaryType {
         self.binary_type.get()
@@ -340,14 +349,28 @@ impl WebSocketMethods for WebSocket {
         /*TODO: This is not up to spec see http://html.spec.whatwg.org/multipage/comms.html search for
                 "If argument is a string"
           TODO: Need to buffer data
-          TODO: bufferedAmount attribute returns the size of the buffer in bytes -
-                this is a required attribute defined in the websocket.webidl file
           TODO: The send function needs to flag when full by using the following
           self.full.set(true). This needs to be done when the buffer is full
         */
         let mut other_sender = self.sender.borrow_mut();
         let my_sender = other_sender.as_mut().unwrap();
+
+        self.buffered_amount.set(self.buffered_amount.get() + (data.0.as_bytes().len() as u32));
+
         let _ = my_sender.lock().unwrap().send_message(Message::Text(data.0));
+
+        if !self.clearing_buffer.get() && self.ready_state.get() == WebSocketRequestState::Open {
+            self.clearing_buffer.set(true);
+
+            let global = self.global.root();
+            let task = box BufferedAmountTask {
+                addr: Trusted::new(global.r().get_cx(), self, global.r().script_chan()),
+            };
+            let chan = global.r().script_chan();
+
+            chan.send(CommonScriptMsg::RunnableMsg(WebSocketEvent, task)).unwrap();
+        }
+
         Ok(())
     }
 
@@ -434,6 +457,24 @@ impl Runnable for ConnectionEstablishedTask {
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(EventTargetCast::from_ref(ws.r()));
+    }
+}
+
+struct BufferedAmountTask {
+    addr: Trusted<WebSocket>,
+}
+
+impl Runnable for BufferedAmountTask {
+    // See https://html.spec.whatwg.org/multipage/#dom-websocket-bufferedamount
+    //
+    // To be compliant with standards, we need to reset bufferedAmount only when the event loop
+    // reaches step 1.  In our implementation, the bytes will already have been sent on a background
+    // thread.
+    fn handler(self: Box<Self>) {
+        let ws = self.addr.root();
+
+        ws.buffered_amount.set(0);
+        ws.clearing_buffer.set(false);
     }
 }
 

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -8037,9 +8037,6 @@
   [WebSocket interface: existence and properties of interface object]
     expected: FAIL
 
-  [WebSocket interface: attribute bufferedAmount]
-    expected: FAIL
-
   [WebSocket interface: attribute extensions]
     expected: FAIL
 

--- a/tests/wpt/metadata/websockets/Secure-Send-65K-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Secure-Send-65K-data.htm.ini
@@ -1,8 +1,0 @@
-[Secure-Send-65K-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send  65K data on a Secure WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send 65K data on a Secure WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Secure-Send-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Secure-Send-data.htm.ini
@@ -1,8 +1,0 @@
-[Secure-Send-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send  data on a Secure WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send data on a Secure WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Secure-Send-paired-surrogates.htm.ini
+++ b/tests/wpt/metadata/websockets/Secure-Send-paired-surrogates.htm.ini
@@ -1,8 +1,0 @@
-[Secure-Send-paired-surrogates.htm]
-  type: testharness
-  [W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Secure-Send-unicode-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Secure-Send-unicode-data.htm.ini
@@ -1,8 +1,0 @@
-[Secure-Send-unicode-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send  unicode data on a Secure WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send unicode data on a Secure WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Send-0byte-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Send-0byte-data.htm.ini
@@ -1,8 +1,0 @@
-[Send-0byte-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send 0 byte data on a WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send 0 byte data on a WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Send-65K-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Send-65K-data.htm.ini
@@ -1,8 +1,0 @@
-[Send-65K-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send 65K data on a WebSocket -  Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send 65K data on a WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Send-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Send-data.htm.ini
@@ -1,8 +1,0 @@
-[Send-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send data on a WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send data on a WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Send-paired-surrogates.htm.ini
+++ b/tests/wpt/metadata/websockets/Send-paired-surrogates.htm.ini
@@ -1,8 +1,0 @@
-[Send-paired-surrogates.htm]
-  type: testharness
-  [W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Send-unicode-data.htm.ini
+++ b/tests/wpt/metadata/websockets/Send-unicode-data.htm.ini
@@ -1,8 +1,0 @@
-[Send-unicode-data.htm]
-  type: testharness
-  [W3C WebSocket API - Send unicode data on a WebSocket - Connection should be opened]
-    expected: FAIL
-
-  [W3C WebSocket API - Send unicode data on a WebSocket - Connection should be closed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/interfaces.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces.html.ini
@@ -6,9 +6,6 @@
   [WebSocket interface: existence and properties of interface prototype object]
     expected: FAIL
 
-  [WebSocket interface: attribute bufferedAmount]
-    expected: FAIL
-
   [WebSocket interface: attribute extensions]
     expected: FAIL
 
@@ -16,9 +13,6 @@
     expected: FAIL
 
   [Stringification of new WebSocket("ws://foo")]
-    expected: FAIL
-
-  [WebSocket interface: new WebSocket("ws://foo") must inherit property "bufferedAmount" with the proper type (6)]
     expected: FAIL
 
   [WebSocket interface: new WebSocket("ws://foo") must inherit property "extensions" with the proper type (10)]

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-deleting.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-deleting.html.ini
@@ -1,5 +1,0 @@
-[bufferedAmount-deleting.html]
-  type: testharness
-  [WebSockets: delete bufferedAmount]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-getting.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-getting.html.ini
@@ -1,5 +1,0 @@
-[bufferedAmount-getting.html]
-  type: testharness
-  [WebSockets: bufferedAmount after send()ing]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-initial.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-initial.html.ini
@@ -1,5 +1,0 @@
-[bufferedAmount-initial.html]
-  type: testharness
-  [WebSockets: getting bufferedAmount]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large.html.ini
@@ -1,5 +1,0 @@
-[bufferedAmount-large.html]
-  type: testharness
-  [WebSockets: bufferedAmount for 65K data]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-readonly.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-readonly.html.ini
@@ -1,5 +1,0 @@
-[bufferedAmount-readonly.html]
-  type: testharness
-  [WebSockets: setting bufferedAmount]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-unicode.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-unicode.html.ini
@@ -1,5 +1,0 @@
-[bufferedAmount-unicode.html]
-  type: testharness
-  [WebSockets: bufferedAmount for unicode data]
-    expected: FAIL
-


### PR DESCRIPTION
This adds a readonly bufferedAmount attribute to Servo's websocket implementation.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7947)

<!-- Reviewable:end -->
