### PR TITLE
Made block type pattern match less inclusive

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1470,7 +1470,7 @@ impl<'a> PostorderNodeMutTraversal for FlowConstructor<'a> {
             // flow here - instead, let it match the inline case
             // below.
             (display::T::block, _, position::T::absolute) |
-            (_, _, position::T::fixed) => {
+            (display::T::block, _, position::T::fixed) => {
                 let construction_result = self.build_flow_for_block(node, None);
                 self.set_flow_construction_result(node, construction_result)
             }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2015,6 +2015,18 @@
             "url": "/_mozilla/css/link_style_order.html"
           }
         ],
+        "css/list_style_fixed_inside_a.html": [
+          {
+            "path": "css/list_style_fixed_inside_a.html",
+            "references": [
+              [
+                "/_mozilla/css/list_style_fixed_inside_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/list_style_fixed_inside_a.html"
+          }
+        ],
         "css/list_style_image_sizing_a.html": [
           {
             "path": "css/list_style_image_sizing_a.html",
@@ -6550,6 +6562,18 @@
             ]
           ],
           "url": "/_mozilla/css/link_style_order.html"
+        }
+      ],
+      "css/list_style_fixed_inside_a.html": [
+        {
+          "path": "css/list_style_fixed_inside_a.html",
+          "references": [
+            [
+              "/_mozilla/css/list_style_fixed_inside_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/list_style_fixed_inside_a.html"
         }
       ],
       "css/list_style_image_sizing_a.html": [

--- a/tests/wpt/mozilla/tests/css/list_style_fixed_inside_a.html
+++ b/tests/wpt/mozilla/tests/css/list_style_fixed_inside_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="match" href="list_style_fixed_inside_ref.html">
+  <style>
+  li {
+      list-style-position: inside;
+      position: fixed;
+  }
+  </style>
+</head>
+
+<body>
+  <ul>
+    <li>x</li>
+  </ul>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/list_style_fixed_inside_ref.html
+++ b/tests/wpt/mozilla/tests/css/list_style_fixed_inside_ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+  li {
+      list-style-position: inside;
+      position: absolute;
+  }
+  </style>
+</head>
+
+<body>
+  <ul>
+    <li>x</li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
Given the comments above the match statement, it seems that fixed-pos check should match only block elements in this case. Doing this change seems to partially resolve the issue where list items with `position:fixed;` styling are not displaying their bullet points. This change only resolves the issue for list items with `list-style-position: inside`, outside positioning is still not functioning correctly. 

https://github.com/servo/servo/issues/8001#issuecomment-149781613

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8129)

<!-- Reviewable:end -->
