### PR TITLE
Remove the unused arguments to hit_test and mouse_over.

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -57,7 +57,7 @@ impl LayoutRPC for LayoutRPCImpl {
     }
 
     /// Requests the node containing the point of interest.
-    fn hit_test(&self, _: TrustedNodeAddress, point: Point2D<f32>) -> Result<HitTestResponse, ()> {
+    fn hit_test(&self, point: Point2D<f32>) -> Result<HitTestResponse, ()> {
         let point = Point2D::new(Au::from_f32_px(point.x), Au::from_f32_px(point.y));
         let resp = {
             let &LayoutRPCImpl(ref rw_data) = self;
@@ -82,8 +82,7 @@ impl LayoutRPC for LayoutRPCImpl {
         Err(())
     }
 
-    fn mouse_over(&self, _: TrustedNodeAddress, point: Point2D<f32>)
-                  -> Result<MouseOverResponse, ()> {
+    fn mouse_over(&self, point: Point2D<f32>) -> Result<MouseOverResponse, ()> {
         let mut mouse_over_list: Vec<DisplayItemMetadata> = vec!();
         let point = Point2D::new(Au::from_f32_px(point.x), Au::from_f32_px(point.y));
         {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -483,30 +483,19 @@ impl Document {
     }
 
     pub fn hit_test(&self, point: &Point2D<f32>) -> Option<UntrustedNodeAddress> {
-        let root = self.GetDocumentElement();
-        let root = match root.r() {
-            Some(root) => root,
-            None => return None,
-        };
-        let root = root.upcast::<Node>();
-        let address = match self.window.layout().hit_test(root.to_trusted_node_address(), *point) {
+        assert!(self.GetDocumentElement().is_some());
+        match self.window.layout().hit_test(*point) {
             Ok(HitTestResponse(node_address)) => Some(node_address),
             Err(()) => {
                 debug!("layout query error");
                 None
             }
-        };
-        address
+        }
     }
 
     pub fn get_nodes_under_mouse(&self, point: &Point2D<f32>) -> Vec<UntrustedNodeAddress> {
-        let root = self.GetDocumentElement();
-        let root = match root.r() {
-            Some(root) => root,
-            None => return vec!(),
-        };
-        let root = root.upcast::<Node>();
-        match self.window.layout().mouse_over(root.to_trusted_node_address(), *point) {
+        assert!(self.GetDocumentElement().is_some());
+        match self.window.layout().mouse_over(*point) {
             Ok(MouseOverResponse(node_address)) => node_address,
             Err(()) => vec!(),
         }

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -101,8 +101,8 @@ pub trait LayoutRPC {
     /// Requests the geometry of this node. Used by APIs such as `clientTop`.
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the node containing the point of interest
-    fn hit_test(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<HitTestResponse, ()>;
-    fn mouse_over(&self, node: TrustedNodeAddress, point: Point2D<f32>) -> Result<MouseOverResponse, ()>;
+    fn hit_test(&self, point: Point2D<f32>) -> Result<HitTestResponse, ()>;
+    fn mouse_over(&self, point: Point2D<f32>) -> Result<MouseOverResponse, ()>;
     /// Query layout for the resolved value of a given CSS property
     fn resolved_style(&self) -> ResolvedStyleResponse;
     fn offset_parent(&self) -> OffsetParentResponse;


### PR DESCRIPTION
I don't think this code is called when there is no document element, but I
added assertions to make sure we notice in case I was wrong.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8548)

<!-- Reviewable:end -->
