### PR TITLE
M1504: Implement support for missing XMLHttpRequest APIs

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -45,6 +45,7 @@ use euclid::size::Size2D;
 use html5ever::tree_builder::QuirksMode;
 use hyper::header::Headers;
 use hyper::method::Method;
+use hyper::mime::Mime;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use js::jsapi::JS_CallUnbarrieredObjectTracer;
 use js::jsapi::{GCTraceKindToAscii, Heap, JSGCTraceKind, JSObject, JSTracer, JS_CallObjectTracer, JS_CallValueTracer};
@@ -286,6 +287,7 @@ no_jsmanaged_fields!(PseudoElement);
 no_jsmanaged_fields!(Length);
 no_jsmanaged_fields!(ElementState);
 no_jsmanaged_fields!(DOMString);
+no_jsmanaged_fields!(Mime);
 
 impl JSTraceable for Box<ScriptChan + Send> {
     #[inline]

--- a/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -65,7 +65,8 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   readonly attribute ByteString statusText;
   ByteString? getResponseHeader(ByteString name);
   ByteString getAllResponseHeaders();
-  // void overrideMimeType(DOMString mime);
+  [Throws]
+  void overrideMimeType(DOMString mime);
   [SetterThrows]
            attribute XMLHttpRequestResponseType responseType;
   readonly attribute any response;

--- a/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
@@ -1,18 +1,9 @@
 [interfaces.html]
   type: testharness
-  [XMLHttpRequest interface: operation overrideMimeType(DOMString)]
-    expected: FAIL
-
-  [XMLHttpRequest interface: calling overrideMimeType(DOMString) on new XMLHttpRequest() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [FormData interface: new FormData() must inherit property "getAll" with the proper type (4)]
     expected: FAIL
 
   [FormData interface: new FormData(form) must inherit property "getAll" with the proper type (4)]
-    expected: FAIL
-
-  [XMLHttpRequest interface: new XMLHttpRequest() must inherit property "overrideMimeType" with the proper type (20)]
     expected: FAIL
 
   [FormData interface: operation getAll(USVString)]

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-done-state.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-done-state.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-done-state.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in DONE state]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-invalid-mime-type.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-invalid-mime-type.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-invalid-mime-type.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in unsent state, invalid MIME types]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-loading-state.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-loading-state.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-loading-state.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in LOADING state]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-utf-8.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-utf-8.htm.ini
@@ -1,5 +1,6 @@
 [overridemimetype-open-state-force-utf-8.htm]
   type: testharness
+  expected: CRASH
   [XMLHttpRequest: overrideMimeType() in open state, enforcing UTF-8 encoding]
     expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-xml.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-xml.htm.ini
@@ -1,5 +1,6 @@
 [overridemimetype-open-state-force-xml.htm]
   type: testharness
+  expected: TIMEOUT
   [XMLHttpRequest: overrideMimeType() in open state, XML MIME type with UTF-8 charset]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-unsent-state-force-shiftjis.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-unsent-state-force-shiftjis.htm.ini
@@ -1,5 +1,6 @@
 [overridemimetype-unsent-state-force-shiftjis.htm]
   type: testharness
+  expected: CRASH
   [XMLHttpRequest: overrideMimeType() in unsent state, enforcing Shift-JIS encoding]
     expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
@@ -8,3 +8,6 @@
   [XML document, windows-1252]
     expected: FAIL
 
+  [HTML document, invalid UTF-8]
+    expected: FAIL
+


### PR DESCRIPTION
We have completed the initial steps for "Implement support for missing XMLHttpRequest APIs"
- Implemented overrideMimeType according to XHR specifications
- Updated the test expectations

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8182)

<!-- Reviewable:end -->
