### PR TITLE
Improve readability of flow tree dump

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -62,6 +62,7 @@ use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto};
 use util::geometry::MAX_RECT;
 use util::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize, WritingMode};
 use util::opts;
+use util::print_tree::PrintTree;
 
 /// Information specific to floated blocks.
 #[derive(Clone, RustcEncodable)]
@@ -2035,15 +2036,18 @@ impl Flow for BlockFlow {
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         (*mutator)(&mut self.fragment)
     }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        print_tree.add_item(format!("↑↑ Fragment for block: {:?}", self.fragment));
+    }
 }
 
 impl fmt::Debug for BlockFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f,
-               "{:?} - {:x}: frag={:?} ({:?})",
+               "{:?}({:x}) {:?}",
                self.class(),
                self.base.debug_id(),
-               self.fragment,
                self.base)
     }
 }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -215,11 +215,11 @@ impl fmt::Debug for SpecificFragmentInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SpecificFragmentInfo::ScannedText(ref info) => {
-                write!(f, " \"{}\"", slice_chars(&*info.run.text, info.range.begin().get() as usize,
+                write!(f, "\"{}\"", slice_chars(&*info.run.text, info.range.begin().get() as usize,
                                                  info.range.end().get() as usize))
             }
             SpecificFragmentInfo::UnscannedText(ref info) => {
-                write!(f, " \"{}\"", info.text)
+                write!(f, "\"{}\"", info.text)
             }
             _ => Ok(())
         }
@@ -2409,13 +2409,32 @@ impl Fragment {
 
 impl fmt::Debug for Fragment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "({} {} ", self.debug_id(), self.specific.get_type()));
-        try!(write!(f, "bb {:?} bp {:?} m {:?}{:?}",
-                    self.border_box,
-                    self.border_padding,
-                    self.margin,
-                    self.specific));
-        write!(f, ")")
+        let border_padding_string = if !self.border_padding.is_zero() {
+            format!(" border_padding={:?}", self.border_padding)
+        } else {
+            "".to_owned()
+        };
+
+        let margin_string = if !self.margin.is_zero() {
+            format!(" margin={:?}", self.margin)
+        } else {
+            "".to_owned()
+        };
+
+        let damage_string = if self.restyle_damage != RestyleDamage::empty() {
+            format!(" damage={:?}", self.restyle_damage)
+        } else {
+            "".to_owned()
+        };
+
+        write!(f, "{}({}) [{:?}] border_box={:?}{}{}{}",
+            self.specific.get_type(),
+            self.debug_id(),
+            self.specific,
+            self.border_box,
+            border_padding_string,
+            margin_string,
+            damage_string)
     }
 }
 

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -33,6 +33,7 @@ use unicode_bidi;
 use util;
 use util::geometry::ZERO_RECT;
 use util::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
+use util::print_tree::PrintTree;
 use util::range::{Range, RangeIndex};
 use wrapper::PseudoElementType;
 
@@ -774,16 +775,6 @@ pub struct InlineFragments {
     /// The fragments themselves.
     pub fragments: Vec<Fragment>,
 }
-
-impl fmt::Debug for InlineFragments {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for fragment in &self.fragments {
-            try!(write!(f, "\n  * {:?}", fragment))
-        }
-        Ok(())
-    }
-}
-
 
 impl InlineFragments {
     /// Creates an empty set of inline fragments.
@@ -1824,15 +1815,21 @@ impl Flow for InlineFlow {
         }
         containing_block_size
     }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        for fragment in &self.fragments.fragments {
+            print_tree.add_item(format!("{:?}", fragment));
+        }
+    }
 }
 
 impl fmt::Debug for InlineFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?} - {:x} - Ovr {:?} - {:?}",
-            self.class(),
-            self.base.debug_id(),
-            flow::base(self).overflow,
-            self.fragments)
+        write!(f,
+               "{:?}({:x}) {:?}",
+               self.class(),
+               self.base.debug_id(),
+               flow::base(self))
     }
 }
 

--- a/components/layout/layout_task.rs
+++ b/components/layout/layout_task.rs
@@ -1251,7 +1251,7 @@ impl LayoutTask {
             }
 
             if opts::get().dump_flow_tree {
-                root_flow.dump();
+                root_flow.print("Post layout flow tree".to_owned());
             }
 
             self.generation += 1;

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use std::sync::Arc;
 use style::properties::ComputedValues;
 use util::logical_geometry::LogicalSize;
+use util::print_tree::PrintTree;
 
 pub struct MulticolFlow {
     pub block_flow: BlockFlow,
@@ -100,6 +101,10 @@ impl Flow for MulticolFlow {
 
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
+    }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
     }
 }
 

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -30,6 +30,7 @@ use table_row::{TableRowFlow};
 use table_row::{self, CellIntrinsicInlineSize, CollapsedBorder, CollapsedBorderProvenance};
 use table_wrapper::TableLayout;
 use util::logical_geometry::LogicalSize;
+use util::print_tree::PrintTree;
 
 /// A table flow corresponded to the table's internal table fragment under a table wrapper flow.
 /// The properties `position`, `float`, and `margin-*` are used on the table wrapper fragment,
@@ -548,6 +549,10 @@ impl Flow for TableFlow {
 
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
+    }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
     }
 }
 

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::sync::Arc;
 use style::properties::ComputedValues;
 use util::logical_geometry::LogicalSize;
