### PR TITLE
Don't require the CanvasFillOrStrokeStyle enum to be public

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -47,7 +47,7 @@ use util::vec::byte_swap;
 
 #[must_root]
 #[derive(JSTraceable, Clone, HeapSizeOf)]
-pub enum CanvasFillOrStrokeStyle {
+enum CanvasFillOrStrokeStyle {
     Color(RGBA),
     Gradient(JS<CanvasGradient>),
     // Pattern(JS<CanvasPattern>),  // https://github.com/servo/servo/pull/6157


### PR DESCRIPTION
CanvasFillOrStrokeStyle is only used in a single file,
so it does not need to be a public enum.

Fixes #8105.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8115)

<!-- Reviewable:end -->
