### PR TITLE
Remove unnecessary uses of #[no_move]

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4927,7 +4927,6 @@ class CGDictionary(CGThing):
                        for m in self.memberInfo]
 
         return (string.Template(
-                "#[no_move]\n" +
                 "pub struct ${selfName} {\n" +
                 "${inheritance}" +
                 "\n".join(memberDecls) + "\n" +

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -453,7 +453,6 @@ impl<T: Reflectable> OptionalRootedReference<T> for Option<Option<Root<T>>> {
 ///
 /// See also [*Exact Stack Rooting - Storing a GCPointer on the CStack*]
 /// (https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/GC/Exact_Stack_Rooting).
-#[no_move]
 pub struct RootCollection {
     roots: UnsafeCell<Vec<*const Reflector>>,
 }

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -149,9 +149,7 @@ pub mod utils;
 /// Generated JS-Rust bindings.
 #[allow(missing_docs, non_snake_case)]
 pub mod codegen {
-    // FIXME(#5853) we shouldn't need to
-    // allow moved_no_move here
-    #[allow(unrooted_must_root, moved_no_move)]
+    #[allow(unrooted_must_root)]
     pub mod Bindings {
         include!(concat!(env!("OUT_DIR"), "/Bindings/mod.rs"));
     }

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -89,6 +89,7 @@ use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::io::{Write, stdout};
+use std::marker::PhantomData;
 use std::mem as std_mem;
 use std::option::Option;
 use std::ptr;
@@ -334,18 +335,18 @@ impl TimerEventChan for MainThreadTimerEventChan {
     }
 }
 
-pub struct StackRootTLS;
+pub struct StackRootTLS<'a>(PhantomData<&'a u32>);
 
-impl StackRootTLS {
-    pub fn new(roots: &RootCollection) -> StackRootTLS {
+impl<'a> StackRootTLS<'a> {
+    pub fn new(roots: &'a RootCollection) -> StackRootTLS<'a> {
         STACK_ROOTS.with(|ref r| {
             r.set(Some(RootCollectionPtr(roots as *const _)))
         });
-        StackRootTLS
+        StackRootTLS(PhantomData)
     }
 }
 
-impl Drop for StackRootTLS {
+impl<'a> Drop for StackRootTLS<'a> {
     fn drop(&mut self) {
         STACK_ROOTS.with(|ref r| r.set(None));
     }


### PR DESCRIPTION
The patch makes RootCollection a bit safer by making the StackRootTLS hold
it in place.

RootedVec was doing an extremely delicate dance and just hoping nobody
messed it up; switch to a Box to be safe.

CodeGenRust seemed to be using no_move for no particularly good reason.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8286)

<!-- Reviewable:end -->
