### PR TITLE
rename WebSocket::Send_Impl

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -295,7 +295,7 @@ impl WebSocket {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-websocket-send
-    fn Send_Impl(&self, data_byte_len: u64) -> Fallible<bool> {
+    fn send_impl(&self, data_byte_len: u64) -> Fallible<bool> {
         let return_after_buffer = match self.ready_state.get() {
             WebSocketRequestState::Connecting => {
                 return Err(Error::InvalidState);
@@ -380,7 +380,7 @@ impl WebSocketMethods for WebSocket {
     fn Send(&self, data: USVString) -> Fallible<()> {
 
         let data_byte_len = data.0.as_bytes().len() as u64;
-        let send_data = try!(self.Send_Impl(data_byte_len));
+        let send_data = try!(self.send_impl(data_byte_len));
 
         if send_data {
             let mut other_sender = self.sender.borrow_mut();
@@ -399,7 +399,7 @@ impl WebSocketMethods for WebSocket {
            If the buffer limit is reached in the first place, there are likely other major problems
         */
         let data_byte_len = data.Size();
-        let send_data = try!(self.Send_Impl(data_byte_len));
+        let send_data = try!(self.send_impl(data_byte_len));
 
         if send_data {
             let mut other_sender = self.sender.borrow_mut();


### PR DESCRIPTION
Previos: `Send_Impl`, now: `send_impl`.

Closes: #8345

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8408)

<!-- Reviewable:end -->
