### PR TITLE
Add CCACHE infra and turn it on in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+env:
+  - CCACHE=/usr/bin/ccache
+
 matrix:
   fast_finish: true
   include:
@@ -13,6 +16,7 @@ matrix:
         directories:
           - .cargo
           - .servo
+          - $HOME/.ccache
       addons:
         apt:
           packages:
@@ -22,6 +26,7 @@ matrix:
             - libosmesa6-dev
             - python-virtualenv
             - xorg-dev
+            - ccache
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 
-env:
-  - CCACHE=/usr/bin/ccache
-
 matrix:
   fast_finish: true
   include:
@@ -17,6 +14,7 @@ matrix:
           - .cargo
           - .servo
           - $HOME/.ccache
+      env: CCACHE=/usr/bin/ccache
       addons:
         apt:
           packages:

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -232,6 +232,9 @@ class MachCommands(CommandBase):
             env['OPENSSL_INCLUDE_DIR'] = path.join(openssl_dir, "include")
             env['OPENSSL_STATIC'] = 'TRUE'
 
+        if not (self.config["build"]["ccache"] == ""):
+            env['CCACHE'] = self.config["build"]["ccache"]
+
         status = call(
             ["cargo", "build"] + opts,
             env=env, cwd=self.servo_crate(), verbose=verbose)

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -107,6 +107,7 @@ class CommandBase(object):
         self.config["build"].setdefault("android", False)
         self.config["build"].setdefault("mode", "")
         self.config["build"].setdefault("debug-mozjs", False)
+        self.config["build"].setdefault("ccache", "")
 
         self.config.setdefault("android", {})
         self.config["android"].setdefault("sdk", "")

--- a/servobuild.example
+++ b/servobuild.example
@@ -36,6 +36,8 @@ rustc-with-gold = true
 android = false
 # Set "debug-mozjs" or use `mach build --debug-mozjs` to build a debug spidermonkey.
 debug-mozjs = false
+# Set to the path to your ccache binary to enable caching of compiler outputs
+#ccache = "/usr/local/bin/ccache"
 
 # Android information
 [android]


### PR DESCRIPTION
r? @Manishearth 

This lets devs configure their use of CCACHE with their .servobuild file, as usual. For build environments, they can either have a .servobuild file or set the CCACHE env var to point at the ccache binary to use.

It also adds support for ccache to our travis builds. Buildbot will come in a separate commit to the saltfs repo.

It is expected that the various cargo makefiles will look at this variable and do the "right thing" to tell their native build to instead use ccache. e.g., https://github.com/servo/mozjs/pull/62

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8366)

<!-- Reviewable:end -->
