### PR TITLE
Remove HTMLTableCellElement fields with parsed attribute values

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -21,7 +21,8 @@ use std::mem;
 use std::ops::Deref;
 use string_cache::{Atom, Namespace};
 use style::values::specified::Length;
-use util::str::{DOMString, parse_unsigned_integer, split_html_space_chars, str_join};
+use util::str::{DOMString, parse_unsigned_integer, parse_legacy_color};
+use util::str::{split_html_space_chars, str_join};
 
 #[derive(JSTraceable, PartialEq, Clone, HeapSizeOf)]
 pub enum AttrValue {
@@ -75,6 +76,11 @@ impl AttrValue {
     pub fn from_atomic(string: DOMString) -> AttrValue {
         let value = Atom::from_slice(&string);
         AttrValue::Atom(value)
+    }
+
+    pub fn from_legacy_color(string: DOMString) -> AttrValue {
+        let parsed = parse_legacy_color(&string).ok();
+        AttrValue::Color(string, parsed)
     }
 
     /// Assumes the `AttrValue` is a `TokenList` and returns its tokens

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -142,10 +142,7 @@ impl VirtualMethods for HTMLBodyElement {
 
     fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
         match name {
-            &atom!("text") => {
-                let parsed = str::parse_legacy_color(&value).ok();
-                AttrValue::Color(value, parsed)
-            },
+            &atom!("text") => AttrValue::from_legacy_color(value),
             _ => self.super_type().unwrap().parse_plain_attribute(name, value),
         }
     }


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8336)

<!-- Reviewable:end -->
