### PR TITLE
Cleanup error handling in resource loaders.

### DIFF
--- a/components/net/about_loader.rs
+++ b/components/net/about_loader.rs
@@ -9,7 +9,7 @@ use hyper::mime::{Mime, SubLevel, TopLevel};
 use mime_classifier::MIMEClassifier;
 use net_traits::ProgressMsg::Done;
 use net_traits::{LoadConsumer, LoadData, Metadata};
-use resource_task::start_sending;
+use resource_task::{send_error, start_sending};
 use std::fs::PathExt;
 use std::sync::Arc;
 use url::Url;
@@ -24,8 +24,10 @@ pub fn factory(mut load_data: LoadData, start_chan: LoadConsumer, classifier: Ar
                 charset: Some("utf-8".to_owned()),
                 headers: None,
                 status: Some(RawStatus(200, "OK".into())),
-            });
-            chan.send(Done(Ok(()))).unwrap();
+            }, classifier, &[]);
+            if let Ok(chan) = chan {
+                let _ = chan.send(Done(Ok(())));
+            }
             return
         }
         "crash" => panic!("Loading the about:crash URL."),
@@ -36,9 +38,7 @@ pub fn factory(mut load_data: LoadData, start_chan: LoadConsumer, classifier: Ar
             load_data.url = Url::from_file_path(&*path).unwrap();
         }
         _ => {
-            start_sending(start_chan, Metadata::default(load_data.url))
-                .send(Done(Err("Unknown about: URL.".to_owned())))
-                .unwrap();
+            send_error(load_data.url, "Unknown about: URL.".to_owned(), start_chan);
             return
         }
     };

--- a/components/net/file_loader.rs
+++ b/components/net/file_loader.rs
@@ -5,13 +5,13 @@
 use mime_classifier::MIMEClassifier;
 use net_traits::ProgressMsg::{Done, Payload};
 use net_traits::{LoadConsumer, LoadData, Metadata};
-use resource_task::{ProgressSender, start_sending, start_sending_sniffed};
+use resource_task::{send_error, start_sending};
 use std::borrow::ToOwned;
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
-use std::path::PathBuf;
 use std::sync::Arc;
+use url::Url;
 use util::task::spawn_named;
 
 static READ_SIZE: usize = 8192;
@@ -33,49 +33,65 @@ fn read_block(reader: &mut File) -> Result<ReadStatus, String> {
     }
 }
 
