### PR TITLE
Replace Atom::from_slice("sizes") with atom!("sizes")

### DIFF
--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -119,18 +119,17 @@ impl VirtualMethods for HTMLLinkElement {
             return;
         }
 
-        let sizes_atom = &Atom::from_slice("sizes");
         let rel = get_attr(self.upcast(), &atom!(rel));
         match attr.local_name() {
             &atom!(href) => {
                 if string_is_stylesheet(&rel) {
                     self.handle_stylesheet_url(&attr.value());
                 } else if is_favicon(&rel) {
-                    let sizes = get_attr(self.upcast(), sizes_atom);
+                    let sizes = get_attr(self.upcast(), &atom!("sizes"));
                     self.handle_favicon_url(rel.as_ref().unwrap(), &attr.value(), &sizes);
                 }
             },
-            atom if atom == sizes_atom => {
+            &atom!("sizes") => {
                 if is_favicon(&rel) {
                     if let Some(ref href) = get_attr(self.upcast(), &atom!("href")) {
                         self.handle_favicon_url(rel.as_ref().unwrap(), href, &Some(attr.value().to_string()));
@@ -163,7 +162,7 @@ impl VirtualMethods for HTMLLinkElement {
 
             let rel = get_attr(element, &atom!("rel"));
             let href = get_attr(element, &atom!("href"));
-            let sizes = get_attr(self.upcast(), &Atom::from_slice("sizes"));
+            let sizes = get_attr(self.upcast(), &atom!("sizes"));
 
             match href {
                 Some(ref href) if string_is_stylesheet(&rel) => {

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -853,7 +853,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1017,7 +1017,7 @@ dependencies = [
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "unicode-bidi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1526,7 +1526,7 @@ dependencies = [
  "selectors 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1579,7 +1579,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1732,7 +1732,7 @@ dependencies = [
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1747,7 +1747,7 @@ dependencies = [
  "cssparser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
@@ -1915,7 +1915,7 @@ dependencies = [
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2068,7 +2068,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,7 +806,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -970,7 +970,7 @@ dependencies = [
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "unicode-bidi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1460,7 +1460,7 @@ dependencies = [
  "selectors 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1504,7 +1504,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1691,7 +1691,7 @@ dependencies = [
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1858,7 +1858,7 @@ dependencies = [
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2001,7 +2001,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "skia 0.0.20130412 (git+https://github.com/servo/skia)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -786,7 +786,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -950,7 +950,7 @@ dependencies = [
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "unicode-bidi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1440,7 +1440,7 @@ dependencies = [
  "selectors 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1484,7 +1484,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1669,7 +1669,7 @@ dependencies = [
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1836,7 +1836,7 @@ dependencies = [
  "serde 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1949,7 +1949,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_plugin 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This PR replaces all occurrences of Atom::from_slice("sizes") with atom!("sizes"). It also updates string_cache to v0.1.17 from 0.1.16.

Right now I've split the crate update and the replace in different commits - should I squash them?

Fixes #8488.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8527)

<!-- Reviewable:end -->
