### PR TITLE
Un-boxed ScriptReflow

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -593,7 +593,7 @@ impl LayoutTask {
                 profile(time::ProfilerCategory::LayoutPerform,
                         self.profiler_metadata(),
                         self.time_profiler_chan.clone(),
-                        || self.handle_reflow(&*data, possibly_locked_rw_data));
+                        || self.handle_reflow(&data, possibly_locked_rw_data));
             },
             Msg::TickAnimations => self.tick_all_animations(possibly_locked_rw_data),
             Msg::ReflowWithNewlyLoadedWebFont => {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -910,7 +910,7 @@ impl Window {
         }
 
         // Send new document and relevant styles to layout.
-        let reflow = box ScriptReflow {
+        let reflow = ScriptReflow {
             reflow_info: Reflow {
                 goal: goal,
                 page_clip_rect: self.page_clip_rect.get(),

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -47,7 +47,7 @@ pub enum Msg {
     SetQuirksMode,
 
     /// Requests a reflow.
-    Reflow(Box<ScriptReflow>),
+    Reflow(ScriptReflow),
 
     /// Get an RPC interface.
     GetRPC(Sender<Box<LayoutRPC + Send>>),


### PR DESCRIPTION
As per #8238 I changed `layout_interface::Msg::Reflow` to store `ScriptReflow` rather than `Box<ScriptReflow>` 

I ran the tests and believe everything passed but this is my first commit to the project so sorry if I messed up the protocol!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8290)

<!-- Reviewable:end -->
