### PR TITLE
Properly resize iframe root layers

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -791,8 +791,20 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         self.pipeline_details.remove(&pipeline_id);
     }
 
-    fn update_layer_if_exists(&mut self, pipeline_id: PipelineId, properties: LayerProperties)
+    fn update_layer_if_exists(&mut self,
+                              pipeline_id: PipelineId,
+                              properties: LayerProperties)
                               -> bool {
+        if let Some(subpage_id) = properties.subpage_pipeline_id {
+            match self.find_layer_with_pipeline_and_layer_id(subpage_id, LayerId::null()) {
+                Some(layer) => {
+                    *layer.bounds.borrow_mut() = Rect::from_untyped(
+                        &Rect::new(Point2D::zero(), properties.rect.size));
+                }
+                None => warn!("Tried to update non-existent subpage root layer: {:?}", subpage_id),
+            }
+        }
+
         match self.find_layer_with_pipeline_and_layer_id(pipeline_id, properties.id) {
             Some(existing_layer) => {
                 existing_layer.update_layer(properties);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4139,6 +4139,18 @@
             "url": "/_mozilla/mozilla/canvas/drawimage_html_image_9.html"
           }
         ],
+        "mozilla/iframe/resize_after_load.html": [
+          {
+            "path": "mozilla/iframe/resize_after_load.html",
+            "references": [
+              [
+                "/_mozilla/mozilla/iframe/resize_after_load_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/mozilla/iframe/resize_after_load.html"
+          }
+        ],
         "mozilla/webgl/clearcolor.html": [
           {
             "path": "mozilla/webgl/clearcolor.html",
@@ -8926,6 +8938,18 @@
             ]
           ],
           "url": "/_mozilla/mozilla/canvas/drawimage_html_image_9.html"
+        }
+      ],
+      "mozilla/iframe/resize_after_load.html": [
+        {
+          "path": "mozilla/iframe/resize_after_load.html",
+          "references": [
+            [
+              "/_mozilla/mozilla/iframe/resize_after_load_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/mozilla/iframe/resize_after_load.html"
         }
       ],
       "mozilla/webgl/clearcolor.html": [

--- a/tests/wpt/mozilla/tests/mozilla/iframe/resize_after_load.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/resize_after_load.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html class="reftest-wait">
+    <head>
+        <meta charset=utf-8>
+        <title>Dynamically growing an iframe element</title>
+        <link rel=match href=/_mozilla/mozilla/iframe/resize_after_load_ref.html>
+    </head>
+
+    <body>
+        <iframe style="border: 0px; display: block; height: 100px; width: 50px" src="resources/green_inner_frame.html"></iframe>
+        <script>
+            var iframe = document.getElementsByTagName('iframe')[0];
+            iframe.onload = function() {
+                document.querySelector('iframe').style.width = "100px";
+
+                // We do this in a timeout, so that the compositor has a chance
+                // to update the layer tree.
+                setTimeout(function() {
+                    document.documentElement.classList.remove("reftest-wait");
+                }, 0);
+            }
+        </script>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/iframe/resize_after_load_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/resize_after_load_ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <body>
+        <div style="height: 100px; width: 100px; background: green;"></div>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/iframe/resources/green_inner_frame.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/resources/green_inner_frame.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+    <body style="background: green;">
+    </body>
+</html>


### PR DESCRIPTION
When a layer containing an iframe changes, we also need to resize the
root layer of the subpage. This ensures that content from the child
layer tree is masked to the new size.

Fixes #8301.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8322)

<!-- Reviewable:end -->
