### PR TITLE
Allow retrieving width/height for non-positioned elements

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -221,13 +221,14 @@ impl PositionRetrievingFragmentBorderBoxIterator {
 }
 
 impl FragmentBorderBoxIterator for PositionRetrievingFragmentBorderBoxIterator {
-    fn process(&mut self, _: &Fragment, _: i32, border_box: &Rect<Au>) {
+    fn process(&mut self, fragment: &Fragment, _: i32, border_box: &Rect<Au>) {
+        let border_padding = fragment.border_padding.to_physical(fragment.style.writing_mode);
         self.result =
             Some(match self.property {
                      PositionProperty::Left => self.position.x,
                      PositionProperty::Top => self.position.y,
-                     PositionProperty::Width => border_box.size.width,
-                     PositionProperty::Height => border_box.size.height,
+                     PositionProperty::Width => border_box.size.width - border_padding.horizontal(),
+                     PositionProperty::Height => border_box.size.height - border_padding.vertical(),
                      // TODO: the following 2 calculations are completely wrong.
                      // They should return the difference between the parent's and this
                      // fragment's border boxes.

--- a/tests/wpt/metadata-css/cssom-1_dev/html/computed-style-001.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/computed-style-001.htm.ini
@@ -3,6 +3,3 @@
   [read_only]
     expected: FAIL
 
-  [relative_property_values]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.decimal.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.decimal.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.decimal.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.em.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.em.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.em.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.exp.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.exp.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.exp.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.hex.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.hex.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.hex.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.octal.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.octal.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.octal.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.percent.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.percent.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.percent.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.plus.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.plus.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.plus.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.space.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.space.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.space.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.trailingjunk.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.trailingjunk.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.trailingjunk.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.whitespace.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.zero.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.zero.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.parse.zero.html]
-  type: testharness
-  [Parsing of non-negative integers]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.decimal.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.decimal.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.decimal.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.em.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.em.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.em.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.exp.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.exp.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.exp.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.hex.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.hex.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.hex.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.octal.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.octal.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.octal.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.percent.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.percent.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.percent.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.plus.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.plus.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.plus.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.space.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.space.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.space.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.trailingjunk.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.trailingjunk.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.trailingjunk.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.whitespace.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.whitespace.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.whitespace.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.zero.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.zero.html.ini
@@ -1,5 +1,0 @@
-[size.attributes.setAttribute.zero.html]
-  type: testharness
-  [Parsing of non-negative integers in setAttribute]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/calc.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/calc.html.ini
@@ -1,11 +1,5 @@
 [calc.html]
   type: testharness
-  [calc(1px + 1pt + 1pc + 1in + 1cm + 1mm)]
-    expected: FAIL
-
-  [calc(0px + 0pt + 0pc + 0in + 0cm + 0mm + 0rem + 0em + 0ex + 0% + 0vw + 0vh + 0vmin + 0vmax)]
-    expected: FAIL
-
   [calc for column-width]
     expected: FAIL
 
@@ -13,8 +7,5 @@
     expected: FAIL
 
   [calc for column-count]
-    expected: FAIL
-
-  [calc(0ch + 0px + 0pt + 0pc + 0in + 0cm + 0mm + 0rem + 0em + 0ex + 0% + 0vw + 0vh + 0vmin + 0vmax)]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/mozilla/getComputedStyle.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/getComputedStyle.html.ini
@@ -1,0 +1,5 @@
+[getComputedStyle.html]
+  type: testharness
+  [getComputedStyle work for elements not in a document]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/tests/mozilla/getComputedStyle.html
+++ b/tests/wpt/mozilla/tests/mozilla/getComputedStyle.html
@@ -24,7 +24,7 @@
                 assert_equals(cs.getPropertyValue("top"), "auto");
                 assert_equals(cs.getPropertyValue("bottom"), "auto");
                 assert_equals(cs.getPropertyValue("width"), "50px");
-                assert_equals(cs.getPropertyValue("height"), "auto");
+                assert_equals(cs.getPropertyValue("height"), "0px");
                 assert_equals(cs.getPropertyValue("color"), "rgb(0, 0, 0)");
             }, "Element's resolved values");
 
@@ -43,8 +43,8 @@
             test(function() {
                 var div = document.createElement("div");
                 div.id = "foo";
-                assert_equals(getComputedStyle(div).getPropertyValue("width"), "");
-            }, "Blank style for elements not in a document");
+                assert_equals(getComputedStyle(div).getPropertyValue("width"), "50px");
+            }, "getComputedStyle work for elements not in a document");
 
         </script>
     </body>


### PR DESCRIPTION
This was causing a bunch of tests in tests/wpt/web-platform-tests/html/semantics/embedded-content/the-canvas-element/size.attributes\* to fail.  They were returning "auto" instead of the correct size. They still fail because the returned size is off by a few pixels, not sure why yet. But this is more correct and may fix other failing tests.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8202)

<!-- Reviewable:end -->
