### PR TITLE
Avoid overflow in freetype/font_context.rs

### DIFF
--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -57,7 +57,8 @@ extern fn ft_realloc(mem: FT_Memory, _cur_size: c_long, new_req_size: c_long,
         let new_actual_size = heap_size_of(new_ptr);
 
         let user = (*mem).user as *mut User;
-        (*user).size += new_actual_size - old_actual_size;
+        (*user).size += new_actual_size;
+        (*user).size -= old_actual_size;
 
         new_ptr
     }


### PR DESCRIPTION
When new_actual_size < old_actual_size, there is an overflow panic since we're using usize. This breaks Reddit for me.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8552)

<!-- Reviewable:end -->
