### PR TITLE
Uncomment some [PutForwards] attributes

### DIFF
--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -80,7 +80,7 @@ enum DocumentReadyState { "loading", "interactive", "complete" };
 // [OverrideBuiltins]
 partial /*sealed*/ interface Document {
   // resource metadata management
-  [/*PutForwards=href, */Unforgeable]
+  [PutForwards=href, Unforgeable]
   readonly attribute Location/*?*/ location;
   readonly attribute DOMString domain;
   // readonly attribute DOMString referrer;

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -13,7 +13,7 @@
   [BinaryName="Self_"] readonly attribute Window self;
   [Unforgeable] readonly attribute Document document;
   //         attribute DOMString name;
-  [/*PutForwards=href, */Unforgeable] readonly attribute Location location;
+  [PutForwards=href, Unforgeable] readonly attribute Location location;
   //readonly attribute History history;
   //[Replaceable] readonly attribute BarProp locationbar;
   //[Replaceable] readonly attribute BarProp menubar;

--- a/tests/wpt/metadata/html/browsers/the-window-object/window-properties.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/window-properties.html.ini
@@ -300,9 +300,6 @@
   [Window unforgeable attribute: window]
     expected: FAIL
 
-  [Window unforgeable attribute: location]
-    expected: FAIL
-
   [Window unforgeable attribute: top]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -1014,9 +1014,6 @@
   [Document interface: calling enableStyleSheetsForSet(DOMString) on document.implementation.createDocument(null, "", null) with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Document interface: document.implementation.createDocument(null, "", null) must have own property "location"]
-    expected: FAIL
-
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "domain" with the proper type (34)]
     expected: FAIL
 
@@ -6574,9 +6571,6 @@
     expected: FAIL
 
   [Window interface: window must inherit property "name" with the proper type (3)]
-    expected: FAIL
-
-  [Window interface: window must have own property "location"]
     expected: FAIL
 
   [Window interface: window must inherit property "history" with the proper type (5)]

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/079.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/079.html.ini
@@ -1,5 +1,4 @@
 [079.html]
   type: testharness
-  [ setting location to javascript URL from event handler ]
-    expected: FAIL
+  expected: TIMEOUT
 


### PR DESCRIPTION
Now that PutForwards was implemented in #5894, we can uncomment the attributes where the forwarded property exists on the target interface. Do we have tests for this?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8005)

<!-- Reviewable:end -->
