### PR TITLE
Remove unnecessary 'node changed' notification

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1935,10 +1935,6 @@ impl NodeMethods for Node {
             NodeTypeId::CharacterData(..) => {
                 let characterdata = self.downcast::<CharacterData>().unwrap();
                 characterdata.SetData(value);
-
-                // Notify the document that the content of this node is different
-                let document = self.owner_doc();
-                document.content_changed(self, NodeDamage::OtherNodeDamage);
             }
             NodeTypeId::DocumentType |
             NodeTypeId::Document => {}


### PR DESCRIPTION
This same notification already happens in `CharacterData::SetData`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8476)

<!-- Reviewable:end -->
