### PR TITLE
Enabled use of FontFamily enum type

### DIFF
--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -208,8 +208,7 @@ impl FontContext {
             }
 
             if !cache_hit {
-                let font_template = self.font_cache_task.find_font_template(family.name()
-                                                                            .to_owned(),
+                let font_template = self.font_cache_task.find_font_template(family.clone(),
                                                                             desc.clone());
                 match font_template {
                     Some(font_template) => {
@@ -340,4 +339,3 @@ impl Hash for LayoutFontGroupCacheKey {
 pub fn invalidate_font_caches() {
     FONT_CACHE_EPOCH.fetch_add(1, Ordering::SeqCst);
 }
-

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -325,7 +325,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
                 PropertyDeclaration::FontFamily(
                     DeclaredValue::Value(
                         font_family::computed_value::T(vec![
-                            font_family::computed_value::FontFamily::FamilyName(
+                            font_family::computed_value::FontFamily::from_atom(
                                 font_family)])))));
         }
 

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -1705,35 +1705,60 @@ pub mod longhands {
         use values::computed::ComputedValueAsSpecified;
         pub use self::computed_value::T as SpecifiedValue;
 
+        const SERIF: &'static str = "serif";
+        const SANS_SERIF: &'static str = "sans-serif";
+        const CURSIVE: &'static str = "cursive";
+        const FANTASY: &'static str = "fantasy";
+        const MONOSPACE: &'static str = "monospace";
+
         impl ComputedValueAsSpecified for SpecifiedValue {}
         pub mod computed_value {
             use cssparser::ToCss;
             use std::fmt;
             use string_cache::Atom;
 
-            #[derive(Debug, PartialEq, Eq, Clone, Hash, HeapSizeOf)]
+            #[derive(Debug, PartialEq, Eq, Clone, Hash, HeapSizeOf, Deserialize, Serialize)]
             pub enum FontFamily {
                 FamilyName(Atom),
-                // Generic
-//                Serif,
-//                SansSerif,
-//                Cursive,
-//                Fantasy,
-//                Monospace,
+                // Generic,
+                Serif,
+                SansSerif,
+                Cursive,
+                Fantasy,
+                Monospace,
             }
             impl FontFamily {
                 #[inline]
                 pub fn name(&self) -> &str {
                     match *self {
                         FontFamily::FamilyName(ref name) => &*name,
+                        FontFamily::Serif => super::SERIF,
+                        FontFamily::SansSerif => super::SANS_SERIF,
+                        FontFamily::Cursive => super::CURSIVE,
+                        FontFamily::Fantasy => super::FANTASY,
+                        FontFamily::Monospace => super::MONOSPACE
+                    }
+                }
+
+                pub fn from_atom(input: Atom) -> FontFamily {
+                    let option = match_ignore_ascii_case! { &input,
+                        super::SERIF => Some(FontFamily::Serif),
+                        super::SANS_SERIF => Some(FontFamily::SansSerif),
+                        super::CURSIVE => Some(FontFamily::Cursive),
+                        super::FANTASY => Some(FontFamily::Fantasy),
+                        super::MONOSPACE => Some(FontFamily::Monospace)
+                        _ => None
+                    };
+
+                    match option {
+                        Some(family) => family,
+                        None => FontFamily::FamilyName(input)
                     }
                 }
             }
             impl ToCss for FontFamily {
                 fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                    match *self {
-                        FontFamily::FamilyName(ref name) => dest.write_str(&*name),
-                    }
+                    dest.write_str(self.name())
                 }
             }
             impl ToCss for T {
@@ -1753,7 +1778,7 @@ pub mod longhands {
 
         #[inline]
         pub fn get_initial_value() -> computed_value::T {
-            computed_value::T(vec![FontFamily::FamilyName(atom!("serif"))])
+            computed_value::T(vec![FontFamily::Serif])
         }
         /// <family-name>#
         /// <family-name> = <string> | [ <ident>+ ]
@@ -1766,14 +1791,15 @@ pub mod longhands {
                 return Ok(FontFamily::FamilyName(Atom::from(&*value)))
             }
             let first_ident = try!(input.expect_ident());
-//            match_ignore_ascii_case! { first_ident,
-//                "serif" => return Ok(Serif),
-//                "sans-serif" => return Ok(SansSerif),
-//                "cursive" => return Ok(Cursive),
-//                "fantasy" => return Ok(Fantasy),
-//                "monospace" => return Ok(Monospace)
-//                _ => {}
-//            }
+
+            match_ignore_ascii_case! { first_ident,
+                SERIF => return Ok(FontFamily::Serif),
+                SANS_SERIF => return Ok(FontFamily::SansSerif),
+                CURSIVE => return Ok(FontFamily::Cursive),
+                FANTASY => return Ok(FontFamily::Fantasy),
+                MONOSPACE => return Ok(FontFamily::Monospace)
+                _ => {}
+            }
             let mut value = first_ident.into_owned();
             while let Ok(ident) = input.try(|input| input.expect_ident()) {
                 value.push_str(" ");


### PR DESCRIPTION
https://github.com/servo/servo/issues/8371

In addition to replacing loose strings with the FontFamily enum in `font_cache_task.rs`, I also centralized the add_generic_font calls into one single function. If centralizing into one function is not desired or if anything else needs to be changed, please let me know.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8420)

<!-- Reviewable:end -->
