### PR TITLE
Add test to constellation to avoid writing reftest image if there are pending frames.

### DIFF
--- a/components/gfx/paint_task.rs
+++ b/components/gfx/paint_task.rs
@@ -212,7 +212,6 @@ pub struct PaintTask<C> {
     layout_to_paint_port: Receiver<LayoutToPaintMsg>,
     chrome_to_paint_port: Receiver<ChromeToPaintMsg>,
     compositor: C,
-    constellation_chan: ConstellationChan<ConstellationMsg>,
 
     /// A channel to the time profiler.
     time_profiler_chan: time::ProfilerChan,
@@ -274,7 +273,6 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
                     layout_to_paint_port: layout_to_paint_port,
                     chrome_to_paint_port: chrome_to_paint_port,
                     compositor: compositor,
-                    constellation_chan: constellation_chan,
                     time_profiler_chan: time_profiler_chan,
                     root_paint_layer: None,
                     paint_permission: false,
@@ -326,14 +324,9 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
                     self.current_epoch = Some(epoch);
                     self.root_paint_layer = Some(Arc::new(paint_layer));
 
-                    if !self.paint_permission {
-                        debug!("PaintTask: paint ready msg");
-                        let ConstellationChan(ref mut c) = self.constellation_chan;
-                        c.send(ConstellationMsg::Ready(self.id)).unwrap();
-                        continue;
+                    if self.paint_permission {
+                        self.initialize_layers();
                     }
-
-                    self.initialize_layers();
                 }
                 // Inserts a new canvas renderer to the layer map
                 Msg::FromLayout(LayoutToPaintMsg::CanvasLayer(layer_id, canvas_renderer)) => {
@@ -341,31 +334,26 @@ impl<C> PaintTask<C> where C: PaintListener + Send + 'static {
                     self.canvas_map.insert(layer_id, canvas_renderer);
                 }
                 Msg::FromChrome(ChromeToPaintMsg::Paint(requests, frame_tree_id)) => {
-                    if !self.paint_permission {
-                        debug!("PaintTask: paint ready msg");
-                        let ConstellationChan(ref mut c) = self.constellation_chan;
-                        c.send(ConstellationMsg::Ready(self.id)).unwrap();
-                        continue;
-                    }
-
-                    let mut replies = Vec::new();
-                    for PaintRequest { buffer_requests, scale, layer_id, epoch, layer_kind }
-                          in requests {
-                        if self.current_epoch == Some(epoch) {
-                            self.paint(&mut replies, buffer_requests, scale, layer_id, layer_kind);
-                        } else {
-                            debug!("PaintTask: Ignoring requests with epoch mismatch: {:?} != {:?}",
-                                   self.current_epoch,
-                                   epoch);
-                            self.compositor.ignore_buffer_requests(buffer_requests);
+                    if self.paint_permission && self.root_paint_layer.is_some() {
+                        let mut replies = Vec::new();
+                        for PaintRequest { buffer_requests, scale, layer_id, epoch, layer_kind }
+                              in requests {
+                            if self.current_epoch == Some(epoch) {
+                                self.paint(&mut replies, buffer_requests, scale, layer_id, layer_kind);
+                            } else {
+                                debug!("PaintTask: Ignoring requests with epoch mismatch: {:?} != {:?}",
+                                       self.current_epoch,
+                                       epoch);
+                                self.compositor.ignore_buffer_requests(buffer_requests);
+                            }
                         }
-                    }
 
-                    debug!("PaintTask: returning surfaces");
-                    self.compositor.assign_painted_buffers(self.id,
-                                                           self.current_epoch.unwrap(),
-                                                           replies,
-                                                           frame_tree_id);
+                        debug!("PaintTask: returning surfaces");
+                        self.compositor.assign_painted_buffers(self.id,
+                                                               self.current_epoch.unwrap(),
+                                                               replies,
+                                                               frame_tree_id);
+                    }
                 }
                 Msg::FromChrome(ChromeToPaintMsg::PaintPermissionGranted) => {
                     self.paint_permission = true;

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -244,7 +244,6 @@ pub enum MouseButton {
 /// Messages from the paint task to the constellation.
 #[derive(Deserialize, Serialize)]
 pub enum PaintMsg {
-    Ready(PipelineId),
     Failure(Failure),
 }
 
@@ -254,6 +253,15 @@ pub enum AnimationState {
     AnimationCallbacksPresent,
     NoAnimationsPresent,
     NoAnimationCallbacksPresent,
+}
+
+/// Used to determine if a script has any pending asynchronous activity.
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum DocumentState {
+    /// The document has been loaded and is idle.
+    Idle,
+    /// The document is either loading or waiting on an event.
+    Pending,
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Using_the_Browser_API#Events

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -80,7 +80,7 @@ use profile_traits::time::{self, ProfilerCategory, profile};
 use script_traits::CompositorEvent::{KeyEvent, MouseButtonEvent, MouseMoveEvent, ResizeEvent};
 use script_traits::CompositorEvent::{TouchEvent};
 use script_traits::{CompositorEvent, ConstellationControlMsg, InitialScriptState, NewLayoutInfo};
-use script_traits::{OpaqueScriptLayoutChannel, ScriptMsg as ConstellationMsg, ScriptState};
+use script_traits::{OpaqueScriptLayoutChannel, ScriptMsg as ConstellationMsg};
 use script_traits::{ScriptTaskFactory, TimerEvent, TimerEventRequest, TimerSource};
 use script_traits::{TouchEventType, TouchId};
 use std::any::Any;
@@ -97,7 +97,6 @@ use std::result::Result;
 use std::sync::atomic::{Ordering, AtomicBool};
 use std::sync::mpsc::{Receiver, Select, Sender, channel};
 use std::sync::{Arc, Mutex};
-use string_cache::Atom;
 use time::{Tm, now};
 use url::{Url, UrlParser};
 use util::opts;
@@ -1014,10 +1013,6 @@ impl ScriptTask {
             ConstellationControlMsg::DispatchFrameLoadEvent {
                 target: pipeline_id, parent: containing_id } =>
                 self.handle_frame_load_event(containing_id, pipeline_id),
-            ConstellationControlMsg::GetCurrentState(sender, pipeline_id) => {
-                let state = self.handle_get_current_state(pipeline_id);
-                sender.send(state).unwrap();
-            },
             ConstellationControlMsg::ReportCSSError(pipeline_id, filename, line, column, msg) =>
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
         }
@@ -1171,40 +1166,6 @@ impl ScriptTask {
             return;
         }
         panic!("Page rect message sent to nonexistent pipeline");
-    }
-
-    /// Get the current state of a given pipeline.
-    fn handle_get_current_state(&self, pipeline_id: PipelineId) -> ScriptState {
-        // Check if the main page load is still pending
-        let loads = self.incomplete_loads.borrow();
-        if let Some(_) = loads.iter().find(|load| load.pipeline_id == pipeline_id) {
-            return ScriptState::DocumentLoading;
-        }
-
-        // If not in pending loads, the page should exist by now.
-        let page = self.root_page();
-        let page = page.find(pipeline_id).expect("GetCurrentState sent to nonexistent pipeline");
-        let doc = page.document();
-
-        // Check if document load event has fired. If the document load
-        // event has fired, this also guarantees that the first reflow
-        // has been kicked off. Since the script task does a join with
-        // layout, this ensures there are no race conditions that can occur
-        // between load completing and the first layout completing.
-        let load_pending = doc.ReadyState() != DocumentReadyState::Complete;
-        if load_pending {
-            return ScriptState::DocumentLoading;
-        }
-
-        // Checks if the html element has reftest-wait attribute present.
-        // See http://testthewebforward.org/docs/reftests.html
-        let html_element = doc.GetDocumentElement();
-        let reftest_wait = html_element.map_or(false, |elem| elem.has_class(&Atom::from("reftest-wait")));
-        if reftest_wait {
-            return ScriptState::DocumentLoading;
-        }
-
-        ScriptState::DocumentLoaded
     }
 
     fn handle_new_layout(&self, new_layout_info: NewLayoutInfo) {
@@ -1708,6 +1669,9 @@ impl ScriptTask {
             document: JS::from_rooted(&document),
             window: JS::from_rooted(&window),
         }));
+
+        let ConstellationChan(ref chan) = self.constellation_chan;
+        chan.send(ConstellationMsg::ActivateDocument(incomplete.pipeline_id)).unwrap();
 
         let is_javascript = incomplete.url.scheme == "javascript";
         let parse_input = if is_javascript {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -97,15 +97,6 @@ pub struct NewLayoutInfo {
     pub content_process_shutdown_chan: IpcSender<()>,
 }
 
-/// Used to determine if a script has any pending asynchronous activity.
-#[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub enum ScriptState {
-    /// The document has been loaded.
-    DocumentLoaded,
-    /// The document is still loading.
-    DocumentLoading,
-}
-
 /// Messages sent from the constellation or layout to the script task.
 #[derive(Deserialize, Serialize)]
 pub enum ConstellationControlMsg {
@@ -142,8 +133,6 @@ pub enum ConstellationControlMsg {
     /// Notifies the script task that a new Web font has been loaded, and thus the page should be
     /// reflowed.
     WebFontLoaded(PipelineId),
-    /// Get the current state of the script task for a given pipeline.
-    GetCurrentState(IpcSender<ScriptState>, PipelineId),
     /// Cause a `load` event to be dispatched at the appropriate frame element.
     DispatchFrameLoadEvent {
         /// The pipeline that has been marked as loaded.

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -6,7 +6,7 @@ use canvas_traits::CanvasMsg;
 use euclid::point::Point2D;
 use euclid::size::Size2D;
 use ipc_channel::ipc::IpcSender;
-use msg::constellation_msg::{AnimationState, IframeLoadInfo, NavigationDirection};
+use msg::constellation_msg::{AnimationState, DocumentState, IframeLoadInfo, NavigationDirection};
 use msg::constellation_msg::{Failure, MozBrowserEvent, PipelineId};
 use msg::constellation_msg::{LoadData, SubpageId};
 use msg::constellation_msg::{MouseButton, MouseEventType};
@@ -66,4 +66,8 @@ pub enum ScriptMsg {
     SetCursor(Cursor),
     /// Notifies the constellation that the viewport has been constrained in some manner
     ViewportConstrained(PipelineId, ViewportConstraints),
+    /// Mark a new document as active
+    ActivateDocument(PipelineId),
+    /// Set the document state for a pipeline (used by screenshot / reftests)
+    SetDocumentState(PipelineId, DocumentState),
 }

--- a/tests/wpt/metadata-css/css21_dev/html4/root-box-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/root-box-003.htm.ini
@@ -1,3 +1,3 @@
 [root-box-003.htm]
   type: reftest
-  expected: TIMEOUT
+  expected: FAIL


### PR DESCRIPTION
This changes several tests that contain <iframe></iframe> from FAIL to TIMEOUT. This is correct
since there is a bug that prevents these iframes from ever rendering.

~~~There are also a few previous FAILs that changed to OK. These may be intermittents or they
may genuinely be fixed by this change.~~~

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8612)

<!-- Reviewable:end -->
