### PR TITLE
Issue #7905: Restore "headless" build on not Linux platforms.

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -824,6 +824,11 @@ impl WindowMethods for Window {
         NativeDisplay::new(ptr::null_mut())
     }
 
+    #[cfg(not(target_os = "linux"))]
+    fn native_display(&self) -> NativeDisplay {
+        NativeDisplay::new()
+    }
+
     /// Helper function to handle keyboard events.
     fn handle_key(&self, _: Key, _: constellation_msg::KeyModifiers) {
     }


### PR DESCRIPTION
Fix https://github.com/servo/servo/issues/7905 by implementing WindowMethods' native_display  in headless mode on "not Linux" platforms.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7957)

<!-- Reviewable:end -->
