### PR TITLE
fix impl of parse_length() + add comments referencing the spec + add …

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1923,6 +1923,7 @@ dependencies = [
 name = "util_tests"
 version = "0.0.1"
 dependencies = [
+ "app_units 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -173,22 +173,11 @@ pub fn parse_unsigned_integer<T: Iterator<Item=char>>(input: T) -> Option<u32> {
     })
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum LengthOrPercentageOrAuto {
     Auto,
     Percentage(f32),
     Length(Au),
-}
-
-impl PartialEq for LengthOrPercentageOrAuto {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (&LengthOrPercentageOrAuto::Auto, &LengthOrPercentageOrAuto::Auto) => true,
-            (&LengthOrPercentageOrAuto::Percentage(x), &LengthOrPercentageOrAuto::Percentage(y)) => x == y,
-            (&LengthOrPercentageOrAuto::Length(x), &LengthOrPercentageOrAuto::Length(y)) => x == y,
-            _ => false,
-        }
-    }
 }
 
 /// TODO: this function can be rewritten to return Result<LengthOrPercentage, _>

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -191,7 +191,9 @@ impl PartialEq for LengthOrPercentageOrAuto {
     }
 }
 
-/// Parses a length per HTML5 § 2.4.4.4. If unparseable, `Auto` is returned.
+/// TODO: this function can be rewritten to return Result<LengthOrPercentage, _>
+/// Parses a dimension value per HTML5 § 2.4.4.4. If unparseable, `Auto` is
+/// returned.
 /// https://html.spec.whatwg.org/multipage/#rules-for-parsing-dimension-values
 pub fn parse_length(mut value: &str) -> LengthOrPercentageOrAuto {
     // Steps 1 & 2 are not relevant
@@ -209,17 +211,10 @@ pub fn parse_length(mut value: &str) -> LengthOrPercentageOrAuto {
         value = &value[1..]
     }
 
-    // Step 6
-    if value.is_empty() {
-        return LengthOrPercentageOrAuto::Auto
-    }
-
-    // Step 7
-    for ch in value.chars() {
-        match ch {
-            '0'...'9' => break,
-            _ => return LengthOrPercentageOrAuto::Auto,
-        }
+    // Steps 6 & 7
+    match value.chars().nth(0) {
+        Some('0'...'9') => {},
+        _ => return LengthOrPercentageOrAuto::Auto,
     }
 
     // Steps 8 to 13
@@ -228,7 +223,7 @@ pub fn parse_length(mut value: &str) -> LengthOrPercentageOrAuto {
     // 2. the first occurence of a '%' (U+0025 PERCENT SIGN)
     // 3. the second occurrence of a '.' (U+002E FULL STOP)
     // 4. the occurrence of a character that is neither a digit nor '%' nor '.'
-    // Note: Step 10 is directly subsumed by From::from_str
+    // Note: Step 10 is directly subsumed by FromStr::from_str
     let mut end_index = value.len();
     let (mut found_full_stop, mut found_percent) = (false, false);
     for (i, ch) in value.chars().enumerate() {

--- a/tests/unit/util/Cargo.toml
+++ b/tests/unit/util/Cargo.toml
@@ -16,6 +16,7 @@ path = "../../../components/util"
 path = "../../../components/plugins"
 
 [dependencies]
+app_units = {version = "0.1", features = ["plugins"]}
 libc = "0.1"
 euclid = {version = "0.3", features = ["plugins"]}
 

--- a/tests/unit/util/lib.rs
+++ b/tests/unit/util/lib.rs
@@ -7,6 +7,7 @@
 #![feature(alloc)]
 
 extern crate alloc;
+extern crate app_units;
 extern crate euclid;
 extern crate libc;
 extern crate util;

--- a/tests/unit/util/str.rs
+++ b/tests/unit/util/str.rs
@@ -2,8 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use util::str::{search_index, split_html_space_chars, str_join};
+use util::str::LengthOrPercentageOrAuto;
+use util::str::{parse_length, search_index, split_html_space_chars, str_join};
 
+
+#[test]
+pub fn test_parse_length() {
+    let mut value = "0%";
+    let mut parsed = parse_length(value);
+    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.0));
+
+    value = "0.000%";
+    parsed = parse_length(value);
+    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.0));
+
+    value = "+5.82%";
+    parsed = parse_length(value);
+    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.0582));
+
+    value = "invalid";
+    parsed = parse_length(value);
+    assert_eq!(parsed, LengthOrPercentageOrAuto::Auto);
+
+    value ="12.2% followed by invalid";
+    parsed = parse_length(value);
+    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.122));
+}
 
 #[test]
 pub fn split_html_space_chars_whitespace() {

--- a/tests/unit/util/str.rs
+++ b/tests/unit/util/str.rs
@@ -2,31 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use util::str::LengthOrPercentageOrAuto;
 use util::str::{parse_length, search_index, split_html_space_chars, str_join};
 
 
 #[test]
 pub fn test_parse_length() {
-    let mut value = "0%";
-    let mut parsed = parse_length(value);
-    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.0));
+    fn check(input: &str, expected: LengthOrPercentageOrAuto) {
+        let parsed = parse_length(input);
+        assert_eq!(parsed, expected);
+    }
 
-    value = "0.000%";
-    parsed = parse_length(value);
-    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.0));
-
-    value = "+5.82%";
-    parsed = parse_length(value);
-    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.0582));
-
-    value = "invalid";
-    parsed = parse_length(value);
-    assert_eq!(parsed, LengthOrPercentageOrAuto::Auto);
-
-    value ="12.2% followed by invalid";
-    parsed = parse_length(value);
-    assert_eq!(parsed, LengthOrPercentageOrAuto::Percentage(0.122));
+    check("0", LengthOrPercentageOrAuto::Length(Au::from_px(0)));
+    check("0.000%", LengthOrPercentageOrAuto::Percentage(0.0));
+    check("+5.82%", LengthOrPercentageOrAuto::Percentage(0.0582));
+    check("invalid", LengthOrPercentageOrAuto::Auto);
+    check("12 followed by invalid", LengthOrPercentageOrAuto::Length(Au::from_px(12)));
 }
 
 #[test]


### PR DESCRIPTION
…unit test

for #8423 

Also, how do I use external crates? Adding an `extern crate app_units` in `tests/unit/util/lib.rs` yields a "can't find crate" error while running the unit test for `str.rs`. This is needed for testing `LengthOrPercentageOrAuto::Length(Au)`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8424)

<!-- Reviewable:end -->
