### PR TITLE
Fix #8443

### DIFF
--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -222,7 +222,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
             .flat_map(|s| s.effective_rules(&self.device).viewport())
             .cascade();
 
-        self.viewport_constraints = ViewportConstraints::maybe_new(self.device.viewport_size, &cascaded_rule);
+        self.viewport_constraints = ViewportConstraints::maybe_new(device.viewport_size, &cascaded_rule);
         if let Some(ref constraints) = self.viewport_constraints {
             device = Device::new(MediaType::Screen, constraints.size);
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5628,6 +5628,12 @@
             "url": "/_mozilla/css/float_relative_to_position.html"
           }
         ],
+        "css/meta_viewport_resize.html": [
+          {
+            "path": "css/meta_viewport_resize.html",
+            "url": "/_mozilla/css/meta_viewport_resize.html"
+          }
+        ],
         "css/test_variable_legal_values.html": [
           {
             "path": "css/test_variable_legal_values.html",

--- a/tests/wpt/mozilla/meta/css/meta_viewport_resize.html.ini
+++ b/tests/wpt/mozilla/meta/css/meta_viewport_resize.html.ini
@@ -1,0 +1,4 @@
+[meta_viewport_resize.html]
+  type: testharness
+  prefs: ["layout.viewport.enabled:true"]
+

--- a/tests/wpt/mozilla/tests/css/meta_viewport_resize.html
+++ b/tests/wpt/mozilla/tests/css/meta_viewport_resize.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Resizing the initial containing block dynamically with &lt;meta name="viewport">
+       https://github.com/servo/servo/issues/8443</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+    var step2 = function() {
+        var iframe = document.getElementsByTagName("iframe")[0];
+        var body_style = iframe.contentWindow.getComputedStyle(iframe.contentDocument.body);
+        if (body_style.width === "500px") {
+          t.done();
+        } else {
+          window.requestAnimationFrame(step2);
+        }
+    };
+
+    var step1 = function() {
+        var iframe = document.getElementsByTagName("iframe")[0];
+        var body_style = iframe.contentWindow.getComputedStyle(iframe.contentDocument.body);
+        if (body_style.width === "400px") {
+          iframe.width = 500;
+          window.requestAnimationFrame(step2);
+        } else {
+          window.requestAnimationFrame(step1);
+        }
+    };
+
+    window.run = step1;
+}, "<body> inside <iframe> has the <iframe>’s width");
+</script>
+<iframe src="meta_viewport_resize_iframe.html" onload="run()" width=400></iframe>

--- a/tests/wpt/mozilla/tests/css/meta_viewport_resize_iframe.html
+++ b/tests/wpt/mozilla/tests/css/meta_viewport_resize_iframe.html
@@ -1,0 +1,4 @@
+<meta name="viewport" content="initial-scale=1.0">
+<body style="margin: 0">
+Test
+


### PR DESCRIPTION
When there are viewport constraints, use the new window size to compute the viewport instead of the old one.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8496)

<!-- Reviewable:end -->
