### PR TITLE
Return the result from query functions.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -1230,7 +1230,7 @@ impl LayoutTask {
                 ReflowQueryType::ContentBoxQuery(node) =>
                     process_content_box_request(node, &mut root_flow, &mut rw_data),
                 ReflowQueryType::ContentBoxesQuery(node) =>
-                    process_content_boxes_request(node, &mut root_flow, &mut rw_data),
+                    rw_data.content_boxes_response = process_content_boxes_request(node, &mut root_flow),
                 ReflowQueryType::NodeGeometryQuery(node) =>
                     rw_data.client_rect_response = self.process_node_geometry_request(node, &mut root_flow),
                 ReflowQueryType::ResolvedStyleQuery(node, ref pseudo, ref property) => {

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -1013,10 +1013,10 @@ impl LayoutTask {
         };
     }
 
-    fn process_offset_parent_query<'a>(&'a self,
-                                       requested_node: TrustedNodeAddress,
-                                       layout_root: &mut FlowRef,
-                                       rw_data: &mut RWGuard<'a>) {
+    fn process_offset_parent_query(&self,
+                                   requested_node: TrustedNodeAddress,
+                                   layout_root: &mut FlowRef)
+                                   -> OffsetParentResponse {
         let requested_node: OpaqueNode = OpaqueNodeMethods::from_script_node(requested_node);
         let mut iterator = ParentOffsetBorderBoxIterator::new(requested_node);
         sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
@@ -1026,13 +1026,13 @@ impl LayoutTask {
                 let parent = iterator.parent_nodes[parent_info_index].as_ref().unwrap();
                 let origin = iterator.node_border_box.origin - parent.border_box.origin;
                 let size = iterator.node_border_box.size;
-                rw_data.offset_parent_response = OffsetParentResponse {
+                OffsetParentResponse {
                     node_address: Some(parent.node_address.to_untrusted_node_address()),
                     rect: Rect::new(origin, size),
-                };
+                }
             }
             None => {
-                rw_data.offset_parent_response = OffsetParentResponse::empty();
+                OffsetParentResponse::empty()
             }
         }
     }
@@ -1244,7 +1244,7 @@ impl LayoutTask {
                                                         &mut rw_data)
                 }
                 ReflowQueryType::OffsetParentQuery(node) =>
-                    self.process_offset_parent_query(node, &mut root_flow, &mut rw_data),
+                    rw_data.offset_parent_response = self.process_offset_parent_query(node, &mut root_flow),
                 ReflowQueryType::NoQuery => {}
             }
         }

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -877,14 +877,14 @@ impl LayoutTask {
                                               traversal);
     }
 
-    fn process_node_geometry_request<'a>(&'a self,
-                                      requested_node: TrustedNodeAddress,
-                                      layout_root: &mut FlowRef,
-                                      rw_data: &mut RWGuard<'a>) {
+    fn process_node_geometry_request(&self,
+                                     requested_node: TrustedNodeAddress,
+                                     layout_root: &mut FlowRef)
+                                     -> Rect<i32> {
         let requested_node: OpaqueNode = OpaqueNodeMethods::from_script_node(requested_node);
         let mut iterator = FragmentLocatingFragmentIterator::new(requested_node);
         sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
-        rw_data.client_rect_response = iterator.client_rect;
+        iterator.client_rect
     }
 
     /// Return the resolved value of property for a given (pseudo)element.
@@ -1232,7 +1232,7 @@ impl LayoutTask {
                 ReflowQueryType::ContentBoxesQuery(node) =>
                     process_content_boxes_request(node, &mut root_flow, &mut rw_data),
                 ReflowQueryType::NodeGeometryQuery(node) =>
-                    self.process_node_geometry_request(node, &mut root_flow, &mut rw_data),
+                    rw_data.client_rect_response = self.process_node_geometry_request(node, &mut root_flow),
                 ReflowQueryType::ResolvedStyleQuery(node, ref pseudo, ref property) => {
                     rw_data.resolved_style_response =
                         self.process_resolved_style_request(node,

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -1228,7 +1228,7 @@ impl LayoutTask {
         if let Some(mut root_flow) = rw_data.layout_root() {
             match data.query_type {
                 ReflowQueryType::ContentBoxQuery(node) =>
-                    process_content_box_request(node, &mut root_flow, &mut rw_data),
+                    rw_data.content_box_response = process_content_box_request(node, &mut root_flow),
                 ReflowQueryType::ContentBoxesQuery(node) =>
                     rw_data.content_boxes_response = process_content_boxes_request(node, &mut root_flow),
                 ReflowQueryType::NodeGeometryQuery(node) =>

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -295,13 +295,13 @@ pub fn process_content_box_request<'a>(requested_node: TrustedNodeAddress,
     };
 }
 
-pub fn process_content_boxes_request<'a>(requested_node: TrustedNodeAddress,
-                                         layout_root: &mut FlowRef,
-                                         rw_data: &mut RWGuard<'a>) {
+pub fn process_content_boxes_request(requested_node: TrustedNodeAddress,
+                                     layout_root: &mut FlowRef)
+                                     -> Vec<Rect<Au>> {
     // FIXME(pcwalton): This has not been updated to handle the stacking context relative
     // stuff. So the position is wrong in most cases.
     let requested_node: OpaqueNode = OpaqueNodeMethods::from_script_node(requested_node);
     let mut iterator = CollectingFragmentBorderBoxIterator::new(requested_node);
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
-    rw_data.content_boxes_response = iterator.rects;
+    iterator.rects
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -10,7 +10,7 @@ use euclid::rect::Rect;
 use flow_ref::FlowRef;
 use fragment::{Fragment, FragmentBorderBoxIterator};
 use gfx::display_list::{DisplayItemMetadata, OpaqueNode};
-use layout_task::{LayoutTaskData, RWGuard};
+use layout_task::LayoutTaskData;
 use msg::constellation_msg::ConstellationChan;
 use msg::constellation_msg::Msg as ConstellationMsg;
 use opaque_node::OpaqueNodeMethods;
@@ -281,18 +281,18 @@ impl FragmentBorderBoxIterator for MarginRetrievingFragmentBorderBoxIterator {
     }
 }
 
-pub fn process_content_box_request<'a>(requested_node: TrustedNodeAddress,
-                                       layout_root: &mut FlowRef,
-                                       rw_data: &mut RWGuard<'a>) {
+pub fn process_content_box_request(requested_node: TrustedNodeAddress,
+                                   layout_root: &mut FlowRef)
+                                   -> Rect<Au> {
     // FIXME(pcwalton): This has not been updated to handle the stacking context relative
     // stuff. So the position is wrong in most cases.
     let requested_node: OpaqueNode = OpaqueNodeMethods::from_script_node(requested_node);
     let mut iterator = UnioningFragmentBorderBoxIterator::new(requested_node);
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
-    rw_data.content_box_response = match iterator.rect {
+    match iterator.rect {
         Some(rect) => rect,
         None       => Rect::zero()
-    };
+    }
 }
 
 pub fn process_content_boxes_request(requested_node: TrustedNodeAddress,


### PR DESCRIPTION
This reduces some unnecessarily tight coupling, makes it clearer what these functions do, and may help avoid bugs where we would return from such a function without updating the relevant field.

It is also a precondition for some future experimentation I'm thinking of doing with this querying design.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8205)

<!-- Reviewable:end -->
