### PR TITLE
Execute XHR timeout callbacks directly. (Fixes #8468.)

### DIFF
--- a/components/profile/heartbeats.rs
+++ b/components/profile/heartbeats.rs
@@ -52,7 +52,6 @@ pub fn init() {
     maybe_create_heartbeat(&mut hbs, ProfilerCategory::ScriptSetViewport);
     maybe_create_heartbeat(&mut hbs, ProfilerCategory::ScriptWebSocketEvent);
     maybe_create_heartbeat(&mut hbs, ProfilerCategory::ScriptWorkerEvent);
-    maybe_create_heartbeat(&mut hbs, ProfilerCategory::ScriptXhrEvent);
     maybe_create_heartbeat(&mut hbs, ProfilerCategory::ApplicationHeartbeat);
     unsafe {
         HBS = Some(mem::transmute(Box::new(hbs)));

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -102,7 +102,6 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::ScriptTimerEvent => "Script Timer Event",
             ProfilerCategory::ScriptWebSocketEvent => "Script Web Socket Event",
             ProfilerCategory::ScriptWorkerEvent => "Script Worker Event",
-            ProfilerCategory::ScriptXhrEvent => "Script Xhr Event",
             ProfilerCategory::ApplicationHeartbeat => "Application Heartbeat",
         };
         format!("{}{}", padding, name)

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -71,7 +71,6 @@ pub enum ProfilerCategory {
     ScriptTimerEvent,
     ScriptWebSocketEvent,
     ScriptWorkerEvent,
-    ScriptXhrEvent,
     ApplicationHeartbeat,
 }
 

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -236,7 +236,6 @@ pub enum ScriptTaskEventCategory {
     SetViewport,
     WebSocketEvent,
     WorkerEvent,
-    XhrEvent,
 }
 
 /// Messages used to control the script event loop
@@ -954,7 +953,6 @@ impl ScriptTask {
                 ScriptTaskEventCategory::TimerEvent => ProfilerCategory::ScriptTimerEvent,
                 ScriptTaskEventCategory::WebSocketEvent => ProfilerCategory::ScriptWebSocketEvent,
                 ScriptTaskEventCategory::WorkerEvent => ProfilerCategory::ScriptWorkerEvent,
-                ScriptTaskEventCategory::XhrEvent => ProfilerCategory::ScriptXhrEvent,
             };
             profile(profiler_cat, None, self.time_profiler_chan.clone(), f)
         } else {


### PR DESCRIPTION
This is a fix for #8468.

Currently XHR timeouts schedule themselves for execution via `CommonScriptMsg::RunnableMsg`s. This was necessary when these timeouts used a separate thread to schedule themselves. Now it's a potential race that should have been eliminated as part of #8168.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8475)

<!-- Reviewable:end -->
