### PR TITLE
Fix iframes flickering on mouse move.

### DIFF
--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -449,17 +449,22 @@ impl RcCompositorLayer for Rc<Layer<CompositorData>> {
                 compositor: &mut IOCompositor<Window>,
                 pipeline_id: PipelineId,
                 new_layers: &[LayerProperties],
-                pipelines_removed: &mut Vec<PipelineId>)
+                pipelines_removed: &mut Vec<PipelineId>,
+                layer_pipeline_id: Option<PipelineId>)
                 where Window: WindowMethods {
             // Traverse children first so that layers are removed
             // bottom up - allowing each layer being removed to properly
             // clean up any tiles it owns.
             for kid in &*layer.children() {
+                let extra_data = kid.extra_data.borrow();
+                let layer_pipeline_id = extra_data.subpage_info.or(layer_pipeline_id);
+
                 collect_old_layers_for_pipeline(kid,
                                                 compositor,
                                                 pipeline_id,
                                                 new_layers,
-                                                pipelines_removed);
+                                                pipelines_removed,
+                                                layer_pipeline_id);
             }
 
             // Retain child layers that also exist in the new layer list.
@@ -477,7 +482,7 @@ impl RcCompositorLayer for Rc<Layer<CompositorData>> {
                     }
                 }
 
-                if let Some(layer_pipeline_id) = extra_data.subpage_info {
+                if let Some(layer_pipeline_id) = layer_pipeline_id {
                     for layer_properties in new_layers.iter() {
                         // Keep this layer if a reference to it exists.
                         if let Some(ref subpage_layer_info) = layer_properties.subpage_layer_info {
@@ -507,7 +512,8 @@ impl RcCompositorLayer for Rc<Layer<CompositorData>> {
                                         compositor,
                                         pipeline_id,
                                         new_layers,
-                                        pipelines_removed);
+                                        pipelines_removed,
+                                        None);
     }
 }
 


### PR DESCRIPTION
Fixes #7867 (and probably several other iframe bugs).

When collecting layers for children of a pipeline, pass through the current
subpage pipeline recursively. This prevents descendant layers (such as scroll
layers) from being collected and re-created on the subsequent paint.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8089)

<!-- Reviewable:end -->
