### PR TITLE
Remove DisplayListBuildingResult

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -164,18 +164,30 @@ impl DisplayList {
         }
     }
 
+
+    /// Creates a new display list which contains a single stacking context.
+    #[inline]
+    pub fn new_with_stacking_context(stacking_context: Arc<StackingContext>) -> Box<DisplayList> {
+        let mut display_list = box DisplayList::new();
+        display_list.positioned_content.push_back(
+            DisplayItem::StackingContextClass(stacking_context));
+        display_list
+    }
+
     /// Appends all display items from `other` into `self`, preserving stacking order and emptying
     /// `other` in the process.
     #[inline]
-    pub fn append_from(&mut self, other: &mut DisplayList) {
-        self.background_and_borders.append(&mut other.background_and_borders);
-        self.block_backgrounds_and_borders.append(&mut other.block_backgrounds_and_borders);
-        self.floats.append(&mut other.floats);
-        self.content.append(&mut other.content);
-        self.positioned_content.append(&mut other.positioned_content);
-        self.outlines.append(&mut other.outlines);
-        self.layered_children.append(&mut other.layered_children);
-        self.layer_info.append(&mut other.layer_info);
+    pub fn append_from(&mut self, other: &mut Option<Box<DisplayList>>) {
+        if let Some(mut other) = other.take() {
+            self.background_and_borders.append(&mut other.background_and_borders);
+            self.block_backgrounds_and_borders.append(&mut other.block_backgrounds_and_borders);
+            self.floats.append(&mut other.floats);
+            self.content.append(&mut other.content);
+            self.positioned_content.append(&mut other.positioned_content);
+            self.outlines.append(&mut other.outlines);
+            self.layered_children.append(&mut other.layered_children);
+            self.layer_info.append(&mut other.layer_info);
+        }
     }
 
     /// Merges all display items from all non-float stacking levels to the `float` stacking level.

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -1084,9 +1084,8 @@ impl LayoutTask {
                     }
                 };
                 let mut display_list = box DisplayList::new();
-                flow::mut_base(flow_ref::deref_mut(layout_root))
-                    .display_list_building_result
-                    .add_to(&mut *display_list);
+                display_list.append_from(&mut flow::mut_base(flow_ref::deref_mut(layout_root))
+                                         .display_list_building_result);
 
                 let origin = Rect::new(Point2D::new(Au(0), Au(0)), root_size);
                 let stacking_context = Arc::new(StackingContext::new(display_list,


### PR DESCRIPTION
Always produce a DisplayList when processing nodes for display list
construction. StackingContexts are now added to the positioned content
section of DisplayLists. This makes the code a bit simpler and opens up
the possibility of producing a StackingContext in another section of
the DisplayList. This doesn't change behavior, but is a cleanup
prerequisite for proper inline stacking context support.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8337)

<!-- Reviewable:end -->
