### PR TITLE
Removced unncessary call to dirty() in Document::node_and_heritage_ch…

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -347,7 +347,6 @@ impl Document {
 
     pub fn content_and_heritage_changed(&self, node: &Node, damage: NodeDamage) {
         node.force_dirty_ancestors(damage);
-        node.dirty(damage);
     }
 
     /// Reflows and disarms the timer if the reflow timer has expired.


### PR DESCRIPTION
Removed unncessary call to dirty() in Document::node_and_heritage_change, since the node is aready dirtied by force_dirty_ancestors().

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8087)

<!-- Reviewable:end -->
