### PR TITLE
Check for an extant attribute before interning in setAttribute

### DIFF
--- a/tests/wpt/web-platform-tests/dom/nodes/attributes.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/attributes.html
@@ -459,4 +459,17 @@ test(function() {
   var el2 = document.createElement("div");
   assert_throws("INUSE_ATTRIBUTE_ERR", function(){el2.setAttributeNode(attrNode)});
 }, "setAttributeNode on bound attribute should throw InUseAttributeError")
+
+test(function() {
+  var e = document.body;
+
+  e.setAttributeNS(null, "FOO", "bar");
+  assert_equals(e.getAttributeNS(null, "FOO"), "bar");
+  assert_equals(e.getAttributeNS(null, "foo"), null);
+
+  e.setAttribute("FOO", "quux");
+  assert_equals(e.getAttributeNS(null, "FOO"), "bar");
+  assert_equals(e.getAttributeNS(null, "foo"), "quux");
+}, "setAttribute and setAttributeNS have different capitalization behavior")
+
 </script>


### PR DESCRIPTION
Interning a DOMString as an atom can be expensive, and that work is unnecessary
if the attribute being added already exists and already has an interned
name. Instead of eagerly interning, first do a linear search over the existing
attributes to see if we can skip interning. This is an optimization that Gecko
already employs, as described in #6906.

I tested Dromaeo's dom subsuite and a super naive micro benchmark of my own
writing.

I haven't looked at Dromaeo's code, but given the units it reports, I'm assuming
that higher is better.

For my super naive micro benchmark, smaller is better.

Here are the results:

```
+---------+-------------------------+----------------------+----------------+
|         | Servo w/out this commit | Servo w/ this commit | Gecko          |
+---------+-------------------------+----------------------+----------------+
| Dromaeo | 2684.37 runs/s          | 2721.35 runs/s       | 2068.78 runs/s |
+---------+-------------------------+----------------------+----------------+
| Micro   | 4985 ms                 | 4540 ms              | 1616 ms        |
+---------+-------------------------+----------------------+----------------+
```

So this seems to yield a slight performance increase, but nothing to write home
about. This could potentially hurt performance when there are many attributes or
if the attribute names are very long; intuitively, neither seem super common to me.

Here is the source of my super naive micro benchmark:

``` html
<!DOCTYPE html>
<body>
    <button onclick="run()">Test</button>
    <h1 id="result"></h1>
    <script>
        function run() {
            var h1 = document.getElementById("result");
            var start = Date.now();
            var i = 10000000;
            while (i--) {
                h1.setAttribute("foobar", "baz");
            }
            h1.textContent = Date.now() - start;
        }
    </script>
</body>
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8645)

<!-- Reviewable:end -->
