### PR TITLE
Make test-wpt run with RUST_BACKTRACE=1 by default #8194

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -283,6 +283,7 @@ class MachCommands(CommandBase):
         hosts_file_path = path.join(self.context.topdir, 'tests', 'wpt', 'hosts')
 
         os.environ["hosts_file_path"] = hosts_file_path
+        os.environ["RUST_BACKTRACE"] = "1"
 
         kwargs["debug"] = not kwargs["release"]
 


### PR DESCRIPTION
Fixes #8194

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8590)

<!-- Reviewable:end -->
