### PR TITLE
Integrate Canvas into the DisplayList

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2106,16 +2106,6 @@ impl Fragment {
                               stacking_relative_border_box.size.height - border_padding.vertical()))
     }
 
-    /// Returns true if this fragment unconditionally layerizes.
-    pub fn needs_layered_stacking_context(&self) -> bool {
-        // Canvas and iframes always layerize, as an special case
-        // FIXME(pcwalton): Don't unconditionally form stacking contexts for each canvas.
-        match self.specific {
-            SpecificFragmentInfo::Canvas(_) => true,
-            _ => false,
-        }
-    }
-
     /// Returns true if this fragment establishes a new stacking context and false otherwise.
     pub fn establishes_stacking_context(&self) -> bool {
         if self.flags.contains(HAS_LAYER) {
@@ -2138,10 +2128,6 @@ impl Fragment {
                 return true
             }
             transform_style::T::auto => {}
-        }
-
-        if self.needs_layered_stacking_context() {
-            return true
         }
 
         // FIXME(pcwalton): Don't unconditionally form stacking contexts for `overflow_x: scroll`

--- a/tests/wpt/mozilla/tests/css/stacked_layers.html
+++ b/tests/wpt/mozilla/tests/css/stacked_layers.html
@@ -43,5 +43,30 @@
             <div class="gray box" style="position: relative; left: 20px; top: -30px;"> </div>
         </div>
 
+        <!-- The canvas should be painted in tree order since it is not positioned and
+             the following div is. -->
+        <div class="test grayest box">
+            <canvas class="box" id="canvas1" style="display: block; padding-left: 10px; padding-top: 10px;" width="50" height="50"></canvas>
+            <div class="gray box" style="position: relative; left: 20px; top: -40px;"> </div>
+        </div>
+
+        <!-- The canvas should be painted in tree order since both it and the inner div are
+             not positioned elements. -->
+        <div class="test grayest box">
+            <canvas class="box" id="canvas2" style="display: block; position: relative; left: 10px; top: 10px;" width="50" height="50"></canvas>
+            <div class="gray box" style="position: relative; left: 20px; top: -30px;"> </div>
+        </div>
+
+        <script>
+            function paintCanvas(id) {
+                var canvas = document.getElementById(id);
+                var context = canvas.getContext("2d");
+                context.fillStyle = "rgb(80, 80, 80)";
+                context.fillRect(0, 0, 100, 100);
+            }
+            paintCanvas("canvas1");
+            paintCanvas("canvas2");
+        </script>
+
     </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/stacked_layers_ref.html
+++ b/tests/wpt/mozilla/tests/css/stacked_layers_ref.html
@@ -34,5 +34,15 @@
         <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
         <div class="gray box" style="margin-left: 20px; margin-top: -40px;"></div>
     </div>
+
+    <div class="test grayest box">
+        <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        <div class="gray box" style="margin-left: 20px; margin-top: -40px;"></div>
+    </div>
+
+    <div class="test grayest box">
+        <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        <div class="gray box" style="margin-left: 20px; margin-top: -40px;"></div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Canvas is currently given a layer at the stacking context level.
Instead it's DisplayItem should be given a layer directly. This fixes
painting order issues where canvases are painted on top of other
positioned content that is later in tree order. It always simplifies
the code a bit.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8140)

<!-- Reviewable:end -->
