### PR TITLE
Eliminate LAYERS_NEEDED_FOR_DESCENDANTS flag

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -580,9 +580,6 @@ bitflags! {
         const IMPACTED_BY_RIGHT_FLOATS = 0b0000_0000_0000_0000_1000,
 
         // text align flags
-        #[doc = "Whether this flow contains a flow that has its own layer within the same absolute"]
-        #[doc = "containing block."]
-        const LAYERS_NEEDED_FOR_DESCENDANTS = 0b0000_0000_0000_0001_0000,
         #[doc = "Whether this flow must have its own layer. Even if this flag is not set, it might"]
         #[doc = "get its own layer if it's deemed to be likely to overlap flows with their own"]
         #[doc = "layer."]
@@ -810,18 +807,12 @@ pub struct LateAbsolutePositionInfo {
     /// context. If the absolute containing block establishes the stacking context for this flow,
     /// and this flow is not itself absolutely-positioned, then this is (0, 0).
     pub stacking_relative_position_of_absolute_containing_block: Point2D<Au>,
-
-    /// Whether the absolute containing block forces positioned descendants to be layerized.
-    ///
-    /// FIXME(pcwalton): Move into `FlowFlags`.
-    pub layers_needed_for_positioned_flows: bool,
 }
 
 impl LateAbsolutePositionInfo {
     pub fn new() -> LateAbsolutePositionInfo {
         LateAbsolutePositionInfo {
             stacking_relative_position_of_absolute_containing_block: Point2D::zero(),
-            layers_needed_for_positioned_flows: false,
         }
     }
 }

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -7,8 +7,8 @@
 #![deny(unsafe_code)]
 
 use app_units::Au;
+use block::{BlockFlow, CandidateBSizeIterator, ISizeAndMarginsComputer};
 use block::{ISizeConstraintInput, ISizeConstraintSolution};
-use block::{self, BlockFlow, CandidateBSizeIterator, ISizeAndMarginsComputer};
 use context::LayoutContext;
 use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode};
 use euclid::{Point2D, Rect};
@@ -775,11 +775,7 @@ impl TableLikeFlow for BlockFlow {
 
             // At this point, `current_block_offset` is at the content edge of our box. Now iterate
             // over children.
-            let mut layers_needed_for_descendants = false;
             for kid in self.base.child_iter() {
-                // Mark flows for layerization if necessary to handle painting order correctly.
-                block::propagate_layer_flag_from_child(&mut layers_needed_for_descendants, kid);
-
                 // Account for spacing or collapsed borders.
                 if kid.is_table_row() {
                     has_rows = true;


### PR DESCRIPTION
This flag is no longer necessary, because stacking contexts can now
create layers lazily for content that needs to be stacked above a
layer. This should reduce the number of layers on pages, hopefully
reducing overdraw.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8334)

<!-- Reviewable:end -->
