### PR TITLE
Clean up restyle damage after it no longer applies

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -27,7 +27,7 @@ use fragment::{InlineAbsoluteHypotheticalFragmentInfo, TableColumnFragmentInfo};
 use fragment::{InlineBlockFragmentInfo, SpecificFragmentInfo, UnscannedTextFragmentInfo};
 use fragment::{WhitespaceStrippingResult};
 use gfx::display_list::OpaqueNode;
-use incremental::{RECONSTRUCT_FLOW, RestyleDamage};
+use incremental::{BUBBLE_ISIZES, RECONSTRUCT_FLOW, RestyleDamage};
 use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFlow, InlineFragmentNodeFlags};
 use inline::{InlineFragmentNodeInfo, LAST_FRAGMENT_OF_ELEMENT};
 use list_item::{ListItemFlow, ListStyleTypeContent};
@@ -1697,7 +1697,8 @@ impl FlowConstructionUtils for FlowRef {
     /// properly computed. (This is not, however, a memory safety problem.)
     fn finish(&mut self) {
         if !opts::get().bubble_inline_sizes_separately {
-            flow_ref::deref_mut(self).bubble_inline_sizes()
+            flow_ref::deref_mut(self).bubble_inline_sizes();
+            flow::mut_base(flow_ref::deref_mut(self)).restyle_damage.remove(BUBBLE_ISIZES);
         }
     }
 }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -10,7 +10,7 @@ use css::matching::{ApplicableDeclarations, ElementMatchMethods, MatchMethods, S
 use flow::{PostorderFlowTraversal, PreorderFlowTraversal};
 use flow::{self, Flow};
 use gfx::display_list::OpaqueNode;
-use incremental::{self, BUBBLE_ISIZES, REFLOW, REFLOW_OUT_OF_FLOW, RestyleDamage};
+use incremental::{self, BUBBLE_ISIZES, REFLOW, REFLOW_OUT_OF_FLOW, REPAINT, RestyleDamage};
 use script::layout_interface::ReflowGoal;
 use selectors::bloom::BloomFilter;
 use std::cell::RefCell;
@@ -390,6 +390,7 @@ impl<'a> PostorderFlowTraversal for BuildDisplayList<'a> {
     #[inline]
     fn process(&self, flow: &mut Flow) {
         flow.build_display_list(self.layout_context);
+        flow::mut_base(flow).restyle_damage.remove(REPAINT);
     }
 
     #[inline]


### PR DESCRIPTION
BUBBLE_ISIZES and REPAINT can become "stuck" on in the default Servo
configuration once they are activated. This is solved by removing these
damage bits after they no longer apply. There isn't a good way to test
this, other than noting that it doesn't break any existing CSS tests.
This will become more important in the future as the REPAINT bit is used
to implement display list patching.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8628)

<!-- Reviewable:end -->
