### PR TITLE
Split chan and receiver_port into script and compositor flavors

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -74,11 +74,17 @@ enum ReadyToSave {
 /// `LayoutTask` in the `layout` crate, and `ScriptTask` in
 /// the `script` crate).
 pub struct Constellation<LTF, STF> {
-    /// A channel through which messages can be sent to this object.
-    pub chan: ConstellationChan,
+    /// A channel through which script messages can be sent to this object.
+    pub script_sender: ConstellationChan,
 
-    /// Receives messages.
-    pub request_port: Receiver<ConstellationMsg>,
+    /// A channel through which compositor messages can be sent to this object.
+    pub compositor_sender: ConstellationChan,
+
+    /// Receives messages from scripts.
+    pub script_receiver: Receiver<ConstellationMsg>,
+
+    /// Receives messages from the compositor
+    pub compositor_receiver: Receiver<ConstellationMsg>,
 
     /// A channel (the implementation of which is port-specific) through which messages can be sent
     /// to the compositor.
@@ -254,12 +260,16 @@ enum ExitPipelineMode {
 
 impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
     pub fn start(state: InitialConstellationState) -> ConstellationChan {
-        let (constellation_port, constellation_chan) = ConstellationChan::new();
-        let constellation_chan_clone = constellation_chan.clone();
+        let (script_receiver, script_sender) = ConstellationChan::new();
+        let (compositor_receiver, compositor_sender) = ConstellationChan::new();
+        let script_sender_clone = script_sender.clone();
+        let compositor_sender_clone = compositor_sender.clone();
         spawn_named("Constellation".to_owned(), move || {
             let mut constellation: Constellation<LTF, STF> = Constellation {
-                chan: constellation_chan_clone,
-                request_port: constellation_port,
+                script_sender: script_sender_clone,
+                compositor_sender: compositor_sender_clone,
+                script_receiver: script_receiver,
+                compositor_receiver: compositor_receiver,
                 compositor_proxy: state.compositor_proxy,
                 devtools_chan: state.devtools_chan,
                 resource_task: state.resource_task,
@@ -300,12 +310,20 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
             PipelineNamespace::install(namespace_id);
             constellation.run();
         });
-        constellation_chan
+        compositor_sender
     }
 
+#[allow(unsafe_code)]
     fn run(&mut self) {
         loop {
-            let request = self.request_port.recv().unwrap();
+            let request = {
+                let receiver_from_script = &self.script_receiver;
+                let receiver_from_compositor = &self.compositor_receiver;
+                select! {
+                    msg = receiver_from_script.recv() => msg.unwrap(),
+                    msg = receiver_from_compositor.recv() => msg.unwrap()
+                }
+            };
             if !self.handle_request(request) {
                 break;
             }
@@ -331,7 +349,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
             Pipeline::create::<LTF, STF>(InitialPipelineState {
                 id: pipeline_id,
                 parent_info: parent_info,
-                constellation_chan: self.chan.clone(),
+                constellation_chan: self.script_sender.clone(),
                 scheduler_chan: self.scheduler_chan.clone(),
                 compositor_proxy: self.compositor_proxy.clone_compositor_proxy(),
                 devtools_chan: self.devtools_chan.clone(),
@@ -1395,7 +1413,7 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
             let (chan, port) = channel();
             self.compositor_proxy.send(CompositorMsg::SetFrameTree(frame_tree,
                                                                    chan,
-                                                                   self.chan.clone()));
+                                                                   self.compositor_sender.clone()));
             if port.recv().is_err() {
                 debug!("Compositor has discarded SetFrameTree");
                 return; // Our message has been discarded, probably shutting down.


### PR DESCRIPTION
Partial #8356. Currently this doesn't build because of a lint denying me to user unsafe code, which unfortunately the select! macro falls under. Not sure what to do there.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8478)

<!-- Reviewable:end -->
