### PR TITLE
Dirty parent when removing a child node.

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -334,8 +334,8 @@ impl Node {
             node.layout_data.dispose(&node);
         }
 
-        let document = child.owner_doc();
-        document.content_and_heritage_changed(child, NodeDamage::OtherNodeDamage);
+        self.owner_doc().content_and_heritage_changed(self, NodeDamage::OtherNodeDamage);
+        child.owner_doc().content_and_heritage_changed(child, NodeDamage::OtherNodeDamage);
     }
 }
 


### PR DESCRIPTION
In Node::remove_child, dirty both the child and the parent. Fixes https://github.com/servo/servo/issues/8135

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8139)

<!-- Reviewable:end -->
