### PR TITLE
M1506 : Refactor GLES2

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1834,7 +1834,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         let show_debug_borders = opts::get().show_debug_borders;
         self.context = Some(rendergl::RenderContext::new(self.native_display.clone(),
                                                          show_debug_borders,
-                                                         opts::get().output_file.is_some()))
+                                                         opts::get().output_file.is_some(),
+                                                         opts::get().graphics_select.clone()))
     }
 
     fn find_topmost_layer_at_point_for_layer(&self,

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1835,7 +1835,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         self.context = Some(rendergl::RenderContext::new(self.native_display.clone(),
                                                          show_debug_borders,
                                                          opts::get().output_file.is_some(),
-                                                         opts::get().graphics_select.clone()))
+                                                         opts::get().use_gl.is_some()))
     }
 
     fn find_topmost_layer_at_point_for_layer(&self,

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1835,7 +1835,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         self.context = Some(rendergl::RenderContext::new(self.native_display.clone(),
                                                          show_debug_borders,
                                                          opts::get().output_file.is_some(),
-                                                         opts::get().use_gl.is_some()))
+                                                         opts::get().use_gl))
     }
 
     fn find_topmost_layer_at_point_for_layer(&self,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -176,6 +176,8 @@ pub struct Opts {
 
     /// Do not use native titlebar
     pub no_native_titlebar: bool,
+
+    pub graphics_select: String,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -381,6 +383,27 @@ fn default_user_agent_string(agent: UserAgent) -> String {
     }.to_owned()
 }
 
+
+enum GraphicOption {
+    GL,
+    ES2,
+  }
+
+  fn default_graphics_select_string(goption: GraphicOption) -> String {
+      match goption {
+          GraphicOption::GL => {
+                //println!("GL");
+                "GL"
+
+          },
+          GraphicOption::ES2 => {
+              //println!("ES2");
+              "ES2"
+          }
+      }.to_owned()
+  }
+
+const DEFAULT_GRAPHICS: GraphicOption = GraphicOption::GL;
 #[cfg(target_os = "android")]
 const DEFAULT_USER_AGENT: UserAgent = UserAgent::Android;
 
@@ -439,6 +462,7 @@ pub fn default_opts() -> Opts {
         convert_mouse_to_touch: false,
         exit_after_load: false,
         no_native_titlebar: false,
+        graphics_select: default_graphics_select_string(DEFAULT_GRAPHICS),
     }
 }
 
@@ -480,6 +504,7 @@ pub fn from_cmdline_args(args: &[String]) {
     opts.optmulti("", "pref",
                   "A preference to set to enable", "dom.mozbrowser.enabled");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
+    opts.optflagopt("G", "graphics", "Select graphics backend (GL or ES2)", "GL");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -581,6 +606,13 @@ pub fn from_cmdline_args(args: &[String]) {
         }
     };
 
