### PR TITLE
Remove AutoJoinScriptTask.

### DIFF
--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -61,7 +61,7 @@ use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::collections::hash_state::DefaultState;
 use std::mem::transmute;
-use std::ops::{Deref, DerefMut, Drop};
+use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -1063,16 +1063,6 @@ impl LayoutTask {
     fn handle_reflow<'a, 'b>(&mut self,
                              data: &ScriptReflow,
                              possibly_locked_rw_data: &mut RwData<'a, 'b>) {
-        // Make sure that every return path from this method joins the script task,
-        // otherwise the script task will panic.
-        struct AutoJoinScriptTask<'a> { data: &'a ScriptReflow };
-        impl<'a> Drop for AutoJoinScriptTask<'a> {
-            fn drop(&mut self) {
-                self.data.script_join_chan.send(()).unwrap();
-            }
-        };
-        let _ajst = AutoJoinScriptTask { data: data };
-
         let document = unsafe { LayoutNode::new(&data.document) };
         let document = document.as_document().unwrap();
 

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -179,6 +179,12 @@ pub struct ScriptReflow {
     pub query_type: ReflowQueryType,
 }
 
+impl Drop for ScriptReflow {
+    fn drop(&mut self) {
+        self.script_join_chan.send(()).unwrap();
+    }
+}
+
 /// Encapsulates a channel to the layout task.
 #[derive(Clone)]
 pub struct LayoutChan(pub Sender<Msg>);


### PR DESCRIPTION
I don't believe there is a case where it would make sense to drop the
ScriptReflow struct without joining the script thread. This approach should
be somewhat more robust, and avoids the code smell of a RAII guard in an
otherwise unused variable.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8545)

<!-- Reviewable:end -->
