### PR TITLE
Make the needs_reflow method actually work correctly.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -329,9 +329,16 @@ impl Document {
     }
 
     pub fn needs_reflow(&self) -> bool {
-        self.GetDocumentElement().is_some() &&
-        (self.upcast::<Node>().get_has_dirty_descendants() ||
-         !self.modified_elements.borrow().is_empty())
+        // FIXME: This should check the dirty bit on the document,
+        // not the document element. Needs some layout changes to make
+        // that workable.
+        match self.GetDocumentElement() {
+            Some(root) => {
+                root.upcast::<Node>().get_has_dirty_descendants() ||
+                !self.modified_elements.borrow().is_empty()
+            }
+            None => false,
+        }
     }
 
     /// Returns the first `base` element in the DOM that has an `href` attribute.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -966,7 +966,11 @@ impl Window {
             return
         }
 
-        self.force_reflow(goal, query_type, reason)
+        self.force_reflow(goal, query_type, reason);
+
+        // If window_size is `None`, we don't reflow, so the document stays dirty.
+        // Otherwise, we shouldn't need a reflow immediately after a reflow.
+        assert!(!self.Document().needs_reflow() || self.window_size.get().is_none());
     }
 
     pub fn layout(&self) -> &LayoutRPC {


### PR DESCRIPTION
The document node is always dirty because layout never clears the bit;
instead, check the dirty bit of the root element.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8441)

<!-- Reviewable:end -->
