### PR TITLE
refactor(htmlhrelement.rs): color setter now uses macro

### DIFF
--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -41,10 +41,7 @@ impl HTMLHRElementMethods for HTMLHRElement {
     make_getter!(Color);
 
     // https://html.spec.whatwg.org/multipage/#dom-hr-color
-    fn SetColor(&self, value: DOMString) {
-        self.upcast::<Element>()
-            .set_attribute(&atom!("color"), AttrValue::from_legacy_color(value));
-    }
+    make_legacy_color_setter!(SetColor, "color");
 }
 
 pub trait HTMLHRLayoutHelpers {


### PR DESCRIPTION
Changed the function in #L44-47 to a macro usage. Fixes #8433.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8444)

<!-- Reviewable:end -->
