### PR TITLE
Disable zipalign until we have stable builder automation to install a…

### DIFF
--- a/support/android/build-apk/src/main.rs
+++ b/support/android/build-apk/src/main.rs
@@ -194,22 +194,7 @@ fn main() {
             process::exit(1);
         }
                  
-        let aligncmd = Command::new(sdk_path.join("tools").join("zipalign"))
-                                  .arg("-f")
-                                  .arg("-v")
-                                  .arg("4")
-                                  .arg(&directory.join("bin").join("Servo-release-unsigned.apk"))
-                                  .arg(&directory.join("bin").join("Servo-release.apk"))
-                                  .stdout(Stdio::inherit())
-                                  .stderr(Stdio::inherit())
-                                  .current_dir(directory.clone())
-                                  .status();
-        if aligncmd.is_err() || aligncmd.unwrap().code().unwrap() != 0 {
-            println!("Error while using `zipalign` to sign the APK.");
-            process::exit(1);
-        }
-        
-        fs::copy(&directory.join("bin").join("Servo-release.apk"),
+        fs::copy(&directory.join("bin").join("Servo-release-unsigned.apk"),
                  &args.output).unwrap();
     }
 


### PR DESCRIPTION
…nd locate it

r? @mbrubeck 

The basic problem here is that `zipalign` is in the tools directory on some installs, in build-tools/22.0 on some, build-tools/20.0 on others, etc. I'll need to find a more stable way of locating the tool (even if it's just shelling out to `find` - I almost autoconf!). Disabling use of it for now since it's optional and is currently breaking our nightly builds.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8460)

<!-- Reviewable:end -->
