### PR TITLE
Opaque DOMString

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -206,16 +206,16 @@ impl NodeInfoToProtocol for NodeInfo {
 
         NodeActorMsg {
             actor: actor_name,
-            baseURI: self.baseURI.0,
+            baseURI: self.baseURI,
             parent: actors.script_to_actor(self.parent.clone()),
             nodeType: self.nodeType,
-            namespaceURI: self.namespaceURI.0,
-            nodeName: self.nodeName.0,
+            namespaceURI: self.namespaceURI,
+            nodeName: self.nodeName,
             numChildren: self.numChildren,
 
-            name: self.name.0,
-            publicId: self.publicId.0,
-            systemId: self.systemId.0,
+            name: self.name,
+            publicId: self.publicId,
+            systemId: self.systemId,
 
             attrs: self.attrs.into_iter().map(|attr| {
                 AttrMsg {
@@ -233,7 +233,7 @@ impl NodeInfoToProtocol for NodeInfo {
 
             isDocumentElement: self.isDocumentElement,
 
-            shortValue: self.shortValue.0,
+            shortValue: self.shortValue,
             incompleteValue: self.incompleteValue,
         }
     }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -225,7 +225,7 @@ fn run_server(sender: Sender<DevtoolsControlMsg>,
             let DevtoolsPageInfo { title, url } = page_info;
             let tab = TabActor {
                 name: actors.new_name("tab"),
-                title: title.0,
+                title: String::from(title),
                 url: url.serialize(),
                 console: console.name(),
                 inspector: inspector.name(),

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -35,13 +35,12 @@ use rustc_serialize::{Decodable, Decoder};
 use std::net::TcpStream;
 use time::Duration;
 use url::Url;
-use util::str::DOMString;
 
 // Information would be attached to NewGlobal to be received and show in devtools.
 // Extend these fields if we need more information.
 #[derive(Deserialize, Serialize)]
 pub struct DevtoolsPageInfo {
-    pub title: DOMString,
+    pub title: String,
     pub url: Url
 }
 
@@ -102,22 +101,22 @@ pub struct AttrInfo {
 #[derive(Deserialize, Serialize)]
 pub struct NodeInfo {
     pub uniqueId: String,
-    pub baseURI: DOMString,
+    pub baseURI: String,
     pub parent: String,
     pub nodeType: u16,
-    pub namespaceURI: DOMString,
-    pub nodeName: DOMString,
+    pub namespaceURI: String,
+    pub nodeName: String,
     pub numChildren: usize,
 
-    pub name: DOMString,
-    pub publicId: DOMString,
-    pub systemId: DOMString,
+    pub name: String,
+    pub publicId: String,
+    pub systemId: String,
 
     pub attrs: Vec<AttrInfo>,
 
     pub isDocumentElement: bool,
 
-    pub shortValue: DOMString,
+    pub shortValue: String,
     pub incompleteValue: bool,
 }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -981,7 +981,7 @@ impl<'ln> ThreadSafeLayoutNode<'ln> {
         }
         if let Some(input) = this.downcast::<HTMLInputElement>() {
             let data = unsafe { input.get_value_for_layout() };
-            return TextContent::Text(data.0);
+            return TextContent::Text(data);
         }
         if let Some(area) = this.downcast::<HTMLTextAreaElement>() {
             let data = unsafe { area.get_value_for_layout() };

--- a/components/net_traits/storage_task.rs
+++ b/components/net_traits/storage_task.rs
@@ -4,7 +4,6 @@
 
 use ipc_channel::ipc::IpcSender;
 use url::Url;
-use util::str::DOMString;
 
 #[derive(Copy, Clone, Deserialize, Serialize, HeapSizeOf)]
 pub enum StorageType {
@@ -19,19 +18,19 @@ pub enum StorageTaskMsg {
     Length(IpcSender<usize>, Url, StorageType),
 
     /// gets the name of the key at the specified index in the associated storage data
-    Key(IpcSender<Option<DOMString>>, Url, StorageType, u32),
+    Key(IpcSender<Option<String>>, Url, StorageType, u32),
 
     /// Gets the available keys in the associated storage data
-    Keys(IpcSender<Vec<DOMString>>, Url, StorageType),
+    Keys(IpcSender<Vec<String>>, Url, StorageType),
 
     /// gets the value associated with the given key in the associated storage data
-    GetItem(IpcSender<Option<DOMString>>, Url, StorageType, DOMString),
+    GetItem(IpcSender<Option<String>>, Url, StorageType, String),
 
     /// sets the value of the given key in the associated storage data
-    SetItem(IpcSender<Result<(bool, Option<DOMString>), ()>>, Url, StorageType, DOMString, DOMString),
+    SetItem(IpcSender<Result<(bool, Option<String>), ()>>, Url, StorageType, String, String),
 
     /// removes the key/value pair for the given key in the associated storage data
-    RemoveItem(IpcSender<Option<DOMString>>, Url, StorageType, DOMString),
+    RemoveItem(IpcSender<Option<String>>, Url, StorageType, String),
 
     /// clears the associated storage data by removing all the key/value pairs
     Clear(IpcSender<bool>, Url, StorageType),

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -42,7 +42,7 @@ pub fn handle_evaluate_js(global: &GlobalRef, eval: String, reply: IpcSender<Eva
             EvaluateJSReply::NumberValue(
                 FromJSValConvertible::from_jsval(cx, rval.handle(), ()).unwrap())
         } else if rval.ptr.is_string() {
-            EvaluateJSReply::StringValue(jsstring_to_str(cx, rval.ptr.to_string()).0)
+            EvaluateJSReply::StringValue(String::from(jsstring_to_str(cx, rval.ptr.to_string())))
         } else if rval.ptr.is_null() {
             EvaluateJSReply::NullValue
         } else {
@@ -164,9 +164,9 @@ pub fn handle_modify_attribute(page: &Rc<Page>,
     for modification in modifications {
         match modification.newValue {
             Some(string) => {
-                let _ = elem.SetAttribute(DOMString(modification.attributeName), DOMString(string));
+                let _ = elem.SetAttribute(DOMString::from(modification.attributeName), DOMString::from(string));
             },
-            None => elem.RemoveAttribute(DOMString(modification.attributeName)),
+            None => elem.RemoveAttribute(DOMString::from(modification.attributeName)),
         }
     }
 }

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -9,7 +9,6 @@ use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::eventtarget::EventTarget;
 use dom::mouseevent::MouseEvent;
 use dom::node::window_from_node;
-use std::borrow::ToOwned;
 use util::str::DOMString;
 
 /// Trait for elements with defined activation behavior
@@ -47,7 +46,7 @@ pub trait Activatable {
         // https://html.spec.whatwg.org/multipage/#fire-a-synthetic-mouse-event
         let win = window_from_node(element);
         let target = element.upcast();
-        let mouse = MouseEvent::new(win.r(), DOMString("click".to_owned()),
+        let mouse = MouseEvent::new(win.r(), DOMString::from("click"),
                                     EventBubbles::DoesNotBubble, EventCancelable::NotCancelable, Some(win.r()), 1,
                                     0, 0, 0, 0, ctrlKey, shiftKey, altKey, metaKey,
                                     0, None);

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -75,12 +75,14 @@ impl Attr {
 impl AttrMethods for Attr {
     // https://dom.spec.whatwg.org/#dom-attr-localname
     fn LocalName(&self) -> DOMString {
-        DOMString((**self.local_name()).to_owned())
+        // FIXME(ajeffrey): convert directly from Atom to DOMString
+        DOMString::from(&**self.local_name())
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-value
     fn Value(&self) -> DOMString {
-        DOMString((**self.value()).to_owned())
+        // FIXME(ajeffrey): convert directly from AttrValue to DOMString
+        DOMString::from(&**self.value())
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-value
@@ -116,7 +118,8 @@ impl AttrMethods for Attr {
 
     // https://dom.spec.whatwg.org/#dom-attr-name
     fn Name(&self) -> DOMString {
-        DOMString((*self.identifier.name).to_owned())
+        // FIXME(ajeffrey): convert directly from Atom to DOMString
+        DOMString::from(&*self.identifier.name)
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-namespaceuri
@@ -124,13 +127,14 @@ impl AttrMethods for Attr {
         let Namespace(ref atom) = self.identifier.namespace;
         match &**atom {
             "" => None,
-            url => Some(DOMString(url.to_owned())),
+            url => Some(DOMString::from(url))
         }
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-prefix
     fn GetPrefix(&self) -> Option<DOMString> {
-        self.prefix().as_ref().map(|p| DOMString((**p).to_owned()))
+        // FIXME(ajeffrey): convert directly from Atom to DOMString
+        self.prefix().as_ref().map(|p| DOMString::from(&**p))
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-ownerelement
@@ -194,8 +198,8 @@ impl Attr {
         let Namespace(ref ns) = self.identifier.namespace;
         AttrInfo {
             namespace: (**ns).to_owned(),
-            name: self.Name().0,
-            value: self.Value().0,
+            name: String::from(self.Name()),
+            value: String::from(self.Value()),
         }
     }
 }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -825,7 +825,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             default = "None"
         else:
             assert defaultValue.type.tag() == IDLType.Tags.domstring
-            default = 'DOMString("%s".to_owned())' % defaultValue.value
+            default = 'DOMString::from("%s")' % defaultValue.value
             if type.nullable():
                 default = "Some(%s)" % default
 

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -159,7 +159,8 @@ impl FromJSValConvertible for USVString {
         }
         let latin1 = JS_StringHasLatin1Chars(jsstr);
         if latin1 {
-            return Ok(USVString(jsstring_to_str(cx, jsstr).0));
+            // FIXME(ajeffrey): Convert directly from DOMString to USVString
+            return Ok(USVString(String::from(jsstring_to_str(cx, jsstr))));
         }
         let mut length = 0;
         let chars = JS_GetTwoByteStringCharsAndLength(cx, ptr::null(), jsstr, &mut length);

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -60,7 +60,8 @@ impl Blob {
     pub fn Constructor_(global: GlobalRef, blobParts: DOMString,
                         blobPropertyBag: &BlobBinding::BlobPropertyBag) -> Fallible<Root<Blob>> {
         //TODO: accept other blobParts types - ArrayBuffer or ArrayBufferView or Blob
-        let bytes: Option<Vec<u8>> = Some(blobParts.0.into_bytes());
+        // FIXME(ajeffrey): convert directly from a DOMString to a Vec<u8>
+        let bytes: Option<Vec<u8>> = Some(String::from(blobParts).into_bytes());
         let typeString = if is_ascii_printable(&blobPropertyBag.type_) {
             &*blobPropertyBag.type_
         } else {
@@ -90,7 +91,7 @@ impl BlobMethods for Blob {
 
     // https://dev.w3.org/2006/webapi/FileAPI/#dfn-type
     fn Type(&self) -> DOMString {
-        DOMString(self.typeString.clone())
+        DOMString::from(self.typeString.clone())
     }
 
     // https://dev.w3.org/2006/webapi/FileAPI/#slice-method-algo

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -37,7 +37,6 @@ use msg::constellation_msg::Msg as ConstellationMsg;
 use net_traits::image::base::PixelFormat;
 use net_traits::image_cache_task::ImageResponse;
 use num::{Float, ToPrimitive};
-use std::borrow::ToOwned;
 use std::str::FromStr;
 use std::sync::mpsc::channel;
 use std::{cmp, fmt};
@@ -536,10 +535,10 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     fn GlobalCompositeOperation(&self) -> DOMString {
         let state = self.state.borrow();
-        DOMString(match state.global_composition {
-            CompositionOrBlending::Composition(op) => op.to_str().to_owned(),
-            CompositionOrBlending::Blending(op) => op.to_str().to_owned(),
-        })
+        match state.global_composition {
+            CompositionOrBlending::Composition(op) => DOMString::from(op.to_str()),
+            CompositionOrBlending::Blending(op) => DOMString::from(op.to_str()),
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
@@ -760,7 +759,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             CanvasFillOrStrokeStyle::Color(ref rgba) => {
                 let mut result = String::new();
                 serialize(rgba, &mut result).unwrap();
-                StringOrCanvasGradientOrCanvasPattern::eString(DOMString(result))
+                StringOrCanvasGradientOrCanvasPattern::eString(DOMString::from(result))
             },
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(Root::from_ref(&*gradient))
@@ -800,7 +799,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             CanvasFillOrStrokeStyle::Color(ref rgba) => {
                 let mut result = String::new();
                 serialize(rgba, &mut result).unwrap();
-                StringOrCanvasGradientOrCanvasPattern::eString(DOMString(result))
+                StringOrCanvasGradientOrCanvasPattern::eString(DOMString::from(result))
             },
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(Root::from_ref(&*gradient))
@@ -1001,11 +1000,11 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linecap
     fn LineCap(&self) -> DOMString {
         let state = self.state.borrow();
-        DOMString(match state.line_cap {
-            LineCapStyle::Butt => "butt".to_owned(),
-            LineCapStyle::Round => "round".to_owned(),
-            LineCapStyle::Square => "square".to_owned(),
-        })
+        match state.line_cap {
+            LineCapStyle::Butt => DOMString::from("butt"),
+            LineCapStyle::Round => DOMString::from("round"),
+            LineCapStyle::Square => DOMString::from("square"),
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linecap
@@ -1019,11 +1018,11 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linejoin
     fn LineJoin(&self) -> DOMString {
         let state = self.state.borrow();
-        DOMString(match state.line_join {
-            LineJoinStyle::Round => "round".to_owned(),
-            LineJoinStyle::Bevel => "bevel".to_owned(),
-            LineJoinStyle::Miter => "miter".to_owned(),
-        })
+        match state.line_join {
+            LineJoinStyle::Round => DOMString::from("round"),
+            LineJoinStyle::Bevel => DOMString::from("bevel"),
+            LineJoinStyle::Miter => DOMString::from("miter"),
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linejoin
@@ -1098,7 +1097,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     fn ShadowColor(&self) -> DOMString {
         let mut result = String::new();
         serialize(&self.state.borrow().shadow_color, &mut result).unwrap();
-        DOMString(result)
+        DOMString::from(result)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -13,7 +13,6 @@ use dom::bindings::js::{LayoutJS, Root};
 use dom::document::Document;
 use dom::element::Element;
 use dom::node::{Node, NodeDamage};
-use std::borrow::ToOwned;
 use std::cell::Ref;
 use util::str::DOMString;
 
@@ -65,7 +64,7 @@ impl CharacterDataMethods for CharacterData {
             // Steps 4.
             Some(count_bytes) => &data_from_offset[..count_bytes],
         };
-        Ok(DOMString(substring.to_owned()))
+        Ok(DOMString::from(substring))
     }
 
     // https://dom.spec.whatwg.org/#dom-characterdata-appenddatadata
@@ -103,9 +102,9 @@ impl CharacterDataMethods for CharacterData {
             new_data.push_str(prefix);
             new_data.push_str(&arg);
             new_data.push_str(suffix);
-            DOMString(new_data)
+            new_data
         };
-        *self.data.borrow_mut() = new_data;
+        *self.data.borrow_mut() = DOMString::from(new_data);
         self.content_changed();
         // FIXME: Once we have `Range`, we should implement step 8 to step 11
         Ok(())

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -69,6 +69,7 @@ impl CharacterDataMethods for CharacterData {
 
     // https://dom.spec.whatwg.org/#dom-characterdata-appenddatadata
     fn AppendData(&self, data: DOMString) {
+        // FIXME(ajeffrey): Efficient append on DOMStrings?
         self.append_data(&*data);
     }
 
@@ -149,7 +150,8 @@ impl CharacterData {
     }
     #[inline]
     pub fn append_data(&self, data: &str) {
-        self.data.borrow_mut().0.push_str(data);
+        // FIXME(ajeffrey): Efficient append on DOMStrings?
+        self.data.borrow_mut().push_str(data);
         self.content_changed();
     }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -74,7 +74,7 @@ impl ConsoleMethods for Console {
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
     fn Assert(&self, condition: bool, message: Option<DOMString>) {
         if !condition {
-            let message = message.unwrap_or_else(|| DOMString("no message".to_owned()));
+            let message = message.unwrap_or_else(|| DOMString::from("no message"));
             println!("Assertion failed: {}", message);
             propagate_console_msg(&self, prepare_message(LogLevel::Error, message));
         }
@@ -84,7 +84,7 @@ impl ConsoleMethods for Console {
 fn prepare_message(logLevel: LogLevel, message: DOMString) -> ConsoleMessage {
     //TODO: Sending fake values for filename, lineNumber and columnNumber in LogMessage; adjust later
     ConsoleMessage {
-        message: message.0,
+        message: String::from(message),
         logLevel: logLevel,
         filename: "test".to_owned(),
         lineNumber: 1,

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -74,26 +74,27 @@ use dom::htmltrackelement::HTMLTrackElement;
 use dom::htmlulistelement::HTMLUListElement;
 use dom::htmlunknownelement::HTMLUnknownElement;
 use dom::htmlvideoelement::HTMLVideoElement;
-use std::borrow::ToOwned;
 use string_cache::{Atom, QualName};
 use util::str::DOMString;
 
 pub fn create_element(name: QualName, prefix: Option<Atom>,
                       document: &Document, creator: ElementCreator)
                       -> Root<Element> {
-    let prefix = prefix.map(|p| DOMString((*p).to_owned()));
+    // FIXME(ajeffrey): Convert directly from Atom to DOMString.
+
+    let prefix = prefix.map(|p| DOMString::from(&*p));
 
     if name.ns != ns!(HTML) {
-        return Element::new(DOMString((*name.local).to_owned()), name.ns, prefix, document);
+        return Element::new(DOMString::from(&*name.local), name.ns, prefix, document);
     }
 
     macro_rules! make(
         ($ctor:ident) => ({
-            let obj = $ctor::new(DOMString((*name.local).to_owned()), prefix, document);
+            let obj = $ctor::new(DOMString::from(&*name.local), prefix, document);
             Root::upcast(obj)
         });
         ($ctor:ident, $($arg:expr),+) => ({
-            let obj = $ctor::new(DOMString((*name.local).to_owned()), prefix, document, $($arg),+);
+            let obj = $ctor::new(DOMString::from(&*name.local), prefix, document, $($arg),+);
             Root::upcast(obj)
         })
     );

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -19,8 +19,8 @@ impl CSS {
         if ident.bytes().any(|b| b == b'\0') {
             return Err(Error::InvalidCharacter);
         }
-        let mut escaped = DOMString::new();
-        serialize_identifier(&ident, &mut escaped.0).unwrap();
-        Ok(escaped)
+        let mut escaped = String::new();
+        serialize_identifier(&ident, &mut escaped).unwrap();
+        Ok(DOMString::from(escaped))
     }
 }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -39,10 +39,10 @@ macro_rules! css_properties(
     ( $([$getter:ident, $setter:ident, $cssprop:expr]),* ) => (
         $(
             fn $getter(&self) -> DOMString {
-                self.GetPropertyValue(DOMString($cssprop.to_owned()))
+                self.GetPropertyValue(DOMString::from($cssprop))
             }
             fn $setter(&self, value: DOMString) -> ErrorResult {
-                self.SetPropertyValue(DOMString($cssprop.to_owned()), value)
+                self.SetPropertyValue(DOMString::from($cssprop), value)
             }
         )*
     );
@@ -131,7 +131,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             }
         });
 
-        DOMString(result.unwrap_or(String::new()))
+        result.map(DOMString::from).unwrap_or(DOMString::new())
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
@@ -165,12 +165,12 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             }
 
             // Step 2.3
-            return DOMString(serialize_shorthand(shorthand, &list));
+            return DOMString::from(serialize_shorthand(shorthand, &list));
         }
 
         // Step 3 & 4
         let result = match owner.get_inline_style_declaration(&property) {
-            Some(declaration) => DOMString(declaration.value()),
+            Some(declaration) => DOMString::from(declaration.value()),
             None => DOMString::new(),
         };
         result
@@ -186,15 +186,15 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
         if let Some(shorthand) = Shorthand::from_name(&property) {
             // Step 2.1 & 2.2 & 2.3
             if shorthand.longhands().iter()
-                                    .map(|&longhand| self.GetPropertyPriority(DOMString(longhand.to_owned())))
+                                    .map(|&longhand| self.GetPropertyPriority(DOMString::from(longhand)))
                                     .all(|priority| priority == "important") {
 
-                return DOMString("important".to_owned());
+                return DOMString::from("important");
             }
         // Step 3
         } else {
             if self.owner.get_important_inline_style_declaration(&property).is_some() {
-                return DOMString("important".to_owned());
+                return DOMString::from("important");
             }
         }
 
@@ -327,12 +327,12 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-cssfloat
     fn CssFloat(&self) -> DOMString {
-        self.GetPropertyValue(DOMString("float".to_owned()))
+        self.GetPropertyValue(DOMString::from("float"))
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-cssfloat
     fn SetCssFloat(&self, value: DOMString) -> ErrorResult {
-        self.SetPropertyValue(DOMString("float".to_owned()), value)
+        self.SetPropertyValue(DOMString::from("float"), value)
     }
 
     // https://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -264,7 +264,7 @@ impl DedicatedWorkerGlobalScope {
 
             {
                 let _ar = AutoWorkerReset::new(global.r(), worker);
-                scope.execute_script(DOMString(source));
+                scope.execute_script(DOMString::from(source));
             }
 
             let reporter_name = format!("worker-reporter-{}", random::<u64>());

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -510,7 +510,7 @@ impl Document {
         self.ready_state.set(state);
 
         let event = Event::new(GlobalRef::Window(&self.window),
-                               DOMString("readystatechange".to_owned()),
+                               DOMString::from("readystatechange"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         let target = self.upcast::<EventTarget>();
@@ -568,7 +568,7 @@ impl Document {
     /// Handles any updates when the document's title has changed.
     pub fn title_changed(&self) {
         // https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsertitlechange
-        self.trigger_mozbrowser_event(MozBrowserEvent::TitleChange(self.Title().0));
+        self.trigger_mozbrowser_event(MozBrowserEvent::TitleChange(String::from(self.Title())));
 
         self.send_title_to_compositor();
     }
@@ -577,7 +577,7 @@ impl Document {
     pub fn send_title_to_compositor(&self) {
         let window = self.window();
         let compositor = window.compositor();
-        compositor.send(ScriptToCompositorMsg::SetTitle(window.pipeline(), Some(self.Title().0))).unwrap();
+        compositor.send(ScriptToCompositorMsg::SetTitle(window.pipeline(), Some(String::from(self.Title())))).unwrap();
     }
 
     pub fn dirty_all_nodes(&self) {
@@ -598,7 +598,7 @@ impl Document {
         debug!("{}: at {:?}", mouse_event_type_string, point);
         let node = match self.hit_test(&point) {
             Some(node_address) => {
-                debug!("node address is {:?}", node_address.0);
+                debug!("node address is {:?}", node_address);
                 node::from_untrusted_node_address(js_runtime, node_address)
             },
             None => return,
@@ -631,7 +631,7 @@ impl Document {
         let y = point.y as i32;
         let clickCount = 1;
         let event = MouseEvent::new(&self.window,
-                                    DOMString(mouse_event_type_string),
+                                    DOMString::from(mouse_event_type_string),
                                     EventBubbles::Bubbles,
                                     EventCancelable::Cancelable,
                                     Some(&self.window),
@@ -669,7 +669,7 @@ impl Document {
         let y = point.y.to_i32().unwrap_or(0);
 
         let mouse_event = MouseEvent::new(&self.window,
-                                          DOMString(event_name),
+                                          DOMString::from(event_name),
                                           EventBubbles::Bubbles,
                                           EventCancelable::Cancelable,
                                           Some(&self.window),
@@ -827,7 +827,7 @@ impl Document {
                 |t| t.Target() == target).cloned());
 
         let event = TouchEvent::new(window,
-                                    DOMString(event_name.to_owned()),
+                                    DOMString::from(event_name),
                                     EventBubbles::Bubbles,
                                     EventCancelable::Cancelable,
                                     Some(window),
@@ -868,7 +868,7 @@ impl Document {
 
         let is_composing = false;
         let is_repeating = state == KeyState::Repeated;
-        let ev_type = DOMString(match state {
+        let ev_type = DOMString::from(match state {
             KeyState::Pressed | KeyState::Repeated => "keydown",
             KeyState::Released => "keyup",
         }.to_owned());
@@ -877,8 +877,8 @@ impl Document {
 
         let keyevent = KeyboardEvent::new(&self.window, ev_type, true, true,
                                           Some(&self.window), 0, Some(key),
-                                          DOMString(props.key_string.to_owned()),
-                                          DOMString(props.code.to_owned()),
+                                          DOMString::from(props.key_string),
+                                          DOMString::from(props.code),
                                           props.location, is_repeating, is_composing,
                                           ctrl, alt, shift, meta,
                                           None, props.key_code);
@@ -889,10 +889,10 @@ impl Document {
         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#keys-cancelable-keys
         if state != KeyState::Released && props.is_printable() && !prevented {
             // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#keypress-event-order
-            let event = KeyboardEvent::new(&self.window, DOMString("keypress".to_owned()),
+            let event = KeyboardEvent::new(&self.window, DOMString::from("keypress"),
                                            true, true, Some(&self.window), 0, Some(key),
-                                           DOMString(props.key_string.to_owned()),
-                                           DOMString(props.code.to_owned()),
+                                           DOMString::from(props.key_string),
+                                           DOMString::from(props.code),
                                            props.location, is_repeating, is_composing,
                                            ctrl, alt, shift, meta,
                                            props.char_code, 0);
@@ -1227,7 +1227,7 @@ impl Document {
         }
         self.domcontentloaded_dispatched.set(true);
         let event = Event::new(GlobalRef::Window(self.window()),
-                               DOMString("DOMContentLoaded".to_owned()),
+                               DOMString::from("DOMContentLoaded"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         let doctarget = self.upcast::<EventTarget>();
@@ -1320,11 +1320,11 @@ impl Document {
             location: Default::default(),
             content_type: match content_type {
                 Some(string) => string,
-                None => DOMString(match is_html_document {
+                None => DOMString::from(match is_html_document {
                     // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-                    IsHTMLDocument::HTMLDocument => "text/html".to_owned(),
+                    IsHTMLDocument::HTMLDocument => "text/html",
                     // https://dom.spec.whatwg.org/#concept-document-content-type
-                    IsHTMLDocument::NonHTMLDocument => "application/xml".to_owned()
+                    IsHTMLDocument::NonHTMLDocument => "application/xml"
                 })
             },
             last_modified: last_modified,
@@ -1332,7 +1332,7 @@ impl Document {
             // https://dom.spec.whatwg.org/#concept-document-quirks
             quirks_mode: Cell::new(NoQuirks),
             // https://dom.spec.whatwg.org/#concept-document-encoding
-            encoding_name: DOMRefCell::new(DOMString("UTF-8".to_owned())),
+            encoding_name: DOMRefCell::new(DOMString::from("UTF-8")),
             is_html_document: is_html_document == IsHTMLDocument::HTMLDocument,
             id_map: DOMRefCell::new(HashMap::new()),
             tag_map: DOMRefCell::new(HashMap::new()),
@@ -1502,7 +1502,7 @@ impl DocumentMethods for Document {
 
     // https://dom.spec.whatwg.org/#dom-document-url
     fn URL(&self) -> DOMString {
-        DOMString(self.url().serialize())
+        DOMString::from(self.url().serialize())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-activeelement
@@ -1544,9 +1544,9 @@ impl DocumentMethods for Document {
 
     // https://dom.spec.whatwg.org/#dom-document-compatmode
     fn CompatMode(&self) -> DOMString {
-        DOMString(match self.quirks_mode.get() {
-            LimitedQuirks | NoQuirks => "CSS1Compat".to_owned(),
-            Quirks => "BackCompat".to_owned()
+        DOMString::from(match self.quirks_mode.get() {
+            LimitedQuirks | NoQuirks => "CSS1Compat",
+            Quirks => "BackCompat"
         })
     }
 
@@ -1767,10 +1767,10 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/multipage/#dom-document-lastmodified
     fn LastModified(&self) -> DOMString {
-        DOMString(match self.last_modified {
-            Some(ref t) => t.clone(),
-            None => time::now().strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string(),
-        })
+        match self.last_modified {
+            Some(ref t) => DOMString::from(t.clone()),
+            None => DOMString::from(time::now().strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string()),
+        }
     }
 
     // https://dom.spec.whatwg.org/#dom-document-createrange
@@ -1827,7 +1827,7 @@ impl DocumentMethods for Document {
             Some(ref title) => {
                 // Steps 3-4.
                 let value = Node::collect_text_contents(title.children());
-                DOMString(str_join(split_html_space_chars(&value), " "))
+                DOMString::from(str_join(split_html_space_chars(&value), " "))
             },
         }
     }
@@ -2096,7 +2096,7 @@ impl DocumentMethods for Document {
         let (tx, rx) = ipc::channel().unwrap();
         let _ = self.window.resource_task().send(GetCookiesForUrl((*url).clone(), tx, NonHTTP));
         let cookies = rx.recv().unwrap();
-        Ok(DOMString(cookies.unwrap_or("".to_owned())))
+        Ok(cookies.map(DOMString::from).unwrap_or(DOMString::from("")))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-cookie
@@ -2106,7 +2106,7 @@ impl DocumentMethods for Document {
         if !is_scheme_host_port_tuple(url) {
             return Err(Error::Security);
         }
-        let _ = self.window.resource_task().send(SetCookiesForUrl((*url).clone(), cookie.0, NonHTTP));
+        let _ = self.window.resource_task().send(SetCookiesForUrl((*url).clone(), String::from(cookie), NonHTTP));
         Ok(())
     }
 
@@ -2256,7 +2256,7 @@ impl DocumentProgressHandler {
     fn dispatch_load(&self) {
         let document = self.addr.root();
         let window = document.window();
-        let event = Event::new(GlobalRef::Window(window), DOMString("load".to_owned()),
+        let event = Event::new(GlobalRef::Window(window), DOMString::from("load"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         let wintarget = window.upcast::<EventTarget>();
@@ -2268,7 +2268,7 @@ impl DocumentProgressHandler {
 
         if let Some(frame_element) = browsing_context.frame_element() {
             let frame_window = window_from_node(frame_element);
-            let event = Event::new(GlobalRef::Window(frame_window.r()), DOMString("load".to_owned()),
+            let event = Event::new(GlobalRef::Window(frame_window.r()), DOMString::from("load"),
                                    EventBubbles::DoesNotBubble,
                                    EventCancelable::NotCancelable);
             event.fire(frame_element.upcast());

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -8,7 +8,6 @@ use dom::bindings::codegen::Bindings::DOMExceptionBinding::DOMExceptionMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
-use std::borrow::ToOwned;
 use util::str::DOMString;
 
 #[repr(u16)]
@@ -70,7 +69,7 @@ impl DOMExceptionMethods for DOMException {
 
     // https://heycam.github.io/webidl/#idl-DOMException-error-names
     fn Name(&self) -> DOMString {
-        DOMString(format!("{:?}", self.code))
+        DOMString::from(format!("{:?}", self.code))
     }
 
     // https://heycam.github.io/webidl/#error-names
@@ -102,11 +101,11 @@ impl DOMExceptionMethods for DOMException {
             DOMErrorName::EncodingError => "The encoding operation (either encoded or decoding) failed."
         };
 
-        DOMString(message.to_owned())
+        DOMString::from(message)
     }
 
     // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-error.prototype.tostring
     fn Stringifier(&self) -> DOMString {
-        DOMString(format!("{}: {}", self.Name(), self.Message()))
+        DOMString::from(format!("{}: {}", self.Name(), self.Message()))
     }
 }

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -22,7 +22,6 @@ use dom::htmlhtmlelement::HTMLHtmlElement;
 use dom::htmltitleelement::HTMLTitleElement;
 use dom::node::Node;
 use dom::text::Text;
-use std::borrow::ToOwned;
 use util::str::DOMString;
 
 // https://dom.spec.whatwg.org/#domimplementation
@@ -109,7 +108,7 @@ impl DOMImplementationMethods for DOMImplementation {
         {
             // Step 3.
             let doc_node = doc.upcast::<Node>();
-            let doc_type = DocumentType::new(DOMString("html".to_owned()), None, None, doc.r());
+            let doc_type = DocumentType::new(DOMString::from("html"), None, None, doc.r());
             doc_node.AppendChild(doc_type.upcast()).unwrap();
         }
 
@@ -117,13 +116,13 @@ impl DOMImplementationMethods for DOMImplementation {
             // Step 4.
             let doc_node = doc.upcast::<Node>();
             let doc_html = Root::upcast::<Node>(
-                HTMLHtmlElement::new(DOMString("html".to_owned()), None, doc.r()));
+                HTMLHtmlElement::new(DOMString::from("html"), None, doc.r()));
             doc_node.AppendChild(&doc_html).expect("Appending failed");
 
             {
                 // Step 5.
                 let doc_head = Root::upcast::<Node>(
-                    HTMLHeadElement::new(DOMString("head".to_owned()), None, doc.r()));
+                    HTMLHeadElement::new(DOMString::from("head"), None, doc.r()));
                 doc_html.AppendChild(&doc_head).unwrap();
 
                 // Step 6.
@@ -132,7 +131,7 @@ impl DOMImplementationMethods for DOMImplementation {
                     Some(title_str) => {
                         // Step 6.1.
                         let doc_title = Root::upcast::<Node>(
-                            HTMLTitleElement::new(DOMString("title".to_owned()), None, doc.r()));
+                            HTMLTitleElement::new(DOMString::from("title"), None, doc.r()));
                         doc_head.AppendChild(&doc_title).unwrap();
 
                         // Step 6.2.
@@ -143,7 +142,7 @@ impl DOMImplementationMethods for DOMImplementation {
             }
 
             // Step 7.
-            let doc_body = HTMLBodyElement::new(DOMString("body".to_owned()), None, doc.r());
+            let doc_body = HTMLBodyElement::new(DOMString::from("body"), None, doc.r());
             doc_html.AppendChild(doc_body.upcast()).unwrap();
         }
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -17,7 +17,6 @@ use dom::document::{Document, IsHTMLDocument};
 use dom::window::Window;
 use parse::html::{ParseContext, parse_html};
 use parse::xml::{self, parse_xml};
-use std::borrow::ToOwned;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -51,7 +50,7 @@ impl DOMParserMethods for DOMParser {
                        ty: DOMParserBinding::SupportedType)
                        -> Fallible<Root<Document>> {
         let url = self.window.get_url();
-        let content_type = DOMString(DOMParserBinding::SupportedTypeValues::strings[ty as usize].to_owned());
+        let content_type = DOMString::from(DOMParserBinding::SupportedTypeValues::strings[ty as usize]);
         let doc = self.window.Document();
         let doc = doc.r();
         let loader = DocumentLoader::new(&*doc.loader());

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -11,7 +11,6 @@ use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::element::Element;
 use dom::node::window_from_node;
-use std::borrow::ToOwned;
 use string_cache::Atom;
 use util::str::{DOMString, HTML_SPACE_CHARACTERS, str_join};
 
@@ -64,7 +63,8 @@ impl DOMTokenListMethods for DOMTokenList {
     // https://dom.spec.whatwg.org/#dom-domtokenlist-item
     fn Item(&self, index: u32) -> Option<DOMString> {
         self.attribute().and_then(|attr| {
-            attr.value().as_tokens().get(index as usize).map(|token| DOMString((**token).to_owned()))
+            // FIXME(ajeffrey): Convert directly from Atom to DOMString
+            attr.value().as_tokens().get(index as usize).map(|token| DOMString::from(&**token))
         })
     }
 
@@ -134,7 +134,7 @@ impl DOMTokenListMethods for DOMTokenList {
     // https://dom.spec.whatwg.org/#stringification-behavior
     fn Stringifier(&self) -> DOMString {
         let tokenlist = self.element.get_tokenlist_attribute(&self.local_name);
-        DOMString(str_join(&tokenlist, "\x20"))
+        DOMString::from(str_join(&tokenlist, "\x20"))
     }
 
     // check-tidy: no specs after this line

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -10,7 +10,6 @@ use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutNullableHeap, Root};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::eventtarget::EventTarget;
-use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::default::Default;
 use string_cache::Atom;
@@ -169,7 +168,7 @@ impl EventMethods for Event {
 
     // https://dom.spec.whatwg.org/#dom-event-type
     fn Type(&self) -> DOMString {
-        DOMString((*self.type_()).to_owned())
+        DOMString::from(&*self.type_()) // FIXME(ajeffrey): Directly convert from Atom to DOMString
     }
 
     // https://dom.spec.whatwg.org/#dom-event-target

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -40,14 +40,14 @@ pub type TrustedFileReader = Trusted<FileReader>;
 
 #[derive(Clone, HeapSizeOf)]
 pub struct ReadMetaData {
-    pub blobtype: DOMString,
-    pub label: Option<DOMString>,
+    pub blobtype: String,
+    pub label: Option<String>,
     pub function: FileReaderFunction
 }
 
 impl ReadMetaData {
-    pub fn new(blobtype: DOMString,
-               label: Option<DOMString>, function: FileReaderFunction) -> ReadMetaData {
+    pub fn new(blobtype: String,
+               label: Option<String>, function: FileReaderFunction) -> ReadMetaData {
         ReadMetaData {
             blobtype: blobtype,
             label: label,
@@ -358,7 +358,7 @@ impl FileReader {
         blob.read_out_buffer(send);
         let type_ = blob.Type();
 
-        let load_data = ReadMetaData::new(type_, label, function);
+        let load_data = ReadMetaData::new(String::from(type_), label.map(String::from), function);
 
         let fr = Trusted::new(global.get_cx(), self, global.script_chan());
         let gen_id = self.generation_id.get();
@@ -379,7 +379,7 @@ impl FileReader {
 #[derive(Clone)]
 pub enum FileReaderEvent {
     ProcessRead(TrustedFileReader, GenerationId),
-    ProcessReadData(TrustedFileReader, GenerationId, DOMString),
+    ProcessReadData(TrustedFileReader, GenerationId),
     ProcessReadError(TrustedFileReader, GenerationId, DOMErrorName),
     ProcessReadEOF(TrustedFileReader, GenerationId, ReadMetaData, Vec<u8>)
 }
@@ -391,7 +391,7 @@ impl Runnable for FileReaderEvent {
             FileReaderEvent::ProcessRead(filereader, gen_id) => {
                 FileReader::process_read(filereader, gen_id);
             },
-            FileReaderEvent::ProcessReadData(filereader, gen_id, _) => {
+            FileReaderEvent::ProcessReadData(filereader, gen_id) => {
                 FileReader::process_read_data(filereader, gen_id);
             },
             FileReaderEvent::ProcessReadError(filereader, gen_id, error) => {
@@ -412,8 +412,7 @@ fn perform_annotated_read_operation(gen_id: GenerationId, data: ReadMetaData, bl
     let task = box FileReaderEvent::ProcessRead(filereader.clone(), gen_id);
     chan.send(CommonScriptMsg::RunnableMsg(FileRead, task)).unwrap();
 
-    let task = box FileReaderEvent::ProcessReadData(filereader.clone(),
-        gen_id, DOMString::new());
+    let task = box FileReaderEvent::ProcessReadData(filereader.clone(), gen_id);
     chan.send(CommonScriptMsg::RunnableMsg(FileRead, task)).unwrap();
 
     let bytes = match blob_contents.recv() {

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -228,7 +228,7 @@ impl FileReader {
         let convert = blob_bytes;
         // Step 7
         let output = enc.decode(convert, DecoderTrap::Replace).unwrap();
-        DOMString(output)
+        DOMString::from(output)
     }
 
     //https://w3c.github.io/FileAPI/#dfn-readAsDataURL
@@ -248,7 +248,7 @@ impl FileReader {
             format!("data:{};base64,{}", data.blobtype, base64)
         };
 
-        DOMString(output)
+        DOMString::from(output)
     }
 }
 
@@ -323,7 +323,7 @@ impl FileReader {
 
         let global = self.global.root();
         let progressevent = ProgressEvent::new(global.r(),
-            DOMString(type_), EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
+            DOMString::from(type_), EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
             total.is_some(), loaded, total.unwrap_or(0));
         progressevent.upcast::<Event>().fire(self.upcast());
     }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -15,7 +15,6 @@ use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::blob::Blob;
 use dom::file::File;
 use dom::htmlformelement::HTMLFormElement;
-use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use util::str::DOMString;
@@ -117,7 +116,7 @@ impl FormData {
     fn get_file_from_blob(&self, value: &Blob, filename: Option<DOMString>) -> Root<File> {
         let global = self.global.root();
         let f = value.downcast::<File>();
-        let name = filename.unwrap_or(f.map(|inner| inner.name().clone()).unwrap_or(DOMString("blob".to_owned())));
+        let name = filename.unwrap_or(f.map(|inner| inner.name().clone()).unwrap_or(DOMString::from("blob")));
         File::new(global.r(), value, name)
     }
 }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -182,7 +182,7 @@ fn follow_hyperlink(subject: &Element, hyperlink_suffix: Option<String>) {
     // Step 6.
     // https://www.w3.org/Bugs/Public/show_bug.cgi?id=28925
     if let Some(suffix) = hyperlink_suffix {
-        href.0.push_str(&suffix);
+        href.push_str(&suffix);
     }
 
     // Step 4-5.

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -19,7 +19,6 @@ use dom::node::{Node, document_from_node, window_from_node};
 use dom::virtualmethods::VirtualMethods;
 use msg::constellation_msg::ConstellationChan;
 use msg::constellation_msg::Msg as ConstellationMsg;
-use std::borrow::ToOwned;
 use std::rc::Rc;
 use string_cache::Atom;
 use time;
@@ -179,7 +178,7 @@ impl VirtualMethods for HTMLBodyElement {
                           let evtarget = window.upcast::<EventTarget>(); // forwarded event
                           evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                                 &name[2..],
-                                                                DOMString((**attr.value()).to_owned()));
+                                                                DOMString::from((**attr.value()).to_owned()));
                           false
                     }
                     _ => true, // HTMLElement::attribute_mutated will take care of this.

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -22,7 +22,6 @@ use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 use selectors::states::*;
 use std::ascii::AsciiExt;
-use std::borrow::ToOwned;
 use std::cell::Cell;
 use util::str::DOMString;
 
@@ -226,7 +225,7 @@ impl<'a> Activatable for &'a HTMLButtonElement {
         if owner.is_none() || self.upcast::<Element>().click_in_progress() {
             return;
         }
-        node.query_selector_iter(DOMString("button[type=submit]".to_owned())).unwrap()
+        node.query_selector_iter(DOMString::from("button[type=submit]")).unwrap()
             .filter_map(Root::downcast::<HTMLButtonElement>)
             .find(|r| r.form_owner() == owner)
             .map(|s| s.r().synthetic_click_activation(ctrlKey, shiftKey, altKey, metaKey));

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -256,7 +256,7 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
 
         // Step 2.
         if self.Width() == 0 || self.Height() == 0 {
-            return Ok(DOMString("data:,".to_owned()));
+            return Ok(DOMString::from("data:,"));
         }
 
         // Step 3.
@@ -277,7 +277,7 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
             }
 
             let encoded = encoded.to_base64(STANDARD);
-            Ok(DOMString(format!("data:{};base64,{}", mime_type, encoded)))
+            Ok(DOMString::from(format!("data:{};base64,{}", mime_type, encoded)))
         } else {
             Err(Error::NotSupported)
         }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -275,7 +275,7 @@ fn to_snake_case(name: DOMString) -> DOMString {
             attr_name.push(ch);
         }
     }
-    DOMString(attr_name)
+    DOMString::from(attr_name)
 }
 
 
@@ -314,7 +314,7 @@ fn to_camel_case(name: &str) -> Option<DOMString> {
             result.push(curr_char);
         }
     }
-    Some(DOMString(result))
+    Some(DOMString::from(result))
 }
 
 impl HTMLElement {
@@ -330,7 +330,7 @@ impl HTMLElement {
     pub fn get_custom_attr(&self, local_name: DOMString) -> Option<DOMString> {
         let local_name = Atom::from_slice(&to_snake_case(local_name));
         self.upcast::<Element>().get_attribute(&ns!(""), &local_name).map(|attr| {
-            DOMString((**attr.value()).to_owned())
+            DOMString::from(&**attr.value()) // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
         })
     }
 
@@ -423,7 +423,8 @@ impl VirtualMethods for HTMLElement {
                 let evtarget = self.upcast::<EventTarget>();
                 evtarget.set_event_handler_uncompiled(cx, url, reflector,
                                                       &name[2..],
-                                                      DOMString((**attr.value()).to_owned()));
+                                                      // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
+                                                      DOMString::from(&**attr.value()));
             },
             _ => {}
         }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -159,7 +159,7 @@ impl HTMLFormElement {
         // TODO: Handle browsing contexts
         // TODO: Handle validation
         let event = Event::new(GlobalRef::Window(win.r()),
-                               DOMString("submit".to_owned()),
+                               DOMString::from("submit"),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable);
         event.fire(self.upcast());
@@ -171,7 +171,7 @@ impl HTMLFormElement {
         // Step 7-8
         let mut action = submitter.action();
         if action.is_empty() {
-            action = DOMString(base.serialize());
+            action = DOMString::from(base.serialize());
         }
         // TODO: Resolve the url relative to the submitter element
         // Step 10-15
@@ -283,7 +283,7 @@ impl HTMLFormElement {
             if prev == '\r' {
                 buf.push('\n');
             }
-            DOMString(buf)
+            DOMString::from(buf)
         }
 
         let mut ret = self.get_unclean_dataset(submitter);
@@ -311,7 +311,7 @@ impl HTMLFormElement {
 
         let win = window_from_node(self);
         let event = Event::new(GlobalRef::Window(win.r()),
-                               DOMString("reset".to_owned()),
+                               DOMString::from("reset"),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable);
         event.fire(self.upcast());

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -29,7 +29,6 @@ use msg::constellation_msg::{ConstellationChan, IframeLoadInfo, MozBrowserEvent}
 use msg::constellation_msg::{NavigationDirection, PipelineId, SubpageId};
 use page::IterablePage;
 use std::ascii::AsciiExt;
-use std::borrow::ToOwned;
 use std::cell::Cell;
 use string_cache::Atom;
 use url::{Url, UrlParser};
@@ -146,7 +145,7 @@ impl HTMLIFrameElement {
                 let mut detail = RootedValue::new(cx, UndefinedValue());
                 event.detail().to_jsval(cx, detail.handle_mut());
                 CustomEvent::new(GlobalRef::Window(window.r()),
-                                 DOMString(event.name().to_owned()),
+                                 DOMString::from(event.name()),
                                  true,
                                  true,
                                  detail.handle())

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -25,7 +25,6 @@ use net_traits::image::base::Image;
 use net_traits::image_cache_task::{ImageResponder, ImageResponse};
 use script_task::ScriptTaskEventCategory::UpdateReplacedElement;
 use script_task::{CommonScriptMsg, Runnable, ScriptChan};
-use std::borrow::ToOwned;
 use std::sync::Arc;
 use string_cache::Atom;
 use url::{Url, UrlParser};
@@ -79,7 +78,7 @@ impl Runnable for ImageResponseHandlerRunnable {
         // Fire image.onload
         let window = window_from_node(document.r());
         let event = Event::new(GlobalRef::Window(window.r()),
-                               DOMString("load".to_owned()),
+                               DOMString::from("load"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(element.upcast());
@@ -149,7 +148,7 @@ impl HTMLImageElement {
                  width: Option<u32>,
                  height: Option<u32>) -> Fallible<Root<HTMLImageElement>> {
         let document = global.as_window().Document();
-        let image = HTMLImageElement::new(DOMString("img".to_owned()), None, document.r());
+        let image = HTMLImageElement::new(DOMString::from("img"), None, document.r());
         if let Some(w) = width {
             image.SetWidth(w);
         }
@@ -295,7 +294,8 @@ impl VirtualMethods for HTMLImageElement {
         match attr.local_name() {
             &atom!(src) => {
                 self.update_image(mutation.new_value(attr).map(|value| {
-                    (DOMString((**value).to_owned()), window_from_node(self).get_url())
+                    // FIXME(ajeffrey): convert directly from AttrValue to DOMString
+                    (DOMString::from(&**value), window_from_node(self).get_url())
                 }));
             },
             _ => {},

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -576,10 +576,11 @@ impl VirtualMethods for HTMLInputElement {
                     mutation.new_value(attr).as_ref().map(|name| name.as_atom()));
             },
             &atom!(placeholder) => {
+                // FIXME(ajeffrey): Should we do in-place mutation of the placeholder?
                 let mut placeholder = self.placeholder.borrow_mut();
-                placeholder.0.clear();
+                placeholder.clear();
                 if let AttributeMutation::Set(_) = mutation {
-                    placeholder.0.extend(
+                    placeholder.extend(
                         attr.value().chars().filter(|&c| c != '\n' && c != '\r'));
                 }
             },

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -137,7 +137,7 @@ impl HTMLInputElement {
 
 pub trait LayoutHTMLInputElementHelpers {
     #[allow(unsafe_code)]
-    unsafe fn get_value_for_layout(self) -> DOMString;
+    unsafe fn get_value_for_layout(self) -> String;
     #[allow(unsafe_code)]
     unsafe fn get_size_for_layout(self) -> u32;
     #[allow(unsafe_code)]
@@ -160,28 +160,28 @@ unsafe fn get_raw_textinput_value(input: LayoutJS<HTMLInputElement>) -> DOMStrin
 
 impl LayoutHTMLInputElementHelpers for LayoutJS<HTMLInputElement> {
     #[allow(unsafe_code)]
-    unsafe fn get_value_for_layout(self) -> DOMString {
+    unsafe fn get_value_for_layout(self) -> String {
         #[allow(unsafe_code)]
-        unsafe fn get_raw_attr_value(input: LayoutJS<HTMLInputElement>, default: &str) -> DOMString {
+        unsafe fn get_raw_attr_value(input: LayoutJS<HTMLInputElement>, default: &str) -> String {
             let elem = input.upcast::<Element>();
             let value = (*elem.unsafe_get())
                 .get_attr_val_for_layout(&ns!(""), &atom!("value"))
                 .unwrap_or(default);
-            DOMString(value.to_owned())
+            String::from(value)
         }
 
         match (*self.unsafe_get()).input_type.get() {
-            InputType::InputCheckbox | InputType::InputRadio => DOMString::new(),
-            InputType::InputFile | InputType::InputImage => DOMString::new(),
+            InputType::InputCheckbox | InputType::InputRadio => String::new(),
+            InputType::InputFile | InputType::InputImage => String::new(),
             InputType::InputButton => get_raw_attr_value(self, ""),
             InputType::InputSubmit => get_raw_attr_value(self, DEFAULT_SUBMIT_VALUE),
             InputType::InputReset => get_raw_attr_value(self, DEFAULT_RESET_VALUE),
             InputType::InputPassword => {
                 let raw = get_raw_textinput_value(self);
                 // The implementation of get_insertion_point_index_for_layout expects a 1:1 mapping of chars.
-                DOMString(raw.chars().map(|_| '●').collect())
+                raw.chars().map(|_| '●').collect()
             }
-            _ => get_raw_textinput_value(self),
+            _ => String::from(get_raw_textinput_value(self)),
         }
     }
 
@@ -371,7 +371,7 @@ fn broadcast_radio_checked(broadcaster: &HTMLInputElement, group: Option<&Atom>)
     // This function is a workaround for lifetime constraint difficulties.
     fn do_broadcast(doc_node: &Node, broadcaster: &HTMLInputElement,
                         owner: Option<&HTMLFormElement>, group: Option<&Atom>) {
-        let iter = doc_node.query_selector_iter(DOMString("input[type=radio]".to_owned())).unwrap()
+        let iter = doc_node.query_selector_iter(DOMString::from("input[type=radio]")).unwrap()
                 .filter_map(Root::downcast::<HTMLInputElement>)
                 .filter(|r| in_same_group(r.r(), owner, group) && broadcaster != r.r());
         for ref r in iter {
@@ -436,11 +436,11 @@ impl HTMLInputElement {
         let mut value = self.Value();
         if &*ty == "radio" || &*ty == "checkbox" {
             if value.is_empty() {
-                value = DOMString("on".to_owned());
+                value = DOMString::from("on");
             }
         }
         Some(FormDatum {
-            ty: DOMString(ty.to_string()),
+            ty: DOMString::from(&*ty), // FIXME(ajeffrey): Convert directly from Atoms to DOMStrings
             name: name,
             value: value
         })
@@ -568,8 +568,8 @@ impl VirtualMethods for HTMLInputElement {
             },
             &atom!(value) if !self.value_changed.get() => {
                 let value = mutation.new_value(attr).map(|value| (**value).to_owned());
-                self.textinput.borrow_mut().set_content(DOMString(
-                    value.unwrap_or_else(|| "".to_owned())));
+                self.textinput.borrow_mut().set_content(
+                    value.map(DOMString::from).unwrap_or(DOMString::from("")));
             },
             &atom!(name) if self.input_type.get() == InputType::InputRadio => {
                 self.radio_group_updated(
@@ -718,7 +718,7 @@ impl Activatable for HTMLInputElement {
                     let group = self.get_radio_group_name();;
 
                     // Safe since we only manipulate the DOM tree after finding an element
-                    let checked_member = doc_node.query_selector_iter(DOMString("input[type=radio]".to_owned()))
+                    let checked_member = doc_node.query_selector_iter(DOMString::from("input[type=radio]"))
                             .unwrap()
                             .filter_map(Root::downcast::<HTMLInputElement>)
                             .find(|r| {
@@ -820,13 +820,13 @@ impl Activatable for HTMLInputElement {
                     let target = self.upcast();
 
                     let event = Event::new(GlobalRef::Window(win.r()),
-                                           DOMString("input".to_owned()),
+                                           DOMString::from("input"),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable);
                     event.fire(target);
 
                     let event = Event::new(GlobalRef::Window(win.r()),
-                                           DOMString("change".to_owned()),
+                                           DOMString::from("change"),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable);
                     event.fire(target);
@@ -851,7 +851,7 @@ impl Activatable for HTMLInputElement {
             return;
         }
         let submit_button;
-        submit_button = node.query_selector_iter(DOMString("input[type=submit]".to_owned())).unwrap()
+        submit_button = node.query_selector_iter(DOMString::from("input[type=submit]")).unwrap()
             .filter_map(Root::downcast::<HTMLInputElement>)
             .find(|r| r.form_owner() == owner);
         match submit_button {
@@ -861,7 +861,7 @@ impl Activatable for HTMLInputElement {
                 }
             }
             None => {
-                let inputs = node.query_selector_iter(DOMString("input".to_owned())).unwrap()
+                let inputs = node.query_selector_iter(DOMString::from("input")).unwrap()
                     .filter_map(Root::downcast::<HTMLInputElement>)
                     .filter(|input| {
                         input.form_owner() == owner && match input.type_() {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -70,7 +70,8 @@ impl HTMLOptionElement {
     }
 }
 
-fn collect_text(element: &Element, value: &mut DOMString) {
+// FIXME(ajeffrey): Provide a way of buffering DOMStrings other than using Strings
+fn collect_text(element: &Element, value: &mut String) {
     let svg_script = *element.namespace() == ns!(SVG) && element.local_name() == &atom!("script");
     let html_script = element.is::<HTMLScriptElement>();
     if svg_script || html_script {
@@ -80,7 +81,7 @@ fn collect_text(element: &Element, value: &mut DOMString) {
     for child in element.upcast::<Node>().children() {
         if child.is::<Text>() {
             let characterdata = child.downcast::<CharacterData>().unwrap();
-            value.0.push_str(&characterdata.Data());
+            value.push_str(&characterdata.Data());
         } else if let Some(element_child) = child.downcast() {
             collect_text(element_child, value);
         }
@@ -96,9 +97,9 @@ impl HTMLOptionElementMethods for HTMLOptionElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-option-text
     fn Text(&self) -> DOMString {
-        let mut content = DOMString::new();
+        let mut content = String::new();
         collect_text(self.upcast(), &mut content);
-        DOMString(str_join(split_html_space_chars(&content), " "))
+        DOMString::from(str_join(split_html_space_chars(&content), " "))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-option-text

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -401,7 +401,7 @@ impl HTMLScriptElement {
                 // TODO: Otherwise, decode the file to Unicode, using character
                 // encoding as the fallback encoding.
 
-                (DOMString(UTF_8.decode(&*bytes, DecoderTrap::Replace).unwrap()),
+                (DOMString::from(UTF_8.decode(&*bytes, DecoderTrap::Replace).unwrap()),
                  true,
                  metadata.final_url)
             },
@@ -549,7 +549,7 @@ impl HTMLScriptElement {
         let window = window_from_node(self);
         let window = window.r();
         let event = Event::new(GlobalRef::Window(window),
-                               DOMString(type_),
+                               DOMString::from(type_),
                                bubbles,
                                cancelable);
         event.fire(self.upcast())

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -21,7 +21,6 @@ use dom::nodelist::NodeList;
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 use selectors::states::*;
-use std::borrow::ToOwned;
 use string_cache::Atom;
 use util::str::DOMString;
 
@@ -153,11 +152,11 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-select-type
     fn Type(&self) -> DOMString {
-        DOMString(if self.Multiple() {
+        DOMString::from(if self.Multiple() {
             "select-multiple"
         } else {
             "select-one"
-        }.to_owned())
+        })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -75,7 +75,7 @@ impl HTMLTableElementMethods for HTMLTableElement {
         let caption = match self.GetCaption() {
             Some(caption) => caption,
             None => {
-                let caption = HTMLTableCaptionElement::new(DOMString("caption".to_owned()),
+                let caption = HTMLTableCaptionElement::new(DOMString::from("caption"),
                                                            None,
                                                            document_from_node(self).r());
                 self.SetCaption(Some(caption.r()));
@@ -94,7 +94,7 @@ impl HTMLTableElementMethods for HTMLTableElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-table-createtbody
     fn CreateTBody(&self) -> Root<HTMLTableSectionElement> {
-        let tbody = HTMLTableSectionElement::new(DOMString("tbody".to_owned()),
+        let tbody = HTMLTableSectionElement::new(DOMString::from("tbody"),
                                                  None,
                                                  document_from_node(self).r());
         let node = self.upcast::<Node>();

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -76,7 +76,7 @@ impl HTMLTableRowElementMethods for HTMLTableRowElement {
         node.insert_cell_or_row(
             index,
             || self.Cells(),
-            || HTMLTableDataCellElement::new(DOMString("td".to_owned()), None, node.owner_doc().r()))
+            || HTMLTableDataCellElement::new(DOMString::from("td"), None, node.owner_doc().r()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tr-deletecell

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -61,7 +61,7 @@ impl HTMLTableSectionElementMethods for HTMLTableSectionElement {
         node.insert_cell_or_row(
             index,
             || self.Rows(),
-            || HTMLTableRowElement::new(DOMString("tr".to_owned()), None, node.owner_doc().r()))
+            || HTMLTableRowElement::new(DOMString::from("tr"), None, node.owner_doc().r()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-deleterow

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -28,7 +28,6 @@ use msg::constellation_msg::ConstellationChan;
 use script_task::ScriptTaskEventCategory::InputEvent;
 use script_task::{CommonScriptMsg, Runnable};
 use selectors::states::*;
-use std::borrow::ToOwned;
 use std::cell::Cell;
 use string_cache::Atom;
 use textinput::{KeyReaction, Lines, TextInput};
@@ -63,7 +62,7 @@ impl LayoutHTMLTextAreaElementHelpers for LayoutJS<HTMLTextAreaElement> {
     #[allow(unrooted_must_root)]
     #[allow(unsafe_code)]
     unsafe fn get_value_for_layout(self) -> String {
-        (*self.unsafe_get()).textinput.borrow_for_layout().get_content().0
+        String::from((*self.unsafe_get()).textinput.borrow_for_layout().get_content())
     }
 
     #[allow(unrooted_must_root)]
@@ -174,7 +173,7 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-type
     fn Type(&self) -> DOMString {
-        DOMString("textarea".to_owned())
+        DOMString::from("textarea")
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-defaultvalue
@@ -238,7 +237,7 @@ impl HTMLTextAreaElement {
         let window = window_from_node(self);
         let window = window.r();
         let event = Event::new(GlobalRef::Window(window),
-                               DOMString("input".to_owned()),
+                               DOMString::from("input"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
 

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -45,7 +45,7 @@ impl HTMLTitleElementMethods for HTMLTitleElement {
                 content.push_str(&text.upcast::<CharacterData>().data());
             }
         }
-        DOMString(content)
+        DOMString::from(content)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-title-text

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -135,7 +135,7 @@ impl LocationMethods for Location {
 
     // https://html.spec.whatwg.org/multipage/#dom-location-href
     fn Stringifier(&self) -> DOMString {
-        DOMString(self.Href().0)
+        DOMString::from(self.Href().0)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-location-search

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -84,7 +84,7 @@ macro_rules! make_url_or_base_getter(
             let url = element.get_url_attribute(&Atom::from_slice($htmlname));
             if url.is_empty() {
                 let window = window_from_node(self);
-                DOMString(window.get_url().serialize())
+                DOMString::from(window.get_url().serialize())
             } else {
                 url
             }
@@ -102,7 +102,6 @@ macro_rules! make_enumerated_getter(
             use dom::bindings::inheritance::Castable;
             use dom::element::Element;
             use std::ascii::AsciiExt;
-            use std::borrow::ToOwned;
             use string_cache::Atom;
             let element = self.upcast::<Element>();
             let mut val = element.get_string_attribute(&Atom::from_slice($htmlname));
@@ -110,7 +109,7 @@ macro_rules! make_enumerated_getter(
             // https://html.spec.whatwg.org/multipage/#attr-fs-method
             match &*val {
                 $($choices)|+ => val,
-                _ => DOMString($default.to_owned())
+                _ => DOMString::from($default)
             }
         }
     );

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -14,7 +14,6 @@ use dom::event::Event;
 use dom::eventtarget::EventTarget;
 use js::jsapi::{RootedValue, HandleValue, Heap, JSContext};
 use js::jsval::JSVal;
-use std::borrow::ToOwned;
 use std::default::Default;
 use util::str::DOMString;
 
@@ -79,7 +78,7 @@ impl MessageEvent {
                           scope: GlobalRef,
                           message: HandleValue) {
         let messageevent = MessageEvent::new(
-            scope, DOMString("message".to_owned()), false, false, message,
+            scope, DOMString::from("message"), false, false, message,
             DOMString::new(), DOMString::new());
         messageevent.upcast::<Event>().fire(target);
     }

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -89,7 +89,7 @@ impl NamedNodeMapMethods for NamedNodeMap {
     // https://heycam.github.io/webidl/#dfn-supported-property-names
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         self.owner.attrs().iter().map(|attr| {
-            DOMString((**attr.name()).to_owned())
+            DOMString::from(&**attr.name()) // FIXME(ajeffrey): Convert directly from &Atom to DOMString
         }).collect()
     }
 }

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::borrow::ToOwned;
 use util::opts;
 use util::str::DOMString;
 
 pub fn Product() -> DOMString {
-    DOMString("Gecko".to_owned())
+    DOMString::from("Gecko")
 }
 
 pub fn TaintEnabled() -> bool {
@@ -15,32 +14,32 @@ pub fn TaintEnabled() -> bool {
 }
 
 pub fn AppName() -> DOMString {
-    DOMString("Netscape".to_owned()) // Like Gecko/Webkit
+    DOMString::from("Netscape") // Like Gecko/Webkit
 }
 
 pub fn AppCodeName() -> DOMString {
-    DOMString("Mozilla".to_owned())
+    DOMString::from("Mozilla")
 }
 
 #[cfg(target_os = "windows")]
 pub fn Platform() -> DOMString {
-    DOMString("Win32".to_owned())
+    DOMString::from("Win32")
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub fn Platform() -> DOMString {
-    DOMString("Linux".to_owned())
+    DOMString::from("Linux")
 }
 
 #[cfg(target_os = "macos")]
 pub fn Platform() -> DOMString {
-    DOMString("Mac".to_owned())
+    DOMString::from("Mac")
 }
 
 pub fn UserAgent() -> DOMString {
-    DOMString(opts::get().user_agent.clone())
+    DOMString::from(&*opts::get().user_agent)
 }
 
 pub fn AppVersion() -> DOMString {
-    DOMString("4.0".to_owned())
+    DOMString::from("4.0")
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -806,17 +806,17 @@ impl Node {
     pub fn summarize(&self) -> NodeInfo {
         NodeInfo {
             uniqueId: self.get_unique_id(),
-            baseURI: self.BaseURI(),
+            baseURI: String::from(self.BaseURI()),
             parent: self.GetParentNode().map(|node| node.get_unique_id()).unwrap_or("".to_owned()),
             nodeType: self.NodeType(),
-            namespaceURI: DOMString::new(), //FIXME
-            nodeName: self.NodeName(),
+            namespaceURI: String::new(), //FIXME
+            nodeName: String::from(self.NodeName()),
             numChildren: self.ChildNodes().Length() as usize,
 
             //FIXME doctype nodes only
-            name: DOMString::new(),
-            publicId: DOMString::new(),
-            systemId: DOMString::new(),
+            name: String::new(),
+            publicId: String::new(),
+            systemId: String::new(),
             attrs: self.downcast().map(Element::summarize).unwrap_or(vec![]),
 
             isDocumentElement:
@@ -825,7 +825,7 @@ impl Node {
                     .map(|elem| elem.upcast::<Node>() == self)
                     .unwrap_or(false),
 
-            shortValue: self.GetNodeValue().unwrap_or_default(), //FIXME: truncate
+            shortValue: self.GetNodeValue().map(String::from).unwrap_or_default(), //FIXME: truncate
             incompleteValue: false, //FIXME: reflect truncation
         }
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1710,13 +1710,14 @@ impl Node {
                 None => (),
             }
         }
-        DOMString(content)
+        DOMString::from(content)
     }
 
     pub fn namespace_to_string(namespace: Namespace) -> Option<DOMString> {
         match namespace {
             ns!("") => None,
-            Namespace(ref ns) => Some(DOMString((**ns).to_owned()))
+            // FIXME(ajeffrey): convert directly from &Atom to DOMString
+            Namespace(ref ns) => Some(DOMString::from(&**ns))
         }
     }
 
@@ -1812,16 +1813,16 @@ impl NodeMethods for Node {
             NodeTypeId::Element(..) => {
                 self.downcast::<Element>().unwrap().TagName()
             }
-            NodeTypeId::CharacterData(CharacterDataTypeId::Text) => DOMString("#text".to_owned()),
+            NodeTypeId::CharacterData(CharacterDataTypeId::Text) => DOMString::from("#text"),
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
                 self.downcast::<ProcessingInstruction>().unwrap().Target()
             }
-            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => DOMString("#comment".to_owned()),
+            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => DOMString::from("#comment"),
             NodeTypeId::DocumentType => {
                 self.downcast::<DocumentType>().unwrap().name().clone()
             },
-            NodeTypeId::DocumentFragment => DOMString("#document-fragment".to_owned()),
-            NodeTypeId::Document => DOMString("#document".to_owned())
+            NodeTypeId::DocumentFragment => DOMString::from("#document-fragment"),
+            NodeTypeId::Document => DOMString::from("#document")
         }
     }
 

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -48,7 +48,9 @@ impl Sink {
         match child {
             NodeOrText::AppendNode(n) => Root::from_ref(&*n),
             NodeOrText::AppendText(t) => {
-                let text = Text::new(DOMString(t.into()), &self.document);
+                // FIXME(ajeffrey): convert directly from tendrils to DOMStrings
+                let s: String = t.into();
+                let text = Text::new(DOMString::from(s), &self.document);
                 Root::upcast(text)
             }
         }

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -83,11 +83,11 @@ impl TextMethods for Text {
                                          .last().unwrap();
         let nodes = first.inclusively_following_siblings()
                          .take_while(|node| node.is::<Text>());
-        let mut text = DOMString::new();
+        let mut text = String::new();
         for ref node in nodes {
             let cdata = node.downcast::<CharacterData>().unwrap();
-            text.0.push_str(&cdata.data());
+            text.push_str(&cdata.data());
         }
-        text
+        DOMString::from(text)
     }
 }

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -72,7 +72,7 @@ impl TextDecoder {
 impl TextDecoderMethods for TextDecoder {
     // https://encoding.spec.whatwg.org/#dom-textdecoder-encoding
     fn Encoding(&self) -> DOMString {
-        DOMString(self.encoding.whatwg_name().unwrap().to_owned())
+        DOMString::from(self.encoding.whatwg_name().unwrap())
     }
 
     // https://encoding.spec.whatwg.org/#dom-textdecoder-fatal

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -66,7 +66,7 @@ impl TextEncoder {
 impl TextEncoderMethods for TextEncoder {
     // https://encoding.spec.whatwg.org/#dom-textencoder-encoding
     fn Encoding(&self) -> DOMString {
-        DOMString(self.encoder.name().to_owned())
+        DOMString::from(self.encoder.name())
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -188,7 +188,7 @@ impl URLMethods for URL {
 
     // https://url.spec.whatwg.org/#dom-url-href
     fn Stringifier(&self) -> DOMString {
-        DOMString(self.Href().0)
+        DOMString::from(self.Href().0)
     }
 
     // https://url.spec.whatwg.org/#dom-url-username

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -119,7 +119,7 @@ impl URLSearchParamsMethods for URLSearchParams {
 
     // https://url.spec.whatwg.org/#stringification-behavior
     fn Stringifier(&self) -> DOMString {
-        DOMString(self.serialize(None))
+        DOMString::from(self.serialize(None))
     }
 }
 

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -42,9 +42,9 @@ pub fn load_script(head: &HTMLHeadElement) {
                 Ok(ref s) if s.ends_with(".js") => "file://".to_owned() + &s[..],
                 _ => continue
             };
-            let new_script = doc.CreateElement(DOMString("script".to_owned())).unwrap();
+            let new_script = doc.CreateElement(DOMString::from("script")).unwrap();
             let new_script = new_script.r();
-            new_script.set_string_attribute(&atom!("src"), DOMString(name));
+            new_script.set_string_attribute(&atom!("src"), DOMString::from(name));
             node.InsertBefore(new_script.upcast(), first_child.r()).unwrap();
         }
     }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -106,7 +106,9 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = ipc::channel().unwrap();
-        self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::GetAttribLocation(self.id, name.0, sender))).unwrap();
+        self.renderer
+            .send(CanvasMsg::WebGL(CanvasWebGLMsg::GetAttribLocation(self.id, String::from(name), sender)))
+            .unwrap();
         Ok(receiver.recv().unwrap())
     }
 
@@ -122,7 +124,9 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = ipc::channel().unwrap();
-        self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::GetUniformLocation(self.id, name.0, sender))).unwrap();
+        self.renderer
+            .send(CanvasMsg::WebGL(CanvasWebGLMsg::GetUniformLocation(self.id, String::from(name), sender)))
+            .unwrap();
         Ok(receiver.recv().unwrap())
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -119,10 +119,10 @@ impl WebGLRenderingContext {
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(global,
-                                                   DOMString("webglcontextcreationerror".to_owned()),
+                                                   DOMString::from("webglcontextcreationerror"),
                                                    EventBubbles::DoesNotBubble,
                                                    EventCancelable::Cancelable,
-                                                   DOMString(msg));
+                                                   DOMString::from(msg));
                 event.upcast::<Event>().fire(canvas.upcast());
                 None
             }
@@ -631,7 +631,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
     fn GetShaderInfoLog(&self, shader: Option<&WebGLShader>) -> Option<DOMString> {
         if let Some(shader) = shader {
-            shader.info_log().map(DOMString)
+            shader.info_log().map(DOMString::from)
         } else {
             None
         }

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -353,7 +353,7 @@ impl WebSocketMethods for WebSocket {
 
     // https://html.spec.whatwg.org/multipage/#dom-websocket-url
     fn Url(&self) -> DOMString {
-        DOMString(self.url.serialize())
+        DOMString::from(self.url.serialize())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-websocket-readystate
@@ -489,7 +489,7 @@ impl Runnable for ConnectionEstablishedTask {
 
         // Step 6.
         let global = ws.global.root();
-        let event = Event::new(global.r(), DOMString("open".to_owned()),
+        let event = Event::new(global.r(), DOMString::from("open"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(ws.upcast());
@@ -531,7 +531,7 @@ impl Runnable for CloseTask {
             //A Bad close
             ws.clean_close.set(false);
             let event = Event::new(global.r(),
-                                   DOMString("error".to_owned()),
+                                   DOMString::from("error"),
                                    EventBubbles::DoesNotBubble,
                                    EventCancelable::Cancelable);
             event.fire(ws.upcast());
@@ -541,12 +541,12 @@ impl Runnable for CloseTask {
          https://html.spec.whatwg.org/multipage/#closeWebSocket
         */
         let close_event = CloseEvent::new(global.r(),
-                                          DOMString("close".to_owned()),
+                                          DOMString::from("close"),
                                           EventBubbles::DoesNotBubble,
                                           EventCancelable::NotCancelable,
                                           ws.clean_close.get(),
                                           ws.code.get(),
-                                          DOMString(reason));
+                                          DOMString::from(reason));
         close_event.upcast::<Event>().fire(ws.upcast());
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -306,7 +306,7 @@ pub fn base64_btoa(input: DOMString) -> Fallible<DOMString> {
 
         // "and then must apply the base64 algorithm to that sequence of
         //  octets, and return the result. [RFC4648]"
-        Ok(DOMString(octets.to_base64(STANDARD)))
+        Ok(DOMString::from(octets.to_base64(STANDARD)))
     }
 }
 
@@ -353,7 +353,7 @@ pub fn base64_atob(input: DOMString) -> Fallible<DOMString> {
     }
 
     match input.from_base64() {
-        Ok(data) => Ok(DOMString(data.iter().map(|&b| b as char).collect::<String>())),
+        Ok(data) => Ok(DOMString::from(data.iter().map(|&b| b as char).collect::<String>())),
         Err(..) => Err(Error::InvalidCharacter)
     }
 }
@@ -1003,7 +1003,7 @@ impl Window {
                     ReflowQueryType::ResolvedStyleQuery(element, pseudo, property.clone()),
                     ReflowReason::Query);
         let ResolvedStyleResponse(resolved) = self.layout_rpc.resolved_style();
-        resolved.map(DOMString)
+        resolved.map(DOMString::from)
     }
 
     pub fn offset_parent_query(&self, node: TrustedNodeAddress) -> (Option<Root<Element>>, Rect<Au>) {

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -85,7 +85,7 @@ impl Worker {
                 let pipeline_id = global.pipeline();
                 let title = format!("Worker for {}", worker_url);
                 let page_info = DevtoolsPageInfo {
-                    title: DOMString(title),
+                    title: title,
                     url: worker_url.clone(),
                 };
                 chan.send(ScriptToDevtoolsControlMsg::NewGlobal((pipeline_id, Some(worker_id)),

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -25,7 +25,6 @@ use js::jsapi::{HandleValue, JSContext, RootedValue};
 use js::jsapi::{JSAutoCompartment, JSAutoRequest};
 use js::jsval::UndefinedValue;
 use script_task::{Runnable, ScriptChan};
-use std::borrow::ToOwned;
 use std::sync::mpsc::{Sender, channel};
 use url::UrlParser;
 use util::str::DOMString;
@@ -129,7 +128,7 @@ impl Worker {
         let worker = address.root();
         let global = worker.r().global.root();
         let event = Event::new(global.r(),
-                               DOMString("error".to_owned()),
+                               DOMString::from("error"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(worker.upcast());
@@ -140,7 +139,7 @@ impl Worker {
         let worker = address.root();
         let global = worker.r().global.root();
         let error = RootedValue::new(global.r().get_cx(), UndefinedValue());
-        let errorevent = ErrorEvent::new(global.r(), DOMString("error".to_owned()),
+        let errorevent = ErrorEvent::new(global.r(), DOMString::from("error"),
                                          EventBubbles::Bubbles, EventCancelable::Cancelable,
                                          message, filename, lineno, colno, error.handle());
         errorevent.upcast::<Event>().fire(worker.upcast());

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -299,7 +299,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
 impl WorkerGlobalScope {
     pub fn execute_script(&self, source: DOMString) {
         match self.runtime.evaluate_script(
-            self.reflector().get_jsobject(), source.0, self.worker_url.serialize(), 1) {
+            self.reflector().get_jsobject(), String::from(source), self.worker_url.serialize(), 1) {
             Ok(_) => (),
             Err(_) => {
                 // TODO: An error needs to be dispatched to the parent.

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -78,6 +78,6 @@ impl WorkerLocationMethods for WorkerLocation {
 
     // https://html.spec.whatwg.org/multipage/#dom-workerlocation-href
     fn Stringifier(&self) -> DOMString {
-        DOMString(self.Href().0)
+        DOMString::from(self.Href().0)
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -722,7 +722,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
     fn GetResponseText(&self) -> Fallible<DOMString> {
         match self.response_type.get() {
             _empty | Text => {
-                Ok(DOMString(match self.ready_state.get() {
+                Ok(DOMString::from(match self.ready_state.get() {
                     XMLHttpRequestState::Loading | XMLHttpRequestState::Done => self.text_response(),
                     _ => "".to_owned()
                 }))
@@ -746,7 +746,7 @@ impl XMLHttpRequest {
         self.ready_state.set(rs);
         let global = self.global.root();
         let event = Event::new(global.r(),
-                               DOMString("readystatechange".to_owned()),
+                               DOMString::from("readystatechange"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::Cancelable);
         event.fire(self.upcast());
@@ -927,7 +927,7 @@ impl XMLHttpRequest {
     fn dispatch_progress_event(&self, upload: bool, type_: String, loaded: u64, total: Option<u64>) {
         let global = self.global.root();
         let progressevent = ProgressEvent::new(global.r(),
-                                               DOMString(type_),
+                                               DOMString::from(type_),
                                                EventBubbles::DoesNotBubble,
                                                EventCancelable::NotCancelable,
                                                total.is_some(), loaded,

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -71,14 +71,14 @@ impl<'a> TreeSink for servohtmlparser::Sink {
                                    ElementCreator::ParserCreated);
 
         for attr in attrs {
-            elem.set_attribute_from_parser(attr.name, DOMString(attr.value.into()), None);
+            elem.set_attribute_from_parser(attr.name, DOMString::from(String::from(attr.value)), None);
         }
 
         JS::from_ref(elem.upcast())
     }
 
     fn create_comment(&mut self, text: StrTendril) -> JS<Node> {
-        let comment = Comment::new(DOMString(text.into()), &*self.document);
+        let comment = Comment::new(DOMString::from(String::from(text)), &*self.document);
         JS::from_ref(comment.upcast())
     }
 
@@ -115,8 +115,8 @@ impl<'a> TreeSink for servohtmlparser::Sink {
                                   system_id: StrTendril) {
         let doc = &*self.document;
         let doctype = DocumentType::new(
-            DOMString(name.into()), Some(DOMString(public_id.into())),
-            Some(DOMString(system_id.into())), doc);
+            DOMString::from(String::from(name)), Some(DOMString::from(String::from(public_id))),
+            Some(DOMString::from(String::from(system_id))), doc);
         doc.upcast::<Node>().AppendChild(doctype.upcast()).expect("Appending failed");
     }
 
@@ -124,7 +124,7 @@ impl<'a> TreeSink for servohtmlparser::Sink {
         let elem = target.downcast::<Element>()
             .expect("tried to set attrs on non-Element in HTML parsing");
         for attr in attrs {
-            elem.set_attribute_from_parser(attr.name, DOMString(attr.value.into()), None);
+            elem.set_attribute_from_parser(attr.name, DOMString::from(String::from(attr.value)), None);
         }
     }
 
@@ -247,7 +247,7 @@ pub fn parse_html(document: &Document,
         ParseContext::Fragment(fc) =>
             ServoHTMLParser::new_for_fragment(Some(url), document, fc),
     };
-    parser.parse_chunk(input.0.into());
+    parser.parse_chunk(String::from(input));
 }
 
 // https://html.spec.whatwg.org/multipage/#parsing-html-fragments

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1632,7 +1632,7 @@ impl ScriptTask {
 
         let content_type = match metadata.content_type {
             Some(ContentType(Mime(TopLevel::Text, SubLevel::Plain, _))) => {
-                Some(DOMString("text/plain".to_owned()))
+                Some(DOMString::from("text/plain"))
             }
             _ => None
         };
@@ -1705,7 +1705,7 @@ impl ScriptTask {
     fn notify_devtools(&self, title: DOMString, url: Url, ids: (PipelineId, Option<WorkerId>)) {
         if let Some(ref chan) = self.devtools_chan {
             let page_info = DevtoolsPageInfo {
-                title: title,
+                title: String::from(title),
                 url: url,
             };
             chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
@@ -1924,7 +1924,7 @@ impl ScriptTask {
         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#event-type-resize
         let uievent = UIEvent::new(window.r(),
-                                   DOMString("resize".to_owned()), EventBubbles::DoesNotBubble,
+                                   DOMString::from("resize"), EventBubbles::DoesNotBubble,
                                    EventCancelable::NotCancelable, Some(window.r()),
                                    0i32);
         uievent.upcast::<Event>().fire(window.upcast());

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -186,6 +186,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                     vec!(insert)
                 };
 
+                // FIXME(ajeffrey): effecient append for DOMStrings
                 let mut new_line = prefix.to_owned();
                 new_line.push_str(&insert_lines[0]);
                 insert_lines[0] = DOMString::from(new_line);
@@ -194,7 +195,8 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.edit_point.index = insert_lines[last_insert_lines_index].len();
                 self.edit_point.line = begin.line + last_insert_lines_index;
 
-                insert_lines[last_insert_lines_index].0.push_str(suffix);
+                // FIXME(ajeffrey): effecient append for DOMStrings
+                insert_lines[last_insert_lines_index].push_str(suffix);
 
                 let mut new_lines = vec!();
                 new_lines.push_all(lines_prefix);

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -137,7 +137,7 @@ impl<T: ClipboardProvider> TextInput<T> {
         if self.selection_begin.is_none() {
             self.selection_begin = Some(self.edit_point);
         }
-        self.replace_selection(DOMString(s.into()));
+        self.replace_selection(DOMString::from(s.into()));
     }
 
     pub fn get_sorted_selection(&self) -> Option<(TextPoint, TextPoint)> {
@@ -181,14 +181,14 @@ impl<T: ClipboardProvider> TextInput<T> {
                 let lines_suffix = &self.lines[end.line + 1..];
 
                 let mut insert_lines = if self.multiline {
-                    insert.split('\n').map(|s| DOMString(s.to_owned())).collect()
+                    insert.split('\n').map(DOMString::from).collect()
                 } else {
                     vec!(insert)
                 };
 
                 let mut new_line = prefix.to_owned();
                 new_line.push_str(&insert_lines[0]);
-                insert_lines[0] = DOMString(new_line);
+                insert_lines[0] = DOMString::from(new_line);
 
                 let last_insert_lines_index = insert_lines.len() - 1;
                 self.edit_point.index = insert_lines[last_insert_lines_index].len();
@@ -441,14 +441,14 @@ impl<T: ClipboardProvider> TextInput<T> {
                 content.push('\n');
             }
         }
-        DOMString(content)
+        DOMString::from(content)
     }
 
     /// Set the current contents of the text input. If this is control supports multiple lines,
     /// any \n encountered will be stripped and force a new logical line.
     pub fn set_content(&mut self, content: DOMString) {
         self.lines = if self.multiline {
-            content.split('\n').map(|s| DOMString(s.to_owned())).collect()
+            content.split('\n').map(DOMString::from).collect()
         } else {
             vec!(content)
         };

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -51,7 +51,7 @@ pub unsafe fn jsval_to_webdriver(cx: *mut JSContext, val: HandleValue) -> WebDri
     } else if val.get().is_string() {
         //FIXME: use jsstring_to_str when jsval grows to_jsstring
         let string: DOMString = FromJSValConvertible::from_jsval(cx, val, StringificationBehavior::Default).unwrap();
-        Ok(WebDriverJSValue::String(string.0))
+        Ok(WebDriverJSValue::String(String::from(string)))
     } else if val.get().is_null() {
         Ok(WebDriverJSValue::Null)
     } else {
@@ -119,7 +119,7 @@ pub fn handle_get_frame_id(page: &Rc<Page>,
 
 pub fn handle_find_element_css(page: &Rc<Page>, _pipeline: PipelineId, selector: String,
                                reply: IpcSender<Result<Option<String>, ()>>) {
-    reply.send(match page.document().QuerySelector(DOMString(selector)) {
+    reply.send(match page.document().QuerySelector(DOMString::from(selector)) {
         Ok(node) => {
             Ok(node.map(|x| x.upcast::<Node>().get_unique_id()))
         }
@@ -131,7 +131,7 @@ pub fn handle_find_elements_css(page: &Rc<Page>,
                                 _pipeline: PipelineId,
                                 selector: String,
                                 reply: IpcSender<Result<Vec<String>, ()>>) {
-    reply.send(match page.document().QuerySelectorAll(DOMString(selector)) {
+    reply.send(match page.document().QuerySelectorAll(DOMString::from(selector)) {
         Ok(ref nodes) => {
             let mut result = Vec::with_capacity(nodes.Length() as usize);
             for i in 0..nodes.Length() {
@@ -155,7 +155,7 @@ pub fn handle_get_active_element(page: &Rc<Page>,
 }
 
 pub fn handle_get_title(page: &Rc<Page>, _pipeline: PipelineId, reply: IpcSender<String>) {
-    reply.send(page.document().Title().0).unwrap();
+    reply.send(String::from(page.document().Title())).unwrap();
 }
 
 pub fn handle_get_text(page: &Rc<Page>,
@@ -164,7 +164,7 @@ pub fn handle_get_text(page: &Rc<Page>,
                        reply: IpcSender<Result<String, ()>>) {
     reply.send(match find_node_by_unique_id(&*page, pipeline, node_id) {
         Some(ref node) => {
-            Ok(node.GetTextContent().map(|x| x.0).unwrap_or("".to_owned()))
+            Ok(node.GetTextContent().map(String::from).unwrap_or("".to_owned()))
         },
         None => Err(())
     }).unwrap();
@@ -176,7 +176,7 @@ pub fn handle_get_name(page: &Rc<Page>,
                        reply: IpcSender<Result<String, ()>>) {
     reply.send(match find_node_by_unique_id(&*page, pipeline, node_id) {
         Some(node) => {
-            Ok(node.downcast::<Element>().unwrap().TagName().0)
+            Ok(String::from(node.downcast::<Element>().unwrap().TagName()))
         },
         None => Err(())
     }).unwrap();

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -36,7 +36,8 @@ impl AttrValue {
     }
 
     pub fn from_atomic_tokens(atoms: Vec<Atom>) -> AttrValue {
-        let tokens = DOMString(str_join(&atoms, "\x20"));
+        // TODO(ajeffrey): effecient conversion of Vec<Atom> to DOMString
+        let tokens = DOMString::from(str_join(&atoms, "\x20"));
         AttrValue::TokenList(tokens, atoms)
     }
 

--- a/components/util/mem.rs
+++ b/components/util/mem.rs
@@ -103,7 +103,7 @@ impl HeapSizeOf for String {
 
 impl HeapSizeOf for DOMString {
     fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
+        heap_size_of(self.as_ptr() as *const c_void)
     }
 }
 

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -32,6 +32,13 @@ impl DOMString {
     pub fn new() -> DOMString {
         DOMString(String::new())
     }
+    // FIXME(ajeffrey): implement more of the String methods on DOMString?
+    pub fn push_str(&mut self, string: &str) {
+        self.0.push_str(string)
+    }
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
 }
 
 impl Default for DOMString {
@@ -178,6 +185,12 @@ impl FromJSValConvertible for DOMString {
                 Ok(jsstring_to_str(cx, jsstr))
             }
         }
+    }
+}
+
+impl Extend<char> for DOMString {
+    fn extend<I>(&mut self, iterable: I) where I: IntoIterator<Item=char> {
+        self.0.extend(iterable)
     }
 }
 

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -26,6 +26,8 @@ use std::str::{CharIndices, FromStr, Split, from_utf8};
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Deserialize, Serialize, Hash, Debug)]
 pub struct DOMString(pub String);
 
+impl !Send for DOMString {}
+
 impl DOMString {
     pub fn new() -> DOMString {
         DOMString(String::new())

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -24,7 +24,7 @@ use std::slice;
 use std::str::{CharIndices, FromStr, Split, from_utf8};
 
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Deserialize, Serialize, Hash, Debug)]
-pub struct DOMString(pub String);
+pub struct DOMString(String);
 
 impl !Send for DOMString {}
 

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -79,6 +79,24 @@ impl<'a> PartialEq<&'a str> for DOMString {
     }
 }
 
+impl From<String> for DOMString {
+    fn from(contents: String) -> DOMString {
+        DOMString(contents)
+    }
+}
+
+impl<'a> From<&'a str> for DOMString {
+    fn from(contents: &str) -> DOMString {
+        DOMString::from(String::from(contents))
+    }
+}
+
+impl From<DOMString> for String {
+    fn from(contents: DOMString) -> String {
+        contents.0
+    }
+}
+
 impl Into<Vec<u8>> for DOMString {
     fn into(self) -> Vec<u8> {
         self.0.into()

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -14,11 +14,10 @@ use msg::constellation_msg::SUPER;
 use msg::constellation_msg::{Key, KeyModifiers};
 use script::clipboard_provider::DummyClipboardContext;
 use script::textinput::{TextInput, Selection, Lines, Direction};
-use std::borrow::ToOwned;
 use util::str::DOMString;
 
 fn text_input(lines: Lines, s: &str) -> TextInput<DummyClipboardContext> {
-    TextInput::new(lines, DOMString(s.to_owned()), DummyClipboardContext::new(""))
+    TextInput::new(lines, DOMString::from(s), DummyClipboardContext::new(""))
 }
 
 #[test]
@@ -86,7 +85,7 @@ fn test_textinput_replace_selection() {
     textinput.adjust_horizontal(2, Selection::NotSelected);
     textinput.adjust_horizontal(2, Selection::Selected);
 
-    textinput.replace_selection(DOMString("xyz".to_owned()));
+    textinput.replace_selection(DOMString::from("xyz"));
     assert_eq!(textinput.get_content(), "abxyzefg");
 }
 
@@ -177,7 +176,7 @@ fn test_textinput_set_content() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
     assert_eq!(textinput.get_content(), "abc\nde\nf");
 
-    textinput.set_content(DOMString("abc\nf".to_owned()));
+    textinput.set_content(DOMString::from("abc\nf"));
     assert_eq!(textinput.get_content(), "abc\nf");
 
     assert_eq!(textinput.edit_point.line, 0);
@@ -185,7 +184,7 @@ fn test_textinput_set_content() {
     textinput.adjust_horizontal(3, Selection::Selected);
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 3);
-    textinput.set_content(DOMString("de".to_owned()));
+    textinput.set_content(DOMString::from("de"));
     assert_eq!(textinput.get_content(), "de");
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 2);
@@ -199,7 +198,7 @@ fn test_clipboard_paste() {
     const MODIFIERS: KeyModifiers = CONTROL;
 
     let mut textinput = TextInput::new(Lines::Single,
-                                       DOMString("defg".to_owned()),
+                                       DOMString::from("defg"),
                                        DummyClipboardContext::new("abc"));
     assert_eq!(textinput.get_content(), "defg");
     assert_eq!(textinput.edit_point.index, 0);


### PR DESCRIPTION
This patch makes DOMString an opaque wrapper round String (currently it's a transparent wrapper).

The changes are:
- Replacing DOMString(foo) by DOMString::from(foo).
- Replacing foo.0 by String::from(foo).
- Adding functions clear, push_str and extend for in-place mutation of DOMStrings.
- Replacing DOMString by String in other threads (devtools, storage and filereader).
- Making DOMString implement !Send.
- Removing the pub attribute from the contents of DOMString.

This enables experimenting with other string representations in the DOM.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8477)

<!-- Reviewable:end -->
