### PR TITLE
Expand DisplayList layer bounds to whole pixels

### DIFF
--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -34,7 +34,7 @@ use std::mem as std_mem;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, Select, Sender, channel};
 use url::Url;
-use util::geometry::ZERO_POINT;
+use util::geometry::{ExpandToPixelBoundaries, ZERO_POINT};
 use util::opts;
 use util::task::spawn_named;
 use util::task::spawn_named_with_send_on_failure;
@@ -85,7 +85,7 @@ impl PaintLayer {
     pub fn new_with_display_list(layer_info: LayerInfo,
                                  display_list: DisplayList)
                                  -> PaintLayer {
-        let bounds = display_list.calculate_bounding_rect();
+        let bounds = display_list.calculate_bounding_rect().expand_to_px_boundaries();
         PaintLayer {
             id: layer_info.layer_id,
             background_color: color::transparent(),

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "app_units"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "compositing"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -624,7 +624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gfx"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -1017,7 +1017,7 @@ dependencies = [
 name = "layout"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
@@ -1177,7 +1177,7 @@ dependencies = [
 name = "msg"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -1523,7 +1523,7 @@ name = "script"
 version = "0.0.1"
 dependencies = [
  "angle 0.1.0 (git+https://github.com/ecoal95/angle?branch=servo)",
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1576,7 +1576,7 @@ dependencies = [
 name = "script_traits"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -1740,7 +1740,7 @@ dependencies = [
 name = "style"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1767,7 +1767,7 @@ dependencies = [
 name = "style_tests"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.1.0 (git+https://github.com/servo/rust-selectors)",
@@ -1916,7 +1916,7 @@ dependencies = [
 name = "util"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -107,3 +107,20 @@ pub fn au_rect_to_f32_rect(rect: Rect<Au>) -> Rect<f32> {
     Rect::new(Point2D::new(rect.origin.x.to_f32_px(), rect.origin.y.to_f32_px()),
               Size2D::new(rect.size.width.to_f32_px(), rect.size.height.to_f32_px()))
 }
+
+pub trait ExpandToPixelBoundaries {
+    fn expand_to_px_boundaries(&self) -> Self;
+}
+
+impl ExpandToPixelBoundaries for Rect<Au> {
+    fn expand_to_px_boundaries(&self) -> Rect<Au> {
+        let bottom_right = self.bottom_right();
+        let bottom_right = Point2D::new(Au::from_px(bottom_right.x.ceil_to_px()),
+                                       Au::from_px(bottom_right.y.ceil_to_px()));
+        let new_origin = Point2D::new(Au::from_px(self.origin.x.to_px()),
+                                      Au::from_px(self.origin.y.to_px()));
+        Rect::new(new_origin,
+                  Size2D::new(bottom_right.x - new_origin.x,
+                              bottom_right.y - new_origin.y))
+    }
+}

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "app_units"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -239,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "compositing"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -580,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gfx"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -966,7 +966,7 @@ dependencies = [
 name = "layout"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
@@ -1126,7 +1126,7 @@ dependencies = [
 name = "msg"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -1454,7 +1454,7 @@ name = "script"
 version = "0.0.1"
 dependencies = [
  "angle 0.1.0 (git+https://github.com/ecoal95/angle?branch=servo)",
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1499,7 +1499,7 @@ dependencies = [
 name = "script_traits"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -1696,7 +1696,7 @@ dependencies = [
 name = "style"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1856,7 +1856,7 @@ dependencies = [
 name = "util"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "app_units"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -231,7 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "compositing"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -582,7 +582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gfx"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -915,7 +915,7 @@ dependencies = [
 name = "layout"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
@@ -1075,7 +1075,7 @@ dependencies = [
 name = "msg"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
@@ -1403,7 +1403,7 @@ name = "script"
 version = "0.0.1"
 dependencies = [
  "angle 0.1.0 (git+https://github.com/ecoal95/angle?branch=servo)",
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1448,7 +1448,7 @@ dependencies = [
 name = "script_traits"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.1.0 (git+https://github.com/pcwalton/ipc-channel)",
@@ -1643,7 +1643,7 @@ dependencies = [
 name = "style"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1803,7 +1803,7 @@ dependencies = [
 name = "util"
 version = "0.0.1"
 dependencies = [
- "app_units 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.2.0 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1919,6 +1919,18 @@
             "url": "/_mozilla/css/last_of_type_pseudo_a.html"
           }
         ],
+        "css/layerization_layer_size.html": [
+          {
+            "path": "css/layerization_layer_size.html",
+            "references": [
+              [
+                "/_mozilla/css/layerization_layer_size_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/layerization_layer_size.html"
+          }
+        ],
         "css/layerization_z_order_a.html": [
           {
             "path": "css/layerization_z_order_a.html",

--- a/tests/wpt/mozilla/tests/css/layerization_layer_size.html
+++ b/tests/wpt/mozilla/tests/css/layerization_layer_size.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<html>
+    <link rel="match" href="/_mozilla/css/layerization_layer_size_ref.html">
+    <style>
+
+      div {
+        position: absolute;
+        left: 0;
+        top: 10.5px;
+        width: 100px;
+        height: 100px;
+        background: green;
+      }
+
+      iframe {
+        border: none;
+      }
+    </style>
+
+    <body>
+        <!-- This div is positioned so should be rendered on top of the following
+             inline iframe. Since the iframe has a layer, the div should also be
+             promoted to a layer. This should not affect its final rendered position. -->
+        <div></div>
+        <iframe></iframe>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/layerization_layer_size_ref.html
+++ b/tests/wpt/mozilla/tests/css/layerization_layer_size_ref.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset=utf-8>
+<html>
+    <style>
+
+      div {
+        position: absolute;
+        left: 0;
+        top: 10.5px;
+        width: 100px;
+        height: 100px;
+        background: green;
+      }
+    </style>
+
+    <body>
+        <div></div>
+    </body>
+</html>


### PR DESCRIPTION
Before passing these layers to the paint task, expand them to pixel
boundaries. This ensures that subpixel edges of the layer will not be
clipped away and helps prevent rounding issues with layer contents.

Fixes #8166.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8244)

<!-- Reviewable:end -->
