### PR TITLE
Added call to event.PreventDefault on html text inputs and textareas.

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -656,6 +656,7 @@ impl VirtualMethods for HTMLInputElement {
                         }
                         RedrawSelection => {
                             self.force_relayout();
+                            event.PreventDefault();
                         }
                         Nothing => (),
                     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -352,9 +352,11 @@ impl VirtualMethods for HTMLTextAreaElement {
                         }
 
                         self.force_relayout();
+                        event.PreventDefault();
                     }
                     KeyReaction::RedrawSelection => {
                         self.force_relayout();
+                        event.PreventDefault();
                     }
                     KeyReaction::Nothing => (),
                 }


### PR DESCRIPTION
This change should prevent page scrolling when up/down buttons are pressed within text inputs and textboxes which should resolve issue #8379.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8400)

<!-- Reviewable:end -->
