### PR TITLE
Changed dom_class type to Option<&'static DOMClass> to fix #7942

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2357,11 +2357,11 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
 
         if self.descriptor.concrete:
             if self.descriptor.proxy:
-                domClass = "&Class"
+                domClass = "Some(&Class)"
             else:
-                domClass = "&Class.dom_class"
+                domClass = "Some(&Class.dom_class)"
         else:
-            domClass = "ptr::null()"
+            domClass = "None"
 
         if self.descriptor.interface.hasInterfaceObject():
             if self.descriptor.interface.ctor():

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -215,7 +215,7 @@ pub fn do_create_interface_objects(cx: *mut JSContext,
                                    proto_class: Option<&'static JSClass>,
                                    constructor: Option<(NonNullJSNative, &'static str, u32)>,
                                    named_constructors: &[(NonNullJSNative, &'static str, u32)],
-                                   dom_class: *const DOMClass,
+                                   dom_class: Option<&'static DOMClass>,
                                    members: &'static NativeProperties,
                                    rval: MutableHandleObject) {
     if let Some(proto_class) = proto_class {
@@ -223,10 +223,15 @@ pub fn do_create_interface_objects(cx: *mut JSContext,
                                           proto_class, members, rval);
     }
 
-    unsafe {
-        if !rval.get().is_null() {
+    if !rval.get().is_null() {
+        let dom_class_ptr = match dom_class {
+            Some(dom_class) => dom_class as *const DOMClass as *const libc::c_void,
+            None            => ptr::null() as *const libc::c_void,
+        };
+
+        unsafe {
             JS_SetReservedSlot(rval.get(), DOM_PROTO_INSTANCE_CLASS_SLOT,
-                               PrivateValue(dom_class as *const libc::c_void));
+                               PrivateValue(dom_class_ptr));
         }
     }
 


### PR DESCRIPTION
I have a feeling that converting `Option<&T>` to `*const libc::c_void` could be less explicit.
Was there any way to do it shorter?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7948)

<!-- Reviewable:end -->
