### PR TITLE
Z-index should be ignored for non-positioned stacking contexts

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1331,7 +1331,7 @@ impl FragmentDisplayListBuilding for Fragment {
         Arc::new(StackingContext::new(display_list,
                                       &border_box,
                                       &overflow,
-                                      self.style().get_box().z_index.number_or_zero(),
+                                      self.effective_z_index(),
                                       filters,
                                       self.style().get_effects().mix_blend_mode,
                                       transform,

--- a/tests/wpt/mozilla/tests/css/stacked_layers.html
+++ b/tests/wpt/mozilla/tests/css/stacked_layers.html
@@ -20,5 +20,12 @@
             <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: fixed;"></div>
             <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: absolute; top: 20px; z-index: 5;"> </div>
         </div>
+
+        <!-- The z-index of the second box should be ignored since it is not a positioned element.
+             so these boxes stack in tree order. -->
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; opacity: 0.999; z-index: -1;"></div>
+            <div class="gray box" style="margin-left: 20px; margin-top: -40px; opacity: 0.999;"> </div>
+        </div>
     </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/stacked_layers_ref.html
+++ b/tests/wpt/mozilla/tests/css/stacked_layers_ref.html
@@ -12,12 +12,17 @@
 <body>
     <div class="test grayest box">
         <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
-        <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: relative; top: 10px; z-index: 5;"></div>
+        <div class="gray box" style="margin-left: 20px; margin-top: 20px; position: relative; z-index: 5;"></div>
     </div>
 
     <div class="test grayest box">
         <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
         <div class="gray box" style="margin-left: 20px; margin-top: 10px; position: absolute; top: 20px; z-index: 5;"></div>
+    </div>
+
+    <div class="test grayest box">
+        <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute; opacity: 0.999;"></div>
+        <div class="gray box" style="margin-left: 20px; margin-top: 20px; position: relative; opacity: 0.999;"></div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
When a stacking-context is not positioned, its z-index should be
ignored. This is per CSS 2 9.9.1. The only exception to this is when
the z-index is applied to an element with display: flex | inline-flex.
inline-flex does not appear to be implemented at this time so we only
do this for flex.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8023)

<!-- Reviewable:end -->
