### PR TITLE
Use typed header API instead of set_raw in set_default_accept_encoding

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -309,7 +309,10 @@ fn set_default_accept_encoding(headers: &mut Headers) {
         return
     }
 
-    headers.set_raw("Accept-Encoding".to_owned(), vec![b"gzip, deflate".to_vec()]);
+    headers.set(AcceptEncoding(vec![
+        qitem(Encoding::Gzip),
+        qitem(Encoding::Deflate)
+    ]));
 }
 
 fn set_default_accept(headers: &mut Headers) {


### PR DESCRIPTION
Fixes #7970

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7971)

<!-- Reviewable:end -->
