### PR TITLE
Compute value of float according to position value

### DIFF
--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -546,7 +546,25 @@ pub mod longhands {
     </%self:longhand>
 
     ${single_keyword("position", "static absolute relative fixed")}
-    ${single_keyword("float", "none left right")}
+
+    <%self:single_keyword_computed name="float" values="none left right">
+        use values::computed::Context;
+
+        impl ToComputedValue for SpecifiedValue {
+            type ComputedValue = computed_value::T;
+
+            #[inline]
+            fn to_computed_value(&self, context: &Context) -> computed_value::T {
+                if context.positioned {
+                    SpecifiedValue::none
+                } else {
+                    *self
+                }
+            }
+        }
+
+    </%self:single_keyword_computed>
+
     ${single_keyword("clear", "none left right both")}
 
     <%self:longhand name="-servo-display-for-hypothetical-box" derived_from="display">

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3961,6 +3961,12 @@
         ]
       },
       "testharness": {
+        "css/float_relative_to_position.html": [
+          {
+            "path": "css/float_relative_to_position.html",
+            "url": "/_mozilla/css/float_relative_to_position.html"
+          }
+        ],
         "css/test_variable_legal_values.html": [
           {
             "path": "css/test_variable_legal_values.html",

--- a/tests/wpt/mozilla/tests/css/float_relative_to_position.html
+++ b/tests/wpt/mozilla/tests/css/float_relative_to_position.html
@@ -3,24 +3,37 @@
 <head>
 <meta charset=utf-8>
 <title>Tests the relationship between float and position</title>
+<style>
+    div {
+        float: left;
+    }
+</style>
 <head>
 <body>
-<div style="position: fixed; float: left"></div>
+<div></div>
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
     test(function() {
         var computed_style = getComputedStyle(document.querySelector("div"))["float"];
-        assert_equals(computed_style, "none");
+        assert_equals(computed_style, "left");
 
-        document.querySelector("div").setAttribute("position", "absolute");
+        document.querySelector("div").setAttribute("style", "position: fixed;");
 
         computed_style = getComputedStyle(document.querySelector("div"))["float"];
         assert_equals(computed_style, "none");
-        });
 
-    <!-- test(); -->
+        document.querySelector("div").setAttribute("style", "position: absolute;");
+
+        computed_style = getComputedStyle(document.querySelector("div"))["float"];
+        assert_equals(computed_style, "none");
+
+        document.querySelector("div").removeAttribute("style");
+
+        computed_style = getComputedStyle(document.querySelector("div"))["float"];
+        assert_equals(computed_style, "left");
+    });
 </script>
 
 </body>

--- a/tests/wpt/mozilla/tests/css/float_relative_to_position.html
+++ b/tests/wpt/mozilla/tests/css/float_relative_to_position.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+<meta charset=utf-8>
+<title>Tests the relationship between float and position</title>
+<head>
+<body>
+<div style="position: fixed; float: left"></div>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+    test(function() {
+        var computed_style = getComputedStyle(document.querySelector("div"))["float"];
+        assert_equals(computed_style, "none");
+
+        document.querySelector("div").setAttribute("position", "absolute");
+
+        computed_style = getComputedStyle(document.querySelector("div"))["float"];
+        assert_equals(computed_style, "none");
+        });
+
+    <!-- test(); -->
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
According to CSS2 Section 9.7, if 'position' has a value of 'absolute'
or 'fixed' the computed value of 'float' should be 'none'.

This changes the float to a single_keyword_computed which checks the
positioned value of the element to compute the float value.

Fixes #8002

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8111)

<!-- Reviewable:end -->
