### PR TITLE
Avoid UnboundLocalError upon "bogus" usage of ./mach create-wpt

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -598,4 +598,5 @@ testing/web-platform/mozilla/tests for Servo-only tests""" % ref_path)
             wpt_kwargs = vars(p.parse_args(args))
             self.context.commands.dispatch("test-wpt", self.context, **wpt_kwargs)
 
-        proc.wait()
+        if editor:
+            proc.wait()


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/8407

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8410)

<!-- Reviewable:end -->
