### PR TITLE
Print process output for TIMEOUT status in WPT UI

### DIFF
--- a/tests/wpt/grouping_formatter.py
+++ b/tests/wpt/grouping_formatter.py
@@ -167,9 +167,10 @@ class GroupingFormatter(base.BaseFormatter):
             self.expected[test_status] += 1
             return self.generate_output(text=None, new_display=new_display)
 
-        # If the test crashed, we also include any process output, because there is a good
-        # chance that the test produced a stack trace.
-        if test_status == "CRASH":
+        # If the test crashed or timed out, we also include any process output,
+        # because there is a good chance that the test produced a stack trace
+        # or other error messages.
+        if test_status in ("CRASH", "TIMEOUT"):
             stack = self.test_output[test_name] + data.get('stack', "")
         else:
             stack = data.get('stack', None)


### PR DESCRIPTION
Tests can time out due to script or runtime errors, which are typically
reported via the Servo process output. Including process output for tests
timing out makes it easier to understand these problems.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8323)

<!-- Reviewable:end -->
