### PR TITLE
Make executing synthesized pinch zoom more similar to zoom

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -204,17 +204,7 @@ impl Window {
                     MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
                     MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
                 };
-
-                if !self.key_modifiers.get().intersects(LEFT_CONTROL | RIGHT_CONTROL) {
-                    self.scroll_window(dx, dy);
-                } else {
-                    let factor = if dy > 0. {
-                        1.1
-                    } else {
-                        1.0 / 1.1
-                    };
-                    self.pinch_zoom(factor);
-                }
+                self.scroll_window(dx, dy);
             },
             Event::Refresh => {
                 self.event_queue.borrow_mut().push(WindowEvent::Refresh);
@@ -232,10 +222,6 @@ impl Window {
         let mut modifiers = self.key_modifiers.get();
         modifiers.toggle(modifier);
         self.key_modifiers.set(modifiers);
-    }
-
-    fn pinch_zoom(&self, factor: f32) {
-        self.event_queue.borrow_mut().push(WindowEvent::PinchZoom(factor));
     }
 
     /// Helper function to send a scroll event.
@@ -646,11 +632,18 @@ impl WindowMethods for Window {
     fn handle_key(&self, key: Key, mods: constellation_msg::KeyModifiers) {
 
         match (mods, key) {
-            (_, Key::Equal) if mods & !SHIFT == CMD_OR_CONTROL => {
-                self.event_queue.borrow_mut().push(WindowEvent::Zoom(1.1));
+            (_, Key::Equal) => {
+                if mods & !SHIFT == CMD_OR_CONTROL {
+                    self.event_queue.borrow_mut().push(WindowEvent::Zoom(1.1));
+                } else if mods & !SHIFT == CMD_OR_CONTROL | ALT {
+                    self.event_queue.borrow_mut().push(WindowEvent::PinchZoom(1.1));
+                }
             }
             (CMD_OR_CONTROL, Key::Minus) => {
                 self.event_queue.borrow_mut().push(WindowEvent::Zoom(1.0 / 1.1));
+            }
+            (_, Key::Minus) if mods == CMD_OR_CONTROL | ALT => {
+                self.event_queue.borrow_mut().push(WindowEvent::PinchZoom(1.0 / 1.1));
             }
             (CMD_OR_CONTROL, Key::Num0) |
             (CMD_OR_CONTROL, Key::Kp0) => {


### PR DESCRIPTION
Synthesized pinch zoom was removed in #8121 so that this combination of
mouse wheel and key press can be handled by the page. I mistakenly
re-implemented it #8215. In order to preserve synthesized pinch zoom,
which is very useful for testing on desktop computers, have it work
similarly to page zoom except with the ALT key pressed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8223)

<!-- Reviewable:end -->
