### PR TITLE
When an iframe loads a new page, dirty and reflow it so that the layout fragment will pick up the new subpage ID.

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -18,7 +18,7 @@ use dom::document::Document;
 use dom::element::{AttributeMutation, Element, RawLayoutElementHelpers};
 use dom::event::Event;
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, window_from_node};
+use dom::node::{Node, NodeDamage, window_from_node};
 use dom::urlhelper::UrlHelper;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::Window;
@@ -119,6 +119,10 @@ impl HTMLIFrameElement {
             // https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadstart
             self.dispatch_mozbrowser_event(MozBrowserEvent::LoadStart);
         }
+
+        // We need to dirty ourselves so that the iframe fragment will be reconstructed with the
+        // new subpage ID.
+        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage)
     }
 
     pub fn process_the_iframe_attributes(&self) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -103,6 +103,8 @@ pub enum ReflowReason {
     ImageLoaded,
     RequestAnimationFrame,
     WebFontLoaded,
+    /// An iframe loaded a new page.
+    IframeLoadedNewPage,
 }
 
 pub type ScrollPoint = Point2D<Au>;
@@ -1346,6 +1348,7 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
         ReflowReason::ImageLoaded => "\tImageLoaded",
         ReflowReason::RequestAnimationFrame => "\tRequestAnimationFrame",
         ReflowReason::WebFontLoaded => "\tWebFontLoaded",
+        ReflowReason::IframeLoadedNewPage => "\tIframeLoadedNewPage",
     });
 
     println!("{}", debug_msg);

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1905,12 +1905,17 @@ impl ScriptTask {
         match subpage_id {
             Some(subpage_id) => {
                 let borrowed_page = self.root_page();
-                let iframe = borrowed_page.find(pipeline_id).and_then(|page| {
-                    let doc = page.document();
-                    doc.find_iframe(subpage_id)
-                });
-                if let Some(iframe) = iframe.r() {
-                    iframe.navigate_child_browsing_context(load_data.url);
+                if let Some(containing_page) = borrowed_page.find(pipeline_id) {
+                    let doc = containing_page.document();
+                    let iframe = doc.find_iframe(subpage_id);
+                    if let Some(iframe) = iframe.r() {
+                        iframe.navigate_child_browsing_context(load_data.url);
+
+                        let window = containing_page.window();
+                        window.reflow(ReflowGoal::ForDisplay,
+                                      ReflowQueryType::NoQuery,
+                                      ReflowReason::IframeLoadedNewPage);
+                    }
                 }
             }
             None => {


### PR DESCRIPTION
This is necessary to make its new contents show up!

Closes #8081.

r? @jdm 

cc @paulrouget @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8662)

<!-- Reviewable:end -->
