### PR TITLE
Issue 8028: `parse_html` should take `Url` rather than `&Url`

### DIFF
--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -63,7 +63,7 @@ impl DOMParserMethods for DOMParser {
                                              None,
                                              DocumentSource::FromParser,
                                              loader);
-                parse_html(document.r(), s, &url, ParseContext::Owner(None));
+                parse_html(document.r(), s, url, ParseContext::Owner(None));
                 document.r().set_ready_state(DocumentReadyState::Complete);
                 Ok(document)
             }

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -262,13 +262,13 @@ pub enum ParseContext<'a> {
 
 pub fn parse_html(document: &Document,
                   input: String,
-                  url: &Url,
+                  url: Url,
                   context: ParseContext) {
     let parser = match context {
         ParseContext::Owner(owner) =>
-            ServoHTMLParser::new(Some(url.clone()), document, owner),
+            ServoHTMLParser::new(Some(url), document, owner),
         ParseContext::Fragment(fc) =>
-            ServoHTMLParser::new_for_fragment(Some(url.clone()), document, fc),
+            ServoHTMLParser::new_for_fragment(Some(url), document, fc),
     };
     parser.r().parse_chunk(input.into());
 }
@@ -300,7 +300,7 @@ pub fn parse_html_fragment(context_node: &Node,
         context_elem: context_node,
         form_elem: form.r(),
     };
-    parse_html(document.r(), input, &url, ParseContext::Fragment(fragment_context));
+    parse_html(document.r(), input, url.clone(), ParseContext::Fragment(fragment_context));
 
     // Step 14.
     let root_element = document.r().GetDocumentElement().expect("no document element");

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1648,7 +1648,7 @@ impl ScriptTask {
             "".to_owned()
         };
 
-        parse_html(document.r(), parse_input, &final_url,
+        parse_html(document.r(), parse_input, final_url,
                    ParseContext::Owner(Some(incomplete.pipeline_id)));
 
         page_remover.neuter();


### PR DESCRIPTION
fixes #8028

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8035)

<!-- Reviewable:end -->
