### PR TITLE
Make layout task fields private

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -8,10 +8,8 @@ use clock_ticks;
 use flow::{self, Flow};
 use gfx::display_list::OpaqueNode;
 use incremental::{self, RestyleDamage};
-use layout_task::{LayoutTask, LayoutTaskData};
 use msg::constellation_msg::{AnimationState, ConstellationChan, Msg, PipelineId};
 use script::layout_interface::Animation;
-use script_traits::ConstellationControlMsg;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::mpsc::{Sender, Receiver};
@@ -137,13 +135,4 @@ pub fn recalc_style_for_animations(flow: &mut Flow,
     for kid in base.children.iter_mut() {
         recalc_style_for_animations(kid, animations)
     }
-}
-
-/// Handles animation updates.
-pub fn tick_all_animations(layout_task: &mut LayoutTask, rw_data: &mut LayoutTaskData) {
-    layout_task.tick_animations(rw_data);
-
-    layout_task.script_chan
-               .send(ConstellationControlMsg::TickAllAnimations(layout_task.id))
-               .unwrap();
 }

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -50,7 +50,7 @@ use query::{MarginPadding, MarginRetrievingFragmentBorderBoxIterator, PositionPr
 use query::{PositionRetrievingFragmentBorderBoxIterator, Side};
 use script::dom::node::LayoutData;
 use script::layout_interface::Animation;
-use script::layout_interface::{LayoutChan, LayoutRPC, OffsetParentResponse};
+use script::layout_interface::{LayoutRPC, OffsetParentResponse};
 use script::layout_interface::{Msg, NewLayoutTaskInfo, Reflow, ReflowGoal, ReflowQueryType};
 use script::layout_interface::{ScriptLayoutChan, ScriptReflow, TrustedNodeAddress};
 use script_traits::{ConstellationControlMsg, LayoutControlMsg, OpaqueScriptLayoutChannel};
@@ -241,7 +241,6 @@ impl LayoutTaskFactory for LayoutTask {
                                          move || {
             { // Ensures layout task is destroyed before we send shutdown message
                 let sender = chan.sender();
-                let layout_chan = LayoutChan(sender);
                 let layout = LayoutTask::new(id,
                                              url,
                                              is_iframe,
@@ -258,7 +257,7 @@ impl LayoutTaskFactory for LayoutTask {
                 let reporter_name = format!("layout-reporter-{}", id);
                 mem_profiler_chan.run_with_memory_reporting(|| {
                     layout.start();
-                }, reporter_name, layout_chan.0, Msg::CollectReports);
+                }, reporter_name, sender, Msg::CollectReports);
             }
             shutdown_chan.send(()).unwrap();
         }, ConstellationMsg::Failure(failure_msg), con_chan);

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -148,9 +148,6 @@ pub struct LayoutTask {
     /// The channel on which the font cache can send messages to us.
     font_cache_sender: Sender<()>,
 
-    /// The channel on which we or others can send messages to ourselves.
-    chan: LayoutChan,
-
     /// The channel on which messages can be sent to the constellation.
     constellation_chan: ConstellationChan,
 
@@ -249,7 +246,6 @@ impl LayoutTaskFactory for LayoutTask {
                                              url,
                                              is_iframe,
                                              chan.receiver(),
-                                             layout_chan.clone(),
                                              pipeline_port,
                                              constellation_chan,
                                              script_chan,
@@ -358,7 +354,6 @@ impl LayoutTask {
            url: Url,
            is_iframe: bool,
            port: Receiver<Msg>,
-           chan: LayoutChan,
            pipeline_port: IpcReceiver<LayoutControlMsg>,
            constellation_chan: ConstellationChan,
            script_chan: Sender<ConstellationControlMsg>,
@@ -408,7 +403,6 @@ impl LayoutTask {
             is_iframe: is_iframe,
             port: port,
             pipeline_port: pipeline_receiver,
-            chan: chan,
             script_chan: script_chan,
             constellation_chan: constellation_chan.clone(),
             paint_chan: paint_chan,


### PR DESCRIPTION
For https://github.com/servo/servo/issues/8471

The second commit I'm slightly less sure about but with `chan` made private this warning was shown:

```
components/layout/layout_task.rs:152:5: 152:21 warning: struct field is never used: `chan`, #[warn(dead_code)] on by default
```

There might be some cleanup around `layout_chan` in https://github.com/hfaulds/servo/blob/make-layout-task-fields-private/components/layout/layout_task.rs#L244-L261 as well but that was a bit beyond me.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8485)

<!-- Reviewable:end -->
