### PR TITLE
Return a LayoutNode with a limited lifetime from layout_node_from_unsafe_layout_node (fixes #3044).

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -1076,9 +1076,7 @@ pub fn layout_node_to_unsafe_layout_node(node: &LayoutNode) -> UnsafeLayoutNode 
     }
 }
 
-// FIXME(#3044): This should be updated to use a real lifetime instead of
-// faking one.
-pub unsafe fn layout_node_from_unsafe_layout_node(node: &UnsafeLayoutNode) -> LayoutNode<'static> {
+pub unsafe fn layout_node_from_unsafe_layout_node(node: &UnsafeLayoutNode) -> LayoutNode {
     let (node, _) = *node;
     mem::transmute(node)
 }


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8208)

<!-- Reviewable:end -->
