### PR TITLE
remove unused methods from ThreadSafeLayoutNode

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -815,25 +815,6 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
         }
     }
 
-    pub fn get_input_value(&self) -> String {
-        unsafe {
-            let input: Option<LayoutJS<HTMLInputElement>> = HTMLInputElementCast::to_layout_js(self.get_jsmanaged());
-            match input {
-                Some(input) => input.get_value_for_layout(),
-                None => panic!("not an input element!")
-            }
-        }
-    }
-
-    pub fn get_input_size(&self) -> u32 {
-        unsafe {
-            match HTMLInputElementCast::to_layout_js(self.get_jsmanaged()) {
-                Some(input) => input.get_size_for_layout(),
-                None => panic!("not an input element!")
-            }
-        }
-    }
-
     pub fn get_unsigned_integer_attribute(self, attribute: UnsignedIntegerAttribute)
                                           -> Option<u32> {
         unsafe {


### PR DESCRIPTION
`get_input_size` and `get_input_value` aren't used in the codebase.

Fixes #8063.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8071)

<!-- Reviewable:end -->
