### PR TITLE
unblock using JS_GC_ZEAL

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2163,12 +2163,10 @@ let obj = RootedObject::new(cx, obj);\
                    "    create_dom_global(\n"
                    "        cx,\n"
                    "        &Class.base as *const js::jsapi::Class as *const JSClass,\n"
+                   "        raw as *const libc::c_void,\n"
                    "        Some(%s))\n"
                    ");\n"
-                   "assert!(!obj.ptr.is_null());\n"
-                   "\n"
-                   "JS_SetReservedSlot(obj.ptr, DOM_OBJECT_SLOT,\n"
-                   "                   PrivateValue(raw as *const libc::c_void));" % TRACE_HOOK_NAME)
+                   "assert!(!obj.ptr.is_null());" % TRACE_HOOK_NAME)
     else:
         create += ("let obj = {\n"
                    "    let _ac = JSAutoCompartment::new(cx, proto.ptr);\n"

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2157,27 +2157,29 @@ let obj = {
 assert!(!obj.is_null());
 let obj = RootedObject::new(cx, obj);\
 """ % (descriptor.name, parent)
+    elif descriptor.isGlobal():
+        create += ("let obj = RootedObject::new(\n"
+                   "    cx,\n"
+                   "    create_dom_global(\n"
+                   "        cx,\n"
+                   "        &Class.base as *const js::jsapi::Class as *const JSClass,\n"
+                   "        Some(%s))\n"
+                   ");\n"
+                   "assert!(!obj.ptr.is_null());\n"
+                   "\n"
+                   "JS_SetReservedSlot(obj.ptr, DOM_OBJECT_SLOT,\n"
+                   "                   PrivateValue(raw as *const libc::c_void));" % TRACE_HOOK_NAME)
     else:
-        if descriptor.isGlobal():
-            create += ("let obj = RootedObject::new(\n"
-                       "    cx,\n"
-                       "    create_dom_global(\n"
-                       "        cx,\n"
-                       "        &Class.base as *const js::jsapi::Class as *const JSClass,\n"
-                       "        Some(%s))\n"
-                       ");\n" % TRACE_HOOK_NAME)
-        else:
-            create += ("let obj = {\n"
-                       "    let _ac = JSAutoCompartment::new(cx, proto.ptr);\n"
-                       "    JS_NewObjectWithGivenProto(\n"
-                       "        cx, &Class.base as *const js::jsapi::Class as *const JSClass, proto.handle())\n"
-                       "};\n"
-                       "let obj = RootedObject::new(cx, obj);\n")
-        create += """\
-assert!(!obj.ptr.is_null());
-
-JS_SetReservedSlot(obj.ptr, DOM_OBJECT_SLOT,
-                   PrivateValue(raw as *const libc::c_void));"""
+        create += ("let obj = {\n"
+                   "    let _ac = JSAutoCompartment::new(cx, proto.ptr);\n"
+                   "    JS_NewObjectWithGivenProto(\n"
+                   "        cx, &Class.base as *const js::jsapi::Class as *const JSClass, proto.handle())\n"
+                   "};\n"
+                   "let obj = RootedObject::new(cx, obj);\n"
+                   "assert!(!obj.ptr.is_null());\n"
+                   "\n"
+                   "JS_SetReservedSlot(obj.ptr, DOM_OBJECT_SLOT,\n"
+                   "                   PrivateValue(raw as *const libc::c_void));")
     return create
 
 

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::PrototypeList;
 use dom::bindings::codegen::PrototypeList::MAX_PROTO_CHAIN_LENGTH;
 use dom::bindings::conversions::native_from_handleobject;
 use dom::bindings::conversions::private_from_proto_check;
-use dom::bindings::conversions::{is_dom_class, jsstring_to_str};
+use dom::bindings::conversions::{is_dom_class, jsstring_to_str, DOM_OBJECT_SLOT};
 use dom::bindings::error::throw_type_error;
 use dom::bindings::error::{Error, ErrorResult, Fallible, throw_invalid_this};
 use dom::bindings::global::GlobalRef;
@@ -625,6 +625,7 @@ pub fn has_property_on_prototype(cx: *mut JSContext, proxy: HandleObject,
 
 /// Create a DOM global object with the given class.
 pub fn create_dom_global(cx: *mut JSContext, class: *const JSClass,
+                         private: *const libc::c_void,
                          trace: JSTraceOp)
                          -> *mut JSObject {
     unsafe {
@@ -640,6 +641,7 @@ pub fn create_dom_global(cx: *mut JSContext, class: *const JSClass,
             return ptr::null_mut();
         }
         let _ac = JSAutoCompartment::new(cx, obj.ptr);
+        JS_SetReservedSlot(obj.ptr, DOM_OBJECT_SLOT, PrivateValue(private));
         JS_InitStandardClasses(cx, obj.handle());
         initialize_global(obj.ptr);
         JS_FireOnNewGlobalObject(cx, obj.handle());


### PR DESCRIPTION
I think these patches move the `JS_SetReservedSlot` call to the right place for #6057.  I'm not sure that the interface to `create_dom_global` is the best; passing a `JSVal` or a `*libc::c_void` seemed about equal, so I'd welcome feedback there.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8226)

<!-- Reviewable:end -->
