### PR TITLE
Properly make stacking contexts for inlines

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2015,6 +2015,18 @@
             "url": "/_mozilla/css/inline_padding_a.html"
           }
         ],
+        "css/inline_stacking_context.html": [
+          {
+            "path": "css/inline_stacking_context.html",
+            "references": [
+              [
+                "/_mozilla/css/inline_stacking_context_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/inline_stacking_context.html"
+          }
+        ],
         "css/inline_text_align_a.html": [
           {
             "path": "css/inline_text_align_a.html",
@@ -6946,6 +6958,18 @@
             ]
           ],
           "url": "/_mozilla/css/inline_padding_a.html"
+        }
+      ],
+      "css/inline_stacking_context.html": [
+        {
+          "path": "css/inline_stacking_context.html",
+          "references": [
+            [
+              "/_mozilla/css/inline_stacking_context_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/inline_stacking_context.html"
         }
       ],
       "css/inline_text_align_a.html": [

--- a/tests/wpt/mozilla/tests/css/inline_stacking_context.html
+++ b/tests/wpt/mozilla/tests/css/inline_stacking_context.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Inline stacking context positioned correctly</title>
+        <link rel=match href="inline_stacking_context_ref.html">
+    </head>
+    <body>
+        <div style="font-size: 25px">
+            <span style="color: transparent;"><img src="100x100_green.png"></span>
+            <img style="filter: blur(0px);" src="100x100_green.png">
+        </div>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/inline_stacking_context_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_stacking_context_ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <div style="font-size: 25px">
+            <span style="color: transparent;"><img src="100x100_green.png"></span>
+            <img src="100x100_green.png">
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Instead of making a stacking context out of inline fragments parent
flow, make the inline fragment itself the stacking context. This fixes
positioning and rendering of these sort of fragments and prevents
over-layerization.

Fixes #7424.
Fixes #5812.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8376)

<!-- Reviewable:end -->
