### PR TITLE
refactor(devtools/lib.rs): Remove unused import

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -54,7 +54,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::error::Error;
 use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::mpsc::{Receiver, RecvError, Sender, channel};
+use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
 use time::precise_time_ns;
 use util::task::spawn_named;


### PR DESCRIPTION
Removed `RecvError` imports from #L57. Fixed #8439.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8442)

<!-- Reviewable:end -->
