### PR TITLE
Support synchronous about:blank loads

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -39,7 +39,7 @@ use profile_traits::time;
 use rand::{Rng, SeedableRng, StdRng, random};
 use script_traits::{AnimationState, AnimationTickType, CompositorEvent};
 use script_traits::{ConstellationControlMsg, ConstellationMsg as FromCompositorMsg};
-use script_traits::{DocumentState, LayoutControlMsg, LoadData};
+use script_traits::{DocumentState, LayoutControlMsg, LoadData, IFrameLoadType};
 use script_traits::{IFrameLoadInfo, IFrameSandboxState, TimerEventRequest};
 use script_traits::{LayoutMsg as FromLayoutMsg, ScriptMsg as FromScriptMsg, ScriptThreadFactory};
 use script_traits::{LogEntry, ServiceWorkerMsg, webdriver_msg};
@@ -555,6 +555,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                     old_pipeline_id: Option<PipelineId>,
                     initial_window_size: Option<TypedSize2D<f32, PagePx>>,
                     script_channel: Option<IpcSender<ConstellationControlMsg>>,
+                    replacement_script_channel: Option<IpcSender<ConstellationControlMsg>>,
                     load_data: LoadData,
                     is_private: bool) {
         if self.shutting_down { return; }
@@ -591,6 +592,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             mem_profiler_chan: self.mem_profiler_chan.clone(),
             window_size: initial_window_size,
             script_chan: script_channel,
+            replacement_script_chan: replacement_script_channel,
             load_data: load_data,
             device_pixel_ratio: self.window_size.device_pixel_ratio,
             pipeline_namespace_id: self.next_pipeline_namespace_id(),
@@ -813,9 +815,8 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 self.handle_pipeline_exited(pipeline_id);
             }
             FromScriptMsg::ScriptLoadedURLInIFrame(load_info) => {
-                debug!("constellation got iframe URL load message {:?} {:?} {:?}",
+                debug!("constellation got iframe URL load message {:?} {:?}",
                        load_info.parent_pipeline_id,
-                       load_info.old_pipeline_id,
                        load_info.new_pipeline_id);
                 self.handle_script_loaded_url_in_iframe_msg(load_info);
             }
@@ -1124,8 +1125,15 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             if let Some(frame_id) = frame_id {
                 let new_pipeline_id = PipelineId::new();
                 let load_data = LoadData::new(failure_url, None, None);
-                self.new_pipeline(new_pipeline_id, frame_id, parent_info, Some(pipeline_id),
-                                  window_size, None, load_data, false);
+                self.new_pipeline(new_pipeline_id,
+                                  frame_id,
+                                  parent_info,
+                                  Some(pipeline_id),
+                                  window_size,
+                                  None,
+                                  None,
+                                  load_data,
+                                  false);
 
                 self.pending_frames.push(FrameChange {
                     frame_id: frame_id,
@@ -1156,7 +1164,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         let window_size = self.window_size.visible_viewport;
         let root_pipeline_id = PipelineId::new();
         let root_frame_id = self.root_frame_id;
-        self.new_pipeline(root_pipeline_id, root_frame_id, None, None, Some(window_size), None,
+        self.new_pipeline(root_pipeline_id, root_frame_id, None, None, Some(window_size), None, None,
                           LoadData::new(url.clone(), None, None), false);
         self.handle_load_start_msg(root_pipeline_id);
         self.pending_frames.push(FrameChange {
@@ -1224,25 +1232,54 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     // parent_pipeline_id's frame tree's children. This message is never the result of a
     // page navigation.
     fn handle_script_loaded_url_in_iframe_msg(&mut self, load_info: IFrameLoadInfo) {
-        let (load_data, script_chan, window_size, is_private) = {
-            let old_pipeline = load_info.old_pipeline_id
-                .and_then(|old_pipeline_id| self.pipelines.get(&old_pipeline_id));
+        let IFrameLoadInfo {
+            load_type,
+            parent_pipeline_id,
+            new_pipeline_id,
+            frame_type,
+            replace,
+            frame_id,
+            ..
+        } = load_info;
 
-            let source_pipeline =  match self.pipelines.get(&load_info.parent_pipeline_id) {
-                Some(source_pipeline) => source_pipeline,
-                None => return warn!("Script loaded url in closed iframe {}.", load_info.parent_pipeline_id),
+        // Compare the pipeline's url to the new url. If the origin is the same,
+        // then reuse the script thread in creating the new pipeline
+        let (script_chan, replacement_script_chan, window_size, old_pipeline_id, load_data, is_private) = {
+            let (old_pipeline, sandbox, load_data, source_script_chan, replacement_script_chan) =
+                match load_type {
+                    IFrameLoadType::Async(async_load) => {
+                        let old_pipeline = async_load.old_pipeline_id
+                            .and_then(|old_pipeline_id| self.pipelines.get(&old_pipeline_id));
+
+                        // If no url is specified, reload.
+                        let load_data = async_load.load_data.unwrap_or_else(|| {
+                            let url = match old_pipeline {
+                                Some(old_pipeline) => old_pipeline.url.clone(),
+                                None => Url::parse("about:blank").expect("infallible"),
+                            };
+                            LoadData::new(url, None, None)
+                        });
+
+                        (old_pipeline,
+                         async_load.sandbox,
+                         load_data,
+                         None,
+                         None)
+                    },
+
+                    IFrameLoadType::Sync((sync_script_chan, script_chan)) => {
+                        (None,
+                         IFrameSandboxState::IFrameUnsandboxed,
+                         LoadData::new(Url::parse("about:blank").expect("infallible"), None, None),
+                         Some(sync_script_chan.to::<ConstellationControlMsg>()),
+                         Some(script_chan.to::<ConstellationControlMsg>()))
+                    }
             };
 
-            // If no url is specified, reload.
-            let load_data = load_info.load_data.unwrap_or_else(|| {
-                let url = match old_pipeline {
-                    Some(old_pipeline) => old_pipeline.url.clone(),
-                    None => Url::parse("about:blank").expect("infallible"),
-                };
-
-                // TODO - loaddata here should have referrer info (not None, None)
-                LoadData::new(url, None, None)
-            });
+            let source_pipeline =  match self.pipelines.get(&parent_pipeline_id) {
+                Some(source_pipeline) => source_pipeline,
+                None => return warn!("Script loaded url in closed iframe {}.", parent_pipeline_id),
+            };
 
             // Compare the pipeline's url to the new url. If the origin is the same,
             // then reuse the script thread in creating the new pipeline
@@ -1252,20 +1289,22 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
             // FIXME(#10968): this should probably match the origin check in
             //                HTMLIFrameElement::contentDocument.
-            let same_script = source_url.host() == load_data.url.host() &&
-                              source_url.port() == load_data.url.port() &&
-                              load_info.sandbox == IFrameSandboxState::IFrameUnsandboxed &&
-                              source_pipeline.is_private == is_private;
+            let same_script = (source_url.host() == load_data.url.host() &&
+                               source_url.port() == load_data.url.port() &&
+                               sandbox == IFrameSandboxState::IFrameUnsandboxed &&
+                               source_pipeline.is_private == is_private) ||
+                              load_data.url.as_str() == "about:blank";
 
             // Reuse the script thread if the URL is same-origin
-            let script_chan = if same_script {
+            let (script_chan, replacement_script_chan) = if same_script {
                 debug!("Constellation: loading same-origin iframe, \
                         parent url {:?}, iframe url {:?}", source_url, load_data.url);
-                Some(source_pipeline.script_chan.clone())
+                (source_script_chan.or_else(|| Some(source_pipeline.script_chan.clone())),
+                 replacement_script_chan)
             } else {
                 debug!("Constellation: loading cross-origin iframe, \
                         parent url {:?}, iframe url {:?}", source_url, load_data.url);
-                None
+                (None, None)
             };
 
             let window_size = old_pipeline.and_then(|old_pipeline| old_pipeline.size);
@@ -1274,26 +1313,27 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 old_pipeline.freeze();
             }
 
-            (load_data, script_chan, window_size, is_private)
+            (script_chan, replacement_script_chan, window_size, old_pipeline.map(|p| p.id), load_data, is_private)
         };
 
 
         // Create the new pipeline, attached to the parent and push to pending frames
-        self.new_pipeline(load_info.new_pipeline_id,
-                          load_info.frame_id,
-                          Some((load_info.parent_pipeline_id, load_info.frame_type)),
-                          load_info.old_pipeline_id,
+        self.new_pipeline(new_pipeline_id,
+                          frame_id,
+                          Some((parent_pipeline_id, frame_type)),
+                          old_pipeline_id,
                           window_size,
                           script_chan,
+                          replacement_script_chan,
                           load_data,
                           is_private);
 
         self.pending_frames.push(FrameChange {
-            frame_id: load_info.frame_id,
-            old_pipeline_id: load_info.old_pipeline_id,
-            new_pipeline_id: load_info.new_pipeline_id,
+            frame_id: frame_id,
+            old_pipeline_id: old_pipeline_id,
+            new_pipeline_id: new_pipeline_id,
             document_ready: false,
-            replace: load_info.replace,
+            replace: replace,
         });
     }
 
@@ -1425,7 +1465,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 let window_size = self.pipelines.get(&source_id).and_then(|source| source.size);
                 let new_pipeline_id = PipelineId::new();
                 let root_frame_id = self.root_frame_id;
-                self.new_pipeline(new_pipeline_id, root_frame_id, None, None, window_size, None, load_data, false);
+                self.new_pipeline(new_pipeline_id, root_frame_id, None, None, window_size, None, None, load_data, false);
                 self.pending_frames.push(FrameChange {
                     frame_id: root_frame_id,
                     old_pipeline_id: Some(source_id),

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -180,12 +180,12 @@ impl HTMLIFrameElement {
         // network load can begin.
         if let Some(receiver) = sync_receiver {
             let msg = receiver.recv().unwrap();
-            assert!(match msg {
-                ConstellationControlMsg::AttachLayout(_) => true,
-                _ => false,
-            });
+            let new_layout_info = match msg {
+                ConstellationControlMsg::AttachLayout(new_layout_info) => new_layout_info,
+                _ => panic!("Expected AttachLayout"),
+            };
             // Synchronously perform the network load associated with this frame.
-            ScriptThread::process_constellation_event(msg);
+            ScriptThread::process_attach_layout(new_layout_info);
         }
 
         if PREFS.is_mozbrowser_enabled() {

--- a/tests/wpt/metadata-css/cssom-1_dev/xhtml1print/cssimportrule.xht.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/xhtml1print/cssimportrule.xht.ini
@@ -1,3 +1,9 @@
 [cssimportrule.xht]
   type: testharness
   expected: TIMEOUT
+  [Basic sanity-checking]
+    expected: FAIL
+
+  [Only whitelisted properties are accessible cross-origin]
+    expected: FAIL
+

--- a/tests/wpt/metadata/WebIDL/ecmascript-binding/es-exceptions/exceptions.html.ini
+++ b/tests/wpt/metadata/WebIDL/ecmascript-binding/es-exceptions/exceptions.html.ini
@@ -24,9 +24,6 @@
   [In iframe: Object.getOwnPropertyDescriptor(exception, "name")]
     expected: FAIL
 
-  [In iframe: Object.getOwnPropertyDescriptor(exception, "message")]
-    expected: FAIL
-
   [In iframe: Object.prototype.toString.call(exception) === "[object DOMException\]"]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/ranges/Range-cloneContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-cloneContents.html.ini
@@ -1,0 +1,3 @@
+[Range-cloneContents.html]
+  type: testharness
+  expected: ERROR

--- a/tests/wpt/metadata/dom/ranges/Range-deleteContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-deleteContents.html.ini
@@ -1,0 +1,3 @@
+[Range-deleteContents.html]
+  type: testharness
+  expected: ERROR

--- a/tests/wpt/metadata/dom/ranges/Range-extractContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-extractContents.html.ini
@@ -1,0 +1,3 @@
+[Range-extractContents.html]
+  type: testharness
+  expected: ERROR

--- a/tests/wpt/metadata/dom/ranges/Range-insertNode.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-insertNode.html.ini
@@ -1,0 +1,5019 @@
+[Range-insertNode.html]
+  type: testharness
+  expected: ERROR
+  [0,1: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [0,1: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [1,1: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [1,1: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [2,1: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [2,1: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [3,1: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [3,1: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [4,2: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [4,2: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [5,2: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [5,2: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [6,6: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [6,6: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [7,6: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [7,6: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [8,4: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [8,4: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [9,4: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [9,4: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [18,1: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [18,1: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [19,1: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [19,1: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [20,1: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [20,1: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [0,0: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [0,0: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [0,2: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [0,2: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [0,3: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [0,3: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [0,4: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [0,4: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [0,5: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [0,5: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [0,6: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [0,6: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [0,7: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [0,7: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [0,8: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [0,8: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [0,9: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [0,9: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [0,10: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [0,10: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [0,11: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [0,11: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [0,12: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [0,12: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [0,13: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [0,13: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [0,14: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [0,14: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [0,15: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [0,15: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [0,16: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [0,16: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [0,17: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [0,17: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [0,18: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [0,18: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [0,19: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [0,19: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [0,20: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [0,20: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [0,21: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [0,21: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [1,0: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\]]
+    expected: FAIL
+
+  [1,0: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\]]
+    expected: FAIL
+
+  [1,2: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [1,2: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [1,3: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1]
+    expected: FAIL
+
+  [1,3: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1]
+    expected: FAIL
+
+  [1,4: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [1,4: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [1,5: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1]
+    expected: FAIL
+
+  [1,5: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1]
+    expected: FAIL
+
+  [1,6: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [1,6: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [1,7: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node document]
+    expected: FAIL
+
+  [1,7: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node document]
+    expected: FAIL
+
+  [1,8: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedDiv]
+    expected: FAIL
+
+  [1,8: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedDiv]
+    expected: FAIL
+
+  [1,9: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoc]
+    expected: FAIL
+
+  [1,9: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoc]
+    expected: FAIL
+
+  [1,10: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara2]
+    expected: FAIL
+
+  [1,10: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara2]
+    expected: FAIL
+
+  [1,11: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlDoc]
+    expected: FAIL
+
+  [1,11: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlDoc]
+    expected: FAIL
+
+  [1,12: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlElement]
+    expected: FAIL
+
+  [1,12: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlElement]
+    expected: FAIL
+
+  [1,13: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [1,13: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [1,14: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [1,14: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [1,15: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node processingInstruction]
+    expected: FAIL
+
+  [1,15: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node processingInstruction]
+    expected: FAIL
+
+  [1,16: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [1,16: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [1,17: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node comment]
+    expected: FAIL
+
+  [1,17: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node comment]
+    expected: FAIL
+
+  [1,18: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedComment]
+    expected: FAIL
+
+  [1,18: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedComment]
+    expected: FAIL
+
+  [1,19: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node docfrag]
+    expected: FAIL
+
+  [1,19: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node docfrag]
+    expected: FAIL
+
+  [1,20: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node doctype]
+    expected: FAIL
+
+  [1,20: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node doctype]
+    expected: FAIL
+
+  [1,21: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [1,21: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [2,0: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [2,0: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [2,2: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [2,2: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [2,3: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [2,3: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [2,4: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [2,4: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [2,5: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [2,5: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [2,6: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [2,6: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [2,7: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [2,7: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [2,8: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [2,8: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [2,9: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [2,9: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [2,10: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [2,10: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [2,11: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [2,11: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [2,12: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [2,12: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [2,13: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [2,13: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [2,14: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [2,14: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [2,15: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [2,15: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [2,16: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [2,16: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [2,17: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [2,17: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [2,18: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [2,18: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [2,19: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [2,19: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [2,20: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [2,20: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [2,21: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [2,21: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [3,0: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [3,0: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [3,2: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [3,2: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [3,3: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [3,3: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [3,4: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [3,4: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [3,5: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [3,5: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [3,6: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [3,6: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [3,7: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [3,7: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [3,8: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [3,8: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [3,9: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [3,9: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [3,10: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [3,10: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [3,11: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [3,11: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [3,12: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [3,12: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [3,13: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [3,13: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [3,14: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [3,14: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [3,15: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [3,15: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [3,16: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [3,16: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [3,17: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [3,17: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [3,18: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [3,18: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [3,19: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [3,19: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [3,20: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [3,20: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [3,21: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [3,21: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [4,0: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [4,0: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [4,1: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [4,1: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [4,3: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [4,3: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [4,4: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [4,4: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [4,5: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [4,5: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [4,6: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [4,6: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [4,7: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [4,7: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [4,8: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [4,8: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [4,9: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [4,9: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [4,10: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [4,10: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [4,11: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [4,11: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [4,12: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [4,12: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [4,13: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [4,13: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [4,14: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [4,14: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [4,15: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [4,15: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [4,16: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [4,16: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [4,17: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [4,17: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [4,18: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [4,18: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [4,19: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [4,19: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [4,20: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [4,20: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [4,21: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [4,21: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [5,0: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [5,0: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [5,1: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [5,1: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [5,3: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [5,3: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [5,4: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [5,4: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [5,5: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [5,5: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [5,6: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [5,6: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [5,7: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [5,7: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [5,8: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [5,8: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [5,9: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [5,9: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [5,10: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [5,10: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [5,11: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [5,11: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [5,12: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [5,12: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [5,13: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [5,13: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [5,14: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [5,14: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [5,15: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [5,15: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [5,16: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [5,16: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [5,17: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [5,17: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [5,18: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [5,18: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [5,19: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [5,19: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [5,20: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [5,20: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [5,21: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [5,21: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [6,0: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [6,0: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [6,1: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [6,1: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [6,2: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [6,2: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [6,3: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [6,3: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [6,4: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [6,4: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [6,5: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [6,5: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [6,7: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [6,7: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [6,8: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [6,8: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [6,9: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [6,9: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [6,10: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [6,10: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [6,11: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [6,11: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [6,12: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [6,12: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [6,13: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [6,13: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [6,14: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [6,14: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [6,15: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [6,15: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [6,16: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [6,16: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [6,17: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [6,17: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [6,18: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [6,18: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [6,19: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [6,19: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [6,20: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [6,20: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [6,21: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [6,21: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [7,0: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [7,0: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [7,1: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [7,1: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [7,2: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [7,2: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [7,3: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [7,3: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [7,4: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [7,4: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [7,5: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [7,5: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [7,7: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [7,7: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [7,8: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [7,8: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [7,9: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [7,9: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [7,10: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [7,10: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [7,11: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [7,11: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [7,12: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [7,12: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [7,13: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [7,13: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [7,14: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [7,14: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [7,15: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [7,15: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [7,16: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [7,16: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [7,17: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [7,17: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [7,18: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [7,18: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [7,19: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [7,19: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [7,20: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [7,20: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [7,21: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [7,21: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [8,0: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [8,0: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [8,1: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [8,1: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [8,2: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [8,2: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [8,3: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [8,3: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [8,5: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [8,5: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [8,6: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [8,6: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [8,7: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [8,7: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [8,8: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [8,8: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [8,9: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [8,9: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [8,10: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [8,10: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [8,11: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [8,11: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [8,12: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [8,12: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [8,13: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [8,13: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [8,14: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [8,14: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [8,15: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [8,15: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [8,16: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [8,16: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [8,17: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [8,17: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [8,18: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [8,18: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [8,19: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [8,19: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [8,20: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [8,20: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [8,21: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [8,21: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [9,0: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [9,0: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [9,1: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [9,1: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [9,2: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [9,2: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [9,3: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [9,3: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [9,5: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [9,5: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [9,6: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [9,6: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [9,7: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [9,7: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [9,8: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [9,8: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [9,9: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [9,9: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [9,10: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [9,10: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [9,11: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [9,11: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [9,12: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [9,12: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [9,13: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [9,13: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [9,14: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [9,14: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [9,15: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [9,15: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [9,16: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [9,16: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [9,17: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [9,17: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [9,18: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [9,18: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [9,19: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [9,19: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [9,20: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [9,20: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [9,21: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [9,21: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [10,0: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [10,0: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [10,1: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [10,1: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [10,2: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [10,2: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [10,3: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [10,3: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [10,4: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [10,4: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [10,5: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [10,5: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [10,6: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [10,6: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [10,7: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node document]
+    expected: FAIL
+
+  [10,7: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node document]
+    expected: FAIL
+
+  [10,8: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [10,8: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [10,9: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [10,9: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [10,10: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [10,10: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [10,11: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [10,11: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [10,12: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [10,12: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [10,13: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [10,13: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [10,14: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [10,14: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [10,15: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [10,15: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [10,16: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [10,16: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [10,17: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [10,17: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [10,18: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [10,18: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [10,19: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [10,19: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [10,20: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [10,20: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [10,21: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [10,21: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [11,0: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [11,0: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [11,1: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [11,1: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [11,2: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [11,2: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [11,3: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [11,3: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [11,4: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [11,4: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [11,5: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [11,5: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [11,6: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [11,6: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [11,7: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [11,7: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [11,8: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [11,8: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [11,9: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [11,9: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [11,10: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [11,10: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [11,11: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [11,11: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [11,12: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [11,12: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [11,13: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [11,13: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [11,14: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [11,14: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [11,15: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [11,15: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [11,16: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [11,16: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [11,17: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [11,17: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [11,18: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [11,18: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [11,19: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [11,19: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [11,20: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [11,20: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [11,21: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [11,21: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [12,0: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [12,0: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [12,1: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [12,1: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [12,2: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [12,2: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [12,3: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [12,3: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [12,4: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [12,4: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [12,5: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [12,5: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [12,6: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [12,6: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [12,7: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [12,7: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [12,8: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [12,8: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [12,9: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [12,9: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [12,10: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [12,10: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [12,11: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [12,11: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [12,12: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [12,12: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [12,13: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [12,13: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [12,14: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [12,14: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [12,15: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [12,15: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [12,16: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [12,16: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [12,17: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [12,17: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [12,18: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [12,18: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [12,19: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [12,19: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [12,20: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [12,20: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [12,21: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [12,21: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [13,0: resulting DOM for range [document.head, 1, document.head, 1\], node paras[0\]]
+    expected: FAIL
+
+  [13,0: resulting range position for range [document.head, 1, document.head, 1\], node paras[0\]]
+    expected: FAIL
+
+  [13,1: resulting DOM for range [document.head, 1, document.head, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [13,1: resulting range position for range [document.head, 1, document.head, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [13,2: resulting DOM for range [document.head, 1, document.head, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [13,2: resulting range position for range [document.head, 1, document.head, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [13,3: resulting DOM for range [document.head, 1, document.head, 1\], node foreignPara1]
+    expected: FAIL
+
+  [13,3: resulting range position for range [document.head, 1, document.head, 1\], node foreignPara1]
+    expected: FAIL
+
+  [13,4: resulting DOM for range [document.head, 1, document.head, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [13,4: resulting range position for range [document.head, 1, document.head, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [13,5: resulting DOM for range [document.head, 1, document.head, 1\], node detachedPara1]
+    expected: FAIL
+
+  [13,5: resulting range position for range [document.head, 1, document.head, 1\], node detachedPara1]
+    expected: FAIL
+
+  [13,6: resulting DOM for range [document.head, 1, document.head, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [13,6: resulting range position for range [document.head, 1, document.head, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [13,7: resulting DOM for range [document.head, 1, document.head, 1\], node document]
+    expected: FAIL
+
+  [13,7: resulting range position for range [document.head, 1, document.head, 1\], node document]
+    expected: FAIL
+
+  [13,8: resulting DOM for range [document.head, 1, document.head, 1\], node detachedDiv]
+    expected: FAIL
+
+  [13,8: resulting range position for range [document.head, 1, document.head, 1\], node detachedDiv]
+    expected: FAIL
+
+  [13,9: resulting DOM for range [document.head, 1, document.head, 1\], node foreignDoc]
+    expected: FAIL
+
+  [13,9: resulting range position for range [document.head, 1, document.head, 1\], node foreignDoc]
+    expected: FAIL
+
+  [13,10: resulting DOM for range [document.head, 1, document.head, 1\], node foreignPara2]
+    expected: FAIL
+
+  [13,10: resulting range position for range [document.head, 1, document.head, 1\], node foreignPara2]
+    expected: FAIL
+
+  [13,11: resulting DOM for range [document.head, 1, document.head, 1\], node xmlDoc]
+    expected: FAIL
+
+  [13,11: resulting range position for range [document.head, 1, document.head, 1\], node xmlDoc]
+    expected: FAIL
+
+  [13,12: resulting DOM for range [document.head, 1, document.head, 1\], node xmlElement]
+    expected: FAIL
+
+  [13,12: resulting range position for range [document.head, 1, document.head, 1\], node xmlElement]
+    expected: FAIL
+
+  [13,13: resulting DOM for range [document.head, 1, document.head, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [13,13: resulting range position for range [document.head, 1, document.head, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [13,14: resulting DOM for range [document.head, 1, document.head, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [13,14: resulting range position for range [document.head, 1, document.head, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [13,15: resulting DOM for range [document.head, 1, document.head, 1\], node processingInstruction]
+    expected: FAIL
+
+  [13,15: resulting range position for range [document.head, 1, document.head, 1\], node processingInstruction]
+    expected: FAIL
+
+  [13,16: resulting DOM for range [document.head, 1, document.head, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [13,16: resulting range position for range [document.head, 1, document.head, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [13,17: resulting DOM for range [document.head, 1, document.head, 1\], node comment]
+    expected: FAIL
+
+  [13,17: resulting range position for range [document.head, 1, document.head, 1\], node comment]
+    expected: FAIL
+
+  [13,18: resulting DOM for range [document.head, 1, document.head, 1\], node detachedComment]
+    expected: FAIL
+
+  [13,18: resulting range position for range [document.head, 1, document.head, 1\], node detachedComment]
+    expected: FAIL
+
+  [13,19: resulting DOM for range [document.head, 1, document.head, 1\], node docfrag]
+    expected: FAIL
+
+  [13,19: resulting range position for range [document.head, 1, document.head, 1\], node docfrag]
+    expected: FAIL
+
+  [13,20: resulting DOM for range [document.head, 1, document.head, 1\], node doctype]
+    expected: FAIL
+
+  [13,20: resulting range position for range [document.head, 1, document.head, 1\], node doctype]
+    expected: FAIL
+
+  [13,21: resulting DOM for range [document.head, 1, document.head, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [13,21: resulting range position for range [document.head, 1, document.head, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [14,0: resulting DOM for range [document.body, 4, document.body, 5\], node paras[0\]]
+    expected: FAIL
+
+  [14,0: resulting range position for range [document.body, 4, document.body, 5\], node paras[0\]]
+    expected: FAIL
+
+  [14,1: resulting DOM for range [document.body, 4, document.body, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [14,1: resulting range position for range [document.body, 4, document.body, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [14,2: resulting DOM for range [document.body, 4, document.body, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [14,2: resulting range position for range [document.body, 4, document.body, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [14,3: resulting DOM for range [document.body, 4, document.body, 5\], node foreignPara1]
+    expected: FAIL
+
+  [14,3: resulting range position for range [document.body, 4, document.body, 5\], node foreignPara1]
+    expected: FAIL
+
+  [14,4: resulting DOM for range [document.body, 4, document.body, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [14,4: resulting range position for range [document.body, 4, document.body, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [14,5: resulting DOM for range [document.body, 4, document.body, 5\], node detachedPara1]
+    expected: FAIL
+
+  [14,5: resulting range position for range [document.body, 4, document.body, 5\], node detachedPara1]
+    expected: FAIL
+
+  [14,6: resulting DOM for range [document.body, 4, document.body, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [14,6: resulting range position for range [document.body, 4, document.body, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [14,7: resulting DOM for range [document.body, 4, document.body, 5\], node document]
+    expected: FAIL
+
+  [14,7: resulting range position for range [document.body, 4, document.body, 5\], node document]
+    expected: FAIL
+
+  [14,8: resulting DOM for range [document.body, 4, document.body, 5\], node detachedDiv]
+    expected: FAIL
+
+  [14,8: resulting range position for range [document.body, 4, document.body, 5\], node detachedDiv]
+    expected: FAIL
+
+  [14,9: resulting DOM for range [document.body, 4, document.body, 5\], node foreignDoc]
+    expected: FAIL
+
+  [14,9: resulting range position for range [document.body, 4, document.body, 5\], node foreignDoc]
+    expected: FAIL
+
+  [14,10: resulting DOM for range [document.body, 4, document.body, 5\], node foreignPara2]
+    expected: FAIL
+
+  [14,10: resulting range position for range [document.body, 4, document.body, 5\], node foreignPara2]
+    expected: FAIL
+
+  [14,11: resulting DOM for range [document.body, 4, document.body, 5\], node xmlDoc]
+    expected: FAIL
+
+  [14,11: resulting range position for range [document.body, 4, document.body, 5\], node xmlDoc]
+    expected: FAIL
+
+  [14,12: resulting DOM for range [document.body, 4, document.body, 5\], node xmlElement]
+    expected: FAIL
+
+  [14,12: resulting range position for range [document.body, 4, document.body, 5\], node xmlElement]
+    expected: FAIL
+
+  [14,13: resulting DOM for range [document.body, 4, document.body, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [14,13: resulting range position for range [document.body, 4, document.body, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [14,14: resulting DOM for range [document.body, 4, document.body, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [14,14: resulting range position for range [document.body, 4, document.body, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [14,15: resulting DOM for range [document.body, 4, document.body, 5\], node processingInstruction]
+    expected: FAIL
+
+  [14,15: resulting range position for range [document.body, 4, document.body, 5\], node processingInstruction]
+    expected: FAIL
+
+  [14,16: resulting DOM for range [document.body, 4, document.body, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [14,16: resulting range position for range [document.body, 4, document.body, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [14,17: resulting DOM for range [document.body, 4, document.body, 5\], node comment]
+    expected: FAIL
+
+  [14,17: resulting range position for range [document.body, 4, document.body, 5\], node comment]
+    expected: FAIL
+
+  [14,18: resulting DOM for range [document.body, 4, document.body, 5\], node detachedComment]
+    expected: FAIL
+
+  [14,18: resulting range position for range [document.body, 4, document.body, 5\], node detachedComment]
+    expected: FAIL
+
+  [14,19: resulting DOM for range [document.body, 4, document.body, 5\], node docfrag]
+    expected: FAIL
+
+  [14,19: resulting range position for range [document.body, 4, document.body, 5\], node docfrag]
+    expected: FAIL
+
+  [14,20: resulting DOM for range [document.body, 4, document.body, 5\], node doctype]
+    expected: FAIL
+
+  [14,20: resulting range position for range [document.body, 4, document.body, 5\], node doctype]
+    expected: FAIL
+
+  [14,21: resulting DOM for range [document.body, 4, document.body, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [14,21: resulting range position for range [document.body, 4, document.body, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [15,0: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [15,0: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [15,1: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [15,1: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [15,2: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [15,2: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [15,3: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [15,3: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [15,4: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [15,4: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [15,5: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [15,5: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [15,6: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [15,6: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [15,7: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node document]
+    expected: FAIL
+
+  [15,7: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node document]
+    expected: FAIL
+
+  [15,8: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [15,8: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [15,9: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [15,9: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [15,10: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [15,10: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [15,11: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [15,11: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [15,12: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [15,12: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [15,13: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [15,13: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [15,14: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [15,14: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [15,15: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [15,15: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [15,16: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [15,16: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [15,17: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [15,17: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [15,18: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [15,18: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [15,19: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [15,19: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [15,20: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [15,20: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [15,21: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [15,21: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [16,0: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [16,0: resulting range position for range [paras[0\], 0, paras[0\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [16,1: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [16,1: resulting range position for range [paras[0\], 0, paras[0\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [16,2: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [16,2: resulting range position for range [paras[0\], 0, paras[0\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [16,3: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [16,3: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [16,4: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [16,4: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [16,5: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [16,5: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [16,6: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [16,6: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [16,7: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node document]
+    expected: FAIL
+
+  [16,7: resulting range position for range [paras[0\], 0, paras[0\], 1\], node document]
+    expected: FAIL
+
+  [16,8: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [16,8: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [16,9: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [16,9: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [16,10: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [16,10: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [16,11: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [16,11: resulting range position for range [paras[0\], 0, paras[0\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [16,12: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node xmlElement]
+    expected: FAIL
+
+  [16,12: resulting range position for range [paras[0\], 0, paras[0\], 1\], node xmlElement]
+    expected: FAIL
+
+  [16,13: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [16,13: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [16,14: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [16,14: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [16,15: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [16,15: resulting range position for range [paras[0\], 0, paras[0\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [16,16: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [16,16: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [16,17: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node comment]
+    expected: FAIL
+
+  [16,17: resulting range position for range [paras[0\], 0, paras[0\], 1\], node comment]
+    expected: FAIL
+
+  [16,18: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedComment]
+    expected: FAIL
+
+  [16,18: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedComment]
+    expected: FAIL
+
+  [16,19: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node docfrag]
+    expected: FAIL
+
+  [16,19: resulting range position for range [paras[0\], 0, paras[0\], 1\], node docfrag]
+    expected: FAIL
+
+  [16,20: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node doctype]
+    expected: FAIL
+
+  [16,20: resulting range position for range [paras[0\], 0, paras[0\], 1\], node doctype]
+    expected: FAIL
+
+  [16,21: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [16,21: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [17,0: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\]]
+    expected: FAIL
+
+  [17,0: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\]]
+    expected: FAIL
+
+  [17,1: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [17,1: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [17,2: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [17,2: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [17,3: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1]
+    expected: FAIL
+
+  [17,3: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1]
+    expected: FAIL
+
+  [17,4: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [17,4: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [17,5: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1]
+    expected: FAIL
+
+  [17,5: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1]
+    expected: FAIL
+
+  [17,6: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [17,6: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [17,7: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node document]
+    expected: FAIL
+
+  [17,7: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node document]
+    expected: FAIL
+
+  [17,8: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedDiv]
+    expected: FAIL
+
+  [17,8: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedDiv]
+    expected: FAIL
+
+  [17,9: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoc]
+    expected: FAIL
+
+  [17,9: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoc]
+    expected: FAIL
+
+  [17,10: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara2]
+    expected: FAIL
+
+  [17,10: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara2]
+    expected: FAIL
+
+  [17,11: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node xmlDoc]
+    expected: FAIL
+
+  [17,11: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node xmlDoc]
+    expected: FAIL
+
+  [17,12: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node xmlElement]
+    expected: FAIL
+
+  [17,12: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node xmlElement]
+    expected: FAIL
+
+  [17,13: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [17,13: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [17,14: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [17,14: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [17,15: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node processingInstruction]
+    expected: FAIL
+
+  [17,15: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node processingInstruction]
+    expected: FAIL
+
+  [17,16: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [17,16: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [17,17: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node comment]
+    expected: FAIL
+
+  [17,17: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node comment]
+    expected: FAIL
+
+  [17,18: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedComment]
+    expected: FAIL
+
+  [17,18: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedComment]
+    expected: FAIL
+
+  [17,19: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node docfrag]
+    expected: FAIL
+
+  [17,19: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node docfrag]
+    expected: FAIL
+
+  [17,20: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node doctype]
+    expected: FAIL
+
+  [17,20: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node doctype]
+    expected: FAIL
+
+  [17,21: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [17,21: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [18,0: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [18,0: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [18,2: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [18,2: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [18,3: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [18,3: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [18,4: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [18,4: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [18,5: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [18,5: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [18,6: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [18,6: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [18,7: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [18,7: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [18,8: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [18,8: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [18,9: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [18,9: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [18,10: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [18,10: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [18,11: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [18,11: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [18,12: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [18,12: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [18,13: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [18,13: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [18,14: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [18,14: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [18,15: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [18,15: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [18,16: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [18,16: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [18,17: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [18,17: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [18,18: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [18,18: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [18,19: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [18,19: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [18,20: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [18,20: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [18,21: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [18,21: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [19,0: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [19,0: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [19,2: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [19,2: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [19,3: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [19,3: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [19,4: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [19,4: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [19,5: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [19,5: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [19,6: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [19,6: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [19,7: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [19,7: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [19,8: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [19,8: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [19,9: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [19,9: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [19,10: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [19,10: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [19,11: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [19,11: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [19,12: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [19,12: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [19,13: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [19,13: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [19,14: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [19,14: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [19,15: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [19,15: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [19,16: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [19,16: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [19,17: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [19,17: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [19,18: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [19,18: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [19,19: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [19,19: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [19,20: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [19,20: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [19,21: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [19,21: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [20,0: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [20,0: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [20,2: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [20,2: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [20,3: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [20,3: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [20,4: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [20,4: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [20,5: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [20,5: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [20,6: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [20,6: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [20,7: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node document]
+    expected: FAIL
+
+  [20,7: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node document]
+    expected: FAIL
+
+  [20,8: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [20,8: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [20,9: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [20,9: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [20,10: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [20,10: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [20,11: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [20,11: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [20,12: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlElement]
+    expected: FAIL
+
+  [20,12: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlElement]
+    expected: FAIL
+
+  [20,13: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [20,13: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [20,14: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [20,14: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [20,15: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [20,15: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [20,16: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [20,16: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [20,17: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node comment]
+    expected: FAIL
+
+  [20,17: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node comment]
+    expected: FAIL
+
+  [20,18: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedComment]
+    expected: FAIL
+
+  [20,18: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedComment]
+    expected: FAIL
+
+  [20,19: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node docfrag]
+    expected: FAIL
+
+  [20,19: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node docfrag]
+    expected: FAIL
+
+  [20,20: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node doctype]
+    expected: FAIL
+
+  [20,20: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node doctype]
+    expected: FAIL
+
+  [20,21: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [20,21: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [21,0: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\]]
+    expected: FAIL
+
+  [21,0: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\]]
+    expected: FAIL
+
+  [21,1: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [21,1: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [21,2: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [21,2: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [21,3: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1]
+    expected: FAIL
+
+  [21,3: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1]
+    expected: FAIL
+
+  [21,4: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [21,4: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [21,5: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1]
+    expected: FAIL
+
+  [21,5: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1]
+    expected: FAIL
+
+  [21,6: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [21,6: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [21,7: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node document]
+    expected: FAIL
+
+  [21,7: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node document]
+    expected: FAIL
+
+  [21,8: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedDiv]
+    expected: FAIL
+
+  [21,8: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedDiv]
+    expected: FAIL
+
+  [21,9: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoc]
+    expected: FAIL
+
+  [21,9: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoc]
+    expected: FAIL
+
+  [21,10: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara2]
+    expected: FAIL
+
+  [21,10: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara2]
+    expected: FAIL
+
+  [21,11: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlDoc]
+    expected: FAIL
+
+  [21,11: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlDoc]
+    expected: FAIL
+
+  [21,12: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlElement]
+    expected: FAIL
+
+  [21,12: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlElement]
+    expected: FAIL
+
+  [21,13: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedTextNode]
+    expected: FAIL
+
+  [21,13: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedTextNode]
+    expected: FAIL
+
+  [21,14: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignTextNode]
+    expected: FAIL
+
+  [21,14: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignTextNode]
+    expected: FAIL
+
+  [21,15: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node processingInstruction]
+    expected: FAIL
+
+  [21,15: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node processingInstruction]
+    expected: FAIL
+
+  [21,16: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [21,16: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [21,17: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node comment]
+    expected: FAIL
+
+  [21,17: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node comment]
+    expected: FAIL
+
+  [21,18: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedComment]
+    expected: FAIL
+
+  [21,18: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedComment]
+    expected: FAIL
+
+  [21,19: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node docfrag]
+    expected: FAIL
+
+  [21,19: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node docfrag]
+    expected: FAIL
+
+  [21,20: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node doctype]
+    expected: FAIL
+
+  [21,20: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node doctype]
+    expected: FAIL
+
+  [21,21: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoctype]
+    expected: FAIL
+
+  [21,21: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoctype]
+    expected: FAIL
+
+  [22,0: resulting DOM for range [testDiv, 2, paras[4\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [22,0: resulting range position for range [testDiv, 2, paras[4\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [22,1: resulting DOM for range [testDiv, 2, paras[4\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [22,1: resulting range position for range [testDiv, 2, paras[4\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [22,2: resulting DOM for range [testDiv, 2, paras[4\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [22,2: resulting range position for range [testDiv, 2, paras[4\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [22,3: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [22,3: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [22,4: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [22,4: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [22,5: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [22,5: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [22,6: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [22,6: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [22,7: resulting DOM for range [testDiv, 2, paras[4\], 1\], node document]
+    expected: FAIL
+
+  [22,7: resulting range position for range [testDiv, 2, paras[4\], 1\], node document]
+    expected: FAIL
+
+  [22,8: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [22,8: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [22,9: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [22,9: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [22,10: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [22,10: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [22,11: resulting DOM for range [testDiv, 2, paras[4\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [22,11: resulting range position for range [testDiv, 2, paras[4\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [22,12: resulting DOM for range [testDiv, 2, paras[4\], 1\], node xmlElement]
+    expected: FAIL
+
+  [22,12: resulting range position for range [testDiv, 2, paras[4\], 1\], node xmlElement]
+    expected: FAIL
+
+  [22,13: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [22,13: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [22,14: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [22,14: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [22,15: resulting DOM for range [testDiv, 2, paras[4\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [22,15: resulting range position for range [testDiv, 2, paras[4\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [22,16: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [22,16: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [22,17: resulting DOM for range [testDiv, 2, paras[4\], 1\], node comment]
+    expected: FAIL
+
+  [22,17: resulting range position for range [testDiv, 2, paras[4\], 1\], node comment]
+    expected: FAIL
+
+  [22,18: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedComment]
+    expected: FAIL
+
+  [22,18: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedComment]
+    expected: FAIL
+
+  [22,19: resulting DOM for range [testDiv, 2, paras[4\], 1\], node docfrag]
+    expected: FAIL
+
+  [22,19: resulting range position for range [testDiv, 2, paras[4\], 1\], node docfrag]
+    expected: FAIL
+
+  [22,20: resulting DOM for range [testDiv, 2, paras[4\], 1\], node doctype]
+    expected: FAIL
+
+  [22,20: resulting range position for range [testDiv, 2, paras[4\], 1\], node doctype]
+    expected: FAIL
+
+  [22,21: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [22,21: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [23,0: resulting DOM for range [document, 0, document, 1\], node paras[0\]]
+    expected: FAIL
+
+  [23,0: resulting range position for range [document, 0, document, 1\], node paras[0\]]
+    expected: FAIL
+
+  [23,1: resulting DOM for range [document, 0, document, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [23,1: resulting range position for range [document, 0, document, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [23,2: resulting DOM for range [document, 0, document, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [23,2: resulting range position for range [document, 0, document, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [23,3: resulting DOM for range [document, 0, document, 1\], node foreignPara1]
+    expected: FAIL
+
+  [23,3: resulting range position for range [document, 0, document, 1\], node foreignPara1]
+    expected: FAIL
+
+  [23,4: resulting DOM for range [document, 0, document, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [23,4: resulting range position for range [document, 0, document, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [23,5: resulting DOM for range [document, 0, document, 1\], node detachedPara1]
+    expected: FAIL
+
+  [23,5: resulting range position for range [document, 0, document, 1\], node detachedPara1]
+    expected: FAIL
+
+  [23,6: resulting DOM for range [document, 0, document, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [23,6: resulting range position for range [document, 0, document, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [23,7: resulting DOM for range [document, 0, document, 1\], node document]
+    expected: FAIL
+
+  [23,7: resulting range position for range [document, 0, document, 1\], node document]
+    expected: FAIL
+
+  [23,8: resulting DOM for range [document, 0, document, 1\], node detachedDiv]
+    expected: FAIL
+
+  [23,8: resulting range position for range [document, 0, document, 1\], node detachedDiv]
+    expected: FAIL
+
+  [23,9: resulting DOM for range [document, 0, document, 1\], node foreignDoc]
+    expected: FAIL
+
+  [23,9: resulting range position for range [document, 0, document, 1\], node foreignDoc]
+    expected: FAIL
+
+  [23,10: resulting DOM for range [document, 0, document, 1\], node foreignPara2]
+    expected: FAIL
+
+  [23,10: resulting range position for range [document, 0, document, 1\], node foreignPara2]
+    expected: FAIL
+
+  [23,11: resulting DOM for range [document, 0, document, 1\], node xmlDoc]
+    expected: FAIL
+
+  [23,11: resulting range position for range [document, 0, document, 1\], node xmlDoc]
+    expected: FAIL
+
+  [23,12: resulting DOM for range [document, 0, document, 1\], node xmlElement]
+    expected: FAIL
+
+  [23,12: resulting range position for range [document, 0, document, 1\], node xmlElement]
+    expected: FAIL
+
+  [23,13: resulting DOM for range [document, 0, document, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [23,13: resulting range position for range [document, 0, document, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [23,14: resulting DOM for range [document, 0, document, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [23,14: resulting range position for range [document, 0, document, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [23,15: resulting DOM for range [document, 0, document, 1\], node processingInstruction]
+    expected: FAIL
+
+  [23,15: resulting range position for range [document, 0, document, 1\], node processingInstruction]
+    expected: FAIL
+
+  [23,16: resulting DOM for range [document, 0, document, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [23,16: resulting range position for range [document, 0, document, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [23,17: resulting DOM for range [document, 0, document, 1\], node comment]
+    expected: FAIL
+
+  [23,17: resulting range position for range [document, 0, document, 1\], node comment]
+    expected: FAIL
+
+  [23,18: resulting DOM for range [document, 0, document, 1\], node detachedComment]
+    expected: FAIL
+
+  [23,18: resulting range position for range [document, 0, document, 1\], node detachedComment]
+    expected: FAIL
+
+  [23,19: resulting DOM for range [document, 0, document, 1\], node docfrag]
+    expected: FAIL
+
+  [23,19: resulting range position for range [document, 0, document, 1\], node docfrag]
+    expected: FAIL
+
+  [23,20: resulting DOM for range [document, 0, document, 1\], node doctype]
+    expected: FAIL
+
+  [23,20: resulting range position for range [document, 0, document, 1\], node doctype]
+    expected: FAIL
+
+  [23,21: resulting DOM for range [document, 0, document, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [23,21: resulting range position for range [document, 0, document, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [24,0: resulting DOM for range [document, 0, document, 2\], node paras[0\]]
+    expected: FAIL
+
+  [24,0: resulting range position for range [document, 0, document, 2\], node paras[0\]]
+    expected: FAIL
+
+  [24,1: resulting DOM for range [document, 0, document, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [24,1: resulting range position for range [document, 0, document, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [24,2: resulting DOM for range [document, 0, document, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [24,2: resulting range position for range [document, 0, document, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [24,3: resulting DOM for range [document, 0, document, 2\], node foreignPara1]
+    expected: FAIL
+
+  [24,3: resulting range position for range [document, 0, document, 2\], node foreignPara1]
+    expected: FAIL
+
+  [24,4: resulting DOM for range [document, 0, document, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [24,4: resulting range position for range [document, 0, document, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [24,5: resulting DOM for range [document, 0, document, 2\], node detachedPara1]
+    expected: FAIL
+
+  [24,5: resulting range position for range [document, 0, document, 2\], node detachedPara1]
+    expected: FAIL
+
+  [24,6: resulting DOM for range [document, 0, document, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [24,6: resulting range position for range [document, 0, document, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [24,7: resulting DOM for range [document, 0, document, 2\], node document]
+    expected: FAIL
+
+  [24,7: resulting range position for range [document, 0, document, 2\], node document]
+    expected: FAIL
+
+  [24,8: resulting DOM for range [document, 0, document, 2\], node detachedDiv]
+    expected: FAIL
+
+  [24,8: resulting range position for range [document, 0, document, 2\], node detachedDiv]
+    expected: FAIL
+
+  [24,9: resulting DOM for range [document, 0, document, 2\], node foreignDoc]
+    expected: FAIL
+
+  [24,9: resulting range position for range [document, 0, document, 2\], node foreignDoc]
+    expected: FAIL
+
+  [24,10: resulting DOM for range [document, 0, document, 2\], node foreignPara2]
+    expected: FAIL
+
+  [24,10: resulting range position for range [document, 0, document, 2\], node foreignPara2]
+    expected: FAIL
+
+  [24,11: resulting DOM for range [document, 0, document, 2\], node xmlDoc]
+    expected: FAIL
+
+  [24,11: resulting range position for range [document, 0, document, 2\], node xmlDoc]
+    expected: FAIL
+
+  [24,12: resulting DOM for range [document, 0, document, 2\], node xmlElement]
+    expected: FAIL
+
+  [24,12: resulting range position for range [document, 0, document, 2\], node xmlElement]
+    expected: FAIL
+
+  [24,13: resulting DOM for range [document, 0, document, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [24,13: resulting range position for range [document, 0, document, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [24,14: resulting DOM for range [document, 0, document, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [24,14: resulting range position for range [document, 0, document, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [24,15: resulting DOM for range [document, 0, document, 2\], node processingInstruction]
+    expected: FAIL
+
+  [24,15: resulting range position for range [document, 0, document, 2\], node processingInstruction]
+    expected: FAIL
+
+  [24,16: resulting DOM for range [document, 0, document, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [24,16: resulting range position for range [document, 0, document, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [24,17: resulting DOM for range [document, 0, document, 2\], node comment]
+    expected: FAIL
+
+  [24,17: resulting range position for range [document, 0, document, 2\], node comment]
+    expected: FAIL
+
+  [24,18: resulting DOM for range [document, 0, document, 2\], node detachedComment]
+    expected: FAIL
+
+  [24,18: resulting range position for range [document, 0, document, 2\], node detachedComment]
+    expected: FAIL
+
+  [24,19: resulting DOM for range [document, 0, document, 2\], node docfrag]
+    expected: FAIL
+
+  [24,19: resulting range position for range [document, 0, document, 2\], node docfrag]
+    expected: FAIL
+
+  [24,20: resulting DOM for range [document, 0, document, 2\], node doctype]
+    expected: FAIL
+
+  [24,20: resulting range position for range [document, 0, document, 2\], node doctype]
+    expected: FAIL
+
+  [24,21: resulting DOM for range [document, 0, document, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [24,21: resulting range position for range [document, 0, document, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [25,0: resulting DOM for range [comment, 2, comment, 3\], node paras[0\]]
+    expected: FAIL
+
+  [25,0: resulting range position for range [comment, 2, comment, 3\], node paras[0\]]
+    expected: FAIL
+
+  [25,1: resulting DOM for range [comment, 2, comment, 3\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [25,1: resulting range position for range [comment, 2, comment, 3\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [25,2: resulting DOM for range [comment, 2, comment, 3\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [25,2: resulting range position for range [comment, 2, comment, 3\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [25,3: resulting DOM for range [comment, 2, comment, 3\], node foreignPara1]
+    expected: FAIL
+
+  [25,3: resulting range position for range [comment, 2, comment, 3\], node foreignPara1]
+    expected: FAIL
+
+  [25,4: resulting DOM for range [comment, 2, comment, 3\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [25,4: resulting range position for range [comment, 2, comment, 3\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [25,5: resulting DOM for range [comment, 2, comment, 3\], node detachedPara1]
+    expected: FAIL
+
+  [25,5: resulting range position for range [comment, 2, comment, 3\], node detachedPara1]
+    expected: FAIL
+
+  [25,6: resulting DOM for range [comment, 2, comment, 3\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [25,6: resulting range position for range [comment, 2, comment, 3\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [25,7: resulting DOM for range [comment, 2, comment, 3\], node document]
+    expected: FAIL
+
+  [25,7: resulting range position for range [comment, 2, comment, 3\], node document]
+    expected: FAIL
+
+  [25,8: resulting DOM for range [comment, 2, comment, 3\], node detachedDiv]
+    expected: FAIL
+
+  [25,8: resulting range position for range [comment, 2, comment, 3\], node detachedDiv]
+    expected: FAIL
+
+  [25,9: resulting DOM for range [comment, 2, comment, 3\], node foreignDoc]
+    expected: FAIL
+
+  [25,9: resulting range position for range [comment, 2, comment, 3\], node foreignDoc]
+    expected: FAIL
+
+  [25,10: resulting DOM for range [comment, 2, comment, 3\], node foreignPara2]
+    expected: FAIL
+
+  [25,10: resulting range position for range [comment, 2, comment, 3\], node foreignPara2]
+    expected: FAIL
+
+  [25,11: resulting DOM for range [comment, 2, comment, 3\], node xmlDoc]
+    expected: FAIL
+
+  [25,11: resulting range position for range [comment, 2, comment, 3\], node xmlDoc]
+    expected: FAIL
+
+  [25,12: resulting DOM for range [comment, 2, comment, 3\], node xmlElement]
+    expected: FAIL
+
+  [25,12: resulting range position for range [comment, 2, comment, 3\], node xmlElement]
+    expected: FAIL
+
+  [25,13: resulting DOM for range [comment, 2, comment, 3\], node detachedTextNode]
+    expected: FAIL
+
+  [25,13: resulting range position for range [comment, 2, comment, 3\], node detachedTextNode]
+    expected: FAIL
+
+  [25,14: resulting DOM for range [comment, 2, comment, 3\], node foreignTextNode]
+    expected: FAIL
+
+  [25,14: resulting range position for range [comment, 2, comment, 3\], node foreignTextNode]
+    expected: FAIL
+
+  [25,15: resulting DOM for range [comment, 2, comment, 3\], node processingInstruction]
+    expected: FAIL
+
+  [25,15: resulting range position for range [comment, 2, comment, 3\], node processingInstruction]
+    expected: FAIL
+
+  [25,16: resulting DOM for range [comment, 2, comment, 3\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [25,16: resulting range position for range [comment, 2, comment, 3\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [25,17: resulting DOM for range [comment, 2, comment, 3\], node comment]
+    expected: FAIL
+
+  [25,17: resulting range position for range [comment, 2, comment, 3\], node comment]
+    expected: FAIL
+
+  [25,18: resulting DOM for range [comment, 2, comment, 3\], node detachedComment]
+    expected: FAIL
+
+  [25,18: resulting range position for range [comment, 2, comment, 3\], node detachedComment]
+    expected: FAIL
+
+  [25,19: resulting DOM for range [comment, 2, comment, 3\], node docfrag]
+    expected: FAIL
+
+  [25,19: resulting range position for range [comment, 2, comment, 3\], node docfrag]
+    expected: FAIL
+
+  [25,20: resulting DOM for range [comment, 2, comment, 3\], node doctype]
+    expected: FAIL
+
+  [25,20: resulting range position for range [comment, 2, comment, 3\], node doctype]
+    expected: FAIL
+
+  [25,21: resulting DOM for range [comment, 2, comment, 3\], node foreignDoctype]
+    expected: FAIL
+
+  [25,21: resulting range position for range [comment, 2, comment, 3\], node foreignDoctype]
+    expected: FAIL
+
+  [26,0: resulting DOM for range [testDiv, 0, comment, 5\], node paras[0\]]
+    expected: FAIL
+
+  [26,0: resulting range position for range [testDiv, 0, comment, 5\], node paras[0\]]
+    expected: FAIL
+
+  [26,1: resulting DOM for range [testDiv, 0, comment, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [26,1: resulting range position for range [testDiv, 0, comment, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [26,2: resulting DOM for range [testDiv, 0, comment, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [26,2: resulting range position for range [testDiv, 0, comment, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [26,3: resulting DOM for range [testDiv, 0, comment, 5\], node foreignPara1]
+    expected: FAIL
+
+  [26,3: resulting range position for range [testDiv, 0, comment, 5\], node foreignPara1]
+    expected: FAIL
+
+  [26,4: resulting DOM for range [testDiv, 0, comment, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [26,4: resulting range position for range [testDiv, 0, comment, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [26,5: resulting DOM for range [testDiv, 0, comment, 5\], node detachedPara1]
+    expected: FAIL
+
+  [26,5: resulting range position for range [testDiv, 0, comment, 5\], node detachedPara1]
+    expected: FAIL
+
+  [26,6: resulting DOM for range [testDiv, 0, comment, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [26,6: resulting range position for range [testDiv, 0, comment, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [26,7: resulting DOM for range [testDiv, 0, comment, 5\], node document]
+    expected: FAIL
+
+  [26,7: resulting range position for range [testDiv, 0, comment, 5\], node document]
+    expected: FAIL
+
+  [26,8: resulting DOM for range [testDiv, 0, comment, 5\], node detachedDiv]
+    expected: FAIL
+
+  [26,8: resulting range position for range [testDiv, 0, comment, 5\], node detachedDiv]
+    expected: FAIL
+
+  [26,9: resulting DOM for range [testDiv, 0, comment, 5\], node foreignDoc]
+    expected: FAIL
+
+  [26,9: resulting range position for range [testDiv, 0, comment, 5\], node foreignDoc]
+    expected: FAIL
+
+  [26,10: resulting DOM for range [testDiv, 0, comment, 5\], node foreignPara2]
+    expected: FAIL
+
+  [26,10: resulting range position for range [testDiv, 0, comment, 5\], node foreignPara2]
+    expected: FAIL
+
+  [26,11: resulting DOM for range [testDiv, 0, comment, 5\], node xmlDoc]
+    expected: FAIL
+
+  [26,11: resulting range position for range [testDiv, 0, comment, 5\], node xmlDoc]
+    expected: FAIL
+
+  [26,12: resulting DOM for range [testDiv, 0, comment, 5\], node xmlElement]
+    expected: FAIL
+
+  [26,12: resulting range position for range [testDiv, 0, comment, 5\], node xmlElement]
+    expected: FAIL
+
+  [26,13: resulting DOM for range [testDiv, 0, comment, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [26,13: resulting range position for range [testDiv, 0, comment, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [26,14: resulting DOM for range [testDiv, 0, comment, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [26,14: resulting range position for range [testDiv, 0, comment, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [26,15: resulting DOM for range [testDiv, 0, comment, 5\], node processingInstruction]
+    expected: FAIL
+
+  [26,15: resulting range position for range [testDiv, 0, comment, 5\], node processingInstruction]
+    expected: FAIL
+
+  [26,16: resulting DOM for range [testDiv, 0, comment, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [26,16: resulting range position for range [testDiv, 0, comment, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [26,17: resulting DOM for range [testDiv, 0, comment, 5\], node comment]
+    expected: FAIL
+
+  [26,17: resulting range position for range [testDiv, 0, comment, 5\], node comment]
+    expected: FAIL
+
+  [26,18: resulting DOM for range [testDiv, 0, comment, 5\], node detachedComment]
+    expected: FAIL
+
+  [26,18: resulting range position for range [testDiv, 0, comment, 5\], node detachedComment]
+    expected: FAIL
+
+  [26,19: resulting DOM for range [testDiv, 0, comment, 5\], node docfrag]
+    expected: FAIL
+
+  [26,19: resulting range position for range [testDiv, 0, comment, 5\], node docfrag]
+    expected: FAIL
+
+  [26,20: resulting DOM for range [testDiv, 0, comment, 5\], node doctype]
+    expected: FAIL
+
+  [26,20: resulting range position for range [testDiv, 0, comment, 5\], node doctype]
+    expected: FAIL
+
+  [26,21: resulting DOM for range [testDiv, 0, comment, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [26,21: resulting range position for range [testDiv, 0, comment, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [27,0: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node paras[0\]]
+    expected: FAIL
+
+  [27,0: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node paras[0\]]
+    expected: FAIL
+
+  [27,1: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [27,1: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [27,2: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [27,2: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [27,3: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1]
+    expected: FAIL
+
+  [27,3: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1]
+    expected: FAIL
+
+  [27,4: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [27,4: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [27,5: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1]
+    expected: FAIL
+
+  [27,5: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1]
+    expected: FAIL
+
+  [27,6: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [27,6: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [27,7: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node document]
+    expected: FAIL
+
+  [27,7: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node document]
+    expected: FAIL
+
+  [27,8: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedDiv]
+    expected: FAIL
+
+  [27,8: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedDiv]
+    expected: FAIL
+
+  [27,9: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignDoc]
+    expected: FAIL
+
+  [27,9: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignDoc]
+    expected: FAIL
+
+  [27,10: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignPara2]
+    expected: FAIL
+
+  [27,10: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignPara2]
+    expected: FAIL
+
+  [27,11: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node xmlDoc]
+    expected: FAIL
+
+  [27,11: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node xmlDoc]
+    expected: FAIL
+
+  [27,12: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node xmlElement]
+    expected: FAIL
+
+  [27,12: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node xmlElement]
+    expected: FAIL
+
+  [27,13: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [27,13: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [27,14: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [27,14: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [27,15: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node processingInstruction]
+    expected: FAIL
+
+  [27,15: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node processingInstruction]
+    expected: FAIL
+
+  [27,16: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [27,16: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [27,17: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node comment]
+    expected: FAIL
+
+  [27,17: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node comment]
+    expected: FAIL
+
+  [27,18: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedComment]
+    expected: FAIL
+
+  [27,18: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedComment]
+    expected: FAIL
+
+  [27,19: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node docfrag]
+    expected: FAIL
+
+  [27,19: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node docfrag]
+    expected: FAIL
+
+  [27,20: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node doctype]
+    expected: FAIL
+
+  [27,20: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node doctype]
+    expected: FAIL
+
+  [27,21: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [27,21: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [28,0: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\]]
+    expected: FAIL
+
+  [28,0: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\]]
+    expected: FAIL
+
+  [28,1: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [28,1: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [28,2: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [28,2: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [28,3: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1]
+    expected: FAIL
+
+  [28,3: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1]
+    expected: FAIL
+
+  [28,4: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [28,4: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [28,5: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1]
+    expected: FAIL
+
+  [28,5: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1]
+    expected: FAIL
+
+  [28,6: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [28,6: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [28,7: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node document]
+    expected: FAIL
+
+  [28,7: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node document]
+    expected: FAIL
+
+  [28,8: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedDiv]
+    expected: FAIL
+
+  [28,8: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedDiv]
+    expected: FAIL
+
+  [28,9: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoc]
+    expected: FAIL
+
+  [28,9: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoc]
+    expected: FAIL
+
+  [28,10: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara2]
+    expected: FAIL
+
+  [28,10: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara2]
+    expected: FAIL
+
+  [28,11: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlDoc]
+    expected: FAIL
+
+  [28,11: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlDoc]
+    expected: FAIL
+
+  [28,12: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlElement]
+    expected: FAIL
+
+  [28,12: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlElement]
+    expected: FAIL
+
+  [28,13: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedTextNode]
+    expected: FAIL
+
+  [28,13: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedTextNode]
+    expected: FAIL
+
+  [28,14: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignTextNode]
+    expected: FAIL
+
+  [28,14: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignTextNode]
+    expected: FAIL
+
+  [28,15: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node processingInstruction]
+    expected: FAIL
+
+  [28,15: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node processingInstruction]
+    expected: FAIL
+
+  [28,16: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [28,16: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [28,17: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node comment]
+    expected: FAIL
+
+  [28,17: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node comment]
+    expected: FAIL
+
+  [28,18: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedComment]
+    expected: FAIL
+
+  [28,18: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedComment]
+    expected: FAIL
+
+  [28,19: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node docfrag]
+    expected: FAIL
+
+  [28,19: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node docfrag]
+    expected: FAIL
+
+  [28,20: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node doctype]
+    expected: FAIL
+
+  [28,20: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node doctype]
+    expected: FAIL
+
+  [28,21: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoctype]
+    expected: FAIL
+
+  [28,21: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoctype]
+    expected: FAIL
+
+  [29,0: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node paras[0\]]
+    expected: FAIL
+
+  [29,0: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node paras[0\]]
+    expected: FAIL
+
+  [29,1: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [29,1: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [29,2: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [29,2: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [29,3: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1]
+    expected: FAIL
+
+  [29,3: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1]
+    expected: FAIL
+
+  [29,4: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [29,4: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [29,5: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1]
+    expected: FAIL
+
+  [29,5: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1]
+    expected: FAIL
+
+  [29,6: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [29,6: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [29,7: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node document]
+    expected: FAIL
+
+  [29,7: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node document]
+    expected: FAIL
+
+  [29,8: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedDiv]
+    expected: FAIL
+
+  [29,8: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedDiv]
+    expected: FAIL
+
+  [29,9: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignDoc]
+    expected: FAIL
+
+  [29,9: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignDoc]
+    expected: FAIL
+
+  [29,10: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignPara2]
+    expected: FAIL
+
+  [29,10: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignPara2]
+    expected: FAIL
+
+  [29,11: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node xmlDoc]
+    expected: FAIL
+
+  [29,11: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node xmlDoc]
+    expected: FAIL
+
+  [29,12: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node xmlElement]
+    expected: FAIL
+
+  [29,12: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node xmlElement]
+    expected: FAIL
+
+  [29,13: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [29,13: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [29,14: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [29,14: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [29,15: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node processingInstruction]
+    expected: FAIL
+
+  [29,15: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node processingInstruction]
+    expected: FAIL
+
+  [29,16: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [29,16: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [29,17: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node comment]
+    expected: FAIL
+
+  [29,17: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node comment]
+    expected: FAIL
+
+  [29,18: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedComment]
+    expected: FAIL
+
+  [29,18: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedComment]
+    expected: FAIL
+
+  [29,19: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node docfrag]
+    expected: FAIL
+
+  [29,19: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node docfrag]
+    expected: FAIL
+
+  [29,20: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node doctype]
+    expected: FAIL
+
+  [29,20: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node doctype]
+    expected: FAIL
+
+  [29,21: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [29,21: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [30,0: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [30,0: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [30,1: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [30,1: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [30,2: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [30,2: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [30,3: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [30,3: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [30,4: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [30,4: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [30,5: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [30,5: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [30,6: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [30,6: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [30,7: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node document]
+    expected: FAIL
+
+  [30,7: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node document]
+    expected: FAIL
+
+  [30,8: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [30,8: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [30,9: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [30,9: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [30,10: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [30,10: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [30,11: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [30,11: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [30,12: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [30,12: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [30,13: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [30,13: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [30,14: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [30,14: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [30,15: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [30,15: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [30,16: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [30,16: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [30,17: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node comment]
+    expected: FAIL
+
+  [30,17: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node comment]
+    expected: FAIL
+
+  [30,18: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [30,18: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [30,19: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [30,19: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [30,20: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [30,20: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [30,21: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [30,21: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [31,0: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [31,0: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [31,1: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [31,1: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [31,2: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [31,2: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [31,3: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [31,3: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [31,4: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [31,4: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [31,5: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [31,5: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [31,6: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [31,6: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [31,7: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node document]
+    expected: FAIL
+
+  [31,7: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node document]
+    expected: FAIL
+
+  [31,8: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [31,8: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [31,9: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [31,9: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [31,10: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [31,10: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [31,11: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [31,11: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [31,12: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [31,12: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [31,13: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [31,13: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [31,14: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [31,14: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [31,15: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [31,15: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [31,16: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [31,16: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [31,17: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node comment]
+    expected: FAIL
+
+  [31,17: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node comment]
+    expected: FAIL
+
+  [31,18: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [31,18: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [31,19: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [31,19: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [31,20: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [31,20: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [31,21: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [31,21: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [32,0: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [32,0: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [32,1: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [32,1: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [32,2: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [32,2: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [32,3: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [32,3: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [32,4: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [32,4: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [32,5: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [32,5: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [32,6: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [32,6: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [32,7: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node document]
+    expected: FAIL
+
+  [32,7: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node document]
+    expected: FAIL
+
+  [32,8: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [32,8: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [32,9: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [32,9: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [32,10: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [32,10: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [32,11: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [32,11: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [32,12: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [32,12: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [32,13: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [32,13: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [32,14: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [32,14: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [32,15: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [32,15: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [32,16: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [32,16: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [32,17: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node comment]
+    expected: FAIL
+
+  [32,17: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node comment]
+    expected: FAIL
+
+  [32,18: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [32,18: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [32,19: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [32,19: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [32,20: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [32,20: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [32,21: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [32,21: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [33,0: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node paras[0\]]
+    expected: FAIL
+
+  [33,0: resulting range position for range [detachedComment, 3, detachedComment, 4\], node paras[0\]]
+    expected: FAIL
+
+  [33,1: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [33,1: resulting range position for range [detachedComment, 3, detachedComment, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [33,2: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [33,2: resulting range position for range [detachedComment, 3, detachedComment, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [33,3: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignPara1]
+    expected: FAIL
+
+  [33,3: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignPara1]
+    expected: FAIL
+
+  [33,4: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [33,4: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [33,5: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedPara1]
+    expected: FAIL
+
+  [33,5: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedPara1]
+    expected: FAIL
+
+  [33,6: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [33,6: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [33,7: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node document]
+    expected: FAIL
+
+  [33,7: resulting range position for range [detachedComment, 3, detachedComment, 4\], node document]
+    expected: FAIL
+
+  [33,8: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedDiv]
+    expected: FAIL
+
+  [33,8: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedDiv]
+    expected: FAIL
+
+  [33,9: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignDoc]
+    expected: FAIL
+
+  [33,9: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignDoc]
+    expected: FAIL
+
+  [33,10: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignPara2]
+    expected: FAIL
+
+  [33,10: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignPara2]
+    expected: FAIL
+
+  [33,11: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node xmlDoc]
+    expected: FAIL
+
+  [33,11: resulting range position for range [detachedComment, 3, detachedComment, 4\], node xmlDoc]
+    expected: FAIL
+
+  [33,12: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node xmlElement]
+    expected: FAIL
+
+  [33,12: resulting range position for range [detachedComment, 3, detachedComment, 4\], node xmlElement]
+    expected: FAIL
+
+  [33,13: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [33,13: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [33,14: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [33,14: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [33,15: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node processingInstruction]
+    expected: FAIL
+
+  [33,15: resulting range position for range [detachedComment, 3, detachedComment, 4\], node processingInstruction]
+    expected: FAIL
+
+  [33,16: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [33,16: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [33,17: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node comment]
+    expected: FAIL
+
+  [33,17: resulting range position for range [detachedComment, 3, detachedComment, 4\], node comment]
+    expected: FAIL
+
+  [33,18: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedComment]
+    expected: FAIL
+
+  [33,18: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedComment]
+    expected: FAIL
+
+  [33,19: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node docfrag]
+    expected: FAIL
+
+  [33,19: resulting range position for range [detachedComment, 3, detachedComment, 4\], node docfrag]
+    expected: FAIL
+
+  [33,20: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node doctype]
+    expected: FAIL
+
+  [33,20: resulting range position for range [detachedComment, 3, detachedComment, 4\], node doctype]
+    expected: FAIL
+
+  [33,21: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignDoctype]
+    expected: FAIL
+
+  [33,21: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignDoctype]
+    expected: FAIL
+
+  [34,0: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\]]
+    expected: FAIL
+
+  [34,0: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\]]
+    expected: FAIL
+
+  [34,1: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [34,1: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [34,2: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [34,2: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [34,3: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1]
+    expected: FAIL
+
+  [34,3: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1]
+    expected: FAIL
+
+  [34,4: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [34,4: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [34,5: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1]
+    expected: FAIL
+
+  [34,5: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1]
+    expected: FAIL
+
+  [34,6: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [34,6: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [34,7: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node document]
+    expected: FAIL
+
+  [34,7: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node document]
+    expected: FAIL
+
+  [34,8: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedDiv]
+    expected: FAIL
+
+  [34,8: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedDiv]
+    expected: FAIL
+
+  [34,9: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoc]
+    expected: FAIL
+
+  [34,9: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoc]
+    expected: FAIL
+
+  [34,10: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara2]
+    expected: FAIL
+
+  [34,10: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara2]
+    expected: FAIL
+
+  [34,11: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlDoc]
+    expected: FAIL
+
+  [34,11: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlDoc]
+    expected: FAIL
+
+  [34,12: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlElement]
+    expected: FAIL
+
+  [34,12: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlElement]
+    expected: FAIL
+
+  [34,13: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [34,13: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [34,14: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [34,14: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [34,15: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node processingInstruction]
+    expected: FAIL
+
+  [34,15: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node processingInstruction]
+    expected: FAIL
+
+  [34,16: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [34,16: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [34,17: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node comment]
+    expected: FAIL
+
+  [34,17: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node comment]
+    expected: FAIL
+
+  [34,18: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedComment]
+    expected: FAIL
+
+  [34,18: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedComment]
+    expected: FAIL
+
+  [34,19: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node docfrag]
+    expected: FAIL
+
+  [34,19: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node docfrag]
+    expected: FAIL
+
+  [34,20: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node doctype]
+    expected: FAIL
+
+  [34,20: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node doctype]
+    expected: FAIL
+
+  [34,21: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [34,21: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [35,0: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\]]
+    expected: FAIL
+
+  [35,0: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\]]
+    expected: FAIL
+
+  [35,1: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [35,1: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [35,2: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [35,2: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [35,3: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1]
+    expected: FAIL
+
+  [35,3: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1]
+    expected: FAIL
+
+  [35,4: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [35,4: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [35,5: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1]
+    expected: FAIL
+
+  [35,5: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1]
+    expected: FAIL
+
+  [35,6: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [35,6: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [35,7: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node document]
+    expected: FAIL
+
+  [35,7: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node document]
+    expected: FAIL
+
+  [35,8: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedDiv]
+    expected: FAIL
+
+  [35,8: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedDiv]
+    expected: FAIL
+
+  [35,9: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoc]
+    expected: FAIL
+
+  [35,9: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoc]
+    expected: FAIL
+
+  [35,10: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara2]
+    expected: FAIL
+
+  [35,10: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara2]
+    expected: FAIL
+
+  [35,11: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlDoc]
+    expected: FAIL
+
+  [35,11: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlDoc]
+    expected: FAIL
+
+  [35,12: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlElement]
+    expected: FAIL
+
+  [35,12: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlElement]
+    expected: FAIL
+
+  [35,13: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedTextNode]
+    expected: FAIL
+
+  [35,13: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedTextNode]
+    expected: FAIL
+
+  [35,14: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignTextNode]
+    expected: FAIL
+
+  [35,14: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignTextNode]
+    expected: FAIL
+
+  [35,15: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node processingInstruction]
+    expected: FAIL
+
+  [35,15: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node processingInstruction]
+    expected: FAIL
+
+  [35,16: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [35,16: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [35,17: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node comment]
+    expected: FAIL
+
+  [35,17: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node comment]
+    expected: FAIL
+
+  [35,18: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedComment]
+    expected: FAIL
+
+  [35,18: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedComment]
+    expected: FAIL
+
+  [35,19: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node docfrag]
+    expected: FAIL
+
+  [35,19: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node docfrag]
+    expected: FAIL
+
+  [35,20: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node doctype]
+    expected: FAIL
+
+  [35,20: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node doctype]
+    expected: FAIL
+
+  [35,21: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoctype]
+    expected: FAIL
+
+  [35,21: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoctype]
+    expected: FAIL
+
+  [36,0: resulting DOM for range [docfrag, 0, docfrag, 0\], node paras[0\]]
+    expected: FAIL
+
+  [36,0: resulting range position for range [docfrag, 0, docfrag, 0\], node paras[0\]]
+    expected: FAIL
+
+  [36,1: resulting DOM for range [docfrag, 0, docfrag, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [36,1: resulting range position for range [docfrag, 0, docfrag, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [36,2: resulting DOM for range [docfrag, 0, docfrag, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [36,2: resulting range position for range [docfrag, 0, docfrag, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [36,3: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignPara1]
+    expected: FAIL
+
+  [36,3: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignPara1]
+    expected: FAIL
+
+  [36,4: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [36,4: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [36,5: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedPara1]
+    expected: FAIL
+
+  [36,5: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedPara1]
+    expected: FAIL
+
+  [36,6: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [36,6: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [36,7: resulting DOM for range [docfrag, 0, docfrag, 0\], node document]
+    expected: FAIL
+
+  [36,7: resulting range position for range [docfrag, 0, docfrag, 0\], node document]
+    expected: FAIL
+
+  [36,8: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedDiv]
+    expected: FAIL
+
+  [36,8: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedDiv]
+    expected: FAIL
+
+  [36,9: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignDoc]
+    expected: FAIL
+
+  [36,9: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignDoc]
+    expected: FAIL
+
+  [36,10: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignPara2]
+    expected: FAIL
+
+  [36,10: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignPara2]
+    expected: FAIL
+
+  [36,11: resulting DOM for range [docfrag, 0, docfrag, 0\], node xmlDoc]
+    expected: FAIL
+
+  [36,11: resulting range position for range [docfrag, 0, docfrag, 0\], node xmlDoc]
+    expected: FAIL
+
+  [36,12: resulting DOM for range [docfrag, 0, docfrag, 0\], node xmlElement]
+    expected: FAIL
+
+  [36,12: resulting range position for range [docfrag, 0, docfrag, 0\], node xmlElement]
+    expected: FAIL
+
+  [36,13: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [36,13: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [36,14: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [36,14: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [36,15: resulting DOM for range [docfrag, 0, docfrag, 0\], node processingInstruction]
+    expected: FAIL
+
+  [36,15: resulting range position for range [docfrag, 0, docfrag, 0\], node processingInstruction]
+    expected: FAIL
+
+  [36,16: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [36,16: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [36,17: resulting DOM for range [docfrag, 0, docfrag, 0\], node comment]
+    expected: FAIL
+
+  [36,17: resulting range position for range [docfrag, 0, docfrag, 0\], node comment]
+    expected: FAIL
+
+  [36,18: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedComment]
+    expected: FAIL
+
+  [36,18: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedComment]
+    expected: FAIL
+
+  [36,19: resulting DOM for range [docfrag, 0, docfrag, 0\], node docfrag]
+    expected: FAIL
+
+  [36,19: resulting range position for range [docfrag, 0, docfrag, 0\], node docfrag]
+    expected: FAIL
+
+  [36,20: resulting DOM for range [docfrag, 0, docfrag, 0\], node doctype]
+    expected: FAIL
+
+  [36,20: resulting range position for range [docfrag, 0, docfrag, 0\], node doctype]
+    expected: FAIL
+
+  [36,21: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [36,21: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [37,0: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\]]
+    expected: FAIL
+
+  [37,0: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\]]
+    expected: FAIL
+
+  [37,1: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [37,1: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [37,2: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [37,2: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [37,3: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1]
+    expected: FAIL
+
+  [37,3: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1]
+    expected: FAIL
+
+  [37,4: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [37,4: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [37,5: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1]
+    expected: FAIL
+
+  [37,5: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1]
+    expected: FAIL
+
+  [37,6: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [37,6: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [37,7: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node document]
+    expected: FAIL
+
+  [37,7: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node document]
+    expected: FAIL
+
+  [37,8: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedDiv]
+    expected: FAIL
+
+  [37,8: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedDiv]
+    expected: FAIL
+
+  [37,9: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoc]
+    expected: FAIL
+
+  [37,9: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoc]
+    expected: FAIL
+
+  [37,10: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara2]
+    expected: FAIL
+
+  [37,10: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara2]
+    expected: FAIL
+
+  [37,11: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node xmlDoc]
+    expected: FAIL
+
+  [37,11: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node xmlDoc]
+    expected: FAIL
+
+  [37,12: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node xmlElement]
+    expected: FAIL
+
+  [37,12: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node xmlElement]
+    expected: FAIL
+
+  [37,13: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [37,13: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [37,14: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [37,14: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [37,15: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node processingInstruction]
+    expected: FAIL
+
+  [37,15: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node processingInstruction]
+    expected: FAIL
+
+  [37,16: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [37,16: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [37,17: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node comment]
+    expected: FAIL
+
+  [37,17: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node comment]
+    expected: FAIL
+
+  [37,18: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedComment]
+    expected: FAIL
+
+  [37,18: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedComment]
+    expected: FAIL
+
+  [37,19: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node docfrag]
+    expected: FAIL
+
+  [37,19: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node docfrag]
+    expected: FAIL
+
+  [37,20: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node doctype]
+    expected: FAIL
+
+  [37,20: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node doctype]
+    expected: FAIL
+
+  [37,21: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoctype]
+    expected: FAIL
+
+  [37,21: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoctype]
+    expected: FAIL
+

--- a/tests/wpt/metadata/dom/ranges/Range-surroundContents.html.ini
+++ b/tests/wpt/metadata/dom/ranges/Range-surroundContents.html.ini
@@ -1,0 +1,5019 @@
+[Range-surroundContents.html]
+  type: testharness
+  expected: ERROR
+  [0,1: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [0,1: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [1,1: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [1,1: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [2,1: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [2,1: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [3,1: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [3,1: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [4,2: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [4,2: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [5,2: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [5,2: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [6,6: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [6,6: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [7,6: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [7,6: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [8,4: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [8,4: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [9,4: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [9,4: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [0,0: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [0,0: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [0,2: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [0,2: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [0,3: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [0,3: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [0,4: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [0,4: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [0,5: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [0,5: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [0,6: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [0,6: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [0,7: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [0,7: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [0,8: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [0,8: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [0,9: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [0,9: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [0,10: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [0,10: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [0,11: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [0,11: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [0,12: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [0,12: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [0,13: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [0,13: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [0,14: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [0,14: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [0,15: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [0,15: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [0,16: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [0,16: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [0,17: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [0,17: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [0,18: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [0,18: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [0,19: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [0,19: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [0,20: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [0,20: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [0,21: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [0,21: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [1,0: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\]]
+    expected: FAIL
+
+  [1,0: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[0\]]
+    expected: FAIL
+
+  [1,2: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [1,2: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [1,3: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1]
+    expected: FAIL
+
+  [1,3: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1]
+    expected: FAIL
+
+  [1,4: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [1,4: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [1,5: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1]
+    expected: FAIL
+
+  [1,5: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1]
+    expected: FAIL
+
+  [1,6: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [1,6: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [1,7: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node document]
+    expected: FAIL
+
+  [1,7: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node document]
+    expected: FAIL
+
+  [1,8: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedDiv]
+    expected: FAIL
+
+  [1,8: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedDiv]
+    expected: FAIL
+
+  [1,9: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoc]
+    expected: FAIL
+
+  [1,9: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoc]
+    expected: FAIL
+
+  [1,10: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara2]
+    expected: FAIL
+
+  [1,10: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignPara2]
+    expected: FAIL
+
+  [1,11: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlDoc]
+    expected: FAIL
+
+  [1,11: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlDoc]
+    expected: FAIL
+
+  [1,12: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlElement]
+    expected: FAIL
+
+  [1,12: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node xmlElement]
+    expected: FAIL
+
+  [1,13: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [1,13: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [1,14: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [1,14: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [1,15: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node processingInstruction]
+    expected: FAIL
+
+  [1,15: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node processingInstruction]
+    expected: FAIL
+
+  [1,16: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [1,16: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [1,17: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node comment]
+    expected: FAIL
+
+  [1,17: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node comment]
+    expected: FAIL
+
+  [1,18: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedComment]
+    expected: FAIL
+
+  [1,18: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node detachedComment]
+    expected: FAIL
+
+  [1,19: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node docfrag]
+    expected: FAIL
+
+  [1,19: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node docfrag]
+    expected: FAIL
+
+  [1,20: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node doctype]
+    expected: FAIL
+
+  [1,20: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node doctype]
+    expected: FAIL
+
+  [1,21: resulting DOM for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [1,21: resulting range position for range [paras[0\].firstChild, 0, paras[0\].firstChild, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [2,0: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [2,0: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [2,2: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [2,2: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [2,3: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [2,3: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [2,4: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [2,4: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [2,5: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [2,5: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [2,6: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [2,6: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [2,7: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [2,7: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [2,8: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [2,8: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [2,9: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [2,9: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [2,10: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [2,10: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [2,11: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [2,11: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [2,12: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [2,12: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [2,13: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [2,13: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [2,14: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [2,14: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [2,15: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [2,15: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [2,16: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [2,16: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [2,17: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [2,17: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [2,18: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [2,18: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [2,19: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [2,19: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [2,20: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [2,20: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [2,21: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [2,21: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [3,0: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [3,0: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [3,2: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [3,2: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [3,3: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [3,3: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [3,4: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [3,4: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [3,5: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [3,5: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [3,6: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [3,6: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [3,7: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [3,7: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [3,8: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [3,8: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [3,9: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [3,9: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [3,10: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [3,10: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [3,11: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [3,11: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [3,12: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [3,12: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [3,13: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [3,13: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [3,14: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [3,14: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [3,15: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [3,15: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [3,16: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [3,16: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [3,17: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [3,17: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [3,18: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [3,18: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [3,19: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [3,19: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [3,20: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [3,20: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [3,21: resulting DOM for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [3,21: resulting range position for range [paras[0\].firstChild, 2, paras[0\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [4,0: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [4,0: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [4,1: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [4,1: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [4,3: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [4,3: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [4,4: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [4,4: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [4,5: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [4,5: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [4,6: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [4,6: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [4,7: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [4,7: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [4,8: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [4,8: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [4,9: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [4,9: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [4,10: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [4,10: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [4,11: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [4,11: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [4,12: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [4,12: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [4,13: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [4,13: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [4,14: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [4,14: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [4,15: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [4,15: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [4,16: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [4,16: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [4,17: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [4,17: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [4,18: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [4,18: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [4,19: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [4,19: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [4,20: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [4,20: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [4,21: resulting DOM for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [4,21: resulting range position for range [paras[1\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [5,0: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [5,0: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\]]
+    expected: FAIL
+
+  [5,1: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [5,1: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [5,3: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [5,3: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1]
+    expected: FAIL
+
+  [5,4: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [5,4: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [5,5: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [5,5: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1]
+    expected: FAIL
+
+  [5,6: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [5,6: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [5,7: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [5,7: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node document]
+    expected: FAIL
+
+  [5,8: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [5,8: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedDiv]
+    expected: FAIL
+
+  [5,9: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [5,9: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoc]
+    expected: FAIL
+
+  [5,10: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [5,10: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignPara2]
+    expected: FAIL
+
+  [5,11: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [5,11: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlDoc]
+    expected: FAIL
+
+  [5,12: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [5,12: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node xmlElement]
+    expected: FAIL
+
+  [5,13: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [5,13: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedTextNode]
+    expected: FAIL
+
+  [5,14: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [5,14: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignTextNode]
+    expected: FAIL
+
+  [5,15: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [5,15: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node processingInstruction]
+    expected: FAIL
+
+  [5,16: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [5,16: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [5,17: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [5,17: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node comment]
+    expected: FAIL
+
+  [5,18: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [5,18: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node detachedComment]
+    expected: FAIL
+
+  [5,19: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [5,19: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node docfrag]
+    expected: FAIL
+
+  [5,20: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [5,20: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node doctype]
+    expected: FAIL
+
+  [5,21: resulting DOM for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [5,21: resulting range position for range [paras[1\].firstChild, 2, paras[1\].firstChild, 9\], node foreignDoctype]
+    expected: FAIL
+
+  [6,0: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [6,0: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [6,1: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [6,1: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [6,2: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [6,2: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [6,3: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [6,3: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [6,4: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [6,4: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [6,5: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [6,5: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [6,7: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [6,7: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [6,8: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [6,8: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [6,9: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [6,9: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [6,10: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [6,10: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [6,11: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [6,11: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [6,12: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [6,12: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [6,13: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [6,13: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [6,14: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [6,14: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [6,15: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [6,15: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [6,16: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [6,16: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [6,17: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [6,17: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [6,18: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [6,18: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [6,19: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [6,19: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [6,20: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [6,20: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [6,21: resulting DOM for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [6,21: resulting range position for range [detachedPara1.firstChild, 0, detachedPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [7,0: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [7,0: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [7,1: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [7,1: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [7,2: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [7,2: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [7,3: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [7,3: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [7,4: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [7,4: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [7,5: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [7,5: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [7,7: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [7,7: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [7,8: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [7,8: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [7,9: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [7,9: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [7,10: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [7,10: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [7,11: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [7,11: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [7,12: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [7,12: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [7,13: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [7,13: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [7,14: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [7,14: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [7,15: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [7,15: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [7,16: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [7,16: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [7,17: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [7,17: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [7,18: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [7,18: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [7,19: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [7,19: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [7,20: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [7,20: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [7,21: resulting DOM for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [7,21: resulting range position for range [detachedPara1.firstChild, 2, detachedPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [8,0: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [8,0: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [8,1: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [8,1: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [8,2: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [8,2: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [8,3: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [8,3: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [8,5: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [8,5: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [8,6: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [8,6: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [8,7: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [8,7: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node document]
+    expected: FAIL
+
+  [8,8: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [8,8: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [8,9: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [8,9: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [8,10: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [8,10: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [8,11: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [8,11: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [8,12: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [8,12: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [8,13: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [8,13: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [8,14: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [8,14: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [8,15: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [8,15: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [8,16: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [8,16: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [8,17: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [8,17: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node comment]
+    expected: FAIL
+
+  [8,18: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [8,18: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [8,19: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [8,19: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [8,20: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [8,20: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [8,21: resulting DOM for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [8,21: resulting range position for range [foreignPara1.firstChild, 0, foreignPara1.firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [9,0: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [9,0: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [9,1: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [9,1: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [9,2: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [9,2: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [9,3: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [9,3: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [9,5: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [9,5: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [9,6: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [9,6: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [9,7: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [9,7: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node document]
+    expected: FAIL
+
+  [9,8: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [9,8: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [9,9: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [9,9: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [9,10: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [9,10: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [9,11: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [9,11: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [9,12: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [9,12: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [9,13: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [9,13: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [9,14: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [9,14: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [9,15: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [9,15: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [9,16: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [9,16: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [9,17: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [9,17: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node comment]
+    expected: FAIL
+
+  [9,18: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [9,18: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [9,19: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [9,19: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [9,20: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [9,20: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [9,21: resulting DOM for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [9,21: resulting range position for range [foreignPara1.firstChild, 2, foreignPara1.firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [10,0: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [10,0: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [10,1: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [10,1: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [10,2: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [10,2: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [10,3: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [10,3: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [10,4: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [10,4: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [10,5: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [10,5: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [10,6: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [10,6: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [10,7: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node document]
+    expected: FAIL
+
+  [10,7: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node document]
+    expected: FAIL
+
+  [10,8: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [10,8: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [10,9: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [10,9: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [10,10: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [10,10: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [10,11: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [10,11: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [10,12: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [10,12: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [10,13: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [10,13: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [10,14: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [10,14: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [10,15: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [10,15: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [10,16: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [10,16: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [10,17: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [10,17: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [10,18: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [10,18: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [10,19: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [10,19: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [10,20: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [10,20: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [10,21: resulting DOM for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [10,21: resulting range position for range [document.documentElement, 0, document.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [11,0: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [11,0: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [11,1: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [11,1: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [11,2: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [11,2: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [11,3: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [11,3: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [11,4: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [11,4: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [11,5: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [11,5: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [11,6: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [11,6: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [11,7: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [11,7: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [11,8: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [11,8: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [11,9: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [11,9: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [11,10: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [11,10: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [11,11: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [11,11: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [11,12: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [11,12: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [11,13: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [11,13: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [11,14: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [11,14: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [11,15: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [11,15: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [11,16: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [11,16: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [11,17: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [11,17: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [11,18: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [11,18: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [11,19: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [11,19: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [11,20: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [11,20: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [11,21: resulting DOM for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [11,21: resulting range position for range [document.documentElement, 0, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [12,0: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [12,0: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\]]
+    expected: FAIL
+
+  [12,1: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [12,1: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [12,2: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [12,2: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [12,3: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [12,3: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1]
+    expected: FAIL
+
+  [12,4: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [12,4: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [12,5: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [12,5: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1]
+    expected: FAIL
+
+  [12,6: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [12,6: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [12,7: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [12,7: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node document]
+    expected: FAIL
+
+  [12,8: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [12,8: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedDiv]
+    expected: FAIL
+
+  [12,9: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [12,9: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoc]
+    expected: FAIL
+
+  [12,10: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [12,10: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignPara2]
+    expected: FAIL
+
+  [12,11: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [12,11: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node xmlDoc]
+    expected: FAIL
+
+  [12,12: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [12,12: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node xmlElement]
+    expected: FAIL
+
+  [12,13: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [12,13: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [12,14: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [12,14: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [12,15: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [12,15: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node processingInstruction]
+    expected: FAIL
+
+  [12,16: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [12,16: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [12,17: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [12,17: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node comment]
+    expected: FAIL
+
+  [12,18: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [12,18: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node detachedComment]
+    expected: FAIL
+
+  [12,19: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [12,19: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node docfrag]
+    expected: FAIL
+
+  [12,20: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [12,20: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node doctype]
+    expected: FAIL
+
+  [12,21: resulting DOM for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [12,21: resulting range position for range [document.documentElement, 1, document.documentElement, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [13,0: resulting DOM for range [document.head, 1, document.head, 1\], node paras[0\]]
+    expected: FAIL
+
+  [13,0: resulting range position for range [document.head, 1, document.head, 1\], node paras[0\]]
+    expected: FAIL
+
+  [13,1: resulting DOM for range [document.head, 1, document.head, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [13,1: resulting range position for range [document.head, 1, document.head, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [13,2: resulting DOM for range [document.head, 1, document.head, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [13,2: resulting range position for range [document.head, 1, document.head, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [13,3: resulting DOM for range [document.head, 1, document.head, 1\], node foreignPara1]
+    expected: FAIL
+
+  [13,3: resulting range position for range [document.head, 1, document.head, 1\], node foreignPara1]
+    expected: FAIL
+
+  [13,4: resulting DOM for range [document.head, 1, document.head, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [13,4: resulting range position for range [document.head, 1, document.head, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [13,5: resulting DOM for range [document.head, 1, document.head, 1\], node detachedPara1]
+    expected: FAIL
+
+  [13,5: resulting range position for range [document.head, 1, document.head, 1\], node detachedPara1]
+    expected: FAIL
+
+  [13,6: resulting DOM for range [document.head, 1, document.head, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [13,6: resulting range position for range [document.head, 1, document.head, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [13,7: resulting DOM for range [document.head, 1, document.head, 1\], node document]
+    expected: FAIL
+
+  [13,7: resulting range position for range [document.head, 1, document.head, 1\], node document]
+    expected: FAIL
+
+  [13,8: resulting DOM for range [document.head, 1, document.head, 1\], node detachedDiv]
+    expected: FAIL
+
+  [13,8: resulting range position for range [document.head, 1, document.head, 1\], node detachedDiv]
+    expected: FAIL
+
+  [13,9: resulting DOM for range [document.head, 1, document.head, 1\], node foreignDoc]
+    expected: FAIL
+
+  [13,9: resulting range position for range [document.head, 1, document.head, 1\], node foreignDoc]
+    expected: FAIL
+
+  [13,10: resulting DOM for range [document.head, 1, document.head, 1\], node foreignPara2]
+    expected: FAIL
+
+  [13,10: resulting range position for range [document.head, 1, document.head, 1\], node foreignPara2]
+    expected: FAIL
+
+  [13,11: resulting DOM for range [document.head, 1, document.head, 1\], node xmlDoc]
+    expected: FAIL
+
+  [13,11: resulting range position for range [document.head, 1, document.head, 1\], node xmlDoc]
+    expected: FAIL
+
+  [13,12: resulting DOM for range [document.head, 1, document.head, 1\], node xmlElement]
+    expected: FAIL
+
+  [13,12: resulting range position for range [document.head, 1, document.head, 1\], node xmlElement]
+    expected: FAIL
+
+  [13,13: resulting DOM for range [document.head, 1, document.head, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [13,13: resulting range position for range [document.head, 1, document.head, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [13,14: resulting DOM for range [document.head, 1, document.head, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [13,14: resulting range position for range [document.head, 1, document.head, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [13,15: resulting DOM for range [document.head, 1, document.head, 1\], node processingInstruction]
+    expected: FAIL
+
+  [13,15: resulting range position for range [document.head, 1, document.head, 1\], node processingInstruction]
+    expected: FAIL
+
+  [13,16: resulting DOM for range [document.head, 1, document.head, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [13,16: resulting range position for range [document.head, 1, document.head, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [13,17: resulting DOM for range [document.head, 1, document.head, 1\], node comment]
+    expected: FAIL
+
+  [13,17: resulting range position for range [document.head, 1, document.head, 1\], node comment]
+    expected: FAIL
+
+  [13,18: resulting DOM for range [document.head, 1, document.head, 1\], node detachedComment]
+    expected: FAIL
+
+  [13,18: resulting range position for range [document.head, 1, document.head, 1\], node detachedComment]
+    expected: FAIL
+
+  [13,19: resulting DOM for range [document.head, 1, document.head, 1\], node docfrag]
+    expected: FAIL
+
+  [13,19: resulting range position for range [document.head, 1, document.head, 1\], node docfrag]
+    expected: FAIL
+
+  [13,20: resulting DOM for range [document.head, 1, document.head, 1\], node doctype]
+    expected: FAIL
+
+  [13,20: resulting range position for range [document.head, 1, document.head, 1\], node doctype]
+    expected: FAIL
+
+  [13,21: resulting DOM for range [document.head, 1, document.head, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [13,21: resulting range position for range [document.head, 1, document.head, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [14,0: resulting DOM for range [document.body, 4, document.body, 5\], node paras[0\]]
+    expected: FAIL
+
+  [14,0: resulting range position for range [document.body, 4, document.body, 5\], node paras[0\]]
+    expected: FAIL
+
+  [14,1: resulting DOM for range [document.body, 4, document.body, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [14,1: resulting range position for range [document.body, 4, document.body, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [14,2: resulting DOM for range [document.body, 4, document.body, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [14,2: resulting range position for range [document.body, 4, document.body, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [14,3: resulting DOM for range [document.body, 4, document.body, 5\], node foreignPara1]
+    expected: FAIL
+
+  [14,3: resulting range position for range [document.body, 4, document.body, 5\], node foreignPara1]
+    expected: FAIL
+
+  [14,4: resulting DOM for range [document.body, 4, document.body, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [14,4: resulting range position for range [document.body, 4, document.body, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [14,5: resulting DOM for range [document.body, 4, document.body, 5\], node detachedPara1]
+    expected: FAIL
+
+  [14,5: resulting range position for range [document.body, 4, document.body, 5\], node detachedPara1]
+    expected: FAIL
+
+  [14,6: resulting DOM for range [document.body, 4, document.body, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [14,6: resulting range position for range [document.body, 4, document.body, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [14,7: resulting DOM for range [document.body, 4, document.body, 5\], node document]
+    expected: FAIL
+
+  [14,7: resulting range position for range [document.body, 4, document.body, 5\], node document]
+    expected: FAIL
+
+  [14,8: resulting DOM for range [document.body, 4, document.body, 5\], node detachedDiv]
+    expected: FAIL
+
+  [14,8: resulting range position for range [document.body, 4, document.body, 5\], node detachedDiv]
+    expected: FAIL
+
+  [14,9: resulting DOM for range [document.body, 4, document.body, 5\], node foreignDoc]
+    expected: FAIL
+
+  [14,9: resulting range position for range [document.body, 4, document.body, 5\], node foreignDoc]
+    expected: FAIL
+
+  [14,10: resulting DOM for range [document.body, 4, document.body, 5\], node foreignPara2]
+    expected: FAIL
+
+  [14,10: resulting range position for range [document.body, 4, document.body, 5\], node foreignPara2]
+    expected: FAIL
+
+  [14,11: resulting DOM for range [document.body, 4, document.body, 5\], node xmlDoc]
+    expected: FAIL
+
+  [14,11: resulting range position for range [document.body, 4, document.body, 5\], node xmlDoc]
+    expected: FAIL
+
+  [14,12: resulting DOM for range [document.body, 4, document.body, 5\], node xmlElement]
+    expected: FAIL
+
+  [14,12: resulting range position for range [document.body, 4, document.body, 5\], node xmlElement]
+    expected: FAIL
+
+  [14,13: resulting DOM for range [document.body, 4, document.body, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [14,13: resulting range position for range [document.body, 4, document.body, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [14,14: resulting DOM for range [document.body, 4, document.body, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [14,14: resulting range position for range [document.body, 4, document.body, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [14,15: resulting DOM for range [document.body, 4, document.body, 5\], node processingInstruction]
+    expected: FAIL
+
+  [14,15: resulting range position for range [document.body, 4, document.body, 5\], node processingInstruction]
+    expected: FAIL
+
+  [14,16: resulting DOM for range [document.body, 4, document.body, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [14,16: resulting range position for range [document.body, 4, document.body, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [14,17: resulting DOM for range [document.body, 4, document.body, 5\], node comment]
+    expected: FAIL
+
+  [14,17: resulting range position for range [document.body, 4, document.body, 5\], node comment]
+    expected: FAIL
+
+  [14,18: resulting DOM for range [document.body, 4, document.body, 5\], node detachedComment]
+    expected: FAIL
+
+  [14,18: resulting range position for range [document.body, 4, document.body, 5\], node detachedComment]
+    expected: FAIL
+
+  [14,19: resulting DOM for range [document.body, 4, document.body, 5\], node docfrag]
+    expected: FAIL
+
+  [14,19: resulting range position for range [document.body, 4, document.body, 5\], node docfrag]
+    expected: FAIL
+
+  [14,20: resulting DOM for range [document.body, 4, document.body, 5\], node doctype]
+    expected: FAIL
+
+  [14,20: resulting range position for range [document.body, 4, document.body, 5\], node doctype]
+    expected: FAIL
+
+  [14,21: resulting DOM for range [document.body, 4, document.body, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [14,21: resulting range position for range [document.body, 4, document.body, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [15,0: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [15,0: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\]]
+    expected: FAIL
+
+  [15,1: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [15,1: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [15,2: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [15,2: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [15,3: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [15,3: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1]
+    expected: FAIL
+
+  [15,4: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [15,4: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [15,5: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [15,5: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1]
+    expected: FAIL
+
+  [15,6: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [15,6: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [15,7: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node document]
+    expected: FAIL
+
+  [15,7: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node document]
+    expected: FAIL
+
+  [15,8: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [15,8: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedDiv]
+    expected: FAIL
+
+  [15,9: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [15,9: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoc]
+    expected: FAIL
+
+  [15,10: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [15,10: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignPara2]
+    expected: FAIL
+
+  [15,11: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [15,11: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlDoc]
+    expected: FAIL
+
+  [15,12: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [15,12: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node xmlElement]
+    expected: FAIL
+
+  [15,13: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [15,13: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [15,14: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [15,14: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [15,15: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [15,15: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node processingInstruction]
+    expected: FAIL
+
+  [15,16: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [15,16: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [15,17: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [15,17: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node comment]
+    expected: FAIL
+
+  [15,18: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [15,18: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node detachedComment]
+    expected: FAIL
+
+  [15,19: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [15,19: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node docfrag]
+    expected: FAIL
+
+  [15,20: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [15,20: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node doctype]
+    expected: FAIL
+
+  [15,21: resulting DOM for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [15,21: resulting range position for range [foreignDoc.documentElement, 0, foreignDoc.documentElement, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [16,0: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [16,0: resulting range position for range [paras[0\], 0, paras[0\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [16,1: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [16,1: resulting range position for range [paras[0\], 0, paras[0\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [16,2: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [16,2: resulting range position for range [paras[0\], 0, paras[0\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [16,3: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [16,3: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [16,4: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [16,4: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [16,5: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [16,5: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [16,6: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [16,6: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [16,7: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node document]
+    expected: FAIL
+
+  [16,7: resulting range position for range [paras[0\], 0, paras[0\], 1\], node document]
+    expected: FAIL
+
+  [16,8: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [16,8: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [16,9: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [16,9: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [16,10: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [16,10: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [16,11: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [16,11: resulting range position for range [paras[0\], 0, paras[0\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [16,12: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node xmlElement]
+    expected: FAIL
+
+  [16,12: resulting range position for range [paras[0\], 0, paras[0\], 1\], node xmlElement]
+    expected: FAIL
+
+  [16,13: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [16,13: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [16,14: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [16,14: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [16,15: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [16,15: resulting range position for range [paras[0\], 0, paras[0\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [16,16: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [16,16: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [16,17: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node comment]
+    expected: FAIL
+
+  [16,17: resulting range position for range [paras[0\], 0, paras[0\], 1\], node comment]
+    expected: FAIL
+
+  [16,18: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node detachedComment]
+    expected: FAIL
+
+  [16,18: resulting range position for range [paras[0\], 0, paras[0\], 1\], node detachedComment]
+    expected: FAIL
+
+  [16,19: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node docfrag]
+    expected: FAIL
+
+  [16,19: resulting range position for range [paras[0\], 0, paras[0\], 1\], node docfrag]
+    expected: FAIL
+
+  [16,20: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node doctype]
+    expected: FAIL
+
+  [16,20: resulting range position for range [paras[0\], 0, paras[0\], 1\], node doctype]
+    expected: FAIL
+
+  [16,21: resulting DOM for range [paras[0\], 0, paras[0\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [16,21: resulting range position for range [paras[0\], 0, paras[0\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [17,0: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\]]
+    expected: FAIL
+
+  [17,0: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\]]
+    expected: FAIL
+
+  [17,1: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [17,1: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [17,2: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [17,2: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [17,3: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1]
+    expected: FAIL
+
+  [17,3: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1]
+    expected: FAIL
+
+  [17,4: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [17,4: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [17,5: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1]
+    expected: FAIL
+
+  [17,5: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1]
+    expected: FAIL
+
+  [17,6: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [17,6: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [17,7: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node document]
+    expected: FAIL
+
+  [17,7: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node document]
+    expected: FAIL
+
+  [17,8: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedDiv]
+    expected: FAIL
+
+  [17,8: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedDiv]
+    expected: FAIL
+
+  [17,9: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoc]
+    expected: FAIL
+
+  [17,9: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoc]
+    expected: FAIL
+
+  [17,10: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara2]
+    expected: FAIL
+
+  [17,10: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignPara2]
+    expected: FAIL
+
+  [17,11: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node xmlDoc]
+    expected: FAIL
+
+  [17,11: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node xmlDoc]
+    expected: FAIL
+
+  [17,12: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node xmlElement]
+    expected: FAIL
+
+  [17,12: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node xmlElement]
+    expected: FAIL
+
+  [17,13: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [17,13: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [17,14: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [17,14: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [17,15: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node processingInstruction]
+    expected: FAIL
+
+  [17,15: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node processingInstruction]
+    expected: FAIL
+
+  [17,16: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [17,16: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [17,17: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node comment]
+    expected: FAIL
+
+  [17,17: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node comment]
+    expected: FAIL
+
+  [17,18: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node detachedComment]
+    expected: FAIL
+
+  [17,18: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node detachedComment]
+    expected: FAIL
+
+  [17,19: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node docfrag]
+    expected: FAIL
+
+  [17,19: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node docfrag]
+    expected: FAIL
+
+  [17,20: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node doctype]
+    expected: FAIL
+
+  [17,20: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node doctype]
+    expected: FAIL
+
+  [17,21: resulting DOM for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [17,21: resulting range position for range [detachedPara1, 0, detachedPara1, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [18,0: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [18,0: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\]]
+    expected: FAIL
+
+  [18,1: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [18,1: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [18,2: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [18,2: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [18,3: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [18,3: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1]
+    expected: FAIL
+
+  [18,4: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [18,4: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [18,5: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [18,5: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1]
+    expected: FAIL
+
+  [18,6: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [18,6: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [18,7: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [18,7: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node document]
+    expected: FAIL
+
+  [18,8: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [18,8: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedDiv]
+    expected: FAIL
+
+  [18,9: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [18,9: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoc]
+    expected: FAIL
+
+  [18,10: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [18,10: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignPara2]
+    expected: FAIL
+
+  [18,11: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [18,11: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlDoc]
+    expected: FAIL
+
+  [18,12: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [18,12: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node xmlElement]
+    expected: FAIL
+
+  [18,13: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [18,13: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [18,14: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [18,14: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [18,15: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [18,15: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node processingInstruction]
+    expected: FAIL
+
+  [18,16: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [18,16: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [18,17: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [18,17: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node comment]
+    expected: FAIL
+
+  [18,18: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [18,18: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node detachedComment]
+    expected: FAIL
+
+  [18,19: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [18,19: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node docfrag]
+    expected: FAIL
+
+  [18,20: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [18,20: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node doctype]
+    expected: FAIL
+
+  [18,21: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [18,21: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [19,0: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [19,0: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\]]
+    expected: FAIL
+
+  [19,1: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [19,1: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [19,2: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [19,2: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [19,3: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [19,3: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1]
+    expected: FAIL
+
+  [19,4: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [19,4: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [19,5: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [19,5: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1]
+    expected: FAIL
+
+  [19,6: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [19,6: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [19,7: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [19,7: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node document]
+    expected: FAIL
+
+  [19,8: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [19,8: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedDiv]
+    expected: FAIL
+
+  [19,9: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [19,9: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoc]
+    expected: FAIL
+
+  [19,10: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [19,10: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignPara2]
+    expected: FAIL
+
+  [19,11: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [19,11: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlDoc]
+    expected: FAIL
+
+  [19,12: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [19,12: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node xmlElement]
+    expected: FAIL
+
+  [19,13: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [19,13: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [19,14: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [19,14: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [19,15: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [19,15: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node processingInstruction]
+    expected: FAIL
+
+  [19,16: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [19,16: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [19,17: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [19,17: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node comment]
+    expected: FAIL
+
+  [19,18: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [19,18: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node detachedComment]
+    expected: FAIL
+
+  [19,19: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [19,19: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node docfrag]
+    expected: FAIL
+
+  [19,20: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [19,20: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node doctype]
+    expected: FAIL
+
+  [19,21: resulting DOM for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [19,21: resulting range position for range [paras[0\].firstChild, 0, paras[1\].firstChild, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [20,0: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [20,0: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [20,1: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [20,1: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [20,2: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [20,2: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [20,3: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [20,3: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [20,4: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [20,4: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [20,5: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [20,5: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [20,6: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [20,6: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [20,7: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node document]
+    expected: FAIL
+
+  [20,7: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node document]
+    expected: FAIL
+
+  [20,8: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [20,8: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [20,9: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [20,9: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [20,10: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [20,10: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [20,11: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [20,11: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [20,12: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlElement]
+    expected: FAIL
+
+  [20,12: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node xmlElement]
+    expected: FAIL
+
+  [20,13: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [20,13: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [20,14: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [20,14: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [20,15: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [20,15: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [20,16: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [20,16: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [20,17: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node comment]
+    expected: FAIL
+
+  [20,17: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node comment]
+    expected: FAIL
+
+  [20,18: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedComment]
+    expected: FAIL
+
+  [20,18: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node detachedComment]
+    expected: FAIL
+
+  [20,19: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node docfrag]
+    expected: FAIL
+
+  [20,19: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node docfrag]
+    expected: FAIL
+
+  [20,20: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node doctype]
+    expected: FAIL
+
+  [20,20: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node doctype]
+    expected: FAIL
+
+  [20,21: resulting DOM for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [20,21: resulting range position for range [paras[0\].firstChild, 3, paras[3\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [21,0: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\]]
+    expected: FAIL
+
+  [21,0: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\]]
+    expected: FAIL
+
+  [21,1: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [21,1: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [21,2: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [21,2: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [21,3: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1]
+    expected: FAIL
+
+  [21,3: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1]
+    expected: FAIL
+
+  [21,4: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [21,4: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [21,5: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1]
+    expected: FAIL
+
+  [21,5: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1]
+    expected: FAIL
+
+  [21,6: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [21,6: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [21,7: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node document]
+    expected: FAIL
+
+  [21,7: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node document]
+    expected: FAIL
+
+  [21,8: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedDiv]
+    expected: FAIL
+
+  [21,8: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedDiv]
+    expected: FAIL
+
+  [21,9: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoc]
+    expected: FAIL
+
+  [21,9: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoc]
+    expected: FAIL
+
+  [21,10: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara2]
+    expected: FAIL
+
+  [21,10: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignPara2]
+    expected: FAIL
+
+  [21,11: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlDoc]
+    expected: FAIL
+
+  [21,11: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlDoc]
+    expected: FAIL
+
+  [21,12: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlElement]
+    expected: FAIL
+
+  [21,12: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node xmlElement]
+    expected: FAIL
+
+  [21,13: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedTextNode]
+    expected: FAIL
+
+  [21,13: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedTextNode]
+    expected: FAIL
+
+  [21,14: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignTextNode]
+    expected: FAIL
+
+  [21,14: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignTextNode]
+    expected: FAIL
+
+  [21,15: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node processingInstruction]
+    expected: FAIL
+
+  [21,15: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node processingInstruction]
+    expected: FAIL
+
+  [21,16: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [21,16: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [21,17: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node comment]
+    expected: FAIL
+
+  [21,17: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node comment]
+    expected: FAIL
+
+  [21,18: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedComment]
+    expected: FAIL
+
+  [21,18: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node detachedComment]
+    expected: FAIL
+
+  [21,19: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node docfrag]
+    expected: FAIL
+
+  [21,19: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node docfrag]
+    expected: FAIL
+
+  [21,20: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node doctype]
+    expected: FAIL
+
+  [21,20: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node doctype]
+    expected: FAIL
+
+  [21,21: resulting DOM for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoctype]
+    expected: FAIL
+
+  [21,21: resulting range position for range [paras[0\], 0, paras[0\].firstChild, 7\], node foreignDoctype]
+    expected: FAIL
+
+  [22,0: resulting DOM for range [testDiv, 2, paras[4\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [22,0: resulting range position for range [testDiv, 2, paras[4\], 1\], node paras[0\]]
+    expected: FAIL
+
+  [22,1: resulting DOM for range [testDiv, 2, paras[4\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [22,1: resulting range position for range [testDiv, 2, paras[4\], 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [22,2: resulting DOM for range [testDiv, 2, paras[4\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [22,2: resulting range position for range [testDiv, 2, paras[4\], 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [22,3: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [22,3: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignPara1]
+    expected: FAIL
+
+  [22,4: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [22,4: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [22,5: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [22,5: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedPara1]
+    expected: FAIL
+
+  [22,6: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [22,6: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [22,7: resulting DOM for range [testDiv, 2, paras[4\], 1\], node document]
+    expected: FAIL
+
+  [22,7: resulting range position for range [testDiv, 2, paras[4\], 1\], node document]
+    expected: FAIL
+
+  [22,8: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [22,8: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedDiv]
+    expected: FAIL
+
+  [22,9: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [22,9: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignDoc]
+    expected: FAIL
+
+  [22,10: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [22,10: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignPara2]
+    expected: FAIL
+
+  [22,11: resulting DOM for range [testDiv, 2, paras[4\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [22,11: resulting range position for range [testDiv, 2, paras[4\], 1\], node xmlDoc]
+    expected: FAIL
+
+  [22,12: resulting DOM for range [testDiv, 2, paras[4\], 1\], node xmlElement]
+    expected: FAIL
+
+  [22,12: resulting range position for range [testDiv, 2, paras[4\], 1\], node xmlElement]
+    expected: FAIL
+
+  [22,13: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [22,13: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedTextNode]
+    expected: FAIL
+
+  [22,14: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [22,14: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignTextNode]
+    expected: FAIL
+
+  [22,15: resulting DOM for range [testDiv, 2, paras[4\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [22,15: resulting range position for range [testDiv, 2, paras[4\], 1\], node processingInstruction]
+    expected: FAIL
+
+  [22,16: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [22,16: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [22,17: resulting DOM for range [testDiv, 2, paras[4\], 1\], node comment]
+    expected: FAIL
+
+  [22,17: resulting range position for range [testDiv, 2, paras[4\], 1\], node comment]
+    expected: FAIL
+
+  [22,18: resulting DOM for range [testDiv, 2, paras[4\], 1\], node detachedComment]
+    expected: FAIL
+
+  [22,18: resulting range position for range [testDiv, 2, paras[4\], 1\], node detachedComment]
+    expected: FAIL
+
+  [22,19: resulting DOM for range [testDiv, 2, paras[4\], 1\], node docfrag]
+    expected: FAIL
+
+  [22,19: resulting range position for range [testDiv, 2, paras[4\], 1\], node docfrag]
+    expected: FAIL
+
+  [22,20: resulting DOM for range [testDiv, 2, paras[4\], 1\], node doctype]
+    expected: FAIL
+
+  [22,20: resulting range position for range [testDiv, 2, paras[4\], 1\], node doctype]
+    expected: FAIL
+
+  [22,21: resulting DOM for range [testDiv, 2, paras[4\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [22,21: resulting range position for range [testDiv, 2, paras[4\], 1\], node foreignDoctype]
+    expected: FAIL
+
+  [23,0: resulting DOM for range [document, 0, document, 1\], node paras[0\]]
+    expected: FAIL
+
+  [23,0: resulting range position for range [document, 0, document, 1\], node paras[0\]]
+    expected: FAIL
+
+  [23,1: resulting DOM for range [document, 0, document, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [23,1: resulting range position for range [document, 0, document, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [23,2: resulting DOM for range [document, 0, document, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [23,2: resulting range position for range [document, 0, document, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [23,3: resulting DOM for range [document, 0, document, 1\], node foreignPara1]
+    expected: FAIL
+
+  [23,3: resulting range position for range [document, 0, document, 1\], node foreignPara1]
+    expected: FAIL
+
+  [23,4: resulting DOM for range [document, 0, document, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [23,4: resulting range position for range [document, 0, document, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [23,5: resulting DOM for range [document, 0, document, 1\], node detachedPara1]
+    expected: FAIL
+
+  [23,5: resulting range position for range [document, 0, document, 1\], node detachedPara1]
+    expected: FAIL
+
+  [23,6: resulting DOM for range [document, 0, document, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [23,6: resulting range position for range [document, 0, document, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [23,7: resulting DOM for range [document, 0, document, 1\], node document]
+    expected: FAIL
+
+  [23,7: resulting range position for range [document, 0, document, 1\], node document]
+    expected: FAIL
+
+  [23,8: resulting DOM for range [document, 0, document, 1\], node detachedDiv]
+    expected: FAIL
+
+  [23,8: resulting range position for range [document, 0, document, 1\], node detachedDiv]
+    expected: FAIL
+
+  [23,9: resulting DOM for range [document, 0, document, 1\], node foreignDoc]
+    expected: FAIL
+
+  [23,9: resulting range position for range [document, 0, document, 1\], node foreignDoc]
+    expected: FAIL
+
+  [23,10: resulting DOM for range [document, 0, document, 1\], node foreignPara2]
+    expected: FAIL
+
+  [23,10: resulting range position for range [document, 0, document, 1\], node foreignPara2]
+    expected: FAIL
+
+  [23,11: resulting DOM for range [document, 0, document, 1\], node xmlDoc]
+    expected: FAIL
+
+  [23,11: resulting range position for range [document, 0, document, 1\], node xmlDoc]
+    expected: FAIL
+
+  [23,12: resulting DOM for range [document, 0, document, 1\], node xmlElement]
+    expected: FAIL
+
+  [23,12: resulting range position for range [document, 0, document, 1\], node xmlElement]
+    expected: FAIL
+
+  [23,13: resulting DOM for range [document, 0, document, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [23,13: resulting range position for range [document, 0, document, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [23,14: resulting DOM for range [document, 0, document, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [23,14: resulting range position for range [document, 0, document, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [23,15: resulting DOM for range [document, 0, document, 1\], node processingInstruction]
+    expected: FAIL
+
+  [23,15: resulting range position for range [document, 0, document, 1\], node processingInstruction]
+    expected: FAIL
+
+  [23,16: resulting DOM for range [document, 0, document, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [23,16: resulting range position for range [document, 0, document, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [23,17: resulting DOM for range [document, 0, document, 1\], node comment]
+    expected: FAIL
+
+  [23,17: resulting range position for range [document, 0, document, 1\], node comment]
+    expected: FAIL
+
+  [23,18: resulting DOM for range [document, 0, document, 1\], node detachedComment]
+    expected: FAIL
+
+  [23,18: resulting range position for range [document, 0, document, 1\], node detachedComment]
+    expected: FAIL
+
+  [23,19: resulting DOM for range [document, 0, document, 1\], node docfrag]
+    expected: FAIL
+
+  [23,19: resulting range position for range [document, 0, document, 1\], node docfrag]
+    expected: FAIL
+
+  [23,20: resulting DOM for range [document, 0, document, 1\], node doctype]
+    expected: FAIL
+
+  [23,20: resulting range position for range [document, 0, document, 1\], node doctype]
+    expected: FAIL
+
+  [23,21: resulting DOM for range [document, 0, document, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [23,21: resulting range position for range [document, 0, document, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [24,0: resulting DOM for range [document, 0, document, 2\], node paras[0\]]
+    expected: FAIL
+
+  [24,0: resulting range position for range [document, 0, document, 2\], node paras[0\]]
+    expected: FAIL
+
+  [24,1: resulting DOM for range [document, 0, document, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [24,1: resulting range position for range [document, 0, document, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [24,2: resulting DOM for range [document, 0, document, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [24,2: resulting range position for range [document, 0, document, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [24,3: resulting DOM for range [document, 0, document, 2\], node foreignPara1]
+    expected: FAIL
+
+  [24,3: resulting range position for range [document, 0, document, 2\], node foreignPara1]
+    expected: FAIL
+
+  [24,4: resulting DOM for range [document, 0, document, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [24,4: resulting range position for range [document, 0, document, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [24,5: resulting DOM for range [document, 0, document, 2\], node detachedPara1]
+    expected: FAIL
+
+  [24,5: resulting range position for range [document, 0, document, 2\], node detachedPara1]
+    expected: FAIL
+
+  [24,6: resulting DOM for range [document, 0, document, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [24,6: resulting range position for range [document, 0, document, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [24,7: resulting DOM for range [document, 0, document, 2\], node document]
+    expected: FAIL
+
+  [24,7: resulting range position for range [document, 0, document, 2\], node document]
+    expected: FAIL
+
+  [24,8: resulting DOM for range [document, 0, document, 2\], node detachedDiv]
+    expected: FAIL
+
+  [24,8: resulting range position for range [document, 0, document, 2\], node detachedDiv]
+    expected: FAIL
+
+  [24,9: resulting DOM for range [document, 0, document, 2\], node foreignDoc]
+    expected: FAIL
+
+  [24,9: resulting range position for range [document, 0, document, 2\], node foreignDoc]
+    expected: FAIL
+
+  [24,10: resulting DOM for range [document, 0, document, 2\], node foreignPara2]
+    expected: FAIL
+
+  [24,10: resulting range position for range [document, 0, document, 2\], node foreignPara2]
+    expected: FAIL
+
+  [24,11: resulting DOM for range [document, 0, document, 2\], node xmlDoc]
+    expected: FAIL
+
+  [24,11: resulting range position for range [document, 0, document, 2\], node xmlDoc]
+    expected: FAIL
+
+  [24,12: resulting DOM for range [document, 0, document, 2\], node xmlElement]
+    expected: FAIL
+
+  [24,12: resulting range position for range [document, 0, document, 2\], node xmlElement]
+    expected: FAIL
+
+  [24,13: resulting DOM for range [document, 0, document, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [24,13: resulting range position for range [document, 0, document, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [24,14: resulting DOM for range [document, 0, document, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [24,14: resulting range position for range [document, 0, document, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [24,15: resulting DOM for range [document, 0, document, 2\], node processingInstruction]
+    expected: FAIL
+
+  [24,15: resulting range position for range [document, 0, document, 2\], node processingInstruction]
+    expected: FAIL
+
+  [24,16: resulting DOM for range [document, 0, document, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [24,16: resulting range position for range [document, 0, document, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [24,17: resulting DOM for range [document, 0, document, 2\], node comment]
+    expected: FAIL
+
+  [24,17: resulting range position for range [document, 0, document, 2\], node comment]
+    expected: FAIL
+
+  [24,18: resulting DOM for range [document, 0, document, 2\], node detachedComment]
+    expected: FAIL
+
+  [24,18: resulting range position for range [document, 0, document, 2\], node detachedComment]
+    expected: FAIL
+
+  [24,19: resulting DOM for range [document, 0, document, 2\], node docfrag]
+    expected: FAIL
+
+  [24,19: resulting range position for range [document, 0, document, 2\], node docfrag]
+    expected: FAIL
+
+  [24,20: resulting DOM for range [document, 0, document, 2\], node doctype]
+    expected: FAIL
+
+  [24,20: resulting range position for range [document, 0, document, 2\], node doctype]
+    expected: FAIL
+
+  [24,21: resulting DOM for range [document, 0, document, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [24,21: resulting range position for range [document, 0, document, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [25,0: resulting DOM for range [comment, 2, comment, 3\], node paras[0\]]
+    expected: FAIL
+
+  [25,0: resulting range position for range [comment, 2, comment, 3\], node paras[0\]]
+    expected: FAIL
+
+  [25,1: resulting DOM for range [comment, 2, comment, 3\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [25,1: resulting range position for range [comment, 2, comment, 3\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [25,2: resulting DOM for range [comment, 2, comment, 3\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [25,2: resulting range position for range [comment, 2, comment, 3\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [25,3: resulting DOM for range [comment, 2, comment, 3\], node foreignPara1]
+    expected: FAIL
+
+  [25,3: resulting range position for range [comment, 2, comment, 3\], node foreignPara1]
+    expected: FAIL
+
+  [25,4: resulting DOM for range [comment, 2, comment, 3\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [25,4: resulting range position for range [comment, 2, comment, 3\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [25,5: resulting DOM for range [comment, 2, comment, 3\], node detachedPara1]
+    expected: FAIL
+
+  [25,5: resulting range position for range [comment, 2, comment, 3\], node detachedPara1]
+    expected: FAIL
+
+  [25,6: resulting DOM for range [comment, 2, comment, 3\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [25,6: resulting range position for range [comment, 2, comment, 3\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [25,7: resulting DOM for range [comment, 2, comment, 3\], node document]
+    expected: FAIL
+
+  [25,7: resulting range position for range [comment, 2, comment, 3\], node document]
+    expected: FAIL
+
+  [25,8: resulting DOM for range [comment, 2, comment, 3\], node detachedDiv]
+    expected: FAIL
+
+  [25,8: resulting range position for range [comment, 2, comment, 3\], node detachedDiv]
+    expected: FAIL
+
+  [25,9: resulting DOM for range [comment, 2, comment, 3\], node foreignDoc]
+    expected: FAIL
+
+  [25,9: resulting range position for range [comment, 2, comment, 3\], node foreignDoc]
+    expected: FAIL
+
+  [25,10: resulting DOM for range [comment, 2, comment, 3\], node foreignPara2]
+    expected: FAIL
+
+  [25,10: resulting range position for range [comment, 2, comment, 3\], node foreignPara2]
+    expected: FAIL
+
+  [25,11: resulting DOM for range [comment, 2, comment, 3\], node xmlDoc]
+    expected: FAIL
+
+  [25,11: resulting range position for range [comment, 2, comment, 3\], node xmlDoc]
+    expected: FAIL
+
+  [25,12: resulting DOM for range [comment, 2, comment, 3\], node xmlElement]
+    expected: FAIL
+
+  [25,12: resulting range position for range [comment, 2, comment, 3\], node xmlElement]
+    expected: FAIL
+
+  [25,13: resulting DOM for range [comment, 2, comment, 3\], node detachedTextNode]
+    expected: FAIL
+
+  [25,13: resulting range position for range [comment, 2, comment, 3\], node detachedTextNode]
+    expected: FAIL
+
+  [25,14: resulting DOM for range [comment, 2, comment, 3\], node foreignTextNode]
+    expected: FAIL
+
+  [25,14: resulting range position for range [comment, 2, comment, 3\], node foreignTextNode]
+    expected: FAIL
+
+  [25,15: resulting DOM for range [comment, 2, comment, 3\], node processingInstruction]
+    expected: FAIL
+
+  [25,15: resulting range position for range [comment, 2, comment, 3\], node processingInstruction]
+    expected: FAIL
+
+  [25,16: resulting DOM for range [comment, 2, comment, 3\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [25,16: resulting range position for range [comment, 2, comment, 3\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [25,17: resulting DOM for range [comment, 2, comment, 3\], node comment]
+    expected: FAIL
+
+  [25,17: resulting range position for range [comment, 2, comment, 3\], node comment]
+    expected: FAIL
+
+  [25,18: resulting DOM for range [comment, 2, comment, 3\], node detachedComment]
+    expected: FAIL
+
+  [25,18: resulting range position for range [comment, 2, comment, 3\], node detachedComment]
+    expected: FAIL
+
+  [25,19: resulting DOM for range [comment, 2, comment, 3\], node docfrag]
+    expected: FAIL
+
+  [25,19: resulting range position for range [comment, 2, comment, 3\], node docfrag]
+    expected: FAIL
+
+  [25,20: resulting DOM for range [comment, 2, comment, 3\], node doctype]
+    expected: FAIL
+
+  [25,20: resulting range position for range [comment, 2, comment, 3\], node doctype]
+    expected: FAIL
+
+  [25,21: resulting DOM for range [comment, 2, comment, 3\], node foreignDoctype]
+    expected: FAIL
+
+  [25,21: resulting range position for range [comment, 2, comment, 3\], node foreignDoctype]
+    expected: FAIL
+
+  [26,0: resulting DOM for range [testDiv, 0, comment, 5\], node paras[0\]]
+    expected: FAIL
+
+  [26,0: resulting range position for range [testDiv, 0, comment, 5\], node paras[0\]]
+    expected: FAIL
+
+  [26,1: resulting DOM for range [testDiv, 0, comment, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [26,1: resulting range position for range [testDiv, 0, comment, 5\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [26,2: resulting DOM for range [testDiv, 0, comment, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [26,2: resulting range position for range [testDiv, 0, comment, 5\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [26,3: resulting DOM for range [testDiv, 0, comment, 5\], node foreignPara1]
+    expected: FAIL
+
+  [26,3: resulting range position for range [testDiv, 0, comment, 5\], node foreignPara1]
+    expected: FAIL
+
+  [26,4: resulting DOM for range [testDiv, 0, comment, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [26,4: resulting range position for range [testDiv, 0, comment, 5\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [26,5: resulting DOM for range [testDiv, 0, comment, 5\], node detachedPara1]
+    expected: FAIL
+
+  [26,5: resulting range position for range [testDiv, 0, comment, 5\], node detachedPara1]
+    expected: FAIL
+
+  [26,6: resulting DOM for range [testDiv, 0, comment, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [26,6: resulting range position for range [testDiv, 0, comment, 5\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [26,7: resulting DOM for range [testDiv, 0, comment, 5\], node document]
+    expected: FAIL
+
+  [26,7: resulting range position for range [testDiv, 0, comment, 5\], node document]
+    expected: FAIL
+
+  [26,8: resulting DOM for range [testDiv, 0, comment, 5\], node detachedDiv]
+    expected: FAIL
+
+  [26,8: resulting range position for range [testDiv, 0, comment, 5\], node detachedDiv]
+    expected: FAIL
+
+  [26,9: resulting DOM for range [testDiv, 0, comment, 5\], node foreignDoc]
+    expected: FAIL
+
+  [26,9: resulting range position for range [testDiv, 0, comment, 5\], node foreignDoc]
+    expected: FAIL
+
+  [26,10: resulting DOM for range [testDiv, 0, comment, 5\], node foreignPara2]
+    expected: FAIL
+
+  [26,10: resulting range position for range [testDiv, 0, comment, 5\], node foreignPara2]
+    expected: FAIL
+
+  [26,11: resulting DOM for range [testDiv, 0, comment, 5\], node xmlDoc]
+    expected: FAIL
+
+  [26,11: resulting range position for range [testDiv, 0, comment, 5\], node xmlDoc]
+    expected: FAIL
+
+  [26,12: resulting DOM for range [testDiv, 0, comment, 5\], node xmlElement]
+    expected: FAIL
+
+  [26,12: resulting range position for range [testDiv, 0, comment, 5\], node xmlElement]
+    expected: FAIL
+
+  [26,13: resulting DOM for range [testDiv, 0, comment, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [26,13: resulting range position for range [testDiv, 0, comment, 5\], node detachedTextNode]
+    expected: FAIL
+
+  [26,14: resulting DOM for range [testDiv, 0, comment, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [26,14: resulting range position for range [testDiv, 0, comment, 5\], node foreignTextNode]
+    expected: FAIL
+
+  [26,15: resulting DOM for range [testDiv, 0, comment, 5\], node processingInstruction]
+    expected: FAIL
+
+  [26,15: resulting range position for range [testDiv, 0, comment, 5\], node processingInstruction]
+    expected: FAIL
+
+  [26,16: resulting DOM for range [testDiv, 0, comment, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [26,16: resulting range position for range [testDiv, 0, comment, 5\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [26,17: resulting DOM for range [testDiv, 0, comment, 5\], node comment]
+    expected: FAIL
+
+  [26,17: resulting range position for range [testDiv, 0, comment, 5\], node comment]
+    expected: FAIL
+
+  [26,18: resulting DOM for range [testDiv, 0, comment, 5\], node detachedComment]
+    expected: FAIL
+
+  [26,18: resulting range position for range [testDiv, 0, comment, 5\], node detachedComment]
+    expected: FAIL
+
+  [26,19: resulting DOM for range [testDiv, 0, comment, 5\], node docfrag]
+    expected: FAIL
+
+  [26,19: resulting range position for range [testDiv, 0, comment, 5\], node docfrag]
+    expected: FAIL
+
+  [26,20: resulting DOM for range [testDiv, 0, comment, 5\], node doctype]
+    expected: FAIL
+
+  [26,20: resulting range position for range [testDiv, 0, comment, 5\], node doctype]
+    expected: FAIL
+
+  [26,21: resulting DOM for range [testDiv, 0, comment, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [26,21: resulting range position for range [testDiv, 0, comment, 5\], node foreignDoctype]
+    expected: FAIL
+
+  [27,0: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node paras[0\]]
+    expected: FAIL
+
+  [27,0: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node paras[0\]]
+    expected: FAIL
+
+  [27,1: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [27,1: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [27,2: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [27,2: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [27,3: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1]
+    expected: FAIL
+
+  [27,3: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1]
+    expected: FAIL
+
+  [27,4: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [27,4: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [27,5: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1]
+    expected: FAIL
+
+  [27,5: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1]
+    expected: FAIL
+
+  [27,6: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [27,6: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [27,7: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node document]
+    expected: FAIL
+
+  [27,7: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node document]
+    expected: FAIL
+
+  [27,8: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedDiv]
+    expected: FAIL
+
+  [27,8: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedDiv]
+    expected: FAIL
+
+  [27,9: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignDoc]
+    expected: FAIL
+
+  [27,9: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignDoc]
+    expected: FAIL
+
+  [27,10: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignPara2]
+    expected: FAIL
+
+  [27,10: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignPara2]
+    expected: FAIL
+
+  [27,11: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node xmlDoc]
+    expected: FAIL
+
+  [27,11: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node xmlDoc]
+    expected: FAIL
+
+  [27,12: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node xmlElement]
+    expected: FAIL
+
+  [27,12: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node xmlElement]
+    expected: FAIL
+
+  [27,13: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [27,13: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedTextNode]
+    expected: FAIL
+
+  [27,14: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [27,14: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignTextNode]
+    expected: FAIL
+
+  [27,15: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node processingInstruction]
+    expected: FAIL
+
+  [27,15: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node processingInstruction]
+    expected: FAIL
+
+  [27,16: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [27,16: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [27,17: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node comment]
+    expected: FAIL
+
+  [27,17: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node comment]
+    expected: FAIL
+
+  [27,18: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node detachedComment]
+    expected: FAIL
+
+  [27,18: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node detachedComment]
+    expected: FAIL
+
+  [27,19: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node docfrag]
+    expected: FAIL
+
+  [27,19: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node docfrag]
+    expected: FAIL
+
+  [27,20: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node doctype]
+    expected: FAIL
+
+  [27,20: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node doctype]
+    expected: FAIL
+
+  [27,21: resulting DOM for range [foreignDoc, 1, foreignComment, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [27,21: resulting range position for range [foreignDoc, 1, foreignComment, 2\], node foreignDoctype]
+    expected: FAIL
+
+  [28,0: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\]]
+    expected: FAIL
+
+  [28,0: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\]]
+    expected: FAIL
+
+  [28,1: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [28,1: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [28,2: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [28,2: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [28,3: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1]
+    expected: FAIL
+
+  [28,3: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1]
+    expected: FAIL
+
+  [28,4: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [28,4: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [28,5: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1]
+    expected: FAIL
+
+  [28,5: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1]
+    expected: FAIL
+
+  [28,6: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [28,6: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [28,7: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node document]
+    expected: FAIL
+
+  [28,7: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node document]
+    expected: FAIL
+
+  [28,8: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedDiv]
+    expected: FAIL
+
+  [28,8: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedDiv]
+    expected: FAIL
+
+  [28,9: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoc]
+    expected: FAIL
+
+  [28,9: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoc]
+    expected: FAIL
+
+  [28,10: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara2]
+    expected: FAIL
+
+  [28,10: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignPara2]
+    expected: FAIL
+
+  [28,11: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlDoc]
+    expected: FAIL
+
+  [28,11: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlDoc]
+    expected: FAIL
+
+  [28,12: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlElement]
+    expected: FAIL
+
+  [28,12: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node xmlElement]
+    expected: FAIL
+
+  [28,13: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedTextNode]
+    expected: FAIL
+
+  [28,13: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedTextNode]
+    expected: FAIL
+
+  [28,14: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignTextNode]
+    expected: FAIL
+
+  [28,14: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignTextNode]
+    expected: FAIL
+
+  [28,15: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node processingInstruction]
+    expected: FAIL
+
+  [28,15: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node processingInstruction]
+    expected: FAIL
+
+  [28,16: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [28,16: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [28,17: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node comment]
+    expected: FAIL
+
+  [28,17: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node comment]
+    expected: FAIL
+
+  [28,18: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedComment]
+    expected: FAIL
+
+  [28,18: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node detachedComment]
+    expected: FAIL
+
+  [28,19: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node docfrag]
+    expected: FAIL
+
+  [28,19: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node docfrag]
+    expected: FAIL
+
+  [28,20: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node doctype]
+    expected: FAIL
+
+  [28,20: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node doctype]
+    expected: FAIL
+
+  [28,21: resulting DOM for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoctype]
+    expected: FAIL
+
+  [28,21: resulting range position for range [foreignDoc.body, 0, foreignTextNode, 36\], node foreignDoctype]
+    expected: FAIL
+
+  [29,0: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node paras[0\]]
+    expected: FAIL
+
+  [29,0: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node paras[0\]]
+    expected: FAIL
+
+  [29,1: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [29,1: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [29,2: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [29,2: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [29,3: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1]
+    expected: FAIL
+
+  [29,3: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1]
+    expected: FAIL
+
+  [29,4: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [29,4: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [29,5: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1]
+    expected: FAIL
+
+  [29,5: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1]
+    expected: FAIL
+
+  [29,6: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [29,6: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [29,7: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node document]
+    expected: FAIL
+
+  [29,7: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node document]
+    expected: FAIL
+
+  [29,8: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedDiv]
+    expected: FAIL
+
+  [29,8: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedDiv]
+    expected: FAIL
+
+  [29,9: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignDoc]
+    expected: FAIL
+
+  [29,9: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignDoc]
+    expected: FAIL
+
+  [29,10: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignPara2]
+    expected: FAIL
+
+  [29,10: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignPara2]
+    expected: FAIL
+
+  [29,11: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node xmlDoc]
+    expected: FAIL
+
+  [29,11: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node xmlDoc]
+    expected: FAIL
+
+  [29,12: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node xmlElement]
+    expected: FAIL
+
+  [29,12: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node xmlElement]
+    expected: FAIL
+
+  [29,13: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [29,13: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [29,14: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [29,14: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [29,15: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node processingInstruction]
+    expected: FAIL
+
+  [29,15: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node processingInstruction]
+    expected: FAIL
+
+  [29,16: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [29,16: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [29,17: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node comment]
+    expected: FAIL
+
+  [29,17: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node comment]
+    expected: FAIL
+
+  [29,18: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node detachedComment]
+    expected: FAIL
+
+  [29,18: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node detachedComment]
+    expected: FAIL
+
+  [29,19: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node docfrag]
+    expected: FAIL
+
+  [29,19: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node docfrag]
+    expected: FAIL
+
+  [29,20: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node doctype]
+    expected: FAIL
+
+  [29,20: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node doctype]
+    expected: FAIL
+
+  [29,21: resulting DOM for range [xmlDoc, 1, xmlComment, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [29,21: resulting range position for range [xmlDoc, 1, xmlComment, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [30,0: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [30,0: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [30,1: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [30,1: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [30,2: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [30,2: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [30,3: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [30,3: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [30,4: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [30,4: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [30,5: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [30,5: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [30,6: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [30,6: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [30,7: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node document]
+    expected: FAIL
+
+  [30,7: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node document]
+    expected: FAIL
+
+  [30,8: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [30,8: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [30,9: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [30,9: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [30,10: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [30,10: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [30,11: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [30,11: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [30,12: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [30,12: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [30,13: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [30,13: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [30,14: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [30,14: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [30,15: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [30,15: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [30,16: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [30,16: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [30,17: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node comment]
+    expected: FAIL
+
+  [30,17: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node comment]
+    expected: FAIL
+
+  [30,18: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [30,18: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [30,19: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [30,19: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [30,20: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [30,20: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [30,21: resulting DOM for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [30,21: resulting range position for range [detachedTextNode, 0, detachedTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [31,0: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [31,0: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [31,1: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [31,1: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [31,2: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [31,2: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [31,3: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [31,3: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [31,4: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [31,4: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [31,5: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [31,5: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [31,6: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [31,6: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [31,7: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node document]
+    expected: FAIL
+
+  [31,7: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node document]
+    expected: FAIL
+
+  [31,8: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [31,8: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [31,9: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [31,9: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [31,10: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [31,10: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [31,11: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [31,11: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [31,12: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [31,12: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [31,13: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [31,13: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [31,14: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [31,14: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [31,15: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [31,15: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [31,16: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [31,16: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [31,17: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node comment]
+    expected: FAIL
+
+  [31,17: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node comment]
+    expected: FAIL
+
+  [31,18: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [31,18: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [31,19: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [31,19: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [31,20: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [31,20: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [31,21: resulting DOM for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [31,21: resulting range position for range [detachedForeignTextNode, 0, detachedForeignTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [32,0: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [32,0: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\]]
+    expected: FAIL
+
+  [32,1: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [32,1: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [32,2: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [32,2: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [32,3: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [32,3: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1]
+    expected: FAIL
+
+  [32,4: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [32,4: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [32,5: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [32,5: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1]
+    expected: FAIL
+
+  [32,6: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [32,6: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [32,7: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node document]
+    expected: FAIL
+
+  [32,7: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node document]
+    expected: FAIL
+
+  [32,8: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [32,8: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedDiv]
+    expected: FAIL
+
+  [32,9: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [32,9: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoc]
+    expected: FAIL
+
+  [32,10: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [32,10: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignPara2]
+    expected: FAIL
+
+  [32,11: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [32,11: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlDoc]
+    expected: FAIL
+
+  [32,12: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [32,12: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node xmlElement]
+    expected: FAIL
+
+  [32,13: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [32,13: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedTextNode]
+    expected: FAIL
+
+  [32,14: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [32,14: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignTextNode]
+    expected: FAIL
+
+  [32,15: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [32,15: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node processingInstruction]
+    expected: FAIL
+
+  [32,16: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [32,16: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [32,17: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node comment]
+    expected: FAIL
+
+  [32,17: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node comment]
+    expected: FAIL
+
+  [32,18: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [32,18: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node detachedComment]
+    expected: FAIL
+
+  [32,19: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [32,19: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node docfrag]
+    expected: FAIL
+
+  [32,20: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [32,20: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node doctype]
+    expected: FAIL
+
+  [32,21: resulting DOM for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [32,21: resulting range position for range [detachedXmlTextNode, 0, detachedXmlTextNode, 8\], node foreignDoctype]
+    expected: FAIL
+
+  [33,0: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node paras[0\]]
+    expected: FAIL
+
+  [33,0: resulting range position for range [detachedComment, 3, detachedComment, 4\], node paras[0\]]
+    expected: FAIL
+
+  [33,1: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [33,1: resulting range position for range [detachedComment, 3, detachedComment, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [33,2: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [33,2: resulting range position for range [detachedComment, 3, detachedComment, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [33,3: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignPara1]
+    expected: FAIL
+
+  [33,3: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignPara1]
+    expected: FAIL
+
+  [33,4: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [33,4: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [33,5: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedPara1]
+    expected: FAIL
+
+  [33,5: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedPara1]
+    expected: FAIL
+
+  [33,6: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [33,6: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [33,7: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node document]
+    expected: FAIL
+
+  [33,7: resulting range position for range [detachedComment, 3, detachedComment, 4\], node document]
+    expected: FAIL
+
+  [33,8: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedDiv]
+    expected: FAIL
+
+  [33,8: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedDiv]
+    expected: FAIL
+
+  [33,9: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignDoc]
+    expected: FAIL
+
+  [33,9: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignDoc]
+    expected: FAIL
+
+  [33,10: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignPara2]
+    expected: FAIL
+
+  [33,10: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignPara2]
+    expected: FAIL
+
+  [33,11: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node xmlDoc]
+    expected: FAIL
+
+  [33,11: resulting range position for range [detachedComment, 3, detachedComment, 4\], node xmlDoc]
+    expected: FAIL
+
+  [33,12: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node xmlElement]
+    expected: FAIL
+
+  [33,12: resulting range position for range [detachedComment, 3, detachedComment, 4\], node xmlElement]
+    expected: FAIL
+
+  [33,13: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [33,13: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [33,14: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [33,14: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [33,15: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node processingInstruction]
+    expected: FAIL
+
+  [33,15: resulting range position for range [detachedComment, 3, detachedComment, 4\], node processingInstruction]
+    expected: FAIL
+
+  [33,16: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [33,16: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [33,17: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node comment]
+    expected: FAIL
+
+  [33,17: resulting range position for range [detachedComment, 3, detachedComment, 4\], node comment]
+    expected: FAIL
+
+  [33,18: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node detachedComment]
+    expected: FAIL
+
+  [33,18: resulting range position for range [detachedComment, 3, detachedComment, 4\], node detachedComment]
+    expected: FAIL
+
+  [33,19: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node docfrag]
+    expected: FAIL
+
+  [33,19: resulting range position for range [detachedComment, 3, detachedComment, 4\], node docfrag]
+    expected: FAIL
+
+  [33,20: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node doctype]
+    expected: FAIL
+
+  [33,20: resulting range position for range [detachedComment, 3, detachedComment, 4\], node doctype]
+    expected: FAIL
+
+  [33,21: resulting DOM for range [detachedComment, 3, detachedComment, 4\], node foreignDoctype]
+    expected: FAIL
+
+  [33,21: resulting range position for range [detachedComment, 3, detachedComment, 4\], node foreignDoctype]
+    expected: FAIL
+
+  [34,0: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\]]
+    expected: FAIL
+
+  [34,0: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\]]
+    expected: FAIL
+
+  [34,1: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [34,1: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [34,2: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [34,2: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [34,3: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1]
+    expected: FAIL
+
+  [34,3: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1]
+    expected: FAIL
+
+  [34,4: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [34,4: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [34,5: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1]
+    expected: FAIL
+
+  [34,5: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1]
+    expected: FAIL
+
+  [34,6: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [34,6: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [34,7: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node document]
+    expected: FAIL
+
+  [34,7: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node document]
+    expected: FAIL
+
+  [34,8: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedDiv]
+    expected: FAIL
+
+  [34,8: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedDiv]
+    expected: FAIL
+
+  [34,9: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoc]
+    expected: FAIL
+
+  [34,9: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoc]
+    expected: FAIL
+
+  [34,10: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara2]
+    expected: FAIL
+
+  [34,10: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignPara2]
+    expected: FAIL
+
+  [34,11: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlDoc]
+    expected: FAIL
+
+  [34,11: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlDoc]
+    expected: FAIL
+
+  [34,12: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlElement]
+    expected: FAIL
+
+  [34,12: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node xmlElement]
+    expected: FAIL
+
+  [34,13: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [34,13: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedTextNode]
+    expected: FAIL
+
+  [34,14: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [34,14: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignTextNode]
+    expected: FAIL
+
+  [34,15: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node processingInstruction]
+    expected: FAIL
+
+  [34,15: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node processingInstruction]
+    expected: FAIL
+
+  [34,16: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [34,16: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [34,17: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node comment]
+    expected: FAIL
+
+  [34,17: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node comment]
+    expected: FAIL
+
+  [34,18: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedComment]
+    expected: FAIL
+
+  [34,18: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node detachedComment]
+    expected: FAIL
+
+  [34,19: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node docfrag]
+    expected: FAIL
+
+  [34,19: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node docfrag]
+    expected: FAIL
+
+  [34,20: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node doctype]
+    expected: FAIL
+
+  [34,20: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node doctype]
+    expected: FAIL
+
+  [34,21: resulting DOM for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [34,21: resulting range position for range [detachedForeignComment, 0, detachedForeignComment, 1\], node foreignDoctype]
+    expected: FAIL
+
+  [35,0: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\]]
+    expected: FAIL
+
+  [35,0: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\]]
+    expected: FAIL
+
+  [35,1: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [35,1: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [35,2: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [35,2: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [35,3: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1]
+    expected: FAIL
+
+  [35,3: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1]
+    expected: FAIL
+
+  [35,4: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [35,4: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [35,5: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1]
+    expected: FAIL
+
+  [35,5: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1]
+    expected: FAIL
+
+  [35,6: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [35,6: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [35,7: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node document]
+    expected: FAIL
+
+  [35,7: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node document]
+    expected: FAIL
+
+  [35,8: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedDiv]
+    expected: FAIL
+
+  [35,8: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedDiv]
+    expected: FAIL
+
+  [35,9: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoc]
+    expected: FAIL
+
+  [35,9: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoc]
+    expected: FAIL
+
+  [35,10: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara2]
+    expected: FAIL
+
+  [35,10: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignPara2]
+    expected: FAIL
+
+  [35,11: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlDoc]
+    expected: FAIL
+
+  [35,11: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlDoc]
+    expected: FAIL
+
+  [35,12: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlElement]
+    expected: FAIL
+
+  [35,12: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node xmlElement]
+    expected: FAIL
+
+  [35,13: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedTextNode]
+    expected: FAIL
+
+  [35,13: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedTextNode]
+    expected: FAIL
+
+  [35,14: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignTextNode]
+    expected: FAIL
+
+  [35,14: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignTextNode]
+    expected: FAIL
+
+  [35,15: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node processingInstruction]
+    expected: FAIL
+
+  [35,15: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node processingInstruction]
+    expected: FAIL
+
+  [35,16: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [35,16: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [35,17: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node comment]
+    expected: FAIL
+
+  [35,17: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node comment]
+    expected: FAIL
+
+  [35,18: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedComment]
+    expected: FAIL
+
+  [35,18: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node detachedComment]
+    expected: FAIL
+
+  [35,19: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node docfrag]
+    expected: FAIL
+
+  [35,19: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node docfrag]
+    expected: FAIL
+
+  [35,20: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node doctype]
+    expected: FAIL
+
+  [35,20: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node doctype]
+    expected: FAIL
+
+  [35,21: resulting DOM for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoctype]
+    expected: FAIL
+
+  [35,21: resulting range position for range [detachedXmlComment, 2, detachedXmlComment, 6\], node foreignDoctype]
+    expected: FAIL
+
+  [36,0: resulting DOM for range [docfrag, 0, docfrag, 0\], node paras[0\]]
+    expected: FAIL
+
+  [36,0: resulting range position for range [docfrag, 0, docfrag, 0\], node paras[0\]]
+    expected: FAIL
+
+  [36,1: resulting DOM for range [docfrag, 0, docfrag, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [36,1: resulting range position for range [docfrag, 0, docfrag, 0\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [36,2: resulting DOM for range [docfrag, 0, docfrag, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [36,2: resulting range position for range [docfrag, 0, docfrag, 0\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [36,3: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignPara1]
+    expected: FAIL
+
+  [36,3: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignPara1]
+    expected: FAIL
+
+  [36,4: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [36,4: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [36,5: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedPara1]
+    expected: FAIL
+
+  [36,5: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedPara1]
+    expected: FAIL
+
+  [36,6: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [36,6: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [36,7: resulting DOM for range [docfrag, 0, docfrag, 0\], node document]
+    expected: FAIL
+
+  [36,7: resulting range position for range [docfrag, 0, docfrag, 0\], node document]
+    expected: FAIL
+
+  [36,8: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedDiv]
+    expected: FAIL
+
+  [36,8: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedDiv]
+    expected: FAIL
+
+  [36,9: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignDoc]
+    expected: FAIL
+
+  [36,9: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignDoc]
+    expected: FAIL
+
+  [36,10: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignPara2]
+    expected: FAIL
+
+  [36,10: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignPara2]
+    expected: FAIL
+
+  [36,11: resulting DOM for range [docfrag, 0, docfrag, 0\], node xmlDoc]
+    expected: FAIL
+
+  [36,11: resulting range position for range [docfrag, 0, docfrag, 0\], node xmlDoc]
+    expected: FAIL
+
+  [36,12: resulting DOM for range [docfrag, 0, docfrag, 0\], node xmlElement]
+    expected: FAIL
+
+  [36,12: resulting range position for range [docfrag, 0, docfrag, 0\], node xmlElement]
+    expected: FAIL
+
+  [36,13: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [36,13: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedTextNode]
+    expected: FAIL
+
+  [36,14: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [36,14: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignTextNode]
+    expected: FAIL
+
+  [36,15: resulting DOM for range [docfrag, 0, docfrag, 0\], node processingInstruction]
+    expected: FAIL
+
+  [36,15: resulting range position for range [docfrag, 0, docfrag, 0\], node processingInstruction]
+    expected: FAIL
+
+  [36,16: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [36,16: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [36,17: resulting DOM for range [docfrag, 0, docfrag, 0\], node comment]
+    expected: FAIL
+
+  [36,17: resulting range position for range [docfrag, 0, docfrag, 0\], node comment]
+    expected: FAIL
+
+  [36,18: resulting DOM for range [docfrag, 0, docfrag, 0\], node detachedComment]
+    expected: FAIL
+
+  [36,18: resulting range position for range [docfrag, 0, docfrag, 0\], node detachedComment]
+    expected: FAIL
+
+  [36,19: resulting DOM for range [docfrag, 0, docfrag, 0\], node docfrag]
+    expected: FAIL
+
+  [36,19: resulting range position for range [docfrag, 0, docfrag, 0\], node docfrag]
+    expected: FAIL
+
+  [36,20: resulting DOM for range [docfrag, 0, docfrag, 0\], node doctype]
+    expected: FAIL
+
+  [36,20: resulting range position for range [docfrag, 0, docfrag, 0\], node doctype]
+    expected: FAIL
+
+  [36,21: resulting DOM for range [docfrag, 0, docfrag, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [36,21: resulting range position for range [docfrag, 0, docfrag, 0\], node foreignDoctype]
+    expected: FAIL
+
+  [37,0: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\]]
+    expected: FAIL
+
+  [37,0: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\]]
+    expected: FAIL
+
+  [37,1: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [37,1: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node paras[0\].firstChild]
+    expected: FAIL
+
+  [37,2: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [37,2: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node paras[1\].firstChild]
+    expected: FAIL
+
+  [37,3: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1]
+    expected: FAIL
+
+  [37,3: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1]
+    expected: FAIL
+
+  [37,4: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [37,4: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara1.firstChild]
+    expected: FAIL
+
+  [37,5: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1]
+    expected: FAIL
+
+  [37,5: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1]
+    expected: FAIL
+
+  [37,6: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [37,6: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedPara1.firstChild]
+    expected: FAIL
+
+  [37,7: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node document]
+    expected: FAIL
+
+  [37,7: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node document]
+    expected: FAIL
+
+  [37,8: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedDiv]
+    expected: FAIL
+
+  [37,8: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedDiv]
+    expected: FAIL
+
+  [37,9: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoc]
+    expected: FAIL
+
+  [37,9: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoc]
+    expected: FAIL
+
+  [37,10: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara2]
+    expected: FAIL
+
+  [37,10: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignPara2]
+    expected: FAIL
+
+  [37,11: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node xmlDoc]
+    expected: FAIL
+
+  [37,11: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node xmlDoc]
+    expected: FAIL
+
+  [37,12: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node xmlElement]
+    expected: FAIL
+
+  [37,12: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node xmlElement]
+    expected: FAIL
+
+  [37,13: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [37,13: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedTextNode]
+    expected: FAIL
+
+  [37,14: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [37,14: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignTextNode]
+    expected: FAIL
+
+  [37,15: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node processingInstruction]
+    expected: FAIL
+
+  [37,15: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node processingInstruction]
+    expected: FAIL
+
+  [37,16: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [37,16: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedProcessingInstruction]
+    expected: FAIL
+
+  [37,17: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node comment]
+    expected: FAIL
+
+  [37,17: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node comment]
+    expected: FAIL
+
+  [37,18: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node detachedComment]
+    expected: FAIL
+
+  [37,18: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node detachedComment]
+    expected: FAIL
+
+  [37,19: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node docfrag]
+    expected: FAIL
+
+  [37,19: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node docfrag]
+    expected: FAIL
+
+  [37,20: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node doctype]
+    expected: FAIL
+
+  [37,20: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node doctype]
+    expected: FAIL
+
+  [37,21: resulting DOM for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoctype]
+    expected: FAIL
+
+  [37,21: resulting range position for range [processingInstruction, 0, processingInstruction, 4\], node foreignDoctype]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/read-text/load-text-plain.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/read-text/load-text-plain.html.ini
@@ -1,0 +1,11 @@
+[load-text-plain.html]
+  type: testharness
+  [Checking document metadata for text file]
+    expected: FAIL
+
+  [Checking DOM for text file]
+    expected: FAIL
+
+  [Checking contents for text file]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/origin/cross-origin-objects/cross-origin-objects.html.ini
+++ b/tests/wpt/metadata/html/browsers/origin/cross-origin-objects/cross-origin-objects.html.ini
@@ -1,3 +1,47 @@
 [cross-origin-objects.html]
   type: testharness
-  expected: ERROR
+  [Basic sanity-checking]
+    expected: FAIL
+
+  [Only whitelisted properties are accessible cross-origin]
+    expected: FAIL
+
+  [[[GetPrototypeOf\]\] should return null]
+    expected: FAIL
+
+  [[[PreventExtensions\]\] should throw for cross-origin objects]
+    expected: FAIL
+
+  [[[GetOwnProperty\]\] - Properties on cross-origin objects should be reported |own|]
+    expected: FAIL
+
+  [[[GetOwnProperty\]\] - Property descriptors for cross-origin properties should be set up correctly]
+    expected: FAIL
+
+  [[[Delete\]\] Should throw on cross-origin objects]
+    expected: FAIL
+
+  [[[DefineOwnProperty\]\] Should throw for cross-origin objects]
+    expected: FAIL
+
+  [[[Enumerate\]\] should return an empty iterator]
+    expected: FAIL
+
+  [[[OwnPropertyKeys\]\] should return all properties from cross-origin objects]
+    expected: FAIL
+
+  [Cross-origin functions get local Function.prototype]
+    expected: FAIL
+
+  [Cross-origin Window accessors get local Function.prototype]
+    expected: FAIL
+
+  [Same-origin observers get different functions for cross-origin objects]
+    expected: FAIL
+
+  [Same-origin obsevers get different accessors for cross-origin Window]
+    expected: FAIL
+
+  [Same-origin observers get different accessors for cross-origin Location]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/the-window-object/accessing-other-browsing-contexts/window_length.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/accessing-other-browsing-contexts/window_length.html.ini
@@ -1,5 +1,6 @@
 [window_length.html]
   type: testharness
+  expected: CRASH
   [No child browsing contexts]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/browsers/windows/browsing-context-first-created.xhtml.ini
+++ b/tests/wpt/metadata/html/browsers/windows/browsing-context-first-created.xhtml.ini
@@ -1,8 +1,5 @@
 [browsing-context-first-created.xhtml]
   type: testharness
-  [Check the history.length of the first created browsing context]
-    expected: FAIL
-
   [Check the document's meta data]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -90,12 +90,6 @@
   [Document interface: iframe.contentDocument must inherit property "origin" with the proper type (3)]
     expected: FAIL
 
-  [Document interface: iframe.contentDocument must inherit property "compatMode" with the proper type (4)]
-    expected: FAIL
-
-  [Document interface: iframe.contentDocument must inherit property "characterSet" with the proper type (5)]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "inputEncoding" with the proper type (6)]
     expected: FAIL
 
@@ -111,31 +105,16 @@
   [Document interface: iframe.contentDocument must inherit property "getElementsByTagName" with the proper type (10)]
     expected: FAIL
 
-  [Document interface: calling getElementsByTagName(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "getElementsByTagNameNS" with the proper type (11)]
-    expected: FAIL
-
-  [Document interface: calling getElementsByTagNameNS(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "getElementsByClassName" with the proper type (12)]
     expected: FAIL
 
-  [Document interface: calling getElementsByClassName(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "createElement" with the proper type (13)]
     expected: FAIL
 
-  [Document interface: calling createElement(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "createElementNS" with the proper type (14)]
-    expected: FAIL
-
-  [Document interface: calling createElementNS(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "createDocumentFragment" with the proper type (15)]
@@ -144,49 +123,25 @@
   [Document interface: iframe.contentDocument must inherit property "createTextNode" with the proper type (16)]
     expected: FAIL
 
-  [Document interface: calling createTextNode(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "createComment" with the proper type (17)]
-    expected: FAIL
-
-  [Document interface: calling createComment(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "createProcessingInstruction" with the proper type (18)]
     expected: FAIL
 
-  [Document interface: calling createProcessingInstruction(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "importNode" with the proper type (19)]
-    expected: FAIL
-
-  [Document interface: calling importNode(Node,boolean) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "adoptNode" with the proper type (20)]
     expected: FAIL
 
-  [Document interface: calling adoptNode(Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "createAttribute" with the proper type (21)]
-    expected: FAIL
-
-  [Document interface: calling createAttribute(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "createAttributeNS" with the proper type (22)]
     expected: FAIL
 
-  [Document interface: calling createAttributeNS(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "createEvent" with the proper type (23)]
-    expected: FAIL
-
-  [Document interface: calling createEvent(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "createRange" with the proper type (24)]
@@ -195,13 +150,7 @@
   [Document interface: iframe.contentDocument must inherit property "createNodeIterator" with the proper type (25)]
     expected: FAIL
 
-  [Document interface: calling createNodeIterator(Node,unsigned long,NodeFilter) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "createTreeWalker" with the proper type (26)]
-    expected: FAIL
-
-  [Document interface: calling createTreeWalker(Node,unsigned long,NodeFilter) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "styleSheets" with the proper type (27)]
@@ -274,9 +223,6 @@
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "getElementsByName" with the proper type (50)]
-    expected: FAIL
-
-  [Document interface: calling getElementsByName(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "getItems" with the proper type (51)]
@@ -408,9 +354,6 @@
   [Document interface: iframe.contentDocument must inherit property "getElementById" with the proper type (82)]
     expected: FAIL
 
-  [Document interface: calling getElementById(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "children" with the proper type (83)]
     expected: FAIL
 
@@ -426,13 +369,7 @@
   [Document interface: iframe.contentDocument must inherit property "prepend" with the proper type (87)]
     expected: FAIL
 
-  [Document interface: calling prepend([object Object\],[object Object\]) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "append" with the proper type (88)]
-    expected: FAIL
-
-  [Document interface: calling append([object Object\],[object Object\]) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "query" with the proper type (89)]
@@ -450,13 +387,7 @@
   [Document interface: iframe.contentDocument must inherit property "querySelector" with the proper type (91)]
     expected: FAIL
 
-  [Document interface: calling querySelector(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "querySelectorAll" with the proper type (92)]
-    expected: FAIL
-
-  [Document interface: calling querySelectorAll(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "onabort" with the proper type (93)]
@@ -646,189 +577,6 @@
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "onwaiting" with the proper type (155)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "ELEMENT_NODE" with the proper type (0)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "ATTRIBUTE_NODE" with the proper type (1)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "TEXT_NODE" with the proper type (2)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "CDATA_SECTION_NODE" with the proper type (3)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "ENTITY_REFERENCE_NODE" with the proper type (4)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "ENTITY_NODE" with the proper type (5)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "PROCESSING_INSTRUCTION_NODE" with the proper type (6)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "COMMENT_NODE" with the proper type (7)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_NODE" with the proper type (8)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_TYPE_NODE" with the proper type (9)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_FRAGMENT_NODE" with the proper type (10)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "NOTATION_NODE" with the proper type (11)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "nodeType" with the proper type (12)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "nodeName" with the proper type (13)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "baseURI" with the proper type (14)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "ownerDocument" with the proper type (15)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "parentNode" with the proper type (16)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "parentElement" with the proper type (17)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "hasChildNodes" with the proper type (18)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "childNodes" with the proper type (19)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "firstChild" with the proper type (20)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "lastChild" with the proper type (21)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "previousSibling" with the proper type (22)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "nextSibling" with the proper type (23)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "nodeValue" with the proper type (24)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "textContent" with the proper type (25)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "normalize" with the proper type (26)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "cloneNode" with the proper type (27)]
-    expected: FAIL
-
-  [Node interface: calling cloneNode(boolean) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "isEqualNode" with the proper type (28)]
-    expected: FAIL
-
-  [Node interface: calling isEqualNode(Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_DISCONNECTED" with the proper type (29)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_PRECEDING" with the proper type (30)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_FOLLOWING" with the proper type (31)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_CONTAINS" with the proper type (32)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_CONTAINED_BY" with the proper type (33)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC" with the proper type (34)]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "compareDocumentPosition" with the proper type (35)]
-    expected: FAIL
-
-  [Node interface: calling compareDocumentPosition(Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "contains" with the proper type (36)]
-    expected: FAIL
-
-  [Node interface: calling contains(Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "lookupPrefix" with the proper type (37)]
-    expected: FAIL
-
-  [Node interface: calling lookupPrefix(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "lookupNamespaceURI" with the proper type (38)]
-    expected: FAIL
-
-  [Node interface: calling lookupNamespaceURI(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "isDefaultNamespace" with the proper type (39)]
-    expected: FAIL
-
-  [Node interface: calling isDefaultNamespace(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "insertBefore" with the proper type (40)]
-    expected: FAIL
-
-  [Node interface: calling insertBefore(Node,Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "appendChild" with the proper type (41)]
-    expected: FAIL
-
-  [Node interface: calling appendChild(Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "replaceChild" with the proper type (42)]
-    expected: FAIL
-
-  [Node interface: calling replaceChild(Node,Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: iframe.contentDocument must inherit property "removeChild" with the proper type (43)]
-    expected: FAIL
-
-  [Node interface: calling removeChild(Node) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: iframe.contentDocument must inherit property "addEventListener" with the proper type (0)]
-    expected: FAIL
-
-  [EventTarget interface: calling addEventListener(DOMString,EventListener,boolean) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: iframe.contentDocument must inherit property "removeEventListener" with the proper type (1)]
-    expected: FAIL
-
-  [EventTarget interface: calling removeEventListener(DOMString,EventListener,boolean) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: iframe.contentDocument must inherit property "dispatchEvent" with the proper type (2)]
-    expected: FAIL
-
-  [EventTarget interface: calling dispatchEvent(Event) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [XMLDocument interface: operation load(DOMString)]
@@ -10636,5 +10384,257 @@
     expected: FAIL
 
   [EventSource interface: operation close()]
+    expected: FAIL
+
+  [Document interface: iframe.contentDocument must inherit property "compatMode" with the proper type (4)]
+    expected: FAIL
+
+  [Document interface: iframe.contentDocument must inherit property "characterSet" with the proper type (5)]
+    expected: FAIL
+
+  [Document interface: calling getElementsByTagName(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling getElementsByTagNameNS(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling getElementsByClassName(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createElement(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createElementNS(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createTextNode(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createComment(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createProcessingInstruction(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling importNode(Node,boolean) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling adoptNode(Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createAttribute(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createAttributeNS(DOMString,DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createEvent(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createNodeIterator(Node,unsigned long,NodeFilter) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling createTreeWalker(Node,unsigned long,NodeFilter) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling getElementsByName(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling getElementById(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling prepend([object Object\],[object Object\]) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling append([object Object\],[object Object\]) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling querySelector(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Document interface: calling querySelectorAll(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "ELEMENT_NODE" with the proper type (0)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "ATTRIBUTE_NODE" with the proper type (1)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "TEXT_NODE" with the proper type (2)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "CDATA_SECTION_NODE" with the proper type (3)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "ENTITY_REFERENCE_NODE" with the proper type (4)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "ENTITY_NODE" with the proper type (5)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "PROCESSING_INSTRUCTION_NODE" with the proper type (6)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "COMMENT_NODE" with the proper type (7)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_NODE" with the proper type (8)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_TYPE_NODE" with the proper type (9)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_FRAGMENT_NODE" with the proper type (10)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "NOTATION_NODE" with the proper type (11)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "nodeType" with the proper type (12)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "nodeName" with the proper type (13)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "baseURI" with the proper type (14)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "ownerDocument" with the proper type (15)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "parentNode" with the proper type (16)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "parentElement" with the proper type (17)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "hasChildNodes" with the proper type (18)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "childNodes" with the proper type (19)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "firstChild" with the proper type (20)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "lastChild" with the proper type (21)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "previousSibling" with the proper type (22)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "nextSibling" with the proper type (23)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "nodeValue" with the proper type (24)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "textContent" with the proper type (25)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "normalize" with the proper type (26)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "cloneNode" with the proper type (27)]
+    expected: FAIL
+
+  [Node interface: calling cloneNode(boolean) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "isEqualNode" with the proper type (28)]
+    expected: FAIL
+
+  [Node interface: calling isEqualNode(Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_DISCONNECTED" with the proper type (29)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_PRECEDING" with the proper type (30)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_FOLLOWING" with the proper type (31)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_CONTAINS" with the proper type (32)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_CONTAINED_BY" with the proper type (33)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC" with the proper type (34)]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "compareDocumentPosition" with the proper type (35)]
+    expected: FAIL
+
+  [Node interface: calling compareDocumentPosition(Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "contains" with the proper type (36)]
+    expected: FAIL
+
+  [Node interface: calling contains(Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "lookupPrefix" with the proper type (37)]
+    expected: FAIL
+
+  [Node interface: calling lookupPrefix(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "lookupNamespaceURI" with the proper type (38)]
+    expected: FAIL
+
+  [Node interface: calling lookupNamespaceURI(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "isDefaultNamespace" with the proper type (39)]
+    expected: FAIL
+
+  [Node interface: calling isDefaultNamespace(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "insertBefore" with the proper type (40)]
+    expected: FAIL
+
+  [Node interface: calling insertBefore(Node,Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "appendChild" with the proper type (41)]
+    expected: FAIL
+
+  [Node interface: calling appendChild(Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "replaceChild" with the proper type (42)]
+    expected: FAIL
+
+  [Node interface: calling replaceChild(Node,Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Node interface: iframe.contentDocument must inherit property "removeChild" with the proper type (43)]
+    expected: FAIL
+
+  [Node interface: calling removeChild(Node) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [EventTarget interface: iframe.contentDocument must inherit property "addEventListener" with the proper type (0)]
+    expected: FAIL
+
+  [EventTarget interface: calling addEventListener(DOMString,EventListener,boolean) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [EventTarget interface: iframe.contentDocument must inherit property "removeEventListener" with the proper type (1)]
+    expected: FAIL
+
+  [EventTarget interface: calling removeEventListener(DOMString,EventListener,boolean) on iframe.contentDocument with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [EventTarget interface: iframe.contentDocument must inherit property "dispatchEvent" with the proper type (2)]
+    expected: FAIL
+
+  [EventTarget interface: calling dispatchEvent(Event) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe-load-event.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe-load-event.html.ini
@@ -3,6 +3,3 @@
   [load event of blob URL]
     expected: FAIL
 
-  [load event of initial about:blank]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html.ini
@@ -1,13 +1,6 @@
 [viewport-change.html]
   type: testharness
-  disabled: unsupported feature and prone to intermittent incorrect results
-  bug: 9560
-  [img (no src), onload, narrow]
-    expected: FAIL
-
-  [img (empty src), onload, narrow]
-    expected: FAIL
-
+  expected: TIMEOUT
   [img (src only) broken image, onload, narrow]
     expected: FAIL
 
@@ -24,33 +17,27 @@
     expected: FAIL
 
   [picture: source (max-width:500px) broken image, img broken image, resize to wide]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: source (max-width:500px) broken image, img valid image, onload, narrow]
     expected: FAIL
 
   [picture: source (max-width:500px) broken image, img valid image, resize to wide]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: source (max-width:500px) valid image, img broken image, onload, narrow]
     expected: FAIL
 
   [picture: source (max-width:500px) valid image, img broken image, resize to wide]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: source (max-width:500px) valid image, img valid image, onload, narrow]
     expected: FAIL
 
   [picture: source (max-width:500px) valid image, img valid image, resize to wide]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: same URL in source (max-width:500px) and img, onload, narrow]
-    expected: FAIL
-
-  [img (no src), onload, wide]
-    expected: FAIL
-
-  [img (empty src), onload, wide]
     expected: FAIL
 
   [img (src only) broken image, onload, wide]
@@ -69,41 +56,26 @@
     expected: FAIL
 
   [picture: source (max-width:500px) broken image, img broken image, resize to narrow]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: source (max-width:500px) broken image, img valid image, onload, wide]
     expected: FAIL
 
   [picture: source (max-width:500px) broken image, img valid image, resize to narrow]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: source (max-width:500px) valid image, img broken image, onload, wide]
     expected: FAIL
 
   [picture: source (max-width:500px) valid image, img broken image, resize to narrow]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: source (max-width:500px) valid image, img valid image, onload, wide]
     expected: FAIL
 
   [picture: source (max-width:500px) valid image, img valid image, resize to narrow]
-    expected: FAIL
+    expected: TIMEOUT
 
   [picture: same URL in source (max-width:500px) and img, onload, wide]
-    expected: FAIL
-
-  [img (empty src), resize to wide]
-    expected: FAIL
-
-  [img (src only) broken image, resize to wide]
-    expected: FAIL
-
-  [img (src only) valid image, resize to wide]
-    expected: FAIL
-
-  [picture: same URL in source (max-width:500px) and img, resize to wide]
-    expected: FAIL
-
-  [picture: same URL in source (max-width:500px) and img, resize to narrow]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html.ini
@@ -1,7 +1,5 @@
 [parse-a-sizes-attribute.html]
   type: testharness
-  disabled: unsupported feature and prone to intermittent incorrect results
-  bug: 9560
   [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (standards mode)]
     expected: FAIL
 
@@ -140,31 +138,31 @@
   [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (standards mode)]
@@ -191,7 +189,7 @@
   [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (standards mode)]
@@ -206,7 +204,7 @@
   [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (standards mode)]
@@ -260,7 +258,7 @@
   [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (standards mode)]
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 100vw, 1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (standards mode)]
@@ -312,6 +310,36 @@
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e102 50w, /images/green-16x16.png?e102 51w" sizes="(&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e103 50w, /images/green-16x16.png?e103 51w" sizes="not (&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e104 50w, /images/green-16x16.png?e104 51w" sizes="(unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e105 50w, /images/green-16x16.png?e105 51w" sizes="not (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e106 50w, /images/green-16x16.png?e106 51w" sizes="(min-width:0) or (unknown-general-enclosed !) 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e107 50w, /images/green-16x16.png?e107 51w" sizes="not ((min-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e108 50w, /images/green-16x16.png?e108 51w" sizes="(max-width:0) or (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e109 50w, /images/green-16x16.png?e109 51w" sizes="not ((max-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="1px" (standards mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (standards mode)]
@@ -452,12 +480,6 @@
   [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (standards mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (standards mode)]
-    expected: FAIL
-
-  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (standards mode)]
-    expected: FAIL
-
   [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (quirks mode)]
     expected: FAIL
 
@@ -596,31 +618,31 @@
   [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (quirks mode)]
@@ -647,7 +669,7 @@
   [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (quirks mode)]
@@ -662,7 +684,7 @@
   [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (quirks mode)]
@@ -716,7 +738,7 @@
   [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (quirks mode)]
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 100vw, 1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (quirks mode)]
@@ -768,6 +790,36 @@
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e102 50w, /images/green-16x16.png?e102 51w" sizes="(&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e103 50w, /images/green-16x16.png?e103 51w" sizes="not (&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e104 50w, /images/green-16x16.png?e104 51w" sizes="(unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e105 50w, /images/green-16x16.png?e105 51w" sizes="not (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e106 50w, /images/green-16x16.png?e106 51w" sizes="(min-width:0) or (unknown-general-enclosed !) 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e107 50w, /images/green-16x16.png?e107 51w" sizes="not ((min-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e108 50w, /images/green-16x16.png?e108 51w" sizes="(max-width:0) or (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e109 50w, /images/green-16x16.png?e109 51w" sizes="not ((max-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="1px" (quirks mode)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (quirks mode)]
@@ -908,12 +960,6 @@
   [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (quirks mode)]
-    expected: FAIL
-
-  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (quirks mode)]
-    expected: FAIL
-
   [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (display:none)]
     expected: FAIL
 
@@ -1052,31 +1098,31 @@
   [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (display:none)]
@@ -1103,7 +1149,7 @@
   [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (display:none)]
@@ -1118,7 +1164,7 @@
   [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (display:none)]
@@ -1172,7 +1218,7 @@
   [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (display:none)]
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 100vw, 1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (display:none)]
@@ -1224,6 +1270,36 @@
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e102 50w, /images/green-16x16.png?e102 51w" sizes="(&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e103 50w, /images/green-16x16.png?e103 51w" sizes="not (&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e104 50w, /images/green-16x16.png?e104 51w" sizes="(unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e105 50w, /images/green-16x16.png?e105 51w" sizes="not (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e106 50w, /images/green-16x16.png?e106 51w" sizes="(min-width:0) or (unknown-general-enclosed !) 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e107 50w, /images/green-16x16.png?e107 51w" sizes="not ((min-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e108 50w, /images/green-16x16.png?e108 51w" sizes="(max-width:0) or (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e109 50w, /images/green-16x16.png?e109 51w" sizes="not ((max-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="1px" (display:none)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (display:none)]
@@ -1364,12 +1440,6 @@
   [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (display:none)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (display:none)]
-    expected: FAIL
-
-  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (display:none)]
-    expected: FAIL
-
   [<img srcset="/images/green-1x1.png?a2 300w, /images/green-16x16.png?a2 301w"> ref sizes="100vw" (width:1000px)]
     expected: FAIL
 
@@ -1508,31 +1578,31 @@
   [<img srcset="/images/green-1x1.png?e43 50w, /images/green-16x16.png?e43 51w" sizes="(min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e44 50w, /images/green-16x16.png?e44 51w" sizes="not (min-width:unknown-mf-value) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e45 50w, /images/green-16x16.png?e45 51w" sizes="(min-width:-1px) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e46 50w, /images/green-16x16.png?e46 51w" sizes="not (min-width:-1px) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e47 50w, /images/green-16x16.png?e47 51w" sizes="(unknown-mf-name) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e48 50w, /images/green-16x16.png?e48 51w" sizes="not (unknown-mf-name) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(&quot;unknown-general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e49 50w, /images/green-16x16.png?e49 51w" sizes="(unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e50 50w, /images/green-16x16.png?e50 51w" sizes="not (unknown &quot;general-enclosed&quot;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e51 50w, /images/green-16x16.png?e51 51w" sizes="unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e52 50w, /images/green-16x16.png?e52 51w" sizes="not unknown-general-enclosed(foo) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e53 50w, /images/green-16x16.png?e53 51w" sizes="print 100vw, 1px"> ref sizes="1px" (width:1000px)]
@@ -1559,7 +1629,7 @@
   [<img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (&quot;unknown-general-enclosed&quot;) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (width:1000px)]
@@ -1574,7 +1644,7 @@
   [<img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e67 50w, /images/green-16x16.png?e67 51w" sizes="(!) 100vw, 1px"> ref sizes="1px" (width:1000px)]
@@ -1628,7 +1698,7 @@
   [<img srcset="/images/green-1x1.png?e83 50w, /images/green-16x16.png?e83 51w" sizes="(.) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
-  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 1px"> ref sizes="1px" (width:1000px)]
+  [<img srcset="/images/green-1x1.png?e84 50w, /images/green-16x16.png?e84 51w" sizes="not (.) 100vw, 1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e85 50w, /images/green-16x16.png?e85 51w" sizes="; 100vw, 1px"> ref sizes="1px" (width:1000px)]
@@ -1680,6 +1750,36 @@
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?e101 50w, /images/green-16x16.png?e101 51w" sizes="(min-width:0) 1px, foo bar"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e102 50w, /images/green-16x16.png?e102 51w" sizes="(&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e103 50w, /images/green-16x16.png?e103 51w" sizes="not (&quot;grammar does not match&quot;) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e104 50w, /images/green-16x16.png?e104 51w" sizes="(unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e105 50w, /images/green-16x16.png?e105 51w" sizes="not (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e106 50w, /images/green-16x16.png?e106 51w" sizes="(min-width:0) or (unknown-general-enclosed !) 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e107 50w, /images/green-16x16.png?e107 51w" sizes="not ((min-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e108 50w, /images/green-16x16.png?e108 51w" sizes="(max-width:0) or (unknown-general-enclosed !) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?e109 50w, /images/green-16x16.png?e109 51w" sizes="not ((max-width:0) or (unknown &quot;general-enclosed&quot;)) 100vw, 1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="1px" (width:1000px)]
+    expected: FAIL
+
+  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?f2 50w, /images/green-16x16.png?f2 51w" sizes=""> ref sizes="100vw" (width:1000px)]
@@ -1818,11 +1918,5 @@
     expected: FAIL
 
   [<img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (width:1000px)]
-    expected: FAIL
-
-  [<img srcset="/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w" sizes="calc(1px"> ref sizes="100vw" (width:1000px)]
-    expected: FAIL
-
-  [<img srcset="/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w" sizes="(min-width:0) calc(1px"> ref sizes="100vw" (width:1000px)]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-template-element/template-element/node-document-changes.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-template-element/template-element/node-document-changes.html.ini
@@ -3,9 +3,9 @@
   [Changing of template element's node document. Test document loaded from a file]
     expected: FAIL
 
-  [Changing of template element's node document. Adobt template element into a document that has a browsing context]
+  [Changing of template element's node document. Test the case when both old and new owner documents of template element have browsing context]
     expected: FAIL
 
-  [Changing of template element's node document. Test the case when both old and new owner documents of template element have browsing context]
+  [Changing of template element's node document. Adobt template element into a document that has a browsing context]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_basic.html.ini
+++ b/tests/wpt/metadata/webstorage/event_basic.html.ini
@@ -1,6 +1,6 @@
 [event_basic.html]
   type: testharness
-  expected: ERROR
+  expected: CRASH
   [sessionStorage mutations fire StorageEvents that are caught by the event listener set via window.onstorage.]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_body_attribute.html.ini
+++ b/tests/wpt/metadata/webstorage/event_body_attribute.html.ini
@@ -1,6 +1,6 @@
 [event_body_attribute.html]
   type: testharness
-  expected: ERROR
+  expected: CRASH
   [sessionStorage mutations fire StorageEvents that are caught by the event listener specified as an attribute on the body.]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_case_sensitive.html.ini
+++ b/tests/wpt/metadata/webstorage/event_case_sensitive.html.ini
@@ -1,6 +1,6 @@
 [event_case_sensitive.html]
   type: testharness
-  expected: ERROR
+  expected: CRASH
   [sessionStorage storage events fire even when only the case of the value changes.]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_local_key.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_key.html.ini
@@ -1,0 +1,3 @@
+[event_local_key.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_local_newvalue.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_newvalue.html.ini
@@ -1,0 +1,3 @@
+[event_local_newvalue.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_local_oldvalue.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_oldvalue.html.ini
@@ -1,0 +1,3 @@
+[event_local_oldvalue.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_local_removeitem.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_removeitem.html.ini
@@ -1,5 +1,6 @@
 [event_local_removeitem.html]
   type: testharness
+  expected: CRASH
   [key property test of local event]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_local_storagearea.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_storagearea.html.ini
@@ -1,0 +1,3 @@
+[event_local_storagearea.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_local_url.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_url.html.ini
@@ -1,0 +1,3 @@
+[event_local_url.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_session_key.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_key.html.ini
@@ -1,0 +1,3 @@
+[event_session_key.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_session_newvalue.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_newvalue.html.ini
@@ -1,0 +1,3 @@
+[event_session_newvalue.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_session_oldvalue.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_oldvalue.html.ini
@@ -1,0 +1,3 @@
+[event_session_oldvalue.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_session_removeitem.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_removeitem.html.ini
@@ -1,5 +1,6 @@
 [event_session_removeitem.html]
   type: testharness
+  expected: CRASH
   [key property test of session event]
     expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_session_storagearea.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_storagearea.html.ini
@@ -1,0 +1,3 @@
+[event_session_storagearea.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_session_url.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_url.html.ini
@@ -1,0 +1,3 @@
+[event_session_url.html]
+  type: testharness
+  expected: CRASH

--- a/tests/wpt/metadata/webstorage/event_setattribute.html.ini
+++ b/tests/wpt/metadata/webstorage/event_setattribute.html.ini
@@ -1,6 +1,6 @@
 [event_setattribute.html]
   type: testharness
-  expected: ERROR
+  expected: CRASH
   [sessionStorage mutations fire StorageEvents that are caught by the event listener attached via setattribute.]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/mozilla/mozbrowser/mozbrowser_loadevents.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/mozbrowser/mozbrowser_loadevents.html.ini
@@ -1,0 +1,5 @@
+[mozbrowser_loadevents.html]
+  type: testharness
+  [mozbrowserloadstart, mozbrowserconnected and mozbrowserloadend are dispatched]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/mozbrowser/mozbrowserlocationchange_event.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/mozbrowser/mozbrowserlocationchange_event.html.ini
@@ -1,0 +1,6 @@
+[mozbrowserlocationchange_event.html]
+  type: testharness
+  expected: TIMEOUT
+  [Browser API; mozbrowserlocationchange event]
+    expected: TIMEOUT
+


### PR DESCRIPTION
@Ms2ger, I would appreciate your thoughts on this design. It leverages the existing synchronous API support for the network load (the same way that sync XHR works), and introduces a one-off channel for the constellation's frame creation notification message when necessary.

Resolves #3924.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8600)

<!-- Reviewable:end -->