+use util::print_tree::PrintTree;
 
 /// A table formatting context.
 pub struct TableCaptionFlow {
@@ -99,6 +100,10 @@ impl Flow for TableCaptionFlow {
 
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
+    }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
     }
 }
 

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -24,6 +24,7 @@ use style::properties::ComputedValues;
 use table::InternalTable;
 use table_row::{CollapsedBorder, CollapsedBorderProvenance};
 use util::logical_geometry::{LogicalMargin, LogicalRect, LogicalSize, WritingMode};
+use util::print_tree::PrintTree;
 use wrapper::{ServoThreadSafeLayoutNode, ThreadSafeLayoutNode};
 
 /// A table formatting context.
@@ -213,6 +214,10 @@ impl Flow for TableCellFlow {
 
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
+    }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
     }
 }
 

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -29,6 +29,7 @@ use style::values::computed::LengthOrPercentageOrAuto;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, InternalTable, VecExt};
 use table_cell::{CollapsedBordersForCell, TableCellFlow};
 use util::logical_geometry::{LogicalSize, PhysicalSide, WritingMode};
+use util::print_tree::PrintTree;
 
 /// A single row of a table.
 pub struct TableRowFlow {
@@ -456,11 +457,15 @@ impl Flow for TableRowFlow {
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
     }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
+    }
 }
 
 impl fmt::Debug for TableRowFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TableRowFlow: {:?}", self.block_flow.fragment)
+        write!(f, "TableRowFlow: {:?}", self.block_flow)
     }
 }
 

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -22,6 +22,7 @@ use style::properties::ComputedValues;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, InternalTable, TableLikeFlow};
 use table_row::{self, CollapsedBordersForRow};
 use util::logical_geometry::{LogicalSize, WritingMode};
+use util::print_tree::PrintTree;
 
 /// A table formatting context.
 pub struct TableRowGroupFlow {
@@ -234,10 +235,14 @@ impl Flow for TableRowGroupFlow {
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
     }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
+    }
 }
 
 impl fmt::Debug for TableRowGroupFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TableRowGroupFlow: {:?}", self.block_flow.fragment)
+        write!(f, "TableRowGroupFlow: {:?}", self.block_flow)
     }
 }

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -34,6 +34,7 @@ use style::values::computed::LengthOrPercentageOrAuto;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize};
 use table_row;
 use util::logical_geometry::LogicalSize;
+use util::print_tree::PrintTree;
 
 #[derive(Copy, Clone, RustcEncodable, Debug)]
 pub enum TableLayout {
@@ -462,14 +463,18 @@ impl Flow for TableWrapperFlow {
     fn mutate_fragments(&mut self, mutator: &mut FnMut(&mut Fragment)) {
         self.block_flow.mutate_fragments(mutator)
     }
+
+    fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
+        self.block_flow.print_extra_flow_children(print_tree);
+    }
 }
 
 impl fmt::Debug for TableWrapperFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.block_flow.base.flags.is_float() {
-            write!(f, "TableWrapperFlow(Float): {:?}", self.block_flow.fragment)
+            write!(f, "TableWrapperFlow(Float): {:?}", self.block_flow)
         } else {
-            write!(f, "TableWrapperFlow: {:?}", self.block_flow.fragment)
+            write!(f, "TableWrapperFlow: {:?}", self.block_flow)
         }
     }
 }

--- a/components/util/logical_geometry.rs
+++ b/components/util/logical_geometry.rs
@@ -175,7 +175,7 @@ impl Debug for DebugWritingMode {
 
     #[cfg(debug_assertions)]
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
-        self.mode.fmt(formatter)
+        write!(formatter, "{}", self.mode)
     }
 }
 
@@ -502,13 +502,18 @@ pub struct LogicalMargin<T> {
 
 impl<T: Debug> Debug for LogicalMargin<T> {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
-        write!(formatter,
-               "LogicalMargin({:?}, inline: {:?}..{:?} block: {:?}..{:?})",
-               self.debug_writing_mode,
-               self.inline_start,
-               self.inline_end,
-               self.block_start,
-               self.block_end)
+        let writing_mode_string = if cfg!(debug_assertions) {
+            format!("{:?}, ", self.debug_writing_mode)
+        } else {
+            "".to_owned()
+        };
+
+        write!(formatter, "LogicalMargin({}i:{:?}..{:?} b:{:?}..{:?})",
+            writing_mode_string,
+            self.inline_start,
+            self.inline_end,
+            self.block_start,
+            self.block_end)
     }
 }
 
@@ -788,9 +793,14 @@ pub struct LogicalRect<T> {
 
 impl<T: Debug> Debug for LogicalRect<T> {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
-        write!(formatter,
-               "LogicalRect({:?}, i{:?}×b{:?}, @ (i{:?},b{:?}))",
-               self.debug_writing_mode,
+        let writing_mode_string = if cfg!(debug_assertions) {
+            format!("{:?}, ", self.debug_writing_mode)
+        } else {
+            "".to_owned()
+        };
+
+        write!(formatter, "LogicalRect({}i{:?}×b{:?}, @ (i{:?},b{:?}))",
+               writing_mode_string,
                self.size.inline,
                self.size.block,
                self.start.i,


### PR DESCRIPTION
Use the PrintTree utility to improve the readability of flow tree
dumps. Blocks and fragments are now split over two dump levels, because
otherwise they are impenetrable. Also start printing the restyle damage of
fragments.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8632)

<!-- Reviewable:end -->
