### PR TITLE
Properly propagate changes when range or trees are mutated

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -18,6 +18,10 @@ DOMInterfaces = {
     'outerObjectHook': 'Some(bindings::utils::outerize_global)',
 },
 
+'Range': {
+	'weakReferenceable': True,
+},
+
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {},
 

--- a/components/script/dom/bindings/weakref.rs
+++ b/components/script/dom/bindings/weakref.rs
@@ -19,7 +19,9 @@ use js::jsapi::{JSTracer, JS_GetReservedSlot, JS_SetReservedSlot};
 use js::jsval::PrivateValue;
 use libc::c_void;
 use std::cell::{Cell, UnsafeCell};
+use std::iter::Iterator;
 use std::mem;
+use std::ops::{Deref, DerefMut, Drop};
 use util::mem::HeapSizeOf;
 
 /// The index of the slot wherein a pointer to the weak holder cell is
@@ -113,6 +115,25 @@ impl<T: WeakReferenceable> HeapSizeOf for WeakRef<T> {
     }
 }
 
+impl<T: WeakReferenceable> PartialEq for WeakRef<T> {
+   fn eq(&self, other: &Self) -> bool {
+        unsafe {
+            (**self.ptr).value.get() == (**other.ptr).value.get()
+        }
+    }
+}
+
+impl<T: WeakReferenceable> PartialEq<T> for WeakRef<T> {
+    fn eq(&self, other: &T) -> bool {
+        unsafe {
+            match (**self.ptr).value.get() {
+                Some(ptr) => *ptr == other,
+                None => false,
+            }
+        }
+    }
+}
+
 no_jsmanaged_fields!(WeakRef<T: WeakReferenceable>);
 
 impl<T: WeakReferenceable> Drop for WeakRef<T> {
@@ -180,5 +201,83 @@ impl<T: WeakReferenceable> JSTraceable for MutableWeakRef<T> {
                 mem::drop((*ptr).take().unwrap());
             }
         }
+    }
+}
+
+/// A vector of weak references. On tracing, the vector retains
+/// only references which still point to live objects.
+#[allow_unrooted_interior]
+#[derive(HeapSizeOf)]
+pub struct WeakRefVec<T: WeakReferenceable> {
+    vec: Vec<WeakRef<T>>,
+}
+
+impl<T: WeakReferenceable> WeakRefVec<T> {
+    /// Create a new vector of weak references.
+    pub fn new() -> Self {
+        WeakRefVec { vec: vec![] }
+    }
+
+    /// Calls a function on each reference which still points to a
+    /// live object. The order of the references isn't preserved.
+    pub fn update<F: FnMut(WeakRefEntry<T>)>(&mut self, mut f: F) {
+        let mut i = 0;
+        while i < self.vec.len() {
+            if self.vec[i].is_alive() {
+                f(WeakRefEntry { vec: self, index: &mut i });
+            } else {
+                self.vec.swap_remove(i);
+            }
+        }
+    }
+
+    /// Clears the vector of its dead references.
+    pub fn retain_alive(&mut self) {
+        self.update(|_| ());
+    }
+}
+
+impl<T: WeakReferenceable> Deref for WeakRefVec<T> {
+    type Target = Vec<WeakRef<T>>;
+
+    fn deref(&self) -> &Vec<WeakRef<T>> {
+        &self.vec
+    }
+}
+
+impl<T: WeakReferenceable> DerefMut for WeakRefVec<T> {
+    fn deref_mut(&mut self) -> &mut Vec<WeakRef<T>> {
+        &mut self.vec
+    }
+}
+
+/// An entry of a vector of weak references. Passed to the closure
+/// given to `WeakRefVec::update`.
+#[allow_unrooted_interior]
+pub struct WeakRefEntry<'a, T: WeakReferenceable + 'a> {
+    vec: &'a mut WeakRefVec<T>,
+    index: &'a mut usize,
+}
+
+impl<'a, T: WeakReferenceable + 'a> WeakRefEntry<'a, T> {
+    /// Remove the entry from the underlying vector of weak references.
+    pub fn remove(self) -> WeakRef<T> {
+        let ref_ = self.vec.swap_remove(*self.index);
+        mem::forget(self);
+        ref_
+    }
+}
+
+impl<'a, T: WeakReferenceable + 'a> Deref for WeakRefEntry<'a, T> {
+    type Target = WeakRef<T>;
+
+    fn deref(&self) -> &WeakRef<T> {
+        &self.vec[*self.index]
+    }
+}
+
+impl<'a, T: WeakReferenceable + 'a> Drop for WeakRefEntry<'a, T> {
+    fn drop(&mut self) {
+        *self.index += 1;
     }
 }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -30,6 +30,22 @@ impl CharacterData {
             data: DOMRefCell::new(data),
         }
     }
