### PR TITLE
Implement Get Element Attribute WebDriver command

### DIFF
--- a/components/msg/webdriver_msg.rs
+++ b/components/msg/webdriver_msg.rs
@@ -15,6 +15,7 @@ pub enum WebDriverScriptCommand {
     FindElementsCSS(String, IpcSender<Result<Vec<String>, ()>>),
     FocusElement(String, IpcSender<Result<(), ()>>),
     GetActiveElement(IpcSender<Option<String>>),
+    GetElementAttribute(String, String, IpcSender<Result<Option<String>, ()>>),
     GetElementTagName(String, IpcSender<Result<String, ()>>),
     GetElementText(String, IpcSender<Result<String, ()>>),
     GetFrameId(WebDriverFrameId, IpcSender<Result<Option<PipelineId>, ()>>),

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1092,6 +1092,8 @@ impl ScriptTask {
                 webdriver_handlers::handle_get_active_element(&page, pipeline_id, reply),
             WebDriverScriptCommand::GetElementTagName(node_id, reply) =>
                 webdriver_handlers::handle_get_name(&page, pipeline_id, node_id, reply),
+            WebDriverScriptCommand::GetElementAttribute(node_id, name, reply) =>
+                webdriver_handlers::handle_get_attribute(&page, pipeline_id, node_id, name, reply),
             WebDriverScriptCommand::GetElementText(node_id, reply) =>
                 webdriver_handlers::handle_get_text(&page, pipeline_id, node_id, reply),
             WebDriverScriptCommand::GetFrameId(frame_id, reply) =>

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -203,6 +203,21 @@ pub fn handle_get_name(page: &Rc<Page>,
     }).unwrap();
 }
 
+pub fn handle_get_attribute(page: &Rc<Page>,
+                            pipeline: PipelineId,
+                            node_id: String,
+                            name: String,
+                            reply: IpcSender<Result<Option<String>, ()>>) {
+    reply.send(match find_node_by_unique_id(&*page, pipeline, node_id) {
+        Some(node) => {
+            Ok(node.downcast::<Element>().unwrap().GetAttribute(DOMString::from(name))
+               .map(String::from))
+        },
+        None => Err(())
+    }).unwrap();
+}
+
+
 pub fn handle_get_url(page: &Rc<Page>,
                       _pipeline: PipelineId,
                       reply: IpcSender<Url>) {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -539,6 +539,21 @@ impl Handler {
         }
     }
 
+    fn handle_element_attribute(&self, element: &WebElement, name: &String) -> WebDriverResult<WebDriverResponse> {
+        let pipeline_id = try!(self.frame_pipeline());
+
+        let (sender, receiver) = ipc::channel().unwrap();
+        let ConstellationChan(ref const_chan) = self.constellation_chan;
+        let cmd = WebDriverScriptCommand::GetElementAttribute(element.id.clone(), name.clone(), sender);
+        let cmd_msg = WebDriverCommandMsg::ScriptCommand(pipeline_id, cmd);
+        const_chan.send(ConstellationMsg::WebDriverCommand(cmd_msg)).unwrap();
+        match receiver.recv().unwrap() {
+            Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse::new(value.to_json()))),
+            Err(_) => Err(WebDriverError::new(ErrorStatus::StaleElementReference,
+                                              "Unable to find element in document"))
+        }
+    }
+
     fn handle_set_timeouts(&mut self, parameters: &TimeoutsParameters) -> WebDriverResult<WebDriverResponse> {
         //TODO: this conversion is crazy, spec should limit these to u32 and check upstream
         let value = parameters.ms as u32;
@@ -732,6 +747,8 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
             WebDriverCommand::GetActiveElement => self.handle_active_element(),
             WebDriverCommand::GetElementText(ref element) => self.handle_element_text(element),
             WebDriverCommand::GetElementTagName(ref element) => self.handle_element_tag_name(element),
+            WebDriverCommand::GetElementAttribute(ref element, ref name) =>
+                self.handle_element_attribute(element, name),
             WebDriverCommand::ExecuteScript(ref x) => self.handle_execute_script(x),
             WebDriverCommand::ExecuteAsyncScript(ref x) => self.handle_execute_async_script(x),
             WebDriverCommand::ElementSendKeys(ref element, ref keys) =>


### PR DESCRIPTION
This intentionally doesn't implement the special handling for boolean
attributes yet, since that requires some kind of exhaustive list of all
such attributes

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8564)

<!-- Reviewable:end -->
