### PR TITLE
Force line-height to 1em for block-in-inline tests.

### DIFF
--- a/tests/wpt/css-tests/css21_dev/html4/block-in-inline-001.htm
+++ b/tests/wpt/css-tests/css21_dev/html4/block-in-inline-001.htm
@@ -10,7 +10,7 @@
   <meta name="flags" content="">
   <meta name="assert" content="When an inline box contains a block box,     the inline box is broken around the block.">
   <style type="text/css">
-   td { border: solid black; padding: 0; background: red; color: red; }
+   td { border: solid black; padding: 0; background: red; color: red; line-height: 1em;}
    .inline { display: inline; background: lime; color: black; }
    .block { display: block; background: green; }
    div { color: black; }

--- a/tests/wpt/css-tests/css21_dev/html4/block-in-inline-002.htm
+++ b/tests/wpt/css-tests/css21_dev/html4/block-in-inline-002.htm
@@ -11,7 +11,7 @@
   <meta name="assert" content="When an inline box contains a block box,     the inline box is broken around the box and its background is drawn     only behind the inline's pieces, not behind the block.">
   <meta name="flags" content="">
   <style type="text/css">
-   td { border: solid black; color: black; padding: 0; background: green; }
+   td { border: solid black; color: black; padding: 0; background: green; line-height: 1em;}
    .inline { display: inline; background: lime; }
    .block { display: block; }
    .a, .c { background: lime; }

--- a/tests/wpt/css-tests/css21_dev/html4/reference/block-in-inline-001-ref.htm
+++ b/tests/wpt/css-tests/css21_dev/html4/reference/block-in-inline-001-ref.htm
@@ -13,6 +13,7 @@
   border: black solid;
   color: black;
   padding: 0;
+  line-height: 1em;
   }
 
   .lime {background-color: lime;}

--- a/tests/wpt/metadata-css/css21_dev/html4/block-in-inline-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-in-inline-001.htm.ini
@@ -1,4 +1,0 @@
-[block-in-inline-001.htm]
-  type: reftest
-  disabled: seems to assume ascent and block size above baseline are equal
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/block-in-inline-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-in-inline-002.htm.ini
@@ -1,4 +1,0 @@
-[block-in-inline-002.htm]
-  type: reftest
-  disabled: seems to assume ascent and block size above baseline are equal
-  expected: FAIL


### PR DESCRIPTION
The used value for line-height varies depending on the default font;
force it to 1em so the background renders consistently.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8663)

<!-- Reviewable:end -->