+
+    #[inline]
+    pub fn data(&self) -> Ref<DOMString> {
+        self.data.borrow()
+    }
+
+    #[inline]
+    pub fn append_data(&self, data: &str) {
+        self.data.borrow_mut().push_str(data);
+        self.content_changed();
+    }
+
+    fn content_changed(&self) {
+        let node = self.upcast::<Node>();
+        node.owner_doc().content_changed(node, NodeDamage::OtherNodeDamage);
+    }
 }
 
 impl CharacterDataMethods for CharacterData {
@@ -140,24 +156,6 @@ impl CharacterDataMethods for CharacterData {
     // https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling
     fn GetNextElementSibling(&self) -> Option<Root<Element>> {
         self.upcast::<Node>().following_siblings().filter_map(Root::downcast).next()
-    }
-}
-
-impl CharacterData {
-    #[inline]
-    pub fn data(&self) -> Ref<DOMString> {
-        self.data.borrow()
-    }
-    #[inline]
-    pub fn append_data(&self, data: &str) {
-        // FIXME(ajeffrey): Efficient append on DOMStrings?
-        self.data.borrow_mut().push_str(data);
-        self.content_changed();
-    }
-
-    fn content_changed(&self) {
-        let node = self.upcast::<Node>();
-        node.owner_doc().content_changed(node, NodeDamage::OtherNodeDamage);
     }
 }
 

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -77,13 +77,17 @@ impl CharacterDataMethods for CharacterData {
 
     // https://dom.spec.whatwg.org/#dom-characterdata-data
     fn SetData(&self, data: DOMString) {
+        let old_length = self.Length();
+        let new_length = data.utf16_units().count() as u32;
         *self.data.borrow_mut() = data;
         self.content_changed();
+        let node = self.upcast::<Node>();
+        node.ranges().replace_code_units(node, 0, old_length, new_length);
     }
 
     // https://dom.spec.whatwg.org/#dom-characterdata-length
     fn Length(&self) -> u32 {
-        self.data.borrow().chars().map(|c| c.len_utf16()).sum::<usize>() as u32
+        self.data.borrow().utf16_units().count() as u32
     }
 
     // https://dom.spec.whatwg.org/#dom-characterdata-substringdata
@@ -144,7 +148,10 @@ impl CharacterDataMethods for CharacterData {
         };
         *self.data.borrow_mut() = DOMString::from(new_data);
         self.content_changed();
-        // FIXME: Once we have `Range`, we should implement step 8 to step 11
+        // Steps 8-11.
+        let node = self.upcast::<Node>();
+        node.ranges().replace_code_units(
+            node, offset, count, arg.utf16_units().count() as u32);
         Ok(())
     }
 

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -6,13 +6,18 @@
 
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
+use dom::bindings::codegen::Bindings::ProcessingInstructionBinding::ProcessingInstructionMethods;
+use dom::bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
 use dom::bindings::codegen::UnionTypes::NodeOrString;
 use dom::bindings::error::{Error, ErrorResult, Fallible};
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{LayoutJS, Root};
+use dom::comment::Comment;
 use dom::document::Document;
 use dom::element::Element;
 use dom::node::{Node, NodeDamage};
+use dom::processinginstruction::ProcessingInstruction;
+use dom::text::Text;
 use std::cell::Ref;
 use util::str::DOMString;
 
@@ -28,6 +33,22 @@ impl CharacterData {
         CharacterData {
             node: Node::new_inherited(document),
             data: DOMRefCell::new(data),
+        }
+    }
+
+    pub fn clone_with_data(&self, data: DOMString, document: &Document) -> Root<Node> {
+        match self.upcast::<Node>().type_id() {
+            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => {
+                Root::upcast(Comment::new(data, &document))
+            }
+            NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
+                let pi = self.downcast::<ProcessingInstruction>().unwrap();
+                Root::upcast(ProcessingInstruction::new(pi.Target(), data, &document))
+            },
+            NodeTypeId::CharacterData(CharacterDataTypeId::Text) => {
+                Root::upcast(Text::new(data, &document))
+            },
+            _ => unreachable!(),
         }
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -53,7 +53,7 @@ use dom::htmltemplateelement::HTMLTemplateElement;
 use dom::htmltextareaelement::{HTMLTextAreaElement, RawLayoutHTMLTextAreaElementHelpers};
 use dom::namednodemap::NamedNodeMap;
 use dom::node::{CLICK_IN_PROGRESS, LayoutNodeHelpers, Node};
-use dom::node::{NodeDamage, SEQUENTIALLY_FOCUSABLE};
+use dom::node::{NodeDamage, SEQUENTIALLY_FOCUSABLE, UnbindContext};
 use dom::node::{document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::text::Text;
@@ -1616,12 +1616,10 @@ impl VirtualMethods for Element {
         }
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
-        if !tree_in_doc {
+        if !context.tree_in_doc {
             return;
         }
 

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -9,7 +9,7 @@ use dom::bindings::js::Root;
 use dom::document::Document;
 use dom::element::{AttributeMutation, Element};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, document_from_node};
+use dom::node::{Node, UnbindContext, document_from_node};
 use dom::virtualmethods::VirtualMethods;
 use string_cache::Atom;
 use url::{Url, UrlParser};
@@ -77,8 +77,8 @@ impl VirtualMethods for HTMLBaseElement {
         self.bind_unbind(tree_in_doc);
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        self.super_type().unwrap().unbind_from_tree(tree_in_doc);
-        self.bind_unbind(tree_in_doc);
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
+        self.bind_unbind(context.tree_in_doc);
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -16,7 +16,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmlformelement::{FormControl, FormSubmitter};
 use dom::htmlformelement::{SubmittedFrom, HTMLFormElement};
-use dom::node::{Node, document_from_node, window_from_node};
+use dom::node::{Node, UnbindContext, document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
@@ -168,10 +168,8 @@ impl VirtualMethods for HTMLButtonElement {
         self.upcast::<Element>().check_ancestors_disabled_state_for_form_control();
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -18,7 +18,7 @@ use dom::document::Document;
 use dom::element::{AttributeMutation, Element, RawLayoutElementHelpers};
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, window_from_node};
+use dom::node::{Node, UnbindContext, window_from_node};
 use dom::urlhelper::UrlHelper;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::Window;
@@ -471,10 +471,8 @@ impl VirtualMethods for HTMLIFrameElement {
         }
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
         // https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded
         if let Some(pipeline_id) = self.pipeline_id.get() {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -23,7 +23,7 @@ use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmlformelement::{FormControl, FormDatum, FormSubmitter, HTMLFormElement};
 use dom::htmlformelement::{ResetFrom, SubmittedFrom};
 use dom::keyboardevent::KeyboardEvent;
-use dom::node::{Node, NodeDamage};
+use dom::node::{Node, NodeDamage, UnbindContext};
 use dom::node::{document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::virtualmethods::VirtualMethods;
@@ -634,10 +634,8 @@ impl VirtualMethods for HTMLInputElement {
         self.upcast::<Element>().check_ancestors_disabled_state_for_form_control();
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -15,7 +15,7 @@ use dom::element::{AttributeMutation, Element};
 use dom::htmlelement::HTMLElement;
 use dom::htmlscriptelement::HTMLScriptElement;
 use dom::htmlselectelement::HTMLSelectElement;
-use dom::node::Node;
+use dom::node::{Node, UnbindContext};
 use dom::text::Text;
 use dom::virtualmethods::VirtualMethods;
 use selectors::states::*;
@@ -207,10 +207,8 @@ impl VirtualMethods for HTMLOptionElement {
         self.pick_if_selected_and_reset();
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -16,7 +16,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::htmloptionelement::HTMLOptionElement;
-use dom::node::{Node, window_from_node};
+use dom::node::{Node, UnbindContext, window_from_node};
 use dom::nodelist::NodeList;
 use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
@@ -196,10 +196,8 @@ impl VirtualMethods for HTMLSelectElement {
         self.upcast::<Element>().check_ancestors_disabled_state_for_form_control();
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -20,7 +20,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmlformelement::{FormControl, HTMLFormElement};
 use dom::keyboardevent::KeyboardEvent;
-use dom::node::{ChildrenMutation, Node, NodeDamage};
+use dom::node::{ChildrenMutation, Node, NodeDamage, UnbindContext};
 use dom::node::{document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::virtualmethods::VirtualMethods;
@@ -300,10 +300,8 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
     }
 
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
-        if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
-        }
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -33,7 +33,6 @@ use dom::bindings::trace::JSTraceable;
 use dom::bindings::trace::RootedVec;
 use dom::bindings::xmlname::namespace_from_domstring;
 use dom::characterdata::CharacterData;
-use dom::comment::Comment;
 use dom::document::{Document, DocumentSource, IsHTMLDocument};
 use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
@@ -1610,10 +1609,9 @@ impl Node {
                 let doc_fragment = DocumentFragment::new(document.r());
                 Root::upcast::<Node>(doc_fragment)
             },
-            NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => {
+            NodeTypeId::CharacterData(_) => {
                 let cdata = node.downcast::<CharacterData>().unwrap();
-                let comment = Comment::new(cdata.Data(), document.r());
-                Root::upcast::<Node>(comment)
+                cdata.clone_with_data(cdata.Data(), &document)
             },
             NodeTypeId::Document(_) => {
                 let document = node.downcast::<Document>().unwrap();
@@ -1638,17 +1636,6 @@ impl Node {
                     element.prefix().as_ref().map(|p| Atom::from(&**p)),
                     document.r(), ElementCreator::ScriptCreated);
                 Root::upcast::<Node>(element)
-            },
-            NodeTypeId::CharacterData(CharacterDataTypeId::Text) => {
-                let cdata = node.downcast::<CharacterData>().unwrap();
-                let text = Text::new(cdata.Data(), document.r());
-                Root::upcast::<Node>(text)
-            },
-            NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
-                let pi = node.downcast::<ProcessingInstruction>().unwrap();
-                let pi = ProcessingInstruction::new(pi.Target(),
-                                                    pi.upcast::<CharacterData>().Data(), document.r());
-                Root::upcast::<Node>(pi)
             },
         };
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -318,15 +318,18 @@ impl Node {
             }
         }
 
+        let context = UnbindContext {
+            tree_in_doc: child.is_in_doc(),
+        };
+
         child.prev_sibling.set(None);
         child.next_sibling.set(None);
         child.parent_node.set(None);
         self.children_count.set(self.children_count.get() - 1);
 
-        let parent_in_doc = self.is_in_doc();
         for node in child.traverse_preorder() {
             node.set_flag(IS_IN_DOC, false);
-            vtable_for(&&*node).unbind_from_tree(parent_in_doc);
+            vtable_for(&&*node).unbind_from_tree(&context);
             node.layout_data.dispose(&node);
         }
 
@@ -2419,4 +2422,11 @@ impl<'a> ChildrenMutation<'a> {
                    -> ChildrenMutation<'a> {
         ChildrenMutation::ReplaceAll { removed: removed, added: added }
     }
+}
+
+/// The context of the unbinding from a tree of a node when one of its
+/// inclusive ancestors is removed.
+pub struct UnbindContext {
+    /// Whether the tree is in a document.
+    pub tree_in_doc: bool,
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -42,6 +42,7 @@ use dom::htmlcollection::HTMLCollection;
 use dom::htmlelement::HTMLElement;
 use dom::nodelist::NodeList;
 use dom::processinginstruction::ProcessingInstruction;
+use dom::range::WeakRangeVec;
 use dom::text::Text;
 use dom::virtualmethods::{VirtualMethods, vtable_for};
 use dom::window::Window;
@@ -107,6 +108,12 @@ pub struct Node {
 
     /// The maximum version of any inclusive descendant of this node.
     inclusive_descendants_version: Cell<u64>,
+
+    /// A vector of weak references to Range instances of which the start
+    /// or end containers are this node. No range should ever be found
+    /// twice in this vector, even if both the start and end containers
+    /// are this node.
+    ranges: WeakRangeVec,
 
     /// Layout information. Only the layout task may touch this data.
     ///
@@ -296,7 +303,7 @@ impl Node {
     /// Removes the given child from this node's list of children.
     ///
     /// Fails unless `child` is a child of this node.
-    fn remove_child(&self, child: &Node) {
+    fn remove_child(&self, child: &Node, cached_index: Option<u32>) {
         assert!(child.parent_node.get().r() == Some(self));
         let prev_sibling = child.GetPreviousSibling();
         match prev_sibling {
@@ -317,9 +324,7 @@ impl Node {
             }
         }
 
-        let context = UnbindContext {
-            tree_in_doc: child.is_in_doc(),
-        };
+        let context = UnbindContext::new(self, prev_sibling.r(), cached_index);
 
         child.prev_sibling.set(None);
         child.next_sibling.set(None);
@@ -435,6 +440,10 @@ impl Node {
 
     pub fn children_count(&self) -> u32 {
         self.children_count.get()
+    }
+
+    pub fn ranges(&self) -> &WeakRangeVec {
+        &self.ranges
     }
 
     #[inline]
@@ -1305,6 +1314,7 @@ impl Node {
             children_count: Cell::new(0u32),
             flags: Cell::new(flags),
             inclusive_descendants_version: Cell::new(0),
+            ranges: WeakRangeVec::new(),
 
             layout_data: LayoutDataRef::new(),
 
@@ -1479,7 +1489,20 @@ impl Node {
         debug_assert!(&*node.owner_doc() == &*parent.owner_doc());
         debug_assert!(child.map_or(true, |child| Some(parent) == child.GetParentNode().r()));
 
-        // Steps 1-2: ranges.
+        // Step 1.
+        let count = if node.is::<DocumentFragment>() {
+            node.children_count()
+        } else {
+            1
+        };
+        // Step 2.
+        if let Some(child) = child {
+            if !parent.ranges.is_empty() {
+                let index = child.index();
+                // Steps 2.1-2.
+                parent.ranges.increase_above(parent, index, count);
+            }
+        }
         let mut new_nodes = RootedVec::new();
         let new_nodes = if let NodeTypeId::DocumentFragment = node.type_id() {
             // Step 3.
@@ -1569,14 +1592,27 @@ impl Node {
     // https://dom.spec.whatwg.org/#concept-node-remove
     fn remove(node: &Node, parent: &Node, suppress_observers: SuppressObserver) {
         assert!(node.GetParentNode().map_or(false, |node_parent| node_parent.r() == parent));
-
-        // Step 1-5: ranges.
+        let cached_index = {
+            if parent.ranges.is_empty() {
+                None
+            } else {
+                // Step 1.
+                let index = node.index();
+                // Steps 2-3 are handled in Node::unbind_from_tree.
+                // Steps 4-5.
+                parent.ranges.decrease_above(parent, index, 1);
+                // Parent had ranges, we needed the index, let's keep track of
+                // it to avoid computing it for other ranges when calling
+                // unbind_from_tree recursively.
+                Some(index)
+            }
+        };
         // Step 6.
         let old_previous_sibling = node.GetPreviousSibling();
         // Steps 7-8: mutation observers.
         // Step 9.
         let old_next_sibling = node.GetNextSibling();
-        parent.remove_child(node);
+        parent.remove_child(node, cached_index);
         if let SuppressObserver::Unsuppressed = suppress_observers {
             vtable_for(&parent).children_changed(
                 &ChildrenMutation::replace(old_previous_sibling.r(),
@@ -2078,28 +2114,26 @@ impl NodeMethods for Node {
 
     // https://dom.spec.whatwg.org/#dom-node-normalize
     fn Normalize(&self) {
-        let mut prev_text: Option<Root<Text>> = None;
-        for child in self.children() {
-            match child.downcast::<Text>() {
-                Some(text) => {
-                    let characterdata = text.upcast::<CharacterData>();
-                    if characterdata.Length() == 0 {
-                        Node::remove(&*child, self, SuppressObserver::Unsuppressed);
-                    } else {
-                        match prev_text {
-                            Some(ref text_node) => {
-                                let prev_characterdata = text_node.upcast::<CharacterData>();
-                                prev_characterdata.append_data(&**characterdata.data());
-                                Node::remove(&*child, self, SuppressObserver::Unsuppressed);
-                            },
-                            None => prev_text = Some(Root::from_ref(text))
-                        }
-                    }
-                },
-                None => {
-                    child.Normalize();
-                    prev_text = None;
+        let mut children = self.children().enumerate().peekable();
+        while let Some((_, node)) = children.next() {
+            if let Some(text) = node.downcast::<Text>() {
+                let cdata = text.upcast::<CharacterData>();
+                let mut length = cdata.Length();
+                if length == 0 {
+                    Node::remove(&node, self, SuppressObserver::Unsuppressed);
+                    continue;
                 }
+                while children.peek().map_or(false, |&(_, ref sibling)| sibling.is::<Text>()) {
+                    let (index, sibling) = children.next().unwrap();
+                    sibling.ranges.drain_to_preceding_text_sibling(&sibling, &node, length);
+                    self.ranges.move_to_text_child_at(self, index as u32, &node, length as u32);
+                    let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
+                    length += sibling_cdata.Length();
+                    cdata.append_data(&sibling_cdata.data());
+                    Node::remove(&sibling, self, SuppressObserver::Unsuppressed);
+                }
+            } else {
+                node.Normalize();
             }
         }
     }
@@ -2338,6 +2372,13 @@ impl VirtualMethods for Node {
             list.as_children_list().children_changed(mutation);
         }
     }
+
+    // This handles the ranges mentioned in steps 2-3 when removing a node.
+    // https://dom.spec.whatwg.org/#concept-node-remove
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        self.super_type().unwrap().unbind_from_tree(context);
+        self.ranges.drain_to_parent(context, self);
+    }
 }
 
 /// A summary of the changes that happened to a node.
@@ -2413,7 +2454,39 @@ impl<'a> ChildrenMutation<'a> {
 
 /// The context of the unbinding from a tree of a node when one of its
 /// inclusive ancestors is removed.
-pub struct UnbindContext {
+pub struct UnbindContext<'a> {
+    /// The index of the inclusive ancestor that was removed.
+    index: Cell<Option<u32>>,
+    /// The parent of the inclusive ancestor that was removed.
+    pub parent: &'a Node,
+    /// The previous sibling of the inclusive ancestor that was removed.
+    prev_sibling: Option<&'a Node>,
     /// Whether the tree is in a document.
     pub tree_in_doc: bool,
+}
+
+impl<'a> UnbindContext<'a> {
+    /// Create a new `UnbindContext` value.
+    fn new(parent: &'a Node,
+           prev_sibling: Option<&'a Node>,
+           cached_index: Option<u32>) -> Self {
+        UnbindContext {
+            index: Cell::new(cached_index),
+            parent: parent,
+            prev_sibling: prev_sibling,
+            tree_in_doc: parent.is_in_doc(),
+        }
+    }
+
+    /// The index of the inclusive ancestor that was removed from the tree.
+    #[allow(unsafe_code)]
+    pub fn index(&self) -> u32 {
+        if let Some(index) = self.index.get() {
+            return index;
+        }
+        let index =
+            self.prev_sibling.map(|sibling| sibling.index() + 1).unwrap_or(0);
+        self.index.set(Some(index));
+        index
+    }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -16,14 +16,17 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::inheritance::{CharacterDataTypeId, NodeTypeId};
 use dom::bindings::js::{JS, MutHeap, Root, RootedReference};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
-use dom::bindings::trace::RootedVec;
+use dom::bindings::trace::{JSTraceable, RootedVec};
+use dom::bindings::weakref::{WeakRef, WeakRefVec};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
 use dom::documentfragment::DocumentFragment;
-use dom::node::Node;
+use dom::node::{Node, UnbindContext};
 use dom::text::Text;
-use std::cell::Cell;
+use js::jsapi::JSTracer;
+use std::cell::{Cell, UnsafeCell};
 use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
+use util::mem::HeapSizeOf;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -52,10 +55,15 @@ impl Range {
                start_container: &Node, start_offset: u32,
                end_container: &Node, end_offset: u32)
                -> Root<Range> {
-        reflect_dom_object(box Range::new_inherited(start_container, start_offset,
-                                                    end_container, end_offset),
-                           GlobalRef::Window(document.window()),
-                           RangeBinding::Wrap)
+        let range = reflect_dom_object(box Range::new_inherited(start_container, start_offset,
+                                                                end_container, end_offset),
+                                       GlobalRef::Window(document.window()),
+                                       RangeBinding::Wrap);
+        start_container.ranges().push(WeakRef::new(&range));
+        if start_container != end_container {
+            end_container.ranges().push(WeakRef::new(&range));
+        }
+        range
     }
 
     // https://dom.spec.whatwg.org/#dom-range
@@ -121,19 +129,31 @@ impl Range {
     }
 
     // https://dom.spec.whatwg.org/#concept-range-bp-set
-    pub fn set_start(&self, node: &Node, offset: u32) {
-        self.start.set(node, offset);
-        if !(self.start <= self.end) {
-            self.end.set(node, offset);
+    fn set_start(&self, node: &Node, offset: u32) {
+        if &self.start.node != node {
+            if self.start.node == self.end.node {
+                node.ranges().push(WeakRef::new(&self));
+            } else if &self.end.node == node {
+                self.StartContainer().ranges().remove(self);
+            } else {
+                node.ranges().push(self.StartContainer().ranges().remove(self));
+            }
         }
+        self.start.set(node, offset);
     }
 
     // https://dom.spec.whatwg.org/#concept-range-bp-set
-    pub fn set_end(&self, node: &Node, offset: u32) {
-        self.end.set(node, offset);
-        if !(self.end >= self.start) {
-            self.start.set(node, offset);
+    fn set_end(&self, node: &Node, offset: u32) {
+        if &self.end.node != node {
+            if self.end.node == self.start.node {
+                node.ranges().push(WeakRef::new(&self));
+            } else if &self.start.node == node {
+                self.EndContainer().ranges().remove(self);
+            } else {
+                node.ranges().push(self.EndContainer().ranges().remove(self));
+            }
         }
+        self.end.set(node, offset);
     }
 
     // https://dom.spec.whatwg.org/#dom-range-comparepointnode-offset
@@ -215,8 +235,12 @@ impl RangeMethods for Range {
             // Step 2.
             Err(Error::IndexSize)
         } else {
-            // Step 3-4.
+            // Step 3.
             self.set_start(node, offset);
+            if !(self.start <= self.end) {
+                // Step 4.
+                self.set_end(node, offset);
+            }
             Ok(())
         }
     }
@@ -230,8 +254,12 @@ impl RangeMethods for Range {
             // Step 2.
             Err(Error::IndexSize)
         } else {
-            // Step 3-4.
+            // Step 3.
             self.set_end(node, offset);
+            if !(self.end >= self.start) {
+                // Step 4.
+                self.set_start(node, offset);
+            }
             Ok(())
         }
     }
@@ -263,9 +291,9 @@ impl RangeMethods for Range {
     // https://dom.spec.whatwg.org/#dom-range-collapse
     fn Collapse(&self, to_start: bool) {
         if to_start {
-            self.end.set(&self.StartContainer(), self.StartOffset());
+            self.set_end(&self.StartContainer(), self.StartOffset());
         } else {
-            self.start.set(&self.EndContainer(), self.EndOffset());
+            self.set_start(&self.EndContainer(), self.EndOffset());
         }
     }
 
@@ -276,9 +304,9 @@ impl RangeMethods for Range {
         // Step 3.
         let index = node.index();
         // Step 4.
-        self.start.set(&parent, index);
+        self.set_start(&parent, index);
         // Step 5.
-        self.end.set(&parent, index + 1);
+        self.set_end(&parent, index + 1);
         Ok(())
     }
 
@@ -291,9 +319,9 @@ impl RangeMethods for Range {
         // Step 2.
         let length = node.len();
         // Step 3.
-        self.start.set(node, 0);
+        self.set_start(node, 0);
         // Step 4.
-        self.end.set(node, length);
+        self.set_end(node, length);
         Ok(())
     }
 
@@ -833,10 +861,12 @@ impl BoundaryPoint {
         }
     }
 
-    fn set(&self, node: &Node, offset: u32) {
-        debug_assert!(!node.is_doctype());
-        debug_assert!(offset <= node.len());
+    pub fn set(&self, node: &Node, offset: u32) {
         self.node.set(node);
+        self.set_offset(offset);
+    }
+
+    pub fn set_offset(&self, offset: u32) {
         self.offset.set(offset);
     }
 }
@@ -892,5 +922,261 @@ fn bp_position(a_node: &Node, a_offset: u32,
     } else {
         // Step 4.
         Some(Ordering::Less)
+    }
+}
+
+pub struct WeakRangeVec {
+    cell: UnsafeCell<WeakRefVec<Range>>,
+}
+
+#[allow(unsafe_code)]
+impl WeakRangeVec {
+    /// Create a new vector of weak references.
+    pub fn new() -> Self {
+        WeakRangeVec { cell: UnsafeCell::new(WeakRefVec::new()) }
+    }
+
+    /// Whether that vector of ranges is empty.
+    pub fn is_empty(&self) -> bool {
+        unsafe { (*self.cell.get()).is_empty() }
+    }
+
+    /// Used for steps 2.1-2. when inserting a node.
+    /// https://dom.spec.whatwg.org/#concept-node-insert
+    pub fn increase_above(&self, node: &Node, offset: u32, delta: u32) {
+        self.map_offset_above(node, offset, |offset| offset + delta);
+    }
+
+    /// Used for steps 4-5. when removing a node.
+    /// https://dom.spec.whatwg.org/#concept-node-remove
+    pub fn decrease_above(&self, node: &Node, offset: u32, delta: u32) {
+        self.map_offset_above(node, offset, |offset| offset - delta);
+    }
+
+    /// Used for steps 2-3. when removing a node.
+    /// https://dom.spec.whatwg.org/#concept-node-remove
+    pub fn drain_to_parent(&self, context: &UnbindContext, child: &Node) {
+        if self.is_empty() {
+            return;
+        }
+
+        let offset = context.index();
+        let parent = context.parent;
+        unsafe {
+            let mut ranges = &mut *self.cell.get();
+
+            ranges.update(|entry| {
+                let range = entry.root().unwrap();
+                if &range.start.node == parent || &range.end.node == parent {
+                    entry.remove();
+                }
+                if &range.start.node == child {
+                    range.start.set(context.parent, offset);
+                }
+                if &range.end.node == child {
+                    range.end.set(context.parent, offset);
+                }
+            });
+
+            (*context.parent.ranges().cell.get()).extend(ranges.drain(..));
+        }
+    }
+
+    /// Used for steps 7.1-2. when normalizing a node.
+    /// https://dom.spec.whatwg.org/#dom-node-normalize
+    pub fn drain_to_preceding_text_sibling(&self, node: &Node, sibling: &Node, length: u32) {
+        if self.is_empty() {
+            return;
+        }
+
+        unsafe {
+            let mut ranges = &mut *self.cell.get();
+
+            ranges.update(|entry| {
+                let range = entry.root().unwrap();
+                if &range.start.node == sibling || &range.end.node == sibling {
+                    entry.remove();
+                }
+                if &range.start.node == node {
+                    range.start.set(sibling, range.StartOffset() + length);
+                }
+                if &range.end.node == node {
+                    range.end.set(sibling, range.EndOffset() + length);
+                }
+            });
+
+            (*sibling.ranges().cell.get()).extend(ranges.drain(..));
+        }
+    }
+
+    /// Used for steps 7.3-4. when normalizing a node.
+    /// https://dom.spec.whatwg.org/#dom-node-normalize
+    pub fn move_to_text_child_at(&self,
+                                 node: &Node, offset: u32,
+                                 child: &Node, new_offset: u32) {
+        unsafe {
+            let child_ranges = &mut *child.ranges().cell.get();
+
+            (*self.cell.get()).update(|entry| {
+                let range = entry.root().unwrap();
+
+                let node_is_start = &range.start.node == node;
+                let node_is_end = &range.end.node == node;
+
+                let move_start = node_is_start && range.StartOffset() == offset;
+                let move_end = node_is_end && range.EndOffset() == offset;
+
+                let remove_from_node = move_start && move_end ||
+                                       move_start && !node_is_end ||
+                                       move_end && !node_is_start;
+
+                let already_in_child = &range.start.node == child || &range.end.node == child;
+                let push_to_child = !already_in_child && (move_start || move_end);
+
+                if remove_from_node {
+                    let ref_ = entry.remove();
+                    if push_to_child {
+                        child_ranges.push(ref_);
+                    }
+                } else if push_to_child {
+                    child_ranges.push(WeakRef::new(&range));
+                }
+
+                if move_start {
+                    range.start.set(child, new_offset);
+                }
+                if move_end {
+                    range.end.set(child, new_offset);
+                }
+            });
+        }
+    }
+
+    /// Used for steps 8-11. when replacing character data.
+    /// https://dom.spec.whatwg.org/#concept-cd-replace
+    pub fn replace_code_units(&self,
+                              node: &Node, offset: u32,
+                              removed_code_units: u32, added_code_units: u32) {
+        self.map_offset_above(node, offset, |range_offset| {
+            if range_offset <= offset + removed_code_units {
+                offset
+            } else {
+                range_offset + added_code_units - removed_code_units
+            }
+        });
+    }
+
+    /// Used for steps 7.2-3. when splitting a text node.
+    /// https://dom.spec.whatwg.org/#concept-text-split
+    pub fn move_to_following_text_sibling_above(&self,
+                                                node: &Node, offset: u32,
+                                                sibling: &Node) {
+        unsafe {
+            let sibling_ranges = &mut *sibling.ranges().cell.get();
+
+            (*self.cell.get()).update(|entry| {
+                let range = entry.root().unwrap();
+                let start_offset = range.StartOffset();
+                let end_offset = range.EndOffset();
+
+                let node_is_start = &range.start.node == node;
+                let node_is_end = &range.end.node == node;
+
+                let move_start = node_is_start && start_offset > offset;
+                let move_end = node_is_end && end_offset > offset;
+
+                let remove_from_node = move_start && move_end ||
+                                       move_start && !node_is_end ||
+                                       move_end && !node_is_start;
+
+                let already_in_sibling =
+                    &range.start.node == sibling || &range.end.node == sibling;
+                let push_to_sibling = !already_in_sibling && (move_start || move_end);
+
+                if remove_from_node {
+                    let ref_ = entry.remove();
+                    if push_to_sibling {
+                        sibling_ranges.push(ref_);
+                    }
+                } else if push_to_sibling {
+                    sibling_ranges.push(WeakRef::new(&range));
+                }
+
+                if move_start {
+                    range.start.set(sibling, start_offset - offset);
+                }
+                if move_end {
+                    range.end.set(sibling, end_offset - offset);
+                }
+            });
+        }
+    }
+
+    /// Used for steps 7.4-5. when splitting a text node.
+    /// https://dom.spec.whatwg.org/#concept-text-split
+    pub fn increment_at(&self, node: &Node, offset: u32) {
+        unsafe {
+            (*self.cell.get()).update(|entry| {
+                let range = entry.root().unwrap();
+                if &range.start.node == node && offset == range.StartOffset() {
+                    range.start.set_offset(offset + 1);
+                }
+                if &range.end.node == node && offset == range.EndOffset() {
+                    range.end.set_offset(offset + 1);
+                }
+            });
+        }
+    }
+
+    /// Used for steps 9.1-2. when splitting a text node.
+    /// https://dom.spec.whatwg.org/#concept-text-split
+    pub fn clamp_above(&self, node: &Node, offset: u32) {
+        self.map_offset_above(node, offset, |_| offset);
+    }
+
+    fn map_offset_above<F: FnMut(u32) -> u32>(&self, node: &Node, offset: u32, mut f: F) {
+        unsafe {
+            (*self.cell.get()).update(|entry| {
+                let range = entry.root().unwrap();
+                let start_offset = range.StartOffset();
+                if &range.start.node == node && start_offset > offset {
+                    range.start.set_offset(f(start_offset));
+                }
+                let end_offset = range.EndOffset();
+                if &range.end.node == node && end_offset > offset {
+                    range.end.set_offset(f(end_offset));
+                }
+            });
+        }
+    }
+
+    fn push(&self, ref_: WeakRef<Range>) {
+        unsafe {
+            (*self.cell.get()).push(ref_);
+        }
+    }
+
+    fn remove(&self, range: &Range) -> WeakRef<Range> {
+        unsafe {
+            let ranges = &mut *self.cell.get();
+            let position = ranges.iter().position(|ref_| {
+                ref_ == range
+            }).unwrap();
+            ranges.swap_remove(position)
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+impl HeapSizeOf for WeakRangeVec {
+    fn heap_size_of_children(&self) -> usize {
+        unsafe { (*self.cell.get()).heap_size_of_children() }
+    }
+}
+
+#[allow(unsafe_code)]
+impl JSTraceable for WeakRangeVec {
+    fn trace(&self, _: *mut JSTracer) {
+        unsafe { (*self.cell.get()).retain_alive() }
     }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -410,12 +410,10 @@ impl RangeMethods for Range {
         }
 
         if end_node == start_node {
-            if let Some(text) = start_node.downcast::<CharacterData>() {
-                // Step 4.1.
-                let clone = start_node.CloneNode(true);
-                // Step 4.2.
-                let text = text.SubstringData(start_offset, end_offset - start_offset);
-                clone.downcast::<CharacterData>().unwrap().SetData(text.unwrap());
+            if let Some(cdata) = start_node.downcast::<CharacterData>() {
+                // Steps 4.1-2.
+                let data = cdata.SubstringData(start_offset, end_offset - start_offset).unwrap();
+                let clone = cdata.clone_with_data(data, &start_node.owner_doc());
                 // Step 4.3.
                 try!(fragment.upcast::<Node>().AppendChild(&clone));
                 // Step 4.4
@@ -429,13 +427,11 @@ impl RangeMethods for Range {
 
         if let Some(child) = first_contained_child {
             // Step 13.
-            if let Some(text) = child.downcast::<CharacterData>() {
+            if let Some(cdata) = child.downcast::<CharacterData>() {
                 assert!(child == start_node);
-                // Step 13.1.
-                let clone = start_node.CloneNode(true); // CharacterData has no children.
-                // Step 13.2
-                let text = text.SubstringData(start_offset, start_node.len() - start_offset);
-                clone.downcast::<CharacterData>().unwrap().SetData(text.unwrap());
+                // Steps 13.1-2.
+                let data = cdata.SubstringData(start_offset, start_node.len() - start_offset).unwrap();
+                let clone = cdata.clone_with_data(data, &start_node.owner_doc());
                 // Step 13.3.
                 try!(fragment.upcast::<Node>().AppendChild(&clone));
             } else {
@@ -466,13 +462,11 @@ impl RangeMethods for Range {
 
         if let Some(child) = last_contained_child {
             // Step 16.
-            if let Some(text) = child.downcast::<CharacterData>() {
+            if let Some(cdata) = child.downcast::<CharacterData>() {
                 assert!(child == end_node);
-                // Step 16.1.
-                let clone = end_node.CloneNode(true); // CharacterData has no children.
-                // Step 16.2.
-                let text = text.SubstringData(0, end_offset);
-                clone.downcast::<CharacterData>().unwrap().SetData(text.unwrap());
+                // Steps 16.1-2.
+                let data = cdata.SubstringData(0, end_offset).unwrap();
+                let clone = cdata.clone_with_data(data, &start_node.owner_doc());
                 // Step 16.3.
                 try!(fragment.upcast::<Node>().AppendChild(&clone));
             } else {

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -206,7 +206,7 @@ impl RangeMethods for Range {
         unreachable!();
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-setstartnode-offset
+    // https://dom.spec.whatwg.org/#dom-range-setstart
     fn SetStart(&self, node: &Node, offset: u32) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.
@@ -221,7 +221,7 @@ impl RangeMethods for Range {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-setendnode-offset
+    // https://dom.spec.whatwg.org/#dom-range-setend
     fn SetEnd(&self, node: &Node, offset: u32) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.
@@ -236,31 +236,31 @@ impl RangeMethods for Range {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-setstartbeforenode
+    // https://dom.spec.whatwg.org/#dom-range-setstartbefore
     fn SetStartBefore(&self, node: &Node) -> ErrorResult {
         let parent = try!(node.GetParentNode().ok_or(Error::InvalidNodeType));
         self.SetStart(parent.r(), node.index())
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-setstartafternode
+    // https://dom.spec.whatwg.org/#dom-range-setstartafter
     fn SetStartAfter(&self, node: &Node) -> ErrorResult {
         let parent = try!(node.GetParentNode().ok_or(Error::InvalidNodeType));
         self.SetStart(parent.r(), node.index() + 1)
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-setendbeforenode
+    // https://dom.spec.whatwg.org/#dom-range-setendbefore
     fn SetEndBefore(&self, node: &Node) -> ErrorResult {
         let parent = try!(node.GetParentNode().ok_or(Error::InvalidNodeType));
         self.SetEnd(parent.r(), node.index())
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-setendafternode
+    // https://dom.spec.whatwg.org/#dom-range-setendafter
     fn SetEndAfter(&self, node: &Node) -> ErrorResult {
         let parent = try!(node.GetParentNode().ok_or(Error::InvalidNodeType));
         self.SetEnd(parent.r(), node.index() + 1)
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-collapsetostart
+    // https://dom.spec.whatwg.org/#dom-range-collapse
     fn Collapse(&self, to_start: bool) {
         if to_start {
             self.end.set(&self.StartContainer(), self.StartOffset());
@@ -269,7 +269,7 @@ impl RangeMethods for Range {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-selectnodenode
+    // https://dom.spec.whatwg.org/#dom-range-selectnode
     fn SelectNode(&self, node: &Node) -> ErrorResult {
         // Steps 1, 2.
         let parent = try!(node.GetParentNode().ok_or(Error::InvalidNodeType));
@@ -282,7 +282,7 @@ impl RangeMethods for Range {
         Ok(())
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-selectnodecontentsnode
+    // https://dom.spec.whatwg.org/#dom-range-selectnodecontents
     fn SelectNodeContents(&self, node: &Node) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.
@@ -297,7 +297,7 @@ impl RangeMethods for Range {
         Ok(())
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-compareboundarypointshow-sourcerange
+    // https://dom.spec.whatwg.org/#dom-range-compareboundarypoints
     fn CompareBoundaryPoints(&self, how: u16, other: &Range)
                              -> Fallible<i16> {
         if how > RangeConstants::END_TO_START {
@@ -342,7 +342,7 @@ impl RangeMethods for Range {
                    &self.EndContainer(), self.EndOffset())
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-ispointinrangenode-offset
+    // https://dom.spec.whatwg.org/#dom-range-ispointinrange
     fn IsPointInRange(&self, node: &Node, offset: u32) -> Fallible<bool> {
         match self.compare_point(node, offset) {
             Ok(Ordering::Less) => Ok(false),
@@ -356,7 +356,7 @@ impl RangeMethods for Range {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-range-comparepointnode-offset
+    // https://dom.spec.whatwg.org/#dom-range-comparepoint
     fn ComparePoint(&self, node: &Node, offset: u32) -> Fallible<i16> {
         self.compare_point(node, offset).map(|order| {
             match order {

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -62,15 +62,18 @@ impl TextMethods for Text {
         // Step 6.
         let parent = node.GetParentNode();
         if let Some(ref parent) = parent {
-            // Step 7.
+            // Step 7.1.
             parent.InsertBefore(new_node.upcast(), node.GetNextSibling().r()).unwrap();
-            // TODO: Ranges.
+            // Steps 7.2-3.
+            node.ranges().move_to_following_text_sibling_above(node, offset, new_node.upcast());
+            // Steps 7.4-5.
+            parent.ranges().increment_at(&parent, node.index() + 1);
         }
         // Step 8.
         cdata.DeleteData(offset, count).unwrap();
         if parent.is_none() {
             // Step 9.
-            // TODO: Ranges
+            node.ranges().clamp_above(&node, offset);
         }
         // Step 10.
         Ok(new_node)

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -42,7 +42,7 @@ use dom::htmltablesectionelement::HTMLTableSectionElement;
 use dom::htmltemplateelement::HTMLTemplateElement;
 use dom::htmltextareaelement::HTMLTextAreaElement;
 use dom::htmltitleelement::HTMLTitleElement;
-use dom::node::{ChildrenMutation, CloneChildrenFlag, Node};
+use dom::node::{ChildrenMutation, CloneChildrenFlag, Node, UnbindContext};
 use string_cache::Atom;
 use util::str::DOMString;
 
@@ -82,9 +82,9 @@ pub trait VirtualMethods {
 
     /// Called when a Node is removed from a tree, where 'tree_in_doc'
     /// indicates whether the tree is part of a Document.
-    fn unbind_from_tree(&self, tree_in_doc: bool) {
+    fn unbind_from_tree(&self, context: &UnbindContext) {
         if let Some(ref s) = self.super_type() {
-            s.unbind_from_tree(tree_in_doc);
+            s.unbind_from_tree(context);
         }
     }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -13,7 +13,6 @@
 #![feature(custom_derive)]
 #![feature(fnbox)]
 #![feature(hashmap_hasher)]
-#![feature(iter_arith)]
 #![feature(mpsc_select)]
 #![feature(nonzero)]
 #![feature(on_unimplemented)]

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -38,10 +38,10 @@ macro_rules! sizeof_checker (
 
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 40);
-sizeof_checker!(size_node, Node, 160);
-sizeof_checker!(size_element, Element, 304);
-sizeof_checker!(size_htmlelement, HTMLElement, 320);
-sizeof_checker!(size_div, HTMLDivElement, 320);
-sizeof_checker!(size_span, HTMLSpanElement, 320);
-sizeof_checker!(size_text, Text, 192);
-sizeof_checker!(size_characterdata, CharacterData, 192);
+sizeof_checker!(size_node, Node, 184);
+sizeof_checker!(size_element, Element, 328);
+sizeof_checker!(size_htmlelement, HTMLElement, 344);
+sizeof_checker!(size_div, HTMLDivElement, 344);
+sizeof_checker!(size_span, HTMLSpanElement, 344);
+sizeof_checker!(size_text, Text, 216);
+sizeof_checker!(size_characterdata, CharacterData, 216);

--- a/tests/wpt/metadata/dom/ranges/Range-deleteContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-deleteContents.html.ini
@@ -1,23 +1,5 @@
 [Range-deleteContents.html]
   type: testharness
-  [Resulting cursor position for range 1 [paras[0\].firstChild, 0, paras[0\].firstChild, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 2 [paras[0\].firstChild, 2, paras[0\].firstChild, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 3 [paras[0\].firstChild, 2, paras[0\].firstChild, 9\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 5 [paras[1\].firstChild, 2, paras[1\].firstChild, 9\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 7 [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 9 [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\]]
-    expected: FAIL
-
   [Resulting cursor position for range 18 [paras[0\].firstChild, 0, paras[1\].firstChild, 0\]]
     expected: FAIL
 
@@ -28,27 +10,6 @@
     expected: FAIL
 
   [Resulting DOM for range 24 [document, 0, document, 2\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 25 [comment, 2, comment, 3\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 30 [detachedTextNode, 0, detachedTextNode, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 31 [detachedForeignTextNode, 0, detachedForeignTextNode, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 32 [detachedXmlTextNode, 0, detachedXmlTextNode, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 33 [detachedComment, 3, detachedComment, 4\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 34 [detachedForeignComment, 0, detachedForeignComment, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 35 [detachedXmlComment, 2, detachedXmlComment, 6\]]
     expected: FAIL
 
   [Resulting DOM for range 10 [document.documentElement, 0, document.documentElement, 1\]]
@@ -64,21 +25,6 @@
     expected: FAIL
 
   [Resulting DOM for range 27 [foreignDoc, 1, foreignComment, 2\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 37 [processingInstruction, 0, processingInstruction, 4\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 38 [paras[1\].firstChild, 0, paras[1\].firstChild, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 39 [paras[1\].firstChild, 2, paras[1\].firstChild, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 40 [detachedPara1.firstChild, 0, detachedPara1.firstChild, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 41 [foreignPara1.firstChild, 0, foreignPara1.firstChild, 1\]]
     expected: FAIL
 
   [Resulting DOM for range 49 [document, 1, document, 2\]]

--- a/tests/wpt/metadata/dom/ranges/Range-extractContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-extractContents.html.ini
@@ -1,23 +1,5 @@
 [Range-extractContents.html]
   type: testharness
-  [Resulting cursor position for range 1 [paras[0\].firstChild, 0, paras[0\].firstChild, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 2 [paras[0\].firstChild, 2, paras[0\].firstChild, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 3 [paras[0\].firstChild, 2, paras[0\].firstChild, 9\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 5 [paras[1\].firstChild, 2, paras[1\].firstChild, 9\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 7 [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 9 [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\]]
-    expected: FAIL
-
   [Resulting cursor position for range 18 [paras[0\].firstChild, 0, paras[1\].firstChild, 0\]]
     expected: FAIL
 
@@ -25,42 +7,6 @@
     expected: FAIL
 
   [Resulting cursor position for range 20 [paras[0\].firstChild, 3, paras[3\], 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 25 [comment, 2, comment, 3\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 30 [detachedTextNode, 0, detachedTextNode, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 31 [detachedForeignTextNode, 0, detachedForeignTextNode, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 32 [detachedXmlTextNode, 0, detachedXmlTextNode, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 33 [detachedComment, 3, detachedComment, 4\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 34 [detachedForeignComment, 0, detachedForeignComment, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 35 [detachedXmlComment, 2, detachedXmlComment, 6\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 37 [processingInstruction, 0, processingInstruction, 4\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 38 [paras[1\].firstChild, 0, paras[1\].firstChild, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 39 [paras[1\].firstChild, 2, paras[1\].firstChild, 8\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 40 [detachedPara1.firstChild, 0, detachedPara1.firstChild, 1\]]
-    expected: FAIL
-
-  [Resulting cursor position for range 41 [foreignPara1.firstChild, 0, foreignPara1.firstChild, 1\]]
     expected: FAIL
 
   [Resulting cursor position for range 50 [paras[2\].firstChild, 4, comment, 2\]]

--- a/tests/wpt/metadata/dom/ranges/Range-mutations.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-mutations.html.ini
@@ -12,13 +12,7 @@
   [paras[0\].firstChild.splitText(paras[0\].firstChild.length), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.splitText(1), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.splitText(1), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.splitText(2), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.splitText(2), with selected range on paras[0\].firstChild from 1 to 3]
@@ -39,13 +33,7 @@
   [paras[1\].firstChild.splitText(paras[1\].firstChild.length), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.splitText(1), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.splitText(1), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.splitText(2), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.splitText(2), with selected range on paras[1\].firstChild from 1 to 3]
@@ -66,13 +54,7 @@
   [foreignTextNode.splitText(foreignTextNode.length), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.splitText(1), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.splitText(1), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.splitText(2), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.splitText(2), with selected range on foreignTextNode from 1 to 3]
@@ -93,13 +75,7 @@
   [xmlTextNode.splitText(xmlTextNode.length), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.splitText(1), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.splitText(1), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.splitText(2), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.splitText(2), with selected range on xmlTextNode from 1 to 3]
@@ -120,13 +96,7 @@
   [detachedTextNode.splitText(detachedTextNode.length), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.splitText(1), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.splitText(1), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.splitText(2), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.splitText(2), with selected range on detachedTextNode from 1 to 3]
@@ -147,13 +117,7 @@
   [detachedForeignTextNode.splitText(detachedForeignTextNode.length), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.splitText(1), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.splitText(1), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.splitText(2), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.splitText(2), with selected range on detachedForeignTextNode from 1 to 3]
@@ -174,13 +138,7 @@
   [detachedXmlTextNode.splitText(detachedXmlTextNode.length), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.splitText(1), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.splitText(1), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.splitText(2), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.splitText(2), with selected range on detachedXmlTextNode from 1 to 3]
@@ -192,43 +150,22 @@
   [paras[0\].firstChild.splitText(1), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [paras[0\].firstChild.splitText(1), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.splitText(1), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.splitText(1), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].firstChild.splitText(1), with selected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.splitText(1), with unselected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.splitText(1), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.splitText(2), with unselected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].firstChild.splitText(2), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.splitText(3), with unselected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.splitText(3), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.splitText(1), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
   [paras[0\].firstChild.splitText(1), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
-  [paras[0\].firstChild.splitText(2), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
     expected: FAIL
 
   [paras[0\].firstChild.splitText(2), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
@@ -249,13 +186,7 @@
   [paras[0\].firstChild.insertData(paras[0\].firstChild.length, "foo"), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.insertData(1, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.insertData(1, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.insertData(2, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.insertData(2, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
@@ -297,13 +228,7 @@
   [paras[1\].firstChild.insertData(paras[1\].firstChild.length, "foo"), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.insertData(1, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.insertData(1, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.insertData(2, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.insertData(2, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
@@ -345,13 +270,7 @@
   [foreignTextNode.insertData(foreignTextNode.length, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.insertData(1, "foo"), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.insertData(1, "foo"), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.insertData(2, "foo"), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.insertData(2, "foo"), with selected range on foreignTextNode from 1 to 3]
@@ -393,13 +312,7 @@
   [xmlTextNode.insertData(xmlTextNode.length, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.insertData(1, "foo"), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.insertData(1, "foo"), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.insertData(2, "foo"), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.insertData(2, "foo"), with selected range on xmlTextNode from 1 to 3]
@@ -441,13 +354,7 @@
   [detachedTextNode.insertData(detachedTextNode.length, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.insertData(1, "foo"), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.insertData(1, "foo"), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.insertData(2, "foo"), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.insertData(2, "foo"), with selected range on detachedTextNode from 1 to 3]
@@ -489,13 +396,7 @@
   [detachedForeignTextNode.insertData(detachedForeignTextNode.length, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.insertData(1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.insertData(1, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.insertData(2, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.insertData(2, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
@@ -537,13 +438,7 @@
   [detachedXmlTextNode.insertData(detachedXmlTextNode.length, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.insertData(1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.insertData(1, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.insertData(2, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.insertData(2, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
@@ -585,13 +480,7 @@
   [comment.insertData(comment.length, "foo"), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.insertData(1, "foo"), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.insertData(1, "foo"), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.insertData(2, "foo"), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.insertData(2, "foo"), with selected range on comment from 1 to 3]
@@ -633,13 +522,7 @@
   [foreignComment.insertData(foreignComment.length, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.insertData(1, "foo"), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.insertData(1, "foo"), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.insertData(2, "foo"), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.insertData(2, "foo"), with selected range on foreignComment from 1 to 3]
@@ -681,13 +564,7 @@
   [xmlComment.insertData(xmlComment.length, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.insertData(1, "foo"), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.insertData(1, "foo"), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.insertData(2, "foo"), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.insertData(2, "foo"), with selected range on xmlComment from 1 to 3]
@@ -729,13 +606,7 @@
   [detachedComment.insertData(detachedComment.length, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.insertData(1, "foo"), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.insertData(1, "foo"), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.insertData(2, "foo"), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.insertData(2, "foo"), with selected range on detachedComment from 1 to 3]
@@ -777,13 +648,7 @@
   [detachedForeignComment.insertData(detachedForeignComment.length, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.insertData(1, "foo"), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.insertData(1, "foo"), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.insertData(2, "foo"), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.insertData(2, "foo"), with selected range on detachedForeignComment from 1 to 3]
@@ -825,13 +690,7 @@
   [detachedXmlComment.insertData(detachedXmlComment.length, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.insertData(1, "foo"), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.insertData(1, "foo"), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.insertData(2, "foo"), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.insertData(2, "foo"), with selected range on detachedXmlComment from 1 to 3]
@@ -879,13 +738,7 @@
   [paras[0\].firstChild.insertData(3, "foo"), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.insertData(1, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
   [paras[0\].firstChild.insertData(1, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
-  [paras[0\].firstChild.insertData(2, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
     expected: FAIL
 
   [paras[0\].firstChild.insertData(2, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
@@ -1482,13 +1335,7 @@
   [paras[0\].firstChild.deleteData(paras[0\].firstChild.length, 2), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.deleteData(1, 2), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.deleteData(1, 2), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.deleteData(2, 2), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.deleteData(2, 2), with selected range on paras[0\].firstChild from 1 to 3]
@@ -1530,13 +1377,7 @@
   [paras[0\].firstChild.deleteData(paras[0\].firstChild.length, 631), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.deleteData(1, 631), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.deleteData(1, 631), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.deleteData(2, 631), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.deleteData(2, 631), with selected range on paras[0\].firstChild from 1 to 3]
@@ -1557,13 +1398,7 @@
   [paras[1\].firstChild.deleteData(paras[1\].firstChild.length, 2), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.deleteData(1, 2), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.deleteData(1, 2), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.deleteData(2, 2), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.deleteData(2, 2), with selected range on paras[1\].firstChild from 1 to 3]
@@ -1605,13 +1440,7 @@
   [paras[1\].firstChild.deleteData(paras[1\].firstChild.length, 631), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.deleteData(1, 631), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.deleteData(1, 631), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.deleteData(2, 631), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.deleteData(2, 631), with selected range on paras[1\].firstChild from 1 to 3]
@@ -1632,13 +1461,7 @@
   [foreignTextNode.deleteData(foreignTextNode.length, 2), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.deleteData(1, 2), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.deleteData(1, 2), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.deleteData(2, 2), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.deleteData(2, 2), with selected range on foreignTextNode from 1 to 3]
@@ -1680,13 +1503,7 @@
   [foreignTextNode.deleteData(foreignTextNode.length, 631), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.deleteData(1, 631), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.deleteData(1, 631), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.deleteData(2, 631), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.deleteData(2, 631), with selected range on foreignTextNode from 1 to 3]
@@ -1707,13 +1524,7 @@
   [xmlTextNode.deleteData(xmlTextNode.length, 2), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.deleteData(1, 2), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.deleteData(1, 2), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.deleteData(2, 2), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.deleteData(2, 2), with selected range on xmlTextNode from 1 to 3]
@@ -1755,13 +1566,7 @@
   [xmlTextNode.deleteData(xmlTextNode.length, 631), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.deleteData(1, 631), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.deleteData(1, 631), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.deleteData(2, 631), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.deleteData(2, 631), with selected range on xmlTextNode from 1 to 3]
@@ -1782,13 +1587,7 @@
   [detachedTextNode.deleteData(detachedTextNode.length, 2), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.deleteData(1, 2), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.deleteData(1, 2), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.deleteData(2, 2), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.deleteData(2, 2), with selected range on detachedTextNode from 1 to 3]
@@ -1830,13 +1629,7 @@
   [detachedTextNode.deleteData(detachedTextNode.length, 631), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.deleteData(1, 631), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.deleteData(1, 631), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.deleteData(2, 631), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.deleteData(2, 631), with selected range on detachedTextNode from 1 to 3]
@@ -1857,13 +1650,7 @@
   [detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 2), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.deleteData(1, 2), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.deleteData(1, 2), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.deleteData(2, 2), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.deleteData(2, 2), with selected range on detachedForeignTextNode from 1 to 3]
@@ -1905,13 +1692,7 @@
   [detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 631), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.deleteData(1, 631), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.deleteData(1, 631), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.deleteData(2, 631), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.deleteData(2, 631), with selected range on detachedForeignTextNode from 1 to 3]
@@ -1932,13 +1713,7 @@
   [detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 2), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.deleteData(1, 2), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.deleteData(1, 2), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.deleteData(2, 2), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.deleteData(2, 2), with selected range on detachedXmlTextNode from 1 to 3]
@@ -1980,13 +1755,7 @@
   [detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 631), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.deleteData(1, 631), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.deleteData(1, 631), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.deleteData(2, 631), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.deleteData(2, 631), with selected range on detachedXmlTextNode from 1 to 3]
@@ -2007,13 +1776,7 @@
   [comment.deleteData(comment.length, 2), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.deleteData(1, 2), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.deleteData(1, 2), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.deleteData(2, 2), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.deleteData(2, 2), with selected range on comment from 1 to 3]
@@ -2055,13 +1818,7 @@
   [comment.deleteData(comment.length, 631), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.deleteData(1, 631), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.deleteData(1, 631), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.deleteData(2, 631), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.deleteData(2, 631), with selected range on comment from 1 to 3]
@@ -2082,13 +1839,7 @@
   [foreignComment.deleteData(foreignComment.length, 2), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.deleteData(1, 2), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.deleteData(1, 2), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.deleteData(2, 2), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.deleteData(2, 2), with selected range on foreignComment from 1 to 3]
@@ -2130,13 +1881,7 @@
   [foreignComment.deleteData(foreignComment.length, 631), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.deleteData(1, 631), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.deleteData(1, 631), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.deleteData(2, 631), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.deleteData(2, 631), with selected range on foreignComment from 1 to 3]
@@ -2157,13 +1902,7 @@
   [xmlComment.deleteData(xmlComment.length, 2), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.deleteData(1, 2), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.deleteData(1, 2), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.deleteData(2, 2), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.deleteData(2, 2), with selected range on xmlComment from 1 to 3]
@@ -2205,13 +1944,7 @@
   [xmlComment.deleteData(xmlComment.length, 631), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.deleteData(1, 631), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.deleteData(1, 631), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.deleteData(2, 631), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.deleteData(2, 631), with selected range on xmlComment from 1 to 3]
@@ -2232,13 +1965,7 @@
   [detachedComment.deleteData(detachedComment.length, 2), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.deleteData(1, 2), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.deleteData(1, 2), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.deleteData(2, 2), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.deleteData(2, 2), with selected range on detachedComment from 1 to 3]
@@ -2280,13 +2007,7 @@
   [detachedComment.deleteData(detachedComment.length, 631), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.deleteData(1, 631), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.deleteData(1, 631), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.deleteData(2, 631), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.deleteData(2, 631), with selected range on detachedComment from 1 to 3]
@@ -2307,13 +2028,7 @@
   [detachedForeignComment.deleteData(detachedForeignComment.length, 2), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.deleteData(1, 2), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.deleteData(1, 2), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.deleteData(2, 2), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.deleteData(2, 2), with selected range on detachedForeignComment from 1 to 3]
@@ -2355,13 +2070,7 @@
   [detachedForeignComment.deleteData(detachedForeignComment.length, 631), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.deleteData(1, 631), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.deleteData(1, 631), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.deleteData(2, 631), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.deleteData(2, 631), with selected range on detachedForeignComment from 1 to 3]
@@ -2382,13 +2091,7 @@
   [detachedXmlComment.deleteData(detachedXmlComment.length, 2), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.deleteData(1, 2), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.deleteData(1, 2), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.deleteData(2, 2), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.deleteData(2, 2), with selected range on detachedXmlComment from 1 to 3]
@@ -2430,13 +2133,7 @@
   [detachedXmlComment.deleteData(detachedXmlComment.length, 631), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.deleteData(1, 631), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.deleteData(1, 631), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.deleteData(2, 631), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.deleteData(2, 631), with selected range on detachedXmlComment from 1 to 3]
@@ -2463,13 +2160,7 @@
   [paras[0\].firstChild.deleteData(3, 2), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.deleteData(1, 2), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
   [paras[0\].firstChild.deleteData(1, 2), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
-  [paras[0\].firstChild.deleteData(2, 2), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
     expected: FAIL
 
   [paras[0\].firstChild.deleteData(2, 2), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
@@ -2490,13 +2181,7 @@
   [paras[0\].firstChild.replaceData(paras[0\].firstChild.length, 0, "foo"), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 0, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 0, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 0, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 0, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
@@ -2538,13 +2223,7 @@
   [paras[0\].firstChild.replaceData(paras[0\].firstChild.length, 1, "foo"), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 1, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 1, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 1, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 1, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
@@ -2565,13 +2244,7 @@
   [paras[0\].firstChild.replaceData(paras[0\].firstChild.length, 1, ""), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 1, ""), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 1, ""), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 1, ""), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 1, ""), with selected range on paras[0\].firstChild from 1 to 3]
@@ -2592,13 +2265,7 @@
   [paras[0\].firstChild.replaceData(paras[0\].firstChild.length, 47, "foo"), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 47, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 47, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 47, "foo"), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 47, "foo"), with selected range on paras[0\].firstChild from 1 to 3]
@@ -2619,13 +2286,7 @@
   [paras[0\].firstChild.replaceData(paras[0\].firstChild.length, 47, ""), with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 47, ""), with unselected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 47, ""), with selected range on paras[0\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 47, ""), with unselected range on paras[0\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 47, ""), with selected range on paras[0\].firstChild from 1 to 3]
@@ -2646,13 +2307,7 @@
   [paras[1\].firstChild.replaceData(paras[1\].firstChild.length, 0, "foo"), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.replaceData(1, 0, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.replaceData(1, 0, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.replaceData(2, 0, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.replaceData(2, 0, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
@@ -2694,13 +2349,7 @@
   [paras[1\].firstChild.replaceData(paras[1\].firstChild.length, 1, "foo"), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.replaceData(1, 1, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.replaceData(1, 1, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.replaceData(2, 1, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.replaceData(2, 1, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
@@ -2721,13 +2370,7 @@
   [paras[1\].firstChild.replaceData(paras[1\].firstChild.length, 1, ""), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.replaceData(1, 1, ""), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.replaceData(1, 1, ""), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.replaceData(2, 1, ""), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.replaceData(2, 1, ""), with selected range on paras[1\].firstChild from 1 to 3]
@@ -2748,13 +2391,7 @@
   [paras[1\].firstChild.replaceData(paras[1\].firstChild.length, 47, "foo"), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.replaceData(1, 47, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.replaceData(1, 47, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.replaceData(2, 47, "foo"), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.replaceData(2, 47, "foo"), with selected range on paras[1\].firstChild from 1 to 3]
@@ -2775,13 +2412,7 @@
   [paras[1\].firstChild.replaceData(paras[1\].firstChild.length, 47, ""), with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.replaceData(1, 47, ""), with unselected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
   [paras[1\].firstChild.replaceData(1, 47, ""), with selected range on paras[1\].firstChild from 1 to 3]
-    expected: FAIL
-
-  [paras[1\].firstChild.replaceData(2, 47, ""), with unselected range on paras[1\].firstChild from 1 to 3]
     expected: FAIL
 
   [paras[1\].firstChild.replaceData(2, 47, ""), with selected range on paras[1\].firstChild from 1 to 3]
@@ -2802,13 +2433,7 @@
   [foreignTextNode.replaceData(foreignTextNode.length, 0, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.replaceData(1, 0, "foo"), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.replaceData(1, 0, "foo"), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.replaceData(2, 0, "foo"), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.replaceData(2, 0, "foo"), with selected range on foreignTextNode from 1 to 3]
@@ -2850,13 +2475,7 @@
   [foreignTextNode.replaceData(foreignTextNode.length, 1, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.replaceData(1, 1, "foo"), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.replaceData(1, 1, "foo"), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.replaceData(2, 1, "foo"), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.replaceData(2, 1, "foo"), with selected range on foreignTextNode from 1 to 3]
@@ -2877,13 +2496,7 @@
   [foreignTextNode.replaceData(foreignTextNode.length, 1, ""), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.replaceData(1, 1, ""), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.replaceData(1, 1, ""), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.replaceData(2, 1, ""), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.replaceData(2, 1, ""), with selected range on foreignTextNode from 1 to 3]
@@ -2904,13 +2517,7 @@
   [foreignTextNode.replaceData(foreignTextNode.length, 47, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.replaceData(1, 47, "foo"), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.replaceData(1, 47, "foo"), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.replaceData(2, 47, "foo"), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.replaceData(2, 47, "foo"), with selected range on foreignTextNode from 1 to 3]
@@ -2931,13 +2538,7 @@
   [foreignTextNode.replaceData(foreignTextNode.length, 47, ""), with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.replaceData(1, 47, ""), with unselected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
   [foreignTextNode.replaceData(1, 47, ""), with selected range on foreignTextNode from 1 to 3]
-    expected: FAIL
-
-  [foreignTextNode.replaceData(2, 47, ""), with unselected range on foreignTextNode from 1 to 3]
     expected: FAIL
 
   [foreignTextNode.replaceData(2, 47, ""), with selected range on foreignTextNode from 1 to 3]
@@ -2958,13 +2559,7 @@
   [xmlTextNode.replaceData(xmlTextNode.length, 0, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.replaceData(1, 0, "foo"), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.replaceData(1, 0, "foo"), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.replaceData(2, 0, "foo"), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.replaceData(2, 0, "foo"), with selected range on xmlTextNode from 1 to 3]
@@ -3006,13 +2601,7 @@
   [xmlTextNode.replaceData(xmlTextNode.length, 1, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.replaceData(1, 1, "foo"), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.replaceData(1, 1, "foo"), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.replaceData(2, 1, "foo"), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.replaceData(2, 1, "foo"), with selected range on xmlTextNode from 1 to 3]
@@ -3033,13 +2622,7 @@
   [xmlTextNode.replaceData(xmlTextNode.length, 1, ""), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.replaceData(1, 1, ""), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.replaceData(1, 1, ""), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.replaceData(2, 1, ""), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.replaceData(2, 1, ""), with selected range on xmlTextNode from 1 to 3]
@@ -3060,13 +2643,7 @@
   [xmlTextNode.replaceData(xmlTextNode.length, 47, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.replaceData(1, 47, "foo"), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.replaceData(1, 47, "foo"), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.replaceData(2, 47, "foo"), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.replaceData(2, 47, "foo"), with selected range on xmlTextNode from 1 to 3]
@@ -3087,13 +2664,7 @@
   [xmlTextNode.replaceData(xmlTextNode.length, 47, ""), with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.replaceData(1, 47, ""), with unselected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
   [xmlTextNode.replaceData(1, 47, ""), with selected range on xmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [xmlTextNode.replaceData(2, 47, ""), with unselected range on xmlTextNode from 1 to 3]
     expected: FAIL
 
   [xmlTextNode.replaceData(2, 47, ""), with selected range on xmlTextNode from 1 to 3]
@@ -3114,13 +2685,7 @@
   [detachedTextNode.replaceData(detachedTextNode.length, 0, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.replaceData(1, 0, "foo"), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.replaceData(1, 0, "foo"), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.replaceData(2, 0, "foo"), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.replaceData(2, 0, "foo"), with selected range on detachedTextNode from 1 to 3]
@@ -3162,13 +2727,7 @@
   [detachedTextNode.replaceData(detachedTextNode.length, 1, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.replaceData(1, 1, "foo"), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.replaceData(1, 1, "foo"), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.replaceData(2, 1, "foo"), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.replaceData(2, 1, "foo"), with selected range on detachedTextNode from 1 to 3]
@@ -3189,13 +2748,7 @@
   [detachedTextNode.replaceData(detachedTextNode.length, 1, ""), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.replaceData(1, 1, ""), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.replaceData(1, 1, ""), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.replaceData(2, 1, ""), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.replaceData(2, 1, ""), with selected range on detachedTextNode from 1 to 3]
@@ -3216,13 +2769,7 @@
   [detachedTextNode.replaceData(detachedTextNode.length, 47, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.replaceData(1, 47, "foo"), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.replaceData(1, 47, "foo"), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.replaceData(2, 47, "foo"), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.replaceData(2, 47, "foo"), with selected range on detachedTextNode from 1 to 3]
@@ -3243,13 +2790,7 @@
   [detachedTextNode.replaceData(detachedTextNode.length, 47, ""), with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.replaceData(1, 47, ""), with unselected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedTextNode.replaceData(1, 47, ""), with selected range on detachedTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedTextNode.replaceData(2, 47, ""), with unselected range on detachedTextNode from 1 to 3]
     expected: FAIL
 
   [detachedTextNode.replaceData(2, 47, ""), with selected range on detachedTextNode from 1 to 3]
@@ -3270,13 +2811,7 @@
   [detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 0, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.replaceData(1, 0, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.replaceData(1, 0, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.replaceData(2, 0, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.replaceData(2, 0, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
@@ -3318,13 +2853,7 @@
   [detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 1, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.replaceData(1, 1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.replaceData(1, 1, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.replaceData(2, 1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.replaceData(2, 1, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
@@ -3345,13 +2874,7 @@
   [detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 1, ""), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.replaceData(1, 1, ""), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.replaceData(1, 1, ""), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.replaceData(2, 1, ""), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.replaceData(2, 1, ""), with selected range on detachedForeignTextNode from 1 to 3]
@@ -3372,13 +2895,7 @@
   [detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 47, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.replaceData(1, 47, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.replaceData(1, 47, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.replaceData(2, 47, "foo"), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.replaceData(2, 47, "foo"), with selected range on detachedForeignTextNode from 1 to 3]
@@ -3399,13 +2916,7 @@
   [detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 47, ""), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.replaceData(1, 47, ""), with unselected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedForeignTextNode.replaceData(1, 47, ""), with selected range on detachedForeignTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignTextNode.replaceData(2, 47, ""), with unselected range on detachedForeignTextNode from 1 to 3]
     expected: FAIL
 
   [detachedForeignTextNode.replaceData(2, 47, ""), with selected range on detachedForeignTextNode from 1 to 3]
@@ -3426,13 +2937,7 @@
   [detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 0, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.replaceData(1, 0, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.replaceData(1, 0, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.replaceData(2, 0, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.replaceData(2, 0, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
@@ -3474,13 +2979,7 @@
   [detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 1, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.replaceData(1, 1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.replaceData(1, 1, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.replaceData(2, 1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.replaceData(2, 1, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
@@ -3501,13 +3000,7 @@
   [detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 1, ""), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.replaceData(1, 1, ""), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.replaceData(1, 1, ""), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.replaceData(2, 1, ""), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.replaceData(2, 1, ""), with selected range on detachedXmlTextNode from 1 to 3]
@@ -3528,13 +3021,7 @@
   [detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 47, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.replaceData(1, 47, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.replaceData(1, 47, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.replaceData(2, 47, "foo"), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.replaceData(2, 47, "foo"), with selected range on detachedXmlTextNode from 1 to 3]
@@ -3555,13 +3042,7 @@
   [detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 47, ""), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.replaceData(1, 47, ""), with unselected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
   [detachedXmlTextNode.replaceData(1, 47, ""), with selected range on detachedXmlTextNode from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlTextNode.replaceData(2, 47, ""), with unselected range on detachedXmlTextNode from 1 to 3]
     expected: FAIL
 
   [detachedXmlTextNode.replaceData(2, 47, ""), with selected range on detachedXmlTextNode from 1 to 3]
@@ -3582,13 +3063,7 @@
   [comment.replaceData(comment.length, 0, "foo"), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.replaceData(1, 0, "foo"), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.replaceData(1, 0, "foo"), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.replaceData(2, 0, "foo"), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.replaceData(2, 0, "foo"), with selected range on comment from 1 to 3]
@@ -3630,13 +3105,7 @@
   [comment.replaceData(comment.length, 1, "foo"), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.replaceData(1, 1, "foo"), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.replaceData(1, 1, "foo"), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.replaceData(2, 1, "foo"), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.replaceData(2, 1, "foo"), with selected range on comment from 1 to 3]
@@ -3657,13 +3126,7 @@
   [comment.replaceData(comment.length, 1, ""), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.replaceData(1, 1, ""), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.replaceData(1, 1, ""), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.replaceData(2, 1, ""), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.replaceData(2, 1, ""), with selected range on comment from 1 to 3]
@@ -3684,13 +3147,7 @@
   [comment.replaceData(comment.length, 47, "foo"), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.replaceData(1, 47, "foo"), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.replaceData(1, 47, "foo"), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.replaceData(2, 47, "foo"), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.replaceData(2, 47, "foo"), with selected range on comment from 1 to 3]
@@ -3711,13 +3168,7 @@
   [comment.replaceData(comment.length, 47, ""), with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.replaceData(1, 47, ""), with unselected range on comment from 1 to 3]
-    expected: FAIL
-
   [comment.replaceData(1, 47, ""), with selected range on comment from 1 to 3]
-    expected: FAIL
-
-  [comment.replaceData(2, 47, ""), with unselected range on comment from 1 to 3]
     expected: FAIL
 
   [comment.replaceData(2, 47, ""), with selected range on comment from 1 to 3]
@@ -3738,13 +3189,7 @@
   [foreignComment.replaceData(foreignComment.length, 0, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.replaceData(1, 0, "foo"), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.replaceData(1, 0, "foo"), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.replaceData(2, 0, "foo"), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.replaceData(2, 0, "foo"), with selected range on foreignComment from 1 to 3]
@@ -3786,13 +3231,7 @@
   [foreignComment.replaceData(foreignComment.length, 1, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.replaceData(1, 1, "foo"), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.replaceData(1, 1, "foo"), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.replaceData(2, 1, "foo"), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.replaceData(2, 1, "foo"), with selected range on foreignComment from 1 to 3]
@@ -3813,13 +3252,7 @@
   [foreignComment.replaceData(foreignComment.length, 1, ""), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.replaceData(1, 1, ""), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.replaceData(1, 1, ""), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.replaceData(2, 1, ""), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.replaceData(2, 1, ""), with selected range on foreignComment from 1 to 3]
@@ -3840,13 +3273,7 @@
   [foreignComment.replaceData(foreignComment.length, 47, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.replaceData(1, 47, "foo"), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.replaceData(1, 47, "foo"), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.replaceData(2, 47, "foo"), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.replaceData(2, 47, "foo"), with selected range on foreignComment from 1 to 3]
@@ -3867,13 +3294,7 @@
   [foreignComment.replaceData(foreignComment.length, 47, ""), with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.replaceData(1, 47, ""), with unselected range on foreignComment from 1 to 3]
-    expected: FAIL
-
   [foreignComment.replaceData(1, 47, ""), with selected range on foreignComment from 1 to 3]
-    expected: FAIL
-
-  [foreignComment.replaceData(2, 47, ""), with unselected range on foreignComment from 1 to 3]
     expected: FAIL
 
   [foreignComment.replaceData(2, 47, ""), with selected range on foreignComment from 1 to 3]
@@ -3894,13 +3315,7 @@
   [xmlComment.replaceData(xmlComment.length, 0, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.replaceData(1, 0, "foo"), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.replaceData(1, 0, "foo"), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.replaceData(2, 0, "foo"), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.replaceData(2, 0, "foo"), with selected range on xmlComment from 1 to 3]
@@ -3942,13 +3357,7 @@
   [xmlComment.replaceData(xmlComment.length, 1, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.replaceData(1, 1, "foo"), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.replaceData(1, 1, "foo"), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.replaceData(2, 1, "foo"), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.replaceData(2, 1, "foo"), with selected range on xmlComment from 1 to 3]
@@ -3969,13 +3378,7 @@
   [xmlComment.replaceData(xmlComment.length, 1, ""), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.replaceData(1, 1, ""), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.replaceData(1, 1, ""), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.replaceData(2, 1, ""), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.replaceData(2, 1, ""), with selected range on xmlComment from 1 to 3]
@@ -3996,13 +3399,7 @@
   [xmlComment.replaceData(xmlComment.length, 47, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.replaceData(1, 47, "foo"), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.replaceData(1, 47, "foo"), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.replaceData(2, 47, "foo"), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.replaceData(2, 47, "foo"), with selected range on xmlComment from 1 to 3]
@@ -4023,13 +3420,7 @@
   [xmlComment.replaceData(xmlComment.length, 47, ""), with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.replaceData(1, 47, ""), with unselected range on xmlComment from 1 to 3]
-    expected: FAIL
-
   [xmlComment.replaceData(1, 47, ""), with selected range on xmlComment from 1 to 3]
-    expected: FAIL
-
-  [xmlComment.replaceData(2, 47, ""), with unselected range on xmlComment from 1 to 3]
     expected: FAIL
 
   [xmlComment.replaceData(2, 47, ""), with selected range on xmlComment from 1 to 3]
@@ -4050,13 +3441,7 @@
   [detachedComment.replaceData(detachedComment.length, 0, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.replaceData(1, 0, "foo"), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.replaceData(1, 0, "foo"), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.replaceData(2, 0, "foo"), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.replaceData(2, 0, "foo"), with selected range on detachedComment from 1 to 3]
@@ -4098,13 +3483,7 @@
   [detachedComment.replaceData(detachedComment.length, 1, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.replaceData(1, 1, "foo"), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.replaceData(1, 1, "foo"), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.replaceData(2, 1, "foo"), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.replaceData(2, 1, "foo"), with selected range on detachedComment from 1 to 3]
@@ -4125,13 +3504,7 @@
   [detachedComment.replaceData(detachedComment.length, 1, ""), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.replaceData(1, 1, ""), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.replaceData(1, 1, ""), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.replaceData(2, 1, ""), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.replaceData(2, 1, ""), with selected range on detachedComment from 1 to 3]
@@ -4152,13 +3525,7 @@
   [detachedComment.replaceData(detachedComment.length, 47, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.replaceData(1, 47, "foo"), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.replaceData(1, 47, "foo"), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.replaceData(2, 47, "foo"), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.replaceData(2, 47, "foo"), with selected range on detachedComment from 1 to 3]
@@ -4179,13 +3546,7 @@
   [detachedComment.replaceData(detachedComment.length, 47, ""), with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.replaceData(1, 47, ""), with unselected range on detachedComment from 1 to 3]
-    expected: FAIL
-
   [detachedComment.replaceData(1, 47, ""), with selected range on detachedComment from 1 to 3]
-    expected: FAIL
-
-  [detachedComment.replaceData(2, 47, ""), with unselected range on detachedComment from 1 to 3]
     expected: FAIL
 
   [detachedComment.replaceData(2, 47, ""), with selected range on detachedComment from 1 to 3]
@@ -4206,13 +3567,7 @@
   [detachedForeignComment.replaceData(detachedForeignComment.length, 0, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.replaceData(1, 0, "foo"), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.replaceData(1, 0, "foo"), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.replaceData(2, 0, "foo"), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.replaceData(2, 0, "foo"), with selected range on detachedForeignComment from 1 to 3]
@@ -4254,13 +3609,7 @@
   [detachedForeignComment.replaceData(detachedForeignComment.length, 1, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.replaceData(1, 1, "foo"), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.replaceData(1, 1, "foo"), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.replaceData(2, 1, "foo"), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.replaceData(2, 1, "foo"), with selected range on detachedForeignComment from 1 to 3]
@@ -4281,13 +3630,7 @@
   [detachedForeignComment.replaceData(detachedForeignComment.length, 1, ""), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.replaceData(1, 1, ""), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.replaceData(1, 1, ""), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.replaceData(2, 1, ""), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.replaceData(2, 1, ""), with selected range on detachedForeignComment from 1 to 3]
@@ -4308,13 +3651,7 @@
   [detachedForeignComment.replaceData(detachedForeignComment.length, 47, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.replaceData(1, 47, "foo"), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.replaceData(1, 47, "foo"), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.replaceData(2, 47, "foo"), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.replaceData(2, 47, "foo"), with selected range on detachedForeignComment from 1 to 3]
@@ -4335,13 +3672,7 @@
   [detachedForeignComment.replaceData(detachedForeignComment.length, 47, ""), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.replaceData(1, 47, ""), with unselected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
   [detachedForeignComment.replaceData(1, 47, ""), with selected range on detachedForeignComment from 1 to 3]
-    expected: FAIL
-
-  [detachedForeignComment.replaceData(2, 47, ""), with unselected range on detachedForeignComment from 1 to 3]
     expected: FAIL
 
   [detachedForeignComment.replaceData(2, 47, ""), with selected range on detachedForeignComment from 1 to 3]
@@ -4362,13 +3693,7 @@
   [detachedXmlComment.replaceData(detachedXmlComment.length, 0, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.replaceData(1, 0, "foo"), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.replaceData(1, 0, "foo"), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.replaceData(2, 0, "foo"), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.replaceData(2, 0, "foo"), with selected range on detachedXmlComment from 1 to 3]
@@ -4410,13 +3735,7 @@
   [detachedXmlComment.replaceData(detachedXmlComment.length, 1, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.replaceData(1, 1, "foo"), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.replaceData(1, 1, "foo"), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.replaceData(2, 1, "foo"), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.replaceData(2, 1, "foo"), with selected range on detachedXmlComment from 1 to 3]
@@ -4437,13 +3756,7 @@
   [detachedXmlComment.replaceData(detachedXmlComment.length, 1, ""), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.replaceData(1, 1, ""), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.replaceData(1, 1, ""), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.replaceData(2, 1, ""), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.replaceData(2, 1, ""), with selected range on detachedXmlComment from 1 to 3]
@@ -4464,13 +3777,7 @@
   [detachedXmlComment.replaceData(detachedXmlComment.length, 47, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.replaceData(1, 47, "foo"), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.replaceData(1, 47, "foo"), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.replaceData(2, 47, "foo"), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.replaceData(2, 47, "foo"), with selected range on detachedXmlComment from 1 to 3]
@@ -4491,13 +3798,7 @@
   [detachedXmlComment.replaceData(detachedXmlComment.length, 47, ""), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.replaceData(1, 47, ""), with unselected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
   [detachedXmlComment.replaceData(1, 47, ""), with selected range on detachedXmlComment from 1 to 3]
-    expected: FAIL
-
-  [detachedXmlComment.replaceData(2, 47, ""), with unselected range on detachedXmlComment from 1 to 3]
     expected: FAIL
 
   [detachedXmlComment.replaceData(2, 47, ""), with selected range on detachedXmlComment from 1 to 3]
@@ -4524,13 +3825,7 @@
   [paras[0\].firstChild.replaceData(3, 0, "foo"), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 0, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 0, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 0, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 0, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
@@ -4557,13 +3852,7 @@
   [paras[0\].firstChild.replaceData(3, 1, "foo"), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 1, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 1, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 1, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 1, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
@@ -4590,13 +3879,7 @@
   [paras[0\].firstChild.replaceData(3, 47, "foo"), with selected range from (paras[0\].firstChild, 1) to (paras[0\], 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.replaceData(1, 47, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
   [paras[0\].firstChild.replaceData(1, 47, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
-    expected: FAIL
-
-  [paras[0\].firstChild.replaceData(2, 47, "foo"), with unselected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
     expected: FAIL
 
   [paras[0\].firstChild.replaceData(2, 47, "foo"), with selected range from (paras[0\], 0) to (paras[0\].firstChild, 3)]
@@ -4659,541 +3942,271 @@
   [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with selected range collapsed at (paras[0\].firstChild, 0)]
     expected: FAIL
 
-  [paras[0\].firstChild.data = "", with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.data = "", with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.data = "foo", with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.data = "foo", with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.data = paras[0\].firstChild.data, with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.data = paras[0\].firstChild.data, with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += "", with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.data += "", with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.data += "foo", with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.data += "foo", with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += paras[0\].firstChild.data, with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.data += paras[0\].firstChild.data, with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = "", with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = "", with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent = "foo", with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.textContent = "foo", with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += "", with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += "", with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent += "foo", with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent += "foo", with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = "", with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = "", with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue = "foo", with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue = "foo", with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += "", with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += "", with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue += "foo", with unselected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue += "foo", with selected range on paras[0\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with unselected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with selected range on paras[0\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[0\].firstChild.data = "", with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.data = "", with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.data = "foo", with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.data = "foo", with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.data = paras[0\].firstChild.data, with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.data = paras[0\].firstChild.data, with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += "", with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.data += "", with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.data += "foo", with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.data += "foo", with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += paras[0\].firstChild.data, with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.data += paras[0\].firstChild.data, with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = "", with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = "", with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent = "foo", with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.textContent = "foo", with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += "", with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += "", with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent += "foo", with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent += "foo", with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = "", with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = "", with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue = "foo", with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue = "foo", with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += "", with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += "", with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue += "foo", with unselected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue += "foo", with selected range collapsed at (paras[0\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with unselected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with selected range collapsed at (paras[0\].firstChild, 1)]
     expected: FAIL
 
-  [paras[0\].firstChild.data = "", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.data = "", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.data = "foo", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.data = "foo", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.data = paras[0\].firstChild.data, with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.data = paras[0\].firstChild.data, with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += "", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.data += "", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.data += "foo", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.data += "foo", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += paras[0\].firstChild.data, with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.data += paras[0\].firstChild.data, with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = "", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = "", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent = "foo", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.textContent = "foo", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += "", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += "", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent += "foo", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent += "foo", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = "", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = "", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue = "foo", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue = "foo", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += "", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += "", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue += "foo", with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue += "foo", with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with unselected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with selected range on paras[0\].firstChild from 0 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.data = "", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.data = "", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.data = "foo", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.data = "foo", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.data = paras[0\].firstChild.data, with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.data = paras[0\].firstChild.data, with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += "", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.data += "", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.data += "foo", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.data += "foo", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += paras[0\].firstChild.data, with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.data += paras[0\].firstChild.data, with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = "", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = "", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent = "foo", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.textContent = "foo", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += "", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += "", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent += "foo", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent += "foo", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = "", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = "", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue = "foo", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue = "foo", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += "", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += "", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue += "foo", with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue += "foo", with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with unselected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with selected range on paras[0\].firstChild from 1 to paras[0\].firstChild.length]
     expected: FAIL
 
-  [paras[0\].firstChild.data = "", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.data = "", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.data = "foo", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.data = "foo", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.data = paras[0\].firstChild.data, with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.data = paras[0\].firstChild.data, with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += "", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.data += "", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.data += "foo", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.data += "foo", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.data += paras[0\].firstChild.data, with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.data += paras[0\].firstChild.data, with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = "", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = "", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent = "foo", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.textContent = "foo", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent = paras[0\].firstChild.textContent, with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += "", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += "", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.textContent += "foo", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.textContent += "foo", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.textContent += paras[0\].firstChild.textContent, with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = "", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = "", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue = "foo", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue = "foo", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue = paras[0\].firstChild.nodeValue, with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += "", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += "", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
-  [paras[0\].firstChild.nodeValue += "foo", with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
   [paras[0\].firstChild.nodeValue += "foo", with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
-    expected: FAIL
-
-  [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with unselected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
     expected: FAIL
 
   [paras[0\].firstChild.nodeValue += paras[0\].firstChild.nodeValue, with selected range collapsed at (paras[0\].firstChild, paras[0\].firstChild.length)]
@@ -5253,541 +4266,271 @@
   [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with selected range collapsed at (paras[1\].firstChild, 0)]
     expected: FAIL
 
-  [paras[1\].firstChild.data = "", with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.data = "", with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.data = "foo", with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.data = "foo", with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.data = paras[1\].firstChild.data, with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.data = paras[1\].firstChild.data, with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += "", with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.data += "", with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.data += "foo", with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.data += "foo", with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += paras[1\].firstChild.data, with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.data += paras[1\].firstChild.data, with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = "", with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = "", with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent = "foo", with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.textContent = "foo", with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += "", with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += "", with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent += "foo", with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent += "foo", with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = "", with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = "", with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue = "foo", with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue = "foo", with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += "", with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += "", with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue += "foo", with unselected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue += "foo", with selected range on paras[1\].firstChild from 0 to 1]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with unselected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with selected range on paras[1\].firstChild from 0 to 1]
     expected: FAIL
 
-  [paras[1\].firstChild.data = "", with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.data = "", with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.data = "foo", with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.data = "foo", with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.data = paras[1\].firstChild.data, with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.data = paras[1\].firstChild.data, with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += "", with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.data += "", with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.data += "foo", with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.data += "foo", with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += paras[1\].firstChild.data, with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.data += paras[1\].firstChild.data, with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = "", with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = "", with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent = "foo", with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.textContent = "foo", with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += "", with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += "", with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent += "foo", with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent += "foo", with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = "", with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = "", with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue = "foo", with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue = "foo", with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += "", with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += "", with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue += "foo", with unselected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue += "foo", with selected range collapsed at (paras[1\].firstChild, 1)]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with unselected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with selected range collapsed at (paras[1\].firstChild, 1)]
     expected: FAIL
 
-  [paras[1\].firstChild.data = "", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.data = "", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.data = "foo", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.data = "foo", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.data = paras[1\].firstChild.data, with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.data = paras[1\].firstChild.data, with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += "", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.data += "", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.data += "foo", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.data += "foo", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += paras[1\].firstChild.data, with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.data += paras[1\].firstChild.data, with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = "", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = "", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent = "foo", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.textContent = "foo", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += "", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += "", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent += "foo", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent += "foo", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = "", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = "", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue = "foo", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue = "foo", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += "", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += "", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue += "foo", with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue += "foo", with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with unselected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with selected range on paras[1\].firstChild from 0 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.data = "", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.data = "", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.data = "foo", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.data = "foo", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.data = paras[1\].firstChild.data, with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.data = paras[1\].firstChild.data, with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += "", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.data += "", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.data += "foo", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.data += "foo", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += paras[1\].firstChild.data, with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.data += paras[1\].firstChild.data, with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = "", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = "", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent = "foo", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.textContent = "foo", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += "", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += "", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent += "foo", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent += "foo", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = "", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = "", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue = "foo", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue = "foo", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += "", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += "", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue += "foo", with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue += "foo", with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with unselected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with selected range on paras[1\].firstChild from 1 to paras[1\].firstChild.length]
     expected: FAIL
 
-  [paras[1\].firstChild.data = "", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.data = "", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.data = "foo", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.data = "foo", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.data = paras[1\].firstChild.data, with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.data = paras[1\].firstChild.data, with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += "", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.data += "", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.data += "foo", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.data += "foo", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.data += paras[1\].firstChild.data, with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.data += paras[1\].firstChild.data, with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = "", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = "", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent = "foo", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.textContent = "foo", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent = paras[1\].firstChild.textContent, with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += "", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += "", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.textContent += "foo", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.textContent += "foo", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.textContent += paras[1\].firstChild.textContent, with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = "", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = "", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue = "foo", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue = "foo", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue = paras[1\].firstChild.nodeValue, with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += "", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += "", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
-  [paras[1\].firstChild.nodeValue += "foo", with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
   [paras[1\].firstChild.nodeValue += "foo", with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
-    expected: FAIL
-
-  [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with unselected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
     expected: FAIL
 
   [paras[1\].firstChild.nodeValue += paras[1\].firstChild.nodeValue, with selected range collapsed at (paras[1\].firstChild, paras[1\].firstChild.length)]
@@ -5847,541 +4590,271 @@
   [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with selected range collapsed at (foreignTextNode, 0)]
     expected: FAIL
 
-  [foreignTextNode.data = "", with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.data = "", with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.data = "foo", with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.data = "foo", with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.data = foreignTextNode.data, with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.data = foreignTextNode.data, with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.data += "", with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.data += "", with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.data += "foo", with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.data += "foo", with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.data += foreignTextNode.data, with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.data += foreignTextNode.data, with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.textContent = "", with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.textContent = "", with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.textContent = "foo", with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.textContent = "foo", with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.textContent = foreignTextNode.textContent, with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.textContent = foreignTextNode.textContent, with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.textContent += "", with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.textContent += "", with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.textContent += "foo", with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.textContent += "foo", with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.textContent += foreignTextNode.textContent, with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.textContent += foreignTextNode.textContent, with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = "", with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = "", with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue = "foo", with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.nodeValue = "foo", with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += "", with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.nodeValue += "", with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.nodeValue += "foo", with unselected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
   [foreignTextNode.nodeValue += "foo", with selected range on foreignTextNode from 0 to 1]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with unselected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
   [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with selected range on foreignTextNode from 0 to 1]
     expected: FAIL
 
-  [foreignTextNode.data = "", with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.data = "", with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.data = "foo", with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.data = "foo", with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.data = foreignTextNode.data, with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.data = foreignTextNode.data, with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.data += "", with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.data += "", with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.data += "foo", with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.data += "foo", with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.data += foreignTextNode.data, with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.data += foreignTextNode.data, with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.textContent = "", with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.textContent = "", with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.textContent = "foo", with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.textContent = "foo", with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.textContent = foreignTextNode.textContent, with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.textContent = foreignTextNode.textContent, with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.textContent += "", with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.textContent += "", with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.textContent += "foo", with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.textContent += "foo", with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.textContent += foreignTextNode.textContent, with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.textContent += foreignTextNode.textContent, with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = "", with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = "", with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue = "foo", with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.nodeValue = "foo", with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += "", with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.nodeValue += "", with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.nodeValue += "foo", with unselected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
   [foreignTextNode.nodeValue += "foo", with selected range collapsed at (foreignTextNode, 1)]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with unselected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
   [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with selected range collapsed at (foreignTextNode, 1)]
     expected: FAIL
 
-  [foreignTextNode.data = "", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.data = "", with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.data = "foo", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.data = "foo", with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.data = foreignTextNode.data, with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.data = foreignTextNode.data, with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.data += "", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.data += "", with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.data += "foo", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.data += "foo", with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.data += foreignTextNode.data, with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.data += foreignTextNode.data, with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.textContent = "", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.textContent = "", with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.textContent = "foo", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.textContent = "foo", with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.textContent = foreignTextNode.textContent, with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.textContent = foreignTextNode.textContent, with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.textContent += "", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.textContent += "", with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.textContent += "foo", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.textContent += "foo", with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.textContent += foreignTextNode.textContent, with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.textContent += foreignTextNode.textContent, with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = "", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = "", with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue = "foo", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.nodeValue = "foo", with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += "", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.nodeValue += "", with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.nodeValue += "foo", with unselected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.nodeValue += "foo", with selected range on foreignTextNode from 0 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with unselected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with selected range on foreignTextNode from 0 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.data = "", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.data = "", with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.data = "foo", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.data = "foo", with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.data = foreignTextNode.data, with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.data = foreignTextNode.data, with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.data += "", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.data += "", with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.data += "foo", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.data += "foo", with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.data += foreignTextNode.data, with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.data += foreignTextNode.data, with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.textContent = "", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.textContent = "", with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.textContent = "foo", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.textContent = "foo", with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.textContent = foreignTextNode.textContent, with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.textContent = foreignTextNode.textContent, with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.textContent += "", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.textContent += "", with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.textContent += "foo", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.textContent += "foo", with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.textContent += foreignTextNode.textContent, with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.textContent += foreignTextNode.textContent, with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = "", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = "", with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue = "foo", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.nodeValue = "foo", with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += "", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.nodeValue += "", with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.nodeValue += "foo", with unselected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
   [foreignTextNode.nodeValue += "foo", with selected range on foreignTextNode from 1 to foreignTextNode.length]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with unselected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
   [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with selected range on foreignTextNode from 1 to foreignTextNode.length]
     expected: FAIL
 
-  [foreignTextNode.data = "", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.data = "", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.data = "foo", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.data = "foo", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.data = foreignTextNode.data, with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.data = foreignTextNode.data, with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.data += "", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.data += "", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.data += "foo", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.data += "foo", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.data += foreignTextNode.data, with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.data += foreignTextNode.data, with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.textContent = "", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.textContent = "", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.textContent = "foo", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.textContent = "foo", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.textContent = foreignTextNode.textContent, with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.textContent = foreignTextNode.textContent, with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.textContent += "", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.textContent += "", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.textContent += "foo", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.textContent += "foo", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.textContent += foreignTextNode.textContent, with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.textContent += foreignTextNode.textContent, with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = "", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = "", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue = "foo", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.nodeValue = "foo", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.nodeValue = foreignTextNode.nodeValue, with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += "", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.nodeValue += "", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
-  [foreignTextNode.nodeValue += "foo", with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
   [foreignTextNode.nodeValue += "foo", with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
-    expected: FAIL
-
-  [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with unselected range collapsed at (foreignTextNode, foreignTextNode.length)]
     expected: FAIL
 
   [foreignTextNode.nodeValue += foreignTextNode.nodeValue, with selected range collapsed at (foreignTextNode, foreignTextNode.length)]
@@ -6441,541 +4914,271 @@
   [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with selected range collapsed at (xmlTextNode, 0)]
     expected: FAIL
 
-  [xmlTextNode.data = "", with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.data = "", with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.data = "foo", with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.data = "foo", with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.data = xmlTextNode.data, with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.data = xmlTextNode.data, with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.data += "", with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.data += "", with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.data += "foo", with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.data += "foo", with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.data += xmlTextNode.data, with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.data += xmlTextNode.data, with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.textContent = "", with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.textContent = "", with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.textContent = "foo", with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.textContent = "foo", with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.textContent = xmlTextNode.textContent, with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.textContent = xmlTextNode.textContent, with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.textContent += "", with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.textContent += "", with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.textContent += "foo", with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.textContent += "foo", with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.textContent += xmlTextNode.textContent, with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.textContent += xmlTextNode.textContent, with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = "", with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = "", with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue = "foo", with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.nodeValue = "foo", with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += "", with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.nodeValue += "", with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.nodeValue += "foo", with unselected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
   [xmlTextNode.nodeValue += "foo", with selected range on xmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with unselected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
   [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with selected range on xmlTextNode from 0 to 1]
     expected: FAIL
 
-  [xmlTextNode.data = "", with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.data = "", with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.data = "foo", with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.data = "foo", with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.data = xmlTextNode.data, with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.data = xmlTextNode.data, with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.data += "", with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.data += "", with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.data += "foo", with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.data += "foo", with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.data += xmlTextNode.data, with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.data += xmlTextNode.data, with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.textContent = "", with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.textContent = "", with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.textContent = "foo", with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.textContent = "foo", with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.textContent = xmlTextNode.textContent, with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.textContent = xmlTextNode.textContent, with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.textContent += "", with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.textContent += "", with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.textContent += "foo", with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.textContent += "foo", with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.textContent += xmlTextNode.textContent, with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.textContent += xmlTextNode.textContent, with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = "", with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = "", with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue = "foo", with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.nodeValue = "foo", with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += "", with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.nodeValue += "", with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.nodeValue += "foo", with unselected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
   [xmlTextNode.nodeValue += "foo", with selected range collapsed at (xmlTextNode, 1)]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with unselected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
   [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with selected range collapsed at (xmlTextNode, 1)]
     expected: FAIL
 
-  [xmlTextNode.data = "", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.data = "", with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.data = "foo", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.data = "foo", with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.data = xmlTextNode.data, with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.data = xmlTextNode.data, with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.data += "", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.data += "", with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.data += "foo", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.data += "foo", with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.data += xmlTextNode.data, with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.data += xmlTextNode.data, with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.textContent = "", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.textContent = "", with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.textContent = "foo", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.textContent = "foo", with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.textContent = xmlTextNode.textContent, with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.textContent = xmlTextNode.textContent, with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.textContent += "", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.textContent += "", with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.textContent += "foo", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.textContent += "foo", with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.textContent += xmlTextNode.textContent, with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.textContent += xmlTextNode.textContent, with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = "", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = "", with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue = "foo", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.nodeValue = "foo", with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += "", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.nodeValue += "", with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.nodeValue += "foo", with unselected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.nodeValue += "foo", with selected range on xmlTextNode from 0 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with unselected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with selected range on xmlTextNode from 0 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.data = "", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.data = "", with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.data = "foo", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.data = "foo", with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.data = xmlTextNode.data, with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.data = xmlTextNode.data, with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.data += "", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.data += "", with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.data += "foo", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.data += "foo", with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.data += xmlTextNode.data, with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.data += xmlTextNode.data, with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.textContent = "", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.textContent = "", with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.textContent = "foo", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.textContent = "foo", with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.textContent = xmlTextNode.textContent, with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.textContent = xmlTextNode.textContent, with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.textContent += "", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.textContent += "", with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.textContent += "foo", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.textContent += "foo", with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.textContent += xmlTextNode.textContent, with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.textContent += xmlTextNode.textContent, with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = "", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = "", with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue = "foo", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.nodeValue = "foo", with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += "", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.nodeValue += "", with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.nodeValue += "foo", with unselected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
   [xmlTextNode.nodeValue += "foo", with selected range on xmlTextNode from 1 to xmlTextNode.length]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with unselected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
   [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with selected range on xmlTextNode from 1 to xmlTextNode.length]
     expected: FAIL
 
-  [xmlTextNode.data = "", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.data = "", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.data = "foo", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.data = "foo", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.data = xmlTextNode.data, with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.data = xmlTextNode.data, with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.data += "", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.data += "", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.data += "foo", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.data += "foo", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.data += xmlTextNode.data, with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.data += xmlTextNode.data, with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.textContent = "", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.textContent = "", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.textContent = "foo", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.textContent = "foo", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.textContent = xmlTextNode.textContent, with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.textContent = xmlTextNode.textContent, with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.textContent += "", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.textContent += "", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.textContent += "foo", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.textContent += "foo", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.textContent += xmlTextNode.textContent, with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.textContent += xmlTextNode.textContent, with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = "", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = "", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue = "foo", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.nodeValue = "foo", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.nodeValue = xmlTextNode.nodeValue, with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += "", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.nodeValue += "", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
-  [xmlTextNode.nodeValue += "foo", with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
   [xmlTextNode.nodeValue += "foo", with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
-    expected: FAIL
-
-  [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with unselected range collapsed at (xmlTextNode, xmlTextNode.length)]
     expected: FAIL
 
   [xmlTextNode.nodeValue += xmlTextNode.nodeValue, with selected range collapsed at (xmlTextNode, xmlTextNode.length)]
@@ -7035,541 +5238,271 @@
   [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with selected range collapsed at (detachedTextNode, 0)]
     expected: FAIL
 
-  [detachedTextNode.data = "", with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.data = "", with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.data = "foo", with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.data = "foo", with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.data = detachedTextNode.data, with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.data = detachedTextNode.data, with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.data += "", with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.data += "", with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.data += "foo", with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.data += "foo", with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.data += detachedTextNode.data, with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.data += detachedTextNode.data, with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.textContent = "", with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.textContent = "", with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.textContent = "foo", with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.textContent = "foo", with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.textContent = detachedTextNode.textContent, with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.textContent = detachedTextNode.textContent, with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.textContent += "", with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.textContent += "", with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.textContent += "foo", with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.textContent += "foo", with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.textContent += detachedTextNode.textContent, with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.textContent += detachedTextNode.textContent, with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = "", with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = "", with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue = "foo", with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.nodeValue = "foo", with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += "", with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.nodeValue += "", with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.nodeValue += "foo", with unselected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedTextNode.nodeValue += "foo", with selected range on detachedTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with unselected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
   [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with selected range on detachedTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedTextNode.data = "", with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.data = "", with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.data = "foo", with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.data = "foo", with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.data = detachedTextNode.data, with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.data = detachedTextNode.data, with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.data += "", with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.data += "", with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.data += "foo", with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.data += "foo", with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.data += detachedTextNode.data, with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.data += detachedTextNode.data, with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.textContent = "", with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.textContent = "", with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.textContent = "foo", with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.textContent = "foo", with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.textContent = detachedTextNode.textContent, with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.textContent = detachedTextNode.textContent, with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.textContent += "", with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.textContent += "", with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.textContent += "foo", with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.textContent += "foo", with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.textContent += detachedTextNode.textContent, with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.textContent += detachedTextNode.textContent, with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = "", with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = "", with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue = "foo", with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.nodeValue = "foo", with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += "", with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.nodeValue += "", with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.nodeValue += "foo", with unselected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
   [detachedTextNode.nodeValue += "foo", with selected range collapsed at (detachedTextNode, 1)]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with unselected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
   [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with selected range collapsed at (detachedTextNode, 1)]
     expected: FAIL
 
-  [detachedTextNode.data = "", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.data = "", with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.data = "foo", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.data = "foo", with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.data = detachedTextNode.data, with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.data = detachedTextNode.data, with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.data += "", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.data += "", with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.data += "foo", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.data += "foo", with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.data += detachedTextNode.data, with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.data += detachedTextNode.data, with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.textContent = "", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.textContent = "", with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.textContent = "foo", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.textContent = "foo", with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.textContent = detachedTextNode.textContent, with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.textContent = detachedTextNode.textContent, with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.textContent += "", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.textContent += "", with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.textContent += "foo", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.textContent += "foo", with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.textContent += detachedTextNode.textContent, with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.textContent += detachedTextNode.textContent, with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = "", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = "", with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue = "foo", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.nodeValue = "foo", with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += "", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.nodeValue += "", with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.nodeValue += "foo", with unselected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.nodeValue += "foo", with selected range on detachedTextNode from 0 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with unselected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with selected range on detachedTextNode from 0 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.data = "", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.data = "", with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.data = "foo", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.data = "foo", with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.data = detachedTextNode.data, with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.data = detachedTextNode.data, with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.data += "", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.data += "", with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.data += "foo", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.data += "foo", with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.data += detachedTextNode.data, with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.data += detachedTextNode.data, with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.textContent = "", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.textContent = "", with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.textContent = "foo", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.textContent = "foo", with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.textContent = detachedTextNode.textContent, with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.textContent = detachedTextNode.textContent, with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.textContent += "", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.textContent += "", with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.textContent += "foo", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.textContent += "foo", with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.textContent += detachedTextNode.textContent, with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.textContent += detachedTextNode.textContent, with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = "", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = "", with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue = "foo", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.nodeValue = "foo", with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += "", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.nodeValue += "", with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.nodeValue += "foo", with unselected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
   [detachedTextNode.nodeValue += "foo", with selected range on detachedTextNode from 1 to detachedTextNode.length]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with unselected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
   [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with selected range on detachedTextNode from 1 to detachedTextNode.length]
     expected: FAIL
 
-  [detachedTextNode.data = "", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.data = "", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.data = "foo", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.data = "foo", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.data = detachedTextNode.data, with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.data = detachedTextNode.data, with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.data += "", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.data += "", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.data += "foo", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.data += "foo", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.data += detachedTextNode.data, with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.data += detachedTextNode.data, with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.textContent = "", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.textContent = "", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.textContent = "foo", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.textContent = "foo", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.textContent = detachedTextNode.textContent, with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.textContent = detachedTextNode.textContent, with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.textContent += "", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.textContent += "", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.textContent += "foo", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.textContent += "foo", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.textContent += detachedTextNode.textContent, with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.textContent += detachedTextNode.textContent, with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = "", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = "", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue = "foo", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.nodeValue = "foo", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.nodeValue = detachedTextNode.nodeValue, with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += "", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.nodeValue += "", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
-  [detachedTextNode.nodeValue += "foo", with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
   [detachedTextNode.nodeValue += "foo", with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
-    expected: FAIL
-
-  [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with unselected range collapsed at (detachedTextNode, detachedTextNode.length)]
     expected: FAIL
 
   [detachedTextNode.nodeValue += detachedTextNode.nodeValue, with selected range collapsed at (detachedTextNode, detachedTextNode.length)]
@@ -7629,541 +5562,271 @@
   [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with selected range collapsed at (detachedForeignTextNode, 0)]
     expected: FAIL
 
-  [detachedForeignTextNode.data = "", with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.data = "", with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.data = "foo", with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.data = "foo", with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.data = detachedForeignTextNode.data, with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.data = detachedForeignTextNode.data, with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += "", with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.data += "", with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.data += "foo", with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.data += "foo", with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += detachedForeignTextNode.data, with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.data += detachedForeignTextNode.data, with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = "", with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = "", with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent = "foo", with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.textContent = "foo", with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += "", with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += "", with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent += "foo", with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent += "foo", with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = "", with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = "", with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue = "foo", with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue = "foo", with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += "", with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += "", with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue += "foo", with unselected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue += "foo", with selected range on detachedForeignTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with unselected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with selected range on detachedForeignTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedForeignTextNode.data = "", with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.data = "", with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.data = "foo", with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.data = "foo", with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.data = detachedForeignTextNode.data, with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.data = detachedForeignTextNode.data, with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += "", with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.data += "", with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.data += "foo", with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.data += "foo", with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += detachedForeignTextNode.data, with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.data += detachedForeignTextNode.data, with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = "", with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = "", with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent = "foo", with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.textContent = "foo", with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += "", with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += "", with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent += "foo", with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent += "foo", with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = "", with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = "", with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue = "foo", with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue = "foo", with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += "", with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += "", with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue += "foo", with unselected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue += "foo", with selected range collapsed at (detachedForeignTextNode, 1)]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with unselected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with selected range collapsed at (detachedForeignTextNode, 1)]
     expected: FAIL
 
-  [detachedForeignTextNode.data = "", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.data = "", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.data = "foo", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.data = "foo", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.data = detachedForeignTextNode.data, with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.data = detachedForeignTextNode.data, with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += "", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.data += "", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.data += "foo", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.data += "foo", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += detachedForeignTextNode.data, with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.data += detachedForeignTextNode.data, with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = "", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = "", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent = "foo", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.textContent = "foo", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += "", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += "", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent += "foo", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent += "foo", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = "", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = "", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue = "foo", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue = "foo", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += "", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += "", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue += "foo", with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue += "foo", with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with unselected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with selected range on detachedForeignTextNode from 0 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.data = "", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.data = "", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.data = "foo", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.data = "foo", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.data = detachedForeignTextNode.data, with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.data = detachedForeignTextNode.data, with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += "", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.data += "", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.data += "foo", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.data += "foo", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += detachedForeignTextNode.data, with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.data += detachedForeignTextNode.data, with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = "", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = "", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent = "foo", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.textContent = "foo", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += "", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += "", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent += "foo", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent += "foo", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = "", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = "", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue = "foo", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue = "foo", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += "", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += "", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue += "foo", with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue += "foo", with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with unselected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with selected range on detachedForeignTextNode from 1 to detachedForeignTextNode.length]
     expected: FAIL
 
-  [detachedForeignTextNode.data = "", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.data = "", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.data = "foo", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.data = "foo", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.data = detachedForeignTextNode.data, with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.data = detachedForeignTextNode.data, with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += "", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.data += "", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.data += "foo", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.data += "foo", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.data += detachedForeignTextNode.data, with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.data += detachedForeignTextNode.data, with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = "", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = "", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent = "foo", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.textContent = "foo", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent = detachedForeignTextNode.textContent, with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += "", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += "", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.textContent += "foo", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.textContent += "foo", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.textContent += detachedForeignTextNode.textContent, with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = "", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = "", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue = "foo", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue = "foo", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue = detachedForeignTextNode.nodeValue, with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += "", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += "", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
-  [detachedForeignTextNode.nodeValue += "foo", with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
   [detachedForeignTextNode.nodeValue += "foo", with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
-    expected: FAIL
-
-  [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
     expected: FAIL
 
   [detachedForeignTextNode.nodeValue += detachedForeignTextNode.nodeValue, with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)]
@@ -8223,541 +5886,271 @@
   [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with selected range collapsed at (detachedXmlTextNode, 0)]
     expected: FAIL
 
-  [detachedXmlTextNode.data = "", with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.data = "", with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.data = "foo", with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.data = "foo", with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.data = detachedXmlTextNode.data, with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.data = detachedXmlTextNode.data, with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += "", with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.data += "", with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.data += "foo", with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.data += "foo", with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += detachedXmlTextNode.data, with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.data += detachedXmlTextNode.data, with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = "", with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = "", with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent = "foo", with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.textContent = "foo", with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += "", with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += "", with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent += "foo", with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent += "foo", with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = "", with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = "", with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue = "foo", with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue = "foo", with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += "", with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += "", with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue += "foo", with unselected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue += "foo", with selected range on detachedXmlTextNode from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with unselected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with selected range on detachedXmlTextNode from 0 to 1]
     expected: FAIL
 
-  [detachedXmlTextNode.data = "", with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.data = "", with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.data = "foo", with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.data = "foo", with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.data = detachedXmlTextNode.data, with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.data = detachedXmlTextNode.data, with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += "", with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.data += "", with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.data += "foo", with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.data += "foo", with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += detachedXmlTextNode.data, with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.data += detachedXmlTextNode.data, with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = "", with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = "", with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent = "foo", with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.textContent = "foo", with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += "", with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += "", with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent += "foo", with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent += "foo", with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = "", with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = "", with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue = "foo", with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue = "foo", with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += "", with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += "", with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue += "foo", with unselected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue += "foo", with selected range collapsed at (detachedXmlTextNode, 1)]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with unselected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with selected range collapsed at (detachedXmlTextNode, 1)]
     expected: FAIL
 
-  [detachedXmlTextNode.data = "", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.data = "", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.data = "foo", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.data = "foo", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.data = detachedXmlTextNode.data, with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.data = detachedXmlTextNode.data, with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += "", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.data += "", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.data += "foo", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.data += "foo", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += detachedXmlTextNode.data, with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.data += detachedXmlTextNode.data, with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = "", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = "", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent = "foo", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.textContent = "foo", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += "", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += "", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent += "foo", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent += "foo", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = "", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = "", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue = "foo", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue = "foo", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += "", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += "", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue += "foo", with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue += "foo", with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with unselected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with selected range on detachedXmlTextNode from 0 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.data = "", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.data = "", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.data = "foo", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.data = "foo", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.data = detachedXmlTextNode.data, with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.data = detachedXmlTextNode.data, with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += "", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.data += "", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.data += "foo", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.data += "foo", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += detachedXmlTextNode.data, with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.data += detachedXmlTextNode.data, with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = "", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = "", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent = "foo", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.textContent = "foo", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += "", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += "", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent += "foo", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent += "foo", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = "", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = "", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue = "foo", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue = "foo", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += "", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += "", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue += "foo", with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue += "foo", with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with unselected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with selected range on detachedXmlTextNode from 1 to detachedXmlTextNode.length]
     expected: FAIL
 
-  [detachedXmlTextNode.data = "", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.data = "", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.data = "foo", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.data = "foo", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.data = detachedXmlTextNode.data, with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.data = detachedXmlTextNode.data, with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += "", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.data += "", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.data += "foo", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.data += "foo", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.data += detachedXmlTextNode.data, with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.data += detachedXmlTextNode.data, with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = "", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = "", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent = "foo", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.textContent = "foo", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent = detachedXmlTextNode.textContent, with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += "", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += "", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.textContent += "foo", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.textContent += "foo", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.textContent += detachedXmlTextNode.textContent, with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = "", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = "", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue = "foo", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue = "foo", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue = detachedXmlTextNode.nodeValue, with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += "", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += "", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
-  [detachedXmlTextNode.nodeValue += "foo", with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
   [detachedXmlTextNode.nodeValue += "foo", with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
-    expected: FAIL
-
-  [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
     expected: FAIL
 
   [detachedXmlTextNode.nodeValue += detachedXmlTextNode.nodeValue, with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)]
@@ -8817,541 +6210,271 @@
   [comment.nodeValue += comment.nodeValue, with selected range collapsed at (comment, 0)]
     expected: FAIL
 
-  [comment.data = "", with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.data = "", with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.data = "foo", with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.data = "foo", with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.data = comment.data, with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.data = comment.data, with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.data += "", with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.data += "", with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.data += "foo", with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.data += "foo", with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.data += comment.data, with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.data += comment.data, with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.textContent = "", with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.textContent = "", with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.textContent = "foo", with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.textContent = "foo", with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.textContent = comment.textContent, with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.textContent = comment.textContent, with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.textContent += "", with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.textContent += "", with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.textContent += "foo", with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.textContent += "foo", with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.textContent += comment.textContent, with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.textContent += comment.textContent, with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.nodeValue = "", with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.nodeValue = "", with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.nodeValue = "foo", with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.nodeValue = "foo", with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.nodeValue = comment.nodeValue, with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.nodeValue = comment.nodeValue, with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.nodeValue += "", with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.nodeValue += "", with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.nodeValue += "foo", with unselected range on comment from 0 to 1]
-    expected: FAIL
-
   [comment.nodeValue += "foo", with selected range on comment from 0 to 1]
-    expected: FAIL
-
-  [comment.nodeValue += comment.nodeValue, with unselected range on comment from 0 to 1]
     expected: FAIL
 
   [comment.nodeValue += comment.nodeValue, with selected range on comment from 0 to 1]
     expected: FAIL
 
-  [comment.data = "", with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.data = "", with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.data = "foo", with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.data = "foo", with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.data = comment.data, with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.data = comment.data, with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.data += "", with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.data += "", with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.data += "foo", with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.data += "foo", with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.data += comment.data, with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.data += comment.data, with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.textContent = "", with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.textContent = "", with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.textContent = "foo", with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.textContent = "foo", with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.textContent = comment.textContent, with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.textContent = comment.textContent, with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.textContent += "", with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.textContent += "", with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.textContent += "foo", with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.textContent += "foo", with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.textContent += comment.textContent, with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.textContent += comment.textContent, with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.nodeValue = "", with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.nodeValue = "", with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.nodeValue = "foo", with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.nodeValue = "foo", with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.nodeValue = comment.nodeValue, with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.nodeValue = comment.nodeValue, with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.nodeValue += "", with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.nodeValue += "", with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.nodeValue += "foo", with unselected range collapsed at (comment, 1)]
-    expected: FAIL
-
   [comment.nodeValue += "foo", with selected range collapsed at (comment, 1)]
-    expected: FAIL
-
-  [comment.nodeValue += comment.nodeValue, with unselected range collapsed at (comment, 1)]
     expected: FAIL
 
   [comment.nodeValue += comment.nodeValue, with selected range collapsed at (comment, 1)]
     expected: FAIL
 
-  [comment.data = "", with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.data = "", with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.data = "foo", with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.data = "foo", with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.data = comment.data, with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.data = comment.data, with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.data += "", with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.data += "", with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.data += "foo", with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.data += "foo", with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.data += comment.data, with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.data += comment.data, with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.textContent = "", with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.textContent = "", with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.textContent = "foo", with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.textContent = "foo", with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.textContent = comment.textContent, with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.textContent = comment.textContent, with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.textContent += "", with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.textContent += "", with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.textContent += "foo", with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.textContent += "foo", with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.textContent += comment.textContent, with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.textContent += comment.textContent, with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.nodeValue = "", with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.nodeValue = "", with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.nodeValue = "foo", with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.nodeValue = "foo", with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.nodeValue = comment.nodeValue, with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.nodeValue = comment.nodeValue, with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.nodeValue += "", with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.nodeValue += "", with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.nodeValue += "foo", with unselected range on comment from 0 to comment.length]
-    expected: FAIL
-
   [comment.nodeValue += "foo", with selected range on comment from 0 to comment.length]
-    expected: FAIL
-
-  [comment.nodeValue += comment.nodeValue, with unselected range on comment from 0 to comment.length]
     expected: FAIL
 
   [comment.nodeValue += comment.nodeValue, with selected range on comment from 0 to comment.length]
     expected: FAIL
 
-  [comment.data = "", with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.data = "", with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.data = "foo", with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.data = "foo", with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.data = comment.data, with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.data = comment.data, with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.data += "", with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.data += "", with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.data += "foo", with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.data += "foo", with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.data += comment.data, with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.data += comment.data, with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.textContent = "", with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.textContent = "", with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.textContent = "foo", with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.textContent = "foo", with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.textContent = comment.textContent, with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.textContent = comment.textContent, with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.textContent += "", with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.textContent += "", with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.textContent += "foo", with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.textContent += "foo", with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.textContent += comment.textContent, with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.textContent += comment.textContent, with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.nodeValue = "", with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.nodeValue = "", with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.nodeValue = "foo", with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.nodeValue = "foo", with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.nodeValue = comment.nodeValue, with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.nodeValue = comment.nodeValue, with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.nodeValue += "", with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.nodeValue += "", with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.nodeValue += "foo", with unselected range on comment from 1 to comment.length]
-    expected: FAIL
-
   [comment.nodeValue += "foo", with selected range on comment from 1 to comment.length]
-    expected: FAIL
-
-  [comment.nodeValue += comment.nodeValue, with unselected range on comment from 1 to comment.length]
     expected: FAIL
 
   [comment.nodeValue += comment.nodeValue, with selected range on comment from 1 to comment.length]
     expected: FAIL
 
-  [comment.data = "", with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.data = "", with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.data = "foo", with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.data = "foo", with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.data = comment.data, with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.data = comment.data, with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.data += "", with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.data += "", with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.data += "foo", with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.data += "foo", with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.data += comment.data, with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.data += comment.data, with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.textContent = "", with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.textContent = "", with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.textContent = "foo", with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.textContent = "foo", with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.textContent = comment.textContent, with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.textContent = comment.textContent, with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.textContent += "", with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.textContent += "", with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.textContent += "foo", with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.textContent += "foo", with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.textContent += comment.textContent, with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.textContent += comment.textContent, with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.nodeValue = "", with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.nodeValue = "", with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.nodeValue = "foo", with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.nodeValue = "foo", with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.nodeValue = comment.nodeValue, with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.nodeValue = comment.nodeValue, with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.nodeValue += "", with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.nodeValue += "", with selected range collapsed at (comment, comment.length)]
     expected: FAIL
 
-  [comment.nodeValue += "foo", with unselected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
   [comment.nodeValue += "foo", with selected range collapsed at (comment, comment.length)]
-    expected: FAIL
-
-  [comment.nodeValue += comment.nodeValue, with unselected range collapsed at (comment, comment.length)]
     expected: FAIL
 
   [comment.nodeValue += comment.nodeValue, with selected range collapsed at (comment, comment.length)]
@@ -9411,541 +6534,271 @@
   [foreignComment.nodeValue += foreignComment.nodeValue, with selected range collapsed at (foreignComment, 0)]
     expected: FAIL
 
-  [foreignComment.data = "", with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.data = "", with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.data = "foo", with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.data = "foo", with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.data = foreignComment.data, with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.data = foreignComment.data, with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.data += "", with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.data += "", with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.data += "foo", with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.data += "foo", with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.data += foreignComment.data, with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.data += foreignComment.data, with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.textContent = "", with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.textContent = "", with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.textContent = "foo", with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.textContent = "foo", with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.textContent = foreignComment.textContent, with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.textContent = foreignComment.textContent, with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.textContent += "", with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.textContent += "", with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.textContent += "foo", with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.textContent += "foo", with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.textContent += foreignComment.textContent, with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.textContent += foreignComment.textContent, with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.nodeValue = "", with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.nodeValue = "", with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.nodeValue = "foo", with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.nodeValue = "foo", with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.nodeValue = foreignComment.nodeValue, with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.nodeValue = foreignComment.nodeValue, with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.nodeValue += "", with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.nodeValue += "", with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.nodeValue += "foo", with unselected range on foreignComment from 0 to 1]
-    expected: FAIL
-
   [foreignComment.nodeValue += "foo", with selected range on foreignComment from 0 to 1]
-    expected: FAIL
-
-  [foreignComment.nodeValue += foreignComment.nodeValue, with unselected range on foreignComment from 0 to 1]
     expected: FAIL
 
   [foreignComment.nodeValue += foreignComment.nodeValue, with selected range on foreignComment from 0 to 1]
     expected: FAIL
 
-  [foreignComment.data = "", with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.data = "", with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.data = "foo", with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.data = "foo", with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.data = foreignComment.data, with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.data = foreignComment.data, with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.data += "", with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.data += "", with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.data += "foo", with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.data += "foo", with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.data += foreignComment.data, with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.data += foreignComment.data, with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.textContent = "", with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.textContent = "", with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.textContent = "foo", with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.textContent = "foo", with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.textContent = foreignComment.textContent, with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.textContent = foreignComment.textContent, with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.textContent += "", with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.textContent += "", with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.textContent += "foo", with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.textContent += "foo", with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.textContent += foreignComment.textContent, with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.textContent += foreignComment.textContent, with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.nodeValue = "", with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.nodeValue = "", with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.nodeValue = "foo", with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.nodeValue = "foo", with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.nodeValue = foreignComment.nodeValue, with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.nodeValue = foreignComment.nodeValue, with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.nodeValue += "", with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.nodeValue += "", with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.nodeValue += "foo", with unselected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
   [foreignComment.nodeValue += "foo", with selected range collapsed at (foreignComment, 1)]
-    expected: FAIL
-
-  [foreignComment.nodeValue += foreignComment.nodeValue, with unselected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
   [foreignComment.nodeValue += foreignComment.nodeValue, with selected range collapsed at (foreignComment, 1)]
     expected: FAIL
 
-  [foreignComment.data = "", with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.data = "", with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.data = "foo", with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.data = "foo", with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.data = foreignComment.data, with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.data = foreignComment.data, with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.data += "", with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.data += "", with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.data += "foo", with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.data += "foo", with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.data += foreignComment.data, with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.data += foreignComment.data, with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.textContent = "", with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.textContent = "", with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.textContent = "foo", with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.textContent = "foo", with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.textContent = foreignComment.textContent, with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.textContent = foreignComment.textContent, with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.textContent += "", with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.textContent += "", with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.textContent += "foo", with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.textContent += "foo", with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.textContent += foreignComment.textContent, with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.textContent += foreignComment.textContent, with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.nodeValue = "", with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.nodeValue = "", with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.nodeValue = "foo", with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.nodeValue = "foo", with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.nodeValue = foreignComment.nodeValue, with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.nodeValue = foreignComment.nodeValue, with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.nodeValue += "", with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.nodeValue += "", with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.nodeValue += "foo", with unselected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.nodeValue += "foo", with selected range on foreignComment from 0 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.nodeValue += foreignComment.nodeValue, with unselected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.nodeValue += foreignComment.nodeValue, with selected range on foreignComment from 0 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.data = "", with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.data = "", with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.data = "foo", with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.data = "foo", with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.data = foreignComment.data, with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.data = foreignComment.data, with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.data += "", with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.data += "", with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.data += "foo", with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.data += "foo", with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.data += foreignComment.data, with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.data += foreignComment.data, with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.textContent = "", with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.textContent = "", with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.textContent = "foo", with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.textContent = "foo", with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.textContent = foreignComment.textContent, with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.textContent = foreignComment.textContent, with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.textContent += "", with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.textContent += "", with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.textContent += "foo", with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.textContent += "foo", with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.textContent += foreignComment.textContent, with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.textContent += foreignComment.textContent, with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.nodeValue = "", with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.nodeValue = "", with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.nodeValue = "foo", with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.nodeValue = "foo", with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.nodeValue = foreignComment.nodeValue, with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.nodeValue = foreignComment.nodeValue, with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.nodeValue += "", with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.nodeValue += "", with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.nodeValue += "foo", with unselected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
   [foreignComment.nodeValue += "foo", with selected range on foreignComment from 1 to foreignComment.length]
-    expected: FAIL
-
-  [foreignComment.nodeValue += foreignComment.nodeValue, with unselected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
   [foreignComment.nodeValue += foreignComment.nodeValue, with selected range on foreignComment from 1 to foreignComment.length]
     expected: FAIL
 
-  [foreignComment.data = "", with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.data = "", with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.data = "foo", with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.data = "foo", with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.data = foreignComment.data, with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.data = foreignComment.data, with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.data += "", with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.data += "", with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.data += "foo", with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.data += "foo", with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.data += foreignComment.data, with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.data += foreignComment.data, with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.textContent = "", with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.textContent = "", with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.textContent = "foo", with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.textContent = "foo", with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.textContent = foreignComment.textContent, with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.textContent = foreignComment.textContent, with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.textContent += "", with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.textContent += "", with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.textContent += "foo", with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.textContent += "foo", with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.textContent += foreignComment.textContent, with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.textContent += foreignComment.textContent, with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.nodeValue = "", with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.nodeValue = "", with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.nodeValue = "foo", with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.nodeValue = "foo", with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.nodeValue = foreignComment.nodeValue, with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.nodeValue = foreignComment.nodeValue, with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.nodeValue += "", with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.nodeValue += "", with selected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
-  [foreignComment.nodeValue += "foo", with unselected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
   [foreignComment.nodeValue += "foo", with selected range collapsed at (foreignComment, foreignComment.length)]
-    expected: FAIL
-
-  [foreignComment.nodeValue += foreignComment.nodeValue, with unselected range collapsed at (foreignComment, foreignComment.length)]
     expected: FAIL
 
   [foreignComment.nodeValue += foreignComment.nodeValue, with selected range collapsed at (foreignComment, foreignComment.length)]
@@ -10005,541 +6858,271 @@
   [xmlComment.nodeValue += xmlComment.nodeValue, with selected range collapsed at (xmlComment, 0)]
     expected: FAIL
 
-  [xmlComment.data = "", with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.data = "", with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.data = "foo", with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.data = "foo", with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.data = xmlComment.data, with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.data = xmlComment.data, with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.data += "", with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.data += "", with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.data += "foo", with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.data += "foo", with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.data += xmlComment.data, with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.data += xmlComment.data, with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.textContent = "", with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.textContent = "", with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.textContent = "foo", with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.textContent = "foo", with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.textContent = xmlComment.textContent, with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.textContent = xmlComment.textContent, with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.textContent += "", with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.textContent += "", with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.textContent += "foo", with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.textContent += "foo", with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.textContent += xmlComment.textContent, with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.textContent += xmlComment.textContent, with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.nodeValue = "", with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.nodeValue = "", with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.nodeValue = "foo", with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.nodeValue = "foo", with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.nodeValue = xmlComment.nodeValue, with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.nodeValue = xmlComment.nodeValue, with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.nodeValue += "", with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.nodeValue += "", with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.nodeValue += "foo", with unselected range on xmlComment from 0 to 1]
-    expected: FAIL
-
   [xmlComment.nodeValue += "foo", with selected range on xmlComment from 0 to 1]
-    expected: FAIL
-
-  [xmlComment.nodeValue += xmlComment.nodeValue, with unselected range on xmlComment from 0 to 1]
     expected: FAIL
 
   [xmlComment.nodeValue += xmlComment.nodeValue, with selected range on xmlComment from 0 to 1]
     expected: FAIL
 
-  [xmlComment.data = "", with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.data = "", with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.data = "foo", with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.data = "foo", with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.data = xmlComment.data, with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.data = xmlComment.data, with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.data += "", with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.data += "", with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.data += "foo", with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.data += "foo", with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.data += xmlComment.data, with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.data += xmlComment.data, with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.textContent = "", with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.textContent = "", with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.textContent = "foo", with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.textContent = "foo", with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.textContent = xmlComment.textContent, with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.textContent = xmlComment.textContent, with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.textContent += "", with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.textContent += "", with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.textContent += "foo", with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.textContent += "foo", with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.textContent += xmlComment.textContent, with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.textContent += xmlComment.textContent, with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.nodeValue = "", with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.nodeValue = "", with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.nodeValue = "foo", with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.nodeValue = "foo", with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.nodeValue = xmlComment.nodeValue, with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.nodeValue = xmlComment.nodeValue, with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.nodeValue += "", with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.nodeValue += "", with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.nodeValue += "foo", with unselected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
   [xmlComment.nodeValue += "foo", with selected range collapsed at (xmlComment, 1)]
-    expected: FAIL
-
-  [xmlComment.nodeValue += xmlComment.nodeValue, with unselected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
   [xmlComment.nodeValue += xmlComment.nodeValue, with selected range collapsed at (xmlComment, 1)]
     expected: FAIL
 
-  [xmlComment.data = "", with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.data = "", with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.data = "foo", with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.data = "foo", with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.data = xmlComment.data, with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.data = xmlComment.data, with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.data += "", with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.data += "", with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.data += "foo", with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.data += "foo", with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.data += xmlComment.data, with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.data += xmlComment.data, with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.textContent = "", with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.textContent = "", with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.textContent = "foo", with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.textContent = "foo", with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.textContent = xmlComment.textContent, with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.textContent = xmlComment.textContent, with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.textContent += "", with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.textContent += "", with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.textContent += "foo", with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.textContent += "foo", with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.textContent += xmlComment.textContent, with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.textContent += xmlComment.textContent, with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.nodeValue = "", with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.nodeValue = "", with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.nodeValue = "foo", with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.nodeValue = "foo", with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.nodeValue = xmlComment.nodeValue, with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.nodeValue = xmlComment.nodeValue, with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.nodeValue += "", with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.nodeValue += "", with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.nodeValue += "foo", with unselected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.nodeValue += "foo", with selected range on xmlComment from 0 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.nodeValue += xmlComment.nodeValue, with unselected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.nodeValue += xmlComment.nodeValue, with selected range on xmlComment from 0 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.data = "", with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.data = "", with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.data = "foo", with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.data = "foo", with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.data = xmlComment.data, with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.data = xmlComment.data, with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.data += "", with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.data += "", with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.data += "foo", with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.data += "foo", with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.data += xmlComment.data, with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.data += xmlComment.data, with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.textContent = "", with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.textContent = "", with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.textContent = "foo", with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.textContent = "foo", with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.textContent = xmlComment.textContent, with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.textContent = xmlComment.textContent, with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.textContent += "", with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.textContent += "", with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.textContent += "foo", with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.textContent += "foo", with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.textContent += xmlComment.textContent, with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.textContent += xmlComment.textContent, with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.nodeValue = "", with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.nodeValue = "", with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.nodeValue = "foo", with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.nodeValue = "foo", with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.nodeValue = xmlComment.nodeValue, with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.nodeValue = xmlComment.nodeValue, with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.nodeValue += "", with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.nodeValue += "", with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.nodeValue += "foo", with unselected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
   [xmlComment.nodeValue += "foo", with selected range on xmlComment from 1 to xmlComment.length]
-    expected: FAIL
-
-  [xmlComment.nodeValue += xmlComment.nodeValue, with unselected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
   [xmlComment.nodeValue += xmlComment.nodeValue, with selected range on xmlComment from 1 to xmlComment.length]
     expected: FAIL
 
-  [xmlComment.data = "", with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.data = "", with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.data = "foo", with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.data = "foo", with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.data = xmlComment.data, with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.data = xmlComment.data, with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.data += "", with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.data += "", with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.data += "foo", with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.data += "foo", with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.data += xmlComment.data, with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.data += xmlComment.data, with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.textContent = "", with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.textContent = "", with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.textContent = "foo", with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.textContent = "foo", with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.textContent = xmlComment.textContent, with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.textContent = xmlComment.textContent, with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.textContent += "", with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.textContent += "", with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.textContent += "foo", with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.textContent += "foo", with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.textContent += xmlComment.textContent, with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.textContent += xmlComment.textContent, with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.nodeValue = "", with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.nodeValue = "", with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.nodeValue = "foo", with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.nodeValue = "foo", with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.nodeValue = xmlComment.nodeValue, with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.nodeValue = xmlComment.nodeValue, with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.nodeValue += "", with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.nodeValue += "", with selected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
-  [xmlComment.nodeValue += "foo", with unselected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
   [xmlComment.nodeValue += "foo", with selected range collapsed at (xmlComment, xmlComment.length)]
-    expected: FAIL
-
-  [xmlComment.nodeValue += xmlComment.nodeValue, with unselected range collapsed at (xmlComment, xmlComment.length)]
     expected: FAIL
 
   [xmlComment.nodeValue += xmlComment.nodeValue, with selected range collapsed at (xmlComment, xmlComment.length)]
@@ -10599,541 +7182,271 @@
   [detachedComment.nodeValue += detachedComment.nodeValue, with selected range collapsed at (detachedComment, 0)]
     expected: FAIL
 
-  [detachedComment.data = "", with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.data = "", with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.data = "foo", with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.data = "foo", with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.data = detachedComment.data, with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.data = detachedComment.data, with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.data += "", with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.data += "", with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.data += "foo", with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.data += "foo", with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.data += detachedComment.data, with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.data += detachedComment.data, with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.textContent = "", with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.textContent = "", with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.textContent = "foo", with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.textContent = "foo", with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.textContent = detachedComment.textContent, with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.textContent = detachedComment.textContent, with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.textContent += "", with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.textContent += "", with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.textContent += "foo", with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.textContent += "foo", with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.textContent += detachedComment.textContent, with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.textContent += detachedComment.textContent, with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.nodeValue = "", with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.nodeValue = "", with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.nodeValue = "foo", with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.nodeValue = "foo", with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.nodeValue = detachedComment.nodeValue, with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.nodeValue = detachedComment.nodeValue, with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.nodeValue += "", with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.nodeValue += "", with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.nodeValue += "foo", with unselected range on detachedComment from 0 to 1]
-    expected: FAIL
-
   [detachedComment.nodeValue += "foo", with selected range on detachedComment from 0 to 1]
-    expected: FAIL
-
-  [detachedComment.nodeValue += detachedComment.nodeValue, with unselected range on detachedComment from 0 to 1]
     expected: FAIL
 
   [detachedComment.nodeValue += detachedComment.nodeValue, with selected range on detachedComment from 0 to 1]
     expected: FAIL
 
-  [detachedComment.data = "", with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.data = "", with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.data = "foo", with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.data = "foo", with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.data = detachedComment.data, with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.data = detachedComment.data, with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.data += "", with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.data += "", with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.data += "foo", with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.data += "foo", with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.data += detachedComment.data, with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.data += detachedComment.data, with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.textContent = "", with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.textContent = "", with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.textContent = "foo", with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.textContent = "foo", with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.textContent = detachedComment.textContent, with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.textContent = detachedComment.textContent, with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.textContent += "", with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.textContent += "", with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.textContent += "foo", with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.textContent += "foo", with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.textContent += detachedComment.textContent, with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.textContent += detachedComment.textContent, with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.nodeValue = "", with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.nodeValue = "", with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.nodeValue = "foo", with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.nodeValue = "foo", with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.nodeValue = detachedComment.nodeValue, with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.nodeValue = detachedComment.nodeValue, with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.nodeValue += "", with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.nodeValue += "", with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.nodeValue += "foo", with unselected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
   [detachedComment.nodeValue += "foo", with selected range collapsed at (detachedComment, 1)]
-    expected: FAIL
-
-  [detachedComment.nodeValue += detachedComment.nodeValue, with unselected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
   [detachedComment.nodeValue += detachedComment.nodeValue, with selected range collapsed at (detachedComment, 1)]
     expected: FAIL
 
-  [detachedComment.data = "", with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.data = "", with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.data = "foo", with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.data = "foo", with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.data = detachedComment.data, with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.data = detachedComment.data, with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.data += "", with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.data += "", with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.data += "foo", with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.data += "foo", with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.data += detachedComment.data, with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.data += detachedComment.data, with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.textContent = "", with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.textContent = "", with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.textContent = "foo", with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.textContent = "foo", with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.textContent = detachedComment.textContent, with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.textContent = detachedComment.textContent, with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.textContent += "", with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.textContent += "", with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.textContent += "foo", with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.textContent += "foo", with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.textContent += detachedComment.textContent, with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.textContent += detachedComment.textContent, with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.nodeValue = "", with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.nodeValue = "", with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.nodeValue = "foo", with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.nodeValue = "foo", with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.nodeValue = detachedComment.nodeValue, with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.nodeValue = detachedComment.nodeValue, with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.nodeValue += "", with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.nodeValue += "", with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.nodeValue += "foo", with unselected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.nodeValue += "foo", with selected range on detachedComment from 0 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.nodeValue += detachedComment.nodeValue, with unselected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.nodeValue += detachedComment.nodeValue, with selected range on detachedComment from 0 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.data = "", with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.data = "", with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.data = "foo", with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.data = "foo", with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.data = detachedComment.data, with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.data = detachedComment.data, with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.data += "", with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.data += "", with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.data += "foo", with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.data += "foo", with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.data += detachedComment.data, with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.data += detachedComment.data, with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.textContent = "", with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.textContent = "", with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.textContent = "foo", with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.textContent = "foo", with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.textContent = detachedComment.textContent, with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.textContent = detachedComment.textContent, with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.textContent += "", with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.textContent += "", with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.textContent += "foo", with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.textContent += "foo", with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.textContent += detachedComment.textContent, with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.textContent += detachedComment.textContent, with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.nodeValue = "", with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.nodeValue = "", with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.nodeValue = "foo", with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.nodeValue = "foo", with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.nodeValue = detachedComment.nodeValue, with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.nodeValue = detachedComment.nodeValue, with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.nodeValue += "", with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.nodeValue += "", with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.nodeValue += "foo", with unselected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
   [detachedComment.nodeValue += "foo", with selected range on detachedComment from 1 to detachedComment.length]
-    expected: FAIL
-
-  [detachedComment.nodeValue += detachedComment.nodeValue, with unselected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
   [detachedComment.nodeValue += detachedComment.nodeValue, with selected range on detachedComment from 1 to detachedComment.length]
     expected: FAIL
 
-  [detachedComment.data = "", with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.data = "", with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.data = "foo", with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.data = "foo", with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.data = detachedComment.data, with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.data = detachedComment.data, with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.data += "", with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.data += "", with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.data += "foo", with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.data += "foo", with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.data += detachedComment.data, with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.data += detachedComment.data, with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.textContent = "", with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.textContent = "", with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.textContent = "foo", with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.textContent = "foo", with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.textContent = detachedComment.textContent, with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.textContent = detachedComment.textContent, with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.textContent += "", with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.textContent += "", with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.textContent += "foo", with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.textContent += "foo", with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.textContent += detachedComment.textContent, with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.textContent += detachedComment.textContent, with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.nodeValue = "", with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.nodeValue = "", with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.nodeValue = "foo", with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.nodeValue = "foo", with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.nodeValue = detachedComment.nodeValue, with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.nodeValue = detachedComment.nodeValue, with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.nodeValue += "", with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.nodeValue += "", with selected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
-  [detachedComment.nodeValue += "foo", with unselected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
   [detachedComment.nodeValue += "foo", with selected range collapsed at (detachedComment, detachedComment.length)]
-    expected: FAIL
-
-  [detachedComment.nodeValue += detachedComment.nodeValue, with unselected range collapsed at (detachedComment, detachedComment.length)]
     expected: FAIL
 
   [detachedComment.nodeValue += detachedComment.nodeValue, with selected range collapsed at (detachedComment, detachedComment.length)]
@@ -11193,541 +7506,271 @@
   [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with selected range collapsed at (detachedForeignComment, 0)]
     expected: FAIL
 
-  [detachedForeignComment.data = "", with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.data = "", with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.data = "foo", with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.data = "foo", with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.data = detachedForeignComment.data, with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.data = detachedForeignComment.data, with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.data += "", with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.data += "", with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.data += "foo", with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.data += "foo", with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.data += detachedForeignComment.data, with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.data += detachedForeignComment.data, with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.textContent = "", with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.textContent = "", with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.textContent = "foo", with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.textContent = "foo", with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.textContent = detachedForeignComment.textContent, with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.textContent = detachedForeignComment.textContent, with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += "", with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.textContent += "", with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.textContent += "foo", with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.textContent += "foo", with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += detachedForeignComment.textContent, with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.textContent += detachedForeignComment.textContent, with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = "", with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = "", with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue = "foo", with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.nodeValue = "foo", with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += "", with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += "", with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue += "foo", with unselected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue += "foo", with selected range on detachedForeignComment from 0 to 1]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with unselected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with selected range on detachedForeignComment from 0 to 1]
     expected: FAIL
 
-  [detachedForeignComment.data = "", with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.data = "", with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.data = "foo", with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.data = "foo", with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.data = detachedForeignComment.data, with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.data = detachedForeignComment.data, with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.data += "", with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.data += "", with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.data += "foo", with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.data += "foo", with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.data += detachedForeignComment.data, with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.data += detachedForeignComment.data, with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.textContent = "", with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.textContent = "", with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.textContent = "foo", with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.textContent = "foo", with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.textContent = detachedForeignComment.textContent, with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.textContent = detachedForeignComment.textContent, with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += "", with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.textContent += "", with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.textContent += "foo", with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.textContent += "foo", with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += detachedForeignComment.textContent, with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.textContent += detachedForeignComment.textContent, with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = "", with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = "", with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue = "foo", with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.nodeValue = "foo", with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += "", with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += "", with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue += "foo", with unselected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue += "foo", with selected range collapsed at (detachedForeignComment, 1)]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with unselected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with selected range collapsed at (detachedForeignComment, 1)]
     expected: FAIL
 
-  [detachedForeignComment.data = "", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.data = "", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.data = "foo", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.data = "foo", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.data = detachedForeignComment.data, with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.data = detachedForeignComment.data, with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.data += "", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.data += "", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.data += "foo", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.data += "foo", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.data += detachedForeignComment.data, with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.data += detachedForeignComment.data, with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.textContent = "", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.textContent = "", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.textContent = "foo", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.textContent = "foo", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.textContent = detachedForeignComment.textContent, with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.textContent = detachedForeignComment.textContent, with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += "", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.textContent += "", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.textContent += "foo", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.textContent += "foo", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += detachedForeignComment.textContent, with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.textContent += detachedForeignComment.textContent, with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = "", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = "", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue = "foo", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.nodeValue = "foo", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += "", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += "", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue += "foo", with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue += "foo", with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with unselected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with selected range on detachedForeignComment from 0 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.data = "", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.data = "", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.data = "foo", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.data = "foo", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.data = detachedForeignComment.data, with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.data = detachedForeignComment.data, with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.data += "", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.data += "", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.data += "foo", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.data += "foo", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.data += detachedForeignComment.data, with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.data += detachedForeignComment.data, with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.textContent = "", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.textContent = "", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.textContent = "foo", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.textContent = "foo", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.textContent = detachedForeignComment.textContent, with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.textContent = detachedForeignComment.textContent, with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += "", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.textContent += "", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.textContent += "foo", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.textContent += "foo", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += detachedForeignComment.textContent, with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.textContent += detachedForeignComment.textContent, with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = "", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = "", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue = "foo", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.nodeValue = "foo", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += "", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += "", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue += "foo", with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue += "foo", with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with unselected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with selected range on detachedForeignComment from 1 to detachedForeignComment.length]
     expected: FAIL
 
-  [detachedForeignComment.data = "", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.data = "", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.data = "foo", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.data = "foo", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.data = detachedForeignComment.data, with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.data = detachedForeignComment.data, with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.data += "", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.data += "", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.data += "foo", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.data += "foo", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.data += detachedForeignComment.data, with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.data += detachedForeignComment.data, with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.textContent = "", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.textContent = "", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.textContent = "foo", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.textContent = "foo", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.textContent = detachedForeignComment.textContent, with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.textContent = detachedForeignComment.textContent, with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += "", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.textContent += "", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.textContent += "foo", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.textContent += "foo", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.textContent += detachedForeignComment.textContent, with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.textContent += detachedForeignComment.textContent, with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = "", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = "", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue = "foo", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.nodeValue = "foo", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue = detachedForeignComment.nodeValue, with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += "", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += "", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
-  [detachedForeignComment.nodeValue += "foo", with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
   [detachedForeignComment.nodeValue += "foo", with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
-    expected: FAIL
-
-  [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
     expected: FAIL
 
   [detachedForeignComment.nodeValue += detachedForeignComment.nodeValue, with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)]
@@ -11787,559 +7830,280 @@
   [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with selected range collapsed at (detachedXmlComment, 0)]
     expected: FAIL
 
-  [detachedXmlComment.data = "", with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.data = "", with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.data = "foo", with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.data = "foo", with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.data = detachedXmlComment.data, with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.data = detachedXmlComment.data, with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.data += "", with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.data += "", with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.data += "foo", with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.data += "foo", with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.data += detachedXmlComment.data, with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.data += detachedXmlComment.data, with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.textContent = "", with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.textContent = "", with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.textContent = "foo", with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.textContent = "foo", with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.textContent = detachedXmlComment.textContent, with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.textContent = detachedXmlComment.textContent, with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += "", with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.textContent += "", with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.textContent += "foo", with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.textContent += "foo", with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += detachedXmlComment.textContent, with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.textContent += detachedXmlComment.textContent, with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = "", with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = "", with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue = "foo", with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.nodeValue = "foo", with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += "", with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += "", with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue += "foo", with unselected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue += "foo", with selected range on detachedXmlComment from 0 to 1]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with unselected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with selected range on detachedXmlComment from 0 to 1]
     expected: FAIL
 
-  [detachedXmlComment.data = "", with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.data = "", with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.data = "foo", with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.data = "foo", with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.data = detachedXmlComment.data, with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.data = detachedXmlComment.data, with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.data += "", with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.data += "", with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.data += "foo", with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.data += "foo", with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.data += detachedXmlComment.data, with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.data += detachedXmlComment.data, with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.textContent = "", with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.textContent = "", with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.textContent = "foo", with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.textContent = "foo", with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.textContent = detachedXmlComment.textContent, with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.textContent = detachedXmlComment.textContent, with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += "", with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.textContent += "", with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.textContent += "foo", with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.textContent += "foo", with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += detachedXmlComment.textContent, with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.textContent += detachedXmlComment.textContent, with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = "", with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = "", with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue = "foo", with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.nodeValue = "foo", with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += "", with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += "", with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue += "foo", with unselected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue += "foo", with selected range collapsed at (detachedXmlComment, 1)]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with unselected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with selected range collapsed at (detachedXmlComment, 1)]
     expected: FAIL
 
-  [detachedXmlComment.data = "", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.data = "", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.data = "foo", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.data = "foo", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.data = detachedXmlComment.data, with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.data = detachedXmlComment.data, with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.data += "", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.data += "", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.data += "foo", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.data += "foo", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.data += detachedXmlComment.data, with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.data += detachedXmlComment.data, with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.textContent = "", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.textContent = "", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.textContent = "foo", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.textContent = "foo", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.textContent = detachedXmlComment.textContent, with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.textContent = detachedXmlComment.textContent, with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += "", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.textContent += "", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.textContent += "foo", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.textContent += "foo", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += detachedXmlComment.textContent, with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.textContent += detachedXmlComment.textContent, with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = "", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = "", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue = "foo", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.nodeValue = "foo", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += "", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += "", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue += "foo", with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue += "foo", with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with unselected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with selected range on detachedXmlComment from 0 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.data = "", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.data = "", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.data = "foo", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.data = "foo", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.data = detachedXmlComment.data, with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.data = detachedXmlComment.data, with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.data += "", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.data += "", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.data += "foo", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.data += "foo", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.data += detachedXmlComment.data, with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.data += detachedXmlComment.data, with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.textContent = "", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.textContent = "", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.textContent = "foo", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.textContent = "foo", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.textContent = detachedXmlComment.textContent, with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.textContent = detachedXmlComment.textContent, with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += "", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.textContent += "", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.textContent += "foo", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.textContent += "foo", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += detachedXmlComment.textContent, with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.textContent += detachedXmlComment.textContent, with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = "", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = "", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue = "foo", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.nodeValue = "foo", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += "", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += "", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue += "foo", with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue += "foo", with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with unselected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with selected range on detachedXmlComment from 1 to detachedXmlComment.length]
     expected: FAIL
 
-  [detachedXmlComment.data = "", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.data = "", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.data = "foo", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.data = "foo", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.data = detachedXmlComment.data, with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.data = detachedXmlComment.data, with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.data += "", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.data += "", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.data += "foo", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.data += "foo", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.data += detachedXmlComment.data, with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.data += detachedXmlComment.data, with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.textContent = "", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.textContent = "", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.textContent = "foo", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.textContent = "foo", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.textContent = detachedXmlComment.textContent, with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.textContent = detachedXmlComment.textContent, with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += "", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.textContent += "", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.textContent += "foo", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.textContent += "foo", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.textContent += detachedXmlComment.textContent, with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.textContent += detachedXmlComment.textContent, with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = "", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = "", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue = "foo", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.nodeValue = "foo", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue = detachedXmlComment.nodeValue, with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += "", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += "", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [detachedXmlComment.nodeValue += "foo", with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
   [detachedXmlComment.nodeValue += "foo", with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
-    expected: FAIL
-
-  [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
   [detachedXmlComment.nodeValue += detachedXmlComment.nodeValue, with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)]
     expected: FAIL
 
-  [testDiv.insertBefore(paras[0\], paras[1\]), with unselected range collapsed at (paras[0\], 0)]
-    expected: FAIL
-
   [testDiv.insertBefore(paras[0\], paras[1\]), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [testDiv.insertBefore(paras[0\], paras[1\]), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [testDiv.insertBefore(paras[0\], paras[1\]), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [testDiv.insertBefore(paras[0\], paras[1\]), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [testDiv.insertBefore(paras[0\], paras[1\]), with selected range collapsed at (paras[0\], 1)]
@@ -12348,13 +8112,7 @@
   [testDiv.insertBefore(paras[0\], paras[1\]), with selected range on testDiv from 0 to 2]
     expected: FAIL
 
-  [testDiv.insertBefore(paras[0\], paras[1\]), with unselected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
   [testDiv.insertBefore(paras[0\], paras[1\]), with selected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
-  [testDiv.insertBefore(paras[0\], paras[1\]), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [testDiv.insertBefore(paras[0\], paras[1\]), with selected range on testDiv from 1 to 2]
@@ -12366,13 +8124,7 @@
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range collapsed at (paras[0\], 1)]
@@ -12381,16 +8133,10 @@
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range on testDiv from 0 to 1]
     expected: FAIL
 
-  [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with unselected range on testDiv from 0 to 2]
-    expected: FAIL
-
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range on testDiv from 0 to 2]
     expected: FAIL
 
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
-  [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [paras[0\].insertBefore(paras[1\], paras[0\].firstChild), with selected range on testDiv from 1 to 2]
@@ -12408,16 +8154,10 @@
   [paras[0\].insertBefore(paras[1\], null), with selected range on testDiv from 0 to 1]
     expected: FAIL
 
-  [paras[0\].insertBefore(paras[1\], null), with unselected range on testDiv from 0 to 2]
-    expected: FAIL
-
   [paras[0\].insertBefore(paras[1\], null), with selected range on testDiv from 0 to 2]
     expected: FAIL
 
   [paras[0\].insertBefore(paras[1\], null), with selected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
-  [paras[0\].insertBefore(paras[1\], null), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [paras[0\].insertBefore(paras[1\], null), with selected range on testDiv from 1 to 2]
@@ -12429,9 +8169,6 @@
   [foreignDoc.insertBefore(detachedComment, foreignDoc.documentElement), with selected range on foreignDoc from 0 to 1]
     expected: FAIL
 
-  [foreignDoc.insertBefore(detachedComment, foreignDoc.documentElement), with unselected range on foreignDoc from 0 to 2]
-    expected: FAIL
-
   [foreignDoc.insertBefore(detachedComment, foreignDoc.documentElement), with selected range on foreignDoc from 0 to 2]
     expected: FAIL
 
@@ -12441,19 +8178,10 @@
   [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with selected range collapsed at (foreignDoc, 0)]
     expected: FAIL
 
-  [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with unselected range on foreignDoc from 0 to 1]
-    expected: FAIL
-
   [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with selected range on foreignDoc from 0 to 1]
     expected: FAIL
 
-  [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with unselected range on foreignDoc from 0 to 2]
-    expected: FAIL
-
   [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with selected range on foreignDoc from 0 to 2]
-    expected: FAIL
-
-  [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with unselected range collapsed at (foreignDoc, 1)]
     expected: FAIL
 
   [foreignDoc.insertBefore(detachedComment, foreignDoc.doctype), with selected range collapsed at (foreignDoc, 1)]
@@ -12465,13 +8193,7 @@
   [paras[0\].insertBefore(xmlTextNode, paras[0\].firstChild), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [paras[0\].insertBefore(xmlTextNode, paras[0\].firstChild), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [paras[0\].insertBefore(xmlTextNode, paras[0\].firstChild), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].insertBefore(xmlTextNode, paras[0\].firstChild), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].insertBefore(xmlTextNode, paras[0\].firstChild), with selected range collapsed at (paras[0\], 1)]
@@ -12492,19 +8214,10 @@
   [paras[0\].insertBefore(document.doctype, paras[0\].firstChild), with selected range on paras[0\] from 0 to 1]
     expected: FAIL
 
-  [testDiv.replaceChild(paras[0\], paras[0\]), with unselected range collapsed at (paras[0\], 0)]
-    expected: FAIL
-
   [testDiv.replaceChild(paras[0\], paras[0\]), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [testDiv.replaceChild(paras[0\], paras[0\]), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [testDiv.replaceChild(paras[0\], paras[0\]), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [testDiv.replaceChild(paras[0\], paras[0\]), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [testDiv.replaceChild(paras[0\], paras[0\]), with selected range collapsed at (paras[0\], 1)]
@@ -12513,13 +8226,7 @@
   [testDiv.replaceChild(paras[0\], paras[0\]), with selected range on testDiv from 0 to 2]
     expected: FAIL
 
-  [testDiv.replaceChild(paras[0\], paras[0\]), with unselected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
   [testDiv.replaceChild(paras[0\], paras[0\]), with selected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
-  [testDiv.replaceChild(paras[0\], paras[0\]), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [testDiv.replaceChild(paras[0\], paras[0\]), with selected range on testDiv from 1 to 2]
@@ -12531,13 +8238,7 @@
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range collapsed at (paras[0\], 1)]
@@ -12546,16 +8247,10 @@
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range on testDiv from 0 to 1]
     expected: FAIL
 
-  [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with unselected range on testDiv from 0 to 2]
-    expected: FAIL
-
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range on testDiv from 0 to 2]
     expected: FAIL
 
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
-  [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [paras[0\].replaceChild(paras[1\], paras[0\].firstChild), with selected range on testDiv from 1 to 2]
@@ -12567,9 +8262,6 @@
   [foreignDoc.replaceChild(detachedComment, foreignDoc.documentElement), with selected range on foreignDoc from 0 to 1]
     expected: FAIL
 
-  [foreignDoc.replaceChild(detachedComment, foreignDoc.documentElement), with unselected range on foreignDoc from 0 to 2]
-    expected: FAIL
-
   [foreignDoc.replaceChild(detachedComment, foreignDoc.documentElement), with selected range on foreignDoc from 0 to 2]
     expected: FAIL
 
@@ -12579,16 +8271,10 @@
   [foreignDoc.replaceChild(detachedComment, foreignDoc.doctype), with selected range collapsed at (foreignDoc, 0)]
     expected: FAIL
 
-  [foreignDoc.replaceChild(detachedComment, foreignDoc.doctype), with unselected range on foreignDoc from 0 to 1]
-    expected: FAIL
-
   [foreignDoc.replaceChild(detachedComment, foreignDoc.doctype), with selected range on foreignDoc from 0 to 1]
     expected: FAIL
 
   [foreignDoc.replaceChild(detachedComment, foreignDoc.doctype), with selected range on foreignDoc from 0 to 2]
-    expected: FAIL
-
-  [foreignDoc.replaceChild(detachedComment, foreignDoc.doctype), with unselected range collapsed at (foreignDoc, 1)]
     expected: FAIL
 
   [foreignDoc.replaceChild(detachedComment, foreignDoc.doctype), with selected range collapsed at (foreignDoc, 1)]
@@ -12597,13 +8283,7 @@
   [paras[0\].replaceChild(xmlTextNode, paras[0\].firstChild), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [paras[0\].replaceChild(xmlTextNode, paras[0\].firstChild), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [paras[0\].replaceChild(xmlTextNode, paras[0\].firstChild), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].replaceChild(xmlTextNode, paras[0\].firstChild), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].replaceChild(xmlTextNode, paras[0\].firstChild), with selected range collapsed at (paras[0\], 1)]
@@ -12624,25 +8304,13 @@
   [paras[0\].replaceChild(document.doctype, paras[0\].firstChild), with selected range on paras[0\] from 0 to 1]
     expected: FAIL
 
-  [testDiv.appendChild(testDiv.lastChild), with unselected range collapsed at (testDiv.lastChild, 0)]
-    expected: FAIL
-
   [testDiv.appendChild(testDiv.lastChild), with selected range collapsed at (testDiv.lastChild, 0)]
-    expected: FAIL
-
-  [testDiv.appendChild(testDiv.lastChild), with unselected range on testDiv.lastChild from 0 to 1]
     expected: FAIL
 
   [testDiv.appendChild(testDiv.lastChild), with selected range on testDiv.lastChild from 0 to 1]
     expected: FAIL
 
-  [testDiv.appendChild(testDiv.lastChild), with unselected range collapsed at (testDiv.lastChild, 1)]
-    expected: FAIL
-
   [testDiv.appendChild(testDiv.lastChild), with selected range collapsed at (testDiv.lastChild, 1)]
-    expected: FAIL
-
-  [testDiv.appendChild(testDiv.lastChild), with unselected range on testDiv from testDiv.childNodes.length - 2 to testDiv.childNodes.length]
     expected: FAIL
 
   [testDiv.appendChild(testDiv.lastChild), with selected range on testDiv from testDiv.childNodes.length - 2 to testDiv.childNodes.length]
@@ -12651,40 +8319,22 @@
   [testDiv.appendChild(testDiv.lastChild), with selected range on testDiv from testDiv.childNodes.length - 2 to testDiv.childNodes.length - 1]
     expected: FAIL
 
-  [testDiv.appendChild(testDiv.lastChild), with unselected range on testDiv from testDiv.childNodes.length - 1 to testDiv.childNodes.length]
-    expected: FAIL
-
   [testDiv.appendChild(testDiv.lastChild), with selected range on testDiv from testDiv.childNodes.length - 1 to testDiv.childNodes.length]
     expected: FAIL
 
   [testDiv.appendChild(testDiv.lastChild), with selected range collapsed at (testDiv, testDiv.childNodes.length - 1)]
     expected: FAIL
 
-  [testDiv.appendChild(testDiv.lastChild), with unselected range collapsed at (testDiv, testDiv.childNodes.length)]
-    expected: FAIL
-
   [testDiv.appendChild(testDiv.lastChild), with selected range collapsed at (testDiv, testDiv.childNodes.length)]
-    expected: FAIL
-
-  [detachedDiv.appendChild(detachedDiv.lastChild), with unselected range collapsed at (detachedDiv.lastChild, 0)]
     expected: FAIL
 
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range collapsed at (detachedDiv.lastChild, 0)]
     expected: FAIL
 
-  [detachedDiv.appendChild(detachedDiv.lastChild), with unselected range on detachedDiv.lastChild from 0 to 1]
-    expected: FAIL
-
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range on detachedDiv.lastChild from 0 to 1]
     expected: FAIL
 
-  [detachedDiv.appendChild(detachedDiv.lastChild), with unselected range collapsed at (detachedDiv.lastChild, 1)]
-    expected: FAIL
-
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range collapsed at (detachedDiv.lastChild, 1)]
-    expected: FAIL
-
-  [detachedDiv.appendChild(detachedDiv.lastChild), with unselected range on detachedDiv from detachedDiv.childNodes.length - 2 to detachedDiv.childNodes.length]
     expected: FAIL
 
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range on detachedDiv from detachedDiv.childNodes.length - 2 to detachedDiv.childNodes.length]
@@ -12693,16 +8343,10 @@
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range on detachedDiv from detachedDiv.childNodes.length - 2 to detachedDiv.childNodes.length - 1]
     expected: FAIL
 
-  [detachedDiv.appendChild(detachedDiv.lastChild), with unselected range on detachedDiv from detachedDiv.childNodes.length - 1 to detachedDiv.childNodes.length]
-    expected: FAIL
-
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range on detachedDiv from detachedDiv.childNodes.length - 1 to detachedDiv.childNodes.length]
     expected: FAIL
 
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range collapsed at (detachedDiv, detachedDiv.childNodes.length - 1)]
-    expected: FAIL
-
-  [detachedDiv.appendChild(detachedDiv.lastChild), with unselected range collapsed at (detachedDiv, detachedDiv.childNodes.length)]
     expected: FAIL
 
   [detachedDiv.appendChild(detachedDiv.lastChild), with selected range collapsed at (detachedDiv, detachedDiv.childNodes.length)]
@@ -12720,16 +8364,10 @@
   [paras[0\].appendChild(paras[1\]), with selected range on testDiv from 0 to 1]
     expected: FAIL
 
-  [paras[0\].appendChild(paras[1\]), with unselected range on testDiv from 0 to 2]
-    expected: FAIL
-
   [paras[0\].appendChild(paras[1\]), with selected range on testDiv from 0 to 2]
     expected: FAIL
 
   [paras[0\].appendChild(paras[1\]), with selected range collapsed at (testDiv, 1)]
-    expected: FAIL
-
-  [paras[0\].appendChild(paras[1\]), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [paras[0\].appendChild(paras[1\]), with selected range on testDiv from 1 to 2]
@@ -12771,19 +8409,10 @@
   [paras[0\].appendChild(document.doctype), with selected range on paras[0\] from 0 to 1]
     expected: FAIL
 
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range collapsed at (paras[0\], 0)]
-    expected: FAIL
-
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range collapsed at (paras[0\], 0)]
     expected: FAIL
 
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range on paras[0\] from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range collapsed at (paras[0\], 1)]
     expected: FAIL
 
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range collapsed at (paras[0\], 1)]
@@ -12792,37 +8421,19 @@
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range collapsed at (testDiv, 0)]
     expected: FAIL
 
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range on testDiv from 0 to 1]
-    expected: FAIL
-
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range on testDiv from 0 to 1]
-    expected: FAIL
-
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range collapsed at (testDiv, 1)]
     expected: FAIL
 
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range collapsed at (testDiv, 1)]
     expected: FAIL
 
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range on testDiv from 0 to 2]
-    expected: FAIL
-
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range on testDiv from 0 to 2]
-    expected: FAIL
-
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range on testDiv from 1 to 2]
     expected: FAIL
 
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range on testDiv from 1 to 2]
     expected: FAIL
 
-  [paras[0\].parentNode.removeChild(paras[0\]), with unselected range collapsed at (testDiv, 2)]
-    expected: FAIL
-
   [paras[0\].parentNode.removeChild(paras[0\]), with selected range collapsed at (testDiv, 2)]
-    expected: FAIL
-
-  [foreignDoc.documentElement.parentNode.removeChild(foreignDoc.documentElement), with unselected range on foreignDoc from 0 to foreignDoc.childNodes.length]
     expected: FAIL
 
   [foreignDoc.documentElement.parentNode.removeChild(foreignDoc.documentElement), with selected range on foreignDoc from 0 to foreignDoc.childNodes.length]


### PR DESCRIPTION
Does the same thing as #6817, but storing Range instances directly in their start and end containers.

Cc @dzbarsky

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8506)

<!-- Reviewable:end -->
