### PR TITLE
Fix misplaced doc comment in plugins/lib.rs

### DIFF
--- a/components/plugins/lib.rs
+++ b/components/plugins/lib.rs
@@ -36,8 +36,8 @@ use syntax::parse::token::intern;
 pub mod jstraceable;
 /// Handles the auto-deriving for `#[derive(HeapSizeOf)]`
 pub mod heap_size;
-/// Autogenerates implementations of Reflectable on DOM structs
 pub mod lints;
+/// Autogenerates implementations of Reflectable on DOM structs
 pub mod reflector;
 /// Utilities for writing plugins
 pub mod casing;


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8231)

<!-- Reviewable:end -->