-fn read_all(reader: &mut File, progress_chan: &ProgressSender)
-            -> Result<(), String> {
-    loop {
-        match try!(read_block(reader)) {
-            ReadStatus::Partial(buf) => progress_chan.send(Payload(buf)).unwrap(),
-            ReadStatus::EOF => return Ok(()),
-        }
-    }
-}
-
 pub fn factory(load_data: LoadData, senders: LoadConsumer, classifier: Arc<MIMEClassifier>) {
     let url = load_data.url;
     assert!(&*url.scheme == "file");
-    spawn_named("file_loader".to_owned(), move || {
-        let metadata = Metadata::default(url.clone());
-        let file_path: Result<PathBuf, ()> = url.to_file_path();
-        match file_path {
-            Ok(file_path) => {
-                match File::open(&file_path) {
-                    Ok(ref mut reader) => {
-                        let res = read_block(reader);
-                        let (res, progress_chan) = match res {
-                            Ok(ReadStatus::Partial(buf)) => {
-                                let progress_chan = start_sending_sniffed(senders, metadata,
-                                                                          classifier, &buf);
-                                progress_chan.send(Payload(buf)).unwrap();
-                                (read_all(reader, &progress_chan), progress_chan)
+    spawn_named("file_loader".to_owned(), move || load(url, senders, classifier));
+}
+
+fn load(url: Url, senders: LoadConsumer, classifier: Arc<MIMEClassifier>) {
+    // Open the file.
+    let reader = url.to_file_path()
+        .map_err(|_| "Cannot parse URL".to_owned())
+        .and_then(|path| File::open(&path).map_err(|e| e.to_string()));
+    let mut reader = match reader {
+        Ok(reader) => reader,
+        Err(e) => {
+            send_error(url, e, senders);
+            return;
+        }
+    };
+
+    // Start reading the file.
+    match read_block(&mut reader) {
+        Ok(ReadStatus::Partial(buf)) => {
+            // We read the first chunk of the file; start sending it across the
+            // channel.
+            // FIXME: Unlikely to happen in practice, but theoretically
+            // `buf` might not contain enough bytes for sniffing to be
+            // deterministic.
+            let metadata = Metadata::default(url);
+            if let Ok(progress_chan) = start_sending(senders, metadata, classifier, &buf) {
+                if progress_chan.send(Payload(buf)).is_err() {
+                    return
+                }
+                loop {
+                    match read_block(&mut reader) {
+                        Ok(ReadStatus::Partial(buf)) => {
+                            if progress_chan.send(Payload(buf)).is_err() {
+                                break;
                             }
-                            Ok(ReadStatus::EOF) | Err(_) =>
-                                (res.map(|_| ()), start_sending(senders, metadata)),
-                        };
-                        progress_chan.send(Done(res)).unwrap();
-                    }
-                    Err(e) => {
-                        let progress_chan = start_sending(senders, metadata);
-                        progress_chan.send(Done(Err(e.description().to_owned()))).unwrap();
+                        }
+                        Ok(ReadStatus::EOF) => {
+                            let _ = progress_chan.send(Done(Ok(())));
+                            break;
+                        }
+                        Err(e) => {
+                            let _ = progress_chan.send(Done(Err(e)));
+                            break;
+                        }
                     }
                 }
             }
-            Err(_) => {
-                let progress_chan = start_sending(senders, metadata);
-                progress_chan.send(Done(Err(url.to_string()))).unwrap();
+        }
+        Ok(ReadStatus::EOF) => {
+            // This is sort of a weird special-case: we successfully read the
+            // file, but it was empty.
+            let metadata = Metadata::default(url);
+            if let Ok(progress_chan) = start_sending(senders, metadata, classifier, &[]) {
+                let _ = progress_chan.send(Done(Ok(())));
             }
         }
-    });
+        Err(e) => send_error(url, e, senders),
+    };
 }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -26,7 +26,7 @@ use net_traits::ProgressMsg::{Done, Payload};
 use net_traits::hosts::replace_hosts;
 use net_traits::{CookieSource, IncludeSubdomains, LoadConsumer, LoadData, Metadata};
 use openssl::ssl::{SSL_VERIFY_PEER, SslContext, SslMethod};
-use resource_task::{start_sending_opt, start_sending_sniffed_opt};
+use resource_task::{send_error, start_sending};
 use std::borrow::ToOwned;
 use std::boxed::FnBox;
 use std::collections::HashSet;
@@ -69,16 +69,6 @@ pub fn factory(hsts_list: Arc<RwLock<HSTSList>>,
                               user_agent)
         })
     }
-}
-
-fn send_error(url: Url, err: String, start_chan: LoadConsumer) {
-    let mut metadata: Metadata = Metadata::default(url);
-    metadata.status = None;
-
-    match start_sending_opt(start_chan, metadata) {
-        Ok(p) => p.send(Done(Err(err))).unwrap(),
-        _ => {}
-    };
 }
 
 enum ReadResult {
@@ -719,7 +709,9 @@ fn send_data<R: Read>(reader: &mut R,
             Ok(ReadResult::Payload(buf)) => buf,
             _ => vec!(),
         };
-        let p = match start_sending_sniffed_opt(start_chan, metadata, classifier, &buf) {
+        // FIXME: We should try to ensure buf contains enough data that
+        // MIME sniffing is deterministic.
+        let p = match start_sending(start_chan, metadata, classifier, &buf) {
             Ok(p) => p,
             _ => return
         };


### PR DESCRIPTION
Make sure loaders always use the fallible, sniffing version of
resource_task::start_sending.  Refactor code to use the utility function
resource_task::send_error where appropriate. Don't panic if the resource
channel is cleaned up prematurely.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/7978)

<!-- Reviewable:end -->
