### PR TITLE
Enable Pattern variant of CanvasFillOrStrokeStyle

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -50,7 +50,7 @@ use util::vec::byte_swap;
 pub enum CanvasFillOrStrokeStyle {
     Color(RGBA),
     Gradient(JS<CanvasGradient>),
-    // Pattern(JS<CanvasPattern>),  // https://github.com/servo/servo/pull/6157
+    Pattern(JS<CanvasPattern>),
 }
 
 // https://html.spec.whatwg.org/multipage/#canvasrenderingcontext2d
@@ -766,6 +766,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(gradient.root())
             },
+            CanvasFillOrStrokeStyle::Pattern(ref pattern) => {
+                StringOrCanvasGradientOrCanvasPattern::eCanvasPattern(pattern.root())
+            }
         }
     }
 
@@ -806,6 +809,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(gradient.root())
             },
+            CanvasFillOrStrokeStyle::Pattern(ref pattern) => {
+                StringOrCanvasGradientOrCanvasPattern::eCanvasPattern(pattern.root())
+            }
         }
     }
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -794,7 +794,10 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
                     Canvas2dMsg::SetStrokeStyle(gradient.r().to_fill_or_stroke_style()));
                 self.ipc_renderer.send(msg).unwrap();
             },
-            _ => {}
+            StringOrCanvasGradientOrCanvasPattern::eCanvasPattern(pattern) => {
+                self.ipc_renderer.send(CanvasMsg::Canvas2d(Canvas2dMsg::SetStrokeStyle(
+                                                            pattern.r().to_fill_or_stroke_style()))).unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
Enables the `Pattern` variant for the enum `CanvasFillOrStrokeStyle`

Fixes #7608

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8104)

<!-- Reviewable:end -->
