### PR TITLE
Remove the Zeroable definition for Finite<T>.

### DIFF
--- a/components/script/dom/bindings/num.rs
+++ b/components/script/dom/bindings/num.rs
@@ -4,15 +4,12 @@
 
 //! The `Finite<T>` struct.
 
-use core::nonzero::Zeroable;
 use num::Float;
 use std::ops::Deref;
 
 /// Encapsulates the IDL restricted float type.
 #[derive(JSTraceable, Clone, Copy, Eq, PartialEq)]
 pub struct Finite<T: Float>(T);
-
-unsafe impl<T: Float> Zeroable for Finite<T> {}
 
 impl<T: Float> Finite<T> {
     /// Create a new `Finite<T: Float>` safely.


### PR DESCRIPTION
I have no idea why it was added, and it appears to be unused.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8248)

<!-- Reviewable:end -->
