### PR TITLE
Add missing css style for image_rendering_auto_a.html

### DIFF
--- a/tests/ref/image_rendering_auto_a.html
+++ b/tests/ref/image_rendering_auto_a.html
@@ -2,6 +2,13 @@
 <html>
 <head>
 <!-- Tests that `image-rendering: auto` uses bilinear filtering. -->
+<style>
+img {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+</style>
 </head>
 <body>
 <img width=100 height=50 src=4x2.png>


### PR DESCRIPTION
There was a missing image position in the test which caused potentially 
wrong comparision of images in basic.list:
!= image_rendering_auto_a.html image_rendering_pixelated_a.html

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8328)

<!-- Reviewable:end -->
