### PR TITLE
Use Travis container-based infra for test-tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-sudo: 9000
-services:
-  - docker
 
 before_install:
   - if [ "$DOCKER" = "1" ]; then docker build -t servo etc/ci/; fi
@@ -13,10 +10,14 @@ script:
 matrix:
   fast_finish: true
   include:
-    - env:
+    - sudo: false
+      env:
       - CMD="./mach test-tidy"
       - DOCKER=0
-    - env:
+    - sudo: 9000
+      services:
+      - docker
+      env:
       - CMD="./mach build -d --verbose"
       - DOCKER=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ matrix:
   include:
     - sudo: false
       env:
-      - CMD="./mach test-tidy"
-      - DOCKER=0
+        - CMD="./mach test-tidy"
+        - DOCKER=0
     - sudo: 9000
       services:
-      - docker
+        - docker
       env:
-      - CMD="./mach build -d --verbose"
-      - DOCKER=1
+        - CMD="./mach build -d --verbose"
+        - DOCKER=1
 
 branches:
   only:


### PR DESCRIPTION
I wasn't aware one could specify options like `sudo` and `services` on a per build-environment basis. Since the container-based builds are faster than normal builds, we should utilize it for test-tidy

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7974)

<!-- Reviewable:end -->
