### PR TITLE
mach_bootstrap: Don't get confused by interrupts

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -91,7 +91,8 @@ def _activate_virtualenv(topdir):
     if python is None:
         sys.exit("Python is not installed. Please install it prior to running mach.")
 
-    if not os.path.exists(virtualenv_path):
+    activate_path = os.path.join(virtualenv_path, "bin", "activate_this.py")
+    if not (os.path.exists(virtualenv_path) and os.path.exists(activate_path)):
         virtualenv = _get_exec(*VIRTUALENV_NAMES)
         if virtualenv is None:
             sys.exit("Python virtualenv is not installed. Please install it prior to running mach.")
@@ -101,7 +102,6 @@ def _activate_virtualenv(topdir):
         except (subprocess.CalledProcessError, OSError):
             sys.exit("Python virtualenv failed to execute properly.")
 
-    activate_path = os.path.join(virtualenv_path, "bin", "activate_this.py")
     execfile(activate_path, dict(__file__=activate_path))
 
     # TODO: Right now, we iteratively install all the requirements by invoking
@@ -123,7 +123,7 @@ def _activate_virtualenv(topdir):
             if os.path.getmtime(req_path) + 10 < os.path.getmtime(marker_path):
                 continue
         except OSError:
-            open(marker_path, 'w').close()
+            pass
 
         pip = _get_exec(*PIP_NAMES)
         if pip is None:
@@ -134,7 +134,7 @@ def _activate_virtualenv(topdir):
         except (subprocess.CalledProcessError, OSError):
             sys.exit("Pip failed to execute properly.")
 
-        os.utime(marker_path, None)
+        open(marker_path, 'w').close()
 
 
 def bootstrap(topdir):


### PR DESCRIPTION
When mach_bootstrap got interrupted while it's setting up virtualenv or
calling out to pip, it wouldn't repeat that step on subsequent runs, and
mach fails because its environment isn't set up properly or dependencies
are missing.

So now we re-run virtualenv if activate_this.py doesn't exist, and only
create the marker file for required packages after pip has returned
successfully.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8364)

<!-- Reviewable:end -->
