### PR TITLE
Browser API: implement iframe.reload()

### DIFF
--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -217,7 +217,7 @@ bitflags! {
 #[derive(Deserialize, Serialize)]
 pub struct IframeLoadInfo {
     /// Url to load
-    pub url: Url,
+    pub url: Option<Url>,
     /// Pipeline ID of the parent of this iframe
     pub containing_pipeline_id: PipelineId,
     /// The new subpage ID for this load

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -90,7 +90,7 @@ impl HTMLIFrameElement {
         (subpage_id, old_subpage_id)
     }
 
-    pub fn navigate_child_browsing_context(&self, url: Url) {
+    pub fn navigate_or_reload_child_browsing_context(&self, url: Option<Url>) {
         let sandboxed = if self.is_sandboxed() {
             IFrameSandboxed
         } else {
@@ -127,7 +127,7 @@ impl HTMLIFrameElement {
             None => url!("about:blank"),
         };
 
-        self.navigate_child_browsing_context(url);
+        self.navigate_or_reload_child_browsing_context(Some(url));
     }
 
     #[allow(unsafe_code)]
@@ -399,7 +399,12 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
 
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/reload
     fn Reload(&self, _hardReload: bool) -> Fallible<()> {
-        Err(Error::NotSupported)
+        if mozbrowser_enabled() {
+            if self.upcast::<Node>().is_in_doc() {
+                self.navigate_or_reload_child_browsing_context(None);
+            }
+        }
+        Ok(())
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/stop

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1943,7 +1943,7 @@ impl ScriptTask {
                     doc.find_iframe(subpage_id)
                 });
                 if let Some(iframe) = iframe.r() {
-                    iframe.navigate_child_browsing_context(load_data.url);
+                    iframe.navigate_or_reload_child_browsing_context(Some(load_data.url));
                 }
             }
             None => {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5643,6 +5643,12 @@
             "url": "/_mozilla/mozilla/mozbrowser/mozbrowsericonchange_event.html"
           }
         ],
+        "mozilla/mozbrowser/reload.html": [
+          {
+            "path": "mozilla/mozbrowser/reload.html",
+            "url": "/_mozilla/mozilla/mozbrowser/reload.html"
+          }
+        ],
         "mozilla/navigator.html": [
           {
             "path": "mozilla/navigator.html",

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/reload.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/reload.html
@@ -1,0 +1,35 @@
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+async_test(function(t) {
+
+  const SRC = "data:,foobar";
+  const RELOAD_MAX_COUNT = 5;
+
+
+  var iframe = document.createElement("iframe");
+  iframe.mozbrowser = "true";
+  iframe.src = SRC;
+
+  var reload_count = 0;
+
+  iframe.addEventListener("mozbrowserloadend", t.step_func(e => {
+    reload_count++;
+    assert_equals(SRC, e.target.src);
+    if (reload_count == RELOAD_MAX_COUNT) {
+      t.done();
+    } else {
+      iframe.reload();
+    }
+  }));
+
+
+  document.body.appendChild(iframe);
+});
+
+</script>
+</body>


### PR DESCRIPTION
fixes #8575

The implementation is naive, and doesn't support the `hardreload` parameter.
And for the test, I'm not sure how else I can test the reload.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8618)

<!-- Reviewable:end -->
