### PR TITLE
Fix uses of JS<T> as a type on the stack

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -315,7 +315,7 @@ impl Attr {
             }
             (old, new) => assert!(old == new)
         }
-        self.owner.set(owner.map(JS::from_ref))
+        self.owner.set(owner);
     }
 
     pub fn owner(&self) -> Option<Root<Element>> {

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -180,7 +180,7 @@ impl Attr {
             name: name,
             namespace: namespace,
             prefix: prefix,
-            owner: MutNullableHeap::new(owner.map(JS::from_ref)),
+            owner: MutNullableHeap::new(owner),
         }
     }
 

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -32,9 +32,10 @@ use js::jsapi::{Heap, JSObject, JSTracer};
 use js::jsval::JSVal;
 use layout_interface::TrustedNodeAddress;
 use script_task::STACK_ROOTS;
-use std::cell::{Cell, UnsafeCell};
+use std::cell::UnsafeCell;
 use std::default::Default;
 use std::ops::Deref;
+use std::ptr;
 use util::mem::HeapSizeOf;
 
 /// A traced reference to a DOM object. Must only be used as a field in other
@@ -54,7 +55,7 @@ impl<T> HeapSizeOf for JS<T> {
 
 impl<T> JS<T> {
     /// Returns `LayoutJS<T>` containing the same pointer.
-    pub unsafe fn to_layout(self) -> LayoutJS<T> {
+    pub unsafe fn to_layout(&self) -> LayoutJS<T> {
         LayoutJS {
             ptr: self.ptr.clone()
         }
@@ -108,8 +109,6 @@ impl<T: Reflectable> LayoutJS<T> {
         (**self.ptr).reflector().get_jsobject().get()
     }
 }
-
-impl<T> Copy for JS<T> {}
 
 impl<T> Copy for LayoutJS<T> {}
 
@@ -208,56 +207,62 @@ impl MutHeapJSVal {
 /// `JS<T>`.
 #[must_root]
 #[derive(JSTraceable)]
-#[derive(HeapSizeOf)]
-pub struct MutHeap<T: HeapGCValue + Copy> {
-    val: Cell<T>,
+pub struct MutHeap<T: HeapGCValue> {
+    val: UnsafeCell<T>,
 }
 
-impl<T: HeapGCValue + Copy> MutHeap<T> {
+impl<T: HeapGCValue> MutHeap<T> {
     /// Create a new `MutHeap`.
     pub fn new(initial: T) -> MutHeap<T> {
         MutHeap {
-            val: Cell::new(initial),
+            val: UnsafeCell::new(initial),
         }
     }
 
     /// Set this `MutHeap` to the given value.
     pub fn set(&self, val: T) {
-        self.val.set(val)
+        unsafe { *self.val.get() = val; }
     }
 
     /// Set the value in this `MutHeap`.
     pub fn get(&self) -> T {
-        self.val.get()
+        unsafe { ptr::read(self.val.get()) }
+    }
+}
+
+impl<T: HeapGCValue> HeapSizeOf for MutHeap<T> {
+    fn heap_size_of_children(&self) -> usize {
+        // See comment on HeapSizeOf for JS<T>.
+        0
     }
 }
 
 /// A mutable holder for GC-managed values such as `JSval` and `JS<T>`, with
-/// nullability represented by an enclosing Option wrapper. Must be used in
-/// place of traditional internal mutability to ensure that the proper GC
-/// barriers are enforced.
+/// nullability represented by an enclosing Option wrapper. Roughly equivalent
+/// to a DOMRefCell<Option<JS<T>>>, but smaller; the cost is that values which
+/// are read must be immediately rooted.
 #[must_root]
-#[derive(JSTraceable, HeapSizeOf)]
-pub struct MutNullableHeap<T: HeapGCValue + Copy> {
-    ptr: Cell<Option<T>>
+#[derive(JSTraceable)]
+pub struct MutNullableHeap<T: HeapGCValue> {
+    ptr: UnsafeCell<Option<T>>
 }
 
-impl<T: HeapGCValue + Copy> MutNullableHeap<T> {
+impl<T: HeapGCValue> MutNullableHeap<T> {
     /// Create a new `MutNullableHeap`.
     pub fn new(initial: Option<T>) -> MutNullableHeap<T> {
         MutNullableHeap {
-            ptr: Cell::new(initial)
+            ptr: UnsafeCell::new(initial)
         }
     }
 
     /// Set this `MutNullableHeap` to the given value.
     pub fn set(&self, val: Option<T>) {
-        self.ptr.set(val);
+        unsafe { *self.ptr.get() = val; }
     }
 
     /// Retrieve a copy of the current optional inner value.
     pub fn get(&self) -> Option<T> {
-        self.ptr.get()
+        unsafe { ptr::read(self.ptr.get()) }
     }
 }
 
@@ -280,7 +285,7 @@ impl<T: Reflectable> MutNullableHeap<JS<T>> {
     /// Retrieve a copy of the inner optional `JS<T>` as `LayoutJS<T>`.
     /// For use by layout, which can't use safe types like Temporary.
     pub unsafe fn get_inner_as_layout(&self) -> Option<LayoutJS<T>> {
-        self.ptr.get().map(|js| js.to_layout())
+        ptr::read(self.ptr.get()).map(|js| js.to_layout())
     }
 
     /// Get a rooted value out of this object
@@ -290,12 +295,19 @@ impl<T: Reflectable> MutNullableHeap<JS<T>> {
     }
 }
 
-impl<T: HeapGCValue + Copy> Default for MutNullableHeap<T> {
+impl<T: HeapGCValue> Default for MutNullableHeap<T> {
     #[allow(unrooted_must_root)]
     fn default() -> MutNullableHeap<T> {
         MutNullableHeap {
-            ptr: Cell::new(None)
+            ptr: UnsafeCell::new(None)
         }
+    }
+}
+
+impl<T: HeapGCValue> HeapSizeOf for MutNullableHeap<T> {
+    fn heap_size_of_children(&self) -> usize {
+        // See comment on HeapSizeOf for JS<T>.
+        0
     }
 }
 

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -211,22 +211,26 @@ pub struct MutHeap<T: HeapGCValue> {
     val: UnsafeCell<T>,
 }
 
-impl<T: HeapGCValue> MutHeap<T> {
+impl<T: Reflectable> MutHeap<JS<T>> {
     /// Create a new `MutHeap`.
-    pub fn new(initial: T) -> MutHeap<T> {
+    pub fn new(initial: &T) -> MutHeap<JS<T>> {
         MutHeap {
-            val: UnsafeCell::new(initial),
+            val: UnsafeCell::new(JS::from_ref(initial)),
         }
     }
 
     /// Set this `MutHeap` to the given value.
-    pub fn set(&self, val: T) {
-        unsafe { *self.val.get() = val; }
+    pub fn set(&self, val: &T) {
+        unsafe {
+            *self.val.get() = JS::from_ref(val);
+        }
     }
 
     /// Set the value in this `MutHeap`.
-    pub fn get(&self) -> T {
-        unsafe { ptr::read(self.val.get()) }
+    pub fn get(&self) -> Root<T> {
+        unsafe {
+            ptr::read(self.val.get()).root()
+        }
     }
 }
 
@@ -247,16 +251,14 @@ pub struct MutNullableHeap<T: HeapGCValue> {
     ptr: UnsafeCell<Option<T>>
 }
 
-impl<T: HeapGCValue> MutNullableHeap<T> {
+impl<T: Reflectable> MutNullableHeap<JS<T>> {
     /// Create a new `MutNullableHeap`.
-    pub fn new(initial: Option<T>) -> MutNullableHeap<T> {
+    pub fn new(initial: Option<&T>) -> MutNullableHeap<JS<T>> {
         MutNullableHeap {
-            ptr: UnsafeCell::new(initial)
+            ptr: UnsafeCell::new(initial.map(JS::from_ref))
         }
     }
-}
 
-impl<T: Reflectable> MutNullableHeap<JS<T>> {
     /// Retrieve a copy of the current inner value. If it is `None`, it is
     /// initialized with the result of `cb` first.
     pub fn or_init<F>(&self, cb: F) -> Root<T>

--- a/components/script/dom/browsercontext.rs
+++ b/components/script/dom/browsercontext.rs
@@ -54,7 +54,7 @@ impl BrowsingContext {
     }
 
     pub fn frame_element(&self) -> Option<Root<Element>> {
-        self.frame_element.map(Root::from_rooted)
+        self.frame_element.as_ref().map(JS::root)
     }
 
     pub fn window_proxy(&self) -> *mut JSObject {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -763,7 +763,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
                 serialize(rgba, &mut result).unwrap();
                 StringOrCanvasGradientOrCanvasPattern::eString(result)
             },
-            CanvasFillOrStrokeStyle::Gradient(gradient) => {
+            CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(gradient.root())
             },
         }
@@ -803,7 +803,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
                 serialize(rgba, &mut result).unwrap();
                 StringOrCanvasGradientOrCanvasPattern::eString(result)
             },
-            CanvasFillOrStrokeStyle::Gradient(gradient) => {
+            CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(gradient.root())
             },
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -297,7 +297,7 @@ impl Document {
             .filter_map(HTMLBaseElementCast::to_root)
             .filter(|element| ElementCast::from_ref(&**element).has_attribute(&atom!("href")))
             .next();
-        self.base_element.set(base.map(|element| JS::from_ref(&*element)));
+        self.base_element.set(base.as_ref().map(Root::r));
     }
 
     pub fn quirks_mode(&self) -> QuirksMode {
@@ -506,7 +506,7 @@ impl Document {
     /// Request that the given element receive focus once the current transaction is complete.
     pub fn request_focus(&self, elem: &Element) {
         if elem.is_focusable_area() {
-            self.possibly_focused.set(Some(JS::from_ref(elem)))
+            self.possibly_focused.set(Some(elem))
         }
     }
 
@@ -520,7 +520,7 @@ impl Document {
             node.set_focus_state(false);
         }
 
-        self.focused.set(self.possibly_focused.get());
+        self.focused.set(self.possibly_focused.get().r());
 
         if let Some(ref elem) = self.focused.get_rooted() {
             let node = NodeCast::from_ref(elem.r());
@@ -852,7 +852,7 @@ impl Document {
     }
 
     pub fn set_current_script(&self, script: Option<&HTMLScriptElement>) {
-        self.current_script.set(script.map(JS::from_ref));
+        self.current_script.set(script);
     }
 
     pub fn trigger_mozbrowser_event(&self, event: MozBrowserEvent) {
@@ -959,7 +959,7 @@ impl Document {
     }
 
     pub fn set_current_parser(&self, script: Option<&ServoHTMLParser>) {
-        self.current_parser.set(script.map(JS::from_ref));
+        self.current_parser.set(script);
     }
 
     pub fn get_current_parser(&self) -> Option<Root<ServoHTMLParser>> {
@@ -1119,8 +1119,7 @@ impl Document {
             let new_doc = Document::new(
                 &*self.window(), None, doctype, None, None,
                 DocumentSource::NotFromParser, DocumentLoader::new(&self.loader()));
-            new_doc.appropriate_template_contents_owner_document.set(
-                Some(JS::from_ref(&*new_doc)));
+            new_doc.appropriate_template_contents_owner_document.set(Some(&new_doc));
             new_doc
         })
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -297,7 +297,7 @@ impl Document {
             .filter_map(HTMLBaseElementCast::to_root)
             .filter(|element| ElementCast::from_ref(&**element).has_attribute(&atom!("href")))
             .next();
-        self.base_element.set(base.as_ref().map(Root::r));
+        self.base_element.set(base.r());
     }
 
     pub fn quirks_mode(&self) -> QuirksMode {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -106,12 +106,12 @@ impl Event {
 
     #[inline]
     pub fn set_current_target(&self, val: &EventTarget) {
-        self.current_target.set(Some(JS::from_ref(val)));
+        self.current_target.set(Some(val));
     }
 
     #[inline]
     pub fn set_target(&self, val: &EventTarget) {
-        self.target.set(Some(JS::from_ref(val)));
+        self.target.set(Some(val));
     }
 
     #[inline]

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -116,7 +116,7 @@ impl FileReader {
 
         let global = fr.global.root();
         let exception = DOMException::new(global.r(), error);
-        fr.error.set(Some(JS::from_rooted(&exception)));
+        fr.error.set(Some(&exception));
 
         fr.dispatch_progress_event("error".to_owned(), 0, None);
         return_on_abort!();
@@ -292,7 +292,7 @@ impl FileReaderMethods for FileReader {
 
         let global = self.global.root();
         let exception = DOMException::new(global.r(), DOMErrorName::AbortError);
-        self.error.set(Some(JS::from_rooted(&exception)));
+        self.error.set(Some(&exception));
 
         self.terminate_ongoing_reading();
         // Steps 5 & 6
@@ -346,7 +346,7 @@ impl FileReader {
         if blob.IsClosed() {
             let global = self.global.root();
             let exception = DOMException::new(global.r(), DOMErrorName::InvalidStateError);
-            self.error.set(Some(JS::from_rooted(&exception)));
+            self.error.set(Some(&exception));
 
             self.dispatch_progress_event("error".to_owned(), 0, None);
             return Ok(());

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -32,7 +32,7 @@ const DEFAULT_WIDTH: u32 = 300;
 const DEFAULT_HEIGHT: u32 = 150;
 
 #[must_root]
-#[derive(JSTraceable, Clone, Copy, HeapSizeOf)]
+#[derive(JSTraceable, Clone, HeapSizeOf)]
 pub enum CanvasContext {
     Context2d(JS<CanvasRenderingContext2D>),
     WebGL(JS<WebGLRenderingContext>),

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -4,13 +4,14 @@
 
 use canvas_traits::{CanvasMsg, FromLayoutMsg};
 use dom::attr::Attr;
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::HTMLCanvasElementBinding;
 use dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::HTMLCanvasElementMethods;
 use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use dom::bindings::codegen::InheritTypes::{ElementCast, HTMLElementCast};
 use dom::bindings::codegen::UnionTypes::CanvasRenderingContext2DOrWebGLRenderingContext;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{HeapGCValue, JS, LayoutJS, MutNullableHeap, Root};
+use dom::bindings::js::{HeapGCValue, JS, LayoutJS, Root};
 use dom::bindings::utils::{Reflectable};
 use dom::canvasrenderingcontext2d::{CanvasRenderingContext2D, LayoutCanvasRenderingContext2DHelpers};
 use dom::document::Document;
@@ -24,7 +25,6 @@ use ipc_channel::ipc::{self, IpcSender};
 use js::jsapi::{HandleValue, JSContext};
 use offscreen_gl_context::GLContextAttributes;
 use std::cell::Cell;
-use std::default::Default;
 use std::iter::repeat;
 use util::str::{DOMString, parse_unsigned_integer};
 
@@ -43,7 +43,7 @@ impl HeapGCValue for CanvasContext {}
 #[dom_struct]
 pub struct HTMLCanvasElement {
     htmlelement: HTMLElement,
-    context: MutNullableHeap<CanvasContext>,
+    context: DOMRefCell<Option<CanvasContext>>,
     width: Cell<u32>,
     height: Cell<u32>,
 }
@@ -59,9 +59,8 @@ impl HTMLCanvasElement {
                      prefix: Option<DOMString>,
                      document: &Document) -> HTMLCanvasElement {
         HTMLCanvasElement {
-            htmlelement:
-                HTMLElement::new_inherited(localName, prefix, document),
-            context: Default::default(),
+            htmlelement: HTMLElement::new_inherited(localName, prefix, document),
+            context: DOMRefCell::new(None),
             width: Cell::new(DEFAULT_WIDTH),
             height: Cell::new(DEFAULT_HEIGHT),
         }
@@ -77,10 +76,10 @@ impl HTMLCanvasElement {
 
     fn recreate_contexts(&self) {
         let size = self.get_size();
-        if let Some(context) = self.context.get() {
-            match context {
-                CanvasContext::Context2d(context) => context.root().r().recreate(size),
-                CanvasContext::WebGL(context) => context.root().r().recreate(size),
+        if let Some(ref context) = *self.context.borrow() {
+            match *context {
+                CanvasContext::Context2d(ref context) => context.root().r().recreate(size),
+                CanvasContext::WebGL(ref context) => context.root().r().recreate(size),
             }
         }
     }
@@ -105,10 +104,10 @@ impl LayoutHTMLCanvasElementHelpers for LayoutJS<HTMLCanvasElement> {
     #[allow(unsafe_code)]
     unsafe fn get_renderer_id(&self) -> Option<usize> {
         let ref canvas = *self.unsafe_get();
-        canvas.context.get().map(|context| {
-            match context {
-                CanvasContext::Context2d(context) => context.to_layout().get_renderer_id(),
-                CanvasContext::WebGL(context) => context.to_layout().get_renderer_id(),
+        canvas.context.borrow_for_layout().as_ref().map(|context| {
+            match *context {
+                CanvasContext::Context2d(ref context) => context.to_layout().get_renderer_id(),
+                CanvasContext::WebGL(ref context) => context.to_layout().get_renderer_id(),
             }
         })
     }
@@ -116,10 +115,10 @@ impl LayoutHTMLCanvasElementHelpers for LayoutJS<HTMLCanvasElement> {
     #[allow(unsafe_code)]
     unsafe fn get_ipc_renderer(&self) -> Option<IpcSender<CanvasMsg>> {
         let ref canvas = *self.unsafe_get();
-        canvas.context.get().map(|context| {
-            match context {
-                CanvasContext::Context2d(context) => context.to_layout().get_ipc_renderer(),
-                CanvasContext::WebGL(context) => context.to_layout().get_ipc_renderer(),
+        canvas.context.borrow_for_layout().as_ref().map(|context| {
+            match *context {
+                CanvasContext::Context2d(ref context) => context.to_layout().get_ipc_renderer(),
+                CanvasContext::WebGL(ref context) => context.to_layout().get_ipc_renderer(),
             }
         })
     }
@@ -138,24 +137,24 @@ impl LayoutHTMLCanvasElementHelpers for LayoutJS<HTMLCanvasElement> {
 
 impl HTMLCanvasElement {
     pub fn ipc_renderer(&self) -> Option<IpcSender<CanvasMsg>> {
-        self.context.get().map(|context| {
-            match context {
-                CanvasContext::Context2d(context) => context.root().r().ipc_renderer(),
-                CanvasContext::WebGL(context) => context.root().r().ipc_renderer(),
+        self.context.borrow().as_ref().map(|context| {
+            match *context {
+                CanvasContext::Context2d(ref context) => context.root().r().ipc_renderer(),
+                CanvasContext::WebGL(ref context) => context.root().r().ipc_renderer(),
             }
         })
     }
 
     pub fn get_or_init_2d_context(&self) -> Option<Root<CanvasRenderingContext2D>> {
-        if self.context.get().is_none() {
+        if self.context.borrow().is_none() {
             let window = window_from_node(self);
             let size = self.get_size();
             let context = CanvasRenderingContext2D::new(GlobalRef::Window(window.r()), self, size);
-            self.context.set(Some(CanvasContext::Context2d(JS::from_rooted(&context))));
+            *self.context.borrow_mut() = Some(CanvasContext::Context2d(JS::from_rooted(&context)));
         }
 
-        match self.context.get().unwrap() {
-            CanvasContext::Context2d(context) => Some(context.root()),
+        match *self.context.borrow().as_ref().unwrap() {
+            CanvasContext::Context2d(ref context) => Some(context.root()),
             _   => None,
         }
     }
@@ -163,7 +162,7 @@ impl HTMLCanvasElement {
     pub fn get_or_init_webgl_context(&self,
                                  cx: *mut JSContext,
                                  attrs: Option<HandleValue>) -> Option<Root<WebGLRenderingContext>> {
-        if self.context.get().is_none() {
+        if self.context.borrow().is_none() {
             let window = window_from_node(self);
             let size = self.get_size();
 
@@ -180,12 +179,12 @@ impl HTMLCanvasElement {
 
             let maybe_ctx = WebGLRenderingContext::new(GlobalRef::Window(window.r()), self, size, attrs);
 
-            self.context.set(maybe_ctx.map( |ctx| CanvasContext::WebGL(JS::from_rooted(&ctx))));
+            *self.context.borrow_mut() = maybe_ctx.map( |ctx| CanvasContext::WebGL(JS::from_rooted(&ctx)));
         }
 
-        if let Some(context) = self.context.get() {
-            match context {
-                CanvasContext::WebGL(context) => Some(context.root()),
+        if let Some(ref context) = *self.context.borrow() {
+            match *context {
+                CanvasContext::WebGL(ref context) => Some(context.root()),
                 _ => None,
             }
         } else {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -758,7 +758,7 @@ impl Activatable for HTMLInputElement {
             InputType::InputRadio => {
                 // We want to restore state only if the element had been changed in the first place
                 if cache.was_mutable {
-                    let old_checked: Option<Root<HTMLInputElement>> = cache.checked_radio.map(|t| t.root());
+                    let old_checked = cache.checked_radio.as_ref().map(|t| t.root());
                     let name = self.get_radio_group_name();
                     match old_checked {
                         Some(ref o) => {

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -205,6 +205,6 @@ impl MouseEventMethods for MouseEvent {
         self.shift_key.set(shiftKeyArg);
         self.meta_key.set(metaKeyArg);
         self.button.set(buttonArg);
-        self.related_target.set(relatedTargetArg.map(JS::from_ref));
+        self.related_target.set(relatedTargetArg);
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1367,7 +1367,7 @@ impl Node {
             last_child: Default::default(),
             next_sibling: Default::default(),
             prev_sibling: Default::default(),
-            owner_doc: MutNullableHeap::new(doc.map(JS::from_ref)),
+            owner_doc: MutNullableHeap::new(doc),
             child_list: Default::default(),
             children_count: Cell::new(0u32),
             flags: Cell::new(flags),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -271,32 +271,32 @@ impl Node {
                 match prev_sibling {
                     None => {
                         assert!(Some(*before) == self.first_child.get_rooted().r());
-                        self.first_child.set(Some(JS::from_ref(new_child)));
+                        self.first_child.set(Some(new_child));
                     },
                     Some(ref prev_sibling) => {
-                        prev_sibling.next_sibling.set(Some(JS::from_ref(new_child)));
-                        new_child.prev_sibling.set(Some(JS::from_ref(prev_sibling.r())));
+                        prev_sibling.next_sibling.set(Some(new_child));
+                        new_child.prev_sibling.set(Some(prev_sibling.r()));
                     },
                 }
-                before.prev_sibling.set(Some(JS::from_ref(new_child)));
-                new_child.next_sibling.set(Some(JS::from_ref(before)));
+                before.prev_sibling.set(Some(new_child));
+                new_child.next_sibling.set(Some(before));
             },
             None => {
                 let last_child = self.GetLastChild();
                 match last_child {
-                    None => self.first_child.set(Some(JS::from_ref(new_child))),
+                    None => self.first_child.set(Some(new_child)),
                     Some(ref last_child) => {
                         assert!(last_child.next_sibling.get().is_none());
-                        last_child.r().next_sibling.set(Some(JS::from_ref(new_child)));
-                        new_child.prev_sibling.set(Some(JS::from_rooted(&last_child)));
+                        last_child.r().next_sibling.set(Some(new_child));
+                        new_child.prev_sibling.set(Some(&last_child));
                     }
                 }
 
-                self.last_child.set(Some(JS::from_ref(new_child)));
+                self.last_child.set(Some(new_child));
             },
         }
 
-        new_child.parent_node.set(Some(JS::from_ref(self)));
+        new_child.parent_node.set(Some(self));
 
         let parent_in_doc = self.is_in_doc();
         for node in new_child.traverse_preorder() {
@@ -315,19 +315,19 @@ impl Node {
         let prev_sibling = child.GetPreviousSibling();
         match prev_sibling {
             None => {
-                self.first_child.set(child.next_sibling.get());
+                self.first_child.set(child.next_sibling.get().r());
             }
             Some(ref prev_sibling) => {
-                prev_sibling.next_sibling.set(child.next_sibling.get());
+                prev_sibling.next_sibling.set(child.next_sibling.get().r());
             }
         }
         let next_sibling = child.GetNextSibling();
         match next_sibling {
             None => {
-                self.last_child.set(child.prev_sibling.get());
+                self.last_child.set(child.prev_sibling.get().r());
             }
             Some(ref next_sibling) => {
-                next_sibling.prev_sibling.set(child.prev_sibling.get());
+                next_sibling.prev_sibling.set(child.prev_sibling.get().r());
             }
         }
 
@@ -591,7 +591,7 @@ impl Node {
                 match self.parent_node.get() {
                     None         => return,
                     Some(parent) => parent,
-                }.root();
+                };
 
             for sibling in parent.r().children() {
                 sibling.r().set_has_dirty_siblings(true);
@@ -660,7 +660,7 @@ impl Node {
 
     pub fn is_parent_of(&self, child: &Node) -> bool {
         match child.parent_node.get() {
-            Some(ref parent) => parent.root().r() == self,
+            Some(ref parent) => parent.r() == self,
             None => false,
         }
     }
@@ -689,7 +689,7 @@ impl Node {
         // Step 2.
         let parent = match parent.get() {
             None => return Ok(()),
-            Some(ref parent) => parent.root(),
+            Some(parent) => parent,
         };
 
         // Step 3.
@@ -702,7 +702,7 @@ impl Node {
         let viable_previous_sibling = match viable_previous_sibling {
             Some(ref viable_previous_sibling) => viable_previous_sibling.next_sibling.get(),
             None => parent.first_child.get(),
-        }.map(|s| s.root());
+        };
 
         // Step 6.
         try!(Node::pre_insert(&node, &parent, viable_previous_sibling.r()));
@@ -718,7 +718,7 @@ impl Node {
         // Step 2.
         let parent = match parent.get() {
             None => return Ok(()),
-            Some(ref parent) => parent.root(),
+            Some(parent) => parent,
         };
 
         // Step 3.
@@ -745,7 +745,7 @@ impl Node {
                 let doc = self.owner_doc();
                 let node = try!(doc.r().node_from_nodes_and_strings(nodes));
                 // Step 3.
-                parent_node.root().r().ReplaceChild(node.r(), self).map(|_| ())
+                parent_node.r().ReplaceChild(node.r(), self).map(|_| ())
             },
         }
     }
@@ -823,11 +823,11 @@ impl Node {
     }
 
     pub fn owner_doc(&self) -> Root<Document> {
-        self.owner_doc.get().unwrap().root()
+        self.owner_doc.get().unwrap()
     }
 
     pub fn set_owner_doc(&self, document: &Document) {
-        self.owner_doc.set(Some(JS::from_ref(document)));
+        self.owner_doc.set(Some(document));
     }
 
     pub fn is_in_html_doc(&self) -> bool {

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -36,7 +36,7 @@ impl NodeIterator {
         NodeIterator {
             reflector_: Reflector::new(),
             root_node: JS::from_ref(root_node),
-            reference_node: MutHeap::new(JS::from_ref(root_node)),
+            reference_node: MutHeap::new(root_node),
             pointer_before_reference_node: Cell::new(true),
             what_to_show: what_to_show,
             filter: filter
@@ -87,7 +87,7 @@ impl NodeIteratorMethods for NodeIterator {
 
     // https://dom.spec.whatwg.org/#dom-nodeiterator-referencenode
     fn ReferenceNode(&self) -> Root<Node> {
-        self.reference_node.get().root()
+        self.reference_node.get()
     }
 
     // https://dom.spec.whatwg.org/#dom-nodeiterator-pointerbeforereferencenode
@@ -99,7 +99,7 @@ impl NodeIteratorMethods for NodeIterator {
     fn NextNode(&self) -> Fallible<Option<Root<Node>>> {
         // https://dom.spec.whatwg.org/#concept-NodeIterator-traverse
         // Step 1.
-        let node = self.reference_node.get().root();
+        let node = self.reference_node.get();
 
         // Step 2.
         let mut before_node = self.pointer_before_reference_node.get();
@@ -114,7 +114,7 @@ impl NodeIteratorMethods for NodeIterator {
             // Step 3-3.
             if result == NodeFilterConstants::FILTER_ACCEPT {
                 // Step 4.
-                self.reference_node.set(JS::from_ref(node.r()));
+                self.reference_node.set(node.r());
                 self.pointer_before_reference_node.set(before_node);
 
                 return Ok(Some(node));
@@ -129,7 +129,7 @@ impl NodeIteratorMethods for NodeIterator {
             // Step 3-3.
             if result == NodeFilterConstants::FILTER_ACCEPT {
                 // Step 4.
-                self.reference_node.set(JS::from_ref(following_node.r()));
+                self.reference_node.set(following_node.r());
                 self.pointer_before_reference_node.set(before_node);
 
                 return Ok(Some(following_node));
@@ -143,7 +143,7 @@ impl NodeIteratorMethods for NodeIterator {
     fn PreviousNode(&self) -> Fallible<Option<Root<Node>>> {
         // https://dom.spec.whatwg.org/#concept-NodeIterator-traverse
         // Step 1.
-        let node = self.reference_node.get().root();
+        let node = self.reference_node.get();
 
         // Step 2.
         let mut before_node = self.pointer_before_reference_node.get();
@@ -158,7 +158,7 @@ impl NodeIteratorMethods for NodeIterator {
             // Step 3-3.
             if result == NodeFilterConstants::FILTER_ACCEPT {
                 // Step 4.
-                self.reference_node.set(JS::from_ref(node.r()));
+                self.reference_node.set(node.r());
                 self.pointer_before_reference_node.set(before_node);
 
                 return Ok(Some(node));
@@ -174,7 +174,7 @@ impl NodeIteratorMethods for NodeIterator {
             // Step 3-3.
             if result == NodeFilterConstants::FILTER_ACCEPT {
                 // Step 4.
-                self.reference_node.set(JS::from_ref(preceding_node.r()));
+                self.reference_node.set(preceding_node.r());
                 self.pointer_before_reference_node.set(before_node);
 
                 return Ok(Some(preceding_node));

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -6,7 +6,7 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::Bindings::NodeListBinding;
 use dom::bindings::codegen::Bindings::NodeListBinding::NodeListMethods;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::js::{JS, MutNullableHeap, Root};
+use dom::bindings::js::{JS, MutNullableHeap, Root, RootedReference};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::node::{ChildrenMutation, Node};
 use dom::window::Window;
@@ -103,7 +103,7 @@ impl ChildrenList {
         let last_visited = node.GetFirstChild();
         ChildrenList {
             node: JS::from_ref(node),
-            last_visited: MutNullableHeap::new(last_visited.as_ref().map(Root::r)),
+            last_visited: MutNullableHeap::new(last_visited.r()),
             last_index: Cell::new(0u32),
         }
     }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -103,8 +103,7 @@ impl ChildrenList {
         let last_visited = node.GetFirstChild();
         ChildrenList {
             node: JS::from_ref(node),
-            last_visited:
-                MutNullableHeap::new(last_visited.as_ref().map(JS::from_rooted)),
+            last_visited: MutNullableHeap::new(last_visited.as_ref().map(Root::r)),
             last_index: Cell::new(0u32),
         }
     }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -64,7 +64,7 @@ impl NodeListMethods for NodeList {
     fn Item(&self, index: u32) -> Option<Root<Node>> {
         match self.list_type {
             NodeListType::Simple(ref elems) => {
-                elems.get(index as usize).map(|node| Root::from_rooted(*node))
+                elems.get(index as usize).map(|node| node.root())
             },
             NodeListType::Children(ref list) => list.item(index),
         }

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -37,7 +37,7 @@ impl StorageEvent {
             oldValue: oldValue,
             newValue: newValue,
             url: url,
-            storageArea: MutNullableHeap::new(storageArea.map(JS::from_ref))
+            storageArea: MutNullableHeap::new(storageArea)
         }
     }
 

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -92,7 +92,7 @@ impl UIEventMethods for UIEvent {
         }
 
         event.InitEvent(type_, can_bubble, cancelable);
-        self.view.set(view.map(JS::from_ref));
+        self.view.set(view);
         self.detail.set(detail);
     }
 }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -86,7 +86,7 @@ impl WebGLProgram {
             return Err(WebGLError::InvalidOperation);
         }
 
-        shader_slot.set(Some(JS::from_ref(shader)));
+        shader_slot.set(Some(shader));
 
         self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::AttachShader(self.id, shader.id()))).unwrap();
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -12,7 +12,7 @@ use dom::bindings::codegen::InheritTypes::{EventCast, EventTargetCast, NodeCast}
 use dom::bindings::codegen::UnionTypes::ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement;
 use dom::bindings::conversions::ToJSValConvertible;
 use dom::bindings::global::{GlobalField, GlobalRef};
-use dom::bindings::js::{JS, LayoutJS, Root};
+use dom::bindings::js::{JS, LayoutJS, MutNullableHeap, Root};
 use dom::bindings::utils::{Reflector, reflect_dom_object};
 use dom::event::{EventBubbles, EventCancelable};
 use dom::htmlcanvaselement::HTMLCanvasElement;
@@ -78,8 +78,8 @@ pub struct WebGLRenderingContext {
     canvas: JS<HTMLCanvasElement>,
     last_error: Cell<Option<WebGLError>>,
     texture_unpacking_settings: Cell<TextureUnpacking>,
-    bound_texture_2d: Cell<Option<JS<WebGLTexture>>>,
-    bound_texture_cube_map: Cell<Option<JS<WebGLTexture>>>,
+    bound_texture_2d: MutNullableHeap<JS<WebGLTexture>>,
+    bound_texture_cube_map: MutNullableHeap<JS<WebGLTexture>>,
 }
 
 impl WebGLRenderingContext {
@@ -104,8 +104,8 @@ impl WebGLRenderingContext {
                 canvas: JS::from_ref(canvas),
                 last_error: Cell::new(None),
                 texture_unpacking_settings: Cell::new(CONVERT_COLORSPACE),
-                bound_texture_2d: Cell::new(None),
-                bound_texture_cube_map: Cell::new(None),
+                bound_texture_2d: MutNullableHeap::new(None),
+                bound_texture_cube_map: MutNullableHeap::new(None),
             }
         })
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -149,8 +149,8 @@ impl WebGLRenderingContext {
 
     pub fn bound_texture_for(&self, target: u32) -> Option<Root<WebGLTexture>> {
         match target {
-            constants::TEXTURE_2D => self.bound_texture_2d.get().map(|t| t.root()),
-            constants::TEXTURE_CUBE_MAP => self.bound_texture_cube_map.get().map(|t| t.root()),
+            constants::TEXTURE_2D => self.bound_texture_2d.get_rooted(),
+            constants::TEXTURE_CUBE_MAP => self.bound_texture_cube_map.get_rooted(),
 
             _ => unreachable!(),
         }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -360,7 +360,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
         if let Some(texture) = texture {
             match texture.bind(target) {
-                Ok(_) => slot.set(Some(JS::from_ref(texture))),
+                Ok(_) => slot.set(Some(texture)),
                 Err(err) => return self.webgl_error(err),
             }
         } else {


### PR DESCRIPTION
`JS<T>` belongs on the heap, and only on the heap.  This is a collection of fixes so that code uses either `Root<T>` or `&T` to pass around garbage-collected pointers.

Ideally, we could completely ban constructing a `JS<T>` outside of constructor functions, but we aren't quite there yet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8026)

<!-- Reviewable:end -->
