### PR TITLE
Update clipboard to a version with chdir("/") removed.

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#ca32bcf47b5e5fcc18e010b077dbf3b541aa6b52"
+source = "git+https://github.com/aweinstock314/rust-clipboard#ef4cf77c9c736e0951df797ff4e1a7c945ce2e34"
 dependencies = [
  "clipboard-win 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#ca32bcf47b5e5fcc18e010b077dbf3b541aa6b52"
+source = "git+https://github.com/aweinstock314/rust-clipboard#ef4cf77c9c736e0951df797ff4e1a7c945ce2e34"
 dependencies = [
  "clipboard-win 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "clipboard"
 version = "0.0.3"
-source = "git+https://github.com/aweinstock314/rust-clipboard#ca32bcf47b5e5fcc18e010b077dbf3b541aa6b52"
+source = "git+https://github.com/aweinstock314/rust-clipboard#ef4cf77c9c736e0951df797ff4e1a7c945ce2e34"
 dependencies = [
  "clipboard-win 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Relevant links:
http://logs.glob.uno/?c=mozilla%23servo&s=9+Oct+2015&e=10+Oct+2015#c279844
https://github.com/aweinstock314/rust-clipboard/commit/ef4cf77c9c736e0951df797ff4e1a7c945ce2e34

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7952)

<!-- Reviewable:end -->