+    let graphics_select = match opt_match.opt_str("G") {
+        Some(ref ga) if ga == "GL" => default_graphics_select_string(GraphicOption::GL),
+        Some(ref ga) if ga == "ES2" => default_graphics_select_string(GraphicOption::ES2),
+        Some(ga) =>  args_fail(&format!("error: unrecognized option:")),
+        None => default_graphics_select_string(GraphicOption::GL),
+    };
+
     let user_agent = match opt_match.opt_str("u") {
         Some(ref ua) if ua == "android" => default_user_agent_string(UserAgent::Android),
         Some(ref ua) if ua == "gonk" => default_user_agent_string(UserAgent::Gonk),
@@ -623,6 +655,7 @@ pub fn from_cmdline_args(args: &[String]) {
         trace_layout: debug_options.trace_layout,
         devtools_port: devtools_port,
         webdriver_port: webdriver_port,
+        graphics_select: graphics_select,
         initial_window_size: initial_window_size,
         user_agent: user_agent,
         multiprocess: opt_match.opt_present("M"),

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -488,7 +488,7 @@ pub fn from_cmdline_args(args: &[String]) {
     opts.optmulti("", "pref",
                   "A preference to set to enable", "dom.mozbrowser.enabled");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optflagopt("G", "graphics", "Set true for GL or false for ES2");
+    opts.optflag("G", "graphics", "Set true for GL or false for ES2");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -488,7 +488,7 @@ pub fn from_cmdline_args(args: &[String]) {
     opts.optmulti("", "pref",
                   "A preference to set to enable", "dom.mozbrowser.enabled");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optflag("G", "graphics", "Set true for GL or false for ES2");
+    opts.optflag("E", "es2", "Select ES2 for backend graphic option");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -590,8 +590,6 @@ pub fn from_cmdline_args(args: &[String]) {
         }
     };
 
-
-
     let user_agent = match opt_match.opt_str("u") {
         Some(ref ua) if ua == "android" => default_user_agent_string(UserAgent::Android),
         Some(ref ua) if ua == "gonk" => default_user_agent_string(UserAgent::Gonk),
@@ -634,7 +632,7 @@ pub fn from_cmdline_args(args: &[String]) {
         trace_layout: debug_options.trace_layout,
         devtools_port: devtools_port,
         webdriver_port: webdriver_port,
-        use_gl:opt_match.opt_present("G"),
+        use_gl:!opt_match.opt_present("E"),
         initial_window_size: initial_window_size,
         user_agent: user_agent,
         multiprocess: opt_match.opt_present("M"),

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -178,7 +178,7 @@ pub struct Opts {
     pub no_native_titlebar: bool,
 
     /// Set graphics renderer to be GL or ES2
-    pub graphics_select: String,
+    pub use_gl: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -388,23 +388,7 @@ fn default_user_agent_string(agent: UserAgent) -> String {
 const DEFAULT_USER_AGENT: UserAgent = UserAgent::Android;
 
 
-enum GraphicOption {
-    GL,
-    ES2,
-  }
 
-  fn default_graphics_select_string(goption: GraphicOption) -> String {
-      match goption {
-          GraphicOption::GL => {
-                "GL"
-          },
-          GraphicOption::ES2 => {
-              "ES2"
-          }
-      }.to_owned()
-  }
-
-const DEFAULT_GRAPHICS: GraphicOption = GraphicOption::GL;
 
 
 // FIXME: This requires https://github.com/servo/servo/issues/7138 to provide the
@@ -462,7 +446,7 @@ pub fn default_opts() -> Opts {
         convert_mouse_to_touch: false,
         exit_after_load: false,
         no_native_titlebar: false,
-        graphics_select: default_graphics_select_string(DEFAULT_GRAPHICS),
+        use_gl: true,
     }
 }
 
@@ -504,7 +488,7 @@ pub fn from_cmdline_args(args: &[String]) {
     opts.optmulti("", "pref",
                   "A preference to set to enable", "dom.mozbrowser.enabled");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optflagopt("G", "graphics", "Select graphics backend (GL or ES2)", "GL");
+    opts.optflagopt("G", "graphics", "Set true for GL or false for ES2");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -606,12 +590,7 @@ pub fn from_cmdline_args(args: &[String]) {
         }
     };
 
-    let graphics_select = match opt_match.opt_str("G") {
-        Some(ref ga) if ga == "GL" => default_graphics_select_string(GraphicOption::GL),
-        Some(ref ga) if ga == "ES2" => default_graphics_select_string(GraphicOption::ES2),
-        Some(ga) =>  args_fail(&format!("error: graphics option should be GL or ES2:")),
-        None => default_graphics_select_string(GraphicOption::GL),
-    };
+
 
     let user_agent = match opt_match.opt_str("u") {
         Some(ref ua) if ua == "android" => default_user_agent_string(UserAgent::Android),
@@ -655,7 +634,7 @@ pub fn from_cmdline_args(args: &[String]) {
         trace_layout: debug_options.trace_layout,
         devtools_port: devtools_port,
         webdriver_port: webdriver_port,
-        graphics_select: graphics_select,
+        use_gl:opt_match.opt_present("G"),
         initial_window_size: initial_window_size,
         user_agent: user_agent,
         multiprocess: opt_match.opt_present("M"),

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -177,6 +177,7 @@ pub struct Opts {
     /// Do not use native titlebar
     pub no_native_titlebar: bool,
 
+    /// Set graphics renderer to be GL or ES2
     pub graphics_select: String,
 }
 
@@ -383,6 +384,9 @@ fn default_user_agent_string(agent: UserAgent) -> String {
     }.to_owned()
 }
 
+#[cfg(target_os = "android")]
+const DEFAULT_USER_AGENT: UserAgent = UserAgent::Android;
+
 
 enum GraphicOption {
     GL,
@@ -392,20 +396,16 @@ enum GraphicOption {
   fn default_graphics_select_string(goption: GraphicOption) -> String {
       match goption {
           GraphicOption::GL => {
-                //println!("GL");
                 "GL"
-
           },
           GraphicOption::ES2 => {
-              //println!("ES2");
               "ES2"
           }
       }.to_owned()
   }
 
 const DEFAULT_GRAPHICS: GraphicOption = GraphicOption::GL;
-#[cfg(target_os = "android")]
-const DEFAULT_USER_AGENT: UserAgent = UserAgent::Android;
+
 
 // FIXME: This requires https://github.com/servo/servo/issues/7138 to provide the
 // correct string in Gonk builds (i.e., it will never be chosen today).
@@ -609,7 +609,7 @@ pub fn from_cmdline_args(args: &[String]) {
     let graphics_select = match opt_match.opt_str("G") {
         Some(ref ga) if ga == "GL" => default_graphics_select_string(GraphicOption::GL),
         Some(ref ga) if ga == "ES2" => default_graphics_select_string(GraphicOption::ES2),
-        Some(ga) =>  args_fail(&format!("error: unrecognized option:")),
+        Some(ga) =>  args_fail(&format!("error: graphics option should be GL or ES2:")),
         None => default_graphics_select_string(GraphicOption::GL),
     };
 


### PR DESCRIPTION
This contains the new command line option to allow selecting the graphics backend (GL or ES2) in components/utils/opts.rs, and use the new command line option to pass an appropriate value in initialize_compositing in components/compositing/compositor.rs

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8277)

<!-- Reviewable:end -->
