### PR TITLE
XHR timeouts use same abstraction as scripts timers. (fixes #3396)

### DIFF
--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -22,8 +22,9 @@ use msg::constellation_msg::{ConstellationChan, PipelineId, WorkerId};
 use net_traits::ResourceTask;
 use profile_traits::mem;
 use script_task::{CommonScriptMsg, ScriptChan, ScriptPort, ScriptTask};
-use script_traits::TimerEventRequest;
+use script_traits::{MsDuration, TimerEventRequest};
 use std::sync::mpsc::Sender;
+use timers::{ScheduledCallback, TimerHandle};
 use url::Url;
 use util::mem::HeapSizeOf;
 
@@ -194,6 +195,23 @@ impl<'a> GlobalRef<'a> {
         match *self {
             GlobalRef::Window(window) => window.set_devtools_wants_updates(send_updates),
             GlobalRef::Worker(worker) => worker.set_devtools_wants_updates(send_updates),
+        }
+    }
+
+    /// Schedule the given `callback` to be invoked after at least `duration` milliseconds have
+    /// passed.
+    pub fn schedule_callback(&self, callback: Box<ScheduledCallback>, duration: MsDuration) -> TimerHandle {
+        match *self {
+            GlobalRef::Window(window) => window.schedule_callback(callback, duration),
+            GlobalRef::Worker(worker) => worker.schedule_callback(callback, duration),
+        }
+    }
+
+    /// Unschedule a previously-scheduled callback.
+    pub fn unschedule_callback(&self, handle: TimerHandle) {
+        match *self {
+            GlobalRef::Window(window) => window.unschedule_callback(handle),
+            GlobalRef::Worker(worker) => worker.unschedule_callback(handle),
         }
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -55,7 +55,7 @@ use profile_traits::mem;
 use rustc_serialize::base64::{FromBase64, STANDARD, ToBase64};
 use script_task::{ScriptChan, ScriptPort, MainThreadScriptMsg, RunnableWrapper};
 use script_task::{SendableMainThreadScriptChan, MainThreadScriptChan, MainThreadTimerEventChan};
-use script_traits::{TimerEventChan, TimerEventId, TimerEventRequest, TimerSource};
+use script_traits::{MsDuration, TimerEventChan, TimerEventId, TimerEventRequest, TimerSource};
 use selectors::parser::PseudoElement;
 use std::ascii::AsciiExt;
 use std::borrow::ToOwned;
@@ -71,7 +71,7 @@ use std::sync::mpsc::TryRecvError::{Disconnected, Empty};
 use std::sync::mpsc::{Sender, channel};
 use string_cache::Atom;
 use time;
-use timers::{ActiveTimers, IsInterval, TimerCallback};
+use timers::{ActiveTimers, IsInterval, ScheduledCallback, TimerCallback, TimerHandle};
 use url::Url;
 use util::geometry::{self, MAX_RECT};
 use util::str::{DOMString, HTML_SPACE_CHARACTERS};
@@ -1081,6 +1081,16 @@ impl Window {
 
     pub fn scheduler_chan(&self) -> Sender<TimerEventRequest> {
         self.scheduler_chan.clone()
+    }
+
+    pub fn schedule_callback(&self, callback: Box<ScheduledCallback>, duration: MsDuration) -> TimerHandle {
+        self.timers.schedule_callback(callback,
+                                      duration,
+                                      TimerSource::FromWindow(self.id.clone()))
+    }
+
+    pub fn unschedule_callback(&self, handle: TimerHandle) {
+        self.timers.unschedule_callback(handle);
     }
 
     pub fn windowproxy_handler(&self) -> WindowProxyHandler {

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -24,12 +24,12 @@ use msg::constellation_msg::{ConstellationChan, PipelineId, WorkerId};
 use net_traits::{ResourceTask, load_whole_resource};
 use profile_traits::mem;
 use script_task::{CommonScriptMsg, ScriptChan, ScriptPort};
-use script_traits::{TimerEventChan, TimerEventId, TimerEventRequest, TimerSource};
+use script_traits::{MsDuration, TimerEventChan, TimerEventId, TimerEventRequest, TimerSource};
 use std::cell::Cell;
 use std::default::Default;
 use std::rc::Rc;
 use std::sync::mpsc::{Receiver, Sender};
-use timers::{ActiveTimers, IsInterval, TimerCallback};
+use timers::{ActiveTimers, IsInterval, ScheduledCallback, TimerCallback, TimerHandle};
 use url::{Url, UrlParser};
 use util::str::DOMString;
 
@@ -141,6 +141,16 @@ impl WorkerGlobalScope {
 
     pub fn scheduler_chan(&self) -> Sender<TimerEventRequest> {
         self.scheduler_chan.clone()
+    }
+
+    pub fn schedule_callback(&self, callback: Box<ScheduledCallback>, duration: MsDuration) -> TimerHandle {
+        self.timers.schedule_callback(callback,
+                                      duration,
+                                      TimerSource::FromWorker)
+    }
+
+    pub fn unschedule_callback(&self, handle: TimerHandle) {
+        self.timers.unschedule_callback(handle);
     }
 
     pub fn get_cx(&self) -> *mut JSContext {

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -7,6 +7,7 @@ use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::global::global_object_for_js_object;
 use dom::bindings::reflector::Reflectable;
+use dom::bindings::trace::JSTraceable;
 use dom::window::ScriptHelpers;
 use euclid::length::Length;
 use js::jsapi::{HandleValue, Heap, RootedValue};
@@ -106,12 +107,25 @@ pub enum TimerCallback {
 enum InternalTimerCallback {
     StringTimerCallback(DOMString),
     FunctionTimerCallback(Rc<Function>, Rc<Vec<Heap<JSVal>>>),
+    InternalCallback(Box<ScheduledCallback>),
 }
 
 impl HeapSizeOf for InternalTimerCallback {
     fn heap_size_of_children(&self) -> usize {
         // FIXME: Rc<T> isn't HeapSizeOf and we can't ignore it due to #6870 and #6871
         0
+    }
+}
+
+pub trait ScheduledCallback: JSTraceable + HeapSizeOf {
+    fn invoke(self: Box<Self>);
+
+    fn box_clone(&self) -> Box<ScheduledCallback>;
+}
+
+impl Clone for Box<ScheduledCallback> {
+    fn clone(&self) -> Box<ScheduledCallback> {
+        self.box_clone()
     }
 }
 
@@ -139,15 +153,6 @@ impl ActiveTimers {
                                is_interval: IsInterval,
                                source: TimerSource)
                                -> i32 {
-        // step 3
-        let TimerHandle(new_handle) = self.next_timer_handle.get();
-        self.next_timer_handle.set(TimerHandle(new_handle + 1));
-
-        let timeout = cmp::max(0, timeout);
-        // step 7
-        let duration = self.clamp_duration(Length::new(timeout as u64));
-        let next_call = self.base_time() + duration;
-
         let callback = match callback {
             TimerCallback::StringTimerCallback(code_str) =>
                 InternalTimerCallback::StringTimerCallback(code_str),
@@ -164,6 +169,38 @@ impl ActiveTimers {
                 InternalTimerCallback::FunctionTimerCallback(function, Rc::new(args))
             }
         };
+
+        let timeout = cmp::max(0, timeout);
+        // step 7
+        let duration = self.clamp_duration(Length::new(timeout as u64));
+
+        let TimerHandle(handle) = self.schedule_internal_callback(callback, duration, is_interval, source);
+        handle
+    }
+
+    pub fn schedule_callback(&self,
+                             callback: Box<ScheduledCallback>,
+                             duration: MsDuration,
+                             source: TimerSource) -> TimerHandle {
+        self.schedule_internal_callback(InternalTimerCallback::InternalCallback(callback),
+                                        duration,
+                                        IsInterval::NonInterval,
+                                        source)
+    }
+
+    // see https://html.spec.whatwg.org/multipage/#timer-initialisation-steps
+    fn schedule_internal_callback(&self,
+                                  callback: InternalTimerCallback,
+                                  duration: MsDuration,
+                                  is_interval: IsInterval,
+                                  source: TimerSource) -> TimerHandle {
+        assert!(self.suspended_since.get().is_none());
+
+        // step 3
+        let TimerHandle(new_handle) = self.next_timer_handle.get();
+        self.next_timer_handle.set(TimerHandle(new_handle + 1));
+
+        let next_call = self.base_time() + duration;
 
         let timer = Timer {
             handle: TimerHandle(new_handle),
@@ -184,11 +221,14 @@ impl ActiveTimers {
         }
 
         // step 10
-        new_handle
+        TimerHandle(new_handle)
     }
 
     pub fn clear_timeout_or_interval(&self, handle: i32) {
-        let handle = TimerHandle(handle);
+        self.unschedule_callback(TimerHandle(handle));
+    }
+
+    pub fn unschedule_callback(&self, handle: TimerHandle) {
         let was_next = self.is_next_timer(handle);
 
         self.timers.borrow_mut().retain(|t| t.handle != handle);
@@ -258,7 +298,10 @@ impl ActiveTimers {
                     }).collect();
 
                     let _ = function.Call_(this, arguments, Report);
-                }
+                },
+                InternalTimerCallback::InternalCallback(callback) => {
+                    callback.invoke();
+                },
             };
 
             self.nesting_level.set(0);

--- a/tests/wpt/metadata/XMLHttpRequest/event-timeout.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/event-timeout.htm.ini
@@ -1,3 +1,0 @@
-[event-timeout.htm]
-  type: testharness
-  disabled: issue 3396


### PR DESCRIPTION
Alright, this is it. Finally the fix for #3396. :D

I'll add two comments via reviewable in a second.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8168)

<!-- Reviewable:end -->
