### PR TITLE
Issue #8113: Support file, about and data schemes as form action.

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -209,7 +209,8 @@ impl HTMLFormElement {
                 load_data.data = Some(parsed_data.into_bytes());
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("ftp", _) | ("javascript", _) | ("data", FormMethod::FormGet) => (),
+            ("file", _) | ("about", _) | ("data", FormMethod::FormGet) |
+            ("ftp", _) | ("javascript", _) => (),
             _ => return // Unimplemented (data and mailto)
         }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5451,6 +5451,12 @@
             "url": "/_mozilla/mozilla/follow-hyperlink.html"
           }
         ],
+        "mozilla/form_submit_about.html": [
+          {
+            "path": "mozilla/form_submit_about.html",
+            "url": "/_mozilla/mozilla/form_submit_about.html"
+          }
+        ],
         "mozilla/getBoundingClientRect.html": [
           {
             "path": "mozilla/getBoundingClientRect.html",

--- a/tests/wpt/mozilla/tests/mozilla/form_submit_about.html
+++ b/tests/wpt/mozilla/tests/mozilla/form_submit_about.html
@@ -1,0 +1,15 @@
+<html>
+    <head>
+        <script src=/resources/testharness.js></script>
+        <script src=/resources/testharnessreport.js></script>
+    </head>
+    <body>
+        <iframe src="form_submit_about_frame.html" id="foo"></iframe>
+        <script>
+            var numOnLoads = 0
+            var t = async_test("about:blank as form target")
+            var iframe = document.getElementById('foo')
+            iframe.onload = t.step_func(function(e) { if (++numOnLoads == 2) t.done() })
+        </script>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/form_submit_about_frame.html
+++ b/tests/wpt/mozilla/tests/mozilla/form_submit_about_frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <form name="my" action="about:blank">
+            <input type="submit" value="Submit about:blank"/>
+        </form>
+        <script>
+            window.onload = function() {
+                document.forms["my"].submit();
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Fix https://github.com/servo/servo/issues/8113 by supporting those schemes as form action and unit test the "about:blank" case

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8293)

<!-- Reviewable:end -->
