### PR TITLE
Remove manual implementations of Send and Sync for BaseFlow.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -937,11 +937,6 @@ pub struct BaseFlow {
     pub flags: FlowFlags,
 }
 
-#[allow(unsafe_code)]
-unsafe impl Send for BaseFlow {}
-#[allow(unsafe_code)]
-unsafe impl Sync for BaseFlow {}
-
 impl fmt::Debug for BaseFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f,


### PR DESCRIPTION
They don't appear to be necessary.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8203)

<!-- Reviewable:end -->
