### PR TITLE
Clarify servo as parallel browser engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Servo Parallel Browser Project
+# The Servo Parallel Browser Engine Project
 
 Servo is a prototype web browser engine written in the
 [Rust](https://github.com/rust-lang/rust) language. It is currently developed on


### PR DESCRIPTION
In the repo title it says servo is a "parallel browser engine" whereas readme says its a "parallel browser". It will be helpful to add a more clear title.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8638)

<!-- Reviewable:end -->
