### PR TITLE
Add `clippy` as a command to mach

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -91,6 +91,16 @@ class MachCommands(CommandBase):
                 subprocess.call(["cargo", "update"] + params,
                                 env=self.build_env())
 
+    @Command('clippy',
+             description='Run Clippy',
+             category='devenv')
+    def clippy(self):
+        features = "--features=script/plugins/clippy"
+
+        with cd(path.join(self.context.topdir, "components", "servo")):
+            return subprocess.call(["cargo", "build", features],
+                                   env=self.build_env())
+
     @Command('rustc',
              description='Run the Rust compiler',
              category='devenv')


### PR DESCRIPTION
This gives mach the ability to run clippy with `./mach clippy`.

Fixes #8134.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8144)

<!-- Reviewable:end -->
