### PR TITLE
Move SetDOMProxyInformation() call from script_task.rs to script/lib.rs

### DIFF
--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -99,6 +99,8 @@ mod unpremultiplytable;
 mod webdriver_handlers;
 
 use dom::bindings::codegen::RegisterBindings;
+use js::jsapi::SetDOMProxyInformation;
+use std::ptr;
 
 #[cfg(target_os = "linux")]
 #[allow(unsafe_code)]
@@ -145,6 +147,7 @@ fn perform_platform_specific_initialization() {}
 pub fn init() {
     unsafe {
         assert_eq!(js::jsapi::JS_Init(), true);
+        SetDOMProxyInformation(ptr::null(), 0, Some(script_task::shadow_check_callback));
     }
 
     // Create the global vtables used by the (generated) DOM

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -49,7 +49,7 @@ use hyper::mime::{Mime, SubLevel, TopLevel};
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::glue::CollectServoSizes;
-use js::jsapi::{DOMProxyShadowsResult, HandleId, HandleObject, RootedValue, SetDOMProxyInformation};
+use js::jsapi::{DOMProxyShadowsResult, HandleId, HandleObject, RootedValue};
 use js::jsapi::{DisableIncrementalGC, JS_AddExtraGCRootsTracer, JS_SetWrapObjectCallbacks};
 use js::jsapi::{GCDescription, GCProgress, JSGCInvocationKind, SetGCSliceCallback};
 use js::jsapi::{JSAutoRequest, JSGCStatus, JS_GetRuntime, JS_SetGCCallback, SetDOMCallbacks};
@@ -582,7 +582,7 @@ unsafe extern "C" fn debug_gc_callback(_rt: *mut JSRuntime, status: JSGCStatus, 
     }
 }
 
-unsafe extern "C" fn shadow_check_callback(_cx: *mut JSContext,
+pub unsafe extern "C" fn shadow_check_callback(_cx: *mut JSContext,
     _object: HandleObject, _id: HandleId) -> DOMProxyShadowsResult {
     // XXX implement me
     DOMProxyShadowsResult::ShadowCheckFailed
@@ -693,7 +693,6 @@ impl ScriptTask {
 
         unsafe {
             unsafe extern "C" fn empty_wrapper_callback(_: *mut JSContext, _: *mut JSObject) -> bool { true }
-            SetDOMProxyInformation(ptr::null(), 0, Some(shadow_check_callback));
             SetDOMCallbacks(runtime.rt(), &DOM_CALLBACKS);
             SetPreserveWrapperCallback(runtime.rt(), Some(empty_wrapper_callback));
             // Pre barriers aren't working correctly at the moment


### PR DESCRIPTION
Actually, I'm not sure whether to move `unsafe extern "C" fn shadow_check_callback` from script_task.rs to lib.rs or to keep it there. cc: @wenderen

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8627)

<!-- Reviewable:end -->
